### PR TITLE
Allow building home-manager in pure-eval / restrict-eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,7 @@ To satisfy the above setup we should elaborate the
     ];
   };
 
-  programs.firefox = {
-    enable = true;
-    enableIcedTea = true;
-  };
+  programs.firefox.enable = true;
 
   services.gpg-agent = {
     enable = true;

--- a/home-manager/home-manager.nix
+++ b/home-manager/home-manager.nix
@@ -19,7 +19,7 @@ let
   };
 
   newsReadIds =
-    if newsReadIdsFile == null
+    if newsReadIdsFile == null || !(builtins.pathExists newsReadIdsFile)
     then {}
     else
       let

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -317,7 +317,7 @@ in
       '' + concatStrings (
         mapAttrsToList (n: v: ''
           insertFile "${sourceStorePath v}" \
-                     "${v.target}" \
+                     "$(HOME= sh -c 'echo ${v.target}')" \
                      "${if v.executable == null
                         then "inherit"
                         else builtins.toString v.executable}" \

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -322,10 +322,6 @@ in
   config = {
     assertions = [
       {
-        assertion = config.home.username != "";
-        message = "Username could not be determined";
-      }
-      {
         assertion = config.home.homeDirectory != "";
         message = "Home directory could not be determined";
       }

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -105,6 +105,10 @@ let
     };
   };
 
+  getEnvOrVar = var: let val = builtins.getEnv var;
+                     in if val == "" then "$" + var
+                     else val;
+
 in
 
 {
@@ -130,13 +134,13 @@ in
     };
 
     home.homeDirectory = mkOption {
-      type = types.path;
+      type = types.either types.path types.str;
       defaultText = "$HOME";
       description = "The user's home directory.";
     };
 
     home.profileDirectory = mkOption {
-      type = types.path;
+      type = types.either types.path types.str;
       defaultText = "~/.nix-profile";
       internal = true;
       readOnly = true;
@@ -328,7 +332,7 @@ in
     ];
 
     home.username = mkDefault (builtins.getEnv "USER");
-    home.homeDirectory = mkDefault (builtins.getEnv "HOME");
+    home.homeDirectory = mkDefault (getEnvOrVar "HOME");
 
     home.profileDirectory =
       if config.submoduleSupport.enable

--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -30,7 +30,7 @@ in
     enable = mkEnableOption "management of XDG base directories";
 
     cacheHome = mkOption {
-      type = types.path;
+      type = types.either types.path types.str;
       defaultText = "~/.cache";
       description = ''
         Absolute path to directory holding application caches.
@@ -47,7 +47,7 @@ in
     };
 
     configHome = mkOption {
-      type = types.path;
+      type = types.either types.path types.str;
       defaultText = "~/.config";
       description = ''
         Absolute path to directory holding application configurations.
@@ -64,7 +64,7 @@ in
     };
 
     dataHome = mkOption {
-      type = types.path;
+      type = types.either types.path types.str;
       defaultText = "~/.local/share";
       description = ''
         Absolute path to directory holding application data.

--- a/modules/programs/go.nix
+++ b/modules/programs/go.nix
@@ -94,8 +94,7 @@ in {
     })
 
     (mkIf (cfg.goBin != null) {
-      home.sessionVariables.GOBIN =
-        "${config.home.homeDirectory}/${cfg.goBin}";
+      home.sessionVariables.GOBIN = "${config.home.homeDirectory}/${cfg.goBin}";
     })
 
     (mkIf (cfg.goPrivate != [ ]) {

--- a/modules/programs/go.nix
+++ b/modules/programs/go.nix
@@ -88,14 +88,14 @@ in {
     }
 
     (mkIf (cfg.goPath != null) {
-      home.sessionVariables.GOPATH = concatStringsSep ":" (map builtins.toPath
+      home.sessionVariables.GOPATH = concatStringsSep ":"
         (map (path: "${config.home.homeDirectory}/${path}")
-          ([ cfg.goPath ] ++ cfg.extraGoPaths)));
+          ([ cfg.goPath ] ++ cfg.extraGoPaths));
     })
 
     (mkIf (cfg.goBin != null) {
       home.sessionVariables.GOBIN =
-        builtins.toPath "${config.home.homeDirectory}/${cfg.goBin}";
+        "${config.home.homeDirectory}/${cfg.goBin}";
     })
 
     (mkIf (cfg.goPrivate != [ ]) {


### PR DESCRIPTION
### Description

This gets `restrict-eval` and `pure-eval` working in home-manager. Some of this requires hacks, but I think it's useful to get to a point where this works. You can test it quickly by adding `--option restrict-eval true -I ~/.config/nixpkgs` to all home-manager commands. `pure-eval` should be equivalent to what flakes is doing, while `restrict-eval` is a little bit less strict (builtins.currentSystem and builtins.currentTime still work).

/cc @rycee @kisik21

### Checklist

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [N/A] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
