### PR TITLE
chromium: add support for brave

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -53,6 +53,7 @@ let
         google-chrome = "Google/Chrome";
         google-chrome-beta = "Google/Chrome Beta";
         google-chrome-dev = "Google/Chrome Dev";
+        brave = "BraveSoftware/Brave-Browser";
       };
 
       configDir = if pkgs.stdenv.isDarwin then
@@ -81,6 +82,7 @@ in {
       browserModule pkgs.google-chrome-beta "Google Chrome Beta" false;
     google-chrome-dev =
       browserModule pkgs.google-chrome-dev "Google Chrome Dev" false;
+    brave = browserModule pkgs.brave "Brave Browser" false;
   };
 
   config = mkMerge [
@@ -88,5 +90,6 @@ in {
     (browserConfig config.programs.google-chrome)
     (browserConfig config.programs.google-chrome-beta)
     (browserConfig config.programs.google-chrome-dev)
+    (browserConfig config.programs.brave)
   ];
 }


### PR DESCRIPTION
Brave Browser is a chromium-based browser, too.

+ it use the same web store with Chromium and Google Chrome.
+ the machanism of installing extensions works, and it's verified on
my macOS box.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
