### PR TITLE
git: Add configured SSL certificate for SMTP

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -290,6 +290,7 @@ in {
                   "ssl")
               else
                 "";
+              smtpSslCertPath = mkIf smtp.tls.enable smtp.tls.certificatesFile;
               smtpServer = smtp.host;
               smtpUser = userName;
               from = address;

--- a/tests/modules/programs/git/git-with-email-expected.conf
+++ b/tests/modules/programs/git/git-with-email-expected.conf
@@ -2,12 +2,14 @@
 	from = "hm@example.org"
 	smtpEncryption = "tls"
 	smtpServer = "smtp.example.org"
+	smtpSslCertPath = "/etc/test/certificates.crt"
 	smtpUser = "home.manager.jr"
 
 [sendemail "hm@example.com"]
 	from = "hm@example.com"
 	smtpEncryption = "ssl"
 	smtpServer = "smtp.example.com"
+	smtpSslCertPath = "/etc/ssl/certs/ca-certificates.crt"
 	smtpUser = "home.manager"
 
 [user]

--- a/tests/modules/programs/git/git-with-email.nix
+++ b/tests/modules/programs/git/git-with-email.nix
@@ -6,6 +6,8 @@ with lib;
   imports = [ ../../accounts/email-test-accounts.nix ];
 
   config = {
+    accounts.email.accounts.hm-account.smtp.tls.certificatesFile =
+      "/etc/test/certificates.crt";
     programs.git = {
       enable = true;
       package = pkgs.gitMinimal;

--- a/tests/modules/programs/git/git-with-msmtp-expected.conf
+++ b/tests/modules/programs/git/git-with-msmtp-expected.conf
@@ -2,6 +2,7 @@
 	from = "hm@example.org"
 	smtpEncryption = "tls"
 	smtpServer = "smtp.example.org"
+	smtpSslCertPath = "/etc/ssl/certs/ca-certificates.crt"
 	smtpUser = "home.manager.jr"
 
 [sendemail "hm@example.com"]


### PR DESCRIPTION
### Description

If you have a custom SSL certificate configured for SMTP TLS, git should
use it.


### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
