### PR TITLE
Add programms.mercurial.tweakDefaults option

### DIFF
--- a/modules/programs/mercurial.nix
+++ b/modules/programs/mercurial.nix
@@ -26,6 +26,14 @@ in {
         description = "Default user name to use.";
       };
 
+      tweakDefaults = mkOption {
+        type = types.bool;
+        description =
+          "Enable functionality that the average user probably wants on by default";
+        example = "tweakdefaults = true;";
+        default = false;
+      };
+
       userEmail = mkOption {
         type = types.str;
         description = "Default user email to use.";
@@ -71,11 +79,16 @@ in {
 
       programs.mercurial.iniContent.ui = {
         username = cfg.userName + " <" + cfg.userEmail + ">";
+
       };
 
       xdg.configFile."hg/hgrc".source =
         iniFormat.generate "hgrc" cfg.iniContent;
     }
+
+    (mkIf (cfg.tweakDefaults) {
+      programs.mercurial.iniContent.ui.tweakdefaults = "yes";
+    })
 
     (mkIf (cfg.ignores != [ ] || cfg.ignoresRegexp != [ ]) {
       programs.mercurial.iniContent.ui.ignore =


### PR DESCRIPTION
### Description

Adds configuration option https://github.com/nix-community/home-manager/issues/1727

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
