### PR TITLE
xcompose: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -155,6 +155,7 @@ let
     (loadModule ./services/window-managers/i3-sway/sway.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/window-managers/xmonad.nix { })
     (loadModule ./services/xcape.nix { condition = hostPlatform.isLinux; })
+    (loadModule ./services/xcompose.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/xembed-sni-proxy.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/xscreensaver.nix { })
     (loadModule ./services/xsuspender.nix { condition = hostPlatform.isLinux; })

--- a/modules/services/xcompose.nix
+++ b/modules/services/xcompose.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  xComposeType = with types; either (lazyAttrsOf xComposeType) str;
+
+  cfg = config.xsession.xCompose;
+
+  xComposeGen = (
+    dic: s: lib.mapAttrs
+      (
+        n: v:
+          if
+            (builtins.isString v)
+          then
+            ''${s}<${n}> : "${v}"''
+          else
+            (xComposeGen v (''${s}<${n}> ''))
+      ) dic
+  );
+
+in
+{
+  options.xsession.xCompose = {
+    enable = mkEnableOption "XCompose";
+    combinations = mkOption {
+      description = "Add compose key combinations";
+      type = xComposeType;
+      default = {};
+      example = literalExample ''
+        {
+          Multi_key = {
+            G = { A = "Α"; B = "Β";};
+            g = { a = "α"; b = "β";};
+          };
+        }'';
+    };
+
+  };
+
+  config = (
+    mkIf (cfg.enable == true) {
+      home.file.".XCompose".text = ''
+        include "%L"
+        ${builtins.concatStringsSep "\n" (lib.collect builtins.isString (xComposeGen cfg.combinations ""))}'';
+    }
+  );
+}


### PR DESCRIPTION
Since `lazyAttrsOf` is now avaible, I've fixed [my previous PR](https://github.com/rycee/home-manager/pull/918).