### PR TITLE
emacs: avoid desktop file collision

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -119,7 +119,7 @@ in {
         Install = { WantedBy = [ "default.target" ]; };
       };
 
-      home.packages = optional cfg.client.enable clientDesktopItem;
+      home.packages = optional cfg.client.enable (hiPrio clientDesktopItem);
     }
 
     (mkIf cfg.socketActivation.enable {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Using `emacsGit` or `emacsGcc` from `nix-community/emacs-overlay` with `services.emacs.client.enable = true` results in a collision at `$home-path/share/applications/emacsclient.desktop`.

The collision is avoided by wrapping the desktop item derivation with `hiPrio`. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
