### PR TITLE
sxhkd: configurable package and command line arguments

### DIFF
--- a/modules/services/sxhkd.nix
+++ b/modules/services/sxhkd.nix
@@ -22,6 +22,20 @@ in
   options.services.sxhkd = {
     enable = mkEnableOption "simple X hotkey daemon";
 
+    package = mkOption {
+      type = types.package;
+      default = pkgs.sxhkd;
+      defaultText = "pkgs.sxhkd";
+      description = "Package containing the <command>sxhkd</command> executable.";
+    };
+
+    extraOptions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Command line arguments to invoke <command>sxhkd</command> with.";
+      example = literalExample ''[ "-m 1" ]'';
+    };
+
     keybindings = mkOption {
       type = types.attrsOf (types.nullOr types.str);
       default = {};
@@ -75,7 +89,7 @@ in
           + "${config.home.profileDirectory}/bin"
           + optionalString (cfg.extraPath != "") ":"
           + cfg.extraPath;
-        ExecStart = "${pkgs.sxhkd}/bin/sxhkd";
+        ExecStart = "${cfg.package}/bin/sxhkd ${toString cfg.extraOptions}";
       };
 
       Install = {

--- a/tests/modules/services/sxhkd/configuration.nix
+++ b/tests/modules/services/sxhkd/configuration.nix
@@ -3,6 +3,10 @@
     services.sxhkd = {
       enable = true;
 
+      package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out" // {
+        outPath = "@sxhkd@";
+      };
+
       keybindings = {
         "super + a" = "run command a";
         "super + b" = null;
@@ -18,9 +22,6 @@
           call command d
       '';
     };
-
-    nixpkgs.overlays =
-      [ (self: super: { sxhkd = pkgs.writeScriptBin "dummy-sxhkd" ""; }) ];
 
     nmt.script = ''
       sxhkdrc=home-files/.config/sxhkd/sxhkdrc

--- a/tests/modules/services/sxhkd/service.nix
+++ b/tests/modules/services/sxhkd/service.nix
@@ -1,8 +1,10 @@
-{ config, ... }:
+{ config, pkgs, ... }:
 {
   config = {
     services.sxhkd = {
       enable = true;
+      package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out" // { outPath = "@sxhkd@"; };
+      extraOptions = [ "-m 1" ];
       extraPath = "/home/the-user/bin:/extra/path/bin";
     };
 
@@ -11,7 +13,7 @@
 
       assertFileExists $serviceFile
 
-      assertFileRegex $serviceFile 'ExecStart=.*/bin/sxhkd'
+      assertFileRegex $serviceFile 'ExecStart=@sxhkd@/bin/sxhkd -m 1'
 
       assertFileRegex $serviceFile \
         'Environment=PATH=.*\.nix-profile/bin:/home/the-user/bin:/extra/path/bin'


### PR DESCRIPTION
### Description

Fixes #1598.

@JonathanReeve I don't use sxhkd, can you confirm this PR resolves your issue?

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
