### PR TITLE
rofi: add support for lists in rasi

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -335,9 +335,10 @@ in {
       default = null;
       type = with types; nullOr (oneOf [ str path themeType ]);
       example = literalExample ''
-        with config.lib.formats.rasi; {
+        let
+          inherit (config.lib.formats.rasi) mkLiteral;
+        in {
           "*" = {
-            # config.lib.formats.rasi.mkLiteral unquotes the value
             background-color = mkLiteral "#000000";
             foreground-color = mkLiteral "rgba ( 250, 251, 252, 100 % )";
             border-color = mkLiteral "#FFFFFF";

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -112,6 +112,8 @@ let
       value.value
     else if isString value then
       ''"${value}"''
+    else if isList value then
+      "[ ${strings.concatStringsSep "," (map mkValueString value)} ]"
     else
       abort "Unhandled value type ${builtins.typeOf value}";
 
@@ -145,7 +147,9 @@ let
     left = 8;
   };
 
-  configType = with types; attrsOf (oneOf [ str int bool rasiLiteral ]);
+  primitive = with types; (oneOf [ str int bool rasiLiteral ]);
+
+  configType = with types; attrsOf (either primitive (listOf primitive));
 
   rasiLiteral = types.submodule {
     options = {
@@ -338,6 +342,10 @@ in {
             foreground-color = mkLiteral "rgba ( 250, 251, 252, 100 % )";
             border-color = mkLiteral "#FFFFFF";
             width = 512;
+          };
+
+          "#inputbar" = {
+            children = map mkLiteral [ "prompt" "entry" ];
           };
 
           "#textbox-prompt-colon" = {

--- a/tests/modules/programs/rofi/custom-theme.nix
+++ b/tests/modules/programs/rofi/custom-theme.nix
@@ -7,7 +7,8 @@ with lib;
     programs.rofi = {
       enable = true;
 
-      theme = with config.lib.formats.rasi; {
+      theme = let inherit (config.lib.formats.rasi) mkLiteral;
+      in {
         "*" = {
           background-color = mkLiteral "#000000";
           foreground-color = mkLiteral "rgba ( 250, 251, 252, 100 % )";

--- a/tests/modules/programs/rofi/custom-theme.nix
+++ b/tests/modules/programs/rofi/custom-theme.nix
@@ -15,6 +15,8 @@ with lib;
           width = 512;
         };
 
+        "#inputbar" = { children = map mkLiteral [ "prompt" "entry" ]; };
+
         "#textbox-prompt-colon" = {
           expand = false;
           str = ":";

--- a/tests/modules/programs/rofi/custom-theme.rasi
+++ b/tests/modules/programs/rofi/custom-theme.rasi
@@ -1,3 +1,7 @@
+#inputbar {
+children: [ prompt,entry ];
+}
+
 #textbox-prompt-colon {
 expand: false;
 margin: 0px 0.3em 0em 0em;


### PR DESCRIPTION
### Description

Just a small thing that I missed from #1748. This is now supported without the need of using strings to represent them:
https://github.com/davatorium/rofi-themes/blob/9a843caa86d15038fda5455b7fb951569dbd227a/Official%20Themes/solarized.rasi#L134

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
