### PR TITLE
home-manager: Add --upgrade option

### DIFF
--- a/doc/man-home-manager.xml
+++ b/doc/man-home-manager.xml
@@ -136,14 +136,18 @@
     
    <arg>
     <group choice="req"> 
-    <arg choice="plain">
-     -v
-    </arg>
-     
-    <arg choice="plain">
-     --verbose
-    </arg>
-     </group>
+     <arg choice="plain">
+      -v
+     </arg>
+      
+     <arg choice="plain">
+      --verbose
+     </arg>
+    </group>
+   </arg>
+    
+   <arg>
+    --upgrade
    </arg>
   </cmdsynopsis>
  </refsynopsisdiv>
@@ -486,6 +490,16 @@
     <listitem>
      <para>
       Activates verbose output.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--upgrade</option>
+    </term>
+    <listitem>
+     <para>
+      Fetch the latest versions for all user nix-channels
      </para>
     </listitem>
    </varlistentry>

--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -56,6 +56,7 @@
 # --dry-run
 # -v
 # --verbose
+# --upgrade
 # build
 # edit
 # expire-generations
@@ -108,6 +109,7 @@
 #   --dry-run
 #   -h
 #   --help
+#   --upgrade
 
 # $ home-manager
 #
@@ -124,6 +126,7 @@
 #   -v           Verbose output
 #   -n           Do a dry run, only prints what actions would be taken
 #   -h           Print this help
+#   --upgrade    Fetch the latest versions for all user nix-channels
 #
 # Commands
 #
@@ -285,7 +288,7 @@ _home-manager_completions ()
     #--------------------------#
 
     local Options
-    Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" "--verbose" "--show-trace" )
+    Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" "--verbose" "--show-trace" "--upgrade" )
 
     # ^ « home-manager »'s options.
 

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -349,6 +349,17 @@ function doShowNews() {
     fi
 }
 
+function maybeUpdateChannels() {
+    # If the --upgrade flag is given, we update channels
+    if [[ ${DO_UPDATE_CHANNELS-} != 1 ]]; then
+        return
+    fi
+
+    setVerboseAndDryRun
+
+    $DRY_RUN_CMD nix-channel --update
+}
+
 function doUninstall() {
     setVerboseAndDryRun
 
@@ -413,6 +424,8 @@ function doHelp() {
     echo "  -v           Verbose output"
     echo "  -n           Do a dry run, only prints what actions would be taken"
     echo "  -h           Print this help"
+    echo "  --upgrade    Fetch the latest versions for all user nix-channels"
+    echo
     echo
     echo "Options passed on to nix-build(1)"
     echo
@@ -505,6 +518,9 @@ while [[ $# -gt 0 ]]; do
         -v|--verbose)
             export VERBOSE=1
             ;;
+        --upgrade)
+            export DO_UPDATE_CHANNELS=1
+            ;;
         *)
             case $COMMAND in
                 expire-generations|remove-generations)
@@ -530,12 +546,15 @@ case $COMMAND in
         doEdit
         ;;
     build)
+        maybeUpdateChannels
         doBuild
         ;;
     instantiate)
+        maybeUpdateChannels
         doInstantiate
         ;;
     switch)
+        maybeUpdateChannels
         doSwitch
         ;;
     generations)


### PR DESCRIPTION
### Description

Adds a `--upgrade` option that mirrors a similar
option in `nixos-rebuild`.
If option is given, it will perform `nix-channel --update`
before build, instantiate and switch commands.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
