### PR TITLE
Experiment with flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,11 @@
+{
+    "inputs": {
+        "nixpkgs": {
+            "inputs": {},
+            "narHash": "sha256-Y5ZOTgInrYYoas3vM8uTPLA2DvFI9YoI6haftIKl9go=",
+            "originalUrl": "nixpkgs",
+            "url": "github:edolstra/nixpkgs/015c9ec3372e328ea6742b409a1e9aa26dab2b31"
+        }
+    },
+    "version": 3
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  edition = 201909;
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-darwin";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      lib.mkHome = configuration:
+        import home-manager/home-manager.nix {
+          inherit pkgs;
+          configuration = configuration // { _module.args.pkgs = pkgs; };
+          nixpkgsSrc = nixpkgs;
+        };
+
+      packages.${system}.home-manager = pkgs.callPackage ./home-manager { };
+
+      defaultPackage.${system} = self.packages.${system}.home-manager;
+
+      homeConfiguration = self.lib.mkHome {
+        home.homeDirectory = "/home/username";
+        home.username = "username";
+      };
+    };
+}

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -1,16 +1,4 @@
-{ runCommand, lib, bash, coreutils, findutils, gnused, less
-
-  # Extra path to Home Manager. If set then this path will be tried
-  # before `$HOME/.config/nixpkgs/home-manager` and
-  # `$HOME/.nixpkgs/home-manager`.
-, path ? null
-}:
-
-let
-
-  pathStr = if path == null then "" else path;
-
-in
+{ runCommand, lib, bash, coreutils, findutils, gnused, less}:
 
 runCommand
   "home-manager"
@@ -33,7 +21,6 @@ runCommand
       --subst-var-by findutils "${findutils}" \
       --subst-var-by gnused "${gnused}" \
       --subst-var-by less "${less}" \
-      --subst-var-by HOME_MANAGER_PATH '${pathStr}'
 
     install -D -m755 ${./completion.bash} \
       $out/share/bash-completion/completions/home-manager

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -32,78 +32,42 @@ function setWorkDir() {
     fi
 }
 
