### PR TITLE
chromium: Fix preinstallation of crx files

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -116,15 +116,15 @@ let
         "${config.xdg.configHome}/${browser}";
 
       extensionJson = ext:
+        assert ext.crxPath != null -> ext.version != null;
         with builtins; {
           name = "${configDir}/External Extensions/${ext.id}.json";
-          value.text = toJSON
-            (if (isPath ext.crxPath && isString ext.version) then {
-              external_crx = ext.crxPath;
-              external_version = ext.version;
-            } else {
-              external_update_url = ext.updateUrl;
-            });
+          value.text = toJSON (if ext.crxPath != null then {
+            external_crx = ext.crxPath;
+            external_version = ext.version;
+          } else {
+            external_update_url = ext.updateUrl;
+          });
         };
 
     in mkIf cfg.enable {


### PR DESCRIPTION
### Description

We currently check `isPath` and `isString` on crxPath and version
respectively, which is

(1) pointless because the module system already does such checks
(2) wrong because isPath means path literal. a derivation therefore is not a path.

### Checklist

- [ ] Change is backwards compatible. - **not entirely.** running a `crxPath` without a `version` would previously **silently fail** while there's now an assert.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
