### PR TITLE
lieer-service: add path to notmuch config to environment

### DIFF
--- a/modules/services/lieer.nix
+++ b/modules/services/lieer.nix
@@ -26,6 +26,8 @@ let
         Type = "oneshot";
         ExecStart = "${pkgs.gmailieer}/bin/gmi sync";
         WorkingDirectory = account.maildir.absPath;
+        Environment =
+          "NOTMUCH_CONFIG=${config.xdg.configHome}/notmuch/notmuchrc";
       };
     };
   };

--- a/tests/modules/services/lieer/lieer-service-expected.service
+++ b/tests/modules/services/lieer/lieer-service-expected.service
@@ -1,4 +1,5 @@
 [Service]
+Environment=NOTMUCH_CONFIG=/home/hm-user/.config/notmuch/notmuchrc
 ExecStart=@lieer@/bin/gmi sync
 Type=oneshot
 WorkingDirectory=/home/hm-user/Mail/hm@example.com


### PR DESCRIPTION
### Description

This change makes the services created via the `lieer` module aware of the `notmuch` config created by the home-mangager `notmuch` module (which is stored in a non-standard location).

Without this change all the `lieer` services created by the `lieer` module failed for me, as they were unable to find the `notmuch` config.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