-# Attempts to set the HOME_MANAGER_CONFIG global variable.
-#
-# If no configuration file can be found then this function will print
-# an error message and exit with an error code.
-function setConfigFile() {
-    if [[ -v HOME_MANAGER_CONFIG ]] ; then
-        if [[ ! -e "$HOME_MANAGER_CONFIG" ]] ; then
-            errorEcho "No configuration file found at $HOME_MANAGER_CONFIG"
-            exit 1
-        fi
-
-        HOME_MANAGER_CONFIG="$(realpath "$HOME_MANAGER_CONFIG")"
+function setFlake() {
+    if [[ -v HOME_MANAGER_FLAKE ]] ; then
         return
     fi
 
-    local defaultConfFile="${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home.nix"
-    local confFile
-    for confFile in "$defaultConfFile" \
-                    "$HOME/.nixpkgs/home.nix" ; do
-        if [[ -e "$confFile" ]] ; then
-            HOME_MANAGER_CONFIG="$(realpath "$confFile")"
-            return
-        fi
-    done
+    # local defaultConfFile="${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home.nix"
+    # local confFile
+    # for confFile in "$defaultConfFile" \
+    #                 "$HOME/.nixpkgs/home.nix" ; do
+    #     if [[ -e "$confFile" ]] ; then
+    #         HOME_MANAGER_CONFIG="$(realpath "$confFile")"
+    #         return
+    #     fi
+    # done
 
-    errorEcho "No configuration file found." \
-         "Please create one at $defaultConfFile"
+    # errorEcho "No configuration file found." \
+    #      "Please create one at $defaultConfFile"
+    errorEcho "No flake found, please pass one."
     exit 1
 }
 
-function setHomeManagerNixPath() {
-    local path
-    for path in "@HOME_MANAGER_PATH@" \
-                "${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home-manager" \
-                "$HOME/.nixpkgs/home-manager" ; do
-        if [[ -e "$path" || "$path" =~ ^https?:// ]] ; then
-            export NIX_PATH="home-manager=$path${NIX_PATH:+:}$NIX_PATH"
-            return
-        fi
-    done
-}
-
 function doBuildAttr() {
-    setConfigFile
-    setHomeManagerNixPath
+    setFlake
 
-    local extraArgs="$*"
-
-    for p in "${EXTRA_NIX_PATH[@]}"; do
-        extraArgs="$extraArgs -I $p"
-    done
+    local attribute="$*"
+    #local extraArgs="$*"
+    local extraArgs=""
 
     if [[ -v VERBOSE ]]; then
         extraArgs="$extraArgs --show-trace"
     fi
 
-    # shellcheck disable=2086
-    if [[ -v USE_NIX2_COMMAND ]]; then
-        nix build \
-            -f "<home-manager/home-manager/home-manager.nix>" \
-            $extraArgs \
-            ${PASSTHROUGH_OPTS[*]} \
-            --argstr confPath "$HOME_MANAGER_CONFIG" \
-            --argstr confAttr "$HOME_MANAGER_CONFIG_ATTRIBUTE"
-    else
-        nix-build \
-            "<home-manager/home-manager/home-manager.nix>" \
-            $extraArgs \
-            ${PASSTHROUGH_OPTS[*]} \
-            --argstr confPath "$HOME_MANAGER_CONFIG" \
-            --argstr confAttr "$HOME_MANAGER_CONFIG_ATTRIBUTE"
-    fi
+    nix build \
+        $HOME_MANAGER_FLAKE#homeConfiguration.$attribute
+        $extraArgs \
+        ${PASSTHROUGH_OPTS[*]}
 }
 
 # Presents news to the user. Takes as argument the path to a "news
@@ -169,13 +133,8 @@ function doBuild() {
 
     local exitCode
 
-    if [[ -v USE_NIX2_COMMAND ]]; then
-        doBuildAttr activationPackage \
-            && exitCode=0 || exitCode=1
-    else
-        doBuildAttr --attr activationPackage \
-            && exitCode=0 || exitCode=1
-    fi
+    doBuildAttr activationPackage \
+        && exitCode=0 || exitCode=1
 
     presentNews "$newsInfo"
 
@@ -307,23 +266,11 @@ function buildNews() {
     local output
     output="$WORK_DIR/news-info.sh"
 
-    if [[ -v USE_NIX2_COMMAND ]]; then
-        doBuildAttr \
+        doBuildAttr newsInfo \
                     --out-link "$output" \
                     --quiet \
                     --arg check false \
-                    --argstr newsReadIdsFile "$(newsReadIdsFile)" \
-                    newsInfo
-    else
-        doBuildAttr \
-                    --out-link "$output" \
-                    --no-build-output \
-                    --quiet \
-                    --arg check false \
-                    --argstr newsReadIdsFile "$(newsReadIdsFile)" \
-                    --attr newsInfo \
-                    > /dev/null
-    fi
+                    --argstr newsReadIdsFile "$(newsReadIdsFile)"
 
     echo "$output"
 }
@@ -460,7 +407,6 @@ function doHelp() {
     echo "  uninstall    Remove Home Manager"
 }
 
-EXTRA_NIX_PATH=()
 HOME_MANAGER_CONFIG_ATTRIBUTE=""
 PASSTHROUGH_OPTS=()
 COMMAND=""
@@ -473,23 +419,16 @@ while [[ $# -gt 0 ]]; do
         build|edit|expire-generations|generations|help|news|packages|remove-generations|switch|uninstall)
             COMMAND="$opt"
             ;;
-        -2)
-            USE_NIX2_COMMAND=1
-            ;;
         -A)
             HOME_MANAGER_CONFIG_ATTRIBUTE="$1"
-            shift
-            ;;
-        -I)
-            EXTRA_NIX_PATH+=("$1")
             shift
             ;;
         -b)
             export HOME_MANAGER_BACKUP_EXT="$1"
             shift
             ;;
-        -f|--file)
-            HOME_MANAGER_CONFIG="$1"
+        -f|--flake)
+            HOME_MANAGER_FLAKE="$1"
             shift
             ;;
         -h|--help)

