### PR TITLE
i18n: set the appropriate LOCALE_ARCHIVE_x_xx variable

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,8 @@
 
 /modules/misc/gtk.nix                                 @rycee
 
+/modules/config/i18n.nix                              @midchildan
+
 /modules/misc/news.nix                                @rycee
 
 /modules/misc/numlock.nix                             @evanjs

--- a/modules/config/i18n.nix
+++ b/modules/config/i18n.nix
@@ -1,0 +1,44 @@
+# The glibc package in nixpkgs is patched to make it possbile to specify
+# an alternative path for the locale archive through a special environment
+# variable. This would allow different versions of glibc to coexist on the
+# same system because each version of glibc could look up different paths
+# for its locale archive should the archive format ever change in
+# incompatible ways.
+#
+# See also:
+# localedef(1)
+# https://nixos.org/manual/nixpkgs/stable/#locales
+# https://github.com/NixOS/nixpkgs/issues/38991
+#
+# XXX: The name of the said environment variable gets updated with each
+# breaking release of the glibcLocales package. Periodically check the link
+# below for changes:
+# https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/pkgs/development/libraries/glibc/nix-locale-archive.patch
+
+{ lib, pkgs, ... }:
+
+with lib;
+
+let
+  inherit (pkgs.glibcLocales) version;
+
+  archivePath = "${pkgs.glibcLocales}/lib/locale/locale-archive";
+
+  # lookup the version of glibcLocales and set the appropriate environment vars
+  localeVars = if (versionAtLeast version "2.27") then {
+    LOCALE_ARCHIVE_2_27 = archivePath;
+  } else if (versionAtLeast version "2.11") then {
+    LOCALE_ARCHIVE_2_11 = archivePath;
+  } else
+    { };
+in {
+  config = {
+    # for shell sessions
+    home.sessionVariables = localeVars;
+
+    # for desktop apps
+    systemd.user.sessionVariables = localeVars;
+  };
+
+  meta.maintainers = with maintainers; [ midchildan ];
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -22,6 +22,7 @@ let
 
   allModules = [
     (loadModule ./accounts/email.nix { })
+    (loadModule ./config/i18n.nix { condition = hostPlatform.isLinux; })
     (loadModule ./files.nix { })
     (loadModule ./home-environment.nix { })
     (loadModule ./manual.nix { })

--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -32,10 +32,7 @@ in {
       dataDirs = concatStringsSep ":"
         (map (profile: "${profile}/share") profiles
           ++ config.targets.genericLinux.extraXdgDataDirs);
-    in {
-      XDG_DATA_DIRS = "${dataDirs}\${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS";
-      LOCALE_ARCHIVE_2_27 = "${pkgs.glibcLocales}/lib/locale/locale-archive";
-    };
+    in { XDG_DATA_DIRS = "${dataDirs}\${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS"; };
 
     home.sessionVariablesExtra = ''
       . "${pkgs.nix}/etc/profile.d/nix.sh"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -76,6 +76,7 @@ import nmt {
   ] ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
     ./modules/targets-darwin
   ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+    ./modules/config/i18n
     ./modules/misc/debug
     ./modules/misc/numlock
     ./modules/misc/pam

--- a/tests/modules/config/i18n/default.nix
+++ b/tests/modules/config/i18n/default.nix
@@ -1,0 +1,17 @@
+{
+  i18n = { ... }: {
+    config = {
+      nmt.script = ''
+        hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
+        assertFileExists $hmEnvFile
+        assertFileRegex $hmEnvFile \
+          '^export LOCALE_ARCHIVE_._..=".*/lib/locale/locale-archive"$'
+
+        envFile=home-files/.config/environment.d/10-home-manager.conf
+        assertFileExists $envFile
+        assertFileRegex $envFile \
+          '^LOCALE_ARCHIVE_._..=.*/lib/locale/locale-archive$'
+      '';
+    };
+  };
+}

--- a/tests/modules/home-environment/session-path.nix
+++ b/tests/modules/home-environment/session-path.nix
@@ -1,6 +1,7 @@
 { config, lib, pkgs, ... }:
 
-{
+let inherit (pkgs.stdenv.hostPlatform) isLinux;
+in {
   imports = [
     ({ ... }: { config.home.sessionPath = [ "foo" ]; })
     ({ ... }: { config.home.sessionPath = [ "bar" "baz" ]; })
@@ -15,7 +16,9 @@
           # Only source this once.
           if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
           export __HM_SESS_VARS_SOURCED=1
+          ${lib.optionalString isLinux ''
 
+            export LOCALE_ARCHIVE_2_27="${pkgs.glibcLocales}/lib/locale/locale-archive"''}
           export XDG_CACHE_HOME="/home/hm-user/.cache"
           export XDG_CONFIG_HOME="/home/hm-user/.config"
           export XDG_DATA_HOME="/home/hm-user/.local/share"

--- a/tests/modules/home-environment/session-variables-expected.txt
+++ b/tests/modules/home-environment/session-variables-expected.txt
@@ -1,7 +1,7 @@
 # Only source this once.
 if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
 export __HM_SESS_VARS_SOURCED=1
-
+@exportLocaleVar@
 export V1="v1"
 export V2="v2-v1"
 export XDG_CACHE_HOME="/home/hm-user/.cache"

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -1,8 +1,18 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
-{
+let
+  inherit (pkgs.stdenv.hostPlatform) isLinux;
+
+  expectedConf = pkgs.substituteAll {
+    src = ./session-variables-expected.txt;
+    # the blank space below is intentional
+    exportLocaleVar = optionalString isLinux ''
+
+      export LOCALE_ARCHIVE_2_27="${pkgs.glibcLocales}/lib/locale/locale-archive"'';
+  };
+in {
   config = {
     home.sessionVariables = {
       V1 = "v1";
@@ -11,9 +21,8 @@ with lib;
 
     nmt.script = ''
       assertFileExists home-path/etc/profile.d/hm-session-vars.sh
-      assertFileContent \
-        home-path/etc/profile.d/hm-session-vars.sh \
-        ${./session-variables-expected.txt}
+      assertFileContent home-path/etc/profile.d/hm-session-vars.sh \
+        ${expectedConf}
     '';
   };
 }

--- a/tests/modules/systemd/session-variables-expected.conf
+++ b/tests/modules/systemd/session-variables-expected.conf
@@ -1,2 +1,3 @@
+LOCALE_ARCHIVE_2_27=@glibcLocales@/lib/locale/locale-archive
 V_int=1
 V_str=2

--- a/tests/modules/systemd/session-variables.nix
+++ b/tests/modules/systemd/session-variables.nix
@@ -2,7 +2,12 @@
 
 with lib;
 
-{
+let
+  expectedConf = pkgs.substituteAll {
+    src = ./session-variables-expected.conf;
+    inherit (pkgs) glibcLocales;
+  };
+in {
   config = {
     systemd.user.sessionVariables = {
       V_int = 1;
@@ -12,7 +17,7 @@ with lib;
     nmt.script = ''
       envFile=home-files/.config/environment.d/10-home-manager.conf
       assertFileExists $envFile
-      assertFileContent $envFile ${./session-variables-expected.conf}
+      assertFileContent $envFile ${expectedConf}
     '';
   };
 }

--- a/tests/modules/targets-linux/generic-linux.nix
+++ b/tests/modules/targets-linux/generic-linux.nix
@@ -17,9 +17,6 @@ with lib;
       assertFileContains \
         home-path/etc/profile.d/hm-session-vars.sh \
         '. "${pkgs.nix}/etc/profile.d/nix.sh"'
-      assertFileContains \
-        home-path/etc/profile.d/hm-session-vars.sh \
-        'export LOCALE_ARCHIVE_2_27="${pkgs.glibcLocales}/lib/locale/locale-archive"'
     '';
   };
 }


### PR DESCRIPTION
### Description

Currently, Home Manager sets the `LOCALE_ARCHIVE_2_27` environment variable when `targets.genericLinux` is enabled. However, this doesn't cover NixOS, where it's common to mix stable and unstable versions of nixpkgs, causing occasional locale breakages.

This PR addresses the NixOS use case by setting `LOCALE_ARCHIVE_2_27` environment variable for all Linux platforms with some additional improvements:

- Also enable for GUI applications with systemd session variables
- Set the appropriate `LOCALE_ARCHIVE_x_xx` by checking the version of glibcLocale

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
