### PR TITLE
chromium: Support ungoogled-chromium

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -99,7 +99,8 @@ let
   browserConfig = cfg:
     let
 
-      browser = (builtins.parseDrvName cfg.package.name).name;
+      drvName = (builtins.parseDrvName cfg.package.name).name;
+      browser = if drvName == "ungoogled-chromium" then "chromium" else drvName;
 
       darwinDirs = {
         chromium = "Chromium";


### PR DESCRIPTION
### Description

The guessed browser name is wrong here, ungoogled-chromium simply uses "chromium" as configuration name.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
