### PR TITLE
remind: add service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -198,6 +198,8 @@
 
 /modules/services/random-background.nix               @rycee
 
+/modules/services/remind.nix                          @markus1189
+
 /modules/services/redshift.nix                        @rycee
 
 /modules/services/status-notifier-watcher.nix         @pltanton

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -174,6 +174,7 @@ let
     (loadModule ./services/pulseeffects.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/random-background.nix { })
     (loadModule ./services/redshift.nix { })
+    (loadModule ./services/remind.nix { })
     (loadModule ./services/rsibreak.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/screen-locker.nix { })
     (loadModule ./services/stalonetray.nix { })

--- a/modules/services/remind.nix
+++ b/modules/services/remind.nix
@@ -1,0 +1,56 @@
+{ config, lib, pkgs, ... }:
+
+let cfg = config.services.remind;
+in with lib; {
+  meta.maintainers = with maintainers; [ markus1189 ];
+
+  options.services.remind = {
+    enable = mkEnableOption "remind daemon";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.remind;
+      defaultText = literalExample "pkgs.remind";
+      description = "Which remind package to install.";
+    };
+
+    remindFile = mkOption {
+      type = types.path;
+      description =
+        "Path to your main main remind file or a directory of files.";
+    };
+
+    remindCommand = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "The command that remind runs when triggered.";
+      example = literalExample ''
+        notify-send remind '%s'
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home = { packages = [ cfg.package ]; };
+
+    systemd.user = {
+      services.remind = let
+        cmd = optionalString (cfg.remindCommand != null)
+          "-k${escapeShellArg cfg.remindCommand}";
+        # Use a separate script due to systemd specifiers conflicting
+        # with remind's substitution filter...
+        script = pkgs.writeShellScript "remind-command-systemd" ''
+          exec ${cfg.package}/bin/remind -z ${cmd} ${cfg.remindFile}
+        '';
+      in {
+        Unit = { Description = "remind daemon"; };
+
+        Service = {
+          ExecStart = "${script}";
+          RestartSec = 3;
+          Restart = "always";
+        };
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -97,6 +97,7 @@ import nmt {
     ./modules/services/kanshi
     ./modules/services/lieer
     ./modules/services/polybar
+    ./modules/services/remind
     ./modules/services/sxhkd
     ./modules/services/window-managers/i3
     ./modules/services/window-managers/sway

--- a/tests/modules/services/remind/basic-configuration.nix
+++ b/tests/modules/services/remind/basic-configuration.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.remind = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-remind" "";
+      remindFile = "/dummy/remind-file";
+      remindCommand = "echo %s";
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/remind.service
+
+      assertFileExists $serviceFile
+    '';
+  };
+}

--- a/tests/modules/services/remind/default.nix
+++ b/tests/modules/services/remind/default.nix
@@ -1,0 +1,1 @@
+{ remind-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

Add a systemd service that runs the `remind` command: https://dianne.skoll.ca/projects/remind/

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.