### PR TITLE
feh: allow binding actions to multiple buttons/keys by passing a list

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -45,6 +45,7 @@ import nmt {
     ./modules/programs/browserpass
     ./modules/programs/dircolors
     ./modules/programs/direnv
+    ./modules/programs/feh
     ./modules/programs/fish
     ./modules/programs/git
     ./modules/programs/gpg

--- a/tests/modules/programs/feh/default.nix
+++ b/tests/modules/programs/feh/default.nix
@@ -1,0 +1,4 @@
+{
+  feh-empty-config = ./feh-empty-settings.nix;
+  feh-bindings = ./feh-bindings.nix;
+}

--- a/tests/modules/programs/feh/feh-bindings-expected-buttons
+++ b/tests/modules/programs/feh/feh-bindings-expected-buttons
@@ -1,0 +1,4 @@
+zoom_in
+next_img C-4
+prev_img 3 C-3
+zoom_out 4

--- a/tests/modules/programs/feh/feh-bindings-expected-keys
+++ b/tests/modules/programs/feh/feh-bindings-expected-keys
@@ -1,0 +1,3 @@
+zoom_in
+prev_img h Left
+zoom_out minus

--- a/tests/modules/programs/feh/feh-bindings.nix
+++ b/tests/modules/programs/feh/feh-bindings.nix
@@ -1,0 +1,33 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    programs.feh.enable = true;
+
+    programs.feh.buttons = {
+      zoom_in = null;
+      zoom_out = 4;
+      next_img = "C-4";
+      prev_img = [ 3 "C-3" ];
+    };
+
+    programs.feh.keybindings = {
+      zoom_in = null;
+      zoom_out = "minus";
+      prev_img = [ "h" "Left" ];
+    };
+
+    nixpkgs.overlays =
+      [ (self: super: { feh = pkgs.writeScriptBin "dummy-feh" ""; }) ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/feh/buttons \
+        ${./feh-bindings-expected-buttons}
+
+      assertFileContent \
+        home-files/.config/feh/keys \
+        ${./feh-bindings-expected-keys}
+    '';
+  };
+}

--- a/tests/modules/programs/feh/feh-empty-settings.nix
+++ b/tests/modules/programs/feh/feh-empty-settings.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    programs.feh.enable = true;
+
+    nixpkgs.overlays =
+      [ (self: super: { feh = pkgs.writeScriptBin "dummy-feh" ""; }) ];
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/feh/buttons
+      assertPathNotExists home-files/.config/feh/keys
+    '';
+  };
+}


### PR DESCRIPTION
### Description

In feh you can bind multiple keys to the same action, but home-manager
only let you set a single key to an action. Now you could cheat and pass
a string with space-separated keys, but with this change you can pass
a list for each action to bind multiple keys to it.

I've also added a couple of tests.

Fixes #1366

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
