### PR TITLE
systemd: support mount units

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -11,6 +11,7 @@ let
       || cfg.targets != {}
       || cfg.timers != {}
       || cfg.paths != {}
+      || cfg.mounts != {}
       || cfg.sessionVariables != {};
 
   toSystemdIni = generators.toINI {
@@ -153,6 +154,13 @@ in
         example = unitExample "Path";
       };
 
+      mounts = mkOption {
+        default = {};
+        type = unitType "mount";
+        description = unitDescription "mount";
+        example = unitExample "Mount";
+      };
+
       startServices = mkOption {
         default = false;
         type = types.bool;
@@ -197,7 +205,7 @@ in
             let
               names = concatStringsSep ", " (
                   attrNames (
-                      cfg.services // cfg.sockets // cfg.targets // cfg.timers // cfg.paths // cfg.sessionVariables
+                      cfg.services // cfg.sockets // cfg.targets // cfg.timers // cfg.paths // cfg.mount // cfg.sessionVariables
                   )
               );
             in
@@ -220,6 +228,8 @@ in
           (buildServices "timer" cfg.timers)
           ++
           (buildServices "path" cfg.paths)
+          ++
+          (buildServices "mount" cfg.mounts)
           ))
 
           sessionVariables


### PR DESCRIPTION
### Description
Allow users to set systemd mount units. They can be used with FUSE filesystems since `util-linux` v2.35. Resolves #1542.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`. **I don't think any of the failures were caused by this change**

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
