### PR TITLE
mbsync: add subFolders option

### DIFF
--- a/modules/programs/mbsync-accounts.nix
+++ b/modules/programs/mbsync-accounts.nix
@@ -125,6 +125,16 @@ in {
       '';
     };
 
+    subFolders = mkOption {
+      type = types.enum [ "Verbatim" "Maildir++" "Legacy" ];
+      default = "Verbatim";
+      example = "Maildir++";
+      description = ''
+        The on-disk folder naming style. This option has no
+        effect when <option>flatten</option> is used.
+      '';
+    };
+
     create = mkOption {
       type = types.enum [ "none" "maildir" "imap" "both" ];
       default = "none";

--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -65,10 +65,13 @@ let
     + genSection "IMAPStore ${name}-remote"
     ({ Account = name; } // mbsync.extraConfig.remote) + "\n"
     + genSection "MaildirStore ${name}-local" ({
-      Path = "${maildir.absPath}/";
       Inbox = "${maildir.absPath}/${folders.inbox}";
-      SubFolders = "Verbatim";
-    } // optionalAttrs (mbsync.flatten != null) { Flatten = mbsync.flatten; }
+    } // optionalAttrs
+      (mbsync.subFolders != "Maildir++" || mbsync.flatten != null) {
+        Path = "${maildir.absPath}/";
+      } // optionalAttrs (mbsync.flatten == null) {
+        SubFolders = mbsync.subFolders;
+      } // optionalAttrs (mbsync.flatten != null) { Flatten = mbsync.flatten; }
       // mbsync.extraConfig.local) + "\n" + genChannels account;
 
   genChannels = account:


### PR DESCRIPTION

### Description

The `SubFolders` option in mbsync controls the folder naming style
in the maildir.  There are three different styles:

* Verbatim - `<maildirPath>/top/sub/subsub`
* Maildir++ - `<inboxPath>/.top.sub.subsub` (used by Dovecot)
* Legacy - `<maildirPath>/top/.sub/.subsub`

Previously, the `SubFolders` option was hardcoded to `Verbatim`.  This
change allows configuration of the `SubFolders` option.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
