### PR TITLE
targets/darwin: copy fonts to ~/Library/Fonts/HomeManager

### DIFF
--- a/modules/targets/darwin/default.nix
+++ b/modules/targets/darwin/default.nix
@@ -19,7 +19,7 @@ let
   writableDefaults = filterAttrs (domain: attrs: attrs != { }) nonNullDefaults;
   activationCmds = mapAttrsToList toActivationCmd writableDefaults;
 in {
-  imports = [ ./keybindings.nix ./linkapps.nix ./search.nix ];
+  imports = [ ./fonts.nix ./keybindings.nix ./linkapps.nix ./search.nix ];
 
   options.targets.darwin.defaults = mkOption {
     type = types.submodule ./options.nix;

--- a/modules/targets/darwin/fonts.nix
+++ b/modules/targets/darwin/fonts.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  homeDir = config.home.homeDirectory;
+  fontsEnv = pkgs.buildEnv {
+    name = "home-manager-fonts";
+    paths = config.home.packages;
+    pathsToLink = "/share/fonts";
+  };
+  fonts = "${fontsEnv}/share/fonts";
+in {
+  # macOS won't recognize symlinked fonts
+  config.home.activation.copyFonts = hm.dag.entryAfter [ "writeBoundary" ] ''
+    copyFonts() {
+      rm -rf ${homeDir}/Library/Fonts/HomeManager || :
+
+      local f
+      find -L "${fonts}" -type f -printf '%P\0' | while IFS= read -rd "" f; do
+        $DRY_RUN_CMD install $VERBOSE_ARG -Dm644 -T \
+          "${fonts}/$f" "${homeDir}/Library/Fonts/HomeManager/$f"
+      done
+    }
+    copyFonts
+  '';
+}


### PR DESCRIPTION
### Description
Enable Home Manager fonts on macOS. Fonts are copied instead of being symlinked because macOS won't recognize symlinked fonts.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.