### PR TITLE
Doc: using home-manager with flakes

### DIFF
--- a/doc/flakes.adoc
+++ b/doc/flakes.adoc
@@ -1,2 +1,119 @@
 [[ch-flakes]]
 == Using Home Manager with Flakes
+
+If you are using flakes to configure your system, you can make your
+home-manager configuration a flake aswell. This will allow you to specify it as
+input in your system configuration where needed.
+
+Add a flake.nix file to the repository you are keeping your home-manager
+configuration in and define one or more outputs. If you already have a home.nix
+file, it can be imported. A minimal flake.nix may look like this:
+
+[source,nix]
+----
+{
+  description = "User configurations for pinpox";
+
+  inputs.nur.url = "github:nix-community/NUR";
+
+  outputs = { self, nixpkgs, dotfiles-awesome, nur}: {
+
+    nixosModules = {
+
+      # User configuration for desktop
+      desktop = {
+        imports = [
+          ./home.nix
+          { nixpkgs.overlays = [ nur.overlay ]; }
+        ];
+      };
+    };
+  };
+}
+
+----
+
+In your system's configuration flake.nix, you will have to add two inputs:
+home-manager itself and your home-manager confgiguration.
+
+as an input and
+import the output from your home-manager flake.nix for any host you wish tho
+use it in:
+
+[source,nix]
+----
+
+  inputs = {
+
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    home-manager.url = "github:nix-community/home-manager/master";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+
+    nixos-home.url = "github:pinpox/nixos-home";
+    nixos-home.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+----
+
+Finally, add the home-manager configuration to the definition of your system:
+
+[source,nix]
+----
+{
+
+  outputs = { self, nixpkgs,  home-manager, nixos-home }:
+    let
+      # Function to create default (common) system config options
+      defFlakeSystem = baseCfg:
+        nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            # Add home-manager option to all configs
+            ({ ... }: {
+              imports = [
+                {
+                  # Set the $NIX_PATH entry for nixpkgs. This is necessary in
+                  # this setup with flakes, otherwise commands like `nix-shell
+                  # -p pkgs.htop` will keep using an old version of nixpkgs.
+                  # With this entry in $NIX_PATH it is possible (and
+                  # recommended) to remove the `nixos` channel for both users
+                  # and root e.g. `nix-channel --remove nixos`. `nix-channel
+                  # --list` should be empty for all users afterwards
+                  nix.nixPath = [ "nixpkgs=${nixpkgs}" ];
+                }
+                baseCfg
+                home-manager.nixosModules.home-manager
+                # DONT set useGlobalPackages! It's not necessary in newer
+                # home-manager versions and does not work with configs using
+                # `nixpkgs.config`
+                { home-manager.useUserPackages = true; }
+              ];
+              # Let 'nixos-version --json' know the Git revision of this flake.
+              system.configurationRevision =
+                nixpkgs.lib.mkIf (self ? rev) self.rev;
+              nix.registry.nixpkgs.flake = nixpkgs;
+            })
+          ];
+        };
+    in {
+      nixosConfigurations = {
+
+        inherit nixpkgs;
+
+        my-awesome-host = defFlakeSystem {
+          imports = [
+
+            # Other configuration modules
+            ./machines/my-host/configuration.nix
+
+            # Add home-manager config
+            { home-manager.users.pinpox = nixos-home.nixosModules.desktop; }
+            }
+
+          ];
+        };
+      };
+    };
+}
+----

--- a/doc/flakes.adoc
+++ b/doc/flakes.adoc
@@ -1,2 +1,2 @@
 [[ch-flakes]]
-== Using home-manager with Flakes
+== Using Home Manager with Flakes

--- a/doc/flakes.adoc
+++ b/doc/flakes.adoc
@@ -1,0 +1,2 @@
+[[ch-flakes]]
+== Using home-manager with Flakes

--- a/doc/flakes.adoc
+++ b/doc/flakes.adoc
@@ -34,7 +34,7 @@ file, it can be imported. A minimal flake.nix may look like this:
 ----
 
 In your system's configuration flake.nix, you will have to add two inputs:
-home-manager itself and your home-manager confgiguration.
+home-manager itself and your home-manager configuration.
 
 as an input and
 import the output from your home-manager flake.nix for any host you wish tho

--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -32,6 +32,7 @@
  </preface>
  <xi:include href="installation.xml" />
  <xi:include href="writing-modules.xml" />
+ <xi:include href="flakes.xml" />
  <xi:include href="contributing.xml" />
  <xi:include href="faq.xml" />
  <appendix xml:id="ch-options">


### PR DESCRIPTION
### Description

Documentation of how to setup home-manager on a flake-enabled NixOS system. See https://github.com/nix-community/home-manager/issues/1683 for previous discussion with @rycee 

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
