### PR TITLE
mako: make module an actual service

### DIFF
--- a/doc/release-notes/rl-2103.adoc
+++ b/doc/release-notes/rl-2103.adoc
@@ -32,6 +32,8 @@ programs.broot.verbs = [
 ];
 ----
 
+* The option <<opt-programs.mako>> has been renamed to <<opt-services.mako>> and now provides a systemd user service.
+
 [[sec-release-21.03-state-version-changes]]
 === State Version Changes
 


### PR DESCRIPTION
### Description
The mako module is currently placed in the directory for services but consists of a `programs` definition instead of a `services` definition. This PR moves it into the `services` namespace and adds a systemd unit for it. This way it behaves like most other services, in particular like dunst (as another notification daemon) and kanshi (as another wayland-specific service).

My primary intention was to add a systemd unit so I don't have to manually add mako to my sway configuration.

This PR is deliberately backwards incompatible, as the module was already intended as a service. Alternatively, to keep backwards compatibility, we could take the same approach as with waybar and add another option to enable systemd integration (the `mako.nix` file should be moved to `modules/programs` then, I think) or keep the `programs.mako` definition around and add a deprecation notice to it (is that possible?).

Would love to hear some input about this, specifically @onny as the maintainer.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
