### PR TITLE
systemd: use `listsAsDuplicateKeys` in `toINI`

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -14,6 +14,7 @@ let
       || cfg.sessionVariables != {};
 
   toSystemdIni = generators.toINI {
+    listsAsDuplicateKeys = true;
     mkKeyValue = key: value:
       let
         value' =

--- a/tests/modules/systemd/services-expected.conf
+++ b/tests/modules/systemd/services-expected.conf
@@ -1,5 +1,0 @@
-[Service]
-ExecStart=/some/exec/start/command --with-arguments "%i"
-
-[Unit]
-Description=A basic test service

--- a/tests/modules/systemd/services.nix
+++ b/tests/modules/systemd/services.nix
@@ -10,6 +10,7 @@ with lib;
       };
 
       Service = {
+        Environment = [ "VAR1=1" "VAR2=2" ];
         ExecStart = ''/some/exec/start/command --with-arguments "%i"'';
       };
     };
@@ -17,7 +18,16 @@ with lib;
     nmt.script = ''
       serviceFile=home-files/.config/systemd/user/test-service@.service
       assertFileExists $serviceFile
-      assertFileContent $serviceFile ${./services-expected.conf}
+      assertFileContent $serviceFile \
+        ${builtins.toFile "services-expected.conf" ''
+          [Service]
+          Environment=VAR1=1
+          Environment=VAR2=2
+          ExecStart=/some/exec/start/command --with-arguments "%i"
+
+          [Unit]
+          Description=A basic test service
+        ''}
     '';
   };
 }


### PR DESCRIPTION
This causes list values to be emitted as a list of key-value pairs instead of a single key-value pair where the value is space separated.

This is useful, e.g., for socket units that would like to specify more than one `ListenStream=` address.