### PR TITLE
dconf: make sure the configuration directory exists

### DIFF
--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -46,6 +46,9 @@ in {
   };
 
   config = mkIf (cfg.enable && cfg.settings != { }) {
+    # Make sure the dconf directory exists.
+    xdg.configFile."dconf/.keep".source = builtins.toFile "keep" "";
+
     home.activation.dconfSettings = hm.dag.entryAfter [ "installPackages" ]
       (let iniFile = pkgs.writeText "hm-dconf.ini" (toDconfIni cfg.settings);
       in ''


### PR DESCRIPTION
Fixes #1731

-------

### Description

Hopefully fixes error when activating a configuration containing dconf settings when no previous dconf setup exists for the user.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.