### PR TITLE
git: correct value of envelopeSender for msmtp

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1865,8 +1865,9 @@ in
       }
       {
         time = "2021-02-25T22:36:43+00:00";
-        condition = config.programs.git.enable
-          && any config.accounts.email.accounts (account: account.msmtp.enable);
+        condition = config.programs.git.enable && any (msmtp: msmtp.enable)
+          (mapAttrsToList (name: account: account.msmtp)
+            config.accounts.email.accounts);
         message = ''
           Git will now defer to msmtp for sending emails if
           'accounts.email.accounts.<name>.msmtp.enable' is true.

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -278,7 +278,7 @@ in {
           with account;
           nameValuePair "sendemail.${name}" (if account.msmtp.enable then {
             smtpServer = "${pkgs.msmtp}/bin/msmtp";
-            envelopeSender = true;
+            envelopeSender = "auto";
             from = address;
           } else
             {

--- a/tests/modules/programs/git/git-with-msmtp-expected.conf
+++ b/tests/modules/programs/git/git-with-msmtp-expected.conf
@@ -5,7 +5,7 @@
 	smtpUser = "home.manager.jr"
 
 [sendemail "hm@example.com"]
-	envelopeSender = true
+	envelopeSender = "auto"
 	from = "hm@example.com"
 	smtpServer = "@msmtp@/bin/msmtp"
 

--- a/tests/modules/programs/git/git-with-msmtp.nix
+++ b/tests/modules/programs/git/git-with-msmtp.nix
@@ -39,7 +39,7 @@ with lib;
       assertGitConfig "sendemail.hm@example.com.from" "hm@example.com"
       assertGitConfig "sendemail.hm-account.from" "hm@example.org"
       assertGitConfig "sendemail.hm@example.com.smtpServer" "${pkgs.msmtp}/bin/msmtp"
-      assertGitConfig "sendemail.hm@example.com.envelopeSender" "true"
+      assertGitConfig "sendemail.hm@example.com.envelopeSender" "auto"
     '';
   };
 }


### PR DESCRIPTION

### Description

The value should be "auto", not `true`.

Also fix news entry.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
