### PR TITLE
Run sudo with -s in the darwin module

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -99,7 +99,7 @@ in
     system.activationScripts.postActivation.text =
       concatStringsSep "\n" (mapAttrsToList (username: usercfg: ''
         echo Activating home-manager configuration for ${username}
-        sudo -u ${username} -i ${pkgs.writeShellScript "activation-${username}" ''
+        sudo -u ${username} -s ${pkgs.writeShellScript "activation-${username}" ''
           ${lib.optionalString (cfg.backupFileExtension != null)
             "export HOME_MANAGER_BACKUP_EXT=${lib.escapeShellArg cfg.backupFileExtension}"}
           ${lib.optionalString cfg.verbose "export VERBOSE=1"}


### PR DESCRIPTION
Currently activation is run with `sudo -i` this defaults to the user's login
shell. This can lead to problems if the user's shell isn't set properly.

By passing `-s` rather than `-i`, `sudo` runs `activate` in `SHELL` instead.
I'm assuming at this point in the activation `SHELL` contains the path to a
bash in the nix store. This should always be a valid shell to run the
`activate` script with.

From the `sudo` manual it seems like this cannot be fixed if `SHELL`
isn't set at this point or by passing a command to `-s` because that
command is then passed to the user's shell.

I had some trouble turning off `useUserPackages` in the darwin module because I'd set my shell manually using `chsh -s $(which fish)`. This set the shell to `/etc/profiles/per-user/${USER}/bin/fish` and that directory disappeared when turning off `useUserPackages` so the HM `activate` script couldn't run because `sudo -i` couldn't find that shell anymore.

I believe my fix makes this work no matter what happens to the user's shell. Note that shell setup, using `chsh` is still required, home-manager doesn't fix this. However, I don't know whether it's important `activate` is run with *a* or specifically the user's login shell.