### PR TITLE
ssh: add possibility to use match conditions inside a host match block

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -62,7 +62,15 @@ let
         type = types.str;
         example = "*.example.org";
         description = ''
-          The host pattern used by this conditional block.
+          Pattern used by this conditional block.
+        '';
+      };
+
+      matchType = mkOption {
+        type = types.nullOr (types.enum ["canonical" "exec" "host" "originalhost" "user" "localuser"]);
+        default = null;
+        description = ''
+          Use Match condition instead of the default Host condition.
         '';
       };
 
@@ -266,7 +274,9 @@ let
   });
 
   matchBlockStr = cf: concatStringsSep "\n" (
-    ["Host ${cf.host}"]
+    let
+      matchType = if cf.matchType != null then "Match ${cf.matchType} ${cf.host}" else "Host ${cf.host}";
+    in [ "${matchType}" ]
     ++ optional (cf.port != null)            "  Port ${toString cf.port}"
     ++ optional (cf.forwardAgent != null)    "  ForwardAgent ${yn cf.forwardAgent}"
     ++ optional cf.forwardX11                "  ForwardX11 yes"


### PR DESCRIPTION
This change enables to create host match blocks where it's possible to check
against flowing arguments.

- canonical
- exec
- host
- originalhost
- user
- localuser