### PR TITLE
WIP: Add flake support to the release-20.03 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /result*
+flake.lock

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -1,3 +1,4 @@
+nixpkgs:
 {
 # Note, this should be "the standard library" + HM extensions.
 lib, pkgs }:
@@ -26,7 +27,7 @@ let
   };
 
   hmModulesDocs = nmd.buildModulesDocs {
-    modules = import ../modules/modules.nix {
+    modules = import ../modules/modules.nix nixpkgs {
       inherit lib pkgs;
       check = false;
     } ++ [ scrubbedPkgsModule ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Home Manager for Nix";
+
+  outputs = { self, nixpkgs }: rec {
+
+    nixosModules.home-manager = import ./nixos nixpkgs;
+
+    lib = {
+      homeManagerConfiguration = { configuration, system, homeDirectory
+        , username
+        , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
+        , check ? true }@args:
+        import ./modules nixpkgs {
+          pkgs = builtins.getAttr system nixpkgs.outputs.legacyPackages;
+          configuration = { ... }: {
+            imports = [ configuration ];
+            home = { inherit homeDirectory username; };
+          };
+          inherit check;
+        };
+    };
+  };
+}

--- a/modules/manual.nix
+++ b/modules/manual.nix
@@ -1,3 +1,4 @@
+nixpkgs:
 { config, lib, pkgs, ... }:
 
 with lib;
@@ -6,7 +7,7 @@ let
 
   cfg = config.manual;
 
-  docs = import ../doc { inherit lib pkgs; };
+  docs = import ../doc nixpkgs { inherit lib pkgs; };
 
 in
 

--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -1,3 +1,4 @@
+nixpkgs:
 # Adapted from Nixpkgs.
 
 { config, lib, pkgs, ... }:
@@ -49,7 +50,7 @@ let
     merge = lib.mergeOneOption;
   };
 
-  _pkgs = import <nixpkgs> (
+  _pkgs = import nixpkgs (
     filterAttrs (n: v: v != null) config.nixpkgs
   );
 

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -1,3 +1,4 @@
+nixpkgs:
 { pkgs
 
   # Note, this should be "the standard library" + HM extensions.
@@ -24,14 +25,14 @@ let
     (loadModule ./accounts/email.nix { })
     (loadModule ./files.nix { })
     (loadModule ./home-environment.nix { })
-    (loadModule ./manual.nix { })
+    (loadModule (import ./manual.nix nixpkgs) { })
     (loadModule ./misc/dconf.nix { })
     (loadModule ./misc/debug.nix { })
     (loadModule ./misc/fontconfig.nix { })
     (loadModule ./misc/gtk.nix { })
     (loadModule ./misc/lib.nix { })
     (loadModule ./misc/news.nix { })
-    (loadModule ./misc/nixpkgs.nix { condition = useNixpkgsModule; })
+    (loadModule (import ./misc/nixpkgs.nix nixpkgs) { condition = useNixpkgsModule; })
     (loadModule ./misc/numlock.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/pam.nix { })
     (loadModule ./misc/qt.nix { })

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -1,3 +1,4 @@
+nixpkgs:
 { config, lib, pkgs, utils, ... }:
 
 with lib;
@@ -12,7 +13,7 @@ let
     specialArgs = { lib = extendedLib; };
     modules = [
       ({ name, ... }: {
-        imports = import ../modules/modules.nix {
+        imports = import ../modules/modules.nix nixpkgs {
           inherit pkgs;
           lib = extendedLib;
           useNixpkgsModule = !cfg.useGlobalPkgs;


### PR DESCRIPTION
### Description
This addresses  #1511. The PR is WIP for a few reasons:
- I'm not sure if this is backwards compatible.
- Running the tests with `nix-shell --pure tests -A run.all` fails with
```shell
error: --- TypeError ------------------------------------------------------------------------------------------------- nix-shell
at: (14:10) in file: /nix/store/aym5m3h0v9jx85kk696a1k514vbvj2zv-source/default.nix

    13|         };
    14|       in [ initModule ./nmt.nix test ] ++ modules;
      |          ^
    15|     };

value is a function while a list was expected
(use '--show-trace' to show detailed location information)
```
However, the same is true for the `bqv-flakes` branch.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.