### PR TITLE
flake: add overlay and packages to build the home-manager package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ os:
 script:
   - ./format -c
   - nix-shell . -A install
-  - nix-shell --pure --max-jobs 10 tests -A run.all
+  - nix-build --max-jobs 10 tests -A all 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,20 +169,14 @@ found in the `tests` project directory.
 The full Home Manager test suite can be run by executing
 
 ```console
-$ nix-shell --pure tests -A run.all
+$ nix-build tests -A all
 ```
 
-in the project root. List all test cases through
-
-```console
-$ nix-shell --pure tests -A list
-```
-
-and run an individual test, for example `alacritty-empty-settings`,
+in the project root. Run an individual test, for example `alacritty-empty-settings`,
 through
 
 ```console
-$ nix-shell --pure tests -A run.alacritty-empty-settings
+$ nix-build tests -A run.alacritty-empty-settings.config.test.toplevel
 ```
 
 [open issues]: https://github.com/rycee/home-manager/issues

--- a/flake.lock
+++ b/flake.lock
@@ -1,11 +1,45 @@
 {
-    "inputs": {
-        "nixpkgs": {
-            "inputs": {},
-            "narHash": "sha256-OiQYSXtgVbxbQwfOFe2L61M6d2X6Ah/E5q0FcJiJ5FM=",
-            "originalUrl": "github:NixOS/nixpkgs",
-            "url": "github:NixOS/nixpkgs/25eaaf8e8ad1d2091003c1573dc004ff0fd2a2c6"
-        }
+  "nodes": {
+    "nixpkgs": {
+      "info": {
+        "lastModified": 1590224735,
+        "narHash": "sha256-AK/LxNa2E1851OAK0mGnBNmvknHxfW4qvCMlIw9yBZs="
+      },
+      "locked": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "80ab05ee4d49a4fe0e2207fb65f401a077d2540a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
     },
-    "version": 3
+    "nmt": {
+      "info": {
+        "lastModified": 1590269023,
+        "narHash": "sha256-VNDyjOFqF17vOpNxc0QJ9W8rY2v610j+ov+sv6oPUl8="
+      },
+      "locked": {
+        "owner": "kloenk",
+        "repo": "nmt",
+        "rev": "6fce291806fb130ce3c2318a06179caa9a381406",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kloenk",
+        "repo": "nmt",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nmt": "nmt"
+      }
+    }
+  },
+  "root": "root",
+  "version": 5
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,25 +1,90 @@
 {
-  edition = 201909;
-
   description = "Home Manager for Nix";
 
-  outputs = { self, nixpkgs }: rec {
-
-    nixosModules.home-manager = import ./nixos nixpkgs;
-
-    lib = {
-      homeManagerConfiguration = { configuration, system, homeDirectory
-        , username
-        , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
-        , check ? true }@args:
-        import ./modules nixpkgs {
-          pkgs = builtins.getAttr system nixpkgs.outputs.legacyPackages;
-          configuration = { ... }: {
-            imports = [ configuration ];
-            home = { inherit homeDirectory username; };
-          };
-          inherit check;
-        };
-    };
+  inputs.nmt = {
+    type = "github";
+    owner = "kloenk";
+    repo = "nmt";
   };
+
+  outputs = inputs@{ self, nixpkgs, nmt }:
+    let
+      lib = nixpkgs.lib; # wtf is self.lib????
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        #"armv5tel-linux"
+        #"armv6l-linux"
+        #"armv7a-linux" # could not get it to evaluate git
+        #"armv7l-linux"
+        "i686-linux"
+        "x86_64-darwin" # "powerpc64le-linux"
+      ];
+
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+
+      # Memoize nixpkgs for different platforms for efficiency.
+      nixpkgsFor = forAllSystems (system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ self.overlay ];
+        });
+
+      tests = system:
+        (import ./tests {
+          nmt = nmt;
+          nixpkgs = nixpkgs;
+          pkgs = import nixpkgs { inherit system; };
+          system = system;
+        });
+    in {
+
+      overlay = import ./overlay.nix;
+
+      legacyPackages = forAllSystems (system: nixpkgsFor.${system});
+
+      packages = forAllSystems
+        (system: { inherit (self.legacyPackages.${system}) home-manager; });
+      defaultPackage =
+        forAllSystems (system: self.packages.${system}.home-manager);
+
+      apps = forAllSystems (system: {
+        home-manager = {
+          type = "app";
+          program = "${self.packages.${system}.home-manager}/bin/home-manager";
+        };
+      });
+      defaultApp = forAllSystems (system: self.apps.${system}.home-manager);
+
+      nixosModules.home-manager = import ./nixos nixpkgs;
+
+      lib = {
+        homeManagerConfiguration = { configuration, system, homeDirectory
+          , username
+          , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
+          , check ? true }@args:
+          import ./modules nixpkgs {
+            pkgs = builtins.getAttr system nixpkgs.outputs.legacyPackages;
+            configuration = { ... }: {
+              imports = [ configuration ];
+              home = { inherit homeDirectory username; };
+            };
+            inherit check;
+          };
+      };
+
+      checks = forAllSystems (system: {
+        test_all = (tests system).all;
+        list = (tests system).list;
+        inherit ((tests system) run);
+      });
+
+      hydraJobs = {
+        inherit (self) packages;
+        tests = lib.mapAttrs'
+          (name: config: lib.nameValuePair name config.config.nmt.toplevel)
+          (tests "x86_64-linux").run;
+      };
+    };
 }

--- a/home-manager/home-manager.nix
+++ b/home-manager/home-manager.nix
@@ -9,7 +9,7 @@ with pkgs.lib;
 
 let
 
