### PR TITLE
fzf: remove non-working historyWidgetCommand option

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -9,7 +9,7 @@ let
 in {
   imports = [
     (mkRemovedOptionModule [ "programs" "fzf" "historyWidgetCommand" ]
-      "This option is no longer supported by FZF.")
+      "This option is no longer supported by fzf.")
   ];
 
   options.programs.fzf = {

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -7,6 +7,11 @@ let
   cfg = config.programs.fzf;
 
 in {
+  imports = [
+    (mkRemovedOptionModule [ "programs" "fzf" "historyWidgetCommand" ]
+      "This option is no longer supported by FZF.")
+  ];
+
   options.programs.fzf = {
     enable = mkEnableOption "fzf - a command-line fuzzy finder";
 
@@ -74,15 +79,6 @@ in {
       '';
     };
 
-    historyWidgetCommand = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      description = ''
-        The command that gets executed as the source for fzf for the
-        CTRL-R keybinding.
-      '';
-    };
-
     historyWidgetOptions = mkOption {
       type = types.listOf types.str;
       default = [ ];
@@ -124,7 +120,6 @@ in {
       (filterAttrs (n: v: v != [ ] && v != null) {
         FZF_ALT_C_COMMAND = cfg.changeDirWidgetCommand;
         FZF_ALT_C_OPTS = cfg.changeDirWidgetOptions;
-        FZF_CTRL_R_COMMAND = cfg.historyWidgetCommand;
         FZF_CTRL_R_OPTS = cfg.historyWidgetOptions;
         FZF_CTRL_T_COMMAND = cfg.fileWidgetCommand;
         FZF_CTRL_T_OPTS = cfg.fileWidgetOptions;


### PR DESCRIPTION
Fixes #1020 

### Description

The environment variable FZF_CTRL_R_COMMAND has never existed
according to `git grep FZF_CTRL_R_COMMAND $(git rev-list --all)`
and `git log -G FZF_CTRL_R_COMMAND`.

This PR marks the option `historyWidgetCommand` as removed and removes all associated logic.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
