### PR TITLE
gnome: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,8 @@
 /modules/misc/fontconfig.nix                          @rycee
 /tests/modules/misc/fontconfig                        @rycee
 
+/modules/misc/gnome.nix                               @liff
+
 /modules/misc/gtk.nix                                 @rycee
 
 /modules/misc/news.nix                                @rycee

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /flake.lock
 /result*
+__pycache__/

--- a/modules/misc/gnome.nix
+++ b/modules/misc/gnome.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.gnome;
+
+  inherit (config.lib) dag;
+
+  customKeybinding = types.submodule {
+    options = {
+      binding = mkOption {
+        type = types.str;
+        description = "The key combination that triggers the command";
+      };
+      command = mkOption {
+        type = types.str;
+        description = "The command to execute";
+      };
+    };
+  };
+
+  # File containing the bindings in JSON format expected by the management script.
+  bindingsJson = pkgs.writeText "gnome-custom-keybindings.json" (builtins.toJSON
+    (lib.mapAttrsToList (name: value: {
+      inherit name;
+      inherit (value) binding command;
+    }) cfg.customKeybindings));
+
+  updateScript = ./gnome_update_custom_keybindings.py;
+
+  python = "${pkgs.python3.withPackages (p: [ p.pygobject3 ])}/bin/python";
+
+in {
+  meta.maintainers = [ maintainers.liff ];
+
+  options = {
+    gnome = {
+      customKeybindings = mkOption {
+        type = types.attrsOf customKeybinding;
+        default = { };
+        example = literalExample ''
+          {
+            "New Terminal" = {
+              binding = "<Super>Return";
+              command = "gnome-terminal";
+            };
+          }
+        '';
+        description = ''
+          Custom keybindings to add to GNOME desktop. The name of the attribute appears
+          as the name of the keybinding.</para>
+
+          <para>The keybindings are stored in DConf path
+          <literal>/org/gnome/settings-daemon/plugins/media-keys/home-manager-managed-keybindings/</literal>.
+        '';
+      };
+    };
+  };
+
+  config = {
+    home.activation.gnomeCustomKeybindings =
+      dag.entryAfter [ "dconfSettings" ] ''
+        ${python} ${updateScript} < ${bindingsJson}
+      '';
+  };
+}

--- a/modules/misc/gnome_update_custom_keybindings.py
+++ b/modules/misc/gnome_update_custom_keybindings.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""
+Manages the home-manager’s `gnome` module’s `customKeybindings` custom keybindings
+using the GSettings_ framework.
+
+The list of keybindings is received in JSON format from the standard input. The JSON
+should be a list containing objects with three string attributes, `name`, `binding`
+and `command`. For example::
+
+  [
+    {"name": "Terminal", "binding": "<Super>Return", "command": "gnome-terminal"},
+    {"name": "Browser",  "binding": "<Super>b",      "command": "firefox"}
+  ]
+
+The home-manager managed keybindings are updated to match the input list. New bindings
+are added as needed and old ones are removed.
+
+.. _GSettings: https://lazka.github.io/pgi-docs/#Gio-2.0/classes/Settings.html
+"""
+import sys
+import json
+from itertools import zip_longest
+from dataclasses import dataclass
+from gi.repository import Gio
+
+
+MEDIA_KEYS_SCHEMA = "org.gnome.settings-daemon.plugins.media-keys"
+"""The GSettings schema for the keyboard shortcuts settings.
+See: https://help.gnome.org/users/gnome-help/stable/keyboard-shortcuts-set.html#custom"""
+
+CUSTOM_KEYBINDINGS_KEY = "custom-keybindings"
+"""The key within `MEDIA_KEYS_SCHEMA` that contains the list of paths to custom key bindings."""
+
+CUSTOM_KEYBINDING_SCHEMA = (
+    "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding"
+)
+"""The GSettings schema for a custom key binding."""
+
+MANAGED_BINDINGS_BASE_PATH = (
+    "/org/gnome/settings-daemon/plugins/media-keys/home-manager-managed-keybindings"
+)
+"""The base path for key bindings managed by this script.
+The individual bindings are named `custom0`, `custom1`, etc. as children of this path."""
+
+
+@dataclass(frozen=True)
+class Binding:
+    """Represents one binding entry in the input JSON array."""
+
+    name: str
+    binding: str
+    command: str
+
+
+if __name__ == "__main__":
+    expected_bindings = json.load(sys.stdin, object_hook=lambda b: Binding(**b))
+
+    # Only activate the changes if the required schemas are installed.
+    schema_source = Gio.SettingsSchemaSource.get_default()
+    if (
+        schema_source.lookup(MEDIA_KEYS_SCHEMA, True) is None
+        or schema_source.lookup(CUSTOM_KEYBINDING_SCHEMA, True) is None
+    ):
+        sys.exit(0)
+
+    media_keys = Gio.Settings.new(MEDIA_KEYS_SCHEMA)
+
+    current_custom_binding_paths = media_keys.get_strv(CUSTOM_KEYBINDINGS_KEY)
+
+    # gather the home-manager-managed binding paths
+    current_managed_binding_paths = [
+        path
+        for path in current_custom_binding_paths
+        if path.startswith(f"{MANAGED_BINDINGS_BASE_PATH}/")
+    ]
+
+    new_custom_binding_paths = current_custom_binding_paths.copy()
+
+    for i, (managed_binding_path, expected_binding) in enumerate(
+        zip_longest(current_managed_binding_paths, expected_bindings)
+    ):
+        if managed_binding_path is None:
+            # more expected bindings than existing: going to add a new binding
+            managed_binding_path = f"{MANAGED_BINDINGS_BASE_PATH}/custom{i}/"
+            new_custom_binding_paths.append(managed_binding_path)
+
+        managed_binding = Gio.Settings.new_with_path(
+            CUSTOM_KEYBINDING_SCHEMA, managed_binding_path
+        )
+        managed_binding.delay()
+
+        if expected_binding is None:
+            # more existing bindings than expected: remove this one
+            managed_binding.reset("name")
+            managed_binding.reset("binding")
+            managed_binding.reset("command")
+            new_custom_binding_paths.remove(managed_binding_path)
+        else:
+            managed_binding.set_string("name", expected_binding.name)
+            managed_binding.set_string("binding", expected_binding.binding)
+            managed_binding.set_string("command", expected_binding.command)
+
+        if managed_binding.get_has_unapplied():
+            managed_binding.apply()
+            managed_binding.sync()
+
+    if new_custom_binding_paths != current_custom_binding_paths:
+        media_keys.set_strv(CUSTOM_KEYBINDINGS_KEY, new_custom_binding_paths)
+        media_keys.sync()

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -28,6 +28,7 @@ let
     (loadModule ./misc/dconf.nix { })
     (loadModule ./misc/debug.nix { })
     (loadModule ./misc/fontconfig.nix { })
+    (loadModule ./misc/gnome.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/gtk.nix { })
     (loadModule ./misc/lib.nix { })
     (loadModule ./misc/news.nix { })


### PR DESCRIPTION
### Description

Adds a new setting, `gnome.customKeybindings` for managing [custom key bindings in GNOME desktop environment](https://help.gnome.org/users/gnome-help/stable/keyboard-shortcuts-set.html#custom). The bindings are kept in a separate DConf/GSettings path so that they don’t interfere with any manually defined entries.

Comes with a dedicated activation script for managing the settings. It’s in Python since I couldn’t easily find GSettings documentation for Ruby and a shell script might have turned out to be longer and hairier :)

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  _I don’t know a safe way to test changing GSettings_

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
