### PR TITLE
neovim: deprecate programs.neovim.configure

### DIFF
--- a/doc/release-notes/rl-2105.adoc
+++ b/doc/release-notes/rl-2105.adoc
@@ -101,6 +101,16 @@ https://github.com/jonls/redshift/blob/master/redshift.conf.sample[redshift.conf
 https://gitlab.com/chinstrap/gammastep/-/blob/master/gammastep.conf.sample[gammastep.conf.sample]
 for the available additional options in each program.
 
+* The `programs.neovim.configure` is deprecated in favor of other `programs.neovim` options;
+please use the other options at your disposal:
++
+[source,nix]
+----
+configure.packages.*.opt  -> programs.neovim.plugins = [ { plugin = ...; optional = true; }]
+configure.packages.*.start  -> programs.neovim.plugins = [ { plugin = ...; }]
+configure.customRC -> programs.neovim.extraConfig
+----
+
 [[sec-release-21.05-state-version-changes]]
 === State Version Changes
 

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -183,6 +183,8 @@ in {
             };
         '';
         description = ''
+          Deprecated. Please use the other options.
+
           Generate your init file from your list of plugins and custom commands,
           and loads it from the store via <command>nvim -u /nix/store/hash-vimrc</command>
 
@@ -250,11 +252,14 @@ in {
     };
 
   in mkIf cfg.enable {
-    assertions = [{
-      assertion = cfg.configure == { } || moduleConfigure == { };
-      message = "The programs.neovim option configure is mutually exclusive"
-        + " with extraConfig and plugins.";
-    }];
+    warnings = optional (cfg.configure != { }) ''
+      programs.neovim.configure is deprecated.
+      Other programs.neovim options can override its settings or ignore them.
+      Please use the other options at your disposal:
+        configure.packages.*.opt  -> programs.neovim.plugins = [ { plugin = ...; optional = true; }]
+        configure.packages.*.start  -> programs.neovim.plugins = [ { plugin = ...; }]
+        configure.customRC -> programs.neovim.extraConfig
+    '';
 
     home.packages = [ cfg.finalPackage ];
 


### PR DESCRIPTION
The `configure` option is not type checked and an artifact of how
nixpkgs is implemented.
We now have the equivalent options in home-manager and managing
interactions between the 2 systems complexifies maintainance of the
module.
Please use the other options at your disposal:
configure.packages.*.opt  -> programs.neovim.plugins = [ { plugin = ...; optional = true; }]
configure.packages.*.start  -> programs.neovim.plugins = [ { plugin = ...; }]
configure.customRC -> programs.neovim.extraConfig

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
