### PR TITLE
Document input.follows in the flake section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,10 @@ as follows:
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    home-manager.url = "github:nix-community/home-manager";
+    home-manager = {
+      url = github:nix-community/home-manager;
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = { home-manager, nixpkgs, ... }: {


### PR DESCRIPTION
I was working on my config and I noticed this little documentation issue. 
Diff after adding `.follows` attribute:
https://github.com/gytis-ivaskevicius/nixfiles/commit/806d8d52f00ed7af43160a1b6cc35cd5cee3ccea#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c