### PR TITLE
zsh: add initFirst option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -302,6 +302,12 @@ in
         description = "Extra commands that should be added to <filename>.zshrc</filename>.";
       };
 
+      initExtraFirst = mkOption {
+        default = "";
+        type = types.lines;
+        description = "Commands that should be added to top of <filename>.zshrc</filename>.";
+      };
+
       envExtra = mkOption {
         default = "";
         type = types.lines;
@@ -417,6 +423,8 @@ in
         ++ optional cfg.oh-my-zsh.enable oh-my-zsh;
 
       home.file."${relToDotDir ".zshrc"}".text = ''
+        ${cfg.initExtraFirst}
+
         typeset -U path cdpath fpath manpath
 
         ${optionalString (cfg.cdpath != []) ''


### PR DESCRIPTION
### Description
Some zsh features must go at top of `.zshrc` e.g.:
```
      initFirst = ''
        # Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
        # Initialization code that may require console input (password prompts, [y/n]
        # confirmations, etc.) must go above this block; everything else may go below.
        if [[ -r "''${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-''${(%):-%n}.zsh" ]]; then
          source "''${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-''${(%):-%n}.zsh"
        fi
      '';
```

### Checklist

- [X] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
