### PR TITLE
mu: fix command

### DIFF
--- a/modules/programs/mu.nix
+++ b/modules/programs/mu.nix
@@ -50,7 +50,7 @@ in {
       # In theory, mu is the only thing that creates that directory, and it is
       # only created during the initial index.
       if [[ ! -d "${dbLocation}" ]]; then
-        $DRY_RUN_CMD mu init ${maildirOption} $VERBOSE_ARG;
+        $DRY_RUN_CMD mu init ${maildirOption} ${myAddresses} $VERBOSE_ARG;
       fi
     '';
   };


### PR DESCRIPTION
----

### Description

<!--

Please provide a brief description of your change.

-->

This just adds the command line flag to the `mu` command to specify the personal email addresses.
I think the email addresses specified as aliases should also be included, should I open a new pull req for that?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.