### PR TITLE
redshift/gammastep: use ini file instead of passing parameters, 2nd try

### DIFF
--- a/doc/release-notes/rl-2105.adoc
+++ b/doc/release-notes/rl-2105.adoc
@@ -72,6 +72,35 @@ programs.rofi.extraConfig = {
 };
 ----
 
+* The `services.redshift.extraOptions` and `services.gammastep.extraOptions`
+options were removed in favor of <<opt-services.redshift.settings>> and
+`services.gammastep.settings`, that are now an attribute set rather
+than a string. They also support new features not available before, for
+example:
++
+[source,nix]
+----
+services.redshift = {
+  dawnTime = "6:00-7:45";
+  duskTime = "18:35-20:15";
+  settings = {
+    redshift = {
+      gamma = 0.8;
+      adjustment-method = "randr";
+    };
+
+    randr = {
+      screen = 0;
+    };
+  };
+};
+----
++
+It is recommended to check either
+https://github.com/jonls/redshift/blob/master/redshift.conf.sample[redshift.conf.sample] or
+https://gitlab.com/chinstrap/gammastep/-/blob/master/gammastep.conf.sample[gammastep.conf.sample]
+for the available additional options in each program.
+
 [[sec-release-21.05-state-version-changes]]
 === State Version Changes
 

--- a/modules/services/redshift-gammastep/gammastep.nix
+++ b/modules/services/redshift-gammastep/gammastep.nix
@@ -4,14 +4,17 @@ with lib;
 
 let
   commonOptions = import ./lib/options.nix {
-    inherit config lib;
+    inherit config lib pkgs;
 
     moduleName = "gammastep";
     programName = "Gammastep";
+    # https://gitlab.com/chinstrap/gammastep/-/commit/1608ed61154cc652b087e85c4ce6125643e76e2f
+    mainSection = "general";
     defaultPackage = pkgs.gammastep;
     examplePackage = "pkgs.gammastep";
     mainExecutable = "gammastep";
     appletExecutable = "gammastep-indicator";
+    xdgConfigFilePath = "gammastep/config.ini";
     serviceDocumentation = "https://gitlab.com/chinstrap/gammastep/";
   };
 

--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -1,32 +1,60 @@
-# Adapted from Nixpkgs.
-
-{ config, lib, moduleName, programName, defaultPackage, examplePackage
-, mainExecutable, appletExecutable, serviceDocumentation }:
+{ config, lib, pkgs, moduleName, mainSection, programName, defaultPackage
+, examplePackage, mainExecutable, appletExecutable, xdgConfigFilePath
+, serviceDocumentation }:
 
 with lib;
 
 let
 
   cfg = config.services.${moduleName};
