### PR TITLE
Add option programs.vim.package

### DIFF
--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -65,6 +65,15 @@ in {
     programs.vim = {
       enable = mkEnableOption "Vim";
 
+      customizable_package = mkOption {
+        type = with types; package;
+        default = pkgs.vim_configurable;
+        example = literalExample "pkgs.vim_configurable.override { python = pkgs.python3; }";
+        description = ''
+          TODO
+        '';
+      };
+
       plugins = mkOption {
         type = with types; listOf (either str package);
         default = defaultPlugins;
@@ -135,7 +144,7 @@ in {
       ${cfg.extraConfig}
     '';
 
-    vim = pkgs.vim_configurable.customize {
+    vim = cfg.customizable_package.customize {
       name = "vim";
       vimrcConfig = {
         inherit customRC;


### PR DESCRIPTION
### Description

Add an option for the user to provide a vim package which will then be installed and configured by home-manager.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
