### PR TITLE
mu: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,6 +83,8 @@
 
 /modules/programs/mpv.nix                             @tadeokondrak
 
+/modules/programs/mu.nix                              @KarlJoad
+
 /modules/programs/ncmpcpp.nix                         @olmokramer
 /tests/modules/programs/ncmpcpp                       @olmokramer
 /tests/modules/programs/ncmpcpp-linux                 @olmokramer

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1680,6 +1680,13 @@ in
           A new module is available: 'programs.pet'.
         '';
       }
+
+      {
+        time = "2020-09-29T21:21:44+00:00";
+        message = ''
+          A new module is available: 'programs.mu'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -90,6 +90,7 @@ let
     (loadModule ./programs/mercurial.nix { })
     (loadModule ./programs/mpv.nix { })
     (loadModule ./programs/msmtp.nix { })
+    (loadModule ./programs/mu.nix { })
     (loadModule ./programs/ncmpcpp.nix { })
     (loadModule ./programs/ne.nix { })
     (loadModule ./programs/neomutt.nix { })

--- a/modules/programs/mu.nix
+++ b/modules/programs/mu.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.mu;
+
+  # Used to generate command line arguments that mu can operate with.
+  genCmdMaildir = path: "--maildir=" + path;
+
+  # Takes the list of accounts with mu.enable = true, and generates a
+  # command-line flag for initializing the mu database.
+  myAddresses = let
+    # List of account sets where mu.enable = true.
+    muAccounts =
+      filter (a: a.mu.enable) (attrValues config.accounts.email.accounts);
+    addrs = map (a: a.address) muAccounts;
+    # Prefix --my-address= to each account's address with mu.enable.
+    addMyAddress = map (addr: "--my-address=" + addr) addrs;
+  in concatStringsSep " " addMyAddress;
+
+in {
+  meta.maintainers = [ maintainers.KarlJoad ];
+
+  options = {
+    programs.mu = {
+      enable = mkEnableOption "mu, a maildir indexer and searcher";
+
+      # No options/config file present for mu, and program author will not be
+      # adding one soon. See https://github.com/djcb/mu/issues/882 for more
+      # information about this.
+    };
+
+    accounts.email.accounts = mkOption {
+      type = with types;
+        attrsOf
+        (submodule { options.mu.enable = mkEnableOption "mu indexing"; });
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.mu ];
+
+    home.activation.runMuInit = let
+      maildirOption = genCmdMaildir config.accounts.email.maildirBasePath;
+      dbLocation = config.xdg.cacheHome + "/mu";
+    in hm.dag.entryAfter [ "writeBoundary" ] ''
+      # If the database directory exists, then `mu init` should NOT be run.
+      # In theory, mu is the only thing that creates that directory, and it is
+      # only created during the initial index.
+      if [[ ! -d "${dbLocation}" ]]; then
+        $DRY_RUN_CMD mu init ${maildirOption} $VERBOSE_ARG;
+      fi
+    '';
+  };
+}


### PR DESCRIPTION
mu: add module

mu is a Maildir indexing program. Right now, there are 2 common
versions (that I know of) that are in-use: 1.2.x and 1.4.x.

Right now, the mu package maintainer does NOT anticipate adding a
configuration file, so there is no need to add options to allow that
to happen. Additionally, there are a few notable differences between
the 2. However, these options are handled as command-line
flags/options when performing the initial index and database creation.
These changes happened in v1.4, and are documented at
https://github.com/djcb/mu/releases/tag/1.4

mu: add myself, KarlJoad, as maintainer to Repo

### Description

<!--

Add the mu maildir indexer and searcher. Tested on NixOS 20.03, using the 20.03 channel nixexprs. 
This yields the 1.2.x version of mu. There are no configuration files that are created or used by this program.

All options are passed as command-line options during the initial index.

This has not yet been tested on other platforms, as I have none at my disposal.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
