### PR TITLE
rofi: add support to custom themes

### DIFF
--- a/tests/modules/programs/rofi/custom-theme-config.rasi
+++ b/tests/modules/programs/rofi/custom-theme-config.rasi
@@ -1,0 +1,6 @@
+configuration {
+location: 0;
+theme: "custom";
+xoffset: 0;
+yoffset: 0;
+}

--- a/tests/modules/programs/rofi/custom-theme.nix
+++ b/tests/modules/programs/rofi/custom-theme.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.rofi = {
+      enable = true;
+
+      theme = with config.lib.formats.rasi; {
+        "*" = {
+          background-color = mkLiteral "#000000";
+          foreground-color = mkLiteral "rgba ( 250, 251, 252, 100 % )";
+          border-color = mkLiteral "#FFFFFF";
+          width = 512;
+        };
+
+        "#textbox-prompt-colon" = {
+          expand = false;
+          str = ":";
+          margin = mkLiteral "0px 0.3em 0em 0em";
+          text-color = mkLiteral "@foreground-color";
+        };
+      };
+    };
+
+    nixpkgs.overlays =
+      [ (self: super: { rofi = pkgs.writeScriptBin "dummy-rofi" ""; }) ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/rofi/config.rasi \
+        ${./custom-theme-config.rasi}
+      assertFileContent \
+        home-files/.local/share/rofi/themes/custom.rasi \
+        ${./custom-theme.rasi}
+    '';
+  };
+}

--- a/tests/modules/programs/rofi/custom-theme.rasi
+++ b/tests/modules/programs/rofi/custom-theme.rasi
@@ -1,0 +1,13 @@
+#textbox-prompt-colon {
+expand: false;
+margin: 0px 0.3em 0em 0em;
+str: ":";
+text-color: @foreground-color;
+}
+
+* {
+background-color: #000000;
+border-color: #FFFFFF;
+foreground-color: rgba ( 250, 251, 252, 100 % );
+width: 512;
+}

--- a/tests/modules/programs/rofi/default.nix
+++ b/tests/modules/programs/rofi/default.nix
@@ -1,4 +1,5 @@
 {
   rofi-valid-config = ./valid-config.nix;
+  rofi-custom-theme = ./custom-theme.nix;
   rofi-assert-on-both-theme-and-colors = ./assert-on-both-theme-and-colors.nix;
 }

--- a/tests/modules/programs/rofi/valid-config.nix
+++ b/tests/modules/programs/rofi/valid-config.nix
@@ -48,6 +48,9 @@ with lib;
       };
     };
 
+    nixpkgs.overlays =
+      [ (self: super: { rofi = pkgs.writeScriptBin "dummy-rofi" ""; }) ];
+
     nmt.script = ''
       assertFileContent \
         home-files/.config/rofi/config.rasi \


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
With this PR now it is possible to define a custom theme directly using Nix, like this:

```nix
{
   programs.rofi.theme = {
      "*" = {
         background-color = "#000000";
         border-color = "FFFFFF";
         width = 512;
      };
      listview = {
         cycle = true;
      };
   };
}
```

And this will be converted to the proper rasi format to be used in rofi.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
