### PR TITLE
fish: add config for init.fish and keybindings.fish in plugins

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -14,8 +14,8 @@ let
           Path to the plugin folder.
           </para><para>
           Relevant pieces will be added to the fish function path and
-          the completion path. The <filename>init.fish</filename> and
-          <filename>key_binding.fish</filename> files are sourced if
+          the completion path. The <filename>$initFile</filename> and
+          <filename>$keyBindingFile</filename> files are sourced if
           they exist.
         '';
       };
@@ -24,6 +24,22 @@ let
         type = types.str;
         description = ''
           The name of the plugin.
+        '';
+      };
+
+      initFile = mkOption {
+        type = types.str;
+        default = "init.fish";
+        description = ''
+          Relative path to the plugin's init file.
+        '';
+      };
+
+      keyBindingFile = mkOption {
+        type = types.str;
+        default = "key_bindings.fish";
+        description = ''
+          Relative path to the plugin's keybindings file.
         '';
       };
     };
@@ -444,12 +460,12 @@ in {
             source $plugin_dir/conf.d/*.fish
           end
 
-          if test -f $plugin_dir/key_bindings.fish
-            source $plugin_dir/key_bindings.fish
+          if test -f $plugin_dir/${plugin.keyBindingFile}
+            source $plugin_dir/${plugin.keyBindingFile}
           end
 
-          if test -f $plugin_dir/init.fish
-            source $plugin_dir/init.fish
+          if test -f $plugin_dir/${plugin.initFile}
+            source $plugin_dir/${plugin.initFile}
           end
         '';
       }) cfg.plugins));


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

Now you can specify plugin init.fish file.


### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
