### PR TITLE
neomutt: fix smtp_pass option

### DIFF
--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -116,7 +116,7 @@ let
           "${smtpProto}://${escape userName}@${smtp.host}${smtpPort}";
       in {
         smtp_url = "'${smtpBaseUrl}'";
-        smtp_pass = "'`${passCmd}`'";
+        smtp_pass = ''"`${passCmd}`"'';
       };
 
   genMaildirAccountConfig = account:

--- a/tests/modules/programs/neomutt/hm-example.com-expected
+++ b/tests/modules/programs/neomutt/hm-example.com-expected
@@ -10,7 +10,7 @@ set mbox_type = Maildir
 set sort = "threads"
 
 # MTA section
-set smtp_pass='`password-command`'
+set smtp_pass="`password-command`"
 set smtp_url='smtps://home.manager@smtp.example.com'
 
 


### PR DESCRIPTION
### Description

neomutt's smtp_pass configuration option was incorrectly quoted to evaluate a shell command given by `accounts.email.accounts.<name>.passwordCommand`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
