### PR TITLE
misc/pam: Enclose session variable values in quotes

### DIFF
--- a/modules/misc/pam.nix
+++ b/modules/misc/pam.nix
@@ -30,7 +30,7 @@ in
   config = mkIf (vars != {}) {
     home.file.".pam_environment".text =
       concatStringsSep "\n" (
-        mapAttrsToList (n: v: "${n} OVERRIDE=${toString v}") vars
+        mapAttrsToList (n: v: "${n} OVERRIDE=\"${toString v}\"") vars
       ) + "\n";
   };
 }


### PR DESCRIPTION
If an unquoted value contains space(s), it’ll just end up not getting set at all.

Escaped `"` is [not supported](https://linux.die.net/man/5/pam_env.conf) so no other processing of the string is done.