### PR TITLE
i3status-rust: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,8 @@
 
 /modules/programs/i3status.nix                        @JustinLovinger
 
+/modules/programs/i3status-rust.nix                   @workflow
+
 /modules/programs/keychain.nix                        @marsam
 
 /modules/programs/lesspipe.nix                        @rycee

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1728,6 +1728,14 @@ in
           A new module is available: 'services.caffeine'.
         '';
       }
+
+      {
+        time = "2020-11-05T22:59:21+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'programs.i3status-rust'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -75,6 +75,7 @@ let
     (loadModule ./programs/home-manager.nix { })
     (loadModule ./programs/htop.nix { })
     (loadModule ./programs/i3status.nix { })
+    (loadModule ./programs/i3status-rust.nix { condition = hostPlatform.isLinux; })
     (loadModule ./programs/info.nix { })
     (loadModule ./programs/irssi.nix { })
     (loadModule ./programs/lieer.nix { })

--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -1,0 +1,265 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.i3status-rust;
+
+  restartI3 = ''
+    i3Socket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/i3/ipc-socket.*
+    if [ -S $i3Socket ]; then
+      echo "Reloading i3"
+      $DRY_RUN_CMD ${config.xsession.windowManager.i3.package}/bin/i3-msg -s $i3Socket restart 1>/dev/null
+    fi
+  '';
+
+  settingsFormat = pkgs.formats.toml { };
+
+in {
+  meta.maintainers = [ maintainers.farlion ];
+
+  options.programs.i3status-rust = {
+    enable = mkEnableOption "a replacement for i3-status written in Rust";
+
+    bars = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+
+          blocks = mkOption {
+            type = settingsFormat.type;
+            default = [
+              {
+                block = "disk_space";
+                path = "/";
+                alias = "/";
+                info_type = "available";
+                unit = "GB";
+                interval = 60;
+                warning = 20.0;
+                alert = 10.0;
+              }
+              {
+                block = "memory";
+                display_type = "memory";
+                format_mem = "{Mup}%";
+                format_swap = "{SUp}%";
+              }
+              {
+                block = "cpu";
+                interval = 1;
+              }
+              {
+                block = "load";
+                interval = 1;
+                format = "{1m}";
+              }
+              { block = "sound"; }
+              {
+                block = "time";
+                interval = 60;
+                format = "%a %d/%m %R";
+              }
+            ];
+            description = ''
+              Configuration blocks to add to i3status-rust
+              <filename>config</filename>. See
+              <link xlink:href="https://github.com/greshake/i3status-rust/blob/master/blocks.md"/>
+              for block options.
+            '';
+            example = literalExample ''
+              [
+                {
+                  block = "disk_space";
+                  path = "/";
+                  alias = "/";
+                  info_type = "available";
+                  unit = "GB";
+                  interval = 60;
+                  warning = 20.0;
+                  alert = 10.0;
+                }
+                {
+                  block = "sound";
+                  format = "{output_name} {volume}%";
+                  on_click = "pavucontrol --tab=3";
+                  mappings = {
+                   "alsa_output.pci-0000_00_1f.3.analog-stereo" = "";
+                   "bluez_sink.70_26_05_DA_27_A4.a2dp_sink" = ""
+                  };
+                }
+              ];
+            '';
+          };
+
+          settings = mkOption {
+            type = settingsFormat.type;
+            default = { };
+            description = ''
+              Any extra options to add to i3status-rust
+              <filename>config</filename>.
+            '';
+            example = literalExample ''
+              {
+                theme =  {
+                  name = "solarized-dark";
+                  overrides = {
+                    idle_bg = "#123456";
+                    idle_fg = "#abcdef";
+                  };
+                };
+              }
+            '';
+          };
+
+          icons = mkOption {
+            type = types.str;
+            default = "none";
+            description = ''
+              The icons set to use. See
+              <link xlink:href="https://github.com/greshake/i3status-rust/blob/master/themes.md"/>
+              for a list of available icon sets.
+            '';
+            example = "awesome5";
+          };
+
+          theme = mkOption {
+            type = types.str;
+            default = "plain";
+            description = ''
+              The theme to use. See
+              <link xlink:href="https://github.com/greshake/i3status-rust/blob/master/themes.md"/>
+              for a list of available themes.
+            '';
+            example = "gruvbox-dark";
+          };
+        };
+      });
+
+      default = {
+        default = {
+          blocks = [
+            {
+              block = "disk_space";
+              path = "/";
+              alias = "/";
+              info_type = "available";
+              unit = "GB";
+              interval = 60;
+              warning = 20.0;
+              alert = 10.0;
+            }
+            {
+              block = "memory";
+              display_type = "memory";
+              format_mem = "{Mup}%";
+              format_swap = "{SUp}%";
+            }
+            {
+              block = "cpu";
+              interval = 1;
+            }
+            {
+              block = "load";
+              interval = 1;
+              format = "{1m}";
+            }
+            { block = "sound"; }
+            {
+              block = "time";
+              interval = 60;
+              format = "%a %d/%m %R";
+            }
+          ];
+        };
+      };
+      description = ''
+        Attribute set of i3status-rust bars, each with their own configuration.
+        Each bar <varname>name</varname> generates a config file suffixed with
+        the bar's <varname>name</varname> from the attribute set, like so:
+        <filename>config-<replaceable>name</replaceable>.toml</filename>.
+        </para><para>
+        This way, multiple config files can be generated, such as for having a
+        top and a bottom bar.
+        </para><para>
+        See
+        <citerefentry>
+         <refentrytitle>i3status-rust</refentrytitle>
+         <manvolnum>1</manvolnum>
+        </citerefentry>
+        for options.
+      '';
+      example = literalExample ''
+        bottom = {
+          blocks = [
+            {
+               block = "disk_space";
+               path = "/";
+               alias = "/";
+               info_type = "available";
+               unit = "GB";
+               interval = 60;
+               warning = 20.0;
+               alert = 10.0;
+             }
+             {
+               block = "memory";
+               display_type = "memory";
+               format_mem = "{Mup}%";
+               format_swap = "{SUp}%";
+             }
+             {
+               block = "cpu";
+               interval = 1;
+             }
+             {
+               block = "load";
+               interval = 1;
+               format = "{1m}";
+             }
+             { block = "sound"; }
+             {
+               block = "time";
+               interval = 60;
+               format = "%a %d/%m %R";
+             }
+          ];
+          settings = {
+            theme =  {
+              name = "solarized-dark";
+              overrides = {
+                idle_bg = "#123456";
+                idle_fg = "#abcdef";
+              };
+            };
+          };
+          icons = "awesome5";
+          theme = "gruvbox-dark";
+        };
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.i3status-rust;
+      defaultText = literalExample "pkgs.i3status-rust";
+      description = "Package providing i3status-rust";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = mapAttrs' (cfgFileSuffix: cfg:
+      nameValuePair ("i3status-rust/config-${cfgFileSuffix}.toml") ({
+        onChange = mkIf config.xsession.windowManager.i3.enable restartI3;
+
+        source = settingsFormat.generate ("config-${cfgFileSuffix}.toml") ({
+          theme = cfg.theme;
+          icons = cfg.icons;
+          block = cfg.blocks;
+        } // cfg.settings);
+      })) cfg.bars;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -86,6 +86,7 @@ import nmt {
     ./modules/programs/autorandr
     ./modules/programs/firefox
     ./modules/programs/getmail
+    ./modules/programs/i3status-rust
     ./modules/programs/ncmpcpp-linux
     ./modules/programs/neovim   # Broken package dependency on Darwin.
     ./modules/programs/rofi

--- a/tests/modules/programs/i3status-rust/default.nix
+++ b/tests/modules/programs/i3status-rust/default.nix
@@ -1,0 +1,6 @@
+{
+  i3status-rust-with-default = ./with-default.nix;
+  i3status-rust-with-custom = ./with-custom.nix;
+  i3status-rust-with-extra-settings = ./with-extra-settings.nix;
+  i3status-rust-with-multiple-bars = ./with-multiple-bars.nix;
+}

--- a/tests/modules/programs/i3status-rust/with-custom.nix
+++ b/tests/modules/programs/i3status-rust/with-custom.nix
@@ -1,0 +1,186 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.i3status-rust = {
+      enable = true;
+      bars = {
+        custom = {
+          blocks = [
+            {
+              block = "disk_space";
+              path = "/";
+              alias = "/";
+              info_type = "available";
+              unit = "GB";
+              interval = 60;
+              warning = 20.0;
+              alert = 10.0;
+            }
+            {
+              block = "memory";
+              display_type = "memory";
+              format_mem = "{Mug}GB ({Mup}%)";
+              format_swap = "{SUp}%";
+            }
+            {
+              block = "cpu";
+              interval = 1;
+              format = "{barchart}";
+            }
+            {
+              block = "load";
+              interval = 1;
+              format = "{1m} {5m}";
+            }
+            {
+              block = "temperature";
+              collapsed = true;
+              interval = 10;
+              format = "{min}° min, {max}° max, {average}° avg";
+              chip = "*-isa-*";
+            }
+            {
+              block = "networkmanager";
+              ap_format = "{ssid} @ {strength}%";
+              on_click = "kcmshell5 kcm_networkmanagement";
+            }
+            {
+              block = "net";
+              device = "enp9s0u2u1u2c2";
+              speed_up = true;
+              interval = 5;
+            }
+            {
+              block = "speedtest";
+              bytes = true;
+            }
+            {
+              block = "xrandr";
+              interval =
+                6000; # Because running the commands causes screen lag, see https://github.com/greshake/i3status-rust/issues/668
+            }
+            {
+              block = "sound";
+              format = "{output_name} {volume}%";
+              on_click = "pavucontrol --tab=3";
+              mappings = {
+                "alsa_output.pci-0000_00_1f.3.analog-stereo" = "";
+                "bluez_sink.70_26_05_DA_27_A4.a2dp_sink" = "";
+              };
+            }
+            {
+              block = "music";
+              player = "spotify";
+              buttons = [ "play" "prev" "next" ];
+              on_collapsed_click = "i3-msg '[class=Spotify] focus'";
+            }
+            {
+              block = "time";
+              interval = 60;
+              format = "%a %d.%m %R";
+            }
+            { block = "battery"; }
+          ];
+
+          icons = "awesome5";
+
+          theme = "gruvbox-dark";
+        };
+      };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        i3status-rust = pkgs.writeScriptBin "dummy-i3status-rust" "";
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/i3status-rust/config-custom.toml
+      assertFileContent home-files/.config/i3status-rust/config-custom.toml \
+        ${
+          pkgs.writeText "i3status-rust-expected-config" ''
+            icons = "awesome5"
+            theme = "gruvbox-dark"
+            [[block]]
+            alert = 10
+            alias = "/"
+            block = "disk_space"
+            info_type = "available"
+            interval = 60
+            path = "/"
+            unit = "GB"
+            warning = 20
+
+            [[block]]
+            block = "memory"
+            display_type = "memory"
+            format_mem = "{Mug}GB ({Mup}%)"
+            format_swap = "{SUp}%"
+
+            [[block]]
+            block = "cpu"
+            format = "{barchart}"
+            interval = 1
+
+            [[block]]
+            block = "load"
+            format = "{1m} {5m}"
+            interval = 1
+
+            [[block]]
+            block = "temperature"
+            chip = "*-isa-*"
+            collapsed = true
+            format = "{min}° min, {max}° max, {average}° avg"
+            interval = 10
+
+            [[block]]
+            ap_format = "{ssid} @ {strength}%"
+            block = "networkmanager"
+            on_click = "kcmshell5 kcm_networkmanagement"
+
+            [[block]]
+            block = "net"
+            device = "enp9s0u2u1u2c2"
+            interval = 5
+            speed_up = true
+
+            [[block]]
+            block = "speedtest"
+            bytes = true
+
+            [[block]]
+            block = "xrandr"
+            interval = 6000
+
+            [[block]]
+            block = "sound"
+            format = "{output_name} {volume}%"
+            on_click = "pavucontrol --tab=3"
+
+            [block.mappings]
+            "alsa_output.pci-0000_00_1f.3.analog-stereo" = ""
+            "bluez_sink.70_26_05_DA_27_A4.a2dp_sink" = ""
+
+            [[block]]
+            block = "music"
+            buttons = ["play", "prev", "next"]
+            on_collapsed_click = "i3-msg '[class=Spotify] focus'"
+            player = "spotify"
+
+            [[block]]
+            block = "time"
+            format = "%a %d.%m %R"
+            interval = 60
+
+            [[block]]
+            block = "battery"
+                                  ''
+        }
+    '';
+  };
+}

