### PR TITLE
mpris-proxy: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -205,6 +205,8 @@
 
 /modules/services/mpdris2.nix                         @pjones
 
+/modules/services/mpris-proxy.nix                     @ThibautMarty
+
 /modules/services/muchsync.nix                        @pacien
 
 /modules/services/network-manager-applet.nix          @rycee

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1914,6 +1914,13 @@ in
         '';
       }
 
+      {
+        time = "2021-04-28T10:00:00+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new service is available: 'services.mpris-proxy'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -168,6 +168,7 @@ let
     (loadModule ./services/mbsync.nix { })
     (loadModule ./services/mpd.nix { })
     (loadModule ./services/mpdris2.nix { condition = hostPlatform.isLinux; })
+    (loadModule ./services/mpris-proxy.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/muchsync.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/network-manager-applet.nix { })
     (loadModule ./services/nextcloud-client.nix { })

--- a/modules/services/mpris-proxy.nix
+++ b/modules/services/mpris-proxy.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.mpris-proxy;
+
+in {
+  meta.maintainers = [ maintainers.thibautmarty ];
+
+  options.services.mpris-proxy.enable = mkEnableOption
+    "a proxy forwarding Bluetooth MIDI controls via MPRIS2 to control media players";
+
+  config = mkIf cfg.enable {
+    systemd.user.services.mpris-proxy = {
+      Unit = {
+        Description =
+          "Proxy forwarding Bluetooth MIDI controls via MPRIS2 to control media players";
+        BindsTo = [ "bluetooth.target" ];
+        After = [ "bluetooth.target" ];
+      };
+
+      Install.WantedBy = [ "bluetooth.target" ];
+
+      Service = {
+        Type = "simple";
+        ExecStart = "${pkgs.bluez}/bin/mpris-proxy";
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Description

This adds a new module service running mpris-proxy from Bluez. It can be used to control media players with bluethooth headsets' buttons. I use it for a few months and it works well.
I welcome feedback for the systemd service (should we use `default.target`? Restart policy? etc).
I did not add tests as the only thing the module does is generating a systemd service (which I assume is well tested). There is no option, no configuration file, etc.

It is also my first new module to home-manager so please tell me if I did something wrong. I have a few more modules that I would like to upstream.
Please note that I'm listed as a maintainer in NixOS so I didn't add myself to home-manager's maintainers.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
