### PR TITLE
Rofi pass

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,6 +119,9 @@
 
 /modules/programs/powerline-go.nix                    @DamienCassou
 
+/modules/programs/rofi-pass.nix                       @seylerius
+/tests/modules/programs/rofi-pass                     @seylerius
+
 /modules/programs/rtorrent.nix                        @marsam
 
 /modules/programs/ssh.nix                             @rycee

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -37,4 +37,14 @@
     github = "matrss";
     githubId = 9308656;
   };
+  seylerius = {
+    email = "sable@seyleri.us";
+    name = "Sable Seyler";
+    github = "seylerius";
+    githubId = 1145981;
+    keys = [{
+      logkeyid = "rsa4096/0x68BF2EAE6D91CAFF";
+      fingerprint = "F0E0 0311 126A CD72 4392  25E6 68BF 2EAE 6D91 CAFF";
+    }];
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1775,6 +1775,13 @@ in
           A new module is available: 'services.pbgopy'.
         '';
       }
+
+      {
+        time = "2020-12-18T22:22:25+00:00";
+        message = ''
+          A new module is available: 'programs.rofi.pass'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -113,6 +113,7 @@ let
     (loadModule ./programs/qutebrowser.nix { })
     (loadModule ./programs/readline.nix { })
     (loadModule ./programs/rofi.nix { })
+    (loadModule ./programs/rofi-pass.nix {  })
     (loadModule ./programs/rtorrent.nix { })
     (loadModule ./programs/skim.nix { })
     (loadModule ./programs/starship.nix { })

--- a/modules/programs/rofi-pass.nix
+++ b/modules/programs/rofi-pass.nix
@@ -1,0 +1,46 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.rofi.pass;
+
+in {
+  meta.maintainers = [ maintainers.seylerius ];
+
+  options.programs.rofi.pass = {
+    enable = mkEnableOption "rofi integration with password-store";
+
+    stores = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Directory roots of your password-stores.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        URL_field='url'
+        USERNAME_field='user'
+        AUTOTYPE_field='autotype'
+      '';
+      description = ''
+        Extra configuration to be added at to the rofi-pass config file.
+        Additional examples can be found at
+        <link xlink:href="https://github.com/carnager/rofi-pass/blob/master/config.example"/>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.rofi-pass ];
+
+    xdg.configFile."rofi-pass/config".text = optionalString (cfg.stores != [ ])
+      ("root=" + (concatStringsSep ":" cfg.stores) + "\n") + cfg.extraConfig
+      + optionalString (cfg.extraConfig != "") "\n";
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -89,6 +89,7 @@ import nmt {
     ./modules/programs/ncmpcpp-linux
     ./modules/programs/neovim   # Broken package dependency on Darwin.
     ./modules/programs/rofi
+    ./modules/programs/rofi-pass
     ./modules/programs/waybar
     ./modules/services/dropbox
     ./modules/services/emacs

--- a/tests/modules/programs/rofi-pass/default.nix
+++ b/tests/modules/programs/rofi-pass/default.nix
@@ -1,0 +1,4 @@
+{
+  rofi-pass-root = ./rofi-pass-root.nix;
+  rofi-pass-config = ./rofi-pass-config.nix;
+}

--- a/tests/modules/programs/rofi-pass/rofi-pass-config.nix
+++ b/tests/modules/programs/rofi-pass/rofi-pass-config.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.rofi = {
+      enable = true;
+
+      pass = {
+        enable = true;
+        extraConfig = ''
+          # Extra config for rofi-pass
+          xdotool_delay=12
+        '';
+      };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: { rofi-pass = pkgs.writeScriptBin "dummy-rofi-pass" ""; })
+    ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/rofi-pass/config \
+        ${
+          pkgs.writeText "rofi-pass-expected-config" ''
+            # Extra config for rofi-pass
+            xdotool_delay=12
+
+          ''
+        }
+    '';
+  };
+}

--- a/tests/modules/programs/rofi-pass/rofi-pass-root.nix
+++ b/tests/modules/programs/rofi-pass/rofi-pass-root.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.rofi = {
+      enable = true;
+
+      pass = {
+        enable = true;
+        stores = [ "~/.local/share/password-store" ];
+      };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: { rofi-pass = pkgs.writeScriptBin "dummy-rofi-pass" ""; })
+    ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/rofi-pass/config \
+        ${
+          pkgs.writeText "rofi-pass-expected-config" ''
+            root=~/.local/share/password-store
+          ''
+        }
+    '';
+  };
+}


### PR DESCRIPTION
### Description

This is a configuration module for the `rofi-pass` package. It's pretty basic at this point, only providing an option to set your password store root, and add extra configuration through the `extraConfig` option. 

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
