### PR TITLE
targets/genericLinux: make locales work

### DIFF
--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -32,7 +32,10 @@ in {
       dataDirs = concatStringsSep ":"
         (map (profile: "${profile}/share") profiles
           ++ config.targets.genericLinux.extraXdgDataDirs);
-    in { XDG_DATA_DIRS = "${dataDirs}\${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS"; };
+    in {
+      XDG_DATA_DIRS = "${dataDirs}\${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS";
+      LOCALE_ARCHIVE_2_27 = "${pkgs.glibcLocales}/lib/locale/locale-archive";
+    };
 
     home.sessionVariablesExtra = ''
       . "${pkgs.nix}/etc/profile.d/nix.sh"

--- a/tests/modules/targets-linux/generic-linux.nix
+++ b/tests/modules/targets-linux/generic-linux.nix
@@ -17,6 +17,9 @@ with lib;
       assertFileContains \
         home-path/etc/profile.d/hm-session-vars.sh \
         '. "${pkgs.nix}/etc/profile.d/nix.sh"'
+      assertFileContains \
+        home-path/etc/profile.d/hm-session-vars.sh \
+        'export LOCALE_ARCHIVE_2_27="${pkgs.glibcLocales}/lib/locale/locale-archive"'
     '';
   };
 }


### PR DESCRIPTION
### Description

export LOCALE_ARCHIVE_2_27 to fix locales on non nixos. this environment variable is nixpkgs-specific so it should not interfere with other software.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