-  env = import ../modules {
+  env = import ../modules <nixpkgs> {
     configuration =
       if confAttr == ""
       then confPath

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -20,7 +20,7 @@ let
     in
       fold f res res.config.warnings;
 
-  extendedLib = import ./lib/stdlib-extended.nix nixpkgs.lib;
+  extendedLib = import ./lib/stdlib-extended.nix (if nixpkgs ? lib then nixpkgs.lib else (import nixpkgs {}).lib);
 
   hmModules =
     import ./modules.nix nixpkgs {

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -9,6 +9,7 @@ nixpkgs:
 
 # If disabled, the pkgs attribute passed to this function is used instead.
 , useNixpkgsModule ? true
+, ...
 }:
 
 with lib;
@@ -54,7 +55,7 @@ let
     (loadModule ./programs/bat.nix { })
     (loadModule ./programs/beets.nix { })
     (loadModule ./programs/broot.nix { })
-    (loadModule ./programs/browserpass.nix { })
+    (loadModule ./programs/browserpass.nix { condition = (hostPlatform.system != "armv7a-linux"); })
     (loadModule ./programs/chromium.nix { condition = hostPlatform.isLinux; })
     (loadModule ./programs/command-not-found/command-not-found.nix { })
     (loadModule ./programs/dircolors.nix { })

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,3 +1,3 @@
-self: super: {
-  home-manager = super.callPackage ./home-manager { path = toString ./.; };
+final: prev: {
+  home-manager = final.callPackage ./home-manager { path = toString ./.; };
 }

--- a/tests/modules/files/executable.nix
+++ b/tests/modules/files/executable.nix
@@ -10,8 +10,8 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-files/executable
-      assertFileIsExecutable home-files/executable;
+      assertFileExists $home_files/executable
+      assertFileIsExecutable $home_files/executable;
     '';
   };
 }

--- a/tests/modules/files/hidden-source.nix
+++ b/tests/modules/files/hidden-source.nix
@@ -7,8 +7,8 @@ with lib;
     home.file.".hidden".source = ./.hidden;
 
     nmt.script = ''
-      assertFileExists home-files/.hidden;
-      assertFileContent home-files/.hidden ${
+      assertFileExists $home_files/.hidden;
+      assertFileContent $home_files/.hidden ${
         builtins.path {
           path = ./.hidden;
           name = "expected";

--- a/tests/modules/files/out-of-store-symlink.nix
+++ b/tests/modules/files/out-of-store-symlink.nix
@@ -11,9 +11,9 @@ in {
     home.file."oos".source = config.lib.file.mkOutOfStoreSymlink filePath;
 
     nmt.script = ''
-      assertLinkExists "home-files/oos"
+      assertLinkExists "$home_files/oos"
 
-      storePath="$(readlink $TESTED/home-files/oos)"
+      storePath="$(readlink $home_files/oos)"
 
       if [[ ! -L $storePath ]]; then
         fail "Expected $storePath to be a symbolic link, but it was not."

--- a/tests/modules/files/source-with-spaces.nix
+++ b/tests/modules/files/source-with-spaces.nix
@@ -7,8 +7,8 @@ with lib;
     home.file."source with spaces!".source = ./. + "/source with spaces!";
 
     nmt.script = ''
-      assertFileExists 'home-files/source with spaces!';
-      assertFileContent 'home-files/source with spaces!' \
+      assertFileExists $home_files/'source with spaces!';
+      assertFileContent $home_files/'source with spaces!' \
         ${
           builtins.path {
             path = ./. + "/source with spaces!";

--- a/tests/modules/files/text.nix
+++ b/tests/modules/files/text.nix
@@ -10,9 +10,9 @@ with lib;
     '';
 
     nmt.script = ''
-      assertFileExists home-files/using-text
-      assertFileIsNotExecutable home-files/using-text
-      assertFileContent home-files/using-text ${./text-expected.txt}
+      assertFileExists $home_files/using-text
+      assertFileIsNotExecutable $home_files/using-text
+      assertFileContent $home_files/using-text ${./text-expected.txt}
     '';
   };
 }

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -10,9 +10,9 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+      assertFileExists $home_path/etc/profile.d/hm-session-vars.sh
       assertFileContent \
-        home-path/etc/profile.d/hm-session-vars.sh \
+        $home_path/etc/profile.d/hm-session-vars.sh \
         ${./session-variables-expected.txt}
     '';
   };

--- a/tests/modules/misc/debug/default.nix
+++ b/tests/modules/misc/debug/default.nix
@@ -4,19 +4,19 @@
     home.packages = with pkgs; [ curl gdb ];
 
     nmt.script = ''
-      [ -L $TESTED/home-path/lib/debug/curl ] \
-        || fail "Debug-symbols for pkgs.curl should exist in \`/home-path/lib/debug'!"
+      [ -L $TESTED/$home_path/lib/debug/curl ] \
+        || fail "Debug-symbols for pkgs.curl should exist in \`/$home_path/lib/debug'!"
 
-      #source $TESTED/home-path/etc/profile.d/hm-session-vars.sh
+      #source $TESTED/$home_path/etc/profile.d/hm-session-vars.sh
       #[[ "$NIX_DEBUG_INFO_DIRS" =~ /lib/debug$ ]] \
         #|| fail "Invalid NIX_DEBUG_INFO_DIRS!"
-      assertFileExists home-path/etc/profile.d/hm-session-vars.sh
-      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      assertFileExists $home_path/etc/profile.d/hm-session-vars.sh
+      assertFileRegex $home_path/etc/profile.d/hm-session-vars.sh \
           'NIX_DEBUG_INFO_DIRS=.*/lib/debug'
 
       # We need to override NIX_DEBUG_INFO_DIRS here as $HOME evalutes to the home
       # of the user who executes this testcase :/
-      { echo quit | PATH="$TESTED/home-path/bin''${PATH:+:}$PATH" NIX_DEBUG_INFO_DIRS=$TESTED/home-path/lib/debug \
+      { echo quit | PATH="$TESTED/$home_path/bin''${PATH:+:}$PATH" NIX_DEBUG_INFO_DIRS=$TESTED/$home_path/lib/debug \
         gdb curl 2>&1 | \
         grep 'Reading symbols from ${builtins.storeDir}/'; \
       } || fail "Failed to read debug symbols from curl in gdb"

--- a/tests/modules/misc/fontconfig/multiple-font-packages.nix
+++ b/tests/modules/misc/fontconfig/multiple-font-packages.nix
@@ -9,7 +9,7 @@ with lib;
     fonts.fontconfig.enable = true;
 
     nmt.script = ''
-      assertDirectoryNotEmpty home-path/lib/fontconfig/cache
+      assertDirectoryNotEmpty $home_path/lib/fontconfig/cache
     '';
   };
 }

--- a/tests/modules/misc/fontconfig/no-font-package.nix
+++ b/tests/modules/misc/fontconfig/no-font-package.nix
@@ -11,7 +11,7 @@ with lib;
     fonts.fontconfig.enable = true;
 
     nmt.script = ''
-      assertPathNotExists home-path/lib/fontconfig/cache
+      assertPathNotExists $home_path/lib/fontconfig/cache
     '';
   };
 }

--- a/tests/modules/misc/fontconfig/single-font-package.nix
+++ b/tests/modules/misc/fontconfig/single-font-package.nix
@@ -9,7 +9,7 @@ with lib;
     fonts.fontconfig.enable = true;
 
     nmt.script = ''
-      assertDirectoryNotEmpty home-path/lib/fontconfig/cache
+      assertDirectoryNotEmpty $home_path/lib/fontconfig/cache
     '';
   };
 }

--- a/tests/modules/misc/pam/session-variables.nix
+++ b/tests/modules/misc/pam/session-variables.nix
@@ -10,9 +10,9 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-files/.pam_environment
+      assertFileExists $home_files/.pam_environment
       assertFileContent \
