### PR TITLE
info: generate dir file directly in profile

### DIFF
--- a/modules/programs/info.nix
+++ b/modules/programs/info.nix
@@ -1,22 +1,21 @@
-# info.nix -- install texinfo, set INFOPATH, create `dir` file
+# info.nix -- install texinfo and create `dir` file
 
 # This is a helper for the GNU info documentation system. By default,
 # the `info` command (and the Info subsystem within Emacs) gives easy
 # access to the info files stored system-wide, but not info files in
 # your ~/.nix-profile.
 
-# We set $INFOPATH to include `/run/current-system/sw/share/info` and
-# `~/.nix-profile/share/info` but it's not enough. Although info can
-# then find files when you explicitly ask for them, it doesn't show
-# them to you in the table of contents on startup. To do that requires
-# a `dir` file. NixOS keeps the system-wide `dir` file up to date, but
-# ignores home-installed packages.
+# Specifically, although info can then find files when you explicitly
+# ask for them, it doesn't show them to you in the table of contents
+# on startup. To do that requires a `dir` file. NixOS keeps the
+# system-wide `dir` file up to date, but ignores files installed in
+# user profiles.
 
-# So this module contains an activation script that generates the
-# `dir` for your home profile. Then when you start info (and both
-# `dir` files are in your $INFOPATH), it will *merge* the contents of
-# the two files, showing you a unified table of contents for all
-# packages. This is really nice.
+# This module contains extra profile commands that generate the `dir`
+# for your home profile. Then when you start info (and both `dir`
+# files are in your $INFOPATH), it will *merge* the contents of the
+# two files, showing you a unified table of contents for all packages.
+# This is really nice.
 
 { config, lib, pkgs, ... }:
 
@@ -26,50 +25,39 @@ let
 
   cfg = config.programs.info;
 
-  # Indexes info files found in this location
-  homeInfoPath = "${config.home.profileDirectory}/share/info";
-
   # Installs this package -- the interactive just means that it
   # includes the curses `info` program. We also use `install-info`
   # from this package in the activation script.
   infoPkg = pkgs.texinfoInteractive;
 
 in {
-  options = {
-    programs.info = {
-      enable = mkEnableOption "GNU Info";
+  imports = [
+    (mkRemovedOptionModule [ "programs" "info" "homeInfoDirLocation" ] ''
+      The `dir` file is now generated as part of the Home Manager profile and
+      will no longer be placed in your home directory.
+    '')
+  ];
 
-      homeInfoDirLocation = mkOption {
-        default = "\${XDG_CACHE_HOME:-$HOME/.cache}/info";
-        description = ''
-          Directory in which to store the info <filename>dir</filename>
-          file within your home.
-        '';
-      };
-    };
-  };
+  options.programs.info.enable = mkEnableOption "GNU Info";
 
   config = mkIf cfg.enable {
-    home.sessionVariables.INFOPATH =
-      "${cfg.homeInfoDirLocation}\${INFOPATH:+:}\${INFOPATH}";
+    home.packages = [
+      infoPkg
 
-    home.activation.createHomeInfoDir =
-      hm.dag.entryAfter [ "installPackages" ] ''
-        oPATH=$PATH
-        export PATH="${lib.makeBinPath [ pkgs.gzip ]}''${PATH:+:}$PATH"
-        $DRY_RUN_CMD mkdir -p "${cfg.homeInfoDirLocation}"
-        $DRY_RUN_CMD rm -f "${cfg.homeInfoDirLocation}/dir"
-        if [[ -d "${homeInfoPath}" ]]; then
-          find -L "${homeInfoPath}" \( -name '*.info' -o -name '*.info.gz' \) \
-            -exec $DRY_RUN_CMD ${infoPkg}/bin/install-info '{}' \
-            "${cfg.homeInfoDirLocation}/dir" \;
-        fi
-        export PATH="$oPATH"
-        unset oPATH
-      '';
-
-    home.packages = [ infoPkg ];
+      # Make sure the target directory is a real directory.
+      (pkgs.runCommandLocal "dummy-info-dir1" { } "mkdir -p $out/share/info")
+      (pkgs.runCommandLocal "dummy-info-dir2" { } "mkdir -p $out/share/info")
+    ];
 
     home.extraOutputsToInstall = [ "info" ];
+
+    home.extraProfileCommands = let infoPath = "$out/share/info";
+    in ''
+      if [[ -w "${infoPath}" && ! -e "${infoPath}/dir" ]]; then
+        PATH="${lib.makeBinPath [ pkgs.gzip infoPkg ]}''${PATH:+:}$PATH" \
+        find -L "${infoPath}" \( -name '*.info' -o -name '*.info.gz' \) \
+          -exec install-info '{}' "${infoPath}/dir" ';'
+      fi
+    '';
   };
 }


### PR DESCRIPTION
### Description

This avoids the need for the activation block. The `dir` file is instead built directly in the installed profile.

CC @league

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.