### PR TITLE
neovim: suffix path with extraPackages

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -47,21 +47,21 @@ let
       " ${p.plugin.pname} {{{
       ${p.config}
       " }}}
+    '' else "";
 
-  moduleConfigure = optionalAttrs (cfg.extraConfig != ""
-    || (lib.filter (hasAttr "config") cfg.plugins) != [ ]) {
-      customRC = cfg.extraConfig
-        + pkgs.lib.concatMapStrings pluginConfig cfg.plugins;
-
-      packages.home-manager = {
-        start = filter (f: f != null) (map (x:
-          if x ? plugin && x.optional == true then null else (x.plugin or x))
+  moduleConfigure = {
+    packages.home-manager = {
+      start = filter (f: f != null) (map (x:
+        if x ? plugin && x.optional == true then null else (x.plugin or x))
+        cfg.plugins);
+      opt = filter (f: f != null)
+        (map (x: if x ? plugin && x.optional == true then x.plugin else null)
           cfg.plugins);
-        opt = filter (f: f != null)
-          (map (x: if x ? plugin && x.optional == true then x.plugin else null)
-            cfg.plugins);
-      };
     };
+    customRC = cfg.extraConfig
+      + pkgs.lib.concatMapStrings pluginConfig cfg.plugins;
+  };
+
   extraMakeWrapperArgs = lib.optionalString (cfg.extraPackages != [ ])
     ''--suffix PATH : "${lib.makeBinPath cfg.extraPackages}"'';
 

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -65,7 +65,7 @@ let
       };
     };
   extraMakeWrapperArgs = lib.optionalString (cfg.extraPackages != [ ])
-    ''--prefix PATH : "${lib.makeBinPath cfg.extraPackages}"'';
+    ''--suffix PATH : "${lib.makeBinPath cfg.extraPackages}"'';
 
 in {
   options = {
@@ -242,8 +242,6 @@ in {
   };
 
   config = let
-    extraMakeWrapperArgs = lib.optionalString (cfg.extraPackages != [ ])
-      ''--prefix PATH : "${lib.makeBinPath cfg.extraPackages}"'';
     neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
       inherit (cfg)
         extraPython3Packages withPython3 extraPythonPackages withPython

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -47,12 +47,13 @@ let
       " ${p.plugin.pname} {{{
       ${p.config}
       " }}}
-    '' else "";
+    '' else
+      "";
 
   moduleConfigure = {
     packages.home-manager = {
-      start = filter (f: f != null) (map (x:
-        if x ? plugin && x.optional == true then null else (x.plugin or x))
+      start = filter (f: f != null) (map
+        (x: if x ? plugin && x.optional == true then null else (x.plugin or x))
         cfg.plugins);
       opt = filter (f: f != null)
         (map (x: if x ? plugin && x.optional == true then x.plugin else null)

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -43,12 +43,10 @@ let
 
   # A function to get the configuration string (if any) from an element of 'plugins'
   pluginConfig = p:
-    if builtins.hasAttr "plugin" p && builtins.hasAttr "config" p then ''
+    if p ? plugin && (p.config or "") != "" then ''
       " ${p.plugin.pname} {{{
       ${p.config}
       " }}}
-    '' else
-      "";
 
   moduleConfigure = optionalAttrs (cfg.extraConfig != ""
     || (lib.filter (hasAttr "config") cfg.plugins) != [ ]) {


### PR DESCRIPTION
### Description

@jlesquembre  like this ?
Fixes https://github.com/nix-community/home-manager/issues/1739 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
