### PR TITLE
Use `eval` instead of `exec` when running $EDITOR

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -165,7 +165,11 @@ function doEdit() {
 
     setConfigFile
 
-    exec "$EDITOR" "$HOME_MANAGER_CONFIG"
+    # Don't quote $EDITOR in order to support values including options, e.g.,
+    # "code --wait".
+    #
+    # shellcheck disable=2086
+    exec $EDITOR "$HOME_MANAGER_CONFIG"
 }
 
 function doBuild() {


### PR DESCRIPTION
### Description

Resolves https://github.com/nix-community/home-manager/issues/1496. It turns out that `exec` does not support $EDITOR values containing arguments, eg. "code --wait". This is in contrast to the majority of tools (git, etc) that do support this usage.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
