### PR TITLE
bash: don't unconditionally set HISTFILE variable

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -30,8 +30,8 @@ in
       };
 
       historyFile = mkOption {
-        type = types.str;
-        default = "$HOME/.bash_history";
+        type = types.nullOr types.str;
+        default = null;
         description = "Location of the bash history file.";
       };
 
@@ -157,9 +157,11 @@ in
       historyControlStr =
         concatStringsSep "\n" (mapAttrsToList (n: v: "${n}=${v}") (
           {
-            HISTFILE = "\"${cfg.historyFile}\"";
             HISTFILESIZE = toString cfg.historyFileSize;
             HISTSIZE = toString cfg.historySize;
+          }
+          // optionalAttrs (cfg.historyFile != null) {
+            HISTFILE = "\"${cfg.historyFile}\"";
           }
           // optionalAttrs (cfg.historyControl != []) {
             HISTCONTROL = concatStringsSep ":" cfg.historyControl;


### PR DESCRIPTION
### Description

The bash module always sets `HISTFILE="$HOME/.bash_history"` in the bashrc. This makes it impossible to tell bash to use a different `HISTFILE` by setting the `HISTFILE` environment variable

    HISTFILE=/tmp/bash_history bash

This changes the default value of `programs.bash.historyFile` to `"${HISTFILE:-$HOME/.bash_history}"`, so the environment variable is used when it is set.

Fixes #962 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

  - I got this error running the tests, but it doesn't seem related:

        error: --- EvalError ----------------------------------------------------------- nix-shell
        at: (17:20) in file: /home/olmo/.local/src/home-manager/modules/programs/i3status-rust.nix

        16| 
        17|   settingsFormat = pkgs.formats.toml { };
          |                    ^
        18| 

        attribute 'formats' missing

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
