### PR TITLE
gpg: allow for duplicate keys in config

### DIFF
--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -23,10 +23,12 @@ in
 
     settings = mkOption {
       type = types.attrsOf (types.either primitiveType (types.listOf types.str));
-      example = {
-        no-comments = false;
-        s2k-cipher-algo = "AES128";
-      };
+      example = literalExample ''
+        {
+          no-comments = false;
+          s2k-cipher-algo = "AES128";
+        }
+      '';
       description = ''
         GnuPG configuration options. Available options are described
         in the gpg manpage:

--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -5,21 +5,24 @@ with lib;
 let
   cfg = config.programs.gpg;
 
-  cfgText =
-    concatStringsSep "\n"
-    (attrValues
-    (mapAttrs (key: value:
-      if isString value
-      then "${key} ${value}"
-      else optionalString value key)
-    cfg.settings));
+  mkKeyValue = key: value:
+    if isString value
+    then "${key} ${value}"
+    else optionalString value key;
 
-in {
+  cfgText = generators.toKeyValue {
+    inherit mkKeyValue;
+    listsAsDuplicateKeys = true;
+  } cfg.settings;
+
+  primitiveType = types.oneOf [ types.str types.bool ];
+in
+{
   options.programs.gpg = {
     enable = mkEnableOption "GnuPG";
 
     settings = mkOption {
-      type = types.attrsOf (types.either types.str types.bool);
+      type = types.attrsOf (types.either primitiveType (types.listOf types.str));
       example = {
         no-comments = false;
         s2k-cipher-algo = "AES128";

--- a/tests/modules/programs/gpg/override-defaults-expected.conf
+++ b/tests/modules/programs/gpg/override-defaults-expected.conf
@@ -14,6 +14,8 @@ require-cross-certification
 s2k-cipher-algo AES128
 s2k-digest-algo SHA512
 throw-keyids
+trusted-key 0xXXXXXXXXXXXXX
+trusted-key 0xYYYYYYYYYYYYY
 use-agent
 verify-options show-uid-validity
 with-fingerprint

--- a/tests/modules/programs/gpg/override-defaults.nix
+++ b/tests/modules/programs/gpg/override-defaults.nix
@@ -11,6 +11,10 @@ with lib;
         no-comments = false;
         s2k-cipher-algo = "AES128";
         throw-keyids = true;
+        trusted-key = [
+          "0xXXXXXXXXXXXXX"
+          "0xYYYYYYYYYYYYY"
+        ];
       };
     };
 


### PR DESCRIPTION
### Description

Fixes #1644 by converting lists to duplicate keys.

The second commit fixes the example `settings` configuration to use `literalExample`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
