### PR TITLE
WIP: Nix 3 compatibility

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -487,13 +487,13 @@ in
       if config.submoduleSupport.externalPackageInstall
       then
         ''
-          if nix-env -q | grep '^home-manager-path$'; then
+          if nix profile info | grep '^home-manager-path$'; then
             $DRY_RUN_CMD nix-env -e home-manager-path
           fi
         ''
       else
         ''
-          $DRY_RUN_CMD nix-env -i ${cfg.path}
+          $DRY_RUN_CMD nix profile install ${cfg.path}
         ''
     );
 

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -488,7 +488,7 @@ in
       then
         ''
           if nix profile info | grep '^home-manager-path$'; then
-            $DRY_RUN_CMD nix-env -e home-manager-path
+            $DRY_RUN_CMD nix profile remove home-manager-path
           fi
         ''
       else


### PR DESCRIPTION
### Description

This changes `nix-env` commands to the corresponding `nix profile` commands. It is not compatible with stable nix. How do we handle this?

Also, I should probably squash these commits and write an in-depth commit message.

See also:   #1561

### Checklist

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
