### PR TITLE
docs: document qt.style and programs.rofi.theme changes

### DIFF
--- a/doc/release-notes/rl-2105.adoc
+++ b/doc/release-notes/rl-2105.adoc
@@ -50,8 +50,8 @@ As a result of this change, <<opt-programs.mpv.package>> is no longer the
 resulting derivation. Use the newly introduced `programs.mpv.finalPackage`
 instead.
 
-* The <<opt-programs.rofi.extraConfig>> option is now an attrset rather
-than a string. To migrate, move the each line into the attrset,
+* The <<opt-programs.rofi.extraConfig>> option is now an attribute set rather
+than a string. To migrate, move each line into the attribute set,
 removing the `rofi.` prefix from the keys. For example,
 +
 [source,nix]
@@ -113,6 +113,22 @@ configure.customRC -> programs.neovim.extraConfig
 
 * Home Manager now respects the `NO_COLOR` environment variable as per
 https://no-color.org/[].
+
+* Qt module now supports <<opt-qt.style.name>> to specify a theme name and
+<<opt-qt.style.package>> to specify a theme package. If you have set
+<<opt-qt.platformTheme>> to `gnome`, a <<opt-qt.style.package>> compatible
+with both Qt and Gtk is now required to be set. For instance:
++
+[source,nix]
+----
+qt = {
+  platformTheme = "gnome";
+  style = {
+    name = "adwaita-dark";
+    package = pkgs.adwaita-qt;
+  };
+};
+----
 
 [[sec-release-21.05-state-version-changes]]
 === State Version Changes

--- a/doc/release-notes/rl-2105.adoc
+++ b/doc/release-notes/rl-2105.adoc
@@ -71,6 +71,34 @@ programs.rofi.extraConfig = {
   modi = "drun,emoji,ssh";
 };
 ----
++
+* The <<opt-programs.rofi.theme>> option now supports defining a theme
+using an attribute set, the following configuration is now possible:
++
+[source,nix]
+----
+programs.rofi.theme = let
+  # Necessary to avoid quoting non-string values
+  inherit (config.lib.formats.rasi) mkLiteral;
+in {
+   "@import" = "~/.config/rofi/theme.rasi";
+
+  "*" = {
+    background-color = mkLiteral "#000000";
+    foreground-color = mkLiteral "rgba ( 250, 251, 252, 100 % )";
+    border-color = mkLiteral "#FFFFFF";
+    width = 512;
+  };
+
+  "#textbox-prompt-colon" = {
+    expand = false;
+    str = ":";
+    margin = mkLiteral "0px 0.3em 0em 0em";
+    text-color = mkLiteral "@foreground-color";
+  };
+};
+----
+
 
 * The `services.redshift.extraOptions` and `services.gammastep.extraOptions`
 options were removed in favor of <<opt-services.redshift.settings>> and


### PR DESCRIPTION
### Description

Add documentation for `qt.style` and `programs.rofi.theme` changes in release notes for 21.05 release.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
