### PR TITLE
services.emacs: avoid desktop item collision

### DIFF
--- a/tests/modules/services/emacs/emacs-emacsclient.desktop
+++ b/tests/modules/services/emacs/emacs-emacsclient.desktop
@@ -1,12 +1,11 @@
 [Desktop Entry]
-Type=Application
-Exec=@emacs@/bin/emacsclient -c %F
-Terminal=false
-Name=Emacs Client
-Icon=emacs
-Comment=Edit text
-GenericName=Text Editor
-MimeType=text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;
 Categories=Utility;TextEditor;
+Comment=Edit text
+Exec=@emacs@/bin/emacsclient -c %u
+GenericName=Text Editor
+Icon=emacs
+MimeType=application/x-shellscript;text/english;text/plain;text/x-c;text/x-c++;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-makefile;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;x-scheme-handler/org-protocol;
+Name=Emacs Client
 StartupWMClass=Emacs
-
+Terminal=false
+Type=Application

--- a/tests/modules/services/emacs/emacs-service.nix
+++ b/tests/modules/services/emacs/emacs-service.nix
@@ -21,7 +21,7 @@ with lib;
     nmt.script = ''
       assertPathNotExists home-files/.config/systemd/user/emacs.socket
       assertFileExists home-files/.config/systemd/user/emacs.service
-      assertFileExists home-path/share/applications/emacsclient.desktop
+      assertFileExists home-files/.local/share/applications/emacsclient.desktop
 
       assertFileContent home-files/.config/systemd/user/emacs.service \
                         ${
@@ -30,7 +30,7 @@ with lib;
                             src = ./emacs-service-emacs.service;
                           }
                         }
-      assertFileContent home-path/share/applications/emacsclient.desktop \
+      assertFileContent home-files/.local/share/applications/emacsclient.desktop \
                         ${./emacs-emacsclient.desktop}
     '';
   };

--- a/tests/modules/services/emacs/emacs-socket-26.nix
+++ b/tests/modules/services/emacs/emacs-socket-26.nix
@@ -22,7 +22,7 @@ with lib;
     nmt.script = ''
       assertFileExists home-files/.config/systemd/user/emacs.socket
       assertFileExists home-files/.config/systemd/user/emacs.service
-      assertFileExists home-path/share/applications/emacsclient.desktop
+      assertFileExists home-files/.local/share/applications/emacsclient.desktop
 
       assertFileContent home-files/.config/systemd/user/emacs.socket \
                         ${./emacs-socket-26-emacs.socket}
@@ -33,7 +33,7 @@ with lib;
                             src = ./emacs-socket-26-emacs.service;
                           }
                         }
-      assertFileContent home-path/share/applications/emacsclient.desktop \
+      assertFileContent home-files/.local/share/applications/emacsclient.desktop \
                         ${./emacs-emacsclient.desktop}
     '';
   };

--- a/tests/modules/services/emacs/emacs-socket-27.nix
+++ b/tests/modules/services/emacs/emacs-socket-27.nix
@@ -24,7 +24,7 @@ in {
     nmt.script = ''
       assertFileExists home-files/.config/systemd/user/emacs.socket
       assertFileExists home-files/.config/systemd/user/emacs.service
-      assertFileExists home-path/share/applications/emacsclient.desktop
+      assertFileExists home-files/.local/share/applications/emacsclient.desktop
 
       assertFileContent home-files/.config/systemd/user/emacs.socket \
                         ${./emacs-socket-27-emacs.socket}
@@ -35,7 +35,7 @@ in {
                             src = ./emacs-socket-27-emacs.service;
                           }
                         }
-      assertFileContent home-path/share/applications/emacsclient.desktop \
+      assertFileContent home-files/.local/share/applications/emacsclient.desktop \
                         ${./emacs-emacsclient.desktop}
     '';
   };


### PR DESCRIPTION
Using emacsGit or emacsGcc from nixos/emacs-overlay with `services.emacs.client.enable = true` results in a collision at `$home-path/share/applications/emacsclient.desktop`.

Instead of installing the desktop item in `home.packages`, link it to `$XDG_DATA_HOME/applications` to avoid the collision. This directory should supersede the desktop items installed in `$XDG_DATA_DIRS`.

In addition, adjust the desktop item to handle `org-protocol://` links as that is not currently supported or easily overridden by the user through Home Manager.

Add `service.emacs.client.mimeTypes` to allow the user to set which MIME types the Emacs client should open by default.

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

