### PR TITLE
zsh: Add dirHashes option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -22,6 +22,10 @@ let
     mapAttrsToList (k: v: "alias -g ${k}=${lib.escapeShellArg v}") cfg.shellGlobalAliases
   );
 
+  dirHashesStr = concatStringsSep "\n" (
+    mapAttrsToList (k: v: ''hash -d ${k}="${v}"'') cfg.dirHashes
+  );
+
   zdotdir = "$HOME/" + cfg.dotDir;
 
   bindkeyCommands = {
@@ -230,6 +234,21 @@ in
         description = ''
           Similar to <varname><link linkend="opt-programs.zsh.shellAliases">opt-programs.zsh.shellAliases</link></varname>,
           but are substituted anywhere on a line.
+        '';
+        type = types.attrsOf types.str;
+      };
+
+      dirHashes = mkOption {
+        default = {};
+        example = literalExample ''
+          {
+            docs  = "$HOME/Documents";
+            vids  = "$HOME/Videos";
+            dl    = "$HOME/Downloads";
+          }
+        '';
+        description = ''
+          An attribute set that adds to named directory hash table.
         '';
         type = types.attrsOf types.str;
       };
@@ -488,6 +507,9 @@ in
 
         # Global Aliases
         ${globalAliasesStr}
+
+        # Named Directory Hashes
+        ${dirHashesStr}
       '';
     }
 


### PR DESCRIPTION
### Description

This change add dirHashes option for `zsh` module to utilize the named directory hash table feature offered by `zsh`. Once example configuration is added, at shell prompt one can then refer to `$HOME/Documents` as `~docs`, `$HOME/Downloads` as `~dl`, et. al.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
