### PR TITLE
files: add an option to copy files instead of linking

### DIFF
--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -70,6 +70,14 @@ with lib;
           '';
         };
 
+        copy = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Copy the file instead of creating a symbolic link.
+          '';
+        };
+
         onChange = mkOption {
           type = types.lines;
           default = "";


### PR DESCRIPTION
### Description

This implements #155 by adding an option to copy files to the home instead of symlinking them:
```
home.file.foo = { 
  text = "content";
  copy = true;
};
```

Although the code works for me, it needs more testing and I have some questions regarding the approach taken, so I'm creating this pull request as a draft.

The idea is that we collect a list of files that we want to copy to the home directory in the `.home-manager-copy` file inside `home-files`. The activation script looks into this file to decide whether it needs to run `ln` or `cp`.  It also now compares file content with the previous generation and proceeds with an update or deletion only if the file hasn't been modified.

Open questions:

1. Is `copy` a good option name? Another one I can think of is `link = false`.
2. Is the `.home-manager-copy` file approach ok or it's better to keep linked and copied files separately?
3. Is there a way to write tests for the activation script?

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
