### PR TITLE
[WIP] picom: use structural settings instead of hardcoded options

### DIFF
--- a/modules/services/compton.nix
+++ b/modules/services/compton.nix
@@ -5,28 +5,8 @@ with lib; {
     old = n: [ "services" "compton" n ];
     new = n: [ "services" "picom" n ];
   in [
-    (mkRenamedOptionModule (old "activeOpacity") (new "activeOpacity"))
-    (mkRenamedOptionModule (old "backend") (new "backend"))
-    (mkRenamedOptionModule (old "blur") (new "blur"))
-    (mkRenamedOptionModule (old "blurExclude") (new "blurExclude"))
-    (mkRenamedOptionModule (old "extraOptions") (new "extraOptions"))
-    (mkRenamedOptionModule (old "fade") (new "fade"))
-    (mkRenamedOptionModule (old "fadeDelta") (new "fadeDelta"))
-    (mkRenamedOptionModule (old "fadeExclude") (new "fadeExclude"))
-    (mkRenamedOptionModule (old "fadeSteps") (new "fadeSteps"))
-    (mkRenamedOptionModule (old "inactiveDim") (new "inactiveDim"))
-    (mkRenamedOptionModule (old "inactiveOpacity") (new "inactiveOpacity"))
-    (mkRenamedOptionModule (old "menuOpacity") (new "menuOpacity"))
-    (mkRenamedOptionModule (old "noDNDShadow") (new "noDNDShadow"))
-    (mkRenamedOptionModule (old "noDockShadow") (new "noDockShadow"))
-    (mkRenamedOptionModule (old "opacityRule") (new "opacityRule"))
+    (mkRenamedOptionModule (old "settings") (new "settings"))
     (mkRenamedOptionModule (old "package") (new "package"))
-    (mkRenamedOptionModule (old "refreshRate") (new "refreshRate"))
-    (mkRenamedOptionModule (old "shadow") (new "shadow"))
-    (mkRenamedOptionModule (old "shadowExclude") (new "shadowExclude"))
-    (mkRenamedOptionModule (old "shadowOffsets") (new "shadowOffsets"))
-    (mkRenamedOptionModule (old "shadowOpacity") (new "shadowOpacity"))
-    (mkChangedOptionModule (old "vSync") (new "vSync") (v: v != "none"))
   ];
 
   options.services.compton.enable = mkEnableOption "Compton X11 compositor" // {


### PR DESCRIPTION
### Description

This PR introduces a structural `settings` option in the spirit of https://github.com/NixOS/rfcs/pull/42 and removes all other options that write to the picom config, which means that it is *not* backwards compatible.


Settings can look now e.g. as following (some of these options require [this PR](https://github.com/yshui/picom/pull/361))
```nix
{
  backend = "glx";
  vsync = false;
  refresh-rate = 0;
  unredir-if-possible = false;
  blur-background = true;
  blur-background-exclude = [ ];
  blur-method = "dual_kawase";
  blur-strength = 10;
  wintypes = {
    dock = {
      corner-radius = 4;
    };
    normal = {
      shadow = true;
    };
  };
  rounded-corners-exclude = [
    "window_type = 'menu'"
    "window_type = 'dock'"
    "window_type = 'dropdown_menu'"
    "window_type = 'popup_menu'"
    "class_g = 'Polybar'"
    "class_g = 'Rofi'"
    "class_g = 'Dunst'"
  ];
  detect-rounded-corners = true;
  corner-radius = 10;
  round-borders = 1;
  frame-opacity = builtins.fromJSON config.lib.base16.theme.alpha;
}
```

The current implementation is still quick and dirty, as I want to request if the removal of backwards compatibility is ok, before I'm investing more time into this.
The configuration converter is a *nix-only* expression and derived from `nixpkgs.lib.toPretty`.
I'm not sure if *nix-only* is the way to go, as there might be some expressions that are not evaluated early enough to primitive values due to lazy evaluation? (correct me if I'm wrong, I'm still new to nix...).

Maybe it is better to use `builtins.toJson` and something like [this converter](https://github.com/imZack/jsonlibconfig) to convert it finally into [libconfig](https://hyperrealm.github.io/libconfig/), the format that is used by picom?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
