### PR TITLE
flake: expose Home Manager lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ as follows:
 }
 ```
 
+Note, the Home Manager library is exported by the flake under
+`lib.hm`.
+
 Releases
 --------
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
     darwinModules.home-manager = import ./nix-darwin;
 
     lib = {
+      hm = import ./modules/lib { lib = nixpkgs.lib; };
       homeManagerConfiguration = { configuration, system, homeDirectory
         , username
         , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages


### PR DESCRIPTION
### Description

cherry picked commit 6dc8de259a36313ebd1ee25b075174e396f53329 authored in https://github.com/nix-community/home-manager/pull/1634.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
