### PR TITLE
obs-studio: Allow package to be configurable

### DIFF
--- a/modules/programs/obs-studio.nix
+++ b/modules/programs/obs-studio.nix
@@ -5,7 +5,6 @@ with lib;
 let
 
   cfg = config.programs.obs-studio;
-  package = pkgs.obs-studio;
 
   mkPluginEnv = packages:
     let
@@ -29,6 +28,15 @@ in {
     programs.obs-studio = {
       enable = mkEnableOption "obs-studio";
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.obs-studio;
+        example = literalExample "pkgs.obs-studio";
+        description = ''
+          OBS Studio package to install.
+        '';
+      };
+
       plugins = mkOption {
         default = [ ];
         example = literalExample "[ pkgs.obs-linuxbrowser ]";
@@ -39,7 +47,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ package ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."obs-studio/plugins" =
       mkIf (cfg.plugins != [ ]) { source = mkPluginEnv cfg.plugins; };

--- a/modules/programs/obs-studio.nix
+++ b/modules/programs/obs-studio.nix
@@ -31,7 +31,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.obs-studio;
-        example = literalExample "pkgs.obs-studio";
+        defaultText = literalExample "pkgs.obs-studio";
         description = ''
           OBS Studio package to install.
         '';


### PR DESCRIPTION
### Description

This PR adds an option to specify which obs package to install.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