+  settingsFormat = pkgs.formats.ini { };
 
 in {
   meta = {
     maintainers = with maintainers; [ rycee petabyteboy thiagokokada ];
   };
 
+  imports = let
+    mkRenamed = old: new:
+      mkRenamedOptionModule ([ "services" moduleName ] ++ old) [
+        "services"
+        moduleName
+        "settings"
+        mainSection
+        new
+      ];
+  in [
+    (mkRemovedOptionModule [ "services" moduleName "extraOptions" ]
+      "All ${programName} configuration is now available through services.${moduleName}.settings instead.")
+    (mkRenamed [ "brightness" "day" ] "brightness-day")
+    (mkRenamed [ "brightness" "night" ] "brightness-night")
+  ];
+
   options = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      example = true;
+    enable = mkEnableOption programName;
+
+    dawnTime = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "6:00-7:45";
       description = ''
-        Enable ${programName} to change your screen's colour temperature
-        depending on the time of day.
+        Set the time interval of dawn manually.
+        The times must be specified as HH:MM in 24-hour format.
+      '';
+    };
+
+    duskTime = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "18:35-20:15";
+      description = ''
+        Set the time interval of dusk manually.
+        The times must be specified as HH:MM in 24-hour format.
       '';
     };
 
     latitude = mkOption {
-      type = types.nullOr types.str;
+      type = with types; nullOr (either str float);
       default = null;
       description = ''
         Your current latitude, between <literal>-90.0</literal> and
@@ -36,7 +64,7 @@ in {
     };
 
     longitude = mkOption {
-      type = types.nullOr types.str;
+      type = with types; nullOr (either str float);
       default = null;
       description = ''
         Your current longitude, between <literal>-180.0</literal> and
@@ -75,26 +103,6 @@ in {
       };
     };
 
-    brightness = {
-      day = mkOption {
-        type = types.str;
-        default = "1";
-        description = ''
-          Screen brightness to apply during the day,
-          between <literal>0.1</literal> and <literal>1.0</literal>.
-        '';
-      };
-
-      night = mkOption {
-        type = types.str;
-        default = "1";
-        description = ''
-          Screen brightness to apply during the night,
-          between <literal>0.1</literal> and <literal>1.0</literal>.
-        '';
-      };
-    };
-
     package = mkOption {
       type = types.package;
       default = defaultPackage;
@@ -113,25 +121,62 @@ in {
       '';
     };
 
-    extraOptions = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      example = [ "-v" "-m randr" ];
+    settings = mkOption {
+      type = types.submodule { freeformType = settingsFormat.type; };
+      default = { };
+      example = literalExample ''
+        {
+          ${mainSection} = {
+            adjustment-method = "randr";
+          };
+          randr = {
+            screen = 0;
+          };
+        };
+      '';
       description = ''
-        Additional command-line arguments to pass to
-        <command>redshift</command>.
+        The configuration to pass to ${programName}.
+        Available options for ${programName} described in
+        <citerefentry>
+          <refentrytitle>${moduleName}</refentrytitle>
+          <manvolnum>1</manvolnum>
+        </citerefentry>.
       '';
     };
   };
 
   config = {
     assertions = [{
-      assertion = cfg.provider == "manual" -> cfg.latitude != null
-        && cfg.longitude != null;
-      message = "Must provide services.${moduleName}.latitude and"
-        + " services.${moduleName}.latitude when"
-        + " services.${moduleName}.provider is set to \"manual\".";
+      assertion = (cfg.settings ? ${mainSection}.dawn-time || cfg.settings
+        ? ${mainSection}.dusk-time)
+        || (cfg.settings.${mainSection}.location-provider) == "geoclue2"
+        || ((cfg.settings.${mainSection}.location-provider) == "manual"
+          && (cfg.settings ? manual.lat || cfg.settings ? manual.lon));
+      message = ''
+        In order for ${programName} to know the time of action, you need to set one of
+          - services.${moduleName}.provider = "geoclue2" for automatically inferring your location
+            (you also need to enable Geoclue2 service separately)
+          - services.${moduleName}.longitude and .latitude for specifying your location manually
+          - services.${moduleName}.dawnTime and .duskTime for specifying the times manually
+      '';
     }];
+
+    services.${moduleName}.settings = {
+      ${mainSection} = {
+        temp-day = cfg.temperature.day;
+        temp-night = cfg.temperature.night;
+        location-provider = cfg.provider;
+        dawn-time = mkIf (cfg.dawnTime != null) cfg.dawnTime;
+        dusk-time = mkIf (cfg.duskTime != null) cfg.duskTime;
+      };
+      manual = mkIf (cfg.provider == "manual") {
+        lat = mkIf (cfg.latitude != null) (toString cfg.latitude);
+        lon = mkIf (cfg.longitude != null) (toString cfg.longitude);
+      };
+    };
+
+    xdg.configFile.${xdgConfigFilePath}.source =
+      settingsFormat.generate xdgConfigFilePath cfg.settings;
 
     systemd.user.services.${moduleName} = {
       Unit = {
@@ -145,21 +190,9 @@ in {
 
       Service = {
         ExecStart = let
-          providerString = if cfg.provider == "manual" then
-            "${cfg.latitude}:${cfg.longitude}"
-          else
-            cfg.provider;
-
-          args = [
-            "-l ${providerString}"
-            "-t ${toString cfg.temperature.day}:${
-              toString cfg.temperature.night
-            }"
-            "-b ${toString cfg.brightness.day}:${toString cfg.brightness.night}"
-          ] ++ cfg.extraOptions;
-
           command = if cfg.tray then appletExecutable else mainExecutable;
-        in "${cfg.package}/bin/${command} ${concatStringsSep " " args}";
+          configFullPath = config.xdg.configHome + "/${xdgConfigFilePath}";
+        in "${cfg.package}/bin/${command} -v -c ${configFullPath}";
         RestartSec = 3;
         Restart = "on-failure";
       };

--- a/modules/services/redshift-gammastep/redshift.nix
+++ b/modules/services/redshift-gammastep/redshift.nix
@@ -4,14 +4,16 @@ with lib;
 
 let
   commonOptions = import ./lib/options.nix {
-    inherit config lib;
+    inherit config lib pkgs;
 
     moduleName = "redshift";
     programName = "Redshift";
+    mainSection = "redshift";
     defaultPackage = pkgs.redshift;
     examplePackage = "pkgs.redshift";
     mainExecutable = "redshift";
     appletExecutable = "redshift-gtk";
+    xdgConfigFilePath = "redshift/redshift.conf";
     serviceDocumentation = "http://jonls.dk/redshift/";
   };
 

--- a/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@gammastep@/bin/gammastep -l 0.0:0.0 -t 5500:3700 -b 1:1
+ExecStart=@gammastep@/bin/gammastep -v -c /home/hm-user/.config/gammastep/config.ini
 Restart=on-failure
 RestartSec=3
 

--- a/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-file-expected.conf
+++ b/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-file-expected.conf
@@ -1,0 +1,13 @@
+[general]
+adjustment-method=randr
+dawn-time=6:00-7:45
+dusk-time=18:35-20:15
+gamma=0.800000
+location-provider=manual
+temp-day=5500
+temp-night=3700
+
+[manual]
+
+[randr]
+screen=0

--- a/tests/modules/services/redshift-gammastep/gammastep-basic-configuration.nix
+++ b/tests/modules/services/redshift-gammastep/gammastep-basic-configuration.nix
@@ -5,8 +5,15 @@
     services.gammastep = {
       enable = true;
       provider = "manual";
-      latitude = "0.0";
-      longitude = "0.0";
+      dawnTime = "6:00-7:45";
+      duskTime = "18:35-20:15";
+      settings = {
+        general = {
+          adjustment-method = "randr";
+          gamma = 0.8;
+        };
+        randr = { screen = 0; };
+      };
     };
 
     nixpkgs.overlays = [
@@ -18,6 +25,9 @@
     ];
 
     nmt.script = ''
+      assertFileContent \
+          home-files/.config/gammastep/config.ini \
+          ${./gammastep-basic-configuration-file-expected.conf}
       assertFileContent \
           home-files/.config/systemd/user/gammastep.service \
           ${./gammastep-basic-configuration-expected.service}

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@redshift@/bin/redshift -l 0.0:0.0 -t 5500:3700 -b 1:1
+ExecStart=@redshift@/bin/redshift -v -c /home/hm-user/.config/redshift/redshift.conf
 Restart=on-failure
 RestartSec=3
 

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration-file-expected.conf
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration-file-expected.conf
@@ -1,0 +1,13 @@
+[manual]
+lat=0.000000
+lon=0.0
+
+[randr]
+screen=0
+
+[redshift]
+adjustment-method=randr
+gamma=0.800000
+location-provider=manual
+temp-day=5500
+temp-night=3700

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration.nix
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration.nix
@@ -5,8 +5,15 @@
     services.redshift = {
       enable = true;
       provider = "manual";
-      latitude = "0.0";
+      latitude = 0.0;
       longitude = "0.0";
+      settings = {
+        redshift = {
+          adjustment-method = "randr";
+          gamma = 0.8;
+        };
+        randr = { screen = 0; };
+      };
     };
 
     nixpkgs.overlays = [
@@ -18,6 +25,9 @@
     ];
 
     nmt.script = ''
+      assertFileContent \
+          home-files/.config/redshift/redshift.conf \
+          ${./redshift-basic-configuration-file-expected.conf}
       assertFileContent \
           home-files/.config/systemd/user/redshift.service \
           ${./redshift-basic-configuration-expected.service}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Second try of PR #1751, including fix for `latitude`/`longitude`/`duskTime` options.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible (mostly, except for `{gammastep/redshift}.extraOptions`).

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
