### PR TITLE
gh: fix protocol setting

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -47,7 +47,9 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ pkgs.gh ];
 
-    xdg.configFile."gh/config.yml".text =
-      builtins.toJSON { inherit (cfg) aliases editor gitProtocol; };
+    xdg.configFile."gh/config.yml".text = builtins.toJSON {
+      inherit (cfg) aliases editor;
+      git_protocol = cfg.gitProtocol;
+    };
   };
 }

--- a/tests/modules/programs/gh/config-file.nix
+++ b/tests/modules/programs/gh/config-file.nix
@@ -15,7 +15,7 @@
       assertFileExists home-files/.config/gh/config.yml
       assertFileContent home-files/.config/gh/config.yml ${
         builtins.toFile "config-file.yml" ''
-          {"aliases":{"co":"pr checkout"},"editor":"vim","gitProtocol":"https"}''
+          {"aliases":{"co":"pr checkout"},"editor":"vim","git_protocol":"https"}''
       }
     '';
   };


### PR DESCRIPTION
### Description

This PR fixes setting the git protocol that the `gh` tool uses.
home-manager currently sets the key to `gitProtocol`, which is incorrect.
This PR sets the key to `git_protocol`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
