### PR TITLE
plan9port: init services module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -202,6 +202,8 @@
 /modules/services/pbgopy.nix                          @ivarwithoutbones
 /tests/modules/services/pbgopy                        @ivarwithoutbones
 
+/modules/services/plan9port.nix                       @ehmry
+
 /modules/services/pulseeffects.nix                    @jonringer
 
 /modules/services/random-background.nix               @rycee

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1804,7 +1804,15 @@ in
             https://github.com/nix-community/home-manager/issues/1691
 
           for discussion.
-      '';
+        '';
+      }
+
+      {
+        time = "2021-01-02T07:49:15+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.plan9port'.
+        '';
       }
     ];
   };

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -173,6 +173,7 @@ let
     (loadModule ./services/pasystray.nix { })
     (loadModule ./services/pbgopy.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/picom.nix { })
+    (loadModule ./services/plan9port.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/polybar.nix { })
     (loadModule ./services/pulseeffects.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/random-background.nix { })

--- a/modules/services/plan9port.nix
+++ b/modules/services/plan9port.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.plan9port;
+
+in {
+  meta.maintainers = [ maintainers.ehmry ];
+
+  options.services.plan9port = {
+    fontsrv.enable =
+      mkEnableOption "the Plan 9 file system access to host fonts";
+    plumber.enable =
+      mkEnableOption "the Plan 9 file system for interprocess messaging";
+  };
+
+  config = {
+
+    systemd.user.services.fontsrv = mkIf cfg.fontsrv.enable {
+      Unit.Description = "the Plan 9 file system access to host fonts";
+      Install.WantedBy = [ "default.target" ];
+      Service.ExecStart = "${pkgs.plan9port}/bin/9 fontsrv";
+    };
+
+    systemd.user.services.plumber = mkIf cfg.plumber.enable {
+      Unit.Description = "file system for interprocess messaging";
+      Install.WantedBy = [ "default.target" ];
+      Service.ExecStart = "${pkgs.plan9port}/bin/9 plumber -f";
+    };
+
+  };
+
+}


### PR DESCRIPTION
### Description

Add a services module for setting up the plan9port file-systems, these are closely related to the acme editor.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
