### PR TITLE
systemd: add support for session variables

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -167,7 +167,7 @@ in
 
       sessionVariables = mkOption {
         default = {};
-        type = types.attrs;
+        type = with types; attrsOf (either bool (either int str));
         example = { EDITOR = "vim"; };
         description = ''
           Environment variables that will be set for the user session.
@@ -202,7 +202,7 @@ in
     # If we run under a Linux system we assume that systemd is
     # available, in particular we assume that systemctl is in PATH.
     (mkIf pkgs.stdenv.isLinux {
-      xdg.configFile =
+      xdg.configFile = mkMerge [
         (listToAttrs (
           (buildServices "service" cfg.services)
           ++
@@ -213,7 +213,10 @@ in
           (buildServices "timer" cfg.timers)
           ++
           (buildServices "path" cfg.paths)
-        )) // sessionVariables;
+          ))
+
+          sessionVariables
+        ];
 
       # Run systemd service reload if user is logged in. If we're
       # running this from the NixOS module then XDG_RUNTIME_DIR is not

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -12,7 +12,8 @@ let
       || cfg.sockets != {}
       || cfg.targets != {}
       || cfg.timers != {}
-      || cfg.paths != {};
+      || cfg.paths != {}
+      || cfg.sessionVariables != {};
 
   toSystemdIni = generators.toINI {
     mkKeyValue = key: value:
@@ -85,6 +86,13 @@ let
     }
   '';
 
+  sessionVariables = mkIf (cfg.sessionVariables != {}) {
+    "environment.d/10-home-manager.conf".text =
+      concatStringsSep "\n" (
+        mapAttrsToList (n: v: "${n}=${toString v}") cfg.sessionVariables
+      ) + "\n";
+    };
+
 in
 
 {
@@ -156,6 +164,20 @@ in
           start is considered successful.
         '';
       };
+
+      sessionVariables = mkOption {
+        default = {};
+        type = types.attrs;
+        example = { EDITOR = "vim"; };
+        description = ''
+          Environment variables that will be set for the user session.
+          The variable values must be as described in
+          <citerefentry>
+            <refentrytitle>environment.d</refentrytitle>
+            <manvolnum>5</manvolnum>
+          </citerefentry>.
+        '';
+      };
     };
   };
 
@@ -168,7 +190,7 @@ in
             let
               names = concatStringsSep ", " (
                   attrNames (
-                      cfg.services // cfg.sockets // cfg.targets // cfg.timers // cfg.paths
+                      cfg.services // cfg.sockets // cfg.targets // cfg.timers // cfg.paths // cfg.sessionVariables
                   )
               );
             in
@@ -181,7 +203,7 @@ in
     # available, in particular we assume that systemctl is in PATH.
     (mkIf pkgs.stdenv.isLinux {
       xdg.configFile =
-        listToAttrs (
+        (listToAttrs (
           (buildServices "service" cfg.services)
           ++
           (buildServices "socket" cfg.sockets)
@@ -191,7 +213,7 @@ in
           (buildServices "timer" cfg.timers)
           ++
           (buildServices "path" cfg.paths)
-        );
+        )) // sessionVariables;
 
       # Run systemd service reload if user is logged in. If we're
       # running this from the NixOS module then XDG_RUNTIME_DIR is not


### PR DESCRIPTION
Via [`environment.d(5)`](http://man7.org/linux/man-pages/man5/environment.d.5.html).