### PR TITLE
autojump: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,9 @@
 
 /modules/programs/aria2.nix                           @JustinLovinger
 
+/modules/programs/autojump.nix                        @evanjs
+/tests/modules/programs/autojump                      @evanjs
+
 /modules/programs/autorandr.nix                       @uvNikita
 
 /modules/programs/bash.nix                            @rycee

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1687,6 +1687,16 @@ in
           A new module is available: 'programs.mu'.
         '';
       }
+
+      {
+        time = "2020-10-08T21:28:16+00:00";
+        message = ''
+          A new module is available: 'programs.autojump'
+
+          The option `programs.bash.enableAutojump` is deprecated and this new
+          module should be used instead.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -49,6 +49,7 @@ let
     (loadModule ./programs/alot.nix { })
     (loadModule ./programs/aria2.nix { })
     (loadModule ./programs/astroid.nix { })
+    (loadModule ./programs/autojump.nix { })
     (loadModule ./programs/autorandr.nix { })
     (loadModule ./programs/bash.nix { })
     (loadModule ./programs/bat.nix { })

--- a/modules/programs/autojump.nix
+++ b/modules/programs/autojump.nix
@@ -1,0 +1,56 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.autojump;
+  package = pkgs.autojump;
+
+in {
+  meta.maintainers = [ maintainers.evanjs ];
+
+  options.programs.autojump = {
+    enable = mkEnableOption "autojump";
+
+    enableBashIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Bash integration.
+      '';
+    };
+
+    enableZshIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Zsh integration.
+      '';
+    };
+
+    enableFishIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Fish integration.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ package ];
+
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkBefore ''
+      . ${package}/share/autojump/autojump.bash
+    '');
+
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      . ${package}/share/autojump/autojump.zsh
+    '';
+
+    programs.fish.promptInit = mkIf cfg.enableFishIntegration ''
+      . ${package}/share/autojump/autojump.fish
+    '';
+  };
+}

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -11,6 +11,14 @@ in
 {
   meta.maintainers = [ maintainers.rycee ];
 
+  imports = [
+    (mkRenamedOptionModule [ "programs" "bash" "enableAutojump" ] [
+      "programs"
+      "autojump"
+      "enable"
+    ])
+  ];
+
   options = {
     programs.bash = {
       enable = mkEnableOption "GNU Bourne-Again SHell";
@@ -94,12 +102,6 @@ in
         '';
       };
 
-      enableAutojump = mkOption {
-        default = false;
-        type = types.bool;
-        description = "Enable the autojump navigation tool.";
-      };
-
       profileExtra = mkOption {
         default = "";
         type = types.lines;
@@ -176,9 +178,6 @@ in
 
           ${aliasesStr}
 
-          ${optionalString cfg.enableAutojump
-            ". ${pkgs.autojump}/share/autojump/autojump.bash"}
-
           ${cfg.initExtra}
         fi
       '';
@@ -216,9 +215,6 @@ in
           ${cfg.logoutExtra}
         '';
       };
-
-      home.packages =
-        optional (cfg.enableAutojump) pkgs.autojump;
     }
   );
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -41,6 +41,7 @@ import nmt {
     ./modules/programs/alacritty
     ./modules/programs/alot
     ./modules/programs/aria2
+    ./modules/programs/autojump
     ./modules/programs/bash
     ./modules/programs/browserpass
     ./modules/programs/dircolors

--- a/tests/modules/programs/autojump/default-settings.nix
+++ b/tests/modules/programs/autojump/default-settings.nix
@@ -1,0 +1,13 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.autojump.enable = true;
+
+    nmt.script = ''
+      assertFileExists home-path/bin/autojump
+    '';
+  };
+}

--- a/tests/modules/programs/autojump/default.nix
+++ b/tests/modules/programs/autojump/default.nix
@@ -1,0 +1,1 @@
+{ autojump = ./default-settings.nix; }


### PR DESCRIPTION
### Description
Add a standalone module for autojump

This adds (implicitly enabled) options for bash (already available), fish, and zsh.

- Add test case for autojump (`programs.autojump.enable = true`)
- Add `mkRenamedOptionModule` option for `programs.bash.enableAutojump`

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.

___
## Note
I have not done any home-manager tests before, and I'm open to any feedback related to the naming of the test cases, if additional tests should be added, or the existing test should be modified.

Also, I was initially tempted to put it all on one line, but ended up following existing usages of `mkRenamedOptionModule` and placed the new definition across multiple lines.
Which style is preferred?

Thanks!