### PR TITLE
tarsnap: Add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -104,6 +104,7 @@ let
     (loadModule ./programs/skim.nix { })
     (loadModule ./programs/starship.nix { })
     (loadModule ./programs/ssh.nix { })
+    (loadModule ./programs/tarsnap.nix { })
     (loadModule ./programs/taskwarrior.nix { })
     (loadModule ./programs/termite.nix { })
     (loadModule ./programs/texlive.nix { })


### PR DESCRIPTION
Add a new tarsnap module, with options for all flags supported in the
~/.tarsnaprc configfile, including documentation pulled from tarsnap's
man-page.