### PR TITLE
alot: set primary email first

### DIFF
--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -7,8 +7,11 @@ let
 
   cfg = config.programs.alot;
 
-  alotAccounts =
+  enabledAccounts =
     filter (a: a.notmuch.enable) (attrValues config.accounts.email.accounts);
+
+  # sorted: primary first
+  alotAccounts = sort (a: b: !(a.primary -> b.primary)) enabledAccounts;
 
   boolStr = v: if v then "True" else "False";
 


### PR DESCRIPTION
Fixes #1601

### Description

 Alot uses the first email in the config as primary email. Because the order in which the email.accounts were sorted was alphabetical, the account set to `primary = true` was not put first in the alot config and thus not considered as primary email for alot.
    
This was fixed by sorting the email accounts again such that accounts with `primary = true` come first.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
