### PR TITLE
home-environment: make sessionVariables a freeform module

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -479,7 +479,7 @@ in
             if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
             export __HM_SESS_VARS_SOURCED=1
 
-            ${config.lib.shell.exportAll cfg.sessionVariables}
+            ${config.lib.shell.exportAll' { colonVars = ["NIX_PATH" "PATH"]; } cfg.sessionVariables}
           '' + lib.optionalString (cfg.sessionPath != [ ]) ''
             export PATH="$PATH''${PATH:+:}${concatStringsSep ":" cfg.sessionPath}"
           '' + cfg.sessionVariablesExtra;

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -229,7 +229,30 @@ in
 
     home.sessionVariables = mkOption {
       default = {};
-      type = types.attrs;
+      type = types.submodule {
+        freeformType = with types;
+          lazyAttrsOf (oneOf [ package str int float ]);
+
+        options = {
+          PATH = mkOption {
+            type = types.envVar;
+            default = "$PATH";
+            defaultText = literalExample ''"$PATH"'';
+            description = ''
+              Content of the <envar>PATH</envar> variable.
+            '';
+          };
+
+          NIX_PATH = mkOption {
+            type = types.envVar;
+            default = "$NIX_PATH";
+            defaultText = literalExample ''"$NIX_PATH"'';
+            description = ''
+              Content of the <envar>NIX_PATH</envar> variable.
+            '';
+          };
+        };
+      };
       example = { EDITOR = "emacs"; GS_OPTIONS = "-sPAPERSIZE=a4"; };
       description = ''
         Environment variables to always set at login.

--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -4,8 +4,25 @@ rec {
   # Produces a Bourne shell like variable export statement.
   export = n: v: ''export ${n}="${toString v}"'';
 
+  export' = { colonVars ? [ ] }:
+    n: v:
+    let
+      replaceMatch = match:
+        lib.replaceStrings [ ":\$${match}:" ":\$${match}" "\$${match}:" ] [
+          "\${${match}:+:\$${match}:}"
+          "\${${match}:+:\$${match}}"
+          "\${${match}:+\$${match}:}"
+        ];
+
+      mkValue = n: v:
+        if builtins.elem n colonVars then replaceMatch n v else toString v;
+    in ''export ${n}="${mkValue n v}"'';
+
   # Given an attribute set containing shell variable names and their
   # assignment, this function produces a string containing an export
   # statement for each set entry.
   exportAll = vars: lib.concatStringsSep "\n" (lib.mapAttrsToList export vars);
+
+  exportAll' = opts: vars:
+    lib.concatStringsSep "\n" (lib.mapAttrsToList (export' opts) vars);
 }

--- a/tests/modules/home-environment/default.nix
+++ b/tests/modules/home-environment/default.nix
@@ -1,4 +1,5 @@
 {
-  home-session-variables = ./session-variables.nix;
   home-session-path = ./session-path.nix;
+  home-session-variables = ./session-variables.nix;
+  home-session-variables-explicit = ./session-variables-explicit.nix;
 }

--- a/tests/modules/home-environment/session-variables-explicit.nix
+++ b/tests/modules/home-environment/session-variables-explicit.nix
@@ -1,3 +1,6 @@
+# Test of explicitly defined options inside the `home.sessionVariables` freeform
+# module.
+
 { config, lib, pkgs, ... }:
 
 let
@@ -10,10 +13,8 @@ let
     export __HM_SESS_VARS_SOURCED=1
 
     export LOCALE_ARCHIVE_2_27="${pkgs.glibcLocales}/lib/locale/locale-archive"
-    export NIX_PATH="$NIX_PATH"
-    export PATH="$PATH"
-    export V1="v1"
-    export V2="v2-v1"
+    export NIX_PATH="testpath=$HOME/testpath:$NIX_PATH"
+    export PATH="$PATH:$HOME/bin"
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
@@ -24,23 +25,28 @@ let
     if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
-    export NIX_PATH="$NIX_PATH"
-    export PATH="$PATH"
-    export V1="v1"
-    export V2="v2-v1"
+    export NIX_PATH="testpath=$HOME/testpath:$NIX_PATH"
+    export PATH="$PATH:$HOME/bin"
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
   '';
 
-  expected = pkgs.writeText "expected" (if isDarwin then darwinExpected else linuxExpected);
+  expected = pkgs.writeText "expected"
+    (if isDarwin then darwinExpected else linuxExpected);
 
 in {
   config = {
-    home.sessionVariables = {
-      V1 = "v1";
-      V2 = "v2-${config.home.sessionVariables.V1}";
-    };
+    home.sessionVariables = lib.mkMerge [
+      {
+        PATH = "$PATH";
+        NIX_PATH = "$NIX_PATH";
+      }
+      {
+        PATH = lib.mkAfter "$HOME/bin";
+        NIX_PATH = lib.mkBefore "testpath=$HOME/testpath";
+      }
+    ];
 
     nmt.script = ''
       assertFileExists home-path/etc/profile.d/hm-session-vars.sh

--- a/tests/modules/home-environment/session-variables-explicit.nix
+++ b/tests/modules/home-environment/session-variables-explicit.nix
@@ -13,8 +13,8 @@ let
     export __HM_SESS_VARS_SOURCED=1
 
     export LOCALE_ARCHIVE_2_27="${pkgs.glibcLocales}/lib/locale/locale-archive"
-    export NIX_PATH="testpath=$HOME/testpath:$NIX_PATH"
-    export PATH="$PATH:$HOME/bin"
+    export NIX_PATH="testpath=$HOME/testpath''${NIX_PATH:+:$NIX_PATH}"
+    export PATH="''${PATH:+$PATH:}$HOME/bin"
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
@@ -25,8 +25,8 @@ let
     if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
-    export NIX_PATH="testpath=$HOME/testpath:$NIX_PATH"
-    export PATH="$PATH:$HOME/bin"
+    export NIX_PATH="testpath=$HOME/testpath''${NIX_PATH:+:$NIX_PATH}"
+    export PATH="''${PATH:+$PATH:}$HOME/bin"
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"


### PR DESCRIPTION
### Description

Also introduce explicit options for `PATH` and `NIX_PATH`.

### Checklist

- [X] Change is backwards compatible: Mostly, it does limit session variable values to `package`, `str`, `int`, and `float` but I think this covers pretty much all use-cases.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.