### PR TITLE
xdg-desktop-entries: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,11 @@
 /modules/misc/xdg-system-dirs.nix                     @tadfisher
 /tests/modules/misc/xdg/system-dirs.nix               @tadfisher
 
+/modules/misc/xdg-desktop-entries.nix                 @cwyc
+/tests/modules/misc/xdg/desktop-entries.nix           @cwyc
+/tests/modules/misc/xdg/desktop-full-expected.desktop @cwyc
+/tests/modules/misc/xdg/desktop-min-expected.desktop  @cwyc
+
 /modules/programs/aria2.nix                           @JustinLovinger
 
 /modules/programs/autojump.nix                        @evanjs

--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -1,0 +1,152 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  desktopEntry = {
+    options = {
+      # Since this module uses the nixpkgs/pkgs/build-support/make-desktopitem function, 
+      # our options and defaults follow its parameters, with the following exceptions:
+
+      # `desktopName` on makeDesktopItem is controlled by `name`.
+      # This is what we'd commonly consider the name of the application.
+      # `name` on makeDesktopItem is controlled by this module's key in the attrset.
+      # This is the file's filename excluding ".desktop".
+
+      # `extraEntries` on makeDesktopItem is controlled by `extraConfig` 
+      # to match what's commonly used by other home manager modules.
+
+      # `terminal` and `startupNotify` on makeDesktopItem ask for "true" or "false" strings,
+      # for usability's sake we ask for a boolean.
+
+      # `mimeType` and `categories` on makeDesktopItem ask for a string in the format "one;two;three;",
+      # for the same reason we ask for a list of strings.
+
+      # `fileValidation` isn't exposed for simplicity's sake
+
+      # Descriptions are taken from the desktop entry spec: 
+      # https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys
+
+      type = mkOption {
+        description = "The type of the desktop entry.";
+        default = "Application";
+        type = types.enum [ "Application" "Link" "Directory" ];
+      };
+
+      exec = mkOption {
+        description = "Program to execute, possibly with arguments.";
+        type = types.str;
+      };
+
+      icon = mkOption {
+        description = "Icon to display in file manager, menus, etc.";
+        type = types.nullOr types.str;
+        default = null;
+      };
+
+      comment = mkOption {
+        description = "Tooltip for the entry.";
+        type = types.nullOr types.str;
+        default = null;
+      };
+
+      terminal = mkOption {
+        description = "Whether the program runs in a terminal window.";
+        type = types.bool;
+        default = false;
+      };
+
+      name = mkOption {
+        description = "Specific name of the application.";
+        type = types.str;
+      };
+
+      genericName = mkOption {
+        description = "Generic name of the application.";
+        type = types.nullOr types.str;
+        default = null;
+      };
+
+      mimeType = mkOption {
+        description = "The MIME type(s) supported by this application.";
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+      };
+
+      categories = mkOption {
+        description =
+          "Categories in which the entry should be shown in a menu.";
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+      };
+
+      startupNotify = mkOption {
+        description = ''
+          If true, it is KNOWN that the application will send a "remove" 
+          message when started with the <literal>DESKTOP_STARTUP_ID</literal> 
+          environment variable set. If false, it is KNOWN that the application 
+          does not work with startup notification at all.'';
+        type = types.nullOr types.bool;
+        default = null;
+      };
+
+      extraConfig = mkOption {
+        description = "Extra lines to add to the desktop file.";
+        type = types.nullOr types.lines;
+        default = null;
+      };
+    };
+  };
+
+  #formatting helpers
+  ifNotNull = a: a': if a == null then null else a';
+  stringBool = bool: if bool then "true" else "false";
+  semicolonList = list:
+    (concatStringsSep ";" list) + ";"; # requires trailing semicolon
+
+  #passing config options to makeDesktopItem in expected format
+  makeFile = name: config:
+    pkgs.makeDesktopItem {
+      name = name;
+      type = config.type;
+      exec = config.exec;
+      icon = config.icon;
+      comment = config.comment;
+      terminal = ifNotNull config.terminal (stringBool config.terminal);
+      desktopName = config.name;
+      genericName = config.genericName;
+      mimeType = ifNotNull config.mimeType (semicolonList config.mimeType);
+      categories =
+        ifNotNull config.categories (semicolonList config.categories);
+      startupNotify =
+        ifNotNull config.startupNotify (stringBool config.startupNotify);
+      extraEntries = config.extraConfig;
+    };
+in {
+  meta.maintainers = with maintainers; [ cwyc ];
+
+  options.xdg.desktopEntries = mkOption {
+    description = ''
+      Desktop Entries allow applications to be shown in your desktop environment's app launcher. </para><para>
+      You can define entries for programs without entries or override existing entries. </para><para>
+      See <link xlink:href="https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys" /> for more information on options.
+    '';
+    default = { };
+    type = types.attrsOf (types.submodule desktopEntry);
+    example = {
+      firefox = {
+        name = "Firefox";
+        genericName = "Web Browser";
+        exec = "firefox %U";
+        terminal = false;
+        categories = [ "Application" "Network" "WebBrowser" ];
+        mimeType = [ "text/html" "text/xml" ];
+      };
+    };
+  };
+
+  config.home.packages = mkIf (config.xdg.desktopEntries != { })
+    (map hiPrio # we need hiPrio to override existing entries
+      (attrsets.mapAttrsToList makeFile config.xdg.desktopEntries));
+
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -41,6 +41,7 @@ let
     (loadModule ./misc/version.nix { })
     (loadModule ./misc/vte.nix { })
     (loadModule ./misc/xdg-system-dirs.nix { condition = hostPlatform.isLinux; })
+    (loadModule ./misc/xdg-desktop-entries.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-mime.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-mime-apps.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-user-dirs.nix { condition = hostPlatform.isLinux; })

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -2,4 +2,5 @@
   xdg-mime-apps-basics = ./mime-apps-basics.nix;
   xdg-file-attr-names = ./file-attr-names.nix;
   xdg-system-dirs = ./system-dirs.nix;
+  xdg-desktop-entries = ./desktop-entries.nix;
 }

