### PR TITLE
redshift/gammastep: re-add/fix brightness options

### DIFF
--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -183,8 +183,10 @@ in {
       ${mainSection} = {
         temp-day = cfg.temperature.day;
         temp-night = cfg.temperature.night;
-        brightness-day = mkIf (cfg.brightness.day != null) (toString cfg.brightness.day);
-        brightness-night = mkIf (cfg.brightness.day != null) (toString cfg.brightness.night);
+        brightness-day =
+          mkIf (cfg.brightness.day != null) (toString cfg.brightness.day);
+        brightness-night =
+          mkIf (cfg.brightness.day != null) (toString cfg.brightness.night);
         location-provider = cfg.provider;
         dawn-time = mkIf (cfg.dawnTime != null) cfg.dawnTime;
         dusk-time = mkIf (cfg.duskTime != null) cfg.duskTime;

--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -26,12 +26,30 @@ in {
   in [
     (mkRemovedOptionModule [ "services" moduleName "extraOptions" ]
       "All ${programName} configuration is now available through services.${moduleName}.settings instead.")
-    (mkRenamed [ "brightness" "day" ] "brightness-day")
-    (mkRenamed [ "brightness" "night" ] "brightness-night")
   ];
 
   options = {
     enable = mkEnableOption programName;
+
+    brightness = {
+      day = mkOption {
+        type = types.str;
+        default = "1";
+        description = ''
+          Screen brightness to apply during the day,
+          between <literal>0.1</literal> and <literal>1.0</literal>.
+        '';
+      };
+
+      night = mkOption {
+        type = types.str;
+        default = "1";
+        description = ''
+          Screen brightness to apply during the night,
+          between <literal>0.1</literal> and <literal>1.0</literal>.
+        '';
+      };
+    };
 
     dawnTime = mkOption {
       type = types.nullOr types.str;
@@ -165,6 +183,8 @@ in {
       ${mainSection} = {
         temp-day = cfg.temperature.day;
         temp-night = cfg.temperature.night;
+        brightness-day = cfg.brightness.day;
+        brightness-night = cfg.brightness.night;
         location-provider = cfg.provider;
         dawn-time = mkIf (cfg.dawnTime != null) cfg.dawnTime;
         dusk-time = mkIf (cfg.duskTime != null) cfg.duskTime;

--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -33,8 +33,8 @@ in {
 
     brightness = {
       day = mkOption {
-        type = types.str;
-        default = "1";
+        type = with types; nullOr (either str float);
+        default = null;
         description = ''
           Screen brightness to apply during the day,
           between <literal>0.1</literal> and <literal>1.0</literal>.
@@ -42,8 +42,8 @@ in {
       };
 
       night = mkOption {
-        type = types.str;
-        default = "1";
+        type = with types; nullOr (either str float);
+        default = null;
         description = ''
           Screen brightness to apply during the night,
           between <literal>0.1</literal> and <literal>1.0</literal>.
@@ -183,8 +183,8 @@ in {
       ${mainSection} = {
         temp-day = cfg.temperature.day;
         temp-night = cfg.temperature.night;
-        brightness-day = cfg.brightness.day;
-        brightness-night = cfg.brightness.night;
+        brightness-day = mkIf (cfg.brightness.day != null) (toString cfg.brightness.day);
+        brightness-night = mkIf (cfg.brightness.day != null) (toString cfg.brightness.night);
         location-provider = cfg.provider;
         dawn-time = mkIf (cfg.dawnTime != null) cfg.dawnTime;
         dusk-time = mkIf (cfg.duskTime != null) cfg.duskTime;

--- a/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-file-expected.conf
+++ b/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-file-expected.conf
@@ -1,5 +1,7 @@
 [general]
 adjustment-method=randr
+brightness-day=1
+brightness-night=1
 dawn-time=6:00-7:45
 dusk-time=18:35-20:15
 gamma=0.800000

--- a/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-file-expected.conf
+++ b/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-file-expected.conf
@@ -1,7 +1,7 @@
 [general]
 adjustment-method=randr
-brightness-day=1
-brightness-night=1
+brightness-day=1.000000
+brightness-night=0.750000
 dawn-time=6:00-7:45
 dusk-time=18:35-20:15
 gamma=0.800000

--- a/tests/modules/services/redshift-gammastep/gammastep-basic-configuration.nix
+++ b/tests/modules/services/redshift-gammastep/gammastep-basic-configuration.nix
@@ -4,6 +4,8 @@
   config = {
     services.gammastep = {
       enable = true;
+      brightness.day = 1.00;
+      brightness.night = 0.75;
       provider = "manual";
       dawnTime = "6:00-7:45";
       duskTime = "18:35-20:15";

--- a/tests/modules/services/redshift-gammastep/gammastep-basic-configuration.nix
+++ b/tests/modules/services/redshift-gammastep/gammastep-basic-configuration.nix
@@ -4,7 +4,7 @@
   config = {
     services.gammastep = {
       enable = true;
-      brightness.day = 1.00;
+      brightness.day = 1.0;
       brightness.night = 0.75;
       provider = "manual";
       dawnTime = "6:00-7:45";

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration-file-expected.conf
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration-file-expected.conf
@@ -7,6 +7,8 @@ screen=0
 
 [redshift]
 adjustment-method=randr
+brightness-day=1
+brightness-night=1
 gamma=0.800000
 location-provider=manual
 temp-day=5500

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration-file-expected.conf
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration-file-expected.conf
@@ -7,8 +7,8 @@ screen=0
 
 [redshift]
 adjustment-method=randr
-brightness-day=1
-brightness-night=1
+brightness-day=1.000000
+brightness-night=0.750000
 gamma=0.800000
 location-provider=manual
 temp-day=5500

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration.nix
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration.nix
@@ -5,7 +5,7 @@
     services.redshift = {
       enable = true;
       brightness = {
-        day = 1.00;
+        day = 1.0;
         night = 0.75;
       };
       provider = "manual";

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration.nix
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration.nix
@@ -4,6 +4,8 @@
   config = {
     services.redshift = {
       enable = true;
+      brightness.day = 1.00;
+      brightness.night = 0.75;
       provider = "manual";
       latitude = 0.0;
       longitude = "0.0";

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration.nix
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration.nix
@@ -4,8 +4,10 @@
   config = {
     services.redshift = {
       enable = true;
-      brightness.day = 1.00;
-      brightness.night = 0.75;
+      brightness = {
+        day = 1.00;
+        night = 0.75;
+      };
       provider = "manual";
       latitude = 0.0;
       longitude = "0.0";


### PR DESCRIPTION
### Description

Switching to using the config files for redshift/gammastep appears to have broken the `brightness.day/night` options and causes a ```The option `services.redshift.brightness' does not exist.``` error. This re-adds the options back with support for the config file.

For example, running with the following options:

```
services.redshift = {
    enable = true;
    latitude = "20";
    longitude = "-71";
    brightness.day = "1";
    brightness.night = "0.75";
    temperature.day = 6500;
    temperature.night = 3500;
};
```

Will output the following config file:

```
[manual]
lat=20
lon=-71

[redshift]
brightness-day=1
brightness-night=0.75
location-provider=manual
temp-day=6500
temp-night=3500
```

Which is correct according to https://github.com/jonls/redshift/blob/master/redshift.conf.sample

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
