### PR TITLE
mpd: Teach to create multiple daemon instances

### DIFF
--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -27,18 +27,6 @@ let
 
   mpdOptions = cfg: {
 
-  };
-
-in {
-
-  ###### interface
-
-  options = {
-
-    services.mpd = {
-
-      enable = mkEnableOption "MPD, the music player daemon";
-
       package = mkOption {
         type = types.package;
         default = pkgs.mpd;
@@ -133,6 +121,18 @@ in {
           configuration.
         '';
       };
+
+  };
+
+in {
+
+  ###### interface
+
+  options = {
+
+    services.mpd = {
+
+      enable = mkEnableOption "MPD, the music player daemon";
 
     } // mpdOptions cfg;
 

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -33,13 +33,7 @@ in {
 
     services.mpd = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable MPD, the music player daemon.
-        '';
-      };
+      enable = mkEnableOption "MPD, the music player daemon";
 
       package = mkOption {
         type = types.package;

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -36,6 +36,14 @@ let
       '';
     };
 
+    autoStart = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether this instance should be started automatically.
+      '';
+    };
+
     musicDirectory = mkOption {
       type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
       default = "${config.home.homeDirectory}/music";
@@ -130,7 +138,7 @@ let
       Description = "Music Player Daemon";
     };
 
-    Install = mkIf (!cfg.network.startWhenNeeded) {
+    Install = mkIf (!cfg.network.startWhenNeeded && cfg.autoStart) {
       WantedBy = [ "default.target" ];
     };
 

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -8,7 +8,7 @@ let
 
   cfg = config.services.mpd;
 
-  mpdConf = pkgs.writeText "mpd.conf" ''
+  mpdConf = cfg: pkgs.writeText "mpd.conf" ''
     music_directory     "${cfg.musicDirectory}"
     playlist_directory  "${cfg.playlistDirectory}"
     ${lib.optionalString (cfg.dbFile != null) ''
@@ -24,6 +24,10 @@ let
 
     ${cfg.extraConfig}
   '';
+
+  mpdOptions = cfg: {
+
+  };
 
 in {
 
@@ -129,7 +133,8 @@ in {
           configuration.
         '';
       };
-    };
+
+    } // mpdOptions cfg;
 
   };
 
@@ -150,7 +155,7 @@ in {
 
       Service = {
         Environment = "PATH=${config.home.profileDirectory}/bin";
-        ExecStart = "${cfg.package}/bin/mpd --no-daemon ${mpdConf}";
+        ExecStart = "${cfg.package}/bin/mpd --no-daemon ${mpdConf cfg}";
         Type = "notify";
         ExecStartPre = ''${pkgs.bash}/bin/bash -c "${pkgs.coreutils}/bin/mkdir -p '${cfg.dataDir}' '${cfg.playlistDirectory}'"'';
       };

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -4,8 +4,6 @@ with lib;
 
 let
 
-  name = "mpd";
-
   cfg = config.services.mpd;
 
   mpdConf = cfg: pkgs.writeText "mpd.conf" ''
@@ -25,7 +23,28 @@ let
     ${cfg.extraConfig}
   '';
 
-  mpdOptions = cfg: {
+  mpdDaemon = { name, ... } @ args: let cfg = args.config; in { options = {
+
+    enable = mkEnableOption "this instance";
+
+    name = mkOption {
+      type = types.str;
+      default = name;
+      example = "nas";
+      description = ''
+        The name of this instance. Defaults to the attribute name.
+      '';
+    };
+
+    default = mkOption {
+      type = types.bool;
+      default = cfg.name == "default";
+      description = ''
+        Whether this instance is the default, and thus uses a service named just
+        <literal>mpd.service</literal>. Defaults to <literal>true</literal> if
+        <option>name</option> is <literal>"default"</literal>.
+      '';
+    };
 
     package = mkOption {
       type = types.package;
@@ -44,6 +63,15 @@ let
       '';
     };
 
+    serviceName = mkOption {
+      type = types.str;
+      default = if cfg.default then "mpd" else "mpd-${cfg.name}";
+      defaultText = ''if default then "mpd" else "mpd-''${name}"'';
+      description = ''
+        The name of this instance's service and data directory.
+      '';
+    };
+
     musicDirectory = mkOption {
       type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
       default = "${config.home.homeDirectory}/music";
@@ -57,7 +85,7 @@ let
     playlistDirectory = mkOption {
       type = with types; either path str;
       default = "${cfg.dataDir}/playlists";
-      defaultText = ''''${dataDir}/playlists'';
+      defaultText = "\${dataDir}/playlists";
       apply = toString;       # Prevent copies to Nix store.
       description = ''
         The directory where mpd stores playlists.
@@ -81,8 +109,8 @@ let
 
     dataDir = mkOption {
       type = with types; either path str;
-      default = "${config.xdg.dataHome}/${name}";
-      defaultText = "$XDG_DATA_HOME/mpd";
+      default = "${config.xdg.dataHome}/${cfg.serviceName}";
+      defaultText = "$XDG_DATA_HOME/\${serviceName}";
       apply = toString;       # Prevent copies to Nix store.
       description = ''
         The directory where MPD stores its state, tag cache,
@@ -130,7 +158,7 @@ let
       '';
     };
 
-  };
+  }; };
 
   mpdService = cfg: {
     Unit = {
@@ -176,20 +204,82 @@ in {
 
     services.mpd = {
 
-      enable = mkEnableOption "MPD, the music player daemon";
+      enable = mkEnableOption "MPD, the music player daemon" // {
+        default = true;
+        example = false;
+      };
 
-    } // mpdOptions cfg;
+      daemons = mkOption {
+        description = ''
+          Each attribute of this option defines a systemd user service that runs
+          an MPD instance. All options default to the primary configuration. The
+          name of each systemd service is
+          <literal>mpd-<replaceable>name</replaceable>.service</literal>,
+          where <replaceable>name</replaceable> is the corresponding attribute
+          name, except for up to one attribute that may have the
+          <literal>default</literal> option set and is named
+          <literal>mpd.service</literal>.
+        
+          For most setups, configuring <literal>daemons.default</literal> is all
+          that's needed.
+        '';
+        default = {};
+        example = literalExample ''
+          {
+            default = {
+              extraConfig = '''
+                audio_output {
+                  type "pulse"
+                  name "PulseAudio"
+                }
+              ''';
+            };
+          }
+        '';
+        type = types.attrsOf (types.submodule mpdDaemon);
+      };
+
+    };
 
   };
+
+  imports = let
+    old = path: [ "services" "mpd" ] ++ path;
+    new = path: [ "services" "mpd" "daemons" "default" ] ++ path;
+    defaultRename = f: path: f (old path) (new path);
+  in [
+    (defaultRename mkRenamedOptionModule [ "package" ])
+    (defaultRename mkRenamedOptionModule [ "musicDirectory" ])
+    (defaultRename mkRenamedOptionModule [ "playlistDirectory" ])
+    (defaultRename mkRenamedOptionModule [ "extraConfig" ])
+    (defaultRename mkRenamedOptionModule [ "dataDir" ])
+    (defaultRename mkRenamedOptionModule [ "network" "listenAddress" ])
+    (defaultRename mkRenamedOptionModule [ "network" "port" ])
+    (defaultRename mkRenamedOptionModule [ "dbFile" ])
+  ];
 
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = mkIf (cfg.enable && cfg.daemons != {}) {
 
-    systemd.user.services.mpd = mpdService cfg;
+    assertions = let
+      defaultCount = count (cfg: cfg.default) (lib.attrValues cfg.daemons);
+    in [
+      { assertion = defaultCount <= 1; message = ''
+        At most 1 MPD instance can be the default, but ${toString defaultCount} are specified.
+      ''; }
+    ];
 
-    systemd.user.sockets.mpd = mpdSocket cfg;
+    systemd.user.services = flip mapAttrs' cfg.daemons (_: daemon: {
+      name = daemon.serviceName;
+      value = mpdService daemon;
+    });
+
+    systemd.user.sockets = flip mapAttrs' cfg.daemons (_: daemon: {
+      name = daemon.serviceName;
+      value = mpdSocket daemon;
+    });
 
   };
 

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -36,15 +36,15 @@ let
       '';
     };
 
-      musicDirectory = mkOption {
-        type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
-        default = "${config.home.homeDirectory}/music";
-        defaultText = "$HOME/music";
-        apply = toString;       # Prevent copies to Nix store.
-        description = ''
-          The directory where mpd reads music from.
-        '';
-      };
+    musicDirectory = mkOption {
+      type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
+      default = "${config.home.homeDirectory}/music";
+      defaultText = "$HOME/music";
+      apply = toString;       # Prevent copies to Nix store.
+      description = ''
+        The directory where mpd reads music from.
+      '';
+    };
 
     playlistDirectory = mkOption {
       type = with types; either path str;
@@ -56,20 +56,20 @@ let
       '';
     };
 
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "";
-        description = ''
-          Extra directives added to to the end of MPD's configuration
-          file, <filename>mpd.conf</filename>. Basic configuration
-          like file location and uid/gid is added automatically to the
-          beginning of the file. For available options see
-          <citerefentry>
-            <refentrytitle>mpd.conf</refentrytitle>
-            <manvolnum>5</manvolnum>
-          </citerefentry>.
-        '';
-      };
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra directives added to to the end of MPD's configuration
+        file, <filename>mpd.conf</filename>. Basic configuration
+        like file location and uid/gid is added automatically to the
+        beginning of the file. For available options see
+        <citerefentry>
+          <refentrytitle>mpd.conf</refentrytitle>
+          <manvolnum>5</manvolnum>
+        </citerefentry>.
+      '';
+    };
 
     dataDir = mkOption {
       type = with types; either path str;
@@ -82,14 +82,14 @@ let
       '';
     };
 
-      network = {
-        startWhenNeeded = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-           Enable systemd socket activation.
-          '';
-        };
+    network = {
+      startWhenNeeded = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable systemd socket activation.
+        '';
+      };
 
       listenAddress = mkOption {
         type = types.str;
@@ -101,13 +101,13 @@ let
         '';
       };
 
-        port = mkOption {
-          type = types.port;
-          default = 6600;
-          description = ''
-            The TCP port on which the the daemon will listen.
-          '';
-        };
+      port = mkOption {
+        type = types.port;
+        default = 6600;
+        description = ''
+          The TCP port on which the the daemon will listen.
+        '';
+      };
 
     };
 

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -27,14 +27,14 @@ let
 
   mpdOptions = cfg: {
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.mpd;
-        defaultText = "pkgs.mpd";
-        description = ''
-          The MPD package to run.
-        '';
-      };
+    package = mkOption {
+      type = types.package;
+      default = pkgs.mpd;
+      defaultText = "pkgs.mpd";
+      description = ''
+        The MPD package to run.
+      '';
+    };
 
       musicDirectory = mkOption {
         type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
@@ -46,15 +46,15 @@ let
         '';
       };
 
-      playlistDirectory = mkOption {
-        type = with types; either path str;
-        default = "${cfg.dataDir}/playlists";
-        defaultText = ''''${dataDir}/playlists'';
-        apply = toString;       # Prevent copies to Nix store.
-        description = ''
-          The directory where mpd stores playlists.
-        '';
-      };
+    playlistDirectory = mkOption {
+      type = with types; either path str;
+      default = "${cfg.dataDir}/playlists";
+      defaultText = ''''${dataDir}/playlists'';
+      apply = toString;       # Prevent copies to Nix store.
+      description = ''
+        The directory where mpd stores playlists.
+      '';
+    };
 
       extraConfig = mkOption {
         type = types.lines;
@@ -71,16 +71,16 @@ let
         '';
       };
 
-      dataDir = mkOption {
-        type = with types; either path str;
-        default = "${config.xdg.dataHome}/${name}";
-        defaultText = "$XDG_DATA_HOME/mpd";
-        apply = toString;       # Prevent copies to Nix store.
-        description = ''
-          The directory where MPD stores its state, tag cache,
-          playlists etc.
-        '';
-      };
+    dataDir = mkOption {
+      type = with types; either path str;
+      default = "${config.xdg.dataHome}/${name}";
+      defaultText = "$XDG_DATA_HOME/mpd";
+      apply = toString;       # Prevent copies to Nix store.
+      description = ''
+        The directory where MPD stores its state, tag cache,
+        playlists etc.
+      '';
+    };
 
       network = {
         startWhenNeeded = mkOption {
@@ -91,15 +91,15 @@ let
           '';
         };
 
-        listenAddress = mkOption {
-          type = types.str;
-          default = "127.0.0.1";
-          example = "any";
-          description = ''
-            The address for the daemon to listen on.
-            Use <literal>any</literal> to listen on all addresses.
-          '';
-        };
+      listenAddress = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        example = "any";
+        description = ''
+          The address for the daemon to listen on.
+          Use <literal>any</literal> to listen on all addresses.
+        '';
+      };
 
         port = mkOption {
           type = types.port;
@@ -109,18 +109,18 @@ let
           '';
         };
 
-      };
+    };
 
-      dbFile = mkOption {
-        type = types.nullOr types.str;
-        default = "${cfg.dataDir}/tag_cache";
-        defaultText = ''''${dataDir}/tag_cache'';
-        description = ''
-          The path to MPD's database. If set to
-          <literal>null</literal> the parameter is omitted from the
-          configuration.
-        '';
-      };
+    dbFile = mkOption {
+      type = types.nullOr types.str;
+      default = "${cfg.dataDir}/tag_cache";
+      defaultText = ''''${dataDir}/tag_cache'';
+      description = ''
+        The path to MPD's database. If set to
+        <literal>null</literal> the parameter is omitted from the
+        configuration.
+      '';
+    };
 
   };
 

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -125,21 +125,21 @@ let
   };
 
   mpdService = cfg: {
-      Unit = {
-        After = [ "network.target" "sound.target" ];
-        Description = "Music Player Daemon";
-      };
+    Unit = {
+      After = [ "network.target" "sound.target" ];
+      Description = "Music Player Daemon";
+    };
 
-      Install = mkIf (!cfg.network.startWhenNeeded) {
-        WantedBy = [ "default.target" ];
-      };
+    Install = mkIf (!cfg.network.startWhenNeeded) {
+      WantedBy = [ "default.target" ];
+    };
 
-      Service = {
-        Environment = "PATH=${config.home.profileDirectory}/bin";
-        ExecStart = "${cfg.package}/bin/mpd --no-daemon ${mpdConf cfg}";
-        Type = "notify";
-        ExecStartPre = ''${pkgs.bash}/bin/bash -c "${pkgs.coreutils}/bin/mkdir -p '${cfg.dataDir}' '${cfg.playlistDirectory}'"'';
-      };
+    Service = {
+      Environment = "PATH=${config.home.profileDirectory}/bin";
+      ExecStart = "${cfg.package}/bin/mpd --no-daemon ${mpdConf cfg}";
+      Type = "notify";
+      ExecStartPre = ''${pkgs.bash}/bin/bash -c "${pkgs.coreutils}/bin/mkdir -p '${cfg.dataDir}' '${cfg.playlistDirectory}'"'';
+    };
   };
 
   mpdSocket = cfg: mkIf cfg.network.startWhenNeeded {

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -51,7 +51,7 @@ in {
       };
 
       musicDirectory = mkOption {
-        type = with types; either path str;
+        type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
         default = "${config.home.homeDirectory}/music";
         defaultText = "$HOME/music";
         apply = toString;       # Prevent copies to Nix store.
@@ -61,7 +61,7 @@ in {
       };
 
       playlistDirectory = mkOption {
-        type = types.path;
+        type = with types; either path str;
         default = "${cfg.dataDir}/playlists";
         defaultText = ''''${dataDir}/playlists'';
         apply = toString;       # Prevent copies to Nix store.
@@ -86,7 +86,7 @@ in {
       };
 
       dataDir = mkOption {
-        type = types.path;
+        type = with types; either path str;
         default = "${config.xdg.dataHome}/${name}";
         defaultText = "$XDG_DATA_HOME/mpd";
         apply = toString;       # Prevent copies to Nix store.


### PR DESCRIPTION
Retools `services.mpd` to work off of a set of daemon configurations instead of just one, allowing for setups like multiple music dirs nicely. Path configuration is also fixed up so you don't end up copying entire music directory hierarchies into the store, unless you really want to.

Check the commit message for an example transition from old style to new and some reasoning on `daemons.<name>.default`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rycee/home-manager/528)
<!-- Reviewable:end -->
