### PR TITLE
bash: improve initialisation

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -111,23 +111,21 @@ in
         '';
       };
 
-      bashrcExtra = mkOption {
-        # Hide for now, may want to rename in the future.
-        visible = false;
-        default = "";
-        type = types.lines;
-        description = ''
-          Extra commands that should be added to
-          <filename>~/.bashrc</filename>.
-        '';
-      };
-
       initExtra = mkOption {
         default = "";
         type = types.lines;
         description = ''
           Extra commands that should be run when initializing an
           interactive shell.
+        '';
+      };
+
+      bashrcExtra = mkOption {
+        default = "";
+        type = types.lines;
+        description = ''
+          Extra commands that should be placed in <filename>~/.bashrc</filename>.
+          Note that these commands will be run even in non-interactive shells.
         '';
       };
 
@@ -171,19 +169,6 @@ in
           }
         ));
     in mkIf cfg.enable {
-      programs.bash.bashrcExtra = ''
-        # Commands that should be applied only for interactive shells.
-        if [[ $- == *i* ]]; then
-          ${historyControlStr}
-
-          ${shoptsStr}
-
-          ${aliasesStr}
-
-          ${cfg.initExtra}
-        fi
-      '';
-
       home.file.".bash_profile".text = ''
         # -*- mode: sh -*-
 
@@ -208,6 +193,17 @@ in
         # -*- mode: sh -*-
 
         ${cfg.bashrcExtra}
+
+        # Commands that should be applied only for interactive shells.
+        [[ $- == *i* ]] || return
+
+        ${historyControlStr}
+
+        ${shoptsStr}
+
+        ${aliasesStr}
+
+        ${cfg.initExtra}
       '';
 
       home.file.".bash_logout" = mkIf (cfg.logoutExtra != "") {


### PR DESCRIPTION
Resolves #1843. Allows aliases to be expanded in `initExtra`, and adds a visible `bashrcExtra` option for commands that should be run in `~/.bashrc` even by non-interactive shells.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
