### PR TITLE
Update home-manager

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -165,7 +165,7 @@ function doEdit() {
 
     setConfigFile
 
-    exec "$EDITOR" "$HOME_MANAGER_CONFIG"
+    ${EDITOR} "$HOME_MANAGER_CONFIG"
 }
 
 function doBuild() {


### PR DESCRIPTION
fix: `home-manager edit` threw an error if your $EDITOR has command line arguments (such as `code -w`)

### Description

The use of `exec` does not allow concatenation of command and arguments in its first argument, and it's not reasonable to assume that $EDITOR is a plain command.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
