### PR TITLE
home-environment: Add option `sessionPrependPath`

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -274,6 +274,14 @@ in
       ];
       description = "Extra directories to add to <envar>PATH</envar>.";
     };
+    home.sessionPrependPath = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      example = [
+        "~/bin"
+      ];
+      description = "Extra directories to add to beginning of <envar>PATH</envar>.";
+    };
 
     home.sessionVariablesExtra = mkOption {
       type = types.lines;
@@ -459,6 +467,8 @@ in
             ${config.lib.shell.exportAll cfg.sessionVariables}
           '' + lib.optionalString (cfg.sessionPath != [ ]) ''
             export PATH="$PATH''${PATH:+:}${concatStringsSep ":" cfg.sessionPath}"
+          '' + lib.optionalString (cfg.sessionPrependPath != [ ]) ''
+            export PATH="${concatStringsSep ":" cfg.sessionPrependPath}''${PATH:+:$PATH}"
           '' + cfg.sessionVariablesExtra;
         }
       )

--- a/tests/modules/home-environment/default.nix
+++ b/tests/modules/home-environment/default.nix
@@ -1,4 +1,6 @@
 {
   home-session-variables = ./session-variables.nix;
   home-session-path = ./session-path.nix;
+  home-session-prepend-path = ./session-prepend-path.nix;
+  home-session-prepend-append-path = ./session-prepend-and-append-path.nix;
 }

--- a/tests/modules/home-environment/session-prepend-and-append-path.nix
+++ b/tests/modules/home-environment/session-prepend-and-append-path.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ({ ... }: { config.home.sessionPrependPath = [ "prefoo" ]; })
+    ({ ... }: { config.home.sessionPrependPath = [ "prebar" "prebaz" ]; })
+    ({ ... }: { config.home.sessionPath = [ "foo" ]; })
+    ({ ... }: { config.home.sessionPath = [ "bar" "baz" ]; })
+  ];
+
+  nmt.script = ''
+    hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
+    assertFileExists $hmSessVars
+    assertFileContains $hmSessVars \
+      'export PATH="prebar:prebaz:prefoo''${PATH:+:$PATH}"'
+    assertFileContains $hmSessVars \
+      'export PATH="$PATH''${PATH:+:}bar:baz:foo"'
+  '';
+}

--- a/tests/modules/home-environment/session-prepend-path.nix
+++ b/tests/modules/home-environment/session-prepend-path.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ({ ... }: { config.home.sessionPrependPath = [ "foo" ]; })
+    ({ ... }: { config.home.sessionPrependPath = [ "bar" "baz" ]; })
+  ];
+
+  nmt.script = ''
+    hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
+    assertFileExists $hmSessVars
+    assertFileContains $hmSessVars \
+      'export PATH="bar:baz:foo''${PATH:+:$PATH}"'
+  '';
+}


### PR DESCRIPTION
### Description

This PR adds an easy way to setup directories to be at the beginning of PATH.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
