### PR TITLE
Directly link home files

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -232,7 +232,7 @@ in
           target="$(realpath -m "$out/$relTarget")"
 
           # Target path must be within $HOME.
-          if [[ ! $target =~ $out ]] ; then
+          if [[ ! $target == $out* ]] ; then
             echo "Error installing file '$relTarget' outside \$HOME" >&2
             exit 1
           fi

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -38,6 +38,12 @@ in
       internal = true;
       description = "Package to contain all home files";
     };
+
+    homeManager.fileType = mkOption {
+      default = fileType;
+      readOnly = true;
+      internal = true;
+    };
   };
 
   config = {

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -1,32 +1,6 @@
-{ homeDirectory, lib, pkgs }:
+{ homeDirectory, storeFileName, lib, pkgs }:
 
 with lib;
-
-let
-
-  # Figures out a valid Nix store name for the given path.
-  storeFileName = path:
-    let
-      # All characters that are considered safe. Note "-" is not
-      # included to avoid "-" followed by digit being interpreted as a
-      # version.
-      safeChars =
-        [ "+" "." "_" "?" "=" ]
-        ++ lowerChars
-        ++ upperChars
-        ++ stringToCharacters "0123456789";
-
-      empties = l: genList (x: "") (length l);
-
-      unsafeInName = stringToCharacters (
-        replaceStrings safeChars (empties safeChars) path
-      );
-
-      safeName = replaceStrings unsafeInName (empties unsafeInName) path;
-    in
-      "home_file_" + safeName;
-
-in
 
 {
   # Constructs a type suitable for a `home.file` like option. The

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -85,10 +85,10 @@ with lib;
       config = {
         target = mkDefault name;
         source = mkIf (config.text != null) (
-          mkDefault (pkgs.writeTextFile {
+          pkgs.writeTextFile {
             inherit (config) executable text;
             name = storeFileName name;
-          })
+          }
         );
       };
     }

--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -90,7 +90,9 @@ in
     })
 
     {
-      home.file = mkMerge [ cfg.configFile cfg.dataFile ];
+      home-file-defs =
+        (builtins.attrValues cfg.configFile) ++
+        (builtins.attrValues cfg.dataFile);
     }
   ];
 }

--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -6,10 +6,7 @@ let
 
   cfg = config.xdg;
 
-  fileType = (import ../lib/file-type.nix {
-    inherit (config.home) homeDirectory;
-    inherit lib pkgs;
-  }).fileType;
+  fileType = config.homeManager.fileType;
 
   defaultCacheHome = "${config.home.homeDirectory}/.cache";
   defaultConfigHome = "${config.home.homeDirectory}/.config";

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -24,17 +24,17 @@ let
 
   buildService = style: name: serviceCfg:
     let
-      source = pkgs.writeText "${name}.${style}" (toSystemdIni serviceCfg);
+      text = toSystemdIni serviceCfg;
 
       wantedBy = target:
         {
           name = "systemd/user/${target}.wants/${name}.${style}";
-          value = { inherit source; };
+          value = { inherit text; };
         };
     in
       singleton {
         name = "systemd/user/${name}.${style}";
-        value = { inherit source; };
+        value = { inherit text; };
       }
       ++
       map wantedBy (serviceCfg.Install.WantedBy or []);


### PR DESCRIPTION
Here's a config for testing:

```nix
{ pkgs }:
let
  nonExecutableFile = pkgs.writeText "a" "a";
  executableFile = pkgs.writeScript "a" "a";
in
  {
    home.file."basic_file".text = "a";

    home.file."test/my/nested/file".text = "a";
    home.file."test/spēcïal chârs".text = "a";

    home.file."test/noExec".text = "a";
    home.file."test/exec" = { executable = true; text = "a"; };

    home.file."test/noExecSrcExec"   = { executable = false; source = executableFile; };
    home.file."test/noExecSrcNoExec" = { executable = false; source = nonExecutableFile; };

    home.file."test/execSrcExec"   = { executable = true; source = executableFile; };
    home.file."test/execSrcNoExec" = { executable = true; source = nonExecutableFile; };

    home.file."test/inheritExecSrcExec"   = { source = executableFile; };
    home.file."test/inheritExecSrcNoExec" = { source = nonExecutableFile; };

    # Mode
    home.file."test/modeNoExecSrcExec" = { mode = "-x"; source = executableFile; };
    home.file."test/modeExecSrcExec"   = { mode = "+x"; source = executableFile; };

    # Disallow setting text and source simultaneously
    # home.file."test/cmtest" = { text = "a"; source = executableFile; };

    # Reject files outside home
    # home.file."../a".source = executableFile;

    # Dirs
    # home.file."test/dir" = { source = /tmp/dir; };
    # home.file."test/dirRecursive" = { source = /tmp/dir; recursive = true; };

    systemd.user.services.myservice = {
      Service.ExecStart = ''${pkgs.coreutils}/bin/true'';
      Install.WantedBy = [ "default.target" ];
    };
  }
```