### PR TITLE
Disambiguate

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ as follows:
           {
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
-            home-manager.users.user = import ./home.nix;
+            home-manager.users.jdoe = import ./home.nix;
           }
         ];
       };


### PR DESCRIPTION
The only other place this is documented is here: https://github.com/nix-community/home-manager/blob/8b3fca4ec5e879f608473fe851cc5077dfb19bbd/modules/misc/news.nix#L515-L525

That is not enough clarity. This change disambiguates by virtue of the well known Jon Doe placeholder.
