### PR TITLE
Generate man cache files

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1664,6 +1664,15 @@ in
           available in menus.
         '';
       }
+
+      {
+        time = "2020-09-09T06:54:59+00:00";
+        condition = config.programs.man.enable;
+        message = ''
+          A new option 'programs.man.generateCaches' was added to
+          support the apropos command.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/man.nix
+++ b/modules/programs/man.nix
@@ -14,11 +14,59 @@ with lib;
           <literal>home.packages</literal>.
         '';
       };
+
+      generateCaches = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to generate the manual page index caches using
+          <citerefentry>
+            <refentrytitle>mandb</refentrytitle>
+            <manvolnum>8</manvolnum>
+          </citerefentry>. This allows searching for a page or
+          keyword using utilities like <citerefentry>
+            <refentrytitle>apropos</refentrytitle>
+            <manvolnum>1</manvolnum>
+          </citerefentry>.
+          </para><para>
+          This feature is disabled by default because it slows down
+          building. If you don't mind waiting a few more seconds when
+          Home Manager builds a new generation, you may safely enable
+          this option.
+        '';
+      };
     };
   };
 
   config = mkIf config.programs.man.enable {
     home.packages = [ pkgs.man ];
     home.extraOutputsToInstall = [ "man" ];
+
+    # This is mostly copy/pasted/adapted from NixOS' documentation.nix.
+    home.file = mkIf config.programs.man.generateCaches {
+      ".manpath".text = let
+        # Generate a directory containing installed packages' manpages.
+        manualPages = pkgs.buildEnv {
+          name = "man-paths";
+          paths = config.home.packages;
+          pathsToLink = [ "/share/man" ];
+          extraOutputsToInstall = [ "man" ];
+          ignoreCollisions = true;
+        };
+
+        # Generate a database of all manpages in ${manualPages}.
+        manualCache = pkgs.runCommandLocal "man-cache" { } ''
+          # Generate a temporary man.conf so mandb knows where to
+          # write cache files.
+          echo "MANDB_MAP ${manualPages}/share/man $out" > man.conf
+
+          # Run mandb to generate cache files:
+          ${pkgs.man-db}/bin/mandb -C man.conf --no-straycats --create \
+            ${manualPages}/share/man
+        '';
+      in ''
+        MANDB_MAP ${config.home.profileDirectory}/share/man ${manualCache}
+      '';
+    };
   };
 }

--- a/modules/programs/man.nix
+++ b/modules/programs/man.nix
@@ -4,14 +4,16 @@ with lib;
 
 {
   options = {
-    programs.man.enable = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable manual pages and the <command>man</command>
-        command. This also includes "man" outputs of all
-        <literal>home.packages</literal>.
-      '';
+    programs.man = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable manual pages and the <command>man</command>
+          command. This also includes "man" outputs of all
+          <literal>home.packages</literal>.
+        '';
+      };
     };
   };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -52,6 +52,7 @@ import nmt {
     ./modules/programs/kakoune
     ./modules/programs/lf
     ./modules/programs/lieer
+    ./modules/programs/man
     ./modules/programs/mbsync
     ./modules/programs/ncmpcpp
     ./modules/programs/ne

--- a/tests/modules/programs/man/apropos.nix
+++ b/tests/modules/programs/man/apropos.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.man = {
+      enable = true;
+      generateCaches = true;
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.manpath
+
+      CACHE_DIR=$(cat $TESTED/home-files/.manpath | cut --delimiter=' ' --fields=3)
+
+      if [[ ! -f "$CACHE_DIR/index.bt" ]]; then
+          fail "Expected man cache files to exist (in $CACHE_DIR) but they were not found."
+      fi
+    '';
+  };
+}

--- a/tests/modules/programs/man/default.nix
+++ b/tests/modules/programs/man/default.nix
@@ -1,0 +1,4 @@
+{
+  man-apropos = ./apropos.nix;
+  man-no-manpath = ./no-manpath.nix;
+}

--- a/tests/modules/programs/man/no-manpath.nix
+++ b/tests/modules/programs/man/no-manpath.nix
@@ -1,0 +1,13 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.man = { enable = true; };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.manpath
+    '';
+  };
+}


### PR DESCRIPTION
### Description

man: Add support for apropos by building a manpage database

The apropos software is useful to get a list of manpages matching a description or to get a list of all manpages. The latter feature is used by Emacs to get manpage completion (M-x man).

To have apropos working, a database of all available manpages must be built with mandb. This is what this commits does.

A [similar change was done for NixOS](https://github.com/NixOS/nixpkgs/commit/edc6a76cc025ef972979dad6692e0fd5d5cfcbbb).

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted
