### PR TITLE
rofi: support top-level clauses in rasi

### DIFF
--- a/tests/modules/programs/rofi/custom-theme.nix
+++ b/tests/modules/programs/rofi/custom-theme.nix
@@ -9,6 +9,8 @@ with lib;
 
       theme = let inherit (config.lib.formats.rasi) mkLiteral;
       in {
+        "@import" = "~/.cache/wal/colors-rofi-dark";
+
         "*" = {
           background-color = mkLiteral "#000000";
           foreground-color = mkLiteral "rgba ( 250, 251, 252, 100 % )";

--- a/tests/modules/programs/rofi/custom-theme.rasi
+++ b/tests/modules/programs/rofi/custom-theme.rasi
@@ -15,3 +15,5 @@ border-color: #FFFFFF;
 foreground-color: rgba ( 250, 251, 252, 100 % );
 width: 512;
 }
+
+@import "~/.cache/wal/colors-rofi-dark"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Support `@import` (or any other top-level option) in `programs.rofi.theme`.

See https://github.com/nix-community/home-manager/pull/1748#issuecomment-774995577 for details.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
