### PR TITLE
keybase, kbfs: update service definitions

### DIFF
--- a/modules/services/keybase.nix
+++ b/modules/services/keybase.nix
@@ -20,17 +20,37 @@ in
 
     systemd.user.services.keybase = {
       Unit = {
-        Description = "Keybase service";
+        Description = "Keybase core service";
+        Requires = [ "keybase.socket" ];
       };
 
       Service = {
-        ExecStart = "${pkgs.keybase}/bin/keybase service --auto-forked";
+        Type = "notify";
+        Environment = [
+          "KEYBASE_SERVICE_TYPE=systemd"
+          "KEYBASE_SYSTEMD=1"
+        ];
+        EnvironmentFile = [
+          "-%E/keybase/keybase.autogen.env"
+          "-%E/keybase/keybase.env"
+        ];
+        PIDFile = "%t/keybase/keybased.pid";
+        ExecStart = "${pkgs.keybase}/bin/keybase service";
         Restart = "on-failure";
-        PrivateTmp = true;
+      };
+    };
+
+    systemd.user.sockets.keybase = {
+      Unit = {
+        Description = "Socket for the Keybase core service";
+      };
+
+      Socket = {
+        ListenStream = "%t/keybase/keybased.sock";
       };
 
       Install = {
-        WantedBy = [ "default.target" ];
+        WantedBy = [ "sockets.target" ];
       };
     };
   };

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -15,14 +15,14 @@ let
       || cfg.paths != {}
       || cfg.sessionVariables != {};
 
+  mkValueString = value:
+    if isBool value then (if value then "true" else "false")
+    else toString value;
+
   toSystemdIni = generators.toINI {
     mkKeyValue = key: value:
-      let
-        value' =
-          if isBool value then (if value then "true" else "false")
-          else toString value;
-      in
-        "${key}=${value'}";
+      if isList value then concatMapStringsSep "\n" (v: "${key}=${mkValueString v}") value
+      else "${key}=${mkValueString value}";
   };
 
   buildService = style: name: serviceCfg:

--- a/tests/modules/systemd/services-expected.conf
+++ b/tests/modules/systemd/services-expected.conf
@@ -1,5 +1,7 @@
 [Service]
 ExecStart=/some/exec/start/command --with-arguments "%i"
+ExecStartPre=/some/exec/start/pre/command first-command
+ExecStartPre=/some/exec/start/pre/command second-command
 
 [Unit]
 Description=A basic test service

--- a/tests/modules/systemd/services.nix
+++ b/tests/modules/systemd/services.nix
@@ -10,6 +10,10 @@ with lib;
       };
 
       Service = {
+        ExecStartPre = [
+          "/some/exec/start/pre/command first-command"
+          "/some/exec/start/pre/command second-command"
+        ];
         ExecStart = ''/some/exec/start/command --with-arguments "%i"'';
       };
     };


### PR DESCRIPTION
Fixes #930 

Replace the keybase/kbfs service definitions with ones inspired by [upstream](https://github.com/keybase/client/tree/master/packaging/linux/systemd).

- Make the path to `fusermount` configurable for use on non-NixOS systems.
- Use socket activation so systemd can manage the keybase/kbfs sockets in between service invocations.
- Switch to "notify" service type as that is supported upstream.
- Remove `PrivateTmp` as it's meaningless for systemd user units.
- Support `$XDG_CONFIG_DIR/keybase/keybase{.autogen}.env`, which is generated by the `keybase ctl init` command which is described in the upstream documentation. 

In the future, we may want to generate `$XDG_CONFIG_DIR/keybase/config.json` or use `keybase config` in an activation script to configure Keybase/KBFS in a more idempotent way.

The tweak to `toSystemdINI` generates repeated lines for the same key for list values, which is needed for multiple `ExecStartPre` commands in this config. This is equivalent to the syntax generated today (values separated by a space) but works for more keys, such as the aforementioned `Exec*` keys. For example, the config line

```
Environment="PATH=/some/path" "FOO=bar"
```

is equivalent to

```
Environment=PATH=/some/path
Environment=FOO=bar
```

I've added a test for this to the `systemd-services` fixture.