### PR TITLE
Add a prefix option overruling shortcut if defined

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -68,13 +68,21 @@ let
       bind -r L resize-pane -R ${toString cfg.resizeAmount}
     ''}
 
-    ${optionalString (cfg.shortcut != defaultShortcut) ''
-      # rebind main key: C-${cfg.shortcut}
-      unbind C-${defaultShortcut}
-      set -g prefix C-${cfg.shortcut}
-      bind ${cfg.shortcut} send-prefix
-      bind C-${cfg.shortcut} last-window
-    ''}
+    ${if cfg.prefix != null
+        then ''
+          # rebind main key: ${cfg.prefix}
+          unbind C-${defaultShortcut}
+          set -g prefix ${cfg.prefix}
+          bind ${cfg.prefix} send-prefix
+        ''
+        else optionalString (cfg.shortcut != defaultShortcut) ''
+          # rebind main key: C-${cfg.shortcut}
+          unbind C-${defaultShortcut}
+          set -g prefix C-${cfg.shortcut}
+          bind ${cfg.shortcut} send-prefix
+          bind C-${cfg.shortcut} last-window
+        ''
+     }
 
     ${optionalString cfg.disableConfirmationPrompt ''
       bind-key & kill-window
@@ -235,6 +243,15 @@ in
           Run the sensible plugin at the top of the configuration. It
           is possible to override the sensible settings using the
           <option>programs.tmux.extraConfig</option> option.
+        '';
+      };
+
+      prefix = mkOption {
+        default = null;
+        example = "C-a";
+        type = types.nullOr types.str;
+        description = ''
+          Set the prefix key. Overrules the "shortcut" option when set.
         '';
       };
 

--- a/tests/modules/programs/tmux/default.nix
+++ b/tests/modules/programs/tmux/default.nix
@@ -5,4 +5,6 @@
   tmux-secure-socket-enabled = ./secure-socket-enabled.nix;
   tmux-disable-confirmation-prompt = ./disable-confirmation-prompt.nix;
   tmux-default-shell = ./default-shell.nix;
+  tmux-shortcut-without-prefix = ./shortcut-without-prefix.nix;
+  tmux-prefix = ./prefix.nix;
 }

--- a/tests/modules/programs/tmux/prefix.conf
+++ b/tests/modules/programs/tmux/prefix.conf
@@ -1,0 +1,32 @@
+# ============================================= #
+# Start with defaults from the Sensible plugin  #
+# --------------------------------------------- #
+run-shell @sensible_rtp@
+# ============================================= #
+
+set  -g default-terminal "screen"
+set  -g base-index      0
+setw -g pane-base-index 0
+
+
+
+
+
+set -g status-keys emacs
+set -g mode-keys   emacs
+
+
+
+# rebind main key: C-a
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+
+
+
+
+setw -g aggressive-resize off
+setw -g clock-mode-style  12
+set  -s escape-time       500
+set  -g history-limit     2000
+

--- a/tests/modules/programs/tmux/prefix.nix
+++ b/tests/modules/programs/tmux/prefix.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.tmux = {
+      enable = true;
+      prefix = "C-a";
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        tmuxPlugins = super.tmuxPlugins // {
+          sensible = super.tmuxPlugins.sensible // { rtp = "@sensible_rtp@"; };
+        };
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.tmux.conf
+      assertFileContent home-files/.tmux.conf \
+        ${./prefix.conf}
+    '';
+  };
+}

--- a/tests/modules/programs/tmux/shortcut-without-prefix.conf
+++ b/tests/modules/programs/tmux/shortcut-without-prefix.conf
@@ -1,0 +1,33 @@
+# ============================================= #
+# Start with defaults from the Sensible plugin  #
+# --------------------------------------------- #
+run-shell @sensible_rtp@
+# ============================================= #
+
+set  -g default-terminal "screen"
+set  -g base-index      0
+setw -g pane-base-index 0
+
+
+
+
+
+set -g status-keys emacs
+set -g mode-keys   emacs
+
+
+
+# rebind main key: C-a
+unbind C-b
+set -g prefix C-a
+bind a send-prefix
+bind C-a last-window
+
+
+
+
+setw -g aggressive-resize off
+setw -g clock-mode-style  12
+set  -s escape-time       500
+set  -g history-limit     2000
+

--- a/tests/modules/programs/tmux/shortcut-without-prefix.nix
+++ b/tests/modules/programs/tmux/shortcut-without-prefix.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.tmux = {
+      enable = true;
+      shortcut = "a";
+      prefix = null;
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        tmuxPlugins = super.tmuxPlugins // {
+          sensible = super.tmuxPlugins.sensible // { rtp = "@sensible_rtp@"; };
+        };
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.tmux.conf
+      assertFileContent home-files/.tmux.conf \
+        ${./shortcut-without-prefix.conf}
+    '';
+  };
+}


### PR DESCRIPTION
<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description

It was not possible to set an arbitrary tmux prefix, ctrl was hardcoded
in the module.
To avoid breaking existing configs I implemented a new option which can
conveniently use the tmux terminology but defaults to null and doesn't
affect behavior when set to null.
I did not completely replicate the behavior for the shortcut option,
i.e., I do not bind "b" to send-prefix but stick to the default of the
prefix binding sending prefix (C-b C-b instead of C-b b) and I do not
bind repetition of the prefix (C-b C-b) to `last-window`, both of these
bring the option closer to the default tmux configuration.

Fixes #1237

I added a test for the new option and one to ensure it doesn't break the old one when set to null.

### Checklist

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.