### PR TITLE
mercurial: Enable configuration of mercurial extensions

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1814,6 +1814,12 @@ in
           A new module is available: 'services.plan9port'.
         '';
       }
+      {
+        time = "2021-01-18T18:56:00+00:00";
+        message = ''
+          A new configuration option is available: 'programs.mercurial.extensions'.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/mercurial.nix
+++ b/modules/programs/mercurial.nix
@@ -21,6 +21,19 @@ in {
         description = "Mercurial package to install.";
       };
 
+      extensions = mkOption {
+        type = types.attrsOf types.string;
+        default = { };
+        description = "Mercurial extensions to enable.";
+        example = ''
+          extensions = {
+            histedit = "";
+            "hgext.convert" = "";
+            purge = "";
+          }
+        '';
+      };
+
       userName = mkOption {
         type = types.str;
         description = "Default user name to use.";
@@ -90,6 +103,10 @@ in {
 
     (mkIf (cfg.aliases != { }) {
       programs.mercurial.iniContent.alias = cfg.aliases;
+    })
+
+    (mkIf (cfg.extensions != [ ]) {
+      programs.mercurial.iniContent.extensions = cfg.extensions;
     })
 
     (mkIf (lib.isAttrs cfg.extraConfig) {


### PR DESCRIPTION
https://github.com/nix-community/home-manager/issues/1729

Fairly standardized use case so it makes sense to map this configuration
in home.nix. This might also enable to use installation paths of
mercurial extensions that are installed via nix.

### Description

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
