### PR TITLE
git: rely on msmtp for smtp if msmtp is enabled

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1863,6 +1863,15 @@ in
           lists to polybar-style 'foo-0, foo-1, ...' lists.
         '';
       }
+      {
+        time = "2021-02-25T22:36:43+00:00";
+        condition = config.programs.git.enable
+          && any config.accounts.email.accounts (account: account.msmtp.enable);
+        message = ''
+          Git will now defer to msmtp for sending emails if
+          'accounts.email.accounts.<name>.msmtp.enable' is true.
+        '';
+      }
     ];
   };
 }

--- a/tests/modules/programs/git/default.nix
+++ b/tests/modules/programs/git/default.nix
@@ -1,5 +1,6 @@
 {
   git-with-email = ./git-with-email.nix;
   git-with-most-options = ./git.nix;
+  git-with-msmtp = ./git-with-msmtp.nix;
   git-with-str-extra-config = ./git-with-str-extra-config.nix;
 }

--- a/tests/modules/programs/git/git-with-msmtp-expected.conf
+++ b/tests/modules/programs/git/git-with-msmtp-expected.conf
@@ -1,0 +1,14 @@
+[sendemail "hm-account"]
+	from = "hm@example.org"
+	smtpEncryption = "tls"
+	smtpServer = "smtp.example.org"
+	smtpUser = "home.manager.jr"
+
+[sendemail "hm@example.com"]
+	envelopeSender = true
+	from = "hm@example.com"
+	smtpServer = "@msmtp@/bin/msmtp"
+
+[user]
+	email = "hm@example.com"
+	name = "H. M. Test"

--- a/tests/modules/programs/git/git-with-msmtp.nix
+++ b/tests/modules/programs/git/git-with-msmtp.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  config = {
+    accounts.email.accounts."hm@example.com".msmtp.enable = true;
+    programs.git = {
+      enable = true;
+      package = pkgs.gitMinimal;
+      userEmail = "hm@example.com";
+      userName = "H. M. Test";
+    };
+
+    home.stateVersion = "20.09";
+
+    nmt.script = ''
+      function assertGitConfig() {
+        local value
+        value=$(${pkgs.gitMinimal}/bin/git config \
+          --file $TESTED/home-files/.config/git/config \
+          --get $1)
+        if [[ $value != $2 ]]; then
+          fail "Expected option '$1' to have value '$2' but it was '$value'"
+        fi
+      }
+
+      assertFileExists home-files/.config/git/config
+      assertFileContent home-files/.config/git/config \
+                        ${
+                          pkgs.substituteAll {
+                            inherit (pkgs) msmtp;
+                            src = ./git-with-msmtp-expected.conf;
+                          }
+                        }
+
+      assertGitConfig "sendemail.hm@example.com.from" "hm@example.com"
+      assertGitConfig "sendemail.hm-account.from" "hm@example.org"
+      assertGitConfig "sendemail.hm@example.com.smtpServer" "${pkgs.msmtp}/bin/msmtp"
+      assertGitConfig "sendemail.hm@example.com.envelopeSender" "true"
+    '';
+  };
+}


### PR DESCRIPTION
### Description

If a user using msmtp to send all their email, it would be preferred if
git used it as well.

The only settings necessary are to set the smtp server to the msmtp
binary and set envelop sender to true, which makes git call msmtp with
the -f flag to set the from address from the email.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
