### PR TITLE
redshift/gammastep: fix deprecated options warning

### DIFF
--- a/modules/services/redshift-gammastep/gammastep.nix
+++ b/modules/services/redshift-gammastep/gammastep.nix
@@ -19,7 +19,7 @@ let
   };
 
 in {
-  meta = commonOptions.meta;
+  inherit (commonOptions) imports meta;
   options.services.gammastep = commonOptions.options;
   config = mkIf config.services.gammastep.enable commonOptions.config;
 }

--- a/modules/services/redshift-gammastep/redshift.nix
+++ b/modules/services/redshift-gammastep/redshift.nix
@@ -18,7 +18,7 @@ let
   };
 
 in {
-  meta = commonOptions.meta;
+  inherit (commonOptions) imports meta;
   options.services.redshift = commonOptions.options;
   config = mkIf config.services.redshift.enable commonOptions.config;
 }


### PR DESCRIPTION
### Description

It was not working since I forgot to inherit imports from commonOptions.

Closes the issue from this comment: https://github.com/nix-community/home-manager/pull/1751#discussion_r576446407. Alternative PR for #1803.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