-        home-files/.pam_environment \
+        $home_files/.pam_environment \
         ${./session-variables-expected.txt}
     '';
   };

--- a/tests/modules/misc/xdg/mime-apps-basics.nix
+++ b/tests/modules/misc/xdg/mime-apps-basics.nix
@@ -19,9 +19,9 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-files/.config/mimeapps.list
+      assertFileExists $home_files/.config/mimeapps.list
       assertFileContent \
-        home-files/.config/mimeapps.list \
+        $home_files/.config/mimeapps.list \
         ${./mime-apps-basics-expected.ini}
     '';
   };

--- a/tests/modules/misc/xsession/basic.nix
+++ b/tests/modules/misc/xsession/basic.nix
@@ -21,19 +21,19 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.xprofile
+      assertFileExists $home_files/.xprofile
       assertFileContent \
-        home-files/.xprofile \
+        $home_files/.xprofile \
         ${./basic-xprofile-expected.txt}
 
-      assertFileExists home-files/.xsession
+      assertFileExists $home_files/.xsession
       assertFileContent \
-        home-files/.xsession \
+        $home_files/.xsession \
         ${./basic-xsession-expected.txt}
 
-      assertFileExists home-files/.config/systemd/user/setxkbmap.service
+      assertFileExists $home_files/.config/systemd/user/setxkbmap.service
       assertFileContent \
-        home-files/.config/systemd/user/setxkbmap.service \
+        $home_files/.config/systemd/user/setxkbmap.service \
         ${./basic-setxkbmap-expected.service}
     '';
   };

--- a/tests/modules/misc/xsession/keyboard-without-layout.nix
+++ b/tests/modules/misc/xsession/keyboard-without-layout.nix
@@ -25,9 +25,9 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.config/systemd/user/setxkbmap.service
+      assertFileExists $home_files/.config/systemd/user/setxkbmap.service
       assertFileContent \
-        home-files/.config/systemd/user/setxkbmap.service \
+        $home_files/.config/systemd/user/setxkbmap.service \
         ${./keyboard-without-layout-expected.service}
     '';
   };

--- a/tests/modules/programs/abook/no-settings.nix
+++ b/tests/modules/programs/abook/no-settings.nix
@@ -10,7 +10,7 @@ with lib;
       [ (self: super: { abook = pkgs.writeScriptBin "dummy-abook" ""; }) ];
 
     nmt.script = ''
-      assertPathNotExists home-files/.config/abook/abookrc
+      assertPathNotExists $home_files/.config/abook/abookrc
     '';
   };
 }

--- a/tests/modules/programs/abook/with-settings.nix
+++ b/tests/modules/programs/abook/with-settings.nix
@@ -32,8 +32,8 @@ with lib;
       [ (self: super: { abook = pkgs.writeScriptBin "dummy-abook" ""; }) ];
 
     nmt.script = ''
-      assertFileExists home-files/.config/abook/abookrc
-      assertFileContent home-files/.config/abook/abookrc ${./with-settings.cfg}
+      assertFileExists $home_files/.config/abook/abookrc
+      assertFileContent $home_files/.config/abook/abookrc ${./with-settings.cfg}
     '';
   };
 }

--- a/tests/modules/programs/alacritty/empty-settings.nix
+++ b/tests/modules/programs/alacritty/empty-settings.nix
@@ -11,7 +11,7 @@ with lib;
     ];
 
     nmt.script = ''
-      assertPathNotExists home-files/.config/alacritty
+      assertPathNotExists $home_files/.config/alacritty
     '';
   };
 }

--- a/tests/modules/programs/alacritty/example-settings.nix
+++ b/tests/modules/programs/alacritty/example-settings.nix
@@ -27,7 +27,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.config/alacritty/alacritty.yml \
+        $home_files/.config/alacritty/alacritty.yml \
         ${./example-settings-expected.yml}
     '';
   };

--- a/tests/modules/programs/alot/alot.nix
+++ b/tests/modules/programs/alot/alot.nix
@@ -28,8 +28,8 @@ with lib;
       [ (self: super: { alot = pkgs.writeScriptBin "dummy-alot" ""; }) ];
 
     nmt.script = ''
-      assertFileExists home-files/.config/alot/config
-      assertFileContent home-files/.config/alot/config ${./alot-expected.conf}
+      assertFileExists $home_files/.config/alot/config
+      assertFileContent $home_files/.config/alot/config ${./alot-expected.conf}
     '';
   };
 }

--- a/tests/modules/programs/aria2/settings.nix
+++ b/tests/modules/programs/aria2/settings.nix
@@ -25,7 +25,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.config/aria2/aria2.conf \
+        $home_files/.config/aria2/aria2.conf \
         ${
           pkgs.writeText "aria2-expected-config.conf" ''
             dht-listen-port=60000

--- a/tests/modules/programs/bash/logout.nix
+++ b/tests/modules/programs/bash/logout.nix
@@ -13,9 +13,9 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-files/.bash_logout
+      assertFileExists $home_files/.bash_logout
       assertFileContent \
-        home-files/.bash_logout \
+        $home_files/.bash_logout \
         ${./logout-expected.txt}
     '';
   };

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -14,9 +14,9 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-files/.profile
+      assertFileExists $home_files/.profile
       assertFileContent \
-        home-files/.profile \
+        $home_files/.profile \
         ${./session-variables-expected.txt}
     '';
   };

--- a/tests/modules/programs/browserpass/browserpass.nix
+++ b/tests/modules/programs/browserpass/browserpass.nix
@@ -11,19 +11,19 @@ with lib;
 
     nmt.script = if pkgs.stdenv.hostPlatform.isDarwin then ''
       for dir in "Google/Chrome" "Chromium" "Mozilla" "Vivaldi"; do
-        assertFileExists "home-files/Library/Application Support/$dir/NativeMessagingHosts/com.github.browserpass.native.json"
+        assertFileExists "$home_files/Library/Application Support/$dir/NativeMessagingHosts/com.github.browserpass.native.json"
       done
 
       for dir in "Google/Chrome" "Chromium" "Vivaldi"; do
-        assertFileExists "home-files/Library/Application Support/$dir/policies/managed/com.github.browserpass.native.json"
+        assertFileExists "$home_files/Library/Application Support/$dir/policies/managed/com.github.browserpass.native.json"
       done
     '' else ''
       for dir in "google-chrome" "chromium" "vivaldi"; do
-        assertFileExists "home-files/.config/$dir/NativeMessagingHosts/com.github.browserpass.native.json"
-        assertFileExists "home-files/.config/$dir/policies/managed/com.github.browserpass.native.json"
+        assertFileExists "$home_files/.config/$dir/NativeMessagingHosts/com.github.browserpass.native.json"
+        assertFileExists "$home_files/.config/$dir/policies/managed/com.github.browserpass.native.json"
       done
 
