### PR TITLE
sway: fix onChange for sway config when sway isn't running

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -396,7 +396,7 @@ in {
     xdg.configFile."sway/config" = {
       source = configFile;
       onChange = ''
-        swaySocket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.$(${pkgs.procps}/bin/pgrep -x sway).sock
+        swaySocket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.$(${pkgs.procps}/bin/pgrep -x sway || ${pkgs.coreutils}/bin/true).sock
         if [ -S $swaySocket ]; then
           echo "Reloading sway"
           $DRY_RUN_CMD ${pkgs.sway}/bin/swaymsg -s $swaySocket reload


### PR DESCRIPTION
### Description

I use home-manager as a NixOS module which means there's a systemd unit running as part of the boot process as opposed to when you use home-manager separately from your NixOS config (or when you're not on NixOS I suppose). That's likely when one would encounter this issue.

So, with that said, for a while now - many months actually - I've had an error from home-manager on boot at the "Activating onFIlesChange" message which in turn meant that the unit didn't run properly. As soon as I started sway and reran the unit however, it ran successfully. For a while I thought it may be something odd in my configuration since it's quite customized so I didn't look too closely at home-manager since I figured others would have encountered this issue.

When I finally had a look I found that the cause of this is very likely this pull request: https://github.com/nix-community/home-manager/pull/1086

I'm not entirely familiar with exactly how these onChange scripts are run but if they are run with the bash "-e" switch it would explain this in full. Basically `pgrep -x somecommand` exits with a non-zero status if it finds no process running with the given name. That means ofc that on boot (when sway isn't running) this script would fail and then fail the unit.

This pull request fixes my problem anyway by always returning a 0 exit status where we attempt to get the pid of sway.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
