### PR TITLE
programs/gnome-shell: init

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,6 +77,8 @@
 
 /modules/programs/git.nix                             @rycee
 
+/modules/programs/gnome-shell.nix                     @tadfisher
+
 /modules/programs/gnome-terminal.nix                  @rycee
 
 /modules/programs/go.nix                              @rvolosatovs

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2084,6 +2084,14 @@ in
           A new module is available: 'programs.mangohud'.
         '';
       }
+
+      {
+        time = "2021-06-13T21:40:02+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'programs.gnome-shell'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -74,6 +74,7 @@ let
     (loadModule ./programs/getmail.nix { condition = hostPlatform.isLinux; })
     (loadModule ./programs/gh.nix { })
     (loadModule ./programs/git.nix { })
+    (loadModule ./programs/gnome-shell.nix { condition = hostPlatform.isLinux; })
     (loadModule ./programs/gnome-terminal.nix { })
     (loadModule ./programs/go.nix { })
     (loadModule ./programs/gpg.nix { })

--- a/modules/programs/gnome-shell.nix
+++ b/modules/programs/gnome-shell.nix
@@ -1,0 +1,114 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.programs.gnome-shell;
+
+  extensionOpts = { config, ... }: {
+    options = {
+      id = mkOption {
+        type = types.str;
+        example = "user-theme@gnome-shell-extensions.gcampax.github.com";
+        description = ''
+          ID of the gnome-shell extension. If not provided, it
+          will be obtained from <varname>package.uuid</varname>.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        example = "pkgs.gnome3.gnome-shell-extensions";
+        description = ''
+          Package providing a gnome-shell extension in
+          <filename>$out/share/gnome-shell/extensions/''${id}</filename>.
+        '';
+      };
+    };
+
+    config = mkIf (hasAttr "uuid" config.package) {
+      id = mkDefault config.package.uuid;
+    };
+  };
+
+  themeOpts = {
+    options = {
+      name = mkOption {
+        type = types.str;
+        example = "Plata-Noir";
+        description = ''
+          Name of the gnome-shell theme.
+        '';
+      };
+      package = mkOption {
+        type = types.nullOr types.package;
+        default = null;
+        example = literalExample "pkgs.plata-theme";
+        description = ''
+          Package providing a gnome-shell theme in
+          <filename>$out/share/themes/''${name}/gnome-shell</filename>.
+        '';
+      };
+    };
+  };
+
+in {
+  meta.maintainers = [ maintainers.tadfisher ];
+
+  options.programs.gnome-shell = {
+    enable = mkEnableOption "gnome-shell customization";
+
+    extensions = mkOption {
+      type = types.listOf (types.submodule extensionOpts);
+      default = [ ];
+      example = literalExample ''
+        [
+          { package = pkgs.gnomeExtensions.dash-to-panel; }
+          {
+            id = "user-theme@gnome-shell-extensions.gcampax.github.com";
+            package = pkgs.gnome3.gnome-shell-extensions;
+          }
+        ]
+      '';
+      description = ''
+        List of gnome-shell extensions.
+      '';
+    };
+
+    theme = mkOption {
+      type = types.nullOr (types.submodule themeOpts);
+      default = null;
+      example = literalExample ''
+        {
+          name = "Plata-Noir";
+          package = [ pkgs.plata-theme ];
+        }
+      '';
+      description = ''
+        Theme to use for gnome-shell.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf (cfg.extensions != [ ]) {
+      dconf.settings."org/gnome/shell" = {
+        disable-user-extensions = false;
+        enabled-extensions = catAttrs "id" cfg.extensions;
+      };
+
+      home.packages = catAttrs "package" cfg.extensions;
+    })
+
+    (mkIf (cfg.theme != null) {
+      dconf.settings."org/gnome/shell/extensions/user-theme".name =
+        cfg.theme.name;
+
+      programs.gnome-shell.extensions = [{
+        id = "user-theme@gnome-shell-extensions.gcampax.github.com";
+        package = pkgs.gnome3.gnome-shell-extensions;
+      }];
+
+      home.packages = [ cfg.theme.package ];
+    })
+  ]);
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -100,6 +100,7 @@ import nmt {
     ./modules/programs/firefox
     ./modules/programs/foot
     ./modules/programs/getmail
+    ./modules/programs/gnome-shell
     ./modules/programs/i3status-rust
     ./modules/programs/mangohud
     ./modules/programs/ncmpcpp-linux

--- a/tests/modules/programs/gnome-shell/default.nix
+++ b/tests/modules/programs/gnome-shell/default.nix
@@ -1,0 +1,1 @@
+{ gnome-shell = ./gnome-shell.nix; }

--- a/tests/modules/programs/gnome-shell/gnome-shell.nix
+++ b/tests/modules/programs/gnome-shell/gnome-shell.nix
@@ -1,0 +1,91 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  dummy-gnome-shell-extensions = pkgs.runCommand "dummy-package" { } ''
+    mkdir -p $out/share/gnome-shell/extensions/dummy-package
+    touch $out/share/gnome-shell/extensions/dummy-package/test
+  '';
+
+  test-extension = pkgs.runCommand "test-extension" { } ''
+    mkdir -p $out/share/gnome-shell/extensions/test-extension
+    touch $out/share/gnome-shell/extensions/test-extension/test
+  '';
+
+  test-extension-uuid =
+    pkgs.runCommand "test-extension-uuid" { uuid = "test-extension-uuid"; } ''
+      mkdir -p $out/share/gnome-shell/extensions/test-extension-uuid
+      touch $out/share/gnome-shell/extensions/test-extension-uuid/test
+    '';
+
+  test-theme = pkgs.runCommand "test-theme" { } ''
+    mkdir -p $out/share/themes/Test/gnome-shell
+    touch $out/share/themes/Test/gnome-shell/test
+  '';
+
+  expectedEnabledExtensions = [
+    "user-theme@gnome-shell-extensions.gcampax.github.com"
+    "test-extension"
+    "test-extension-uuid"
+  ];
+
+  actualEnabledExtensions =
+    catAttrs "value" config.dconf.settings."org/gnome/shell".enabled-extensions;
+
+in {
+  nixpkgs.overlays = [
+    (self: super: {
+      gnome3 = super.gnome3.overrideScope' (gself: gsuper: {
+        gnome-shell-extensions = dummy-gnome-shell-extensions;
+      });
+    })
+  ];
+
+  programs.gnome-shell.enable = true;
+
+  programs.gnome-shell.extensions = [
+    {
+      id = "test-extension";
+      package = test-extension;
+    }
+    { package = test-extension-uuid; }
+  ];
+
+  programs.gnome-shell.theme = {
+    name = "Test";
+    package = test-theme;
+  };
+
+  assertions = [
+    {
+      assertion =
+        config.dconf.settings."org/gnome/shell".disable-user-extensions
+        == false;
+      message = "Expected disable-user-extensions to be false.";
+    }
+    {
+      assertion =
+        all (e: elem e actualEnabledExtensions) expectedEnabledExtensions;
+      message = ''
+        Expected enabled-extensions to contain all of:
+          ${toString expectedEnabledExtensions}
+        But it was:
+          ${toString actualEnabledExtensions}
+      '';
+    }
+    {
+      assertion =
+        config.dconf.settings."org/gnome/shell/extensions/user-theme".name
+        == "Test";
+      message = "Expected extensions/user-theme/name to be 'Test'.";
+    }
+  ];
+
+  nmt.script = ''
+    assertFileExists home-path/share/gnome-shell/extensions/dummy-package/test
+    assertFileExists home-path/share/gnome-shell/extensions/test-extension/test
+    assertFileExists home-path/share/gnome-shell/extensions/test-extension-uuid/test
+    assertFileExists home-path/share/themes/Test/gnome-shell/test
+  '';
+}


### PR DESCRIPTION
### Description

Fixes #284.

Adds `programs.gnome-shell` for customizing Gnome Shell extensions and theme.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
