### PR TITLE
Sway: fix bar command when package is null

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -4,6 +4,9 @@
 with lib;
 
 let
+  isI3 = moduleName == "i3";
+  isSway = !isI3;
+
   fonts = mkOption {
     type = types.listOf types.str;
     default = [ "monospace 8" ];
@@ -26,7 +29,7 @@ let
         default = false;
         description = "Whether to run command on each ${moduleName} restart.";
       };
-    } // optionalAttrs (moduleName == "i3") {
+    } // optionalAttrs isI3 {
       notification = mkOption {
         type = types.bool;
         default = true;
@@ -120,7 +123,7 @@ let
         default = "${cfg.package}/bin/${moduleName}bar";
         defaultText = "i3bar";
         description = "Command that will be used to start a bar.";
-        example = if moduleName == "i3" then
+        example = if isI3 then
           "\${pkgs.i3-gaps}/bin/i3bar -t"
         else
           "\${pkgs.waybar}/bin/waybar";
@@ -311,7 +314,7 @@ in {
         titlebar = mkOption {
           type = types.bool;
           default = !isGaps;
-          defaultText = if moduleName == "i3" then
+          defaultText = if isI3 then
             "xsession.windowManager.i3.package != nixpkgs.i3-gaps (titlebar should be disabled for i3-gaps)"
           else
             "false";
@@ -354,7 +357,7 @@ in {
         titlebar = mkOption {
           type = types.bool;
           default = !isGaps;
-          defaultText = if moduleName == "i3" then
+          defaultText = if isI3 then
             "xsession.windowManager.i3.package != nixpkgs.i3-gaps (titlebar should be disabled for i3-gaps)"
           else
             "false";
@@ -408,14 +411,14 @@ in {
         };
 
         followMouse = mkOption {
-          type = if moduleName == "sway" then
+          type = if isSway then
             types.either (types.enum [ "yes" "no" "always" ]) types.bool
           else
             types.bool;
-          default = if moduleName == "sway" then "yes" else true;
+          default = if isSway then "yes" else true;
           description = "Whether focus should follow the mouse.";
           apply = val:
-            if (moduleName == "sway" && isBool val) then
+            if (isSway && isBool val) then
               (if val then "yes" else "no")
             else
               val;
@@ -645,7 +648,7 @@ in {
 
       See <link xlink:href="https://i3wm.org/docs/userguide.html#_automatically_starting_applications_on_i3_startup"/>.
     '';
-    example = if moduleName == "i3" then
+    example = if isI3 then
       literalExample ''
         [
         { command = "systemctl --user restart polybar"; always = true; notification = false; }
@@ -743,7 +746,7 @@ in {
       };
     });
     default = null;
-    description = if moduleName == "sway" then ''
+    description = if isSway then ''
       Gaps related settings.
     '' else ''
       i3Gaps related settings. The i3-gaps package must be used for these features to work.
@@ -752,7 +755,7 @@ in {
 
   terminal = mkOption {
     type = types.str;
-    default = if moduleName == "i3" then
+    default = if isI3 then
       "i3-sensible-terminal"
     else
       "${pkgs.rxvt-unicode-unwrapped}/bin/urxvt";
@@ -762,7 +765,7 @@ in {
 
   menu = mkOption {
     type = types.str;
-    default = if moduleName == "sway" then
+    default = if isSway then
       "${pkgs.dmenu}/bin/dmenu_path | ${pkgs.dmenu}/bin/dmenu | ${pkgs.findutils}/bin/xargs swaymsg exec --"
     else
       "${pkgs.dmenu}/bin/dmenu_run";

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -120,7 +120,11 @@ let
 
       command = mkOption {
         type = types.str;
-        default = "${cfg.package}/bin/${moduleName}bar";
+        default = let
+          # If the user uses the "system" Sway (i.e. cfg.package == null) then the bar has
+          # to come from a different package
+          pkg = if isSway && isNull cfg.package then pkgs.sway else cfg.package;
+        in "${pkg}/bin/${moduleName}bar";
         defaultText = "i3bar";
         description = "Command that will be used to start a bar.";
         example = if isI3 then

--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -3,4 +3,5 @@
   sway-post-2003 = ./sway-post-2003.nix;
   sway-followmouse = ./sway-followmouse.nix;
   sway-followmouse-legacy = ./sway-followmouse-legacy.nix;
+  sway-null-package = ./sway-null-package.nix;
 }

--- a/tests/modules/services/window-managers/sway/sway-null-package.conf
+++ b/tests/modules/services/window-managers/sway/sway-null-package.conf
@@ -1,0 +1,117 @@
+font pango:monospace 8
+floating_modifier Mod1
+default_border pixel 2
+default_floating_border pixel 2
+hide_edge_borders none
+focus_wrapping no
+focus_follows_mouse yes
+focus_on_window_activation smart
+mouse_warping output
+workspace_layout default
+workspace_auto_back_and_forth no
+
+client.focused #4c7899 #285577 #ffffff #2e9ef4 #285577
+client.focused_inactive #333333 #5f676a #ffffff #484e50 #5f676a
+client.unfocused #333333 #222222 #888888 #292d2e #222222
+client.urgent #2f343a #900000 #ffffff #900000 #900000
+client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
+client.background #ffffff
+
+bindsym Mod1+1 workspace number 1
+bindsym Mod1+2 workspace number 2
+bindsym Mod1+3 workspace number 3
+bindsym Mod1+4 workspace number 4
+bindsym Mod1+5 workspace number 5
+bindsym Mod1+6 workspace number 6
+bindsym Mod1+7 workspace number 7
+bindsym Mod1+8 workspace number 8
+bindsym Mod1+9 workspace number 9
+bindsym Mod1+Down focus down
+bindsym Mod1+Left focus left
+bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym Mod1+Right focus right
+bindsym Mod1+Shift+1 move container to workspace number 1
+bindsym Mod1+Shift+2 move container to workspace number 2
+bindsym Mod1+Shift+3 move container to workspace number 3
+bindsym Mod1+Shift+4 move container to workspace number 4
+bindsym Mod1+Shift+5 move container to workspace number 5
+bindsym Mod1+Shift+6 move container to workspace number 6
+bindsym Mod1+Shift+7 move container to workspace number 7
+bindsym Mod1+Shift+8 move container to workspace number 8
+bindsym Mod1+Shift+9 move container to workspace number 9
+bindsym Mod1+Shift+Down move down
+bindsym Mod1+Shift+Left move left
+bindsym Mod1+Shift+Right move right
+bindsym Mod1+Shift+Up move up
+bindsym Mod1+Shift+c reload
+bindsym Mod1+Shift+e exec swaynag -t warning -m 'You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.' -b 'Yes, exit sway' 'swaymsg exit'
+bindsym Mod1+Shift+h move left
+bindsym Mod1+Shift+j move down
+bindsym Mod1+Shift+k move up
+bindsym Mod1+Shift+l move right
+bindsym Mod1+Shift+minus move scratchpad
+bindsym Mod1+Shift+q kill
+bindsym Mod1+Shift+space floating toggle
+bindsym Mod1+Up focus up
+bindsym Mod1+a focus parent
+bindsym Mod1+b splith
+bindsym Mod1+d exec @dmenu@/bin/dmenu_run
+bindsym Mod1+e layout toggle split
+bindsym Mod1+f fullscreen toggle
+bindsym Mod1+h focus left
+bindsym Mod1+j focus down
+bindsym Mod1+k focus up
+bindsym Mod1+l focus right
+bindsym Mod1+minus scratchpad show
+bindsym Mod1+r mode resize
+bindsym Mod1+s layout stacking
+bindsym Mod1+space focus mode_toggle
+bindsym Mod1+v splitv
+bindsym Mod1+w layout tabbed
+
+
+
+mode "resize" {
+bindsym Down resize grow height 10 px
+bindsym Escape mode default
+bindsym Left resize shrink width 10 px
+bindsym Return mode default
+bindsym Right resize grow width 10 px
+bindsym Up resize shrink height 10 px
+bindsym h resize shrink width 10 px
+bindsym j resize grow height 10 px
+bindsym k resize shrink height 10 px
+bindsym l resize grow width 10 px
+}
+
+
+bar {
+  
+  font pango:monospace 8
+  mode dock
+  hidden_state hide
+  position bottom
+  status_command @i3status@/bin/i3status
+  swaybar_command @sway@/bin/swaybar
+  workspace_buttons yes
+  strip_workspace_numbers no
+  tray_output primary
+  colors {
+    background #000000
+    statusline #ffffff
+    separator #666666
+    focused_workspace #4c7899 #285577 #ffffff
+    active_workspace #333333 #5f676a #ffffff
+    inactive_workspace #333333 #222222 #888888
+    urgent_workspace #2f343a #900000 #ffffff
+    binding_mode #2f343a #900000 #ffffff
+  }
+  
+}
+
+
+
+
+
+
+exec "systemctl --user import-environment; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-null-package.nix
+++ b/tests/modules/services/window-managers/sway/sway-null-package.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  dummy-package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out";
+
+in {
+  config = {
+    # Enables the default bar configuration
+    home.stateVersion = "20.09";
+
+    wayland.windowManager.sway = {
+      enable = true;
+      package = null;
+      config.menu = "${pkgs.dmenu}/bin/dmenu_run";
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        dmenu = dummy-package // { outPath = "@dmenu@"; };
+        rxvt-unicode-unwrapped = dummy-package // {
+          outPath = "@rxvt-unicode-unwrapped@";
+        };
+        i3status = dummy-package // { outPath = "@i3status@"; };
+        sway = dummy-package // { outPath = "@sway@"; };
+        xwayland = dummy-package // { outPath = "@xwayland@"; };
+      })
+    ];
+
+    assertions = [{
+      assertion =
+        !elem config.wayland.windowManager.sway.config.bars [ [ { } ] [ ] ];
+      message =
+        "The default Sway bars configuration should be set for this test (sway-null-package) to work.";
+    }];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/sway/config
+      assertFileContent home-files/.config/sway/config \
+        ${./sway-null-package.conf}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Fixes #1714

First commit refactors the `moduleName` check to use variables, it can be dropped if unnecessary.

cc: @alexarice

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
