### PR TITLE
etesync-dav: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -184,6 +184,8 @@
 
 /modules/services/emacs.nix                           @tadfisher
 
+/modules/services/etesync-dav.nix                     @Valodim
+
 /modules/services/flameshot.nix                       @moredhel
 
 /modules/services/fluidsynth.nix                      @Valodim

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1946,7 +1946,7 @@ in
           A new module is available: 'programs.lazygit'.
         '';
       }
-      
+
       {
         time = "2021-04-27T00:00:00+00:00";
         message = ''
@@ -1954,6 +1954,13 @@ in
         '';
       }
 
+      {
+        time = "2021-05-06T20:47:37+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.etesync-dav'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -151,6 +151,7 @@ let
     (loadModule ./services/dunst.nix { })
     (loadModule ./services/dwm-status.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/emacs.nix { condition = hostPlatform.isLinux; })
+    (loadModule ./services/etesync-dav.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/flameshot.nix { })
     (loadModule ./services/fluidsynth.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/redshift-gammastep/gammastep.nix { condition = hostPlatform.isLinux; })

--- a/modules/services/etesync-dav.nix
+++ b/modules/services/etesync-dav.nix
@@ -1,0 +1,62 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.etesync-dav;
+
+  toEnvironmentCfg = vars:
+    (concatStringsSep " "
+      (mapAttrsToList (k: v: "${k}=${escapeShellArg v}") vars));
+
+in {
+  meta.maintainers = [ maintainers.valodim ];
+
+  options.services.etesync-dav = {
+    enable = mkEnableOption "etesync-dav";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.etesync-dav;
+      defaultText = "pkgs.etesync-dav";
+      description = "The etesync-dav derivation to use.";
+    };
+
+    serverUrl = mkOption {
+      type = types.str;
+      default = "https://api.etesync.com/";
+      description = "The URL to the etesync server.";
+    };
+
+    settings = mkOption {
+      type = types.attrsOf (types.oneOf [ types.str types.int ]);
+      default = { };
+      example = literalExample ''
+        {
+          ETESYNC_LISTEN_ADDRESS = "localhost";
+          ETESYNC_LISTEN_PORT = 37385;
+        }
+      '';
+      description = ''
+        Settings for etesync-dav, passed as environment variables.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    systemd.user.services.etesync-dav = {
+      Unit = { Description = "etesync-dav"; };
+
+      Service = {
+        ExecStart = "${cfg.package}/bin/etesync-dav";
+        Environment =
+          toEnvironmentCfg ({ ETESYNC_URL = cfg.serverUrl; } // cfg.settings);
+      };
+
+      Install = { WantedBy = [ "default.target" ]; };
+    };
+  };
+}


### PR DESCRIPTION
### Description

Module for the local dav proxy component of [etesync](https://www.etesync.com/), etesync-dav.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

It's a pretty trivial module that only adds a systemd file. Not sure what I would test for, just the existence of the systemd files and its contents from the variables?

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
