### PR TITLE
zathura: allow configuring the package used

### DIFF
--- a/modules/programs/zathura.nix
+++ b/modules/programs/zathura.nix
@@ -20,6 +20,13 @@ in {
       Zathura, a highly customizable and functional document viewer
       focused on keyboard interaction'';
 
+    package = mkOption {
+      type = types.package;
+      default = pkgs.zathura;
+      defaultText = "pkgs.zathura";
+      description = "The Zathura package to use";
+    };
+
     options = mkOption {
       default = { };
       type = with types; attrsOf (either str (either bool int));
@@ -49,7 +56,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.zathura ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."zathura/zathurarc".text = concatStringsSep "\n" ([ ]
       ++ optional (cfg.extraConfig != "") cfg.extraConfig


### PR DESCRIPTION

### Description

Closes #1633

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
