### PR TITLE
xdg.systemDirs: init module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,9 @@
 
 /modules/misc/xdg-user-dirs.nix                       @pacien
 
+/modules/misc/xdg-system-dirs.nix                     @tadfisher
+/tests/modules/misc/xdg/system-dirs.nix               @tadfisher
+
 /modules/programs/aria2.nix                           @JustinLovinger
 
 /modules/programs/autojump.nix                        @evanjs

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1965,7 +1965,7 @@ in
           The option 'services.sxhkd.extraPath' has been deprecated.
         '';
       }
-      
+
       {
         time = "2021-05-06T20:47:37+00:00";
         condition = hostPlatform.isLinux;
@@ -1978,6 +1978,26 @@ in
         time = "2021-05-06T11:01:41+00:00";
         message = ''
           A new module is available: 'programs.nix-index'.
+        '';
+      }
+
+      {
+        time = "2021-05-10T18:50:07+00:00";
+        message = ''
+          A new module is available: 'xdg.systemDirs'. Options are:
+
+          - xdg.systemDirs.config
+
+            Extra directory names to add to $XDG_CONFIG_DIRS in the user
+            session.
+
+          - xdg.systemDirs.data
+
+            Extra directory names to add to $XDG_DATA_DIRS in the user
+            session.
+
+          These variables are visible in both systemd user services and
+          login shells.
         '';
       }
     ];

--- a/modules/misc/xdg-system-dirs.nix
+++ b/modules/misc/xdg-system-dirs.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.xdg.systemDirs;
+
+  configDirs = concatStringsSep ":" cfg.config;
+
+  dataDirs = concatStringsSep ":" cfg.data;
+
+in {
+  meta.maintainers = with maintainers; [ tadfisher ];
+
+  options.xdg.systemDirs = {
+    config = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = literalExample ''[ "/etc/xdg" ]'';
+      description = ''
+        Directory names to add to <envar>XDG_CONFIG_DIRS</envar>
+        in the user session.
+      '';
+    };
+
+    data = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = literalExample ''[ "/usr/share" "/usr/local/share" ]'';
+      description = ''
+        Directory names to add to <envar>XDG_DATA_DIRS</envar>
+        in the user session.
+      '';
+    };
+  };
+
+  config = mkMerge [
+    (mkIf (cfg.config != [ ]) {
+      systemd.user.sessionVariables.XDG_CONFIG_DIRS =
+        "${configDirs}\${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}";
+    })
+
+    (mkIf (cfg.data != [ ]) {
+      systemd.user.sessionVariables.XDG_DATA_DIRS =
+        "${dataDirs}\${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}";
+    })
+  ];
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -40,6 +40,7 @@ let
     (loadModule ./misc/tmpfiles.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/version.nix { })
     (loadModule ./misc/vte.nix { })
+    (loadModule ./misc/xdg-system-dirs.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-mime.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-mime-apps.nix { condition = hostPlatform.isLinux; })
     (loadModule ./misc/xdg-user-dirs.nix { condition = hostPlatform.isLinux; })

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -333,6 +333,11 @@ in
             unset systemdStatus
           ''
       );
+
+      # Export environment variables in systemd.user.sessionVariables to login shells.
+      home.sessionVariablesExtra = optionalString (cfg.sessionVariables != {}) ''
+        export $(${pkgs.systemd}/lib/systemd/user-environment-generators/30-systemd-environment-d-generator)
+      '';
     })
   ];
 }

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -15,6 +15,7 @@ let
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
+    export $(${pkgs.systemd}/lib/systemd/user-environment-generators/30-systemd-environment-d-generator)
   '';
 
   darwinExpected = ''

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -1,4 +1,5 @@
 {
   xdg-mime-apps-basics = ./mime-apps-basics.nix;
   xdg-file-attr-names = ./file-attr-names.nix;
+  xdg-system-dirs = ./system-dirs.nix;
 }

--- a/tests/modules/misc/xdg/system-dirs.nix
+++ b/tests/modules/misc/xdg/system-dirs.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    xdg.systemDirs.config = [ "/etc/xdg" "/foo/bar" ];
+    xdg.systemDirs.data = [ "/usr/local/share" "/usr/share" "/baz/quux" ];
+
+    nmt.script = ''
+      envFile=home-files/.config/environment.d/10-home-manager.conf
+      assertFileExists $envFile
+      assertFileContent $envFile ${
+        pkgs.writeText "expected" ''
+          LOCALE_ARCHIVE_2_27=${pkgs.glibcLocales}/lib/locale/locale-archive
+          XDG_CONFIG_DIRS=/etc/xdg:/foo/bar''${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}
+          XDG_DATA_DIRS=/usr/local/share:/usr/share:/baz/quux''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}
+        ''
+      }
+
+      sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
+      assertFileExists $sessionVarsFile
+      assertFileContains $sessionVarsFile \
+        'export $(${pkgs.systemd}/lib/systemd/user-environment-generators/30-systemd-environment-d-generator)'
+    '';
+  };
+}