-      assertFileExists "home-files/.mozilla/native-messaging-hosts/com.github.browserpass.native.json"
+      assertFileExists "$home_files/.mozilla/native-messaging-hosts/com.github.browserpass.native.json"
     '';
   };
 }

--- a/tests/modules/programs/dircolors/settings.nix
+++ b/tests/modules/programs/dircolors/settings.nix
@@ -20,7 +20,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.dir_colors \
+        $home_files/.dir_colors \
         ${./settings-expected.conf}
     '';
   };

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -25,11 +25,11 @@ with lib;
 
     nmt.script = ''
       assertFileRegex \
-        home-path/bin/firefox \
+        $home_path/bin/firefox \
         MOZ_APP_LAUNCHER
 
       assertFileContent \
-        home-files/.mozilla/firefox/test/user.js \
+        $home_files/.mozilla/firefox/test/user.js \
         ${./profile-settings-expected-user.js}
     '';
   };

--- a/tests/modules/programs/firefox/state-version-19_09.nix
+++ b/tests/modules/programs/firefox/state-version-19_09.nix
@@ -24,7 +24,7 @@ with lib;
 
     nmt.script = ''
       assertFileRegex \
-        home-path/bin/firefox \
+        $home_path/bin/firefox \
         MOZ_APP_LAUNCHER
     '';
   };

--- a/tests/modules/programs/fish/functions.nix
+++ b/tests/modules/programs/fish/functions.nix
@@ -34,13 +34,13 @@ in {
       description =
         "if fish.function is set, check file exists and contents match";
       script = ''
-        assertFileExists home-files/.config/fish/functions/func.fish
+        assertFileExists $home_files/.config/fish/functions/func.fish
         echo ${func}
-        assertFileContent home-files/.config/fish/functions/func.fish ${func}
+        assertFileContent $home_files/.config/fish/functions/func.fish ${func}
 
-        assertFileExists home-files/.config/fish/functions/func-event.fish
+        assertFileExists $home_files/.config/fish/functions/func-event.fish
         echo ${funcEvent}
-        assertFileContent home-files/.config/fish/functions/func-event.fish ${funcEvent}
+        assertFileContent $home_files/.config/fish/functions/func-event.fish ${funcEvent}
       '';
 
     };

--- a/tests/modules/programs/fish/no-functions.nix
+++ b/tests/modules/programs/fish/no-functions.nix
@@ -14,7 +14,7 @@ with lib;
       description =
         "if fish.functions is blank, the functions folder should not exist.";
       script = ''
-        assertPathNotExists home-files/.config/fish/functions
+        assertPathNotExists $home_files/.config/fish/functions
       '';
 
     };

--- a/tests/modules/programs/fish/plugins.nix
+++ b/tests/modules/programs/fish/plugins.nix
@@ -50,9 +50,9 @@ in {
       description =
         "if fish.plugins set, check conf.d file exists and contents match";
       script = ''
-        assertDirectoryExists home-files/.config/fish/conf.d
-        assertFileExists home-files/.config/fish/conf.d/plugin-foo.fish
-        assertFileContent home-files/.config/fish/conf.d/plugin-foo.fish ${generatedConfdFile}
+        assertDirectoryExists $home_files/.config/fish/conf.d
+        assertFileExists $home_files/.config/fish/conf.d/plugin-foo.fish
+        assertFileContent $home_files/.config/fish/conf.d/plugin-foo.fish ${generatedConfdFile}
       '';
 
     };

--- a/tests/modules/programs/getmail/getmail.nix
+++ b/tests/modules/programs/getmail/getmail.nix
@@ -19,8 +19,8 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-files/.getmail/getmailhm@example.com
-      assertFileContent home-files/.getmail/getmailhm@example.com ${
+      assertFileExists $home_files/.getmail/getmailhm@example.com
+      assertFileContent $home_files/.getmail/getmailhm@example.com ${
         ./getmail-expected.conf
       }
     '';

--- a/tests/modules/programs/git/default.nix
+++ b/tests/modules/programs/git/default.nix
@@ -1,5 +1,6 @@
 {
+  git-most-options = ./git.nix;
   git-with-email = ./git-with-email.nix;
-  git-with-most-options = ./git.nix;
   git-with-str-extra-config = ./git-with-str-extra-config.nix;
 }
+

--- a/tests/modules/programs/git/git-with-email.nix
+++ b/tests/modules/programs/git/git-with-email.nix
@@ -17,15 +17,15 @@ with lib;
       function assertGitConfig() {
         local value
         value=$(${pkgs.git}/bin/git config \
-          --file $TESTED/home-files/.config/git/config \
+          --file $home_files/.config/git/config \
           --get $1)
         if [[ $value != $2 ]]; then
           fail "Expected option '$1' to have value '$2' but it was '$value'"
         fi
       }
 
-      assertFileExists home-files/.config/git/config
-      assertFileContent home-files/.config/git/config ${
+      assertFileExists $home_files/.config/git/config
+      assertFileContent $home_files/.config/git/config ${
         ./git-with-email-expected.conf
       }
 

--- a/tests/modules/programs/git/git-with-str-extra-config.nix
+++ b/tests/modules/programs/git/git-with-str-extra-config.nix
@@ -15,8 +15,8 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-files/.config/git/config
-      assertFileContent home-files/.config/git/config \
+      assertFileExists $home_files/.config/git/config
+      assertFileContent $home_files/.config/git/config \
         ${./git-with-str-extra-config-expected.conf}
     '';
   };

--- a/tests/modules/programs/git/git.nix
+++ b/tests/modules/programs/git/git.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, pkgs, lib, ... }:
 
 let
 
@@ -20,65 +18,62 @@ let
       git_include_path = pkgs.writeText "contents"
         (builtins.readFile ./git-expected-include.conf);
     };
