### PR TITLE
wlsunset: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -216,6 +216,9 @@
 
 /modules/services/window-managers/i3-sway/sway.nix    @alexarice
 
+/modules/services/wlsunset.nix                        @matrss
+/tests/modules/services/wlsunset                      @matrss
+
 /modules/services/xcape.nix                           @nickhu
 
 /modules/services/xembed-sni-proxy.nix                @rycee

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -31,4 +31,10 @@
     github = "olmokramer";
     githubId = 3612514;
   };
+  matrss = {
+    name = "Matthias Riße";
+    email = "matrss@users.noreply.github.com";
+    github = "matrss";
+    githubId = 9308656;
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1759,6 +1759,14 @@ in
             ];
         '';
       }
+
+      {
+        time = "2020-12-01T20:46:14+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.wlsunset'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -192,6 +192,7 @@ let
     (loadModule ./services/window-managers/i3-sway/i3.nix { })
     (loadModule ./services/window-managers/i3-sway/sway.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/window-managers/xmonad.nix { })
+    (loadModule ./services/wlsunset.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/xcape.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/xembed-sni-proxy.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/xscreensaver.nix { })

--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -1,0 +1,97 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.wlsunset;
+
+in {
+  meta.maintainers = [ maintainers.matrss ];
+
+  options.services.wlsunset = {
+    enable = mkEnableOption "Whether to enable wlsunset.";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.wlsunset;
+      defaultText = "pkgs.wlsunset";
+      description = ''
+        wlsunset derivation to use.
+      '';
+    };
+
+    latitude = mkOption {
+      type = types.str;
+      description = ''
+        Your current latitude, between <literal>-90.0</literal> and
+        <literal>90.0</literal>.
+      '';
+    };
+
+    longitude = mkOption {
+      type = types.str;
+      description = ''
+        Your current longitude, between <literal>-180.0</literal> and
+        <literal>180.0</literal>.
+      '';
+    };
+
+    temperature = {
+      day = mkOption {
+        type = types.int;
+        default = 6500;
+        description = ''
+          Colour temperature to use during the day, in Kelvin (K).
+          This value must be greater than <literal>temperature.night</literal>.
+        '';
+      };
+
+      night = mkOption {
+        type = types.int;
+        default = 4000;
+        description = ''
+          Colour temperature to use during the night, in Kelvin (K).
+          This value must be smaller than <literal>temperature.day</literal>.
+        '';
+      };
+    };
+
+    gamma = mkOption {
+      type = types.str;
+      default = "1.0";
+      description = ''
+        Gamma value to use.
+      '';
+    };
+
+    systemdTarget = mkOption {
+      type = types.str;
+      default = "graphical-session.target";
+      description = ''
+        Systemd target to bind to.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.wlsunset = {
+      Unit = {
+        Description = "Day/night gamma adjustments for Wayland compositors.";
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        ExecStart = let
+          args = [
+            "-l ${cfg.latitude}"
+            "-L ${cfg.longitude}"
+            "-t ${toString cfg.temperature.night}"
+            "-T ${toString cfg.temperature.day}"
+            "-g ${cfg.gamma}"
+          ];
+        in "${cfg.package}/bin/wlsunset ${concatStringsSep " " args}";
+      };
+
+      Install = { WantedBy = [ cfg.systemdTarget ]; };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -99,6 +99,7 @@ import nmt {
     ./modules/services/sxhkd
     ./modules/services/window-managers/i3
     ./modules/services/window-managers/sway
+    ./modules/services/wlsunset
     ./modules/systemd
     ./modules/targets-linux
   ]);

--- a/tests/modules/services/wlsunset/default.nix
+++ b/tests/modules/services/wlsunset/default.nix
@@ -1,0 +1,1 @@
+{ wlsunset-service = ./wlsunset-service.nix; }

--- a/tests/modules/services/wlsunset/wlsunset-service-expected.service
+++ b/tests/modules/services/wlsunset/wlsunset-service-expected.service
@@ -1,0 +1,9 @@
+[Install]
+WantedBy=test.target
+
+[Service]
+ExecStart=@wlsunset@/bin/wlsunset -l 12.3 -L 128.8 -t 3500 -T 6000 -g 0.6
+
+[Unit]
+Description=Day/night gamma adjustments for Wayland compositors.
+PartOf=graphical-session.target

--- a/tests/modules/services/wlsunset/wlsunset-service.nix
+++ b/tests/modules/services/wlsunset/wlsunset-service.nix
@@ -1,0 +1,25 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.wlsunset = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-wlsunset" "" // {
+        outPath = "@wlsunset@";
+      };
+      latitude = "12.3";
+      longitude = "128.8";
+      temperature.day = 6000;
+      temperature.night = 3500;
+      gamma = "0.6";
+      systemdTarget = "test.target";
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/wlsunset.service
+
+      assertFileExists $serviceFile
+      assertFileContent $serviceFile ${./wlsunset-service-expected.service}
+    '';
+  };
+}


### PR DESCRIPTION
### Description
This PR adds a service module for `wlsunset`, a program for day/night gamma adjustments
on wayland. This module was requested in #1625.

Only think that I am not quite satisfied with is the description for `gamma`, but I couldn't figure out what exactly it does and upstream doesn't seem to say much about it aswell.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
