### PR TITLE
qutebrowser: add option to load autoconfig

### DIFF
--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -51,6 +51,14 @@ in {
       '';
     };
 
+    loadAutoconfig = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Load settings configured via the GUI.
+      '';
+    };
+
     searchEngines = mkOption {
       type = types.attrsOf types.str;
       default = { };
@@ -256,7 +264,12 @@ in {
     home.packages = [ cfg.package ];
 
     xdg.configFile."qutebrowser/config.py".text = concatStringsSep "\n" ([ ]
-      ++ mapAttrsToList (formatLine "c.") cfg.settings
+      ++ [
+        "${if cfg.loadAutoconfig then
+          "config.load_autoconfig()"
+        else
+          "config.load_autoconfig(False)"}"
+      ] ++ mapAttrsToList (formatLine "c.") cfg.settings
       ++ mapAttrsToList (formatDictLine "c.aliases") cfg.aliases
       ++ mapAttrsToList (formatDictLine "c.url.searchengines") cfg.searchEngines
       ++ mapAttrsToList (formatDictLine "c.bindings.key_mappings")

--- a/tests/modules/programs/qutebrowser/keybindings.nix
+++ b/tests/modules/programs/qutebrowser/keybindings.nix
@@ -29,6 +29,7 @@ with lib;
         home-files/.config/qutebrowser/config.py \
         ${
           pkgs.writeText "qutebrowser-expected-config.py" ''
+            config.load_autoconfig(False)
             c.bindings.default = {}
             config.bind(",l", "config-cycle spellcheck.languages [\"en-GB\"] [\"en-US\"]", mode="normal")
             config.bind("<Ctrl-v>", "spawn mpv {url}", mode="normal")

--- a/tests/modules/programs/qutebrowser/settings.nix
+++ b/tests/modules/programs/qutebrowser/settings.nix
@@ -35,6 +35,7 @@ with lib;
         home-files/.config/qutebrowser/config.py \
         ${
           pkgs.writeText "qutebrowser-expected-config.py" ''
+            config.load_autoconfig(False)
             c.colors.hints.bg = "#000000"
             c.colors.hints.fg = "#ffffff"
             c.colors.tabs.bar.bg = "#000000"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Fix #1774 by adding a `loadAutoconfig` option 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
