### PR TITLE
sway: fix startup example

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -645,13 +645,22 @@ in {
 
       See <link xlink:href="https://i3wm.org/docs/userguide.html#_automatically_starting_applications_on_i3_startup"/>.
     '';
-    example = literalExample ''
-      [
-      { command = "systemctl --user restart polybar"; always = true; notification = false; }
-      { command = "dropbox start"; notification = false; }
-      { command = "firefox"; workspace = "1: web"; }
-      ];
-    '';
+    example = if moduleName == "i3" then
+      literalExample ''
+        [
+        { command = "systemctl --user restart polybar"; always = true; notification = false; }
+        { command = "dropbox start"; notification = false; }
+        { command = "firefox"; workspace = "1: web"; }
+        ];
+      ''
+    else
+      literalExample ''
+        [
+        { command = "systemctl --user restart waybar"; always = true; }
+        { command = "dropbox start"; }
+        { command = "firefox"; }
+        ]
+      '';
   };
 
   gaps = mkOption {


### PR DESCRIPTION
### Description

Fixes #1515 . Example for `wayland.windowManager.config.startup`
referenced options `notification` and `workspace` which are not valid
for sway.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
