### PR TITLE
nixos: add sharedModules and extraSpecialArgs options

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -9,7 +9,10 @@ let
   extendedLib = import ../modules/lib/stdlib-extended.nix pkgs.lib;
 
   hmModule = types.submoduleWith {
-    specialArgs = { lib = extendedLib; };
+    specialArgs = { 
+      lib = extendedLib; 
+      darwinConfig = config;
+    };
     modules = [
       ({ name, ... }: {
         imports = import ../modules/modules.nix {

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -12,7 +12,7 @@ let
     specialArgs = { 
       lib = extendedLib; 
       darwinConfig = config;
-    };
+    } // cfg.extraSpecialArgs;
     modules = [
       ({ name, ... }: {
         imports = import ../modules/modules.nix {
@@ -29,7 +29,7 @@ let
           home.homeDirectory = config.users.users.${name}.home;
         };
       })
-    ];
+    ] ++ cfg.sharedModules;
   };
 
 in
@@ -55,6 +55,24 @@ in
         description = ''
           On activation move existing files by appending the given
           file extension rather than exiting with an error.
+        '';
+      };
+
+      extraSpecialArgs = mkOption {
+        type = types.attrs;
+        default = { };
+        example = literalExample "{ modulesPath = ../modules; }";
+        description = ''
+          Extra <literal>specialArgs</literal> passed to Home Manager.
+        '';
+      };
+
+      sharedModules = mkOption {
+        type = with types; listOf (oneOf [ attrs (functionTo attrs) path ]);
+        default = [ ];
+        example = literalExample "[ { home.packages = [ nixpkgs-fmt ]; } ]";
+        description = ''
+          Extra modules added to all users.
         '';
       };
 

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -12,7 +12,7 @@ let
     specialArgs = {
       lib = extendedLib;
       nixosConfig = config;
-    };
+    } // cfg.extraSpecialArgs;
     modules = [
       ({ name, ... }: {
         imports = import ../modules/modules.nix {
@@ -34,7 +34,7 @@ let
           home.homeDirectory = config.users.users.${name}.home;
         };
       })
-    ];
+    ] ++ cfg.sharedModules;
   };
 
   serviceEnvironment = optionalAttrs (cfg.backupFileExtension != null) {
@@ -62,6 +62,24 @@ in {
         description = ''
           On activation move existing files by appending the given
           file extension rather than exiting with an error.
+        '';
+      };
+
+      extraSpecialArgs = mkOption {
+        type = types.attrs;
+        default = { };
+        example = literalExample "{ modulesPath = ../modules; }";
+        description = ''
+          Extra <literal>specialArgs</literal> passed to Home Manager.
+        '';
+      };
+
+      sharedModules = mkOption {
+        type = with types; listOf (oneOf [ attrs (functionTo attrs) path ]);
+        default = [ ];
+        example = literalExample "[ { home.packages = [ nixpkgs-fmt ]; } ]";
+        description = ''
+          Extra modules added to all users.
         '';
       };
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

closes #1698

This allows users of the nixos and nix-darwin module to set shared modules for all users and extra specialArgs to be available to home-manager modules.

The latter is named extraSpecialArgs just like the argument to modules/default.nix. This could be confusing since the the two are independent in code, but they do mean the same thing so I think the name fits.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
