### PR TITLE
octant: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1782,6 +1782,13 @@ in
           A new module is available: 'programs.rofi.pass'.
         '';
       }
+
+      {
+        time = "2020-12-31T14:16:47+00:00";
+        message = ''
+          A new module is available: 'programs.octant'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -103,6 +103,7 @@ let
     (loadModule ./programs/notmuch.nix { })
     (loadModule ./programs/nushell.nix { })
     (loadModule ./programs/obs-studio.nix { })
+    (loadModule ./programs/octant.nix { })
     (loadModule ./programs/offlineimap.nix { })
     (loadModule ./programs/opam.nix { })
     (loadModule ./programs/password-store.nix { })

--- a/modules/programs/octant.nix
+++ b/modules/programs/octant.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.octant;
+
+  mkPluginEnv = packages:
+    let
+      pluginDirs = map (pkg: "${pkg}/bin") packages;
+      plugins = concatMapStringsSep " " (p: "${p}/*") pluginDirs;
+    in pkgs.runCommandLocal "octant-plugins" { } ''
+      mkdir $out
+      [[ '${plugins}' ]] || exit 0
+      for plugin in ${plugins}; do
+        ln -s "$plugin" $out/
+      done
+    '';
+
+in {
+  meta.maintainers = with maintainers; [ jk ];
+
+  options = {
+    programs.octant = {
+      enable = mkEnableOption "octant";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.octant;
+        defaultText = literalExample "pkgs.octant";
+        example = literalExample "pkgs.octant-other";
+        description = "The Octant package to use.";
+      };
+
+      plugins = mkOption {
+        default = [ ];
+        example = literalExample "[ pkgs.starboard-octant-plugin ]";
+        description = "Optional Octant plugins.";
+        type = types.listOf types.package;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."octant/plugins" =
+      mkIf (cfg.plugins != [ ]) { source = mkPluginEnv cfg.plugins; };
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Added octant module based on obs module

Might need to wait for octant & starboard-octant-plugin to make it to nixpkgs unstable before this is useful

Octant is in unstable but the starboard plugin isn't yet https://search.nixos.org/packages?channel=unstable&show=starboard&from=0&size=30&sort=relevance&query=octant

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
