### PR TITLE
mpv: add extraConfig

### DIFF
--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -116,6 +116,21 @@ in {
           }
         '';
       };
+
+      extraConfig = mkOption {
+        description = ''
+          Extra settings to add to <filename>mpv.conf</filename>.
+        '';
+        type = types.lines;
+        default = "";
+        example = literalExample ''
+          profile = gpu-hq
+          profile = slow
+
+          [slow]
+          framedrop = no
+        '';
+      };
     };
   };
 
@@ -128,9 +143,10 @@ in {
           pkgs.wrapMpv pkgs.mpv-unwrapped { scripts = cfg.scripts; })
       ];
     }
-    (mkIf (cfg.config != { } || cfg.profiles != { }) {
+    (mkIf (cfg.config != { } || cfg.profiles != { } || cfg.extraConfig != "") {
       xdg.configFile."mpv/mpv.conf".text = ''
         ${optionalString (cfg.config != { }) (renderOptions cfg.config)}
+        ${cfg.extraConfig}
         ${optionalString (cfg.profiles != { }) (renderProfiles cfg.profiles)}
       '';
     })


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
There exist mpv configurations which cannot be expressed in
programs.mpv.config. For example, it is impossible to use multiple
'profile' attributes. This commit adds the conventional extraConfig
escape hatch to allow for these kinds of configurations.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- ~~If this PR adds a new module~~

  - [ ] ~~Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~~

  - [ ] ~~Added myself and the module files to `.github/CODEOWNERS`.~~