### PR TITLE
Improve flake homeManagerConfiguration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
       lib = {
         hm = import ./modules/lib { lib = nixpkgs.lib; };
         homeManagerConfiguration = { configuration, system, homeDirectory
-          , username, extraSpecialArgs ? { }
+          , username, extraModules ? [ ], extraSpecialArgs ? { }
           , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
           , check ? true, stateVersion ? "20.09" }@args:
           assert nixpkgs.lib.versionAtLeast stateVersion "20.09";
@@ -36,7 +36,7 @@
           import ./modules {
             inherit pkgs check extraSpecialArgs;
             configuration = { ... }: {
-              imports = [ configuration ];
+              imports = [ configuration ] ++ extraModules;
               home = { inherit homeDirectory stateVersion username; };
               nixpkgs = { inherit (pkgs) config overlays; };
             };

--- a/flake.nix
+++ b/flake.nix
@@ -30,12 +30,15 @@
         homeManagerConfiguration = { configuration, system, homeDirectory
           , username, extraSpecialArgs ? { }
           , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
-          , check ? true }@args:
+          , check ? true, stateVersion ? "20.09" }@args:
+          assert nixpkgs.lib.versionAtLeast stateVersion "20.09";
+
           import ./modules {
             inherit pkgs check extraSpecialArgs;
             configuration = { ... }: {
               imports = [ configuration ];
-              home = { inherit homeDirectory username; };
+              home = { inherit homeDirectory stateVersion username; };
+              nixpkgs = { inherit (pkgs) config overlays; };
             };
           };
       };


### PR DESCRIPTION
### Description

This includes two changes:

#### Fix pkgs passed to configuration
When I passed a custom pkgs which adds a few new packages via overlays, they did not end up in my configuration modules, but when I updated `extraSpecialArgs` to include the `pkgs` then all worked fine.

#### Separate config from custom modules
I have a bunch of custom home-manager modules, some private ones not ready for prime-time and some coming from third party packages. I think it would be nice to separate those from the regular configuration (just like home-manager itself does). I named it `extraModules`.

Instead of:
```
configuration = {
  imports = [
    emacs-config.homeManagerModules.emacsConfig
    ./home.nix
   ];
};
```
    
You can do:
```
configuration = ./home.nix;
extraModules = [ emacs-config.homeManagerModules.emacsConfig ];
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```