### PR TITLE
chromium: add support for external extensions

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -44,17 +44,17 @@ let
                   readOnly = pkgs.stdenv.isDarwin;
                 };
                 crxPath = mkOption {
-                  type = either path bool;
+                  type = nullOr path;
                   description =
                     "Path to the extension's crx file. (Linux only)";
-                  default = false;
+                  default = null;
                   visible = pkgs.stdenv.isLinux;
                 };
                 version = mkOption {
-                  type = either str bool;
+                  type = nullOr str;
                   description =
                     "The extension's version, required for local installation. (Linux only)";
-                  default = false;
+                  default = null;
                   visible = pkgs.stdenv.isLinux;
                 };
               };


### PR DESCRIPTION
### Description
This allows the installation of external (outside of the Chrome Web Store) extensions, both local and remote, based on the [Alternative extension distribution options](https://developer.chrome.com/docs/extensions/mv2/external_extensions/) documentation.
Backward compatibility  for the list of string ids is maintained but I removed it from the example.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
