### PR TITLE
Fix typo that prevents man pages from building

### DIFF
--- a/doc/release-notes/rl-1903.adoc
+++ b/doc/release-notes/rl-1903.adoc
@@ -5,7 +5,7 @@ The 19.03 release branch became the stable branch in April, 2019.
 
 [[sec-release-19.03-highlights]]
 === Highlights
-:opt-home-file-source: opt-home.file._name__.source
+:opt-home-file-source: opt-home.file._name_.source
 
 This release has the following notable changes:
 


### PR DESCRIPTION
This was fixed in master by 0399839, but not in bqv-flakes, and causes an error when trying to build the man pages.
