### PR TITLE
afew: add the 'filters' option

### DIFF
--- a/modules/programs/afew.nix
+++ b/modules/programs/afew.nix
@@ -22,8 +22,8 @@ let
     let
       mkNode = nodeName: filter:
         let
-          before = (filter.before or cfg.defaultBefore);
-          after = (filter.after or cfg.defaultAfter);
+          before = (filter.before or ["@end"]);
+          after = (filter.after or ["@begin"]);
           filterName = (filter.class or "Filter");
           filterKV = (removeAttrs filter ["after" "before" "class"]) // {
             "#nodeName" = nodeName;
@@ -62,24 +62,6 @@ in
 {
   options.programs.afew = {
     enable = mkEnableOption "the afew initial tagging script for Notmuch";
-
-    defaultBefore = mkOption {
-      type = types.listOf types.string;
-      default = ["@end"];
-      description = ''
-        List of node names in the DAG that filters should appear
-        before by default.
-      '';
-    };
-
-    defaultAfter = mkOption {
-      type = types.listOf types.string;
-      default = ["@begin"];
-      description = ''
-        List of node names in the DAG that filters should appear after
-        by default.
-      '';
-    };
 
     defaultFilters = mkOption {
       type = types.attrsOf types.attrs;

--- a/modules/programs/afew.nix
+++ b/modules/programs/afew.nix
@@ -77,7 +77,11 @@ in
     };
 
     filters = mkOption {
-      type = types.attrsOf types.attrs;
+      type = with types;
+        let
+          primitive = either bool (either int str);
+        in
+          attrsOf (attrsOf (either primitive (listOf primitive)));
       default = {
         spam = { class = "SpamFilter"; before = ["@begin"]; after = []; };
         killThreads = { class = "KillThreadsFilter"; before = ["@begin"]; after = []; };

--- a/modules/programs/afew.nix
+++ b/modules/programs/afew.nix
@@ -72,7 +72,7 @@ in
       description = ''
         An initial value for the filters DAG. It should only contain
         "dummy" nodes. Those dummy nodes are conventionally prefixed
-        with @.
+        with <literal>@</literal>.
       '';
     };
 

--- a/modules/programs/afew.nix
+++ b/modules/programs/afew.nix
@@ -21,19 +21,19 @@ let
 
      Example:
        filters = [
-            { class="Class", q="a"; }
-            { q = "b"}
-          ]
-      => [{ name = "Class.1"; value = { "q" = "a"; }; } { name = "Filter.2"; value = { "q" = "b"; }; }]
+         { class="Class", q="a"; }
+         { q = "b"}
+       ]
+      => [{ name = "Class.1"; value = { "q" = "a"; }; }
+          { name = "Filter.2"; value = { "q" = "b"; }; }]
   */
   processAfewFilters = afewFilters:
     let
-      getClass = attrs:
-        attrByPath ["class"] "Filter" attrs;
-      removeClass = attrs:
-        filterAttrs (n: v: n != "class") attrs;
-      indexed = xs:
-        imap0 (i: v: v // { class = "${getClass v}.${toString (i+1000)}"; }) xs;
+      getClass = attrs: attrs.class or "Filter";
+      removeClass = filterAttrs (n: v: n != "class");
+      indexed = imap0 (i: v:
+        v // { class = "${getClass v}.${toString (i+1000)}"; }
+      );
       toPair = mkKey: mkValue: attrs:
         nameValuePair (mkKey attrs) (mkValue attrs);
     in
@@ -72,15 +72,17 @@ in
         options are described in the afew manual: <link
         xlink:href="https://afew.readthedocs.io/en/latest/configuration.html" />.
       '';
-      example = ''[
-        { class = "SpamFilter"; }
+      example = literalExample ''
+        [
+          { class = "SpamFilter"; }
 
-        { query = "frompointyheaded@boss.com";
-          tags = ["-new" "+boss"];
-          message = "Message from above"; }
+          { query = "frompointyheaded@boss.com";
+            tags = ["-new" "+boss"];
+            message = "Message from above"; }
 
-        { class = "InboxFilter"; }
-      ]'';
+          { class = "InboxFilter"; }
+        ]
+      '';
     };
 
     extraConfig = mkOption {
@@ -97,7 +99,7 @@ in
         [InboxFilter]
       '';
       description = ''
-        Extra lines prepended to afew configuration file. Available
+        Extra lines prepended to the afew configuration file. Available
         configuration options are described in the afew manual: <link
         xlink:href="https://afew.readthedocs.io/en/latest/configuration.html" />.
       '';


### PR DESCRIPTION
Hello!

This PR adds a new `filters` option to the afew module. This new option allows one to write filter declarations in a more structured way. See the `filters.example` and `extraConfig.example` configuration options.

It is backward compatible, no changes to existing configurations are necessary.

Would you be interested in merging this into master?

Have a nice day,
Alex