### PR TITLE
msmtp: fix passwordeval

### DIFF
--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -26,8 +26,7 @@ let
         tls_fingerprint = msmtp.tls.fingerprint;
       } // optionalAttrs (smtp.port != null) { port = toString smtp.port; }
         // optionalAttrs (passwordCommand != null) {
-          passwordeval =
-            ''${pkgs.bash}/bin/bash -c "${toString passwordCommand}"'';
+          passwordeval = toString passwordCommand;
         } // msmtp.extraConfig) ++ optional primary ''
 
           account default : ${name}'');


### PR DESCRIPTION
### Description

My PR got merged a bit too soon: https://github.com/nix-community/home-manager/pull/1643

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
