### PR TITLE
firefox: drop enableAdobeFlash option

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -67,6 +67,8 @@ in
   meta.maintainers = [ maintainers.rycee ];
 
   imports = [
+    (mkRemovedOptionModule ["programs" "firefox" "enableAdobeFlash"]
+      "Support for this option has been removed.")
     (mkRemovedOptionModule ["programs" "firefox" "enableGoogleTalk"]
       "Support for this option has been removed.")
     (mkRemovedOptionModule ["programs" "firefox" "enableIcedTea"]
@@ -215,12 +217,6 @@ in
         description = "Attribute set of Firefox profiles.";
       };
 
-      enableAdobeFlash = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to enable the unfree Adobe Flash plugin.";
-      };
-
       enableGnomeExtensions = mkOption {
         type = types.bool;
         default = false;
@@ -272,7 +268,6 @@ in
       let
         # The configuration expected by the Firefox wrapper.
         fcfg = {
-          enableAdobeFlash = cfg.enableAdobeFlash;
           enableGnomeExtensions = cfg.enableGnomeExtensions;
         };
 


### PR DESCRIPTION

### Description

Drop the `enableAdobeFlash` option for firefox.

It was removed in nixpkgs (https://github.com/NixOS/nixpkgs/pull/112335) and now causes an error on rebuilds.

```
error: Your configuration mentions firefox.enableAdobeFlash. All plugin related options have been removed, since Firefox from version 52 onwards no longer supports npapi plugins (see https://support.mozilla.org/en-US/kb/npapi-plugins).
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.
  - sans the newsboat test

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
