### PR TITLE
gnome-terminal: Add audibleBell option

### DIFF
--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -228,11 +228,18 @@ let
           </variablelist>
         '';
       };
+
+      audibleBell = mkOption {
+        default = true;
+        type = types.bool;
+        description = "Turn on/off the terminal's bell.";
+      };
     };
   });
 
   buildProfileSet = pcfg:
     {
+      audible-bell = pcfg.audibleBell;
       visible-name = pcfg.visibleName;
       scrollbar-policy = if pcfg.showScrollbar then "always" else "never";
       scrollback-lines = pcfg.scrollbackLines;


### PR DESCRIPTION
### Description

Turn on/off the terminal's bell. A small video showcasing how the `audible-bell` key controls the terminal's bell: 

![Screencast from 12-21-2020 09_18_36 PM](https://user-images.githubusercontent.com/2049686/102898257-3cddf000-4437-11eb-9a0c-78d71bbcccbc.gif)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```


