### PR TITLE
brave: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,6 +36,8 @@
 
 /modules/programs/beets.nix                           @rycee
 
+/modules/programs/brave.nix                           @workflow
+
 /modules/programs/broot.nix                           @aheaume
 
 /modules/programs/dircolors.nix                       @JustinLovinger

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -52,6 +52,7 @@ let
     (loadModule ./programs/autorandr.nix { })
     (loadModule ./programs/bash.nix { })
     (loadModule ./programs/bat.nix { })
+    (loadModule ./programs/brave.nix { condition = hostPlatform.isLinux; })
     (loadModule ./programs/beets.nix { })
     (loadModule ./programs/broot.nix { })
     (loadModule ./programs/browserpass.nix { })

--- a/modules/programs/brave.nix
+++ b/modules/programs/brave.nix
@@ -1,0 +1,77 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  browserModule = defaultPkg: name: visible:
+    let browser = (builtins.parseDrvName defaultPkg.name).name;
+    in {
+      enable = mkOption {
+        inherit visible;
+        default = false;
+        example = true;
+        description = "Whether to enable ${name}.";
+        type = lib.types.bool;
+      };
+
+      package = mkOption {
+        inherit visible;
+        type = types.package;
+        default = defaultPkg;
+        defaultText = literalExample "pkgs.${browser}";
+        description = "The ${name} package to use.";
+      };
+
+      extensions = mkOption {
+        inherit visible;
+        type = types.listOf types.str;
+        default = [ ];
+        example = literalExample ''
+          [
+            "chlffgpmiacpedhhbkiomidkjlcfhogd" # pushbullet
+            "mbniclmhobmnbdlbpiphghaielnnpgdp" # lightshot
+            "gcbommkclmclpchllfjekcdonpmejbdp" # https everywhere
+            "cjpalhdlnbpafiamejdnhcphjbkeiagm" # ublock origin
+          ]
+        '';
+        description = ''
+          List of ${name} extensions to install.
+          To find the extension ID, check its URL on the
+          <link xlink:href="https://chrome.google.com/webstore/category/extensions">Chrome Web Store</link>.
+        '';
+      };
+    };
+
+  browserConfig = cfg:
+    let
+
+      browser = "Brave-Browser";
+
+      configDir = if pkgs.stdenv.isDarwin then
+        "Library/Application Support/${vendor}/${browser}"
+      else
+        "${config.xdg.configHome}/${vendor}/${browser}";
+
+      extensionJson = ext: {
+        name = "${configDir}/External Extensions/${ext}.json";
+        value.text = builtins.toJSON {
+          external_update_url =
+            "https://clients2.google.com/service/update2/crx";
+        };
+      };
+
+      vendor = "BraveSoftware";
+
+    in mkIf cfg.enable {
+      home.packages = [ cfg.package ];
+      home.file = listToAttrs (map extensionJson cfg.extensions);
+    };
+
+in {
+  meta.maintainers = [ maintainers.farlion ];
+
+  options.programs = { brave = browserModule pkgs.brave "Brave Browser" true; };
+
+  config = mkMerge [ (browserConfig config.programs.brave) ];
+}


### PR DESCRIPTION

### Description

This adds the [Brave Browser] module along with basic docs and the ability to have
externally installed extensions.

Note: I didn't add any tests because I'm lazy, and `chromium` doesn't have any either. Happy to add basic tests for both in a later PR.

Resolves #1205

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.

[Brave Browser]: https://brave.com/