### PR TITLE
WIP: Firefox policies w/ extensions integration

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -394,20 +394,6 @@ in
           Service = {
             Type = "oneshot";
 
-            # We will never need this, as `/run/user/:UID/` is created at each boot
-            # and will therefore wipe the file
-            # ExecStop = (toString (pkgs.writeShellScript "remove-firefox-policies-file" ''
-            #   # set our runtime dir + policies location here 
-            #   # XDG_RUNTIME_DIR="/run/user/$(id -u)"
-            #   XDG_RUNTIME_DIR="/run/user/$($DRY_RUN_CMD  ${pkgs.coreutils}/bin/id -u)"
-            #   POLICIES_LOCATION="$XDG_RUNTIME_DIR/firefox/policies.json"
-
-            #   # if the file exists, delete it
-            #   if [[ -f $POLICIES_LOCATION ]]; then
-            #     ${pkgs.coreutils}/bin/rm $POLICIES_LOCATION
-            #   fi
-            # ''));
-
             ExecStart = let
               policiesFile = pkgs.writeText "policies.json" (mkPolicies cfg);
             in (toString (pkgs.writeShellScript "write-firefox-policies-file" ''

--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -393,6 +393,7 @@ in
 
           Service = {
             Type = "oneshot";
+            RemainAfterExit = true;
 
             ExecStart = let
               policiesFile = pkgs.writeText "policies.json" (mkPolicies cfg);

--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -382,29 +382,74 @@ in
       })
     );
 
-    home.activation.runtime = hm.dag.entryAfter [ "writeBoundary" ] (let
-      policiesFile = pkgs.writeText "policies.json" (mkPolicies cfg);
-      shouldRun = (cfg.extensions != [] || cfg.extraPolicies != {});
-    in ''
-      # check if this should run, if not just exit 0
-      if [[ ! ${pkgs.lib.boolToString shouldRun} ]]; then
-        exit 0
-      fi
+    systemd.user = {
+      paths = {
+        firefox-policies-writer = {
+          Unit = { Description = "Firefox Policies Writer"; };
+          Path = {
+# 13:27:29  eyJhb | Can't seem to find this, but I have a path unit, where I would like to monitor $XDG_RUNTIME_DIR, can I use           │ ablackack
+#                 | "$XDG_RUNTIME_DIR/something/file" as a path variable?                                                                │ Adbray
+# 13:28:56 damjan | wild guess, not. but maybe try %t                                                                                    │ adema
+# 113:29:59  eyJhb | Is there a list of varibales some place damjan ? - Also it IS a user path unit, just in case                         │ Aelius
+# 113:30:21 damjan | eyJhb: afaik man systemd.unit                                                                                        │ af1cs
+# 113:30:54 damjan | https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Specifiers                                        │ Ahti333_
+# 113:31:04  eyJhb | Uhh, nice. Lets see                                                                                                  │ aib
+# 113:31:35  eyJhb | Or maybe the userid will work, if any work in that variable...                                                       │ aidalgol
+            # PathExists = "/run/user/$XDG_RUNTIME_DIR/firefox/policies.json";
+            PathExists = "/run/user/1000/firefox/policies.json";
+            MakeDirectory = true;
+            DirectoryMode = 0700;
+          };
+        };
+      };
+      services = {
+        firefox-policies-writer = {
+          Unit = { Description = "Firefox Policies Writer"; };
 
-      # set our runtime dir + policies location here 
-      XDG_RUNTIME_DIR="/run/user/$(id -u)"
-      POLICIES_LOCATION="$XDG_RUNTIME_DIR/firefox/policies.json"
+          Install = { WantedBy = [ "default.target" ]; };
 
-      # create the dir, so it exists else other operations will fail
-      mkdir -p "$XDG_RUNTIME_DIR/firefox"
+          Service = {
+            Environment = [ "XDG_RUNTIME_DIR=/run/user/1000" ];
+            Type = "simple";
 
-      # first remove the dir, if it exists
-      if [[ -f $POLICIES_LOCATION ]]; then
-        rm $POLICIES_LOCATION
-      fi
+            ExecStart = let
+              policiesFile = pkgs.writeText "policies.json" (mkPolicies cfg);
+            in (toString (pkgs.writeShellScript "dropbox-start" ''
+              # if file exists, then we do nothing
+              if [[ -f $XDG_RUNTIME_DIR/firefox/policies.json ]]; then
+                rm $XDG_RUNTIME_DIR/firefox/policies.json
+              fi
 
-      # actually link it
-      ln -s ${policiesFile} $POLICIES_LOCATION
-    '');
+              ln -s ${policiesFile} $XDG_RUNTIME_DIR/firefox/policies.json
+            ''));
+        };
+      };
+    };
+  };
+
+    # home.activation.runtime = hm.dag.entryAfter [ "writeBoundary" ] (let
+    #   policiesFile = pkgs.writeText "policies.json" (mkPolicies cfg);
+    #   shouldRun = (cfg.extensions != [] || cfg.extraPolicies != {});
+    # in ''
+    #   # check if this should run, if not just exit 0
+    #   if [[ ! ${pkgs.lib.boolToString shouldRun} ]]; then
+    #     exit 0
+    #   fi
+
+    #   # set our runtime dir + policies location here 
+    #   XDG_RUNTIME_DIR="/run/user/$(id -u)"
+    #   POLICIES_LOCATION="$XDG_RUNTIME_DIR/firefox/policies.json"
+
+    #   # create the dir, so it exists else other operations will fail
+    #   mkdir -p "$XDG_RUNTIME_DIR/firefox"
+
+    #   # first remove the dir, if it exists
+    #   if [[ -f $POLICIES_LOCATION ]]; then
+    #     rm $POLICIES_LOCATION
+    #   fi
+
+    #   # actually link it
+    #   ln -s ${policiesFile} $POLICIES_LOCATION
+    # '');
   };
 }

