### PR TITLE
xmonad: add libFiles option

### DIFF
--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -75,27 +75,86 @@ in {
           by Home Manager.
         '';
       };
+
+      libFiles = mkOption {
+        type = types.attrsOf (types.oneOf [ types.path ]);
+        default = { };
+        example = literalExample ''
+          {
+            "Tools.hs" = pkgs.writeText "Tools.hs" '''
+               module Tools where
+               screenshot = "scrot"
+             ''';
+          }
+        '';
+        description = ''
+          Additional files that will be saved in
+          <filename>~/.xmonad/lib/</filename> and included in the configuration
+          build. The keys are the file names while the values are paths to the
+          contents of the files.
+        '';
+      };
     };
   };
 
-  config = mkIf cfg.enable (mkMerge [
+  config = let
+
+    xmonadBin = "${
+        pkgs.runCommandLocal "xmonad-compile" {
+          nativeBuildInputs = [ xmonad ];
+        } ''
+          mkdir -p $out/bin
+
+          export XMONAD_CONFIG_DIR="$(pwd)/xmonad-config"
+          export XMONAD_DATA_DIR="$(pwd)/data"
+          export XMONAD_CACHE_DIR="$(pwd)/cache"
+
+          mkdir -p "$XMONAD_CONFIG_DIR/lib" "$XMONAD_CACHE_DIR" "$XMONAD_DATA_DIR"
+
+          cp ${cfg.config} xmonad-config/xmonad.hs
+
+          declare -A libFiles
+          libFiles=(${
+            concatStringsSep " "
+            (mapAttrsToList (name: value: "['${name}']='${value}'")
+              cfg.libFiles)
+          })
+          for key in "''${!libFiles[@]}"; do
+            cp "''${libFiles[$key]}" "xmonad-config/lib/$key";
+          done
+
+          xmonad --recompile
+
+          # The resulting binary name depends on the arch and os
+          # https://github.com/xmonad/xmonad/blob/56b0f850bc35200ec23f05c079eca8b0a1f90305/src/XMonad/Core.hs#L565-L572
+          mv "$XMONAD_DATA_DIR/xmonad-${pkgs.hostPlatform.system}" $out/bin/
+        ''
+      }/bin/xmonad-${pkgs.hostPlatform.system}";
+
+  in mkIf cfg.enable (mkMerge [
     {
       home.packages = [ (lowPrio xmonad) ];
-      xsession.windowManager.command = "${xmonad}/bin/xmonad";
+      xsession.windowManager.command = xmonadBin;
     }
 
     (mkIf (cfg.config != null) {
       home.file.".xmonad/xmonad.hs".source = cfg.config;
-      home.file.".xmonad/xmonad.hs".onChange = ''
-        echo "Recompiling xmonad"
-        $DRY_RUN_CMD ${config.xsession.windowManager.command} --recompile
-
-        # Attempt to restart xmonad if X is running.
-        if [[ -v DISPLAY ]] ; then
-          echo "Restarting xmonad"
-          $DRY_RUN_CMD ${config.xsession.windowManager.command} --restart
-        fi
-      '';
+      home.file.".xmonad/xmonad-${pkgs.hostPlatform.system}" = {
+        source = xmonadBin;
+        onChange = ''
+          # Attempt to restart xmonad if X is running.
+          if [[ -v DISPLAY ]] ; then
+            echo "Restarting xmonad"
+            $DRY_RUN_CMD ${config.xsession.windowManager.command} --restart
+          fi
+        '';
+      };
     })
+
+    {
+      home.file = mapAttrs' (name: value:
+        attrsets.nameValuePair (".xmonad/lib/" + name) { source = value; })
+        cfg.libFiles;
+    }
   ]);
 }


### PR DESCRIPTION
The libFiles option allows home-manager to manage additional files for
xmonad in `.xmonad/lib`. The advantage of doing it like this compared to
just using `home.file.".xmonad/lib/File.hs".source` is, that we can
detect file changes and recompile xmonad accordingly.

### Description

This commit adds an option `libFiles` that allows to add additional files to `.xmonad/libs/`.
The xmonad recompilation process can access files stored in this directory as modules, therefore they can influence the configuration. When we would add these files via  `home.file.".xmonad/lib/File.hs".source`, changes to them would not cause xmonad to be recompiled, thereby making it necessary to call `xmonad --recompile && xmonad -- restart` after `home-manager switch`.

If such files are added via the new `libFiles` option, changes to them cause a recompilation.

Right now, unfortunately, if both `xmonad.hs` and the files in `libFiles` change, xmonad is recompiled once for every changed file, as I don't know yet how one could implement this in an elegant way.

Note, that right now there are no tests for xmonad but since only an option is added to an xmonad specific file, other components should not be affected (also, when running `nix-shell --pure tests -A run.all` against the branch I'm tracking, `release-20.09`, all tests passed).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.