### PR TITLE
emacs: add extraConfig option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: ./format -c
     - run: nix-shell . -A install
-    - run: nix-shell --pure tests -A run.all
+    - run: nix-shell --arg enableBig false --pure tests -A run.all

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> {}, enableBig ? true }:
 
 let
 
@@ -135,5 +135,7 @@ import nmt {
     ./modules/services/wlsunset
     ./modules/systemd
     ./modules/targets-linux
+  ] ++ lib.optionals enableBig [
+    ./modules/programs/emacs
   ]);
 }

--- a/tests/modules/programs/emacs/default.nix
+++ b/tests/modules/programs/emacs/default.nix
@@ -1,0 +1,1 @@
+{ emacs-extra-config = ./extra-config.nix; }

--- a/tests/modules/programs/emacs/extra-config.nix
+++ b/tests/modules/programs/emacs/extra-config.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  testScript = pkgs.writeText "test.el" ''
+    ;; Emacs won't automatically load default.el when --script is specified
+    (load "default")
+    (kill-emacs (if (eq hm 'home-manager) 0 1))
+  '';
+
+  emacsBin = "${config.programs.emacs.finalPackage}/bin/emacs";
+
+in {
+  programs.emacs = {
+    enable = true;
+    package = pkgs.emacs-nox;
+    extraConfig = "(setq hm 'home-manager)";
+  };
+
+  # running emacs with --script would enable headless mode
+  nmt.script = ''
+    if ! ${emacsBin} --script ${testScript}; then
+      fail "Failed to load default.el."
+    fi
+  '';
+}


### PR DESCRIPTION
### Description

This would make it easy to set variables with Nix-computed paths in the configuration.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
