### PR TITLE
[20.09] flake: add extraSpecialArgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,11 +9,11 @@
     lib = {
       hm = import ./modules/lib { lib = nixpkgs.lib; };
       homeManagerConfiguration = { configuration, system, homeDirectory
-        , username
+        , username, extraSpecialArgs ? { }
         , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
         , check ? true }@args:
         import ./modules {
-          inherit pkgs check;
+          inherit pkgs check extraSpecialArgs;
           configuration = { ... }: {
             imports = [ configuration ];
             home = { inherit homeDirectory username; };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -4,6 +4,8 @@
 
   # Whether to check that each option has a matching declaration.
 , check ? true
+  # Extra arguments passed to specialArgs.
+, extraSpecialArgs ? { }
 }:
 
 with lib;
@@ -31,7 +33,7 @@ let
     modules = [ configuration ] ++ hmModules;
     specialArgs = {
       modulesPath = builtins.toString ./.;
-    };
+    } // extraSpecialArgs;
   };
 
   module = showWarnings (


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This allows flake user to pass extra arguments to all modules.

Backport of commit cf5dad76c1ee452224da39f13129c4ff84351a5c.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
