### PR TITLE
WIP: Emacs backport

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,6 +92,8 @@
 
 /modules/services/dunst.nix                           @rycee
 
+/modules/services/emacs.nix                           @tadfisher
+
 /modules/services/flameshot.nix                       @moredhel
 
 /modules/services/gnome-keyring.nix                   @rycee

--- a/format
+++ b/format
@@ -35,7 +35,6 @@ find . -name '*.nix' \
   ! -path ./modules/programs/afew.nix \
   ! -path ./modules/programs/alot.nix \
   ! -path ./modules/programs/bash.nix \
-  ! -path ./modules/programs/emacs.nix \
   ! -path ./modules/programs/firefox.nix \
   ! -path ./modules/programs/gpg.nix \
   ! -path ./modules/programs/lesspipe.nix \

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1481,6 +1481,16 @@ in
           A new module is available: 'programs.dircolors'
         '';
       }
+
+      {
+        time = "2020-06-11T18:06:37+00:00";
+        condition = config.services.emacs.enable;
+        message = ''
+          The Emacs service now supports systemd socket activation.
+
+          It can be enabled through the option 'services.emacs.socketActivation.enable'.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -8,7 +8,7 @@ let
 
   # Copied from all-packages.nix, with modifications to support
   # overrides.
-  emacsPackages = let epkgs = pkgs.emacsPackagesGen cfg.package;
+  emacsPackages = let epkgs = pkgs.emacsPackagesFor cfg.package;
   in epkgs.overrideScope' cfg.overrides;
 
   emacsWithPackages = emacsPackages.emacsWithPackages;

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -8,16 +8,12 @@ let
 
   # Copied from all-packages.nix, with modifications to support
   # overrides.
-  emacsPackages =
-    let
-      epkgs = pkgs.emacsPackagesGen cfg.package;
-    in
-      epkgs.overrideScope' cfg.overrides;
+  emacsPackages = let epkgs = pkgs.emacsPackagesGen cfg.package;
+  in epkgs.overrideScope' cfg.overrides;
+
   emacsWithPackages = emacsPackages.emacsWithPackages;
 
-in
-
-{
+in {
   meta.maintainers = [ maintainers.rycee ];
 
   options = {
@@ -33,7 +29,7 @@ in
       };
 
       extraPackages = mkOption {
-        default = self: [];
+        default = self: [ ];
         type = hm.types.selectorFunction;
         defaultText = "epkgs: []";
         example = literalExample "epkgs: [ epkgs.emms epkgs.magit ]";
@@ -45,7 +41,7 @@ in
       };
 
       overrides = mkOption {
-        default = self: super: {};
+        default = self: super: { };
         type = hm.types.overlayFunction;
         defaultText = "self: super: {}";
         example = literalExample ''

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -7,9 +7,40 @@ let
   cfg = config.services.emacs;
   emacsCfg = config.programs.emacs;
   emacsBinPath = "${emacsCfg.finalPackage}/bin";
+  # Adapted from upstream emacs.desktop
+  clientDesktopItem = pkgs.makeDesktopItem rec {
+    name = "emacsclient";
+    desktopName = "Emacs Client";
+    genericName = "Text Editor";
+    comment = "Edit text";
+    mimeType =
+      "text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;";
+    exec = "${emacsBinPath}/emacsclient ${
+        concatStringsSep " " cfg.client.arguments
+      } %F";
+    icon = "emacs";
+    type = "Application";
+    terminal = "false";
+    categories = "Utility;TextEditor;";
+    extraEntries = ''
+      StartupWMClass=Emacs
+    '';
+  };
 
 in {
-  options.services.emacs = { enable = mkEnableOption "the Emacs daemon"; };
+  options.services.emacs = {
+    enable = mkEnableOption "the Emacs daemon";
+    client = {
+      enable = mkEnableOption "generation of Emacs client desktop file";
+      arguments = mkOption {
+        type = with types; listOf str;
+        default = [ "-c" ];
+        description = ''
+          Command-line arguments to pass to <command>emacsclient</command>.
+        '';
+      };
+    };
+  };
 
   config = mkIf cfg.enable {
     assertions = [{
@@ -38,5 +69,7 @@ in {
 
       Install = { WantedBy = [ "default.target" ]; };
     };
+
+    home.packages = optional cfg.client.enable clientDesktopItem;
   };
 }

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -7,6 +7,8 @@ let
   cfg = config.services.emacs;
   emacsCfg = config.programs.emacs;
   emacsBinPath = "${emacsCfg.finalPackage}/bin";
+  emacsVersion = getVersion emacsCfg.finalPackage;
+
   # Adapted from upstream emacs.desktop
   clientDesktopItem = pkgs.makeDesktopItem rec {
     name = "emacsclient";
@@ -27,9 +29,26 @@ let
     '';
   };
 
+  # Match the default socket path for the Emacs version so emacsclient continues
+  # to work without wrapping it. It might be worthwhile to allow customizing the
+  # socket path, but we would want to wrap emacsclient in the user profile to
+  # connect to the alternative socket by default for Emacs 26, and set
+  # EMACS_SOCKET_NAME for Emacs 27.
+  #
+  # As systemd doesn't perform variable expansion for the ListenStream param, we
+  # would also have to solve the problem of matching the shell path to the path
+  # used in the socket unit, which would likely involve templating. It seems of
+  # little value for the most common use case of one Emacs daemon per user
+  # session.
+  socketPath = if versionAtLeast emacsVersion "27" then
+    "%t/emacs/server"
+  else
+    "%T/emacs%U/server";
+
 in {
   options.services.emacs = {
     enable = mkEnableOption "the Emacs daemon";
+
     client = {
       enable = mkEnableOption "generation of Emacs client desktop file";
       arguments = mkOption {
@@ -40,36 +59,78 @@ in {
         '';
       };
     };
-  };
 
-  config = mkIf cfg.enable {
-    assertions = [{
-      assertion = emacsCfg.enable;
-      message = "The Emacs service module requires"
-        + " 'programs.emacs.enable = true'.";
-    }];
-
-    systemd.user.services.emacs = {
-      Unit = {
-        Description = "Emacs: the extensible, self-documenting text editor";
-        Documentation =
-          "info:emacs man:emacs(1) https://gnu.org/software/emacs/";
-
-        # Avoid killing the Emacs session, which may be full of
-        # unsaved buffers.
-        X-RestartIfChanged = false;
-      };
-
-      Service = {
-        ExecStart =
-          "${pkgs.runtimeShell} -l -c 'exec ${emacsBinPath}/emacs --fg-daemon'";
-        ExecStop = "${emacsBinPath}/emacsclient --eval '(kill-emacs)'";
-        Restart = "on-failure";
-      };
-
-      Install = { WantedBy = [ "default.target" ]; };
+    # Attrset for forward-compatibility; there may be a need to customize the
+    # socket path, though allowing for such is not easy to do as systemd socket
+    # units don't perform variable expansion for 'ListenStream'.
+    socketActivation = {
+      enable = mkEnableOption "systemd socket activation for the Emacs service";
     };
-
-    home.packages = optional cfg.client.enable clientDesktopItem;
   };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      assertions = [
+        {
+          assertion = emacsCfg.enable;
+          message = "The Emacs service module requires"
+            + " 'programs.emacs.enable = true'.";
+        }
+        {
+          assertion = cfg.socketActivation.enable
+            -> versionAtLeast emacsVersion "26";
+          message = "Socket activation requires Emacs 26 or newer.";
+        }
+      ];
+
+      systemd.user.services.emacs = {
+        Unit = {
+          Description = "Emacs: the extensible, self-documenting text editor";
+          Documentation =
+            "info:emacs man:emacs(1) https://gnu.org/software/emacs/";
+
+          # Avoid killing the Emacs session, which may be full of
+          # unsaved buffers.
+          X-RestartIfChanged = false;
+        };
+
+        Service = {
+          ExecStart = "${emacsBinPath}/emacs --fg-daemon${
+            # In case the user sets 'server-directory' or 'server-name' in
+            # their Emacs config, we want to specify the socket path explicitly
+            # so launching 'emacs.service' manually doesn't break emacsclient
+            # when using socket activation.
+              optionalString cfg.socketActivation.enable ''="${socketPath}"''
+            }";
+          # We use '(kill-emacs 0)' to avoid exiting with a failure code, which
+          # would restart the service immediately.
+          ExecStop = "${emacsBinPath}/emacsclient --eval '(kill-emacs 0)'";
+          Restart = "on-failure";
+        };
+      } // optionalAttrs (!cfg.socketActivation.enable) {
+        Install = { WantedBy = [ "default.target" ]; };
+      };
+
+      home.packages = optional cfg.client.enable clientDesktopItem;
+    }
+
+    (mkIf cfg.socketActivation.enable {
+      systemd.user.sockets.emacs = {
+        Unit = {
+          Description = "Emacs: the extensible, self-documenting text editor";
+          Documentation =
+            "info:emacs man:emacs(1) https://gnu.org/software/emacs/";
+        };
+
+        Socket = {
+          ListenStream = socketPath;
+          FileDescriptorName = "server";
+          SocketMode = "0600";
+          DirectoryMode = "0700";
+        };
+
+        Install = { WantedBy = [ "sockets.target" ]; };
+      };
+    })
+  ]);
 }

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -46,6 +46,8 @@ let
     "%T/emacs%U/server";
 
 in {
+  meta.maintainers = [ maintainers.tadfisher ];
+
   options.services.emacs = {
     enable = mkEnableOption "the Emacs daemon";
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -52,6 +52,7 @@ import nmt {
     ./modules/misc/xdg
     ./modules/misc/xsession
     ./modules/programs/abook
+    ./modules/services/emacs
     ./modules/programs/firefox
     ./modules/programs/getmail
     ./modules/services/lieer

--- a/tests/modules/services/emacs/default.nix
+++ b/tests/modules/services/emacs/default.nix
@@ -1,0 +1,5 @@
+{
+  emacs-service = ./emacs-service.nix;
+  emacs-socket-26 = ./emacs-socket-26.nix;
+  emacs-socket-27 = ./emacs-socket-27.nix;
+}

--- a/tests/modules/services/emacs/emacs-emacsclient.desktop
+++ b/tests/modules/services/emacs/emacs-emacsclient.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Exec=@emacs@/bin/emacsclient -c %F
+Terminal=false
+Name=Emacs Client
+Icon=emacs
+Comment=Edit text
+GenericName=Text Editor
+MimeType=text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;
+Categories=Utility;TextEditor;
+StartupWMClass=Emacs
+

--- a/tests/modules/services/emacs/emacs-service-emacs.service
+++ b/tests/modules/services/emacs/emacs-service-emacs.service
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=@emacs@/bin/emacs --fg-daemon
+ExecStop=@emacs@/bin/emacsclient --eval '(kill-emacs 0)'
+Restart=on-failure
+
+[Unit]
+Description=Emacs: the extensible, self-documenting text editor
+Documentation=info:emacs man:emacs(1) https://gnu.org/software/emacs/
+X-RestartIfChanged=false

--- a/tests/modules/services/emacs/emacs-service-emacs.service
+++ b/tests/modules/services/emacs/emacs-service-emacs.service
@@ -2,7 +2,7 @@
 WantedBy=default.target
 
 [Service]
-ExecStart=@emacs@/bin/emacs --fg-daemon
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon"
 ExecStop=@emacs@/bin/emacsclient --eval '(kill-emacs 0)'
 Restart=on-failure
 

--- a/tests/modules/services/emacs/emacs-service.nix
+++ b/tests/modules/services/emacs/emacs-service.nix
@@ -24,7 +24,12 @@ with lib;
       assertFileExists home-path/share/applications/emacsclient.desktop
 
       assertFileContent home-files/.config/systemd/user/emacs.service \
-                        ${./emacs-service-emacs.service}
+                        ${
+                          pkgs.substituteAll {
+                            inherit (pkgs) runtimeShell;
+                            src = ./emacs-service-emacs.service;
+                          }
+                        }
       assertFileContent home-path/share/applications/emacsclient.desktop \
                         ${./emacs-emacsclient.desktop}
     '';

--- a/tests/modules/services/emacs/emacs-service.nix
+++ b/tests/modules/services/emacs/emacs-service.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    nixpkgs.overlays = [
+      (self: super: rec {
+        emacs = pkgs.writeShellScriptBin "dummy-emacs" "" // {
+          outPath = "@emacs@";
+        };
+        emacsPackagesFor = _:
+          makeScope super.newScope (_: { emacsWithPackages = _: emacs; });
+      })
+    ];
+
+    programs.emacs.enable = true;
+    services.emacs.enable = true;
+    services.emacs.client.enable = true;
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/systemd/user/emacs.socket
+      assertFileExists home-files/.config/systemd/user/emacs.service
+      assertFileExists home-path/share/applications/emacsclient.desktop
+
+      assertFileContent home-files/.config/systemd/user/emacs.service \
+                        ${./emacs-service-emacs.service}
+      assertFileContent home-path/share/applications/emacsclient.desktop \
+                        ${./emacs-emacsclient.desktop}
+    '';
+  };
+}

--- a/tests/modules/services/emacs/emacs-socket-26-emacs.service
+++ b/tests/modules/services/emacs/emacs-socket-26-emacs.service
@@ -1,0 +1,9 @@
+[Service]
+ExecStart=@emacs@/bin/emacs --fg-daemon="%T/emacs%U/server"
+ExecStop=@emacs@/bin/emacsclient --eval '(kill-emacs 0)'
+Restart=on-failure
+
+[Unit]
+Description=Emacs: the extensible, self-documenting text editor
+Documentation=info:emacs man:emacs(1) https://gnu.org/software/emacs/
+X-RestartIfChanged=false

--- a/tests/modules/services/emacs/emacs-socket-26-emacs.service
+++ b/tests/modules/services/emacs/emacs-socket-26-emacs.service
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=@emacs@/bin/emacs --fg-daemon="%T/emacs%U/server"
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon='%T/emacs%U/server'"
 ExecStop=@emacs@/bin/emacsclient --eval '(kill-emacs 0)'
 Restart=on-failure
 

--- a/tests/modules/services/emacs/emacs-socket-26-emacs.socket
+++ b/tests/modules/services/emacs/emacs-socket-26-emacs.socket
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=sockets.target
+
+[Socket]
+DirectoryMode=0700
+FileDescriptorName=server
+ListenStream=%T/emacs%U/server
+SocketMode=0600
+
+[Unit]
+Description=Emacs: the extensible, self-documenting text editor
+Documentation=info:emacs man:emacs(1) https://gnu.org/software/emacs/

--- a/tests/modules/services/emacs/emacs-socket-26.nix
+++ b/tests/modules/services/emacs/emacs-socket-26.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    nixpkgs.overlays = [
+      (self: super: rec {
+        emacs = pkgs.writeShellScriptBin "dummy-emacs-26.3" "" // {
+          outPath = "@emacs@";
+        };
+        emacsPackagesFor = _:
+          makeScope super.newScope (_: { emacsWithPackages = _: emacs; });
+      })
+    ];
+
+    programs.emacs.enable = true;
+    services.emacs.enable = true;
+    services.emacs.client.enable = true;
+    services.emacs.socketActivation.enable = true;
+
+    nmt.script = ''
+      assertFileExists home-files/.config/systemd/user/emacs.socket
+      assertFileExists home-files/.config/systemd/user/emacs.service
+      assertFileExists home-path/share/applications/emacsclient.desktop
+
+      assertFileContent home-files/.config/systemd/user/emacs.socket \
+                        ${./emacs-socket-26-emacs.socket}
+      assertFileContent home-files/.config/systemd/user/emacs.service \
+                        ${./emacs-socket-26-emacs.service}
+      assertFileContent home-path/share/applications/emacsclient.desktop \
+                        ${./emacs-emacsclient.desktop}
+    '';
+  };
+}

