### PR TITLE
firefox: add enableGnomeExtensions option

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -220,6 +220,16 @@ in
         default = false;
         description = "Whether to enable the unfree Adobe Flash plugin.";
       };
+
+      enableGnomeExtensions = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable the GNOME Shell native host connector.
+          You need set NixOS's `services.gnome3.chrome-gnome-shell.enable`
+          to <literal>true</literal>.
+        '';
+      };
     };
   };
 
@@ -262,6 +272,7 @@ in
         # The configuration expected by the Firefox wrapper.
         fcfg = {
           enableAdobeFlash = cfg.enableAdobeFlash;
+          enableGnomeExtensions = cfg.enableGnomeExtensions;
         };
 
         # A bit of hackery to force a config into the wrapper.


### PR DESCRIPTION
### Description
Because this module overrides firefox nixpkgs config, Gnome Shell integration doesn't work.
See [services.gnome3.chrome-gnome-shell.enable](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/desktops/gnome3/chrome-gnome-shell.nix).

This PR fixes it.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