-
 in {
-  config = {
-    programs.git = mkMerge [
-      {
+  programs.git = lib.mkMerge [
+    {
+      enable = true;
+      package = pkgs.gitMinimal;
+      aliases = {
+        a1 = "foo";
+        a2 = "bar";
+        escapes = ''"\n	'';
+      };
+      extraConfig = {
+        extra = {
+          name = "value";
+          multiple = [ 1 ];
+        };
+      };
+      ignores = [ "*~" "*.swp" ];
+      includes = [
+        { path = "~/path/to/config.inc"; }
+        {
+          path = "~/path/to/conditional.inc";
+          condition = "gitdir:~/src/dir";
+        }
+        {
+          condition = "gitdir:~/src/dir";
+          contents = gitInclude;
+        }
+      ];
+      signing = {
+        gpgPath = "path-to-gpg";
+        key = "00112233445566778899AABBCCDDEEFF";
+        signByDefault = true;
+      };
+      userEmail = "user@example.org";
+      userName = "John Doe";
+      lfs.enable = true;
+      delta = {
         enable = true;
-        package = pkgs.gitMinimal;
-        aliases = {
-          a1 = "foo";
-          a2 = "bar";
-          escapes = ''"\n	'';
-        };
-        extraConfig = {
-          extra = {
-            name = "value";
-            multiple = [ 1 ];
-          };
-        };
-        ignores = [ "*~" "*.swp" ];
-        includes = [
-          { path = "~/path/to/config.inc"; }
-          {
-            path = "~/path/to/conditional.inc";
-            condition = "gitdir:~/src/dir";
-          }
-          {
-            condition = "gitdir:~/src/dir";
-            contents = gitInclude;
-          }
-        ];
-        signing = {
-          gpgPath = "path-to-gpg";
-          key = "00112233445566778899AABBCCDDEEFF";
-          signByDefault = true;
-        };
-        userEmail = "user@example.org";
-        userName = "John Doe";
-        lfs.enable = true;
-        delta = {
-          enable = true;
-          options = [ "--dark" ];
-        };
-      }
+        options = [ "--dark" ];
+      };
+    }
 
-      {
-        aliases.a2 = mkForce "baz";
-        extraConfig."extra \"backcompat.with.dots\"".previously = "worked";
-        extraConfig.extra.boolean = true;
-        extraConfig.extra.integer = 38;
-        extraConfig.extra.multiple = [ 2 ];
-        extraConfig.extra.subsection.value = "test";
-      }
-    ];
+    {
+      aliases.a2 = lib.mkForce "baz";
+      extraConfig."extra \"backcompat.with.dots\"".previously = "worked";
+      extraConfig.extra.boolean = true;
+      extraConfig.extra.integer = 38;
+      extraConfig.extra.multiple = [ 2 ];
+      extraConfig.extra.subsection.value = "test";
+    }
+  ];
 
-    nmt.script = ''
-      assertFileExists home-files/.config/git/config
-      assertFileContent home-files/.config/git/config ${
-        substituteExpected ./git-expected.conf
-      }
-    '';
-  };
+  nmt.script = ''
+    assertFileExists $home_files/.config/git/config
+    assertFileContent $home_files/.config/git/config ${
+      substituteExpected ./git-expected.conf
+    }
+  '';
 }

--- a/tests/modules/programs/gpg/override-defaults.nix
+++ b/tests/modules/programs/gpg/override-defaults.nix
@@ -15,8 +15,8 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-files/.gnupg/gpg.conf
-      assertFileContent home-files/.gnupg/gpg.conf ${./override-defaults-expected.conf}
+      assertFileExists $home_files/.gnupg/gpg.conf
+      assertFileContent $home_files/.gnupg/gpg.conf ${./override-defaults-expected.conf}
     '';
   };
 }

--- a/tests/modules/programs/i3status/with-custom.nix
+++ b/tests/modules/programs/i3status/with-custom.nix
@@ -38,7 +38,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.config/i3status/config \
+        $home_files/.config/i3status/config \
         ${
           pkgs.writeText "i3status-expected-config" ''
             general {

--- a/tests/modules/programs/i3status/with-default.nix
+++ b/tests/modules/programs/i3status/with-default.nix
@@ -15,7 +15,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.config/i3status/config \
+        $home_files/.config/i3status/config \
         ${
           pkgs.writeText "i3status-expected-config" ''
             general {

--- a/tests/modules/programs/kakoune/whitespace-highlighter.nix
+++ b/tests/modules/programs/kakoune/whitespace-highlighter.nix
@@ -21,12 +21,12 @@ with lib;
         "^add-highlighter\\s\\+global\\/\\?\\s\\+show-whitespaces\\s\\+"
         + "\\(-\\w\\+\\s\\+.\\s\\+\\)*";
     in ''
-      assertFileExists home-files/.config/kak/kakrc
-      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-lf\s\+1\b'
-      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-spc\s\+2\b'
-      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-nbsp\s\+3\b'
-      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-tab\s\+4\b'
-      assertFileRegex home-files/.config/kak/kakrc '${lineStart}-tabpad\s\+5\b'
+      assertFileExists $home_files/.config/kak/kakrc
+      assertFileRegex $home_files/.config/kak/kakrc '${lineStart}-lf\s\+1\b'
+      assertFileRegex $home_files/.config/kak/kakrc '${lineStart}-spc\s\+2\b'
+      assertFileRegex $home_files/.config/kak/kakrc '${lineStart}-nbsp\s\+3\b'
+      assertFileRegex $home_files/.config/kak/kakrc '${lineStart}-tab\s\+4\b'
+      assertFileRegex $home_files/.config/kak/kakrc '${lineStart}-tabpad\s\+5\b'
     '';
   };
 }

--- a/tests/modules/programs/lf/all-options.nix
+++ b/tests/modules/programs/lf/all-options.nix
@@ -79,8 +79,8 @@ in {
       [ (self: super: { lf = pkgs.writeScriptBin "dummy-lf" ""; }) ];
 
     nmt.script = ''
-      assertFileExists home-files/.config/lf/lfrc
-      assertFileContent home-files/.config/lf/lfrc ${expected}
+      assertFileExists $home_files/.config/lf/lfrc
+      assertFileContent $home_files/.config/lf/lfrc ${expected}
     '';
   };
 }

--- a/tests/modules/programs/lf/minimal-options.nix
+++ b/tests/modules/programs/lf/minimal-options.nix
@@ -11,8 +11,8 @@ in {
       [ (self: super: { lf = pkgs.writeScriptBin "dummy-lf" ""; }) ];
 
     nmt.script = ''
-      assertFileExists home-files/.config/lf/lfrc
-      assertFileContent home-files/.config/lf/lfrc ${expected}
+      assertFileExists $home_files/.config/lf/lfrc
+      assertFileContent $home_files/.config/lf/lfrc ${expected}
     '';
   };
 }

--- a/tests/modules/programs/lf/no-pv-keybind.nix
+++ b/tests/modules/programs/lf/no-pv-keybind.nix
@@ -36,8 +36,8 @@ in {
       [ (self: super: { lf = pkgs.writeScriptBin "dummy-lf" ""; }) ];
 
     nmt.script = ''
-      assertFileExists home-files/.config/lf/lfrc
-      assertFileContent home-files/.config/lf/lfrc ${expected}
+      assertFileExists $home_files/.config/lf/lfrc
+      assertFileContent $home_files/.config/lf/lfrc ${expected}
     '';
   };
 }

