### PR TITLE
vscode: Add `args` option to keybindings, make `when` optional

### DIFF
--- a/tests/modules/programs/vscode/keybindings.nix
+++ b/tests/modules/programs/vscode/keybindings.nix
@@ -20,6 +20,11 @@ let
       command = "deleteFile";
       when = "explorerViewletVisible";
     }
+    {
+      key = "ctrl+r";
+      command = "run";
+      args = { command = "echo file"; };
+    }
   ];
 
   targetPath = if pkgs.stdenv.hostPlatform.isDarwin then
@@ -43,6 +48,13 @@ let
         "command": "deleteFile",
         "key": "d",
         "when": "explorerViewletVisible"
+      },
+      {
+        "args": {
+          "command": "echo file"
+        },
+        "command": "run",
+        "key": "ctrl+r"
       }
     ]
   '';
@@ -51,17 +63,8 @@ in {
     programs.vscode = {
       enable = true;
       keybindings = bindings;
+      package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
     };
-
-    nixpkgs.overlays = [
-      (self: super: {
-        vscode = pkgs.runCommandLocal "vscode" { pname = "vscode"; } ''
-          mkdir -p $out/bin
-          touch $out/bin/code
-          chmod +x $out/bin/code;
-        '';
-      })
-    ];
 
     nmt.script = ''
       assertFileExists "home-files/${targetPath}"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~If this PR adds a new module~

  - [x] ~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~

  - [x] ~Added myself and the module files to `.github/CODEOWNERS`.~
