### PR TITLE
bash-my-aws: init at 20191231

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -43,6 +43,7 @@ let
     (loadModule ./programs/astroid.nix { })
     (loadModule ./programs/autorandr.nix { })
     (loadModule ./programs/bash.nix { })
+    (loadModule ./programs/bash-my-aws.nix { })
     (loadModule ./programs/bat.nix { })
     (loadModule ./programs/beets.nix { })
     (loadModule ./programs/broot.nix { })

--- a/modules/programs/bash-my-aws.nix
+++ b/modules/programs/bash-my-aws.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.bash-my-aws;
+
+in
+
+{
+  options.programs.bash-my-aws = {
+    enable = mkEnableOption "bash-my-aws - CLI commands for AWS";
+
+    enableBashIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Bash integration.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.bash-my-aws ];
+
+    home.file.".bash-my-aws".source = pkgs.bash-my-aws;
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
+      if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
+        . ${pkgs.bash-my-aws}/aliases
+        . ${pkgs.bash-my-aws}/bash_completion.sh
+      fi
+    '';
+
+  };
+}


### PR DESCRIPTION
This requires https://github.com/NixOS/nixpkgs/pull/76793 so will be a WIP until merged. I'm not 100% sure if this should  optimise for home-manager style or use substituteInPlace to allow for native nixpkgs usage. I've engaged upstream to see if it can be made friendlier to nix (https://github.com/bash-my-aws/bash-my-aws/issues/269)