--- a/tests/modules/programs/lieer/lieer.nix
+++ b/tests/modules/programs/lieer/lieer.nix
@@ -15,8 +15,8 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/Mail/hm@example.com/.gmailieer.json
-      assertFileContent home-files/Mail/hm@example.com/.gmailieer.json \
+      assertFileExists $home_files/Mail/hm@example.com/.gmailieer.json
+      assertFileContent $home_files/Mail/hm@example.com/.gmailieer.json \
                         ${./lieer-expected.json}
     '';
   };

--- a/tests/modules/programs/mbsync/mbsync.nix
+++ b/tests/modules/programs/mbsync/mbsync.nix
@@ -21,8 +21,8 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-files/.mbsyncrc
-      assertFileContent home-files/.mbsyncrc ${./mbsync-expected.conf}
+      assertFileExists $home_files/.mbsyncrc
+      assertFileContent $home_files/.mbsyncrc ${./mbsync-expected.conf}
     '';
   };
 }

--- a/tests/modules/programs/neomutt/neomutt-with-msmtp.nix
+++ b/tests/modules/programs/neomutt/neomutt-with-msmtp.nix
@@ -26,12 +26,12 @@ with lib;
       [ (self: super: { neomutt = pkgs.writeScriptBin "dummy-neomutt" ""; }) ];
 
     nmt.script = ''
-      assertFileExists home-files/.config/neomutt/neomuttrc
-      assertFileExists home-files/.config/neomutt/hm@example.com
-      assertFileContent home-files/.config/neomutt/neomuttrc ${
+      assertFileExists $home_files/.config/neomutt/neomuttrc
+      assertFileExists $home_files/.config/neomutt/hm@example.com
+      assertFileContent $home_files/.config/neomutt/neomuttrc ${
         ./neomutt-expected.conf
       }
-      assertFileContent home-files/.config/neomutt/hm@example.com ${
+      assertFileContent $home_files/.config/neomutt/hm@example.com ${
         ./hm-example.com-msmtp-expected.conf
       }
     '';

--- a/tests/modules/programs/neomutt/neomutt.nix
+++ b/tests/modules/programs/neomutt/neomutt.nix
@@ -29,12 +29,12 @@ with lib;
       [ (self: super: { neomutt = pkgs.writeScriptBin "dummy-neomutt" ""; }) ];
 
     nmt.script = ''
-      assertFileExists home-files/.config/neomutt/neomuttrc
-      assertFileExists home-files/.config/neomutt/hm@example.com
-      assertFileContent home-files/.config/neomutt/neomuttrc ${
+      assertFileExists $home_files/.config/neomutt/neomuttrc
+      assertFileExists $home_files/.config/neomutt/hm@example.com
+      assertFileContent $home_files/.config/neomutt/neomuttrc ${
         ./neomutt-expected.conf
       }
-      assertFileContent home-files/.config/neomutt/hm@example.com ${
+      assertFileContent $home_files/.config/neomutt/hm@example.com ${
         ./hm-example.com-expected
       }
     '';

--- a/tests/modules/programs/newsboat/newsboat-basics-2003.nix
+++ b/tests/modules/programs/newsboat/newsboat-basics-2003.nix
@@ -28,7 +28,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.newsboat/urls \
+        $home_files/.newsboat/urls \
         ${./newsboat-basics-urls-2003.txt}
     '';
   };

--- a/tests/modules/programs/newsboat/newsboat-basics.nix
+++ b/tests/modules/programs/newsboat/newsboat-basics.nix
@@ -26,7 +26,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.newsboat/urls \
+        $home_files/.newsboat/urls \
         ${./newsboat-basics-urls.txt}
     '';
   };

--- a/tests/modules/programs/qutebrowser/keybindings.nix
+++ b/tests/modules/programs/qutebrowser/keybindings.nix
@@ -24,7 +24,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.config/qutebrowser/config.py \
+        $home_files/.config/qutebrowser/config.py \
         ${
           pkgs.writeText "qutebrowser-expected-config.py" ''
             config.bind(",l", "config-cycle spellcheck.languages [\"en-GB\"] [\"en-US\"]", mode="normal")

--- a/tests/modules/programs/qutebrowser/settings.nix
+++ b/tests/modules/programs/qutebrowser/settings.nix
@@ -32,7 +32,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.config/qutebrowser/config.py \
+        $home_files/.config/qutebrowser/config.py \
         ${
           pkgs.writeText "qutebrowser-expected-config.py" ''
             c.colors.hints.bg = "#000000"

--- a/tests/modules/programs/readline/using-all-options.nix
+++ b/tests/modules/programs/readline/using-all-options.nix
@@ -24,7 +24,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.inputrc \
+        $home_files/.inputrc \
         ${./using-all-options.txt}
     '';
   };

--- a/tests/modules/programs/rofi/assert-on-both-theme-and-colors.nix
+++ b/tests/modules/programs/rofi/assert-on-both-theme-and-colors.nix
@@ -25,7 +25,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/result \
+        $home_files/result \
         ${./assert-on-both-theme-and-colors-expected.json}
     '';
   };

--- a/tests/modules/programs/ssh/default-config.nix
+++ b/tests/modules/programs/ssh/default-config.nix
@@ -10,9 +10,11 @@ with lib;
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
     nmt.script = ''
-      assertFileExists home-files/.ssh/config
-      assertFileContent home-files/.ssh/config ${./default-config-expected.conf}
-      assertFileContent home-files/assertions ${./no-assertions.json}
+      assertFileExists $home_files/.ssh/config
+      assertFileContent $home_files/.ssh/config ${
+        ./default-config-expected.conf
+      }
+      assertFileContent $home_files/assertions ${./no-assertions.json}
     '';
   };
 }

--- a/tests/modules/programs/ssh/forwards-dynamic-bind-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-dynamic-bind-path-with-port-asserts.nix
@@ -21,7 +21,7 @@ with lib;
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
     nmt.script = ''
-      assertFileContent home-files/result ${
+      assertFileContent $home_files/result ${
         ./forwards-paths-with-ports-error.json
       }
     '';

--- a/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts.nix
@@ -28,11 +28,11 @@ with lib;
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
     nmt.script = ''
-      assertFileExists home-files/.ssh/config
+      assertFileExists $home_files/.ssh/config
       assertFileContent \
-        home-files/.ssh/config \
+        $home_files/.ssh/config \
         ${./forwards-dynamic-valid-bind-no-asserts-expected.conf}
-      assertFileContent home-files/result ${./no-assertions.json}
+      assertFileContent $home_files/result ${./no-assertions.json}
     '';
   };
 }

