### PR TITLE
add option home-manager.sharedModules

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -34,6 +34,7 @@ let
           home.homeDirectory = config.users.users.${name}.home;
         };
       })
+      ({ ... }: { imports = cfg.sharedModules; })
     ];
   };
 
@@ -62,6 +63,16 @@ in {
         description = ''
           On activation move existing files by appending the given
           file extension rather than exiting with an error.
+        '';
+      };
+
+      sharedModules = mkOption {
+        type = types.listOf
+          (types.anything // { description = "Home Manager module"; });
+        default = [ ];
+        example = [ /path/to/module.nix ];
+        description = ''
+          Home Manager modules that are shared among all users.
         '';
       };
 


### PR DESCRIPTION
### Description
This option is for modules shared among all users to avoid having to import all the same modules on every user

I've tested with a module that adds an option and if enabled add an extra package using `writeShellScriptBin`.

Also tested using nixos-option if the option appears too if I create another user
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
