### PR TITLE
gnome-terminal: enable VTE OSC7 support for bash and zsh

### DIFF
--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -8,7 +8,7 @@ let
 
   vteInitStr = ''
     # gnome-terminal: Show current directory in the terminal window title.
-    type __vte_prompt_command &>/dev/null || . ${pkgs.gnome3.vte}/etc/profile.d/vte.sh
+    . ${pkgs.gnome3.vte}/etc/profile.d/vte.sh
   '';
 
   profileColorsSubModule = types.submodule (
@@ -171,7 +171,7 @@ in
           nameValuePair ("${dconfPath}/profiles:/:${n}") (buildProfileSet v)
         ) cfg.profile;
 
-    programs.bash.initExtra = vteInitStr;
+    programs.bash.initExtra = mkBefore vteInitStr;
     programs.zsh.initExtra = vteInitStr;
   };
 }

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -6,6 +6,11 @@ let
 
   cfg = config.programs.gnome-terminal;
 
+  vteInitStr = ''
+    # gnome-terminal: Show current directory in the terminal window title.
+    type __vte_prompt_command &>/dev/null || . ${pkgs.gnome3.vte}/etc/profile.d/vte.sh
+  '';
+
   profileColorsSubModule = types.submodule (
     { ... }: {
       options = {
@@ -165,5 +170,8 @@ in
         // mapAttrs' (n: v:
           nameValuePair ("${dconfPath}/profiles:/:${n}") (buildProfileSet v)
         ) cfg.profile;
+
+    programs.bash.initExtra = vteInitStr;
+    programs.zsh.initExtra = vteInitStr;
   };
 }


### PR DESCRIPTION
Adopted from the [termite module](https://github.com/rycee/home-manager/blob/67ebe16b406950651de09448cd5afdb437545be6/modules/programs/termite.nix#L9).