--- a/tests/modules/programs/ssh/forwards-local-bind-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-local-bind-path-with-port-asserts.nix
@@ -25,7 +25,7 @@ with lib;
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
     nmt.script = ''
-      assertFileContent home-files/result ${
+      assertFileContent $home_files/result ${
         ./forwards-paths-with-ports-error.json
       }
     '';

--- a/tests/modules/programs/ssh/forwards-local-host-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-local-host-path-with-port-asserts.nix
@@ -25,7 +25,7 @@ with lib;
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
     nmt.script = ''
-      assertFileContent home-files/result ${
+      assertFileContent $home_files/result ${
         ./forwards-paths-with-ports-error.json
       }
     '';

--- a/tests/modules/programs/ssh/forwards-remote-bind-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-remote-bind-path-with-port-asserts.nix
@@ -25,7 +25,7 @@ with lib;
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
     nmt.script = ''
-      assertFileContent home-files/result ${
+      assertFileContent $home_files/result ${
         ./forwards-paths-with-ports-error.json
       }
     '';

--- a/tests/modules/programs/ssh/forwards-remote-host-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-remote-host-path-with-port-asserts.nix
@@ -25,7 +25,7 @@ with lib;
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
     nmt.script = ''
-      assertFileContent home-files/result ${
+      assertFileContent $home_files/result ${
         ./forwards-paths-with-ports-error.json
       }
     '';

--- a/tests/modules/programs/ssh/match-blocks-attrs.nix
+++ b/tests/modules/programs/ssh/match-blocks-attrs.nix
@@ -47,11 +47,11 @@ with lib;
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
     nmt.script = ''
-      assertFileExists home-files/.ssh/config
+      assertFileExists $home_files/.ssh/config
       assertFileContent \
-        home-files/.ssh/config \
+        $home_files/.ssh/config \
         ${./match-blocks-attrs-expected.conf}
-      assertFileContent home-files/assertions ${./no-assertions.json}
+      assertFileContent $home_files/assertions ${./no-assertions.json}
     '';
   };
 }

--- a/tests/modules/programs/starship/settings.nix
+++ b/tests/modules/programs/starship/settings.nix
@@ -42,7 +42,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.config/starship.toml \
+        $home_files/.config/starship.toml \
         ${./settings-expected.toml}
     '';
   };

--- a/tests/modules/programs/texlive/texlive-minimal.nix
+++ b/tests/modules/programs/texlive/texlive-minimal.nix
@@ -7,7 +7,7 @@ with lib;
     programs.texlive.enable = true;
 
     nmt.script = ''
-      assertFileExists home-path/bin/tex
+      assertFileExists $home_path/bin/tex
     '';
   };
 }

--- a/tests/modules/programs/tmux/disable-confirmation-prompt.nix
+++ b/tests/modules/programs/tmux/disable-confirmation-prompt.nix
@@ -18,8 +18,8 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.tmux.conf
-      assertFileContent home-files/.tmux.conf \
+      assertFileExists $home_files/.tmux.conf
+      assertFileContent $home_files/.tmux.conf \
         ${./disable-confirmation-prompt.conf}
     '';
   };

--- a/tests/modules/programs/tmux/emacs-with-plugins.nix
+++ b/tests/modules/programs/tmux/emacs-with-plugins.nix
@@ -42,8 +42,8 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.tmux.conf
-      assertFileContent home-files/.tmux.conf ${./emacs-with-plugins.conf}
+      assertFileExists $home_files/.tmux.conf
+      assertFileContent $home_files/.tmux.conf ${./emacs-with-plugins.conf}
     '';
   };
 }

--- a/tests/modules/programs/tmux/not-enabled.nix
+++ b/tests/modules/programs/tmux/not-enabled.nix
@@ -7,7 +7,7 @@ with lib;
     programs.tmux = { enable = false; };
 
     nmt.script = ''
-      assertPathNotExists home-files/.tmux.conf
+      assertPathNotExists $home_files/.tmux.conf
     '';
   };
 }

--- a/tests/modules/programs/tmux/secure-socket-enabled.nix
+++ b/tests/modules/programs/tmux/secure-socket-enabled.nix
@@ -10,8 +10,8 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-path/etc/profile.d/hm-session-vars.sh
-      assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+      assertFileExists $home_path/etc/profile.d/hm-session-vars.sh
+      assertFileContains $home_path/etc/profile.d/hm-session-vars.sh \
         'export TMUX_TMPDIR="''${XDG_RUNTIME_DIR:-"/run/user/\$(id -u)"}"'
     '';
   };

--- a/tests/modules/programs/tmux/vi-all-true.nix
+++ b/tests/modules/programs/tmux/vi-all-true.nix
@@ -22,8 +22,8 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.tmux.conf
-      assertFileContent home-files/.tmux.conf ${./vi-all-true.conf}
+      assertFileExists $home_files/.tmux.conf
+      assertFileContent $home_files/.tmux.conf ${./vi-all-true.conf}
     '';
   };
 }

--- a/tests/modules/programs/zsh/history-path-new-custom.nix
+++ b/tests/modules/programs/zsh/history-path-new-custom.nix
@@ -14,7 +14,7 @@ with lib;
       [ (self: super: { zsh = pkgs.writeScriptBin "dummy-zsh" ""; }) ];
 
     nmt.script = ''
-      assertFileRegex home-files/.zshrc '^HISTFILE="$HOME/some/directory/zsh_history"$'
+      assertFileRegex $home_files/.zshrc '^HISTFILE="$HOME/some/directory/zsh_history"$'
     '';
   };
 }

--- a/tests/modules/programs/zsh/history-path-new-default.nix
+++ b/tests/modules/programs/zsh/history-path-new-default.nix
@@ -11,7 +11,7 @@ with lib;
       [ (self: super: { zsh = pkgs.writeScriptBin "dummy-zsh" ""; }) ];
 
     nmt.script = ''
-      assertFileRegex home-files/.zshrc '^HISTFILE="$HOME/.zsh_history"$'
+      assertFileRegex $home_files/.zshrc '^HISTFILE="$HOME/.zsh_history"$'
     '';
   };
 }

--- a/tests/modules/programs/zsh/history-path-old-custom.nix
+++ b/tests/modules/programs/zsh/history-path-old-custom.nix
@@ -14,7 +14,7 @@ with lib;
       [ (self: super: { zsh = pkgs.writeScriptBin "dummy-zsh" ""; }) ];
 
     nmt.script = ''
-      assertFileRegex home-files/.zshrc '^HISTFILE="$HOME/some/directory/zsh_history"$'
+      assertFileRegex $home_files/.zshrc '^HISTFILE="$HOME/some/directory/zsh_history"$'
     '';
   };
 }

