### PR TITLE
home-manager: Respect NO_COLOR

### DIFF
--- a/doc/release-notes/rl-2105.adoc
+++ b/doc/release-notes/rl-2105.adoc
@@ -111,6 +111,9 @@ configure.packages.*.start  -> programs.neovim.plugins = [ { plugin = ...; }]
 configure.customRC -> programs.neovim.extraConfig
 ----
 
+* Home Manager now respects the `NO_COLOR` environment variable as per
+https://no-color.org/[].
+
 [[sec-release-21.05-state-version-changes]]
 === State Version Changes
 

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -221,7 +221,7 @@ function doSwitch() {
 function doListGens() {
     # Whether to colorize the generations output.
     local color="never"
-    if [[ -t 1 ]]; then
+    if [[ ! -v NO_COLOR && -t 1 ]]; then
         color="always"
     fi
 

--- a/modules/lib-bash/color-echo.sh
+++ b/modules/lib-bash/color-echo.sh
@@ -1,5 +1,7 @@
 # The check for terminal output and color support is heavily inspired
 # by https://unix.stackexchange.com/a/10065.
+#
+# Allow opt out by respecting the `NO_COLOR` environment variable.
 
 function setupColors() {
     normalColor=""
@@ -7,8 +9,8 @@ function setupColors() {
     warnColor=""
     noteColor=""
 
-    # Check if stdout is a terminal.
-    if [[ -t 1 ]]; then
+    # Enable colors for terminals, and allow opting out.
+    if [[ ! -v NO_COLOR && -t 1 ]]; then
         # See if it supports colors.
         local ncolors
         ncolors=$(tput colors)

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1873,6 +1873,13 @@ in
           'accounts.email.accounts.<name>.msmtp.enable' is true.
         '';
       }
+      {
+        time = "2021-03-03T22:16:05+00:00";
+        message = ''
+          Home Manager now respects the 'NO_COLOR' environment variable as per
+          https://no-color.org/.
+        '';
+      }
     ];
   };
 }


### PR DESCRIPTION
### Description

This PR changes home-manager to respect the NO_COLOR environment
variable to disable coloring from output generated by home-manager.

This initiative can be found more on https://no-color.org/


### Checklist

- [x] Change is backwards compatible.

- ~~[ ] Code formatted with `./format`.~~

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- ~~[ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~~

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~~If this PR adds a new module~~

  - ~~[ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~~

  - ~~[ ] Added myself and the module files to `.github/CODEOWNERS`.~~