### PR TITLE
waybar: fix systemd service

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -356,8 +356,6 @@ in {
             "Highly customizable Wayland bar for Sway and Wlroots based compositors.";
           Documentation = "https://github.com/Alexays/Waybar/wiki";
           PartOf = [ "graphical-session.target" ];
-          Requisite = [ "dbus.service" ];
-          After = [ "dbus.service" ];
         };
 
         Service = {

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -9,8 +9,6 @@ RestartSec=1sec
 Type=dbus
 
 [Unit]
-After=dbus.service
 Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
 Documentation=https://github.com/Alexays/Waybar/wiki
 PartOf=graphical-session.target
-Requisite=dbus.service


### PR DESCRIPTION
The current definition makes waybar wait for dbus.service, but that never happens because dbus.service is started on demand by dbus.socket.

Per systemd docs: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Implicit%20Dependencies

- Services with Type=dbus set automatically acquire dependencies of type Requires= and After= on dbus.socket.

- Socket activated services are automatically ordered after their activating .socket units via an automatic After= dependency. Services also pull in all .socket units listed in Sockets= via automatic Wants= and After= dependencies.

Removing Requisite/After makes the service properly start for me, simply specifying Type=dbus is enough.

Refs #1370

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
