### PR TITLE
polybar: allow extra environment variables to be set

### DIFF
--- a/tests/modules/services/polybar/basic-configuration.nix
+++ b/tests/modules/services/polybar/basic-configuration.nix
@@ -22,6 +22,8 @@
           label = "%time%  %date%";
         };
       };
+      extraEnv = { DISPLAY = ":0"; };
+      extraPathDirs = [ "/run/current-system/sw/bin" ];
       extraConfig = ''
         [module/date]
         type = internal/date


### PR DESCRIPTION
### Description

For some custom modules, it is sometimes necessary to set extra environment variables such as `DISPLAY=:0` as well as to make some other binaries available in the `PATH`, such as the usual Unix tools like `cat`, `head`, etc.

Before this change, my (not ideal) workaround looked as follows.

```nix
let
  myenv = [
    ''"DISPLAY=:0"''
    ''"PATH=${mypolybar}/bin:/run/wrappers/bin:/run/current-system/sw/bin"''
  ];
in 
{
  services.polybar = {
    enable = true;
    package = mypolybar;
    config = ./config.ini;
    script = ''
      polybar top 2>${config.xdg.configHome}/polybar/logs/top.log &
      polybar bottom 2>${config.xdg.configHome}/polybar/logs/bottom.log &
    '';
  };

  systemd.user.services.polybar.Service.Environment = pkgs.lib.mkForce myenv;
}
```

With these new options, I would be able to declare the extra environment variables without resorting to `mkForce`.

```nix
{
  services.polybar = {
    enable = true;
    package = mypolybar;
    config = ./config.ini;
    extraEnv = {
      DISPLAY = ":0";
    };
    extraPathDirs = [ "/run/current-system/sw/bin" ];
    script = ''
      polybar top 2>${config.xdg.configHome}/polybar/logs/top.log &
      polybar bottom 2>${config.xdg.configHome}/polybar/logs/bottom.log &
    '';
  };
}
```

### Notes 

I get an error when trying to build the docs or run the tests which is unrelated to this change. I guess it means I need a newer Nix version? 

```shell
> nix-build -A docs.html                                                                                                ERROR
error: attribute 'anything' missing, at /home/gvolpe/workspace/home-manager/modules/programs/matplotlib.nix:26:28
(use '--show-trace' to show detailed location information)

> nix --version
nix (Nix) 2.3.7
```

I'm on NixOS unstable, FWIW, but I think the last time I updated my channels was in September so I might not have the `anything` keyword supported in my version.

```shell
> nix-channel --list
home-manager https://github.com/rycee/home-manager/archive/master.tar.gz

> [root@nixos:/]# nix-channel --list
nixos https://nixos.org/channels/nixos-unstable
```

Anyway, I tested the change with my [polybar config](https://github.com/gvolpe/nix-config/blob/master/home/services/polybar/default.nix) using the new options and it works fine. I had to comment out my `neovim` configuration, though, because I was getting the same error I got when running the tests.

```shell
home-manager -I home-manager=$HOME/workspace/home-manager switch
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
