### PR TITLE
sxhkd: remove extraPath parameter

### DIFF
--- a/modules/services/sxhkd.nix
+++ b/modules/services/sxhkd.nix
@@ -43,15 +43,6 @@ in
           i3-msg {workspace,move container to workspace} {1-10}
       '';
     };
-
-    extraPath = mkOption {
-      default = "";
-      type = types.envVar;
-      description = ''
-        Additional <envar>PATH</envar> entries to search for commands.
-      '';
-      example = "/home/some-user/bin:/extra/path/bin";
-    };
   };
 
   config = mkIf cfg.enable {
@@ -70,11 +61,6 @@ in
       };
 
       Service = {
-        Environment =
-          "PATH="
-          + "${config.home.profileDirectory}/bin"
-          + optionalString (cfg.extraPath != "") ":"
-          + cfg.extraPath;
         ExecStart = "${pkgs.sxhkd}/bin/sxhkd";
       };
 

--- a/tests/modules/services/sxhkd/service.nix
+++ b/tests/modules/services/sxhkd/service.nix
@@ -3,7 +3,6 @@
   config = {
     services.sxhkd = {
       enable = true;
-      extraPath = "/home/the-user/bin:/extra/path/bin";
     };
 
     nmt.script = ''
@@ -12,9 +11,6 @@
       assertFileExists $serviceFile
 
       assertFileRegex $serviceFile 'ExecStart=.*/bin/sxhkd'
-
-      assertFileRegex $serviceFile \
-        'Environment=PATH=.*\.nix-profile/bin:/home/the-user/bin:/extra/path/bin'
     '';
   };
 }


### PR DESCRIPTION
Applications launched with sxhkd inherit `PATH` of systemd service. When sxhkd launches terminal the shell does not have the `PATH` user expects to see. In my case it broke `sudo` and some other cli apps.

In original PR https://github.com/rycee/home-manager/pull/842#discussion_r324876829 @rycee suggested to remove the parameter and force user to use nix pkgs in command.

Alternatevly user can enable `xsession.importedVariables = ["PATH"];` if they need sxhkd to access apps from user `PATH`

