### PR TITLE
docs: NixOS and nix-darwin option documentation

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -26,27 +26,78 @@ let
     }];
   };
 
-  hmModulesDocs = nmd.buildModulesDocs {
+  buildModulesDocs = args:
+    nmd.buildModulesDocs ({
+      moduleRootPaths = [ ./.. ];
+      mkModuleUrl = path:
+        "https://github.com/nix-community/home-manager/blob/master/${path}#blob-path";
+      channelName = "home-manager";
+    } // args);
+
+  hmModulesDocs = buildModulesDocs {
     modules = import ../modules/modules.nix {
       inherit lib pkgs;
       check = false;
     } ++ [ scrubbedPkgsModule ];
-    moduleRootPaths = [ ./.. ];
-    mkModuleUrl = path:
-      "https://github.com/nix-community/home-manager/blob/master/${path}#blob-path";
-    channelName = "home-manager";
     docBook.id = "home-manager-options";
+  };
+
+  nixosModuleDocs = buildModulesDocs {
+    modules = let
+      nixosModule = module: pkgs.path + "/nixos/modules" + module;
+      mockedNixos = with lib; {
+        options = {
+          environment.pathsToLink = mkSinkUndeclaredOptions { };
+          systemd.services = mkSinkUndeclaredOptions { };
+          users.users = mkSinkUndeclaredOptions { };
+        };
+      };
+    in [
+      ../nixos/default.nix
+      mockedNixos
+      (nixosModule "/misc/assertions.nix")
+      scrubbedPkgsModule
+    ];
+    docBook = {
+      id = "nixos-options";
+      optionIdPrefix = "nixos-opt";
+    };
+  };
+
+  nixDarwinModuleDocs = buildModulesDocs {
+    modules = let
+      nixosModule = module: pkgs.path + "/nixos/modules" + module;
+      mockedNixDarwin = with lib; {
+        options = {
+          environment.pathsToLink = mkSinkUndeclaredOptions { };
+          system.activationScripts.postActivation.text =
+            mkSinkUndeclaredOptions { };
+          users.users = mkSinkUndeclaredOptions { };
+        };
+      };
+    in [
+      ../nix-darwin/default.nix
+      mockedNixDarwin
+      (nixosModule "/misc/assertions.nix")
+      scrubbedPkgsModule
+    ];
+    docBook = {
+      id = "nix-darwin-options";
+      optionIdPrefix = "nix-darwin-opt";
+    };
   };
 
   docs = nmd.buildDocBookDocs {
     pathName = "home-manager";
-    modulesDocs = [ hmModulesDocs ];
+    modulesDocs = [ hmModulesDocs nixDarwinModuleDocs nixosModuleDocs ];
     documentsDirectory = ./.;
     documentType = "book";
     chunkToc = ''
       <toc>
         <d:tocentry xmlns:d="http://docbook.org/ns/docbook" linkend="book-home-manager-manual"><?dbhtml filename="index.html"?>
           <d:tocentry linkend="ch-options"><?dbhtml filename="options.html"?></d:tocentry>
+          <d:tocentry linkend="ch-nixos-options"><?dbhtml filename="nixos-options.html"?></d:tocentry>
+          <d:tocentry linkend="ch-nix-darwin-options"><?dbhtml filename="nix-darwin-options.html"?></d:tocentry>
           <d:tocentry linkend="ch-tools"><?dbhtml filename="tools.html"?></d:tocentry>
           <d:tocentry linkend="ch-release-notes"><?dbhtml filename="release-notes.html"?></d:tocentry>
         </d:tocentry>

--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -38,6 +38,14 @@
   <title>Configuration Options</title>
   <xi:include href="./nmd-result/home-manager-options.xml" />
  </appendix>
+ <appendix xml:id="ch-nixos-options">
+  <title>NixOS Module Options</title>
+  <xi:include href="./nmd-result/nixos-options.xml" />
+ </appendix>
+ <appendix xml:id="ch-nix-darwin-options">
+  <title>nix-darwin Module Options</title>
+  <xi:include href="./nmd-result/nix-darwin-options.xml" />
+ </appendix>
  <appendix xml:id="ch-tools">
   <title>Tools</title>
   <xi:include href="./man-home-manager.xml" />

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -36,7 +36,7 @@ in
     home-manager = {
       useUserPackages = mkEnableOption ''
         installation of user packages through the
-        <option>users.users.‹name?›.packages</option> option.
+        <option>users.users.&lt;name?&gt;.packages</option> option.
       '';
 
       useGlobalPkgs = mkEnableOption ''
@@ -60,6 +60,9 @@ in
       users = mkOption {
         type = types.attrsOf hmModule;
         default = {};
+        # Set as not visible to prevent the entire submodule being included in
+        # the documentation.
+        visible = false;
         description = ''
           Per-user Home Manager configuration.
         '';

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -46,7 +46,7 @@ in {
     home-manager = {
       useUserPackages = mkEnableOption ''
         installation of user packages through the
-        <option>users.users.‹name?›.packages</option> option.
+        <option>users.users.&lt;name&gt;.packages</option> option.
       '';
 
       useGlobalPkgs = mkEnableOption ''
@@ -70,6 +70,9 @@ in {
       users = mkOption {
         type = types.attrsOf hmModule;
         default = { };
+        # Set as not visible to prevent the entire submodule being included in
+        # the documentation.
+        visible = false;
         description = ''
           Per-user Home Manager configuration.
         '';


### PR DESCRIPTION
### Description

Makes the manual include generated option documentation for NixOS and nix-darwin modules.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.