### PR TITLE
zsh: add default keymap configuration

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -193,10 +193,10 @@ in
       };
 
       defaultKeymap = mkOption {
-        type = types.nullOr (types.enum [ "emacs" "viins" "vicmd" ]);
+        type = types.nullOr (types.enum (attrNames bindkeyCommands));
         default = null;
         example = "emacs";
-        description = "The default base keymap to use";
+        description = "The default base keymap to use.";
       };
 
       sessionVariables = mkOption {
@@ -316,8 +316,10 @@ in
 
         HELPDIR="${pkgs.zsh}/share/zsh/$ZSH_VERSION/help"
 
-        ${if cfg.defaultKeymap != null && hasAttr cfg.defaultKeymap bindkeyCommands
-          then getAttr cfg.defaultKeymap bindkeyCommands else ""}
+        ${optionalString (cfg.defaultKeymap != null) ''
+          # Use ${cfg.defaultKeymap} keymap as the default.
+          ${getAttr cfg.defaultKeymap bindkeyCommands}
+        ''}
 
         ${concatStrings (map (plugin: ''
           path+="$HOME/${pluginsDir}/${plugin.name}"

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -19,6 +19,12 @@ let
 
   zdotdir = "$HOME/" + cfg.dotDir;
 
+  bindkeyCommands = {
+    emacs = "bindkey -e";
+    viins = "bindkey -v";
+    vicmd = "bindkey -a";
+  };
+
   historyModule = types.submodule ({ config, ... }: {
     options = {
       size = mkOption {
@@ -186,6 +192,13 @@ in
         description = "Options related to commands history configuration.";
       };
 
+      defaultKeymap = mkOption {
+        type = types.nullOr (types.enum [ "emacs" "viins" "vicmd" ]);
+        default = null;
+        example = "emacs";
+        description = "The default base keymap to use";
+      };
+
       sessionVariables = mkOption {
         default = {};
         type = types.attrs;
@@ -302,6 +315,9 @@ in
         done
 
         HELPDIR="${pkgs.zsh}/share/zsh/$ZSH_VERSION/help"
+
+        ${if cfg.defaultKeymap != null && hasAttr cfg.defaultKeymap bindkeyCommands
+          then getAttr cfg.defaultKeymap bindkeyCommands else ""}
 
         ${concatStrings (map (plugin: ''
           path+="$HOME/${pluginsDir}/${plugin.name}"


### PR DESCRIPTION
Adds `zsh.deafultKeymap` configuration option.

This can be useful, for example, with `fzf.enableZshIntegration=true` because a `bindkey -e` in `initExtra` will wipe out the fzf keybindings that end up being set earlier).