--- a/tests/modules/programs/i3status-rust/with-default.nix
+++ b/tests/modules/programs/i3status-rust/with-default.nix
@@ -1,0 +1,58 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.i3status-rust = { enable = true; };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        i3status-rust = pkgs.writeScriptBin "dummy-i3status-rust" "";
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/i3status-rust/config-default.toml
+      assertFileContent home-files/.config/i3status-rust/config-default.toml \
+        ${
+          pkgs.writeText "i3status-rust-expected-config" ''
+            icons = "none"
+            theme = "plain"
+            [[block]]
+            alert = 10
+            alias = "/"
+            block = "disk_space"
+            info_type = "available"
+            interval = 60
+            path = "/"
+            unit = "GB"
+            warning = 20
+
+            [[block]]
+            block = "memory"
+            display_type = "memory"
+            format_mem = "{Mup}%"
+            format_swap = "{SUp}%"
+
+            [[block]]
+            block = "cpu"
+            interval = 1
+
+            [[block]]
+            block = "load"
+            format = "{1m}"
+            interval = 1
+
+            [[block]]
+            block = "sound"
+
+            [[block]]
+            block = "time"
+            format = "%a %d/%m %R"
+            interval = 60
+                      ''
+        }
+    '';
+  };
+}

--- a/tests/modules/programs/i3status-rust/with-extra-settings.nix
+++ b/tests/modules/programs/i3status-rust/with-extra-settings.nix
@@ -1,0 +1,202 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.i3status-rust = {
+      enable = true;
+      bars = {
+        extra-settings = {
+          blocks = [
+            {
+              block = "disk_space";
+              path = "/";
+              alias = "/";
+              info_type = "available";
+              unit = "GB";
+              interval = 60;
+              warning = 20.0;
+              alert = 10.0;
+            }
+            {
+              block = "memory";
+              display_type = "memory";
+              format_mem = "{Mug}GB ({Mup}%)";
+              format_swap = "{SUp}%";
+            }
+            {
+              block = "cpu";
+              interval = 1;
+              format = "{barchart}";
+            }
+            {
+              block = "load";
+              interval = 1;
+              format = "{1m} {5m}";
+            }
+            {
+              block = "temperature";
+              collapsed = true;
+              interval = 10;
+              format = "{min}° min, {max}° max, {average}° avg";
+              chip = "*-isa-*";
+            }
+            {
+              block = "networkmanager";
+              ap_format = "{ssid} @ {strength}%";
+              on_click = "kcmshell5 kcm_networkmanagement";
+            }
+            {
+              block = "net";
+              device = "enp9s0u2u1u2c2";
+              speed_up = true;
+              interval = 5;
+            }
+            {
+              block = "speedtest";
+              bytes = true;
+            }
+            {
+              block = "xrandr";
+              interval =
+                6000; # Because running the commands causes screen lag, see https://github.com/greshake/i3status-rust/issues/668
+            }
+            {
+              block = "sound";
+              format = "{output_name} {volume}%";
+              on_click = "pavucontrol --tab=3";
+              mappings = {
+                "alsa_output.pci-0000_00_1f.3.analog-stereo" = "";
+                "bluez_sink.70_26_05_DA_27_A4.a2dp_sink" = "";
+              };
+            }
+            {
+              block = "music";
+              player = "spotify";
+              buttons = [ "play" "prev" "next" ];
+              on_collapsed_click = "i3-msg '[class=Spotify] focus'";
+            }
+            {
+              block = "time";
+              interval = 60;
+              format = "%a %d.%m %R";
+            }
+            { block = "battery"; }
+          ];
+
+          icons = "awesome5";
+
+          settings = {
+            theme = {
+              name = "solarized-dark";
+              overrides = {
+                idle_bg = "#123456";
+                idle_fg = "#abcdef";
+              };
+            };
+          };
+
+          theme = "gruvbox-dark";
+        };
+      };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        i3status-rust = pkgs.writeScriptBin "dummy-i3status-rust" "";
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/i3status-rust/config-extra-settings.toml 
+      assertFileContent home-files/.config/i3status-rust/config-extra-settings.toml \
+        ${
+          pkgs.writeText "i3status-rust-expected-config" ''
+            icons = "awesome5"
+            [[block]]
+            alert = 10
+            alias = "/"
+            block = "disk_space"
+            info_type = "available"
+            interval = 60
+            path = "/"
+            unit = "GB"
+            warning = 20
+
+            [[block]]
+            block = "memory"
+            display_type = "memory"
+            format_mem = "{Mug}GB ({Mup}%)"
+            format_swap = "{SUp}%"
+
+            [[block]]
+            block = "cpu"
+            format = "{barchart}"
+            interval = 1
+
+            [[block]]
+            block = "load"
+            format = "{1m} {5m}"
+            interval = 1
+
+            [[block]]
+            block = "temperature"
+            chip = "*-isa-*"
+            collapsed = true
+            format = "{min}° min, {max}° max, {average}° avg"
+            interval = 10
+
+            [[block]]
+            ap_format = "{ssid} @ {strength}%"
+            block = "networkmanager"
+            on_click = "kcmshell5 kcm_networkmanagement"
+
+            [[block]]
+            block = "net"
+            device = "enp9s0u2u1u2c2"
+            interval = 5
+            speed_up = true
+
+            [[block]]
+            block = "speedtest"
+            bytes = true
+
+            [[block]]
+            block = "xrandr"
+            interval = 6000
+
+            [[block]]
+            block = "sound"
+            format = "{output_name} {volume}%"
+            on_click = "pavucontrol --tab=3"
+
+            [block.mappings]
+            "alsa_output.pci-0000_00_1f.3.analog-stereo" = ""
+            "bluez_sink.70_26_05_DA_27_A4.a2dp_sink" = ""
+
+            [[block]]
+            block = "music"
+            buttons = ["play", "prev", "next"]
+            on_collapsed_click = "i3-msg '[class=Spotify] focus'"
+            player = "spotify"
+
+            [[block]]
+            block = "time"
+            format = "%a %d.%m %R"
+            interval = 60
+
+            [[block]]
+            block = "battery"
+
+            [theme]
+            name = "solarized-dark"
+
+            [theme.overrides]
+            idle_bg = "#123456"
+            idle_fg = "#abcdef"
+                                              ''
+        }
+    '';
+  };
+}

