### PR TITLE
home-manager: add zsh completion

### DIFF
--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -1,0 +1,54 @@
+#compdef home-manager
+
+local state ret=1
+
+_arguments \
+  '-A[attribute]:ATTRIBUTE:()' \
+  '-I[search path]:PATH:_files -/' \
+  '-b[backup files]:EXT:()' \
+  '--cores[cores]:NUM:()' \
+  '--keep-failed[keep failed]' \
+  '--keep-going[keep going]' \
+  '(-h --help)'{--help,-h}'[help]' \
+  '(-v --verbose)'{--verbose,-v}'[verbose]' \
+  '(-n --dry-run)'{--dry-run,-n}'[dry run]' \
+  '(-f --file)'{--file,-f}'[configuration file]:FILE:_files' \
+  '(-j --max-jobs)'{--max-jobs,-j}'[max jobs]:NUM:()' \
+  '--option[option]:NAME VALUE:()' \
+  '--show-trace[show trace]' \
+  '1: :->cmds' \
+  '*:: :->args' && ret=0
+
+case "$state" in
+  cmds)
+    _values 'command' \
+      'help[help]' \
+      'edit[edit]' \
+      'build[build]' \
+      'switch[switch]' \
+      'generations[list generations]' \
+      'remove-generations[remove generations]' \
+      'expire-generations[expire generations]' \
+      'packages[managed packages]' \
+      'news[read the news]' \
+      'uninstall[uninstall]' && ret=0
+    ;;
+  args)
+    case $line[1] in
+      remove-generations)
+        _values 'generations' \
+          $(home-manager generations | cut -d ' ' -f 5) && ret=0
+        ;;
+      build|switch)
+        _arguments \
+          '--cores[cores]:NUM:()' \
+          '--keep-failed[keep failed]' \
+          '--keep-going[keep going]' \
+          '--max-jobs[max jobs]:NUM:()' \
+          '--option[option]:NAME VALUE:()' \
+          '--show-trace[show trace]'
+        ;;
+    esac
+esac
+
+return ret

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -37,4 +37,6 @@ runCommand
 
     install -D -m755 ${./completion.bash} \
       $out/share/bash-completion/completions/home-manager
+    install -D -m755 ${./completion.zsh} \
+      $out/share/zsh/site-functions/_home-manager
   ''


### PR DESCRIPTION
### Description

Add zsh completion to home-manager based on work from @Sean1708 see  #1075

Looks like
```
$ home-manager<TAB>
-- command --
build               -- build
edit                -- edit
expire-generations  -- expire generations
generations         -- list generations
help                -- help
news                -- read the news
packages            -- managed packages
remove-generations  -- remove generations
switch              -- switch
uninstall           -- uninstall

$ home-manager -<TAB>
-- option --
-b                 -- backup files                                                                                                                                         
--cores            -- cores                                                                                                                                                
--dry-run      -n  -- dry run                                                                                                                                              
--file         -f  -- configuration file                                                                                                                                   
--help         -h  -- help                                                                                                                                                 
-I                 -- search path                                                                                                                                          
--keep-failed      -- keep failed                                                                                                                                          
--keep-going       -- keep going                                                                                                                                           
--max-jobs     -j  -- max jobs                                                                                                                                             
--option           -- option                                                                                                                                               
--show-trace       -- show trace                                                                                                                                           
--verbose      -v  -- verbose                                                                                                                                              
-- command --
expire-generations  -- expire generations
remove-generations  -- remove generations
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```