### PR TITLE
starship: remove deprecated character.symbol setting

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -50,7 +50,10 @@ in {
             "$character"
           ];
           scan_timeout = 10;
-          character.symbol = "➜";
+          character = {
+            success_symbol = "➜";
+            error_symbol = "➜";
+          };
         }
       '';
       description = ''

--- a/tests/modules/programs/starship/settings-expected.toml
+++ b/tests/modules/programs/starship/settings-expected.toml
@@ -18,7 +18,8 @@ style = "bold yellow"
 threshold = 30
 
 [character]
-symbol = "➜"
+error_symbol = "➜"
+success_symbol = "➜"
 
 [memory_usage]
 threshold = -1

--- a/tests/modules/programs/starship/settings.nix
+++ b/tests/modules/programs/starship/settings.nix
@@ -17,7 +17,10 @@ with lib;
             "$character"
           ];
           scan_timeout = 10;
-          character.symbol = "➜";
+          character = {
+            success_symbol = "➜";
+            error_symbol = "➜";
+          };
           package.disabled = true;
           memory_usage.threshold = -1;
           aws.style = "bold blue";


### PR DESCRIPTION
### Description

Updating Starship docs, fixes #1550.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```