### PR TITLE
accounts: Allow sendMailCommand to be set only once per account.

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -240,6 +240,15 @@ let
         '';
       };
 
+      sendMailCommand = mkOption {
+        type = types.nullOr types.str;
+        description = ''
+          Command to send a mail. If msmtp is enabled for the account,
+          then this is set to
+          <command>msmtpq --read-envelope-from --read-recipients</command>.
+        '';
+      };
+
       folders = mkOption {
         type = types.submodule {
           options = {

--- a/modules/programs/alot-accounts.nix
+++ b/modules/programs/alot-accounts.nix
@@ -7,10 +7,10 @@ with lib;
   options.alot = {
     sendMailCommand = mkOption {
       type = types.nullOr types.str;
+      default = config.sendMailCommand;
       description = ''
-        Command to send a mail. If msmtp is enabled for the account,
-        then this is set to
-        <command>msmtpq --read-envelope-from --read-recipients</command>.
+        Override command to send a mail. Defaults to this account's
+        sendMailCommand.
       '';
     };
 
@@ -47,12 +47,5 @@ with lib;
         Extra settings to add to this Alot account configuration.
       '';
     };
-  };
-
-  config = mkIf config.notmuch.enable {
-    alot.sendMailCommand = mkOptionDefault (if config.msmtp.enable then
-      "msmtpq --read-envelope-from --read-recipients"
-    else
-      null);
   };
 }

--- a/modules/programs/astroid-accounts.nix
+++ b/modules/programs/astroid-accounts.nix
@@ -8,10 +8,10 @@ with lib;
 
     sendMailCommand = mkOption {
       type = types.str;
+      default = config.sendMailCommand;
       description = ''
-        Command to send a mail. If msmtp is enabled for the account,
-        then this is set to
-        <command>msmtpq --read-envelope-from --read-recipients</command>.
+        Override command to send a mail. Defaults to this account's
+        sendMailCommand.
       '';
     };
 
@@ -23,10 +23,5 @@ with lib;
         Extra settings to add to this astroid account configuration.
       '';
     };
-  };
-
-  config = mkIf config.notmuch.enable {
-    astroid.sendMailCommand = mkIf config.msmtp.enable
-      (mkOptionDefault "msmtpq --read-envelope-from --read-recipients");
   };
 }

--- a/modules/programs/msmtp-accounts.nix
+++ b/modules/programs/msmtp-accounts.nix
@@ -45,4 +45,11 @@ with lib;
       '';
     };
   };
+
+  config = {
+    sendMailCommand = mkOptionDefault (if config.msmtp.enable then
+      "msmtpq --read-envelope-from --read-recipients"
+    else
+      null);
+  };
 }

--- a/modules/programs/neomutt-accounts.nix
+++ b/modules/programs/neomutt-accounts.nix
@@ -8,19 +8,12 @@ with lib;
 
     sendMailCommand = mkOption {
       type = types.nullOr types.str;
-      default = if config.msmtp.enable then
-        "msmtpq --read-envelope-from --read-recipients"
-      else
-        null;
-      defaultText = literalExample ''
-        if config.msmtp.enable then
-          "msmtpq --read-envelope-from --read-recipients"
-        else
-          null
-      '';
+      default = config.sendMailCommand;
       example = "msmtpq --read-envelope-from --read-recipients";
       description = ''
-        Command to send a mail. If not set, neomutt will be in charge of sending mails.
+        Override command to send a mail. Defaults to this account's
+        sendMailCommand.
+        If not set or null, neomutt will be in charge of sending mails.
       '';
     };
 


### PR DESCRIPTION
### Description

There was three different account configs with almost identical default configuration. We can move that configuration up for much cleaner configs both for the user and for the modules.

If you are using notmuch, it is somewhat reasonable to switch between neomutt and astroid.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
