### PR TITLE
fix: change spotifyd config format ini -> toml

### DIFF
--- a/modules/services/spotifyd.nix
+++ b/modules/services/spotifyd.nix
@@ -6,9 +6,9 @@ let
 
   cfg = config.services.spotifyd;
 
-  configFile = pkgs.writeText "spotifyd.conf" ''
-    ${generators.toINI { } cfg.settings}
-  '';
+  tomlFormat = pkgs.formats.toml { };
+
+  configFile = tomlFormat.generate "spotifyd.conf" cfg.settings;
 
 in {
   options.services.spotifyd = {
@@ -27,7 +27,7 @@ in {
     };
 
     settings = mkOption {
-      type = types.attrsOf (types.attrsOf types.str);
+      type = tomlFormat.type;
       default = { };
       description = "Configuration for spotifyd";
       example = literalExample ''


### PR DESCRIPTION
### Description

#1754 
configure spotifyd with toml as it now expects, instead of ini

### Checklist

- [N/A] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [N/A] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted 