### PR TITLE
getmail: fix configuration mailboxes generation

### DIFF
--- a/modules/programs/getmail.nix
+++ b/modules/programs/getmail.nix
@@ -11,8 +11,7 @@ let
     with account;
     let
       passCmd = concatMapStringsSep ", " (x: "'${x}'") passwordCommand;
-      renderedMailboxes =
-        concatMapStringsSep ", " (x: "'${x}'") getmail.mailboxes;
+      renderedMailboxes = concatMapStrings (x: "'${x}', ") getmail.mailboxes;
       retrieverType = if imap.tls.enable then
         "SimpleIMAPSSLRetriever"
       else

--- a/tests/modules/programs/getmail/getmail-expected.conf
+++ b/tests/modules/programs/getmail/getmail-expected.conf
@@ -5,7 +5,7 @@ server = imap.example.com
 port = 993
 username = home.manager
 password_command = ('password-command')
-mailboxes = ( 'INBOX', 'Sent', 'Work' )
+mailboxes = ( 'INBOX', 'Sent', 'Work',  )
 
 [destination]
 type = MDA_external


### PR DESCRIPTION
### Description

Getmail's configuration mailboxes value must be a tuple of string or the string "ALL". The generated value was broken if `accounts.email.accounts.<name>.getmail.mailboxes` was a list of only one string (but not "ALL"): the generated expression `( "str" )` was not a tuple but a string. It worked for "ALL" because getmail accept this string as a special case.
Now, we always generate a tuple (by adding a comma, even with a list of size one) except if the option is set to "ALL":
- `"ALL"` generates `mailboxes = ( 'ALL' )`
- `[ "INBOX" ]` generates `mailboxes = ( 'INBOX',  )` (instead of incorrect `mailboxes = ( 'INBOX' )`)
- `[ "INBOX" "Drafts" ]` generates `mailboxes = ( 'INBOX', 'Drafts',  )`
- to maintain backwards compatilibty, `[ "ALL" ]` still generates `mailboxes = ( 'ALL' )`

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
