### PR TITLE
[20.03] unison: fix escaping of arguments

### DIFF
--- a/modules/services/unison.nix
+++ b/modules/services/unison.nix
@@ -60,7 +60,7 @@ let
     };
   };
 
-  serialiseArg = key: val: "-${key}=${escapeShellArg val}";
+  serialiseArg = key: val: escapeShellArg "-${key}=${escape [ "=" ] val}";
 
   serialiseArgs = args: concatStringsSep " " (mapAttrsToList serialiseArg args);
 


### PR DESCRIPTION
systemd's ExecStart= must take arguments fully quoted:
`"-sshargs=-i somekey"`
and not
`-ssargs="-i somekey"`

Additionally, inside arguments passed to unison, = characters must be
quoted. After unquotation by systemd, one must have
`-sshargs=-o Foo\=4`
instead of
`-sshargs=-o Foo=4`

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible. Well it's a bugfix...

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