--- a/tests/modules/misc/xdg/desktop-entries.nix
+++ b/tests/modules/misc/xdg/desktop-entries.nix
@@ -1,0 +1,53 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    xdg.desktopEntries = {
+      full = { # full definition
+        type = "Application";
+        exec = "test --option";
+        icon = "test";
+        comment = "My Application";
+        terminal = true;
+        name = "Test";
+        genericName = "Web Browser";
+        mimeType = [ "text/html" "text/xml" ];
+        categories = [ "Application" "Network" "WebBrowser" ];
+        startupNotify = false;
+        extraConfig = ''
+          NoDisplay=false
+          DBusActivatable=false
+        '';
+      };
+      min = { # minimal definition
+        exec = "test --option";
+        name = "Test";
+      };
+    };
+
+    #testing that preexisting entries in the store are overridden
+    home.packages = [
+      (pkgs.makeDesktopItem {
+        name = "full";
+        desktopName = "We don't want this";
+        exec = "no";
+      })
+      (pkgs.makeDesktopItem {
+        name = "min";
+        desktopName = "We don't want this";
+        exec = "no";
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-path/share/applications/full.desktop
+      assertFileExists home-path/share/applications/min.desktop
+      assertFileContent home-path/share/applications/full.desktop \
+        ${./desktop-full-expected.desktop}
+      assertFileContent home-path/share/applications/min.desktop \
+        ${./desktop-min-expected.desktop}
+    '';
+  };
+}

--- a/tests/modules/misc/xdg/desktop-entries.nix
+++ b/tests/modules/misc/xdg/desktop-entries.nix
@@ -14,12 +14,17 @@ with lib;
         name = "Test";
         genericName = "Web Browser";
         mimeType = [ "text/html" "text/xml" ];
-        categories = [ "Application" "Network" "WebBrowser" ];
+        categories = [ "Network" "WebBrowser" ];
         startupNotify = false;
         extraConfig = ''
-          NoDisplay=false
-          DBusActivatable=false
+          [X-ExtraSection]
+          Exec=foo -o
         '';
+        settings = {
+          Keywords = "calc;math";
+          DBusActivatable = "false";
+        };
+        fileValidation = true;
       };
       min = { # minimal definition
         exec = "test --option";

--- a/tests/modules/misc/xdg/desktop-full-expected.desktop
+++ b/tests/modules/misc/xdg/desktop-full-expected.desktop
@@ -1,14 +1,16 @@
 [Desktop Entry]
-Type=Application
-Exec=test --option
-Terminal=true
-Name=Test
-Icon=test
+Categories=Network;WebBrowser;
 Comment=My Application
-GenericName=Web Browser
-MimeType=text/html;text/xml;
-Categories=Application;Network;WebBrowser;
-StartupNotify=false
-NoDisplay=false
 DBusActivatable=false
+Exec=test --option
+GenericName=Web Browser
+Icon=test
+Keywords=calc;math
+MimeType=text/html;text/xml;
+Name=Test
+StartupNotify=false
+Terminal=true
+Type=Application
+[X-ExtraSection]
+Exec=foo -o
 

--- a/tests/modules/misc/xdg/desktop-full-expected.desktop
+++ b/tests/modules/misc/xdg/desktop-full-expected.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Type=Application
+Exec=test --option
+Terminal=true
+Name=Test
+Icon=test
+Comment=My Application
+GenericName=Web Browser
+MimeType=text/html;text/xml;
+Categories=Application;Network;WebBrowser;
+StartupNotify=false
+NoDisplay=false
+DBusActivatable=false
+

--- a/tests/modules/misc/xdg/desktop-min-expected.desktop
+++ b/tests/modules/misc/xdg/desktop-min-expected.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Exec=test --option
+Terminal=false
+Name=Test
+

--- a/tests/modules/misc/xdg/desktop-min-expected.desktop
+++ b/tests/modules/misc/xdg/desktop-min-expected.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
-Type=Application
 Exec=test --option
-Terminal=false
 Name=Test
-
+Terminal=false
+Type=Application


### PR DESCRIPTION
### Description
This is a module to manage .desktop files in ~/.local/share/applications/, which define entries in your desktop environment's app launcher.
It allows you to override app launcher entries that are already installed in your nix profile, and to create new ones.
It uses the [makeDesktopItem](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/make-desktopitem/default.nix) package, and its options mostly follow the package's parameters.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