--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -63,7 +63,6 @@ let
   #       "Folder": "FolderName"
   #     }
   #   ]
-  # TODO(eyjhb) CHANGE THIS!
   semanticTypes = with types; rec {
     policiesAtom = oneOf [ int bool str ];
     policiesAll = oneOf [ policiesAtom (listOf policiesAll) (attrsOf policiesAll) ];
@@ -401,11 +400,11 @@ in
               set -xe
 
               # set our runtime dir + policies location here 
-              XDG_RUNTIME_DIR="/run/user/$($DRY_RUN_CMD  ${pkgs.coreutils}/bin/id -u)"
+              XDG_RUNTIME_DIR="/run/user/$(${pkgs.coreutils}/bin/id -u)"
               POLICIES_LOCATION="$XDG_RUNTIME_DIR/firefox/policies.json"
 
               # create the dir, so it exists else other operations will fail
-              $DRY_RUN_CMD ${pkgs.coreutils}/bin/mkdir -p "$XDG_RUNTIME_DIR/firefox"
+              ${pkgs.coreutils}/bin/mkdir -p "$XDG_RUNTIME_DIR/firefox"
 
               # if the file exists, delete it
               if [[ -f $POLICIES_LOCATION ]]; then
@@ -413,7 +412,7 @@ in
               fi
 
               # actually link it
-              $DRY_RUN_CMD ${pkgs.coreutils}/bin/ln -s ${policiesFile} $POLICIES_LOCATION
+              ${pkgs.coreutils}/bin/ln -s ${policiesFile} $POLICIES_LOCATION
             ''));
           };
         };


### PR DESCRIPTION
### Description
Ability to provide a list of extensions, that will be installed in a correct way (none-hacky), which is supported from the Mozilla point of view.

Currently this will not work, as it also requires some work to be done on how the Firefox addons are generated.

This also relies on the work here https://github.com/NixOS/nixpkgs/pull/94898 , as a custom patch is required to make the policies on a pr. profile basis.
It can be made user wide, but that would not be that useful for some.

Maybe supporting both would be good? Any input @rycee , on what you think?

This is the config I use atm.

```
{ config, pkgs, lib, ... }:

let
  ffxpis = pkgs.recurseIntoAttrs (pkgs.callPackage ./modules/firefox {});
in {
    programs.firefox = {
      enable = true;
      package = pkgs.firefox-policies;

      profiles = {
        "default" = {
          id = 0;
          extensions = with ffxpis; [
            https-everywhere
            bitwarden
            i-dont-care-about-cookies
            ublock-origin
            surfingkeys_ff
          ];


          settings = {
            "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
            "svg.context-properties.content.enabled" = true;
          };
          extraPolicies = {
            DontCheckDefaultBrowser = false;
            OfferToSaveLogins = false;
          };

          userChrome = ''
          '';
        };
      };
    };
}
```

Where I use this version, to generate my plugins. Slightly modified default.nix, with a python rewrite of the current version - https://gitlab.com/eyJhb/nix-firefox-addons

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
