### PR TITLE
systemd: allow creating slices

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -7,6 +7,7 @@ let
   cfg = config.systemd.user;
 
   enabled = cfg.services != {}
+      || cfg.slices != {}
       || cfg.sockets != {}
       || cfg.targets != {}
       || cfg.timers != {}
@@ -125,6 +126,13 @@ in
         example = unitExample "Service";
       };
 
+      slices = mkOption {
+        default = {};
+        type = unitType "slices";
+        description = unitDescription "slices";
+        example = unitExample "Slices";
+      };
+
       sockets = mkOption {
         default = {};
         type = unitType "socket";
@@ -197,7 +205,8 @@ in
             let
               names = concatStringsSep ", " (
                   attrNames (
-                      cfg.services // cfg.sockets // cfg.targets // cfg.timers // cfg.paths // cfg.sessionVariables
+                      cfg.services // cfg.slices // cfg.sockets // cfg.targets
+                      // cfg.timers // cfg.paths // cfg.sessionVariables
                   )
               );
             in
@@ -212,6 +221,8 @@ in
       xdg.configFile = mkMerge [
         (listToAttrs (
           (buildServices "service" cfg.services)
+          ++
+          (buildServices "slices" cfg.slices)
           ++
           (buildServices "socket" cfg.sockets)
           ++


### PR DESCRIPTION
### Description

This PR allows creating systemd slices.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
