### PR TITLE
Fix kakoune hook group

### DIFF
--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -574,7 +574,7 @@ let
     hookString = h:
       concatStringsSep " " [
         "hook"
-        "${optionalString (h.group != null) "-group ${group}"}"
+        "${optionalString (h.group != null) "-group ${h.group}"}"
         "${optionalString (h.once) "-once"}"
         "global"
         "${h.name}"


### PR DESCRIPTION
### Description

Fix `undefined variable 'group' ...` error when trying to configure kakoune hook.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