--- a/tests/modules/services/emacs/emacs-socket-26.nix
+++ b/tests/modules/services/emacs/emacs-socket-26.nix
@@ -27,7 +27,12 @@ with lib;
       assertFileContent home-files/.config/systemd/user/emacs.socket \
                         ${./emacs-socket-26-emacs.socket}
       assertFileContent home-files/.config/systemd/user/emacs.service \
-                        ${./emacs-socket-26-emacs.service}
+                        ${
+                          pkgs.substituteAll {
+                            inherit (pkgs) runtimeShell;
+                            src = ./emacs-socket-26-emacs.service;
+                          }
+                        }
       assertFileContent home-path/share/applications/emacsclient.desktop \
                         ${./emacs-emacsclient.desktop}
     '';

--- a/tests/modules/services/emacs/emacs-socket-27-emacs.service
+++ b/tests/modules/services/emacs/emacs-socket-27-emacs.service
@@ -1,0 +1,9 @@
+[Service]
+ExecStart=@emacs@/bin/emacs --fg-daemon="%t/emacs/server"
+ExecStop=@emacs@/bin/emacsclient --eval '(kill-emacs 0)'
+Restart=on-failure
+
+[Unit]
+Description=Emacs: the extensible, self-documenting text editor
+Documentation=info:emacs man:emacs(1) https://gnu.org/software/emacs/
+X-RestartIfChanged=false

