### PR TITLE
Generic Linux: Propagate XDG_DATA_DIRS as user vars via systemd

### DIFF
--- a/tests/modules/targets-linux/generic-linux.nix
+++ b/tests/modules/targets-linux/generic-linux.nix
@@ -10,21 +10,22 @@ with lib;
     };
 
     nmt.script = ''
-      assertFileExists home-path/etc/profile.d/hm-session-vars.sh
-
-      assertFileContains \
-        home-path/etc/profile.d/hm-session-vars.sh \
+      hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
+      assertFileExists $hmEnvFile
+      assertFileContains $hmEnvFile \
         'export XDG_DATA_DIRS="''${NIX_STATE_DIR:-/nix/var/nix}/profiles/default/share:/home/hm-user/.nix-profile/share:/foo''${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS"'
-      assertFileContains \
-        home-path/etc/profile.d/hm-session-vars.sh \
+      assertFileContains $hmEnvFile \
         '. "${pkgs.nix}/etc/profile.d/nix.sh"'
 
-      assertFileContains \
-        home-path/etc/profile.d/hm-session-vars.sh \
+      assertFileContains $hmEnvFile \
         'export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:$TERMINFO_DIRS''${TERMINFO_DIRS:+:}/etc/terminfo:/lib/terminfo:/usr/share/terminfo"'
-      assertFileContains \
-        home-path/etc/profile.d/hm-session-vars.sh \
+      assertFileContains $hmEnvFile \
         'export TERM="$TERM"'
+
+      envFile=home-files/.config/environment.d/10-home-manager.conf
+      assertFileExists $envFile
+      assertFileContains $envFile \
+        'XDG_DATA_DIRS=''${NIX_STATE_DIR:-/nix/var/nix}/profiles/default/share:/home/hm-user/.nix-profile/share:/foo''${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS'
     '';
   };
 }


### PR DESCRIPTION
### Description

Fix #1439 where desktop applications won't show up in launchers, especially Wayland based but also potentially other ones that are launched by systemd.

This populates the file `~/.config/environment.d/10-home-manager.conf` that will be sourced by systemd and propagated to the sub-processes.

This seems to be the most reliable (only?) way to propagate these variables into the system as per:
https://wiki.archlinux.org/index.php/environment_variables#Per_user

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
