### PR TITLE
Add option services.nextcloud.package

### DIFF
--- a/modules/services/nextcloud-client.nix
+++ b/modules/services/nextcloud-client.nix
@@ -2,12 +2,25 @@
 
 with lib;
 
-{
+let
+
+  cfg = config.services.nextcloud-client;
+
+in {
   options = {
-    services.nextcloud-client = { enable = mkEnableOption "Nextcloud Client"; };
+    services.nextcloud-client = {
+      enable = mkEnableOption "Nextcloud Client";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.nextcloud-client;
+        defaultText = literalExample "pkgs.nextcloud-client";
+        description = "The package to use for the nextcloud client binary.";
+      };
+    };
   };
 
-  config = mkIf config.services.nextcloud-client.enable {
+  config = mkIf cfg.enable {
     systemd.user.services.nextcloud-client = {
       Unit = {
         Description = "Nextcloud Client";
@@ -17,7 +30,7 @@ with lib;
 
       Service = {
         Environment = "PATH=${config.home.profileDirectory}/bin";
-        ExecStart = "${pkgs.nextcloud-client}/bin/nextcloud";
+        ExecStart = "${cfg.package}/bin/nextcloud";
       };
 
       Install = { WantedBy = [ "graphical-session.target" ]; };


### PR DESCRIPTION
### Description

Allows one to configure nextcloud to use a different package than the
default package.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```