### PR TITLE
Change systemd restart policy for redshift

### DIFF
--- a/modules/services/redshift.nix
+++ b/modules/services/redshift.nix
@@ -156,7 +156,7 @@ in {
           command = if cfg.tray then "redshift-gtk" else "redshift";
         in "${cfg.package}/bin/${command} ${concatStringsSep " " args}";
         RestartSec = 3;
-        Restart = "always";
+        Restart = "on-failure";
       };
     };
   };


### PR DESCRIPTION
If you disable the redshift's fade animation with options `[ "-o" "-P" ]`, you'll
notice that redshift continually reddens your screen every three
seconds. Running `journalctl --user -lfu redshift` confirms that this is because
redshift is restarting every three seconds per the systemd configuration that
home-manager currently generates. You can confirm this `systemctl --user cat
redshift`.

I'm unsure why we should continually restart redshift. I'm using the
"on-failure" setting for my setup, which works just fine.