### PR TITLE
starship: update prompt_order to format in example

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -43,7 +43,12 @@ in {
       example = literalExample ''
         {
           add_newline = false;
-          prompt_order = [ "line_break" "package" "line_break" "character" ];
+          format = lib.concatStrings [
+            "$line_break"
+            "$package"
+            "$line_break"
+            "$character"
+          ];
           scan_timeout = 10;
           character.symbol = "➜";
         }

--- a/tests/modules/programs/starship/settings-expected.toml
+++ b/tests/modules/programs/starship/settings-expected.toml
@@ -1,5 +1,5 @@
 add_newline = false
-prompt_order = ["line_break", "package", "line_break", "character"]
+format = "$line_break$package$line_break$character"
 scan_timeout = 10
 
 [aws]

--- a/tests/modules/programs/starship/settings.nix
+++ b/tests/modules/programs/starship/settings.nix
@@ -10,7 +10,12 @@ with lib;
       settings = mkMerge [
         {
           add_newline = false;
-          prompt_order = [ "line_break" "package" "line_break" "character" ];
+          format = concatStrings [
+            "$line_break"
+            "$package"
+            "$line_break"
+            "$character"
+          ];
           scan_timeout = 10;
           character.symbol = "➜";
           package.disabled = true;


### PR DESCRIPTION
### Description

As of Starship 0.45.0, [`prompt_order` has been replaced with `format`](https://starship.rs/migrating-to-0.45.0/#prompt-order-has-been-replaced-by-a-root-level-format).

> Previously to v0.45.0, prompt_order would accept an array of module names in the order which they should be rendered by Starship.
> 
> Starship v0.45.0 instead accepts a format value, allowing for customization of the prompt outside of the modules themselves.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
