### PR TITLE
sway & i3: validate configuration at build time

### DIFF
--- a/tests/modules/services/window-managers/i3/i3-followmouse.nix
+++ b/tests/modules/services/window-managers/i3/i3-followmouse.nix
@@ -14,7 +14,9 @@ with lib;
       (self: super: {
         dmenu = super.dmenu // { outPath = "@dmenu@"; };
 
-        i3 = super.i3 // { outPath = "@i3@"; };
+        i3 = super.writeScriptBin "i3" "" // { outPath = "@i3@"; };
+
+        i3-gaps = super.writeScriptBin "i3" "" // { outPath = "@i3-gaps@"; };
 
         i3status = super.i3status // { outPath = "@i3status@"; };
       })

--- a/tests/modules/services/window-managers/i3/i3-keybindings.nix
+++ b/tests/modules/services/window-managers/i3/i3-keybindings.nix
@@ -19,9 +19,10 @@ with lib;
     nixpkgs.overlays = [
       (self: super: {
         dmenu = super.dmenu // { outPath = "@dmenu@"; };
-
-        i3 = super.i3 // { outPath = "@i3@"; };
-
+        i3 = super.writeScriptBin "i3" "" // { outPath = "@i3@"; };
+        i3-gaps = super.writeScriptBin "i3-gaps" "" // {
+          outPath = "@i3-gaps@";
+        };
         i3status = super.i3status // { outPath = "@i3status@"; };
       })
     ];

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -92,7 +92,7 @@ bar {
   hidden_state hide
   position bottom
   status_command @i3status@/bin/i3status
-  swaybar_command @sway/bin/swaybar
+  swaybar_command @sway@/bin/swaybar
   workspace_buttons yes
   strip_workspace_numbers no
   tray_output primary

--- a/tests/modules/services/window-managers/sway/sway-default.nix
+++ b/tests/modules/services/window-managers/sway/sway-default.nix
@@ -6,9 +6,7 @@ with lib;
   config = {
     wayland.windowManager.sway = {
       enable = true;
-      package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out" // {
-        outPath = "@sway";
-      };
+      package = pkgs.writeScriptBin "sway" "" // { outPath = "@sway@"; };
       # overriding findutils causes issues
       config.menu = "${pkgs.dmenu}/bin/dmenu_run";
     };

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy.nix
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     wayland.windowManager.sway = {
       enable = true;
-
+      package = pkgs.writeScriptBin "sway" "" // { outPath = "@sway@"; };
       config = {
         focus.followMouse = false;
         menu = "${pkgs.dmenu}/bin/dmenu_run";
@@ -20,9 +20,6 @@ with lib;
         rxvt-unicode-unwrapped = super.rxvt-unicode-unwrapped // {
           outPath = "@rxvt-unicode-unwrapped@";
         };
-        sway-unwrapped =
-          pkgs.runCommandLocal "dummy-sway-unwrapped" { version = "1"; }
-          "mkdir $out";
         swaybg = pkgs.writeScriptBin "dummy-swaybg" "";
         xwayland = pkgs.writeScriptBin "xwayland" "";
       })

--- a/tests/modules/services/window-managers/sway/sway-followmouse.nix
+++ b/tests/modules/services/window-managers/sway/sway-followmouse.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     wayland.windowManager.sway = {
       enable = true;
-
+      package = pkgs.writeScriptBin "sway" "" // { outPath = "@sway@"; };
       config = {
         focus.followMouse = "always";
         menu = "${pkgs.dmenu}/bin/dmenu_run";
@@ -20,9 +20,6 @@ with lib;
         rxvt-unicode-unwrapped = super.rxvt-unicode-unwrapped // {
           outPath = "@rxvt-unicode-unwrapped@";
         };
-        sway-unwrapped =
-          pkgs.runCommandLocal "dummy-sway-unwrapped" { version = "1"; }
-          "mkdir $out";
         swaybg = pkgs.writeScriptBin "dummy-swaybg" "";
         xwayland = pkgs.writeScriptBin "xwayland" "";
       })

--- a/tests/modules/services/window-managers/sway/sway-post-2003.nix
+++ b/tests/modules/services/window-managers/sway/sway-post-2003.nix
@@ -8,9 +8,7 @@ with lib;
 
     wayland.windowManager.sway = {
       enable = true;
-      package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out" // {
-        outPath = "@sway";
-      };
+      package = pkgs.writeScriptBin "sway" "" // { outPath = "@sway@"; };
       # overriding findutils causes issues
       config.menu = "${pkgs.dmenu}/bin/dmenu_run";
     };


### PR DESCRIPTION
### Description

Sway and i3 both support validating the configuration at build time.
This PR makes it such that the configuration can be validated at build time.

Should I gate this behind an option?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
