### PR TITLE
waybar: improve warnings to allow using CSS ids in a module's name

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -2,9 +2,9 @@
 
 let
   inherit (lib)
-    attrByPath attrNames concatMap concatMapStringsSep elem filter filterAttrs
-    flip foldl' hasPrefix mergeAttrs optionalAttrs stringLength subtractLists
-    types unique;
+    any attrByPath attrNames concatMap concatMapStringsSep elem filter
+    filterAttrs flip foldl' hasPrefix mergeAttrs optionalAttrs removePrefix
+    stringLength subtractLists types unique;
   inherit (lib.options) literalExample mkEnableOption mkOption;
   inherit (lib.modules) mkIf mkMerge;
 
@@ -15,8 +15,10 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
-  # Taken from <https://github.com/Alexays/Waybar/blob/adaf84304865e143e4e83984aaea6f6a7c9d4d96/src/factory.cpp>
+  # Taken from <https://github.com/Alexays/Waybar/blob/cc3acf8102c71d470b00fd55126aef4fb335f728/src/factory.cpp> (2020/10/10)
+  # Order is preserved from the file for easier matching
   defaultModuleNames = [
+    "battery"
     "sway/mode"
     "sway/workspaces"
     "sway/window"
@@ -36,11 +38,15 @@ let
     "sndio"
     "temperature"
     "bluetooth"
-    "battery"
   ];
 
+  # Allow specifying a CSS class after the default module name
+  isValidDefaultModuleName = x:
+    any (name: hasPrefix name x && hasPrefix "#" (removePrefix name x))
+    defaultModuleNames;
+
   isValidCustomModuleName = x:
-    elem x defaultModuleNames || (hasPrefix "custom/" x && stringLength x > 7);
+    hasPrefix "custom/" x && stringLength x > 7 || isValidDefaultModuleName x;
 
   margins = let
     mkMargin = name: {

--- a/tests/modules/programs/waybar/settings-complex-expected.json
+++ b/tests/modules/programs/waybar/settings-complex-expected.json
@@ -25,7 +25,8 @@
       "memory",
       "backlight",
       "tray",
-      "battery",
+      "battery#bat1",
+      "battery#bat2",
       "clock"
     ],
     "output": [

--- a/tests/modules/programs/waybar/settings-complex.nix
+++ b/tests/modules/programs/waybar/settings-complex.nix
@@ -24,7 +24,8 @@ in {
           "memory"
           "backlight"
           "tray"
-          "battery"
+          "battery#bat1"
+          "battery#bat2"
           "clock"
         ];
 


### PR DESCRIPTION
### Description

Fixes #1682.

Previously, a warning would be emitted if a module was specified with a CSS identifier `battery#bat1` (the part after the hash).

cc: @jwijenbergh

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
