### PR TITLE
xdg: disambiguate file attr names

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -101,11 +101,13 @@ in
 
     {
       home.file = mkMerge [
-        cfg.configFile
-        cfg.dataFile
-        {
-          "${config.xdg.cacheHome}/.keep".text = "";
-        }
+        (mapAttrs'
+          (name: file: nameValuePair "${config.xdg.configHome}/${name}" file)
+          cfg.configFile)
+        (mapAttrs'
+          (name: file: nameValuePair "${config.xdg.dataHome}/${name}" file)
+          cfg.dataFile)
+        { "${config.xdg.cacheHome}/.keep".text = ""; }
       ];
     }
   ];

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -1,1 +1,4 @@
-{ xdg-mime-apps-basics = ./mime-apps-basics.nix; }
+{
+  xdg-mime-apps-basics = ./mime-apps-basics.nix;
+  xdg-file-attr-names = ./file-attr-names.nix;
+}

--- a/tests/modules/misc/xdg/file-attr-names.nix
+++ b/tests/modules/misc/xdg/file-attr-names.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    xdg.configFile.test.text = "config";
+    xdg.dataFile.test.text = "data";
+    home.file.test.text = "home";
+
+    nmt.script = ''
+      assertFileExists home-files/.config/test
+      assertFileExists home-files/.local/share/test
+      assertFileExists home-files/test
+      assertFileContent \
+        home-files/.config/test \
+        ${builtins.toFile "test" "config"}
+      assertFileContent \
+        home-files/.local/share/test \
+        ${builtins.toFile "test" "data"}
+      assertFileContent \
+        home-files/test \
+        ${builtins.toFile "test" "home"}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Currently, the following results in chaos:

```nix
{
  xdg = {
    configFile.name.text = "config";
    dataFile.name.text = "data";
    #dataFile.name.source = ./file; # or for more confusion!
  };
  #home.file.name.text = "root"; # this would conflict as well
}
```

The xdg module tries to `mkMerge` the separate definitions into `home.file` because they have the same attr name, even though their `.target` paths differ. Adding any sort of unique prefix prevents this from happening. This change technically isn't backward-compatible because it could be observed in the case that someone is actually relying on the existing behaviour (is there any sane reason to set both `xdg.configFile.name.x` and `home.file.name.y`, expecting them to be the same file?).

### Checklist

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
