### PR TITLE
chromium: enable it for all platforms

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -56,7 +56,7 @@ let
     (loadModule ./programs/beets.nix { })
     (loadModule ./programs/broot.nix { })
     (loadModule ./programs/browserpass.nix { })
-    (loadModule ./programs/chromium.nix { condition = hostPlatform.isLinux; })
+    (loadModule ./programs/chromium.nix { })
     (loadModule ./programs/command-not-found/command-not-found.nix { })
     (loadModule ./programs/dircolors.nix { })
     (loadModule ./programs/direnv.nix { })


### PR DESCRIPTION
### Description

Make module `programs.chromium` available on all platforms, rather than restricting it on Linux only.

### Example
 Although nixpkgs doesn't provide a usable chromium app on macOS, users can still implement their own derivation for installing chromium app, such as:

```nix
# macos-chromium
{ stdenv, fetchurl, unzip, undmg }:

stdenv.mkDerivation rec {
  pname = "chromium";
  version = "804618";

  buildInputs = [ unzip undmg ];
  sourceRoot = ".";
  phases = [ "unpackPhase" "installPhase" ];
  installPhase = ''
    mkdir -p "$out/Applications"
    cp -r chrome-mac/Chromium.app "$out/Applications/Chromium.app"
  '';

  src = fetchurl {
    name = "Chromium-${version}.zip";
    url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/${version}/chrome-mac.zip";
    sha256 = "12hq4sr7i7qm6qrz4pqgcdaxd9nw30blhvpki2m6ck3lmk0zc0a3";
  };

  meta = with stdenv.lib; {
    description = "Free and open-source web browser.";
    homepage = "https://www.chromium.org/Home";
    platforms = platforms.darwin;
  };
}
```

Use it with `home-manager`: 

```nix
  home-manager.users."${username}" = {
    programs.chromium = {
      enable = true;
      package = pkgs.custom.macos-chromium # here
      extensions = [
        # Security & Privacy
        "fgmjlmbojbkmdpofahffgcpkhkngfpef" # Startpage — Private Search Engine
        "einpaelgookohagofgnnkcfjbkkgepnp" # Random User-Agent
        "cjpalhdlnbpafiamejdnhcphjbkeiagm" # uBlock Origin
        "gcbommkclmclpchllfjekcdonpmejbdp" # HTTPS Everywhere
      ];
    };
  };
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

