### PR TITLE
mbsync: replace Master/Slave with Far/Near

### DIFF
--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -24,8 +24,8 @@ let
 
   masterSlaveMapping = {
     none = "None";
-    imap = "Master";
-    maildir = "Slave";
+    imap = "Far";
+    maildir = "Near";
     both = "Both";
   };
 
@@ -85,8 +85,8 @@ let
   genAccountWideChannel = account:
     with account;
     genSection "Channel ${name}" ({
-      Master = ":${name}-remote:";
-      Slave = ":${name}-local:";
+      Far = ":${name}-remote:";
+      Near = ":${name}-local:";
       Patterns = mbsync.patterns;
       Create = masterSlaveMapping.${mbsync.create};
       Remove = masterSlaveMapping.${mbsync.remove};
@@ -115,8 +115,8 @@ let
             else
               "";
         in genSection "Channel ${groupName}-${channel.name}" ({
-          Master = ":${storeName}-remote:${channel.masterPattern}";
-          Slave = ":${storeName}-local:${channel.slavePattern}";
+          Far = ":${storeName}-remote:${channel.masterPattern}";
+          Near = ":${storeName}-local:${channel.slavePattern}";
         } // channel.extraConfig) + genChannelPatterns channel.patterns;
       # Given the group name, and a attr set of channels within that group,
       # Generate a list of strings for each channels' configuration.


### PR DESCRIPTION
..to silence the warning on start

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
