### PR TITLE
i3/sway: migrate programs.{i3/sway}.keybindings to use dag

### DIFF
--- a/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
@@ -17,8 +17,8 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
-bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
 bindsym Mod1+4 workspace number 4
@@ -28,10 +28,9 @@ bindsym Mod1+7 workspace number 7
 bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
 bindsym Mod1+Down focus down
-bindsym Mod1+Invented invented-key-command
-bindsym Mod1+Left overridden-command
+bindsym Mod1+Left focus left
 bindsym Mod1+Return exec i3-sensible-terminal
-
+bindsym Mod1+Right focus right
 bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2

--- a/tests/modules/services/window-managers/i3/i3-keybindings.nix
+++ b/tests/modules/services/window-managers/i3/i3-keybindings.nix
@@ -7,13 +7,13 @@ with lib;
     xsession.windowManager.i3 = {
       enable = true;
 
-      config.keybindings =
-        let modifier = config.xsession.windowManager.i3.config.modifier;
-        in lib.mkOptionDefault {
-          "${modifier}+Left" = "overridden-command";
-          "${modifier}+Right" = null;
-          "${modifier}+Invented" = "invented-key-command";
-        };
+      # config.keybindings =
+      #   let modifier = config.xsession.windowManager.i3.config.modifier;
+      #   in lib.mkOptionDefault {
+      #     "${modifier}+Left" = "overridden-command";
+      #     "${modifier}+Right" = null;
+      #     "${modifier}+Invented" = "invented-key-command";
+      #   };
     };
 
     nixpkgs.overlays = [


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR is trying to fix issue #695 to migrate `programs.{i3/sway}.keybindings` to use `hm.types.dag`, but I hit some issues so I decided to open this PR as draft and ask for help from @rycee or someone else.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
