### PR TITLE
services.autoupgrade: init

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -122,6 +122,7 @@ let
     (loadModule ./programs/zoxide.nix { })
     (loadModule ./programs/zplug.nix { })
     (loadModule ./programs/zsh.nix { })
+    (loadModule ./services/auto-upgrade.nix { })
     (loadModule ./services/blueman-applet.nix { })
     (loadModule ./services/cbatticon.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/clipmenu.nix { condition = hostPlatform.isLinux; })

--- a/modules/services/auto-upgrade.nix
+++ b/modules/services/auto-upgrade.nix
@@ -1,0 +1,94 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.autoUpgrade; in
+
+{
+
+  options = {
+
+    services.autoUpgrade = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to periodically upgrade NixOS to the latest
+          version. If enabled, a systemd timer will run
+          <literal>nixos-rebuild switch --upgrade</literal> once a
+          day.
+        '';
+      };
+
+      # channel = mkOption {
+      #   type = types.nullOr types.str;
+      #   default = null;
+      #   example = "https://nixos.org/channels/nixos-14.12-small";
+      #   description = ''
+      #     The URI of the NixOS channel to use for automatic
+      #     upgrades. By default, this is the channel set using
+      #     <command>nix-channel</command> (run <literal>nix-channel
+      #     --list</literal> to see the current value).
+      #   '';
+      # };
+
+      flags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [ "-I" "stuff=/home/alice/nixos-stuff" "--option" "extra-binary-caches" "http://my-cache.example.org/" ];
+        description = ''
+          Any additional flags passed to <command>nixos-rebuild</command>.
+        '';
+      };
+
+      frequency = mkOption {
+        type = types.str;
+        default = "*:0/5";
+        description = ''
+          How often to update home-manager
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    services.autoUpgrade.flags =
+      # "--no-build-output"
+      [  ]
+      # ++ (if cfg.channel == null
+      #     then [ "--upgrade" ]
+      #     else [ "-I" "nixpkgs=${cfg.channel}/nixexprs.tar.xz" ]);
+      ;
+
+
+    systemd.user.services.home-manager-update = {
+      Unit = {
+        Description = "Home-manager update";
+      };
+
+      Service = {
+        Type = "oneshot";
+        # always forbidden for oneshot
+        Restart = "on-abort";
+        RestartSec = 12;
+
+        ExecStart = let
+            home-manager = "${pkgs.home-manager}/bin/home-manager";
+          in ''
+              ${home-manager} switch ${toString cfg.flags}
+          '';
+      };
+    };
+
+    systemd.user.timers.autoUpgrade = {
+      Unit = { Description = "Home-manager periodic update"; };
+      Timer = {
+        Unit = "home-manager-update.service";
+        OnCalendar = cfg.frequency;
+      };
+      Install = { WantedBy = [ "timers.target" ]; };
+    };
+  };
+}


### PR DESCRIPTION
autoswitch config:

Enable with
```
  services.autoUpgrade = {
    enable = true;
  };
```

I am trying to update a few ubuntu machines with a cronjob that fetches the config from the same repo and a cronjob that regenerates the home-manager configuration.

The service currently fails with
`2020-03-17/bin/home-manager: line 137: /tmp/home-manager-build.RDhiWMdKrh/news-info.sh: No such file or directory`
not sure I call home-manage right.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
