### PR TITLE
Use pkgs.path when possible

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -205,10 +205,8 @@ let
     config = {
       _module.args.baseModules = modules;
       _module.args.pkgsPath = lib.mkDefault (
-        if versionAtLeast config.home.stateVersion "20.09" then
-          pkgs.path
-        else
-          <nixpkgs>);
+        pkgs.path or <nixpkgs>
+      );
       _module.args.pkgs = lib.mkDefault pkgs;
       _module.check = check;
       lib = lib.hm;


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Using home-manager module at current master in flakes fails due to use of channels (`<nixpkgs>`) in module.nix.
This removes channels when possible, thus making home-manager easier to use in flake nixos configurations. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`. (Some unrelated stuff fails for some meta reason)

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
