### PR TITLE
screen: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1814,6 +1814,13 @@ in
           A new module is available: 'services.plan9port'.
         '';
       }
+
+      {
+        time = "2021-01-23T20:14:39+00:00";
+        message = ''
+          A new module is available: 'programs.screen'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -117,6 +117,7 @@ let
     (loadModule ./programs/rofi.nix { })
     (loadModule ./programs/rofi-pass.nix {  })
     (loadModule ./programs/rtorrent.nix { })
+    (loadModule ./programs/screen.nix { })
     (loadModule ./programs/skim.nix { })
     (loadModule ./programs/starship.nix { })
     (loadModule ./programs/ssh.nix { })

--- a/modules/programs/screen.nix
+++ b/modules/programs/screen.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.screen;
+
+in {
+  options = {
+    programs.screen = {
+      enable = mkEnableOption "GNU screen";
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Extra configuration to write to <filename>~/.screenrc</filename>.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.screen ];
+    home.file.".screenrc".text = cfg.extraConfig;
+  };
+}


### PR DESCRIPTION
At this pont it's very simplistic and only allows user to provide
configuration file and doesn't allow to specify any of individual
options

Tested by switching to configuration using `home-manager -I home-manager=$HOME/devel/home-manager`