### PR TITLE
mako: Add extraConfig attribute

### DIFF
--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -271,6 +271,15 @@ in {
         '';
       };
 
+      extraConfig = mkOption {
+        default = "";
+        type = types.lines;
+        example = literalExample ''
+          [urgency=low]
+          border-color=#b8bb26
+        '';
+        description = "Additional configuration.";
+      };
     };
   };
 
@@ -311,6 +320,8 @@ in {
       ${optionalInteger "default-timeout" cfg.defaultTimeout}
       ${optionalBoolean "ignore-timeout" cfg.ignoreTimeout}
       ${optionalString "group-by" cfg.groupBy}
+
+      ${cfg.extraConfig}
     '';
   };
 }


### PR DESCRIPTION
### Description

Mako allows for more configuration, specifically options in sections of the form `[field=value field2=value2 ...]`. This can be useful for things like in the example and having different colors for urgency levels.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.