### PR TITLE
dconf: inform D-Bus about ca.desrt.dconf.service

### DIFF
--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -59,6 +59,9 @@ in
   };
 
   config = mkIf (cfg.enable && cfg.settings != {}) {
+    xdg.dataFile."dbus-1/services/ca.desrt.dconf.service".source =
+        "${pkgs.gnome3.dconf}/share/dbus-1/services/ca.desrt.dconf.service";
+
     home.activation.dconfSettings = dag.entryAfter ["installPackages"] (
       let
         iniFile = pkgs.writeText "hm-dconf.ini" (toDconfIni cfg.settings);


### PR DESCRIPTION
Should avoid the need for adding
```
services.dbus.packages = with pkgs; [ gnome3.dconf ]
```
on NixOS. But I'm uncertain about the effect on other systems. It might conflict with the distro-installed dconf.