### PR TITLE
mpv: fix issue #1725 and add tests

### DIFF
--- a/doc/release-notes/rl-2103.adoc
+++ b/doc/release-notes/rl-2103.adoc
@@ -32,6 +32,24 @@ programs.broot.verbs = [
 ];
 ----
 
+* The <<opt-programs.mpv.package>> option has been changed to allow custom
+derivations. The following configuration is now possible:
++
+[source,nix]
+----
+programs.mpv.package = (pkgs.wrapMpv (pkgs.mpv-unwrapped.override {
+  vapoursynthSupport = true;
+}) {
+  extraMakeWrapperArgs = [
+    "--prefix" "LD_LIBRARY_PATH" ":" "${pkgs.vapoursynth-mvtools}/lib/vapoursynth"
+  ];
+});
+----
++
+As a result of this change, <<opt-programs.mpv.package>> is no longer the
+resulting derivation. Use the newly introduced `programs.mpv.finalPackage`
+instead.
+
 [[sec-release-21.03-state-version-changes]]
 === State Version Changes
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -47,4 +47,10 @@
       fingerprint = "F0E0 0311 126A CD72 4392  25E6 68BF 2EAE 6D91 CAFF";
     }];
   };
+  thiagokokada = {
+    email = "thiagokokada@gmail.com";
+    name = "Thiago Kenji Okada";
+    github = "thiagokokada";
+    githubId = 844343;
+  };
 }

--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -50,7 +50,7 @@ let
     renderOptions { profile = concatStringsSep "," profiles; };
 
   mpvPackage = if cfg.scripts == [ ] then
-    pkgs.mpv
+    cfg.package
   else
     pkgs.wrapMpv pkgs.mpv-unwrapped { scripts = cfg.scripts; };
 
@@ -61,7 +61,18 @@ in {
 
       package = mkOption {
         type = types.package;
+        default = pkgs.mpv;
+        example = literalExample
+          "pkgs.wrapMpv (pkgs.mpv-unwrapped.override { vapoursynthSupport = true; }) { youtubeSupport = true; }";
+        description = ''
+          Package providing mpv.
+        '';
+      };
+
+      finalPackage = mkOption {
+        type = types.package;
         readOnly = true;
+        visible = false;
         description = ''
           Resulting mpv package.
         '';
@@ -91,7 +102,7 @@ in {
         example = literalExample ''
           {
             profile = "gpu-hq";
-            force-window = "yes";
+            force-window = true;
             ytdl-format = "bestvideo+bestaudio";
             cache-default = 4000000;
           }
@@ -154,8 +165,16 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
+      assertions = [
+        {
+          assertion = (cfg.scripts == [ ]) || (cfg.package == pkgs.mpv);
+          message = ''The programs.mpv "package" option is mutually exclusive with "scripts" option.'';
+        }
+      ];
+    }
+    {
       home.packages = [ mpvPackage ];
-      programs.mpv.package = mpvPackage;
+      programs.mpv.finalPackage = mpvPackage;
     }
     (mkIf (cfg.config != { } || cfg.profiles != { }) {
       xdg.configFile."mpv/mpv.conf".text = ''

--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -165,12 +165,11 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
-      assertions = [
-        {
-          assertion = (cfg.scripts == [ ]) || (cfg.package == pkgs.mpv);
-          message = ''The programs.mpv "package" option is mutually exclusive with "scripts" option.'';
-        }
-      ];
+      assertions = [{
+        assertion = (cfg.scripts == [ ]) || (cfg.package == pkgs.mpv);
+        message = ''
+          The programs.mpv "package" option is mutually exclusive with "scripts" option.'';
+      }];
     }
     {
       home.packages = [ mpvPackage ];

--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -188,5 +188,5 @@ in {
     })
   ]);
 
-  meta.maintainers = with maintainers; [ tadeokondrak ];
+  meta.maintainers = with maintainers; [ tadeokondrak thiagokokada ];
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -59,6 +59,7 @@ import nmt {
     ./modules/programs/lieer
     ./modules/programs/man
     ./modules/programs/mbsync
+    ./modules/programs/mpv
     ./modules/programs/ncmpcpp
     ./modules/programs/ne
     ./modules/programs/neomutt

--- a/tests/modules/programs/mpv/default.nix
+++ b/tests/modules/programs/mpv/default.nix
@@ -1,0 +1,4 @@
+{
+  mpv-example-settings = ./mpv-example-settings.nix;
+  mpv-invalid-settings = ./mpv-invalid-settings.nix;
+}

--- a/tests/modules/programs/mpv/mpv-example-settings-expected-bindings
+++ b/tests/modules/programs/mpv/mpv-example-settings-expected-bindings
@@ -1,0 +1,3 @@
+Alt+0 set window-scale 0.5
+WHEEL_DOWN seek -10
+WHEEL_UP seek 10

--- a/tests/modules/programs/mpv/mpv-example-settings-expected-config
+++ b/tests/modules/programs/mpv/mpv-example-settings-expected-config
@@ -1,0 +1,13 @@
+profile=%6%gpu-hq
+
+cache-default=%7%4000000
+force-window=%3%yes
+ytdl-format=%19%bestvideo+bestaudio
+
+[fast]
+vo=%5%vdpau
+
+[protocol.dvd]
+alang=%2%en
+profile-desc=%26%profile for dvd:// streams
+

--- a/tests/modules/programs/mpv/mpv-example-settings.nix
+++ b/tests/modules/programs/mpv/mpv-example-settings.nix
@@ -1,0 +1,46 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    programs.mpv = {
+      enable = true;
+      package = pkgs.mpvDummy;
+
+      bindings = {
+        WHEEL_UP = "seek 10";
+        WHEEL_DOWN = "seek -10";
+        "Alt+0" = "set window-scale 0.5";
+      };
+
+      config = {
+        force-window = true;
+        ytdl-format = "bestvideo+bestaudio";
+        cache-default = 4000000;
+      };
+
+      profiles = {
+        fast = { vo = "vdpau"; };
+        "protocol.dvd" = {
+          profile-desc = "profile for dvd:// streams";
+          alang = "en";
+        };
+      };
+
+      defaultProfiles = [ "gpu-hq" ];
+    };
+
+    nixpkgs.overlays = [
+      (self: super: { mpvDummy = pkgs.runCommandLocal "mpv" { } "mkdir $out"; })
+    ];
+
+    nmt.script = ''
+      assertFileContent \
+         home-files/.config/mpv/mpv.conf \
+         ${./mpv-example-settings-expected-config}
+      assertFileContent \
+         home-files/.config/mpv/input.conf \
+         ${./mpv-example-settings-expected-bindings}
+    '';
+  };
+
+}