--- a/tests/modules/systemd/session-variables.nix
+++ b/tests/modules/systemd/session-variables.nix
@@ -15,6 +15,11 @@
         V_int=1
         V_str=2
       ''}
+
+      sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
+      assertFileExists $sessionVarsFile
+      assertFileContains $sessionVarsFile \
+        'export $(${pkgs.systemd}/lib/systemd/user-environment-generators/30-systemd-environment-d-generator)'
     '';
   };
 }

--- a/tests/modules/targets-linux/generic-linux.nix
+++ b/tests/modules/targets-linux/generic-linux.nix
@@ -2,26 +2,36 @@
 
 with lib;
 
-{
+let
+  expectedXdgDataDirs = concatStringsSep ":" [
+    "\${NIX_STATE_DIR:-/nix/var/nix}/profiles/default/share"
+    "/home/hm-user/.nix-profile/share"
+    "/usr/share/ubuntu"
+    "/usr/local/share"
+    "/usr/share"
+    "/var/lib/snapd/desktop"
+    "/foo"
+  ];
+
+in {
   config = {
-    targets.genericLinux = {
-      enable = true;
-      extraXdgDataDirs = [ "/foo" ];
-    };
+    targets.genericLinux.enable = true;
+
+    xdg.systemDirs.data = [ "/foo" ];
 
     nmt.script = ''
-      assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+      envFile=home-files/.config/environment.d/10-home-manager.conf
+      assertFileExists $envFile
+      assertFileContains $envFile \
+        'XDG_DATA_DIRS=${expectedXdgDataDirs}''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}'
+      assertFileContains $envFile \
+        'TERMINFO_DIRS=/home/hm-user/.nix-profile/share/terminfo:$TERMINFO_DIRS''${TERMINFO_DIRS:+:}/etc/terminfo:/lib/terminfo:/usr/share/terminfo'
 
-      assertFileContains \
-        home-path/etc/profile.d/hm-session-vars.sh \
-        'export XDG_DATA_DIRS="''${NIX_STATE_DIR:-/nix/var/nix}/profiles/default/share:/home/hm-user/.nix-profile/share:/foo''${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS"'
-      assertFileContains \
-        home-path/etc/profile.d/hm-session-vars.sh \
+      sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
+      assertFileExists $sessionVarsFile
+      assertFileContains $sessionVarsFile \
         '. "${pkgs.nix}/etc/profile.d/nix.sh"'
 
-      assertFileContains \
-        home-path/etc/profile.d/hm-session-vars.sh \
-        'export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:$TERMINFO_DIRS''${TERMINFO_DIRS:+:}/etc/terminfo:/lib/terminfo:/usr/share/terminfo"'
       assertFileContains \
         home-path/etc/profile.d/hm-session-vars.sh \
         'export TERM="$TERM"'


### PR DESCRIPTION


### Description

<!--

Please provide a brief description of your change.

-->

There is a need to manage XDG Base Directory system directory environment variables in Home Manager modules; see #284. There is an existing mechanism in `targets.genericLinux.extraXdgDataDirs`, but this does not apply to NixOS systems.

Furthermore, it is important that `XDG_CONFIG_DIRS` and `XDG_DATA_DIRS` are set in both login shells (to support getty and SSH sessions) as well as the systemd user manager (to propagate them to user services and
desktop environments); see #1794.

The first need is addressed by adding the `xdg.systemDirs` module, which configures lists of directory names for both `config` and `data` directories. These are then wriiten to `$XDG_CONFIG_DIR/environment.d/10-home-manager.conf` and picked up by
the systemd user manager, via the existing `systemd.user.sessionVariables` mechanism.

To make these, and other variables set in `systemd.user.sessionVariables`, available in login shells, an additional step is added to `etc/profile.d/hm-session-vars.sh` which exports the result of `user-environment-generators/30-systemd-environment-d-generator` which is shipped with systemd. The effect of this generator is to print variables set on the systemd user manager such that shells can import these into their environment.

cc @terlar: This supersedes your work in #1794.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
