### PR TITLE
slack: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -120,7 +120,7 @@ let
     (loadModule ./services/redshift.nix { })
     (loadModule ./services/rsibreak.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/screen-locker.nix { })
-    (loadModule ./services/slack.nix { })
+    (loadModule ./services/slack.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/stalonetray.nix { })
     (loadModule ./services/status-notifier-watcher.nix { })
     (loadModule ./services/syncthing.nix { })

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -120,6 +120,7 @@ let
     (loadModule ./services/redshift.nix { })
     (loadModule ./services/rsibreak.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/screen-locker.nix { })
+    (loadModule ./services/slack.nix { })
     (loadModule ./services/stalonetray.nix { })
     (loadModule ./services/status-notifier-watcher.nix { })
     (loadModule ./services/syncthing.nix { })

--- a/modules/services/slack.nix
+++ b/modules/services/slack.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.slack;
+in {
+
+  options.services.slack = {
+    enable = mkEnableOption "Slack chat daemon";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.slack;
+      defaultText = "pkgs.slack";
+      example = literalExample "pkgs.slack";
+      description = ''
+        Slack derivation to use.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    systemd.user.services.slack = {
+      Unit = {
+        Description = "Slack chat";
+        After = [ "graphical-session-pre.target" ];
+      };
+
+      Service = {
+        ExecStart = "${pkgs.slack}/bin/slack --startup --rxLogging";
+        Restart = "on-failure";
+        RestartSec = 3;
+      };
+
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
Added a systemd to run `slack` at startup.
If you have a tray you should also see the `slack` applet appear at startup.
This allows you to quickly launch slack and receive notifications with your notification-daemon of choice.