### PR TITLE
sway: add config.seat

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -166,6 +166,15 @@ let
         '';
       };
 
+      seat = mkOption {
+        type = types.attrsOf (types.attrsOf types.str);
+        default = { };
+        example = { "*" = { hide_cursor = "0000"; }; };
+        description = ''
+          An attribute set that defines seats. See man sway_input for options.
+        '';
+      };
+
       modes = mkOption {
         type = types.attrsOf (types.attrsOf types.str);
         default = {
@@ -234,6 +243,13 @@ let
     }
   '';
 
+  seatStr = name: attrs: ''
+    seat "${name}" {
+    ${concatStringsSep "\n"
+    (mapAttrsToList (name: value: "${name} ${value}") attrs)}
+    }
+  '';
+
   outputStr = name: attrs: ''
     output "${name}" {
     ${concatStringsSep "\n"
@@ -276,6 +292,7 @@ let
       ${keycodebindingsStr keycodebindings}
       ${concatStringsSep "\n" (mapAttrsToList inputStr input)}
       ${concatStringsSep "\n" (mapAttrsToList outputStr output)}
+      ${concatStringsSep "\n" (mapAttrsToList seatStr seat)}
       ${concatStringsSep "\n" (mapAttrsToList modeStr modes)}
       ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
       ${concatStringsSep "\n" (map barStr bars)}

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -71,6 +71,7 @@ bindsym Mod1+w layout tabbed
 
 
 
+
 mode "resize" {
 bindsym Down resize grow height 10 px
 bindsym Escape mode default

--- a/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
@@ -71,6 +71,7 @@ bindsym Mod1+w layout tabbed
 
 
 
+
 mode "resize" {
 bindsym Down resize grow height 10 px
 bindsym Escape mode default

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
@@ -71,6 +71,7 @@ bindsym Mod1+w layout tabbed
 
 
 
+
 mode "resize" {
 bindsym Down resize grow height 10 px
 bindsym Escape mode default


### PR DESCRIPTION
### Description

Adds seat configuration for sway

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