--- a/tests/modules/services/emacs/emacs-socket-27-emacs.service
+++ b/tests/modules/services/emacs/emacs-socket-27-emacs.service
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=@emacs@/bin/emacs --fg-daemon="%t/emacs/server"
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon='%t/emacs/server'"
 ExecStop=@emacs@/bin/emacsclient --eval '(kill-emacs 0)'
 Restart=on-failure
 

--- a/tests/modules/services/emacs/emacs-socket-27-emacs.socket
+++ b/tests/modules/services/emacs/emacs-socket-27-emacs.socket
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=sockets.target
+
+[Socket]
+DirectoryMode=0700
+FileDescriptorName=server
+ListenStream=%t/emacs/server
+SocketMode=0600
+
+[Unit]
+Description=Emacs: the extensible, self-documenting text editor
+Documentation=info:emacs man:emacs(1) https://gnu.org/software/emacs/

--- a/tests/modules/services/emacs/emacs-socket-27.nix
+++ b/tests/modules/services/emacs/emacs-socket-27.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+in {
+  config = {
+    nixpkgs.overlays = [
+      (self: super: rec {
+        emacs = pkgs.writeShellScriptBin "dummy-emacs-27.0.91" "" // {
+          outPath = "@emacs@";
+        };
+        emacsPackagesFor = _:
+          makeScope super.newScope (_: { emacsWithPackages = _: emacs; });
+      })
+    ];
+
+    programs.emacs.enable = true;
+    services.emacs.enable = true;
+    services.emacs.client.enable = true;
+    services.emacs.socketActivation.enable = true;
+
+    nmt.script = ''
+      assertFileExists home-files/.config/systemd/user/emacs.socket
+      assertFileExists home-files/.config/systemd/user/emacs.service
+      assertFileExists home-path/share/applications/emacsclient.desktop
+
+      assertFileContent home-files/.config/systemd/user/emacs.socket \
+                        ${./emacs-socket-27-emacs.socket}
+      assertFileContent home-files/.config/systemd/user/emacs.service \
+                        ${./emacs-socket-27-emacs.service}
+      assertFileContent home-path/share/applications/emacsclient.desktop \
+                        ${./emacs-emacsclient.desktop}
+    '';
+  };
+}

--- a/tests/modules/services/emacs/emacs-socket-27.nix
+++ b/tests/modules/services/emacs/emacs-socket-27.nix
@@ -29,7 +29,12 @@ in {
       assertFileContent home-files/.config/systemd/user/emacs.socket \
                         ${./emacs-socket-27-emacs.socket}
       assertFileContent home-files/.config/systemd/user/emacs.service \
-                        ${./emacs-socket-27-emacs.service}
+                        ${
+                          pkgs.substituteAll {
+                            inherit (pkgs) runtimeShell;
+                            src = ./emacs-socket-27-emacs.service;
+                          }
+                        }
       assertFileContent home-path/share/applications/emacsclient.desktop \
                         ${./emacs-emacsclient.desktop}
     '';


### PR DESCRIPTION
### Description

Backport emacs changes because `.desktop` and socket activation is cool.

Unfortunately, client seems to hang when i try to connect to socket-activated server. :/ I'll try logging in again perhaps.

CC @tadfisher 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
