### PR TITLE
pulseeffects: add option to specify package

### DIFF
--- a/modules/services/pulseeffects.nix
+++ b/modules/services/pulseeffects.nix
@@ -14,6 +14,14 @@ in {
   options.services.pulseeffects = {
     enable = mkEnableOption "Pulseeffects daemon";
 
+    package = mkOption {
+      type = types.package;
+      default = pkgs.pulseeffects;
+      defaultText = literalExample "pkgs.pulseeffects";
+      description = "Pulseeffects package to use.";
+      example = literalExample "pkgs.pulseeffects-pw";
+    };
+
     preset = mkOption {
       type = types.str;
       default = "";
@@ -28,7 +36,7 @@ in {
     # running pulseeffects will just attach itself to gapplication service
     # at-spi2-core is to minimize journalctl noise of:
     # "AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files"
-    home.packages = [ pkgs.pulseeffects pkgs.at-spi2-core ];
+    home.packages = [ cfg.package pkgs.at-spi2-core ];
 
     # Will need to add `services.dbus.packages = with pkgs; [ gnome3.dconf ];`
     # to /etc/nixos/configuration.nix for daemon to work correctly
@@ -45,8 +53,8 @@ in {
 
       Service = {
         ExecStart =
-          "${pkgs.pulseeffects}/bin/pulseeffects --gapplication-service ${presetOpts}";
-        ExecStop = "${pkgs.pulseeffects}/bin/pulseeffects --quit";
+          "${cfg.package}/bin/pulseeffects --gapplication-service ${presetOpts}";
+        ExecStop = "${cfg.package}/bin/pulseeffects --quit";
         Restart = "on-failure";
         RestartSec = 5;
       };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Fix #1824 by adding an option to specify the pulseeffects package
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
