### PR TITLE
neomutt: fix duplicated extraConfig in account

### DIFF
--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -124,7 +124,7 @@ let
     let
       folderHook = mapAttrsToList setOption (genCommonFolderHooks account // {
         folder = "'${account.maildir.absPath}'";
-      }) ++ optional (neomutt.extraConfig != "") neomutt.extraConfig;
+      });
     in ''
       ${concatStringsSep "\n" folderHook}
     '';

--- a/tests/modules/programs/neomutt/hm-example.com-expected
+++ b/tests/modules/programs/neomutt/hm-example.com-expected
@@ -25,8 +25,6 @@ set realname='H. M. Test'
 set record='+Sent'
 set spoolfile='+Inbox'
 set trash='+Trash'
-color status cyan default
-
 
 
 # Extra configuration

--- a/tests/modules/programs/neomutt/hm-example.com-msmtp-expected.conf
+++ b/tests/modules/programs/neomutt/hm-example.com-msmtp-expected.conf
@@ -24,8 +24,6 @@ set realname='H. M. Test'
 set record='+Sent'
 set spoolfile='+Inbox'
 set trash='+Trash'
-color status cyan default
-
 
 
 # Extra configuration


### PR DESCRIPTION
### Description

The `accounts.email.accounts.<name>.neomutt.extraConfig` option is included twice in the resulting config file for the account. One time as part of the `mraSection`, one time as part of `accountStr` (`accountStr` includes the `mraSection`). This removes that duplication. I opted to keep the one in `accounStr`, since `extraConfig` doesn't necessarily have anything to do with the `mraSection`.

Fixes #1214.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```