### PR TITLE
docs: rephrase warning section slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,17 @@ options, please see the [Home Manager manual][manual].
 Words of warning
 ----------------
 
-This project is under development. I personally use it to manage
-several user configurations but it may fail catastrophically for you.
-So beware!
+Unfortunately, it is quite possible to get difficult to understand
+errors when working with Home Manager, such as infinite loops with no
+clear source reference. You should therefore be comfortable using the
+Nix language and the various tools in the Nix ecosystem. Reading
+through the [Nix Pills][] document is a good way to familiarize
+yourself with them.
 
-Before using Home Manager you should be comfortable using the Nix
-language and the various tools in the Nix ecosystem. Reading through
-the [Nix Pills][] document is a good way to familiarize yourself with
-them.
+If you are not very familiar with Nix but still want to use Home
+Manager then you are strongly encouraged to start with a small and
+very simple configuration and gradually make it more elaborate as you
+learn.
 
 In some cases Home Manager cannot detect whether it will overwrite a
 previous manual configuration. For example, the Gnome Terminal module


### PR DESCRIPTION
### Description

Rephrases the warning section of the README file.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.