### PR TITLE
home-environment: allow adding to $PATH

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -264,6 +264,17 @@ in
       '';
     };
 
+    home.sessionPath = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      example = [
+        ".git/safe/../../bin"
+        "\${xdg.configHome}/emacs/bin"
+        "~/.local/bin"
+      ];
+      description = "Extra directories to add to <envar>PATH</envar>.";
+    };
+
     home.sessionVariablesExtra = mkOption {
       type = types.lines;
       default = "";
@@ -446,6 +457,8 @@ in
             export __HM_SESS_VARS_SOURCED=1
 
             ${config.lib.shell.exportAll cfg.sessionVariables}
+          '' + lib.optionalString (cfg.sessionPath != [ ]) ''
+            export PATH="$PATH''${PATH:+:}${concatStringsSep ":" cfg.sessionPath}"
           '' + cfg.sessionVariablesExtra;
         }
       )

--- a/tests/modules/home-environment/default.nix
+++ b/tests/modules/home-environment/default.nix
@@ -1,3 +1,4 @@
 {
   home-session-variables = ./session-variables.nix;
+  home-session-path = ./session-path.nix;
 }

--- a/tests/modules/home-environment/session-path.nix
+++ b/tests/modules/home-environment/session-path.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ({ ... }: { config.home.sessionPath = [ "foo" ]; })
+    ({ ... }: { config.home.sessionPath = [ "bar" "baz" ]; })
+  ];
+
+  nmt.script = ''
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileContent \
+      home-path/etc/profile.d/hm-session-vars.sh \
+      ${
+        pkgs.writeText "session-path-expected.txt" ''
+          # Only source this once.
+          if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
+          export __HM_SESS_VARS_SOURCED=1
+
+          export XDG_CACHE_HOME="/home/hm-user/.cache"
+          export XDG_CONFIG_HOME="/home/hm-user/.config"
+          export XDG_DATA_HOME="/home/hm-user/.local/share"
+          export PATH="$PATH''${PATH:+:}bar:baz:foo"
+        ''
+      }
+  '';
+
+}


### PR DESCRIPTION
### Description

Sometimes I'll have some things installed to my dot files that provide
a collection of executables (doom-emacs, org-capture), or need a
`$HOME/bin` or similar to keep a handful of quick scripts and wanted to
be able to do it decrlaratively.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
