### PR TITLE
github-ci: run tests individually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: ./format -c
     - run: nix-shell . -A install
-    - run: nix-shell --pure tests -A run.all
+    - run: for t in $(nix-shell tests -A list | grep -v all) ; do nix-shell --pure tests -A run.$t ; done


### PR DESCRIPTION
By running the tests in separate Nix processes we avoid the memory buildup that seem to happen with `run.all`.