### PR TITLE
qt: add qt.style option

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -44,19 +44,72 @@ in {
           </variablelist>
         '';
       };
+
+      style = {
+        name = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "adwaita-dark";
+          relatedPackages = [ "adwaita-qt" [ "libsForQt5" "qtstyleplugins" ] ];
+          description = ''
+            Selects the style to use for Qt5 applications.</para>
+            <para>The options are
+            <variablelist>
+              <varlistentry>
+                <term><literal>adwaita</literal></term>
+                <term><literal>adwaita-dark</literal></term>
+                <listitem><para>Use Adwaita Qt style with
+                  <link xlink:href="https://github.com/FedoraQt/adwaita-qt">adwaita</link>
+                </para></listitem>
+              </varlistentry>
+              <varlistentry>
+                <term><literal>cleanlooks</literal></term>
+                <term><literal>gtk2</literal></term>
+                <term><literal>motif</literal></term>
+                <term><literal>plastique</literal></term>
+                <listitem><para>Use styles from
+                  <link xlink:href="https://github.com/qt/qtstyleplugins">qtstyleplugins</link>
+                </para></listitem>
+              </varlistentry>
+            </variablelist>
+          '';
+        };
+
+        package = mkOption {
+          type = types.nullOr types.package;
+          default = null;
+          example = literalExample "pkgs.adwaita-qt";
+          description = "Theme package to be used in Qt5 applications.";
+        };
+      };
     };
   };
 
   config = mkIf (cfg.enable && cfg.platformTheme != null) {
-    home.sessionVariables.QT_QPA_PLATFORMTHEME =
-      if cfg.platformTheme == "gnome" then "gnome" else "gtk2";
+    assertions = [{
+      assertion = (cfg.platformTheme == "gnome")
+        -> ((cfg.style.name != null) && (cfg.style.package != null));
+      message = ''
+        `qt.platformTheme` "gnome" must have `qt.style` set to a theme that
+        supports both Qt and Gtk, for example "adwaita" or "adwaita-dark".
+      '';
+    }];
+
+    # Necessary because home.sessionVariables is of types.attrs
+    home.sessionVariables = (filterAttrs (n: v: v != null) {
+      QT_QPA_PLATFORMTHEME =
+        if cfg.platformTheme == "gnome" then "gnome" else "gtk2";
+      QT_STYLE_OVERRIDE = cfg.style.name;
+    });
 
     home.packages = if cfg.platformTheme == "gnome" then
       [ pkgs.qgnomeplatform ]
+      ++ lib.optionals (cfg.style.package != null) [ cfg.style.package ]
     else
       [ pkgs.libsForQt5.qtstyleplugins ];
 
-    xsession.importedVariables = [ "QT_QPA_PLATFORMTHEME" ];
+    xsession.importedVariables = [ "QT_QPA_PLATFORMTHEME" ]
+      ++ lib.optionals (cfg.style != null) [ "QT_STYLE_OVERRIDE" ];
 
     # Enable GTK+ style for Qt4 in either case.
     # It doesn’t support the platform theme packages.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -84,6 +84,7 @@ import nmt {
     ./modules/misc/debug
     ./modules/misc/numlock
     ./modules/misc/pam
+    ./modules/misc/qt
     ./modules/misc/xdg
     ./modules/misc/xsession
     ./modules/programs/abook

--- a/tests/modules/misc/qt/default.nix
+++ b/tests/modules/misc/qt/default.nix
@@ -1,0 +1,4 @@
+{
+  qt-platform-theme-gtk = ./qt-platform-theme-gtk.nix;
+  qt-platform-theme-gnome = ./qt-platform-theme-gnome.nix;
+}

--- a/tests/modules/misc/qt/qt-platform-theme-gnome.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gnome.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    qt = {
+      enable = true;
+      platformTheme = "gnome";
+      style = {
+        name = "adwaita";
+        package = pkgs.dummyTheme;
+      };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        dummyTheme = pkgs.runCommandLocal "theme" { } "mkdir $out";
+      })
+    ];
+
+    nmt.script = ''
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QT_QPA_PLATFORMTHEME="gnome"'
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QT_STYLE_OVERRIDE="adwaita"'
+    '';
+  };
+}

--- a/tests/modules/misc/qt/qt-platform-theme-gtk.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gtk.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    qt = {
+      enable = true;
+      platformTheme = "gtk";
+    };
+
+    nmt.script = ''
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QT_QPA_PLATFORMTHEME="gtk2"'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

This allows you to set a theme for Qt applications. For example, if you want to use `adwaita-qt` theme to have uniform look between Gtk and Qt applications, you can use it like this:

```nix
{
  qt = {
    enable = true;
    platformTheme = "gnome";
    style = {
      name = "adwaita";
      package = pkgs.adwaita-qt;
    };
  };
}
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
