### PR TITLE
msmtp: Use XDG config directory

### DIFF
--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -66,7 +66,7 @@ in
   config = mkIf cfg.enable {
     home.packages = [ pkgs.msmtp ];
 
-    home.file.".msmtprc".text = configFile msmtpAccounts;
+    xdg.configFile."msmtp/config".text = configFile msmtpAccounts;
 
     home.sessionVariables =  {
       MSMTP_QUEUE = "${config.xdg.dataHome}/msmtp/queue";


### PR DESCRIPTION
msmtp supports XDG base directories spec since [some time ago](https://gitlab.marlam.de/marlam/msmtp/commit/af2f409da5c2659989f2a1520cac777f738226bb), so change configuration file location to use `xdg.configFile`.