### PR TITLE
Starship: improve zsh terminal check

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -103,7 +103,7 @@ in {
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      if [ -z "$INSIDE_EMACS" ]; then
+      if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then
         eval "$(${cfg.package}/bin/starship init zsh)"
       fi
     '';


### PR DESCRIPTION
Matches zsh's check with bash and fish, checking for a dumb terminal and
allowing vterm inside Emacs.

See #1238 and #1248

- [x] Change is backwards compatible.


- [ ] Code formatted with `./format`.
- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```