### PR TITLE
flameshot: fix issues (probably race condition) with the tray icon and taffybar

### DIFF
--- a/modules/services/flameshot.nix
+++ b/modules/services/flameshot.nix
@@ -22,6 +22,7 @@ in {
           "graphical-session-pre.target"
           "polybar.service"
           "stalonetray.service"
+          "status-notifier-watcher.service"
           "taffybar.service"
         ];
         PartOf = [ "graphical-session.target" ];
@@ -31,6 +32,9 @@ in {
 
       Service = {
         Environment = "PATH=${config.home.profileDirectory}/bin";
+        # There seems to be a race condition with taffybars status-notifier-watcher:
+        # no tray icon although service is started after taffybar and status-notifier-watcher
+        ExecStartPre = "${pkgs.coreutils}/bin/sleep 1";
         ExecStart = "${package}/bin/flameshot";
         Restart = "on-abort";
       };


### PR DESCRIPTION
### Description

I had quite some issues with the sni tray icon of flameshot and taffybar:
The tray icon hasn't showed up after start, although flameshot was running.

Flameshot starts after the taffybar and status-notifier-watcher service has started (I checked the systemd log).
Both are configured as well with home-manager.

My rather *hacky* fix is to start flameshot 1 second delayed.
Open for other suggestions, but I'm not sure if there currently is a better fix for this issue.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
