### PR TITLE
sway&i3: fix configuration validation missing environment variables

### DIFF
--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -198,6 +198,7 @@ let
     pkgs.runCommandLocal "i3-config" { buildInputs = [ cfg.package ]; } ''
       # We have to make sure the wrapper does not start a dbus session
       export DBUS_SESSION_BUS_ADDRESS=1
+      export XDG_RUNTIME_DIR=$PWD
 
       # A zero exit code means i3 succesfully validated the configuration
       i3 -c ${configFile} -C -d all || {

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -295,6 +295,7 @@ let
     pkgs.runCommandLocal "sway-config" { buildInputs = [ cfg.package ]; } ''
       # We have to make sure the wrapper does not start a dbus session
       export DBUS_SESSION_BUS_ADDRESS=1
+      export XDG_RUNTIME_DIR=$PWD
 
       # A zero exit code means Sway succesfully validated the configuration
       sway --config ${configFile} --validate --debug || {


### PR DESCRIPTION
### Description

https://github.com/nix-community/home-manager/issues/1613

I'm not sure how I missed this. Last I verified my configuration with Sway it didn't require the `$XDG_RUNTIME_DIR` to be set.

https://github.com/swaywm/sway/issues/4691

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
