### PR TITLE
neomutt: Added an option to specify virtual mailbox names.

### DIFF
--- a/modules/programs/neomutt-accounts.nix
+++ b/modules/programs/neomutt-accounts.nix
@@ -32,5 +32,24 @@ with lib;
         Extra lines to add to the folder hook for this account.
       '';
     };
+
+    onlyVirtualMailbox = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Don't use the mailboxes option of neomutt. Only use virtual-mailboxes.
+        Has no effect if notmuch is not enabled.
+      '';
+    };
+
+    virtualMailboxName = mkOption {
+      type = types.str;
+      default = "My INBOX";
+      description = ''
+        The name of virtual mailbox when using neomut and notmuch.
+        Has no effect if notmuch is not enabled.
+      '';
+    };
   };
 }

--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -128,9 +128,15 @@ let
     '';
 
   registerAccount = account:
-    with account; ''
+    with account;
+    let
+      mailboxes = if neomutt.onlyVirtualMailbox && account.notmuch.enable then
+        ""
+      else
+        ''mailboxes "${account.maildir.absPath}/${folders.inbox}"'';
+    in ''
       # register account ${name}
-      mailboxes "${account.maildir.absPath}/${folders.inbox}"
+      ${mailboxes}
       folder-hook ${account.maildir.absPath}/ " \
           source ${accountFilename account} "
     '';
@@ -167,7 +173,7 @@ let
     with account; ''
       # notmuch section
       set nm_default_uri = "notmuch://${config.accounts.email.maildirBasePath}"
-      virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
+      virtual-mailboxes "${neomutt.virtualMailboxName}" "notmuch://?query=tag:inbox"
     '';
 
   accountStr = account:


### PR DESCRIPTION


### Description

When using both neomutt and notmuch, virtual mailboxes previously were
named "My INBOX". This change makes it user configurable for each
account. The reasoning behind this change is partly due to neomutt/neomutt#2226
and partly just to allow personalization.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
