### PR TITLE
Support overriding the default host for ssh

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -235,7 +235,7 @@ in
       description = ''
         The host pattern used by the main configuration block.
       '';
-    }
+    };
 
     userKnownHostsFile = mkOption {
       type = types.str;

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -324,7 +324,7 @@ in
         map matchBlockStr (
         builtins.attrValues cfg.matchBlocks))}
 
-      Host ${yn cfg.host}
+      Host ${cfg.host}
         ForwardAgent ${yn cfg.forwardAgent}
         Compression ${yn cfg.compression}
         ServerAliveInterval ${toString cfg.serverAliveInterval}

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -228,6 +228,14 @@ in
         the known hosts file.
       '';
     };
+    
+    host = mkOption {
+      default = "*";
+      type = types.str;
+      description = ''
+        The host pattern used by the main configuration block.
+      '';
+    }
 
     userKnownHostsFile = mkOption {
       type = types.str;
@@ -316,7 +324,7 @@ in
         map matchBlockStr (
         builtins.attrValues cfg.matchBlocks))}
 
-      Host *
+      Host ${yn cfg.host}
         ForwardAgent ${yn cfg.forwardAgent}
         Compression ${yn cfg.compression}
         ServerAliveInterval ${toString cfg.serverAliveInterval}


### PR DESCRIPTION
Instead of forcing an `*` block to exist, this adds support for specifying something like `* !example.com` so that the main options don't collide with those described in `matchBlocks`