### PR TITLE
mcfly: fix when non-interactive with fish

### DIFF
--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -66,7 +66,9 @@ in {
 
       programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
         source "${pkgs.mcfly}/share/mcfly/mcfly.fish"
-        mcfly_key_bindings
+        if status is-interactive
+          mcfly_key_bindings
+        end
       '';
 
       home.sessionVariables.MCFLY_KEY_SCHEME = cfg.keyScheme;


### PR DESCRIPTION
### Description

`mcfly_key_bindings` is only defined for interactive sessions.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.

cc @marsam