--- a/tests/modules/programs/mpv/mpv-invalid-settings-expected.json
+++ b/tests/modules/programs/mpv/mpv-invalid-settings-expected.json
@@ -1,0 +1,1 @@
+["The programs.mpv \"package\" option is mutually exclusive with \"scripts\" option."]

--- a/tests/modules/programs/mpv/mpv-invalid-settings.nix
+++ b/tests/modules/programs/mpv/mpv-invalid-settings.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    programs.mpv = {
+      enable = true;
+      package = pkgs.mpvDummy;
+      scripts = [ pkgs.mpvScript ];
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        mpvDummy = pkgs.runCommandLocal "mpv" { } "mkdir $out";
+        mpvScript =
+          pkgs.runCommandLocal "mpvScript" { scriptName = "something"; }
+          "mkdir $out";
+      })
+    ];
+
+    home.file.result.text = builtins.toJSON
+      (map (a: a.message) (lib.filter (a: !a.assertion) config.assertions));
+
+    nmt.script = ''
+      assertFileContent \
+         home-files/result \
+         ${./mpv-invalid-settings-expected.json}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

This allows mpv module to be customized with support for more advanced features than the `programs.mpv.scripts` current support. For example, with this change now this is possible:

```nix
{
  programs.mpv.package = (pkgs.wrapMpv (pkgs.mpv-unwrapped.override {
    vapoursynthSupport = true;
  }) {
    extraMakeWrapperArgs = [
      "--prefix" "LD_LIBRARY_PATH" ":" "${pkgs.vapoursynth-mvtools}/lib/vapoursynth"
    ];
  });
}

```

Since `programs.mpv.package` doesn't necessary reflect the final derivation anymore (see #1524), we introduce `programs.mpv.finalPackage` that has the resulting derivation.

Closes issue #1725.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible. (mostly, except for the `programs.mpv.finalPackage` that is documented)

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
