### PR TITLE
treewide: replace attrs by formats or types.anything

### DIFF
--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -3,9 +3,8 @@
 with lib;
 
 let
-
   cfg = config.programs.alacritty;
-
+  yamlFormat = pkgs.formats.yaml { };
 in {
   options = {
     programs.alacritty = {
@@ -19,7 +18,7 @@ in {
       };
 
       settings = mkOption {
-        type = types.attrs;
+        type = yamlFormat.type;
         default = { };
         example = literalExample ''
           {
@@ -51,6 +50,11 @@ in {
       home.packages = [ cfg.package ];
 
       xdg.configFile."alacritty/alacritty.yml" = mkIf (cfg.settings != { }) {
+        # TODO: Replace by the generate function but need to figure out how to
+        # handle the escaping first.
+        #
+        # source = yamlFormat.generate "alacritty.yml" cfg.settings;
+
         text =
           replaceStrings [ "\\\\" ] [ "\\" ] (builtins.toJSON cfg.settings);
       };

--- a/modules/programs/astroid-accounts.nix
+++ b/modules/programs/astroid-accounts.nix
@@ -16,7 +16,7 @@ with lib;
     };
 
     extraConfig = mkOption {
-      type = types.attrs;
+      type = types.attrsOf types.anything;
       default = { };
       example = { select_query = ""; };
       description = ''

--- a/modules/programs/beets.nix
+++ b/modules/programs/beets.nix
@@ -6,6 +6,8 @@ let
 
   cfg = config.programs.beets;
 
+  yamlFormat = pkgs.formats.yaml { };
+
 in {
   meta.maintainers = [ maintainers.rycee ];
 
@@ -39,7 +41,7 @@ in {
       };
 
       settings = mkOption {
-        type = types.attrs;
+        type = yamlFormat.type;
         default = { };
         description = ''
           Configuration written to
@@ -52,7 +54,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."beets/config.yaml".text =
-      builtins.toJSON config.programs.beets.settings;
+    xdg.configFile."beets/config.yaml".source =
+      yamlFormat.generate "beets-config" cfg.settings;
   };
 }

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -101,7 +101,7 @@ let
       };
 
       contents = mkOption {
-        type = types.attrs;
+        type = types.attrsOf types.anything;
         default = { };
         description = ''
           Configuration to include. If empty then a path must be given.

--- a/modules/programs/matplotlib.nix
+++ b/modules/programs/matplotlib.nix
@@ -23,7 +23,7 @@ in {
 
     config = mkOption {
       default = { };
-      type = types.attrs;
+      type = types.attrsOf types.anything;
       description = ''
         Add terms to the <filename>matplotlibrc</filename> file to
         control the default matplotlib behavior.

--- a/modules/programs/mercurial.nix
+++ b/modules/programs/mercurial.nix
@@ -6,6 +6,8 @@ let
 
   cfg = config.programs.mercurial;
 
+  iniFormat = pkgs.formats.ini { };
+
 in {
 
   options = {
@@ -30,19 +32,19 @@ in {
       };
 
       aliases = mkOption {
-        type = types.attrs;
+        type = types.attrsOf types.anything;
         default = { };
         description = "Mercurial aliases to define.";
       };
 
       extraConfig = mkOption {
-        type = types.either types.attrs types.lines;
+        type = types.either (types.attrsOf types.anything) types.lines;
         default = { };
         description = "Additional configuration to add.";
       };
 
       iniContent = mkOption {
-        type = types.attrsOf types.attrs;
+        type = iniFormat.type;
         internal = true;
       };
 
@@ -71,7 +73,8 @@ in {
         username = cfg.userName + " <" + cfg.userEmail + ">";
       };
 
-      xdg.configFile."hg/hgrc".text = generators.toINI { } cfg.iniContent;
+      xdg.configFile."hg/hgrc".source =
+        iniFormat.generate "hgrc" cfg.iniContent;
     }
 
     (mkIf (cfg.ignores != [ ] || cfg.ignoresRegexp != [ ]) {

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -156,7 +156,7 @@ in {
       };
 
       configure = mkOption {
-        type = types.attrs;
+        type = types.attrsOf types.anything;
         default = { };
         example = literalExample ''
           configure = {

--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -78,7 +78,7 @@ in {
     };
 
     settings = mkOption {
-      type = types.attrs;
+      type = types.attrsOf types.anything;
       default = { };
       description = ''
         Options to add to qutebrowser <filename>config.py</filename> file.

--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -40,7 +40,7 @@ in {
       enable = mkEnableOption "Task Warrior";
 
       config = mkOption {
-        type = types.attrs;
+        type = types.attrsOf types.anything;
         default = { };
         example = literalExample ''
           {

--- a/modules/programs/urxvt.nix
+++ b/modules/programs/urxvt.nix
@@ -124,7 +124,7 @@ in {
 
     extraConfig = mkOption {
       default = { };
-      type = types.attrs;
+      type = types.attrsOf types.anything;
       description = "Additional configuration to add.";
       example = { "shading" = 15; };
     };

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -8,6 +8,8 @@ let
 
   vscodePname = cfg.package.pname;
 
+  jsonFormat = pkgs.formats.json { };
+
   configDir = {
     "vscode" = "Code";
     "vscode-insiders" = "Code - Insiders";
@@ -46,7 +48,7 @@ in {
       };
 
       userSettings = mkOption {
-        type = types.attrs;
+        type = jsonFormat.type;
         default = { };
         example = literalExample ''
           {
@@ -125,10 +127,10 @@ in {
       toSymlink = concatMap toPaths cfg.extensions;
     in foldr (a: b: a // b) {
       "${configFilePath}" = mkIf (cfg.userSettings != { }) {
-        text = builtins.toJSON cfg.userSettings;
+        source = jsonFormat.generate "vscode-user-settings" cfg.userSettings;
       };
       "${keybindingsFilePath}" = mkIf (cfg.keybindings != [ ]) {
-        text = builtins.toJSON cfg.keybindings;
+        source = jsonFormat.generate "vscode-keybindings" cfg.keybindings;
       };
     } toSymlink;
   };

--- a/modules/services/dwm-status.nix
+++ b/modules/services/dwm-status.nix
@@ -5,11 +5,13 @@ with lib;
 let
   cfg = config.services.dwm-status;
 
+  jsonFormat = pkgs.formats.json { };
+
   features = [ "audio" "backlight" "battery" "cpu_load" "network" "time" ];
 
-  configText = builtins.toJSON ({ inherit (cfg) order; } // cfg.extraConfig);
+  finalConfig = { inherit (cfg) order; } // cfg.extraConfig;
 
-  configFile = pkgs.writeText "dwm-status.json" configText;
+  configFile = jsonFormat.generate "dwm-status.json" finalConfig;
 
 in {
   options = {
@@ -30,7 +32,7 @@ in {
       };
 
       extraConfig = mkOption {
-        type = types.attrs;
+        type = jsonFormat.type;
         default = { };
         example = literalExample ''
           {

--- a/modules/services/hound.nix
+++ b/modules/services/hound.nix
@@ -6,12 +6,14 @@ let
 
   cfg = config.services.hound;
 
-  configFile = pkgs.writeText "hound-config.json" (builtins.toJSON {
+  jsonFormat = pkgs.formats.json { };
+
+  configFile = jsonFormat.generate "hound-config.json" {
     max-concurrent-indexers = cfg.maxConcurrentIndexers;
     dbpath = cfg.databasePath;
     repos = cfg.repositories;
     health-check-url = "/healthz";
-  });
+  };
 
   houndOptions = [ "--addr ${cfg.listenAddress}" "--conf ${configFile}" ];
 
@@ -41,7 +43,7 @@ in {
     };
 
     repositories = mkOption {
-      type = types.attrsOf (types.uniq types.attrs);
+      type = types.attrsOf jsonFormat.type;
       default = { };
       example = literalExample ''
         {

--- a/modules/services/xsuspender.nix
+++ b/modules/services/xsuspender.nix
@@ -6,6 +6,8 @@ let
 
   cfg = config.services.xsuspender;
 
+  iniFormat = pkgs.formats.ini { };
+
   xsuspenderOptions = types.submodule {
     options = {
       matchWmClassContains = mkOption {
@@ -139,7 +141,7 @@ in {
       };
 
       iniContent = mkOption {
-        type = types.attrsOf types.attrs;
+        type = iniFormat.type;
         internal = true;
       };
     };
@@ -170,7 +172,8 @@ in {
     # To make the xsuspender tool available.
     home.packages = [ pkgs.xsuspender ];
 
-    xdg.configFile."xsuspender.conf".text = generators.toINI { } cfg.iniContent;
+    xdg.configFile."xsuspender.conf".source =
+      iniFormat.generate "xsuspender.conf" cfg.iniContent;
 
     systemd.user.services.xsuspender = {
       Unit = {

--- a/tests/modules/programs/alacritty/default.nix
+++ b/tests/modules/programs/alacritty/default.nix
@@ -1,4 +1,5 @@
 {
   alacritty-example-settings = ./example-settings.nix;
   alacritty-empty-settings = ./empty-settings.nix;
+  alacritty-merging-settings = ./settings-merging.nix;
 }

--- a/tests/modules/programs/alacritty/settings-merging-expected.yml
+++ b/tests/modules/programs/alacritty/settings-merging-expected.yml
@@ -1,0 +1,1 @@
+{"font":{"bold":{"family":"SFMono"},"normal":{"family":"SFMono"}},"key_bindings":[{"chars":"\x0c","key":"K","mods":"Control"}],"window":{"dimensions":{"columns":200,"lines":3}}}

--- a/tests/modules/programs/alacritty/settings-merging.nix
+++ b/tests/modules/programs/alacritty/settings-merging.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.alacritty = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-alacritty" "";
+
+      settings = {
+        window.dimensions = {
+          lines = 3;
+          columns = 200;
+        };
+
+        key_bindings = [{
+          key = "K";
+          mods = "Control";
+          chars = "\\x0c";
+        }];
+
+        font = let
+          defaultFont =
+            lib.mkMerge [ (lib.mkIf true "SFMono") (lib.mkIf false "Iosevka") ];
+        in {
+          normal.family = defaultFont;
+          bold.family = defaultFont;
+        };
+      };
+    };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/alacritty/alacritty.yml \
+        ${./settings-merging-expected.yml}
+    '';
+  };
+}

--- a/tests/modules/programs/vscode/keybindings.nix
+++ b/tests/modules/programs/vscode/keybindings.nix
@@ -27,7 +27,25 @@ let
   else
     ".config/Code/User/keybindings.json";
 
-  expectedJson = pkgs.writeText "expected.json" (builtins.toJSON bindings);
+  expectedJson = pkgs.writeText "expected.json" ''
+    [
+      {
+        "command": "editor.action.clipboardCopyAction",
+        "key": "ctrl+c",
+        "when": "textInputFocus && false"
+      },
+      {
+        "command": "deleteFile",
+        "key": "ctrl+c",
+        "when": ""
+      },
+      {
+        "command": "deleteFile",
+        "key": "d",
+        "when": "explorerViewletVisible"
+      }
+    ]
+  '';
 in {
   config = {
     programs.vscode = {


### PR DESCRIPTION
### Description

Replaces all instances of:
- `types.attrs` with `types.attrsOf types.anything` where it made sense
- `types.attrs` with `pkgs.format.{json,yaml,ini}` where it made sense

There are places where replacing `types.attrs` broke the evaluation and so wasn't done:
- pam
- home-environment
- bash
- zsh

### Checklist

- [ ] Change is backwards compatible.

- [x ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
