### PR TITLE
Rofi power

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -237,3 +237,6 @@
 /modules/xresources.nix                               @rycee
 
 /modules/xsession.nix                                 @rycee
+
+/modules/programs/rofi-power.nix                      @seylerius
+/tests/modules/programs/rofi-power/*                  @seylerius

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -239,4 +239,4 @@
 /modules/xsession.nix                                 @rycee
 
 /modules/programs/rofi-power.nix                      @seylerius
-/tests/modules/programs/rofi-power/*                  @seylerius
+/tests/modules/programs/rofi-power                    @seylerius

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -37,4 +37,14 @@
     github = "matrss";
     githubId = 9308656;
   };
+  seylerius = {
+    email = "sable@seyleri.us";
+    name = "Sable Seyler";
+    github = "seylerius";
+    githubId = 1145981;
+    keys = [{
+      logkeyid = "rsa4096/0x68BF2EAE6D91CAFF";
+      fingerprint = "F0E0 0311 126A CD72 4392  25E6 68BF 2EAE 6D91 CAFF";
+    }];
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -206,6 +206,7 @@ let
     (loadModule ./xsession.nix { })
     (loadModule (pkgs.path + "/nixos/modules/misc/assertions.nix") { })
     (loadModule (pkgs.path + "/nixos/modules/misc/meta.nix") { })
+    (loadModule ./programs/rofi-power.nix { })
   ];
 
   modules = map (getAttr "file") (filter (getAttr "condition") allModules);

--- a/modules/programs/rofi-power.nix
+++ b/modules/programs/rofi-power.nix
@@ -44,8 +44,9 @@ in {
       logoutCommand = mkOption {
         default = "";
         type = types.str;
-        description =
-          "The command used to logout. Required if the Logout state is enabled.";
+        description = ''
+          The command used to logout. Required if the Logout state is enabled.
+        '';
       };
 
       # validation = mkSinkUndeclaredOptions { description = "Sink for validation assert"; };

--- a/modules/programs/rofi-power.nix
+++ b/modules/programs/rofi-power.nix
@@ -10,8 +10,7 @@ with lib;
 let
   cfg = config.programs.rofi.power;
   rofi-power = { states, logoutCmd }:
-    pkgs.writeScriptBin "rofi-power" ''
-      #!${pkgs.stdenv.shell}
+    pkgs.writeShellScriptBin "rofi-power" ''
       chosen=$(cat <<EOF | rofi -dmenu -i
       ${states}
       EOF

--- a/modules/programs/rofi-power.nix
+++ b/modules/programs/rofi-power.nix
@@ -43,7 +43,7 @@ in {
 
       logoutCommand = mkOption {
         default = "";
-        type = lib.types.str;
+        type = types.str;
         description =
           "The command used to logout. Required if the Logout state is enabled.";
       };

--- a/modules/programs/rofi-power.nix
+++ b/modules/programs/rofi-power.nix
@@ -1,0 +1,112 @@
+{ config, lib, pkgs, ... }:
+
+# Largely based on adnan360's power.sh gist:
+# https://gist.github.com/adnan360/f86012baeb4c9ca4f1af033550b03033
+#
+# Depends on rofi
+
+with lib;
+
+let
+  cfg = config.programs.rofi.power;
+  rofi-power = { states, logoutCmd }:
+    pkgs.writeScriptBin "rofi-power" ''
+      #!${pkgs.stdenv.shell}
+      chosen=$(cat <<EOF | rofi -dmenu -i
+      ${states}
+      EOF
+      )
+
+      if [[ $chosen == "Logout" ]]; then
+        ${logoutCmd}
+      elif [[ $chosen == "Shutdown" ]]; then
+        systemctl poweroff
+      elif [[ $chosen == "Reboot" ]]; then
+        systemctl reboot
+      elif [[ $chosen == "Suspend" ]]; then
+        systemctl suspend
+      elif [[ $chosen == "Hibernate" ]]; then
+        systemctl hibernate
+      elif [[ $chosen == "Hybrid-sleep" ]]; then
+        systemctl hibernate
+      elif [[ $chosen == "Suspend-then-hibernate" ]]; then
+        systemctl suspend-then-hibernate
+      fi
+    '';
+
+in {
+  meta.maintainers = [ maintainers.seylerius ];
+
+  options = {
+    programs.rofi.power = {
+      enable = mkEnableOption "Power menu based on rofi and systemd";
+
+      logoutCommand = mkOption {
+        default = "";
+        type = lib.types.str;
+        description =
+          "The command used to logout. Required if the Logout state is enabled.";
+      };
+
+      # validation = mkSinkUndeclaredOptions { description = "Sink for validation assert"; };
+
+      # Allow toggling of individual power states
+      states = {
+        logout = mkOption {
+          default = true;
+          type = lib.types.bool;
+          description = "Toggle for Logout target";
+        };
+        shutdown = mkOption {
+          default = true;
+          type = lib.types.bool;
+          description = "Toggle for Shutdown target";
+        };
+        reboot = mkOption {
+          default = true;
+          type = lib.types.bool;
+          description = "Toggle for Reboot target";
+        };
+        suspend = mkOption {
+          default = true;
+          type = lib.types.bool;
+          description = "Toggle for Suspend target";
+        };
+        hibernate = mkOption {
+          default = true;
+          type = lib.types.bool;
+          description = "Toggle for Hibernate target";
+        };
+        hybridSleep = mkOption {
+          default = true;
+          type = lib.types.bool;
+          description = "Toggle for Hybrid-sleep target";
+        };
+        suspendThenHibernate = mkOption {
+          default = true;
+          type = lib.types.bool;
+          description = "Toggle for Suspend-then-Hibernate target";
+        };
+      };
+    };
+  };
+
+  config =
+    mkIf (cfg.enable && (cfg.states.logout -> (cfg.logoutCommand != ""))) {
+      # programs.rofi.power.validation = assert (cfg.states.logout -> (cfg.logoutCommand != null)); cfg.logoutCommand;
+      home.packages = [
+        (rofi-power {
+          states = (pkgs.lib.concatStringsSep "\n" ([ "[Cancel]" ]
+            ++ optionals cfg.states.logout [ "Logout" ]
+            ++ optionals cfg.states.shutdown [ "Shutdown" ]
+            ++ optionals cfg.states.reboot [ "Reboot" ]
+            ++ optionals cfg.states.suspend [ "Suspend" ]
+            ++ optionals cfg.states.hibernate [ "Hibernate" ]
+            ++ optionals cfg.states.hybridSleep [ "Hybrid-sleep" ]
+            ++ optionals cfg.states.suspendThenHibernate
+            [ "Suspend-then-hibernate" ]));
+          logoutCmd = cfg.logoutCommand;
+        })
+      ];
+    };
+}

--- a/modules/programs/rofi-power.nix
+++ b/modules/programs/rofi-power.nix
@@ -57,6 +57,7 @@ in {
           type = lib.types.bool;
           description = "Toggle for Logout target";
         };
+
         shutdown = mkOption {
           default = true;
           type = lib.types.bool;

--- a/modules/programs/rofi-power.nix
+++ b/modules/programs/rofi-power.nix
@@ -97,7 +97,7 @@ in {
       # programs.rofi.power.validation = assert (cfg.states.logout -> (cfg.logoutCommand != null)); cfg.logoutCommand;
       home.packages = [
         (rofi-power {
-          states = (pkgs.lib.concatStringsSep "\n" ([ "[Cancel]" ]
+          states = concatStringsSep "\n" ([ "[Cancel]" ]
             ++ optionals cfg.states.logout [ "Logout" ]
             ++ optionals cfg.states.shutdown [ "Shutdown" ]
             ++ optionals cfg.states.reboot [ "Reboot" ]

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 
 let
 
@@ -14,23 +14,19 @@ let
   modules = import ../modules/modules.nix {
     inherit lib pkgs;
     check = false;
-  } ++ [
-    {
-      # Fix impurities. Without these some of the user's environment
-      # will leak into the tests through `builtins.getEnv`.
-      xdg.enable = true;
-      home.username = "hm-user";
-      home.homeDirectory = "/home/hm-user";
+  } ++ [{
+    # Fix impurities. Without these some of the user's environment
+    # will leak into the tests through `builtins.getEnv`.
+    xdg.enable = true;
+    home.username = "hm-user";
+    home.homeDirectory = "/home/hm-user";
 
-      # Avoid including documentation since this will cause
-      # unnecessary rebuilds of the tests.
-      manual.manpages.enable = false;
-    }
-  ];
+    # Avoid including documentation since this will cause
+    # unnecessary rebuilds of the tests.
+    manual.manpages.enable = false;
+  }];
 
-in
-
-import nmt {
+in import nmt {
   inherit lib pkgs modules;
   testedAttrPath = [ "home" "activationPackage" ];
   tests = builtins.foldl' (a: b: a // (import b)) { } ([
@@ -73,35 +69,36 @@ import nmt {
     ./modules/programs/zplug
     ./modules/programs/zsh
     ./modules/xresources
-  ] ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
-    ./modules/targets-darwin
-  ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
-    ./modules/misc/debug
-    ./modules/misc/numlock
-    ./modules/misc/pam
-    ./modules/misc/xdg
-    ./modules/misc/xsession
-    ./modules/programs/abook
-    ./modules/programs/autorandr
-    ./modules/programs/firefox
-    ./modules/programs/getmail
-    ./modules/programs/i3status-rust
-    ./modules/programs/ncmpcpp-linux
-    ./modules/programs/neovim   # Broken package dependency on Darwin.
-    ./modules/programs/rofi
-    ./modules/programs/waybar
-    ./modules/services/dropbox
-    ./modules/services/emacs
-    ./modules/services/fluidsynth
-    ./modules/services/kanshi
-    ./modules/services/lieer
-    ./modules/services/pbgopy
-    ./modules/services/polybar
-    ./modules/services/sxhkd
-    ./modules/services/window-managers/i3
-    ./modules/services/window-managers/sway
-    ./modules/services/wlsunset
-    ./modules/systemd
-    ./modules/targets-linux
-  ]);
+  ] ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin
+    [ ./modules/targets-darwin ]
+    ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+      ./modules/misc/debug
+      ./modules/misc/numlock
+      ./modules/misc/pam
+      ./modules/misc/xdg
+      ./modules/misc/xsession
+      ./modules/programs/abook
+      ./modules/programs/autorandr
+      ./modules/programs/firefox
+      ./modules/programs/getmail
+      ./modules/programs/i3status-rust
+      ./modules/programs/ncmpcpp-linux
+      ./modules/programs/neovim # Broken package dependency on Darwin.
+      ./modules/programs/rofi
+      ./modules/programs/rofi-power
+      ./modules/programs/waybar
+      ./modules/services/dropbox
+      ./modules/services/emacs
+      ./modules/services/fluidsynth
+      ./modules/services/kanshi
+      ./modules/services/lieer
+      ./modules/services/pbgopy
+      ./modules/services/polybar
+      ./modules/services/sxhkd
+      ./modules/services/window-managers/i3
+      ./modules/services/window-managers/sway
+      ./modules/services/wlsunset
+      ./modules/systemd
+      ./modules/targets-linux
+    ]);
 }

--- a/tests/modules/programs/rofi-power/default.nix
+++ b/tests/modules/programs/rofi-power/default.nix
@@ -1,0 +1,1 @@
+{ rofi-power-states = ./rofi-power-states.nix; }

--- a/tests/modules/programs/rofi-power/rofi-power-states.nix
+++ b/tests/modules/programs/rofi-power/rofi-power-states.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.rofi.power = {
+      enable = true;
+      states.hibernate = false;
+    };
+
+    nixpkgs.overlays = [
+      (self: super: { rofi-power = pkgs.writeScriptBin "dummy-rofi-power" ""; })
+    ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/rofi-power/states \
+        ${
+          pkgs.writeText "rofi-power-expected-states" ''
+            [Cancel]
+            Logout
+            Shutdown
+            Reboot
+            Suspend
+            Hybrid-sleep
+            Suspend-then-hibernate''
+        }
+    '';
+  };
+}


### PR DESCRIPTION
### Description

This is a power-menu script based on rofi, generated to a shellscript using a trivial builder. It uses systemd to implement the suspending and rebooting and whatnot, and is configurable in which set of states are provided as choices. I am not sure how to test it, though. The existing test I added, rofi-power-states, is from an earlier version of this that stored the states configuration in an external file. Current best idea is to compare the contents of the shellscript, skipping the first line, but I can't think of how to specify the path to be tested. Very open to suggestions. Also, I haven't squashed this down to clean commits yet; it's still showing a lot of my process. Can clean that up.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
