### PR TITLE
targets/genericLinux: set TERMINFO_DIRS

### DIFF
--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -32,10 +32,27 @@ in {
       dataDirs = concatStringsSep ":"
         (map (profile: "${profile}/share") profiles
           ++ config.targets.genericLinux.extraXdgDataDirs);
-    in { XDG_DATA_DIRS = "${dataDirs}\${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS"; };
+
+      # https://github.com/archlinux/svntogit-packages/blob/packages/ncurses/trunk/PKGBUILD
+      # https://salsa.debian.org/debian/ncurses/-/blob/master/debian/rules
+      # https://src.fedoraproject.org/rpms/ncurses/blob/main/f/ncurses.spec
+      # https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-libs/ncurses/ncurses-6.2-r1.ebuild
+      distroTerminfoDirs = concatStringsSep ":" [
+        "/etc/terminfo" # debian, fedora, gentoo
+        "/lib/terminfo" # debian
+        "/usr/share/terminfo" # package default, all distros
+      ];
+    in {
+      XDG_DATA_DIRS = "${dataDirs}\${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS";
+      TERMINFO_DIRS =
+        "${profileDirectory}/share/terminfo:$TERMINFO_DIRS\${TERMINFO_DIRS:+:}${distroTerminfoDirs}";
+    };
 
     home.sessionVariablesExtra = ''
       . "${pkgs.nix}/etc/profile.d/nix.sh"
+
+      # reset TERM with new TERMINFO available (if any)
+      export TERM="$TERM"
     '';
 
     # We need to source both nix.sh and hm-session-vars.sh as noted in

--- a/tests/modules/targets-linux/generic-linux.nix
+++ b/tests/modules/targets-linux/generic-linux.nix
@@ -11,12 +11,20 @@ with lib;
 
     nmt.script = ''
       assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+
       assertFileContains \
         home-path/etc/profile.d/hm-session-vars.sh \
         'export XDG_DATA_DIRS="''${NIX_STATE_DIR:-/nix/var/nix}/profiles/default/share:/home/hm-user/.nix-profile/share:/foo''${XDG_DATA_DIRS:+:}$XDG_DATA_DIRS"'
       assertFileContains \
         home-path/etc/profile.d/hm-session-vars.sh \
         '. "${pkgs.nix}/etc/profile.d/nix.sh"'
+
+      assertFileContains \
+        home-path/etc/profile.d/hm-session-vars.sh \
+        'export TERMINFO_DIRS="/home/hm-user/.nix-profile/share/terminfo:$TERMINFO_DIRS''${TERMINFO_DIRS:+:}/etc/terminfo:/lib/terminfo:/usr/share/terminfo"'
+      assertFileContains \
+        home-path/etc/profile.d/hm-session-vars.sh \
+        'export TERM="$TERM"'
     '';
   };
 }


### PR DESCRIPTION
### Description
This makes terminfo descriptions in installed packages available to shell sessions. Not needed for NixOS, which does the same thing already.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.