### PR TITLE
mpv: remove package option, as it’s unused

### DIFF
--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -55,14 +55,6 @@ in {
     programs.mpv = {
       enable = mkEnableOption "mpv";
 
-      package = mkOption {
-        type = types.package;
-        readOnly = true;
-        description = ''
-          Resulting mpv package.
-        '';
-      };
-
       scripts = mkOption {
         type = with types; listOf (either package str);
         default = [ ];


### PR DESCRIPTION
### Description

Maybe I'm wrong, but I guess the `package` option of mpv is unused currently. This was confusing to me, expecting this thing to actually do something meaningful.

So either it should be fixed (which I don't know how) or removed (which this PR does).

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
