### PR TITLE
home-manager: enable nix run for activationPackage

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -552,6 +552,9 @@ in
 
             cp ${activationScript} $out/activate
 
+            mkdir $out/bin
+            ln -s $out/activate $out/bin/home-manager-generation
+
             substituteInPlace $out/activate \
               --subst-var-by GENERATION_DIR $out
 


### PR DESCRIPTION
### Description

Adds a symlink from `$out/activate` to `$out/bin/home-manager-generation` in the home-manager-generation activationPackage.
This makes it possible for people who put their home-manager configuration in a flake (not as a part of a NixOS configuration)
to update their home with: 
```nix run flake#homeMangerConfigurations.<name>.activationPackage```
Instead of  with `nix build <stuff> && ./result/activate` which is more cumbersome, and pollutes your `gcroots/auto` with stray symlinks to your current folder.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.
    
[  ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  * I don't think there are tests for activationPackage

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
