### PR TITLE
programs.neovim: write config in $XDG_CONFIG_HOME/init.vim

### DIFF
--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -23,9 +23,8 @@ with lib;
     };
 
     nmt.script = ''
-      vimrc=$(grep -Po "(?<=-u )[^ ]*" < "${
-        builtins.toJSON config.programs.neovim.finalPackage
-      }/bin/nvim")
+      vimrc="$TESTED/home-files/.config/nvim/init.vim"
+      assertFileExists home-files/.config/nvim/init.vim
       # We need to remove the unkown store paths in the config
       TESTED="" assertFileContent \
         <( ${pkgs.perl}/bin/perl -pe "s|\Q$NIX_STORE\E/[a-z0-9]{32}-|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" < "$vimrc"


### PR DESCRIPTION
instead of wrapping the configuration, which has sideeffects just put the init.vim in its expected place
https://github.com/NixOS/nixpkgs/issues/55376

This relies on a function I may change in the future so not sure we should merge this (but if I change it in nixpkgs, I would update the module straightaway).

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
