### PR TITLE
numlock: add test

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,9 @@
 
 /modules/misc/news.nix                                @rycee
 
+/modules/misc/numlock.nix                             @evanjs
+/tests/modules/misc/numlock                           @evanjs
+
 /modules/misc/pam.nix                                 @rycee
 /tests/modules/misc/pam                               @rycee
 

--- a/modules/misc/numlock.nix
+++ b/modules/misc/numlock.nix
@@ -7,6 +7,8 @@ let
   cfg = config.xsession.numlock;
 
 in {
+  meta.maintainers = [ maintainers.evanjs ];
+
   options = { xsession.numlock.enable = mkEnableOption "Num Lock"; };
 
   config = mkIf cfg.enable {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -75,6 +75,7 @@ import nmt {
   ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
     ./meta # Suffices to run on one platform.
     ./modules/misc/debug
+    ./modules/misc/numlock
     ./modules/misc/pam
     ./modules/misc/xdg
     ./modules/misc/xsession

--- a/tests/modules/misc/numlock/default.nix
+++ b/tests/modules/misc/numlock/default.nix
@@ -1,0 +1,1 @@
+{ numlock = ./numlock.nix; }

--- a/tests/modules/misc/numlock/numlock.nix
+++ b/tests/modules/misc/numlock/numlock.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    xsession.numlock.enable = true;
+
+    nixpkgs.overlays = [
+      (self: super: { numlockx = pkgs.writeScriptBin "dummy-numlockx" ""; })
+    ];
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/numlockx.service
+      assertFileExists $serviceFile
+    '';
+  };
+}


### PR DESCRIPTION
### Description
<!--

Please provide a brief description of your change.

-->

- Add evanjs to CODEOWNERS for numlock and numlock test
- Add evanjs to maintainers for numlock module

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