--- a/tests/modules/programs/i3status-rust/with-multiple-bars.nix
+++ b/tests/modules/programs/i3status-rust/with-multiple-bars.nix
@@ -1,0 +1,106 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.i3status-rust = {
+      enable = true;
+
+      bars = {
+
+        top = {
+          blocks = [
+            {
+              block = "disk_space";
+              path = "/";
+              alias = "/";
+              info_type = "available";
+              unit = "GB";
+              interval = 60;
+              warning = 20.0;
+              alert = 10.0;
+            }
+            {
+              block = "memory";
+              display_type = "memory";
+              format_mem = "{Mug}GB ({Mup}%)";
+              format_swap = "{SUp}%";
+            }
+          ];
+        };
+
+        bottom = {
+          blocks = [
+            {
+              block = "cpu";
+              interval = 1;
+              format = "{barchart}";
+            }
+            {
+              block = "load";
+              interval = 1;
+              format = "{1m} {5m}";
+            }
+          ];
+          icons = "awesome5";
+
+          theme = "gruvbox-dark";
+        };
+
+      };
+
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        i3status-rust = pkgs.writeScriptBin "dummy-i3status-rust" "";
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/i3status-rust/config-top.toml
+      assertFileContent home-files/.config/i3status-rust/config-top.toml \
+        ${
+          pkgs.writeText "i3status-rust-expected-config" ''
+            icons = "none"
+            theme = "plain"
+            [[block]]
+            alert = 10
+            alias = "/"
+            block = "disk_space"
+            info_type = "available"
+            interval = 60
+            path = "/"
+            unit = "GB"
+            warning = 20
+
+            [[block]]
+            block = "memory"
+            display_type = "memory"
+            format_mem = "{Mug}GB ({Mup}%)"
+            format_swap = "{SUp}%"
+          ''
+        }
+
+      assertFileExists home-files/.config/i3status-rust/config-bottom.toml
+      assertFileContent \
+        home-files/.config/i3status-rust/config-bottom.toml \
+        ${
+          pkgs.writeText "i3status-rust-expected-config" ''
+            icons = "awesome5"
+            theme = "gruvbox-dark"
+            [[block]]
+            block = "cpu"
+            format = "{barchart}"
+            interval = 1
+
+            [[block]]
+            block = "load"
+            format = "{1m} {5m}"
+            interval = 1
+          ''
+        }
+    '';
+  };
+}


### PR DESCRIPTION
### Description

This adds the i3status-rust module, a replacement for `i3status` written in pure Rust.

See: https://github.com/greshake/i3status-rust

Configuration file is in TOML format, and I chose to keep the options loosely typed (according to https://github.com/Infinisil/rfcs/blob/config-option/rfcs/0042-config-option.md) to avoid expected frequent breaking with upstream changes in i3status-rust.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
