### PR TITLE
meli: init module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,6 +84,8 @@
 
 /modules/programs/mcfly.nix                           @marsam
 
+/modules/programs/meli.nix                            @colemickens
+
 /modules/programs/mpv.nix                             @tadeokondrak
 
 /modules/programs/mu.nix                              @KarlJoad

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -88,6 +88,7 @@ let
     (loadModule ./programs/matplotlib.nix { })
     (loadModule ./programs/mbsync.nix { })
     (loadModule ./programs/mcfly.nix { })
+    (loadModule ./programs/meli.nix { })
     (loadModule ./programs/mercurial.nix { })
     (loadModule ./programs/mpv.nix { })
     (loadModule ./programs/msmtp.nix { })

--- a/modules/programs/meli.nix
+++ b/modules/programs/meli.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.meli;
+  settingsFormat = pkgs.formats.toml { };
+in {
+  meta.maintainers = [ hm.maintainers.colemickens ];
+
+  options.programs.meli = {
+    enable = mkEnableOption "meli";
+
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      description = ''
+        meli's settings (will be converted to TOML)
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.meli ];
+
+    xdg.configFile."meli/config.toml".source =
+      (settingsFormat.generate "meli-config.toml" cfg.settings);
+  };
+}


### PR DESCRIPTION
### Description

This adds a `home-manager` module for `meli`: https://meli.delivery

See here for an example usage with Gmail: https://github.com/colemickens/nixcfg/commit/b6a5d4e6e93d4ea48a19efedf083d3d2cd6d7d4b

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/rycee/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/rycee/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/rycee/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/rycee/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
