### PR TITLE
caffeine: add service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -136,6 +136,8 @@
 
 /modules/programs/zsh/prezto.nix                      @NickHu
 
+/modules/services/caffeine.nix                        @uvNikita
+
 /modules/services/cbatticon.nix                       @pmiddend
 
 /modules/services/clipmenu.nix                        @DamienCassou

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1720,6 +1720,14 @@ in
           A new module is available: 'programs.gh'.
         '';
       }
+
+      {
+        time = "2020-11-01T11:17:02+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.caffeine'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -132,6 +132,7 @@ let
     (loadModule ./programs/zsh.nix { })
     (loadModule ./programs/zsh/prezto.nix { })
     (loadModule ./services/blueman-applet.nix { })
+    (loadModule ./services/caffeine.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/cbatticon.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/clipmenu.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/compton.nix { })

--- a/modules/services/caffeine.nix
+++ b/modules/services/caffeine.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.caffeine;
+
+in {
+  meta.maintainers = [ maintainers.uvnikita ];
+
+  options = {
+    services.caffeine = { enable = mkEnableOption "Caffeine service"; };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.caffeine = {
+      Unit = { Description = "caffeine"; };
+
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+
+      Service = {
+        Restart = "on-failure";
+        PrivateTmp = true;
+        ProtectSystem = "full";
+        ProtectHome = "yes";
+        Type = "exec";
+        Slice = "session.slice";
+        ExecStart = "${pkgs.caffeine-ng}/bin/caffeine";
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Description

> Caffeine is a little daemon that sits in your systray, and prevents the screensaver from showing up, or the system from going to sleep. It does so when an application is fullscreened (eg: youtube), or when you click on the systray icon (which you can do, when, eg: reading).

See https://github.com/caffeine-ng/caffeine-ng.

I didn't add any tests since we are not generating any config for the service at the moment.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
