### PR TITLE
gnome-terminal: Add backspace- and delete-binding settings

### DIFF
--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -6,6 +6,14 @@ let
 
   cfg = config.programs.gnome-terminal;
 
+  eraseBinding = types.enum [
+    "auto"
+    "ascii-backspace"
+    "ascii-delete"
+    "delete-sequence"
+    "tty"
+  ];
+
   backForeSubModule = types.submodule ({ ... }: {
     options = {
       foreground = mkOption {
@@ -136,6 +144,90 @@ let
         type = types.bool;
         description = "Run command as a login shell.";
       };
+
+      backspaceBinding = mkOption {
+        default = "ascii-delete";
+        type = eraseBinding;
+        description = ''
+          Which string the terminal should send to an application when the user
+          presses the <emphasis>Backspace</emphasis> key.
+
+          <variablelist>
+            <varlistentry>
+              <term><literal>auto</literal></term>
+              <listitem><para>
+                Attempt to determine the right value from the terminal's IO settings.
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term><literal>ascii-backspace</literal></term>
+              <listitem><para>
+                Send an ASCII backspace character (0x08).
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term><literal>ascii-delete</literal></term>
+              <listitem><para>
+                Send an ASCII delete character (0x7F).
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term><literal>delete-sequence</literal></term>
+              <listitem><para>
+                Send the <quote>@7</quote> control sequence.
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term><literal>tty</literal></term>
+              <listitem><para>
+                Send terminal’s <quote>erase</quote> setting.
+              </para></listitem>
+            </varlistentry>
+          </variablelist>
+        '';
+      };
+
+      deleteBinding = mkOption {
+        default = "delete-sequence";
+        type = eraseBinding;
+        description = ''
+          Which string the terminal should send to an application when the user
+          presses the <emphasis>Delete</emphasis> key.
+
+          <variablelist>
+            <varlistentry>
+              <term><literal>auto</literal></term>
+              <listitem><para>
+                Send the <quote>@7</quote> control sequence.
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term><literal>ascii-backspace</literal></term>
+              <listitem><para>
+                Send an ASCII backspace character (0x08).
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term><literal>ascii-delete</literal></term>
+              <listitem><para>
+                Send an ASCII delete character (0x7F).
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term><literal>delete-sequence</literal></term>
+              <listitem><para>
+                Send the <quote>@7</quote> control sequence.
+              </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term><literal>tty</literal></term>
+              <listitem><para>
+                Send terminal’s <quote>erase</quote> setting.
+              </para></listitem>
+            </varlistentry>
+          </variablelist>
+        '';
+      };
     };
   });
 
@@ -147,6 +239,8 @@ let
       cursor-shape = pcfg.cursorShape;
       cursor-blink-mode = pcfg.cursorBlinkMode;
       login-shell = pcfg.loginShell;
+      backspace-binding = pcfg.backspaceBinding;
+      delete-binding = pcfg.deleteBinding;
     } // (if (pcfg.customCommand != null) then {
       use-custom-command = true;
       custom-command = pcfg.customCommand;


### PR DESCRIPTION
### Description

These settings control the string sent by gnome-terminal when the respective keys are pressed. The options are the ones described in libvte documentation of [`VteEraseBinding`](https://developer.gnome.org/vte/0.48/VteTerminal.html#VteEraseBinding).

The default values for the settings are the same as gnome-terminal’s own defaults.

I did not add tests as it is (currently?) not possible to test dconf modifications in isolation.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
