### PR TITLE
neovim: add extraPackages

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -204,7 +204,7 @@ in
       };
 
       extraPackages = mkOption {
-        type = with types; listOf attrs;
+        type = with types; listOf package;
         default = [ ];
         example = "extraPackages: [ pkgs.shfmt ]";
         description = "Extra packages available to nvim.";

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -54,7 +54,10 @@ let
     // optionalAttrs (cfg.plugins != [] ) {
       packages.home-manager.start = map (x: x.plugin or x) cfg.plugins;
     };
-
+  extraMakeWrapperArgs =
+    if builtins.hasAttr "extraPackages" cfg
+    then " --prefix PATH : '${lib.makeBinPath cfg.extraPackages}'"
+    else "";
 in
 
 {
@@ -200,6 +203,13 @@ in
         '';
       };
 
+      extraPackages = mkOption {
+        type = with types; listOf attrs;
+        default = [ ];
+        example = "extraPackages: [ pkgs.shfmt ]";
+        description = "Extra packages available to nvim.";
+      };
+
       plugins = mkOption {
         type = with types; listOf (either package pluginWithConfigType);
         default = [ ];
@@ -241,6 +251,7 @@ in
         extraPythonPackages withPython
         withNodeJs withRuby viAlias vimAlias;
 
+      extraMakeWrapperArgs = extraMakeWrapperArgs;
       configure = cfg.configure // moduleConfigure;
     };
 

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -204,7 +204,7 @@ in
       extraPackages = mkOption {
         type = with types; listOf package;
         default = [ ];
-        example = "extraPackages: [ pkgs.shfmt ]";
+        example = "[ pkgs.shfmt ]";
         description = "Extra packages available to nvim.";
       };
 

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -54,10 +54,8 @@ let
     // optionalAttrs (cfg.plugins != [] ) {
       packages.home-manager.start = map (x: x.plugin or x) cfg.plugins;
     };
-  extraMakeWrapperArgs =
-    if builtins.hasAttr "extraPackages" cfg
-    then " --prefix PATH : '${lib.makeBinPath cfg.extraPackages}'"
-    else "";
+    extraMakeWrapperArgs = lib.optionalString (cfg.extraPackages != [])
+      '' --prefix PATH : "${lib.makeBinPath cfg.extraPackages}"'';
 in
 
 {


### PR DESCRIPTION
### Description

Add an option to add packages to the PATH of nvim.  This may be usefull to make extra programes availible for plugins and/or for usage in `:! myprogram`

Fixes: #894 

I created this because I needed this myself. This is my first PR here, feedback is very welcome.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- ~If this PR adds a new module~

  - Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - Added myself and the module files to `.github/CODEOWNERS`.
