### PR TITLE
gh: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,9 @@
 
 /modules/programs/firefox.nix                         @rycee
 
+/modules/programs/gh.nix                              @Gerschtli
+/tests/modules/programs/gh                            @Gerschtli
+
 /modules/programs/git.nix                             @rycee
 
 /modules/programs/gnome-terminal.nix                  @rycee

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1713,6 +1713,13 @@ in
           A new module is available: 'services.gammastep'.
         '';
       }
+
+      {
+        time = "2020-10-22T21:30:42+00:00";
+        message = ''
+          A new module is available: 'programs.gh'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -67,6 +67,7 @@ let
     (loadModule ./programs/fish.nix { })
     (loadModule ./programs/fzf.nix { })
     (loadModule ./programs/getmail.nix { condition = hostPlatform.isLinux; })
+    (loadModule ./programs/gh.nix { })
     (loadModule ./programs/git.nix { })
     (loadModule ./programs/gnome-terminal.nix { })
     (loadModule ./programs/go.nix { })

--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -1,0 +1,53 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.gh;
+
+in {
+  meta.maintainers = [ maintainers.gerschtli ];
+
+  options.programs.gh = {
+    enable = mkEnableOption "GitHub CLI tool";
+
+    aliases = mkOption {
+      type = with types; attrsOf str;
+      default = { };
+      example = literalExample ''
+        {
+          co = "pr checkout";
+          pv = "pr view";
+        }
+      '';
+      description = ''
+        Aliases that allow you to create nicknames for gh commands.
+      '';
+    };
+
+    editor = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        The editor that gh should run when creating issues, pull requests, etc.
+        If blank, will refer to environment.
+      '';
+    };
+
+    gitProtocol = mkOption {
+      type = types.enum [ "https" "ssh" ];
+      default = "https";
+      description = ''
+        The protocol to use when performing Git operations.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.gitAndTools.gh ];
+
+    xdg.configFile."gh/config.yml".text =
+      builtins.toJSON { inherit (cfg) aliases editor gitProtocol; };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -48,6 +48,7 @@ import nmt {
     ./modules/programs/direnv
     ./modules/programs/feh
     ./modules/programs/fish
+    ./modules/programs/gh
     ./modules/programs/git
     ./modules/programs/gpg
     ./modules/programs/i3status

--- a/tests/modules/programs/gh/config-file.nix
+++ b/tests/modules/programs/gh/config-file.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    programs.gh = {
+      enable = true;
+      aliases = { co = "pr checkout"; };
+      editor = "vim";
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        gitAndTools = super.gitAndTools // {
+          gh = pkgs.writeScriptBin "dummy-gh" "";
+        };
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/gh/config.yml
+      assertFileContent home-files/.config/gh/config.yml ${
+        builtins.toFile "config-file.yml" ''
+          {"aliases":{"co":"pr checkout"},"editor":"vim","gitProtocol":"https"}''
+      }
+    '';
+  };
+}

--- a/tests/modules/programs/gh/default.nix
+++ b/tests/modules/programs/gh/default.nix
@@ -1,0 +1,1 @@
+{ gh-config-file = ./config-file.nix; }


### PR DESCRIPTION
### Description

Add module for new GitHub CLI Tool.

**Note**: I ran all tests but like in master the evaluation failed but my added test cases work.
```
$ nix-shell --pure tests -A run.all
trace: warning: In file /home/tobias/projects/home-manager/tests/lib/types/list-or-dag-merge.nix
a list is being assigned to the option 'tested.dag'.
This will soon be an error due to the list form being deprecated.
Please use the attribute set form instead with DAG functions to
express the desired order of entries.

trace: warning: In file /home/tobias/projects/home-manager/tests/lib/types/list-or-dag-merge.nix
a list is being assigned to the option 'tested.dag'.
This will soon be an error due to the list form being deprecated.
Please use the attribute set form instead with DAG functions to
express the desired order of entries.

error: --- TypeError ------------------------------------------------------------------------------------------------------------------------ nix-shell
'renderBinding' at /home/tobias/projects/home-manager/modules/programs/ncmpcpp.nix:23:19 called with unexpected argument '_module'
(use '--show-trace' to show detailed location information)
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
