### PR TITLE
fish: Fix regression due to changes in nixpkgs.

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -343,7 +343,12 @@ in {
         # if we haven't sourced the general config, do it
         if not set -q __fish_general_config_sourced
 
-          set -p fish_function_path ${pkgs.fish-foreign-env}/share/fish-foreign-env/functions
+          set --prepend fish_function_path ${
+            if pkgs ? fishPlugins && pkgs.fishPlugins ? foreign-env then
+              "${pkgs.fishPlugins.foreign-env}/share/fish/vendor_functions.d"
+            else
+              "${pkgs.fish-foreign-env}/share/fish-foreign-env/functions"
+          }
           fenv source ${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh > /dev/null
           set -e fish_function_path[1]
 


### PR DESCRIPTION
### Description

Fix for changes in nixpkgs fish plugin organisation on unstable:

https://github.com/NixOS/nixpkgs/commit/d94921db12d9c9e2d3e9c2e6e25e50f03f789ecb

fixes #1701  #1702 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```