### PR TITLE
Allow type 'package' for systemd unit attrs

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -58,7 +58,7 @@ let
 
   unitType = unitKind: with types;
     let
-      primitive = either bool (either int str);
+      primitive = oneOf [ bool int str package ];
     in
       attrsOf (attrsOf (attrsOf (either primitive (listOf primitive))))
       // {


### PR DESCRIPTION
This is a common type for, e.g., 'Service.ExecStart'