### PR TITLE
newsboat: use XDG config directory

### DIFF
--- a/modules/programs/newsboat.nix
+++ b/modules/programs/newsboat.nix
@@ -94,7 +94,7 @@ in {
 
   config = mkIf cfg.enable {
     home.packages = [ pkgs.newsboat ];
-    home.file.".newsboat/urls".text = let
+    xdg.configFile."newsboat/urls".text = let
       mkUrlEntry = u:
         concatStringsSep " " ([ u.url ] ++ map wrapQuote u.tags
           ++ optional (u.title != null) (wrapQuote "~${u.title}"));
@@ -108,7 +108,7 @@ in {
     else
       urls ++ queries) + "\n";
 
-    home.file.".newsboat/config".text = ''
+    xdg.configFile."newsboat/config".text = ''
       max-items ${toString cfg.maxItems}
       browser ${cfg.browser}
       reload-threads ${toString cfg.reloadThreads}

--- a/tests/modules/programs/newsboat/newsboat-basics-2003.nix
+++ b/tests/modules/programs/newsboat/newsboat-basics-2003.nix
@@ -28,7 +28,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.newsboat/urls \
+        home-files/.config/newsboat/urls \
         ${./newsboat-basics-urls-2003.txt}
     '';
   };

--- a/tests/modules/programs/newsboat/newsboat-basics.nix
+++ b/tests/modules/programs/newsboat/newsboat-basics.nix
@@ -26,7 +26,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.newsboat/urls \
+        home-files/.config/newsboat/urls \
         ${./newsboat-basics-urls.txt}
     '';
   };


### PR DESCRIPTION
### Description
[5.14. XDG Base Directory Support](https://newsboat.org/releases/2.19/docs/newsboat.html#_xdg_base_directory_support)

### Checklist
- [x] Change is backwards compatible.

Note: configuration directory changed from `~/.newsboat/` to `$XDG_CONFIG_HOME/newsboat/`.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
