### PR TITLE
Remove myself from HM's maintained maintainers list

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -25,16 +25,6 @@
     github = "cwyc";
     githubId = 16950437;
   };
-  berbiche = {
-    name = "Nicolas Berbiche";
-    email = "berbiche@users.noreply.github.com";
-    github = "berbiche";
-    githubId = 20448408;
-    keys = [{
-      longkeyid = "rsa4096/0xB461292445C6E696";
-      fingerprint = "D446 E58D 87A0 31C7 EC15  88D7 B461 2924 45C6 E696";
-    }];
-  };
   olmokramer = {
     name = "Olmo Kramer";
     email = "olmokramer@users.noreply.github.com";

--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -161,7 +161,7 @@ let
       };
     };
 in {
-  meta.maintainers = [ hm.maintainers.berbiche ];
+  meta.maintainers = with lib.maintainers; [ berbiche ];
 
   options.programs.waybar = with lib.types; {
     enable = mkEnableOption "Waybar";


### PR DESCRIPTION
### Description

I recently had my first package added to nixpkgs and am now in the official list of maintainers so this information is no longer required here.

``` console
$ nix flake list-inputs
git+file:///home/nicolas/dev/github.com/home-manager
└───nixpkgs: github:NixOS/nixpkgs/a920bf43082e35faad01a5cc43d5212dfc3c9f26

$ nix eval 'github:NixOS/nixpkgs/a920bf43082e35faad01a5cc43d5212dfc3c9f26#lib.maintainers.berbiche'
{ email = ...; github = ...; ... }
```