--- a/home-manager/home-manager.nix
+++ b/home-manager/home-manager.nix
@@ -1,6 +1,6 @@
-{ pkgs ? import <nixpkgs> {}
-, confPath
-, confAttr
+{ pkgs
+, configuration
+, nixpkgsSrc
 , check ? true
 , newsReadIdsFile ? null
 }:
@@ -10,12 +10,7 @@ with pkgs.lib;
 let
 
   env = import ../modules {
-    configuration =
-      if confAttr == ""
-      then confPath
-      else (import confPath).${confAttr};
-    pkgs = pkgs;
-    check = check;
+    inherit configuration pkgs check nixpkgsSrc;
   };
 
   newsReadIds =

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,5 +1,6 @@
 { configuration
 , pkgs
+, nixpkgsSrc
 , lib ? pkgs.stdenv.lib
 
   # Whether to check that each option has a matching declaration.
@@ -22,7 +23,7 @@ let
   rawModule = lib.evalModules {
     modules =
       [ configuration ]
-      ++ (import ./modules.nix { inherit check lib pkgs; });
+      ++ (import ./modules.nix { inherit check lib pkgs nixpkgsSrc; });
     specialArgs = {
       modulesPath = builtins.toString ./.;
     };

--- a/modules/manual.nix
+++ b/modules/manual.nix
@@ -24,7 +24,7 @@ in
 
     manual.manpages.enable = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       example = false;
       description = ''
         Whether to install the configuration manual page. The manual can

--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -141,12 +141,12 @@ in
   };
 
   config = {
-    _module.args = {
-      pkgs = _pkgs;
-      pkgs_i686 =
-        if _pkgs.stdenv.isLinux && _pkgs.stdenv.hostPlatform.isx86
-        then _pkgs.pkgsi686Linux
-        else { };
-    };
+    # _module.args = {
+    #   pkgs = _pkgs;
+    #   pkgs_i686 =
+    #     if _pkgs.stdenv.isLinux && _pkgs.stdenv.hostPlatform.isx86
+    #     then _pkgs.pkgsi686Linux
+    #     else { };
+    # };
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -1,5 +1,6 @@
 { pkgs
 , lib
+, nixpkgsSrc # XXX little hack since modules are not exposed yet in the flake
 
   # Whether to enable module type checking.
 , check ? true
@@ -149,8 +150,8 @@ let
     (loadModule ./xcursor.nix { })
     (loadModule ./xresources.nix { })
     (loadModule ./xsession.nix { })
-    (loadModule <nixpkgs/nixos/modules/misc/assertions.nix> { })
-    (loadModule <nixpkgs/nixos/modules/misc/meta.nix> { })
+    (loadModule "${nixpkgsSrc}/nixos/modules/misc/assertions.nix" { })
+    (loadModule "${nixpkgsSrc}/nixos/modules/misc/meta.nix" { })
   ];
 
   modules = map (getAttr "file") (filter (getAttr "condition") allModules);


### PR DESCRIPTION
I was curious to see what would be required to make home-manager work with
flakes, so I took a stab at it. I'm posting this here for those who are curious
about it.

It works surprisingly well. It delegate all the issues of finding nixpkgs and the
home-manager source tree to nix itself, so a lot of the `update-home` script can
be simplified.

To use it, create a new flake that provide a `homeConfiguration`, built using
`home-manager.lib.mkHome`, like so:

```
{
  edition = 201909;

  inputs.home-manager.uri = "/Users/georgesdubus/dev/perso/home-manager";

  outputs = { self, nixpkgs, home-manager }: {

    homeConfiguration = home-manager.lib.mkHome {
      imports = [ ./home.nix ];
      home.homeDirectory = "/Users/georgesdubus";
      home.username = "georgesdubus";
    };
  };
}

```
Then build the activation package with
`nix build .#homeConfiguration.activationPackage`. Or run the home-manager
script like so:
`nix run /Users/georgesdubus/dev/perso/home-manager -c home-manager build -f .`.
This assumes that you have a flake-enabled nix that you can get with `nix run nixpkgs.nixFlakes`.

Outstanding issues include:
- I've hardcoded it to darwin because that's the plaform I develop on, but it
  should be too much of a problem to fix that.
- Because the evaluation is pure, there is no way to access the $USER and $HOME
  environment variables, which means they need to be passed manually. I'm
  guessing it could be made nicer by having the wrapping script get them and
  pass them.
- Since the flake takes care of providing nixpkgs, it's not possible to provide
  configuration for it in `options.nixpkgs`. I believe this is still an open
  question for the flake RFC, so wait and see.
- Channels are not available, and nixos modules are not yet exposed from the
  nixpkgs flake, so the source of nixpkgs is passed manually to find the
  `assertions.nix` and `meta.nix` modules.
- I'm guessing we'll want to get closer to the behaviour of nixos-rebuild, once
  it's been finalized (multiple attributes in the `homeConfiguration` output,
  that kind of things)
- The manual didn't work out the box. I disabled it rather than looking into it.