### PR TITLE
polybar: allow config to be more nix-like

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1852,6 +1852,17 @@ in
           A new module is available: 'programs.sbt'.
         '';
       }
+
+      {
+        time = "2021-02-20T00:00:00+00:00";
+        condition = config.services.polybar.enable;
+        message = ''
+          The polybar configuration can now be written in a more nix-friendly format.
+          The new 'services.polybar.settings' option is an alternative to
+          'services.polybar.config' that supports nested keys and converts nix
+          lists to polybar-style 'foo-0, foo-1, ...' lists.
+        '';
+      }
     ];
   };
 }

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -9,6 +9,36 @@ let
   eitherStrBoolIntList = with types;
     either str (either bool (either int (listOf str)));
 
+  # Convert a key/val pair to the insane format that polybar uses.
+  # Each input key/val pair may return several output key/val pairs.
+  convertPolybarKeyVal = key: val:
+    # Convert { foo = [ "a" "b" ]; }
+    # to {
+    #   foo-0 = "a";
+    #   foo-1 = "b";
+    # }
+    if isList val then
+      concatLists (imap0 (i: convertPolybarKeyVal "${key}-${toString i}") val)
+      # Convert {
+      #   foo.text = "a";
+      #   foo.font = 1;
+      # } to {
+      #   foo = "a";
+      #   foo-font = 1;
+      # }
+    else if isAttrs val && !lib.isDerivation val then
+      concatLists (mapAttrsToList
+        (k: convertPolybarKeyVal (if k == "text" then key else "${key}-${k}"))
+        val)
+      # Base case
+    else
+      [ (nameValuePair key val) ];
+
+  convertPolybarSection = _: attrs:
+    listToAttrs (concatLists (mapAttrsToList convertPolybarKeyVal attrs));
+
+  # Converts an attrset to INI text, quoting values as expected by polybar.
+  # This does no more fancy conversion.
   toPolybarIni = generators.toINI {
     mkKeyValue = key: value:
       let
@@ -24,8 +54,11 @@ let
       in "${key}=${value'}";
   };
 
-  configFile = pkgs.writeText "polybar.conf"
-    (toPolybarIni cfg.config + "\n" + cfg.extraConfig);
+  configFile = pkgs.writeText "polybar.conf" ''
+    ${toPolybarIni cfg.config}
+    ${toPolybarIni (mapAttrs convertPolybarSection cfg.settings)}
+    ${cfg.extraConfig}
+  '';
 
 in {
   options = {
@@ -54,6 +87,7 @@ in {
         description = ''
           Polybar configuration. Can be either path to a file, or set of attributes
           that will be used to create the final configuration.
+          See also <option>services.polybar.settings</option> for a more nix-friendly format.
         '';
         default = { };
         example = literalExample ''
@@ -72,6 +106,56 @@ in {
               date = "%d.%m.%y";
               time = "%H:%M";
               label = "%time%  %date%";
+            };
+          }
+        '';
+      };
+
+      settings = mkOption {
+        type = types.attrsOf types.attrs;
+        description = ''
+          Polybar configuration. This takes a nix attrset and converts it to the
+          strange data format that polybar uses.
+          Each entry will be converted to a section in the output file.
+          Several things are treated specially: nested keys are converted
+          to dash-separated keys; the special <literal>text</literal> key is ignored as a nested key,
+          to allow mixing different levels of nesting; and lists are converted to
+          polybar's <literal>foo-0, foo-1, ...</literal> format.
+          </para><para>
+          For example:
+          <programlisting language="nix">
+          "module/volume" = {
+            type = "internal/pulseaudio";
+            format.volume = "&lt;ramp-volume&gt; &lt;label-volume&gt;";
+            label.muted.text = "🔇";
+            label.muted.foreground = "#666";
+            ramp.volume = ["🔈" "🔉" "🔊"];
+            click.right = "pavucontrol &amp;";
+          }
+          </programlisting>
+          becomes:
+          <programlisting language="ini">
+          [module/volume]
+          type=internal/pulseaudio
+          format-volume=&lt;ramp-volume&gt; &lt;label-volume&gt;
+          label-muted=🔇
+          label-muted-foreground=#666
+          ramp-volume-0=🔈
+          ramp-volume-1=🔉
+          ramp-volume-2=🔊
+          click-right=pavucontrol &amp;
+          </programlisting>
+        '';
+        default = { };
+        example = literalExample ''
+          {
+            "module/volume" = {
+              type = "internal/pulseaudio";
+              format.volume = "<ramp-volume> <label-volume>";
+              label.muted.text = "🔇";
+              label.muted.foreground = "#666";
+              ramp.volume = ["🔈" "🔉" "🔊"];
+              click.right = "pavucontrol &";
             };
           }
         '';

--- a/tests/modules/services/polybar/basic-configuration.conf
+++ b/tests/modules/services/polybar/basic-configuration.conf
@@ -12,6 +12,16 @@ label=%time%  %date%
 time=%H:%M
 type=internal/date
 
+[module/volume]
+click-right=pavucontrol &
+format-volume=<ramp-volume> <label-volume>
+label-muted=🔇
+label-muted-foreground=#666
+ramp-volume-0=🔈
+ramp-volume-1=🔉
+ramp-volume-2=🔊
+type=internal/pulseaudio
+
 [module/date]
 type = internal/date
 interval = 5
@@ -19,3 +29,4 @@ date = "%d.%m.%y"
 time = %H:%M
 format-prefix-foreground = ${colors.foreground-alt}
 label = %time%  %date%
+

--- a/tests/modules/services/polybar/basic-configuration.nix
+++ b/tests/modules/services/polybar/basic-configuration.nix
@@ -22,6 +22,16 @@
           label = "%time%  %date%";
         };
       };
+      settings = {
+        "module/volume" = {
+          type = "internal/pulseaudio";
+          format.volume = "<ramp-volume> <label-volume>";
+          label.muted.text = "🔇";
+          label.muted.foreground = "#666";
+          ramp.volume = [ "🔈" "🔉" "🔊" ];
+          click.right = "pavucontrol &";
+        };
+      };
       extraConfig = ''
         [module/date]
         type = internal/date


### PR DESCRIPTION
### Description

Polybar's config format is a bit strange, and lists in particular are annoying to handle. This enables using normal nix lists and nested attrsets instead.

I had to  create a new option because this change would not be backwards-compatible, because the INI converter currently converts lists of strings to space-separated values, and this new option does something else. I expect that this is only relevant for the `modules-left` etc bar setting, but that's enough to break things :(.

I'm not sure how to name this new option. I named it `settings` because I thought we might decide to deprecate `config` in its favor later.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.