--- a/tests/modules/programs/zsh/history-path-old-default.nix
+++ b/tests/modules/programs/zsh/history-path-old-default.nix
@@ -11,7 +11,7 @@ with lib;
       [ (self: super: { zsh = pkgs.writeScriptBin "dummy-zsh" ""; }) ];
 
     nmt.script = ''
-      assertFileRegex home-files/.zshrc '^HISTFILE="$HOME/.zsh_history"$'
+      assertFileRegex $home_files/.zshrc '^HISTFILE="$HOME/.zsh_history"$'
     '';
   };
 }

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -20,9 +20,9 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.zshrc
-      assertFileRegex home-files/.zshrc 'export V1="v1"'
-      assertFileRegex home-files/.zshrc 'export V2="v2-v1"'
+      assertFileExists $home_files/.zshrc
+      assertFileRegex $home_files/.zshrc 'export V1="v1"'
+      assertFileRegex $home_files/.zshrc 'export V2="v2-v1"'
     '';
   };
 }

--- a/tests/modules/services/lieer/lieer-service.nix
+++ b/tests/modules/services/lieer/lieer-service.nix
@@ -22,12 +22,12 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.config/systemd/user/lieer-hm-example-com.service
-      assertFileExists home-files/.config/systemd/user/lieer-hm-example-com.timer
+      assertFileExists $home_files/.config/systemd/user/lieer-hm-example-com.service
+      assertFileExists $home_files/.config/systemd/user/lieer-hm-example-com.timer
 
-      assertFileContent home-files/.config/systemd/user/lieer-hm-example-com.service \
+      assertFileContent $home_files/.config/systemd/user/lieer-hm-example-com.service \
                         ${./lieer-service-expected.service}
-      assertFileContent home-files/.config/systemd/user/lieer-hm-example-com.timer \
+      assertFileContent $home_files/.config/systemd/user/lieer-hm-example-com.timer \
                         ${./lieer-service-expected.timer}
     '';
   };

--- a/tests/modules/services/polybar/basic-configuration.nix
+++ b/tests/modules/services/polybar/basic-configuration.nix
@@ -34,14 +34,14 @@
     };
 
     nmt.script = ''
-      serviceFile=home-files/.config/systemd/user/polybar.service
+      serviceFile=$home_files/.config/systemd/user/polybar.service
 
       assertFileExists $serviceFile
       assertFileRegex $serviceFile 'X-Restart-Triggers=.*polybar\.conf'
       assertFileRegex $serviceFile 'ExecStart=.*/bin/polybar-start'
 
-      assertFileExists home-files/.config/polybar/config
-      assertFileContent home-files/.config/polybar/config \
+      assertFileExists $home_files/.config/polybar/config
+      assertFileContent $home_files/.config/polybar/config \
           ${./basic-configuration.conf}
     '';
   };

--- a/tests/modules/services/sxhkd/configuration.nix
+++ b/tests/modules/services/sxhkd/configuration.nix
@@ -23,7 +23,7 @@
       [ (self: super: { sxhkd = pkgs.writeScriptBin "dummy-sxhkd" ""; }) ];
 
     nmt.script = ''
-      sxhkdrc=home-files/.config/sxhkd/sxhkdrc
+      sxhkdrc=$home_files/.config/sxhkd/sxhkdrc
 
       assertFileExists $sxhkdrc
 

--- a/tests/modules/services/sxhkd/service.nix
+++ b/tests/modules/services/sxhkd/service.nix
@@ -7,7 +7,7 @@
     };
 
     nmt.script = ''
-      serviceFile=home-files/.config/systemd/user/sxhkd.service
+      serviceFile=$home_files/.config/systemd/user/sxhkd.service
 
       assertFileExists $serviceFile
 

--- a/tests/modules/services/window-managers/i3/i3-keybindings.nix
+++ b/tests/modules/services/window-managers/i3/i3-keybindings.nix
@@ -27,8 +27,8 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.config/i3/config
-      assertFileContent home-files/.config/i3/config \
+      assertFileExists $home_files/.config/i3/config
+      assertFileContent $home_files/.config/i3/config \
         ${./i3-keybindings-expected.conf}
     '';
   };

--- a/tests/modules/systemd/services.nix
+++ b/tests/modules/systemd/services.nix
@@ -15,7 +15,7 @@ with lib;
     };
 
     nmt.script = ''
-      serviceFile=home-files/.config/systemd/user/test-service@.service
+      serviceFile=$home_files/.config/systemd/user/test-service@.service
       assertFileExists $serviceFile
       assertFileContent $serviceFile ${./services-expected.conf}
     '';

--- a/tests/modules/systemd/session-variables.nix
+++ b/tests/modules/systemd/session-variables.nix
@@ -10,7 +10,7 @@ with lib;
     };
 
     nmt.script = ''
-      envFile=home-files/.config/environment.d/10-home-manager.conf
+      envFile=$home_files/.config/environment.d/10-home-manager.conf
       assertFileExists $envFile
       assertFileContent $envFile ${./session-variables-expected.conf}
     '';

--- a/tests/modules/systemd/timers.nix
+++ b/tests/modules/systemd/timers.nix
@@ -13,7 +13,7 @@ with lib;
     };
 
     nmt.script = ''
-      unitDir=home-files/.config/systemd/user
+      unitDir=$home_files/.config/systemd/user
       timerFile=$unitDir/test-timer.timer
 
       assertFileExists $timerFile

--- a/tests/modules/targets/generic-linux.nix
+++ b/tests/modules/targets/generic-linux.nix
@@ -7,12 +7,12 @@ with lib;
     targets.genericLinux.enable = true;
 
     nmt.script = ''
-      assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+      assertFileExists $home_path/etc/profile.d/hm-session-vars.sh
       assertFileContains \
-        home-path/etc/profile.d/hm-session-vars.sh \
+        $home_path/etc/profile.d/hm-session-vars.sh \
         'export XDG_DATA_DIRS="/nix/var/nix/profiles/default/share:/home/hm-user/.nix-profile/share''${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS"'
       assertFileContains \
-        home-path/etc/profile.d/hm-session-vars.sh \
+        $home_path/etc/profile.d/hm-session-vars.sh \
         '. "${pkgs.nix}/etc/profile.d/nix.sh"'
     '';
   };

--- a/tests/modules/xresources/xresources.nix
+++ b/tests/modules/xresources/xresources.nix
@@ -15,8 +15,8 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-files/.Xresources
-      assertFileContent home-files/.Xresources ${./xresources-expected.conf}
+      assertFileExists $home_files/.Xresources
+      assertFileContent $home_files/.Xresources ${./xresources-expected.conf}
     '';
   };
 }


### PR DESCRIPTION
### Description
add overlay and package atribute to the flake.nix, so the home-manager binary can be build via flakes


### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.

CC: @kisik21