### PR TITLE
Support test assertions on warnings

### DIFF
--- a/tests/asserts.nix
+++ b/tests/asserts.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options.test.asserts = {
+    warnings = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether warning asserts are enabled.";
+      };
+
+      expected = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          List of expected warnings.
+        '';
+      };
+    };
+  };
+
+  config = mkIf config.test.asserts.warnings.enable {
+    home.file = {
+      "asserts/warnings.actual".text = concatStringsSep ''
+
+        --
+      '' config.warnings;
+    };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/asserts/warnings.actual \
+        ${
+          pkgs.writeText "warnings.expected" (concatStringsSep ''
+
+            --
+          '' config.test.asserts.warnings.expected)
+        }
+    '';
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -25,6 +25,8 @@ let
       # Avoid including documentation since this will cause
       # unnecessary rebuilds of the tests.
       manual.manpages.enable = false;
+
+      imports = [ ./asserts.nix ];
     }
   ];
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,8 +7,8 @@ let
   nmt = pkgs.fetchFromGitLab {
     owner = "rycee";
     repo = "nmt";
-    rev = "26af5c54c88695ed73be93a9eae6b71f2d76d04a";
-    sha256 = "1m10cwjh63qkz2rgnm0wk16pxh52lp8i9kjfv6cfhbzl5df4q95p";
+    rev = "d2cc8c1042b1c2511f68f40e2790a8c0e29eeb42";
+    sha256 = "1ykcvyx82nhdq167kbnpgwkgjib8ii7c92y3427v986n2s5lsskc";
   };
 
   modules = import ../modules/modules.nix {

--- a/tests/modules/programs/git/git-with-str-extra-config.nix
+++ b/tests/modules/programs/git/git-with-str-extra-config.nix
@@ -14,6 +14,12 @@ with lib;
       userName = "John Doe";
     };
 
+    test.asserts.warnings.expected = [''
+      Using programs.git.extraConfig as a string option is
+      deprecated and will be removed in the future. Please
+      change to using it as an attribute set instead.
+    ''];
+
     nmt.script = ''
       assertFileExists home-files/.config/git/config
       assertFileContent home-files/.config/git/config \

--- a/tests/modules/programs/lieer/lieer.nix
+++ b/tests/modules/programs/lieer/lieer.nix
@@ -8,7 +8,10 @@ with lib;
   config = {
     programs.lieer.enable = true;
 
-    accounts.email.accounts = { "hm@example.com".lieer.enable = true; };
+    accounts.email.accounts."hm@example.com" = {
+      lieer.enable = true;
+      notmuch.enable = true;
+    };
 
     nixpkgs.overlays = [
       (self: super: { gmailieer = pkgs.writeScriptBin "dummy-gmailieer" ""; })

--- a/tests/modules/programs/waybar/broken-settings.nix
+++ b/tests/modules/programs/waybar/broken-settings.nix
@@ -66,6 +66,10 @@ in {
       }];
     };
 
+    # Remove when https://github.com/nix-community/home-manager/issues/1686 is
+    # fixed.
+    test.asserts.warnings.enable = false;
+
     nmt.description = ''
       Test for the broken configuration
       https://github.com/nix-community/home-manager/pull/1329#issuecomment-653253069

--- a/tests/modules/programs/waybar/settings-complex.nix
+++ b/tests/modules/programs/waybar/settings-complex.nix
@@ -50,6 +50,10 @@ in {
       }];
     };
 
+    # Remove when https://github.com/nix-community/home-manager/issues/1686 is
+    # fixed.
+    test.asserts.warnings.enable = false;
+
     nmt.script = ''
       assertPathNotExists home-files/.config/waybar/style.css
       assertFileContent \

--- a/tests/modules/services/lieer/lieer-service.nix
+++ b/tests/modules/services/lieer/lieer-service.nix
@@ -11,6 +11,7 @@ with lib;
     accounts.email.accounts = {
       "hm@example.com".lieer.enable = true;
       "hm@example.com".lieer.sync.enable = true;
+      "hm@example.com".notmuch.enable = true;
     };
 
     nixpkgs.overlays = [


### PR DESCRIPTION
### Description

This adds basic support for asserting the presence/content of warnings. All tests will by default assert that no warnings are present.

See https://github.com/nix-community/home-manager/pull/1687 and https://github.com/nix-community/home-manager/pull/1687

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.