### PR TITLE
playerctld: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -209,6 +209,9 @@
 
 /modules/services/plan9port.nix                       @ehmry
 
+/modules/services/playerctld.nix                      @fendse
+/tests/modules/playerctld                             @fendse
+
 /modules/services/pulseeffects.nix                    @jonringer
 
 /modules/services/random-background.nix               @rycee

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -53,4 +53,10 @@
     github = "thiagokokada";
     githubId = 844343;
   };
+  fendse = {
+    email = "46252070+Fendse@users.noreply.github.com";
+    github = "Fendse";
+    githubId = 46252070;
+    name = "Sara Johnsson";
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1814,6 +1814,14 @@ in
           A new module is available: 'services.plan9port'.
         '';
       }
+
+      {
+        time = "2021-01-31T11:23:30+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.playerctld'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -175,6 +175,7 @@ let
     (loadModule ./services/pbgopy.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/picom.nix { })
     (loadModule ./services/plan9port.nix { condition = hostPlatform.isLinux; })
+    (loadModule ./services/playerctld.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/polybar.nix { })
     (loadModule ./services/pulseeffects.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/random-background.nix { })

--- a/modules/services/playerctld.nix
+++ b/modules/services/playerctld.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.playerctld;
+
+in {
+  meta.maintainers = [ maintainers.fendse ];
+
+  options.services.playerctld = {
+    enable = mkEnableOption "playerctld daemon";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.playerctl;
+      defaultText = literalExample "pkgs.playerctl";
+      description = "The playerctl package to use.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.playerctld = {
+      Unit.Description = "MPRIS media player daemon";
+
+      Install.WantedBy = [ "default.target" ];
+
+      Service = {
+        ExecStart = "${cfg.package}/bin/playerctld";
+        Type = "dbus";
+        BusName = "org.mpris.MediaPlayer2.playerctld";
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -102,6 +102,7 @@ import nmt {
     ./modules/services/lieer
     ./modules/services/redshift-gammastep
     ./modules/services/pbgopy
+    ./modules/services/playerctld
     ./modules/services/polybar
     ./modules/services/sxhkd
     ./modules/services/window-managers/i3

--- a/tests/modules/services/playerctld/basic.nix
+++ b/tests/modules/services/playerctld/basic.nix
@@ -1,0 +1,31 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.playerctld.enable = true;
+    services.playerctld.package = pkgs.writeScriptBin "playerctld" "" // {
+      outPath = "@playerctld@";
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/playerctld.service
+
+      assertFileExists "$serviceFile"
+
+      assertFileContent "$serviceFile" "${
+        pkgs.writeText "playerctld-test" ''
+          [Install]
+          WantedBy=default.target
+
+          [Service]
+          BusName=org.mpris.MediaPlayer2.playerctld
+          ExecStart=@playerctld@/bin/playerctld
+          Type=dbus
+
+          [Unit]
+          Description=MPRIS media player daemon
+        ''
+      }"
+    '';
+  };
+}

--- a/tests/modules/services/playerctld/default.nix
+++ b/tests/modules/services/playerctld/default.nix
@@ -1,0 +1,1 @@
+{ playerctld-basic = ./basic.nix; }


### PR DESCRIPTION
### Description

Add a module that sets up playerctld as a service

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
