### PR TITLE
Add home-manager lib to flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ as follows:
 }
 ```
 
+Note, the Home Manager library is exported by the flake under
+`lib.hm`.
+
 Releases
 --------
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
     darwinModules.home-manager = import ./nix-darwin;
 
     lib = {
+      hm = import ./modules/lib { lib = nixpkgs.lib; };
       homeManagerConfiguration = { configuration, system, homeDirectory
         , username
         , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages


### PR DESCRIPTION
Hello o/

Accessing the home-manager lib is useful, especially for extending home manager functionality such as adding entries to dags.

When using flakes, we cannot do path imports such as `<home-manager/modules/lib>`, this MR adds the attribute `lib.hm` to the flake provided by home-manager.