### PR TITLE
syncthing: make syncthing tray package configurable

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2000,6 +2000,27 @@ in
           login shells.
         '';
       }
+
+      {
+        time = "2021-05-18T12:22:42+00:00";
+        condition = config.services.syncthing != {};
+        message = ''
+          Setting 'services.syncthing.tray' as a boolean will be deprecated in
+          the future.
+
+          This is to make the syncthing tray package configurable, with
+          `services.syncthing.tray.package`, following QSyncthingTray becoming
+          no longer actively maintained. The default syncthing tray package has
+          also changed to https://github.com/Martchus/syncthingtray. To
+          continue as before, set `services.syncthing.tray.enable`.
+
+          See
+
+            https://github.com/nix-community/home-manager/pulls/1257
+
+          for discussion.
+        '';
+      }
     ];
   };
 }

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -10,9 +10,34 @@ with lib;
       enable = mkEnableOption "Syncthing continuous file synchronization";
 
       tray = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable QSyncthingTray service.";
+        type = with types;
+          either bool (submodule {
+            options = {
+              enable = mkOption {
+                type = types.bool;
+                default = false;
+                description = "Whether to enable a syncthing tray service.";
+              };
+
+              command = mkOption {
+                type = types.str;
+                default = "syncthingtray";
+                defaultText = literalExample "syncthingtray";
+                example = literalExample "qsyncthingtray";
+                description = "Syncthing tray command to use.";
+              };
+
+              package = mkOption {
+                type = types.package;
+                default = pkgs.syncthingtray-minimal;
+                defaultText = literalExample "pkgs.syncthingtray-minimal";
+                example = literalExample "pkgs.qsyncthingtray";
+                description = "Syncthing tray package to use.";
+              };
+            };
+          });
+        default = { enable = false; };
+        description = "Syncthing tray service configuration.";
       };
     };
   };
@@ -43,28 +68,57 @@ with lib;
       };
     })
 
-    (mkIf config.services.syncthing.tray {
-      systemd.user.services = {
-        qsyncthingtray = {
-          Unit = {
-            Description = "QSyncthingTray";
-            After = [
-              "graphical-session-pre.target"
-              "polybar.service"
-              "taffybar.service"
-              "stalonetray.service"
-            ];
-            PartOf = [ "graphical-session.target" ];
-          };
+    (mkIf (isAttrs config.services.syncthing.tray
+      && config.services.syncthing.tray.enable) {
+        systemd.user.services = {
+          ${config.services.syncthing.tray.package.pname} = {
+            Unit = {
+              Description = config.services.syncthing.tray.package.pname;
+              After = [
+                "graphical-session-pre.target"
+                "polybar.service"
+                "taffybar.service"
+                "stalonetray.service"
+              ];
+              PartOf = [ "graphical-session.target" ];
+            };
 
-          Service = {
-            Environment = "PATH=${config.home.profileDirectory}/bin";
-            ExecStart = "${pkgs.qsyncthingtray}/bin/QSyncthingTray";
-          };
+            Service = {
+              ExecStart =
+                "${config.services.syncthing.tray.package}/bin/${config.services.syncthing.tray.command}";
+            };
 
-          Install = { WantedBy = [ "graphical-session.target" ]; };
+            Install = { WantedBy = [ "graphical-session.target" ]; };
+          };
         };
-      };
-    })
+      })
+
+    # deprecated
+    (mkIf (isBool config.services.syncthing.tray
+      && config.services.syncthing.tray) {
+        systemd.user.services = {
+          "syncthingtray" = {
+            Unit = {
+              Description = "syncthingtray";
+              After = [
+                "graphical-session-pre.target"
+                "polybar.service"
+                "taffybar.service"
+                "stalonetray.service"
+              ];
+              PartOf = [ "graphical-session.target" ];
+            };
+
+            Service = {
+              ExecStart = "${pkgs.syncthingtray-minimal}/bin/syncthingtray";
+            };
+
+            Install = { WantedBy = [ "graphical-session.target" ]; };
+          };
+        };
+        warnings = [
+          "Specifying 'services.syncthing.tray' as a boolean is deprecated, set 'services.syncthing.tray.enable' instead. See https://github.com/nix-community/home-manager/pull/1257."
+        ];
+      })
   ];
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -114,6 +114,7 @@ import nmt {
     ./modules/services/polybar
     ./modules/services/redshift-gammastep
     ./modules/services/sxhkd
+    ./modules/services/syncthing
     ./modules/services/window-managers/i3
     ./modules/services/window-managers/sway
     ./modules/services/wlsunset

--- a/tests/modules/services/syncthing/default.nix
+++ b/tests/modules/services/syncthing/default.nix
@@ -1,0 +1,4 @@
+{
+  syncthing-tray = ./tray.nix;
+  syncthing-tray-as-bool-triggers-warning = ./tray-as-bool-triggers-warning.nix;
+}

--- a/tests/modules/services/syncthing/tray-as-bool-triggers-warning.nix
+++ b/tests/modules/services/syncthing/tray-as-bool-triggers-warning.nix
@@ -1,0 +1,17 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    services.syncthing.tray = true;
+
+    test.asserts.warnings.expected = [
+      "Specifying 'services.syncthing.tray' as a boolean is deprecated, set 'services.syncthing.tray.enable' instead. See https://github.com/nix-community/home-manager/pull/1257."
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/systemd/user/syncthingtray.service
+    '';
+  };
+}

--- a/tests/modules/services/syncthing/tray.nix
+++ b/tests/modules/services/syncthing/tray.nix
@@ -1,0 +1,13 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    services.syncthing.tray.enable = true;
+
+    nmt.script = ''
+      assertFileExists home-files/.config/systemd/user/syncthingtray.service
+    '';
+  };
+}


### PR DESCRIPTION
Also sets the default syncthing tray package to
https://github.com/Martchus/syncthingtray instead of
https://github.com/sieren/QSyncthingTray, which indirectly fixes #603

<!--

  Please fill the description and checklist to the best of your
  ability.

-->

### Description



### Checklist

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/CONTRIBUTING.md#commits) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
