### PR TITLE
vim: Add support for optional packages in vim

### DIFF
--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -63,11 +63,7 @@ let
 
   optionalPlugins = let
     vpkgs = pkgs.vimPlugins;
-    getPkg = p:
-      if isDerivation p then
-        [ p ]
-      else
-        optional (isString p && hasAttr p vpkgs) vpkgs.${p};
+    getPkg = p: [ p ];
   in concatMap getPkg cfg.optionalPlugins;
 
 in {
@@ -176,8 +172,8 @@ in {
     };
   in mkIf cfg.enable {
     assertions = let
-      packagesNotFound = filter (p: isString p && (!hasAttr p pkgs.vimPlugins))
-        (cfg.plugins ++ cfg.optionalPlugins);
+      packagesNotFound =
+        filter (p: isString p && (!hasAttr p pkgs.vimPlugins)) cfg.plugins;
     in [{
       assertion = packagesNotFound == [ ];
       message = "Following VIM plugin not found in pkgs.vimPlugins: ${
@@ -185,13 +181,12 @@ in {
         }";
     }];
 
-    warnings =
-      let stringPlugins = filter isString (cfg.plugins ++ cfg.optionalPlugins);
-      in optional (stringPlugins != [ ]) ''
-        Specifying VIM plugins using strings is deprecated, found ${
-          concatMapStringsSep ", " (p: ''"${p}"'') stringPlugins
-        } as strings.
-      '';
+    warnings = let stringPlugins = filter isString cfg.plugins;
+    in optional (stringPlugins != [ ]) ''
+      Specifying VIM plugins using strings is deprecated, found ${
+        concatMapStringsSep ", " (p: ''"${p}"'') stringPlugins
+      } as strings.
+    '';
 
     home.packages = [ cfg.package ];
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -63,6 +63,7 @@ import nmt {
     ./modules/programs/starship
     ./modules/programs/texlive
     ./modules/programs/tmux
+    ./modules/programs/vim
     ./modules/programs/zplug
     ./modules/programs/zsh
     ./modules/xresources

--- a/tests/modules/programs/vim/default.nix
+++ b/tests/modules/programs/vim/default.nix
@@ -1,0 +1,4 @@
+{
+  vim-install = ./install.nix;
+  vim-plugins = ./plugins.nix;
+}

--- a/tests/modules/programs/vim/install.nix
+++ b/tests/modules/programs/vim/install.nix
@@ -11,6 +11,7 @@ with lib;
     };
 
     nmt.script = ''
+      # files aren't created in the $TESTED dir
       function assertAbsoluteFileExists() {
         if [[ ! -f "$1" ]]; then
           fail "Expected $1 to exist but it was not found."
@@ -23,11 +24,11 @@ with lib;
         fi
       }
 
-
       assertFileExists home-path/bin/vim
       assertFileIsExecutable home-path/bin/vim
 
-      rc_file=$(find /nix/store/ -type f -iname '*-vimrc' -not -iname '*nixos*' | tail -n1)
+      # load the rc file from the nix shim
+      rc_file=$(tail -n1 "$TESTED/home-path/bin/vim" | cut -d " " -f 4)
       assertAbsoluteFileExists "$rc_file"
       assertAbsoluteFileContains "$rc_file" "set background=dark"
     '';

--- a/tests/modules/programs/vim/install.nix
+++ b/tests/modules/programs/vim/install.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.vim = {
+      enable = true;
+
+      settings = { background = "dark"; };
+    };
+
+    nmt.script = ''
+      function assertAbsoluteFileExists() {
+        if [[ ! -f "$1" ]]; then
+          fail "Expected $1 to exist but it was not found."
+        fi
+      }
+
+      function assertAbsoluteFileContains() {
+        if ! grep -qF "$2" "$1"; then
+          fail "Expected $1 to contain $2 but it did not."
+        fi
+      }
+
+
+      assertFileExists home-path/bin/vim
+      assertFileIsExecutable home-path/bin/vim
+
+      rc_file=$(find /nix/store/ -type f -iname '*-vimrc' -not -iname '*nixos*' | tail -n1)
+      assertAbsoluteFileExists "$rc_file"
+      assertAbsoluteFileContains "$rc_file" "set background=dark"
+    '';
+  };
+}
+

--- a/tests/modules/programs/vim/plugins.nix
+++ b/tests/modules/programs/vim/plugins.nix
@@ -14,7 +14,24 @@ with lib;
     };
 
     nmt.script = ''
-      assertDirectoryExists home-path/share/vim-plugins/fzf
+      # need to verify absolute locations
+      function assertAbsoluteDirExists() {
+        if [[ ! -d "$1" ]]; then
+          fail "Expected $1 to exist but it was not found."
+        fi
+      }
+
+      # load the rc file from the nix shim and fetch the runtimepath value
+      rc_file=$(tail -n1 "$TESTED/home-path/bin/vim" | cut -d " " -f 4)
+      pack_path=$(grep runtimepath "$rc_file" | cut -d = -f 2)/pack/home-manager
+
+      # start packages
+      assertAbsoluteDirExists "$pack_path/start/ack-vim"
+      assertAbsoluteDirExists "$pack_path/start/fzf"
+      assertAbsoluteDirExists "$pack_path/start/vim-sensible"
+
+      # optional packages
+      assertAbsoluteDirExists "$pack_path/opt/fzf-vim"
     '';
   };
 }

--- a/tests/modules/programs/vim/plugins.nix
+++ b/tests/modules/programs/vim/plugins.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.fzf.enable = true;
+
+    programs.vim = {
+      enable = true;
+
+      plugins = [ pkgs.vimPlugins.ack-vim ];
+      optionalPlugins = [ pkgs.vimPlugins.fzf-vim ];
+    };
+
+    nmt.script = ''
+      assertDirectoryExists home-path/share/vim-plugins/fzf
+    '';
+  };
+}


### PR DESCRIPTION
@rycee (didn't see a code owner for this module)

### Description

The vim package in nixpkgs supports both start and opt packages, where
the latter represents packages that should be installed but not
necessarily loaded on startup.

Currently, only startup plugins are supported, which means we need to load all plugins even when they aren't relevant. An example would be vim-go, which while super helpful for go files serves
little value when opening up a ruby file yet takes time/resources when starting up.

Loading of these optional plugins is done via autocmd commands added to
your vim config. See [here](https://nixos.wiki/wiki/Vim#Using_vim.27s_builtin_packaging_capability) for an example.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`.
- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

There were no tests for the existing module. I did my best to test the installation (in isolation) and then add a separate test for plugins. Had to get a beat on nmt, so pardon any sloppiness here. I'm happy to adjust as needed.