### PR TITLE
sway: restore use of pkgs.sway

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -399,7 +399,7 @@ in {
         swaySocket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.$(${pkgs.procps}/bin/pgrep -x sway || ${pkgs.coreutils}/bin/true).sock
         if [ -S $swaySocket ]; then
           echo "Reloading sway"
-          $DRY_RUN_CMD ${cfg.package}/bin/swaymsg -s $swaySocket reload
+          $DRY_RUN_CMD ${pkgs.sway}/bin/swaymsg -s $swaySocket reload
         fi
       '';
     };

--- a/tests/modules/services/window-managers/sway/sway-default.nix
+++ b/tests/modules/services/window-managers/sway/sway-default.nix
@@ -2,26 +2,28 @@
 
 with lib;
 
-{
+let
+
+  dummy-package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out";
+
+in {
   config = {
     wayland.windowManager.sway = {
       enable = true;
-      package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out" // {
-        outPath = "@sway";
-      };
+      package = dummy-package // { outPath = "@sway"; };
       # overriding findutils causes issues
       config.menu = "${pkgs.dmenu}/bin/dmenu_run";
     };
 
     nixpkgs.overlays = [
       (self: super: {
-        dummy-package = super.runCommandLocal "dummy-package" { } "mkdir $out";
-        dmenu = self.dummy-package // { outPath = "@dmenu@"; };
-        rxvt-unicode-unwrapped = self.dummy-package // {
+        dmenu = dummy-package // { outPath = "@dmenu@"; };
+        rxvt-unicode-unwrapped = dummy-package // {
           outPath = "@rxvt-unicode-unwrapped@";
         };
-        i3status = self.dummy-package // { outPath = "@i3status@"; };
-        xwayland = self.dummy-package // { outPath = "@xwayland@"; };
+        i3status = dummy-package // { outPath = "@i3status@"; };
+        sway = dummy-package // { outPath = "@sway@"; };
+        xwayland = dummy-package // { outPath = "@xwayland@"; };
       })
     ];
 

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy.nix
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy.nix
@@ -2,10 +2,15 @@
 
 with lib;
 
-{
+let
+
+  dummy-package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out";
+
+in {
   config = {
     wayland.windowManager.sway = {
       enable = true;
+      package = dummy-package // { outPath = "@sway"; };
 
       config = {
         focus.followMouse = false;
@@ -16,15 +21,17 @@ with lib;
 
     nixpkgs.overlays = [
       (self: super: {
-        dmenu = super.dmenu // { outPath = "@dmenu@"; };
-        rxvt-unicode-unwrapped = super.rxvt-unicode-unwrapped // {
+        dmenu = dummy-package // { outPath = "@dmenu@"; };
+        rxvt-unicode-unwrapped = dummy-package // {
           outPath = "@rxvt-unicode-unwrapped@";
         };
-        sway-unwrapped =
-          pkgs.runCommandLocal "dummy-sway-unwrapped" { version = "1"; }
-          "mkdir $out";
-        swaybg = pkgs.writeScriptBin "dummy-swaybg" "";
-        xwayland = pkgs.writeScriptBin "xwayland" "";
+        sway = dummy-package // { outPath = "@sway@"; };
+        sway-unwrapped = dummy-package // {
+          outPath = "@sway-unwrapped@";
+          version = "1";
+        };
+        swaybg = dummy-package // { outPath = "@swaybg@"; };
+        xwayland = dummy-package // { outPath = "@xwayland@"; };
       })
     ];
 

--- a/tests/modules/services/window-managers/sway/sway-followmouse.nix
+++ b/tests/modules/services/window-managers/sway/sway-followmouse.nix
@@ -2,10 +2,15 @@
 
 with lib;
 
-{
+let
+
+  dummy-package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out";
+
+in {
   config = {
     wayland.windowManager.sway = {
       enable = true;
+      package = dummy-package // { outPath = "@sway"; };
 
       config = {
         focus.followMouse = "always";
@@ -16,15 +21,14 @@ with lib;
 
     nixpkgs.overlays = [
       (self: super: {
-        dmenu = super.dmenu // { outPath = "@dmenu@"; };
-        rxvt-unicode-unwrapped = super.rxvt-unicode-unwrapped // {
+        dmenu = dummy-package // { outPath = "@dmenu@"; };
+        rxvt-unicode-unwrapped = dummy-package // {
           outPath = "@rxvt-unicode-unwrapped@";
         };
-        sway-unwrapped =
-          pkgs.runCommandLocal "dummy-sway-unwrapped" { version = "1"; }
-          "mkdir $out";
-        swaybg = pkgs.writeScriptBin "dummy-swaybg" "";
-        xwayland = pkgs.writeScriptBin "xwayland" "";
+        sway = dummy-package // { outPath = "@sway@"; };
+        sway-unwrapped = dummy-package // { version = "1"; };
+        swaybg = dummy-package // { outPath = "@swaybg@"; };
+        xwayland = dummy-package // { outPath = "@xwayland@"; };
       })
     ];
 

--- a/tests/modules/services/window-managers/sway/sway-post-2003.nix
+++ b/tests/modules/services/window-managers/sway/sway-post-2003.nix
@@ -2,28 +2,30 @@
 
 with lib;
 
-{
+let
+
+  dummy-package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out";
+
+in {
   config = {
     home.stateVersion = "20.09";
 
     wayland.windowManager.sway = {
       enable = true;
-      package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out" // {
-        outPath = "@sway";
-      };
+      package = dummy-package // { outPath = "@sway"; };
       # overriding findutils causes issues
       config.menu = "${pkgs.dmenu}/bin/dmenu_run";
     };
 
     nixpkgs.overlays = [
       (self: super: {
-        dummy-package = super.runCommandLocal "dummy-package" { } "mkdir $out";
-        dmenu = self.dummy-package // { outPath = "@dmenu@"; };
-        rxvt-unicode-unwrapped = self.dummy-package // {
+        dmenu = dummy-package // { outPath = "@dmenu@"; };
+        rxvt-unicode-unwrapped = dummy-package // {
           outPath = "@rxvt-unicode-unwrapped@";
         };
-        i3status = self.dummy-package // { outPath = "@i3status@"; };
-        xwayland = self.dummy-package // { outPath = "@xwayland@"; };
+        sway = dummy-package // { outPath = "@sway@"; };
+        i3status = dummy-package // { outPath = "@i3status@"; };
+        xwayland = dummy-package // { outPath = "@xwayland@"; };
       })
     ];
 


### PR DESCRIPTION
Using the final package in the `onChange` block broke some use cases. This restores the old behavior and instead solves the test dependencies in a different way.

Fixes #1611