### PR TITLE
waybar: fix slow service stop

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -378,6 +378,7 @@ in {
           ExecStart = "${cfg.package}/bin/waybar";
           Restart = "always";
           RestartSec = "1sec";
+          KillMode = "mixed";
         };
 
         Install = { WantedBy = [ "graphical-session.target" ]; };

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -4,6 +4,7 @@ WantedBy=graphical-session.target
 [Service]
 BusName=fr.arouillard.waybar
 ExecStart=@waybar@/bin/waybar
+KillMode=mixed
 Restart=always
 RestartSec=1sec
 Type=dbus


### PR DESCRIPTION
### Description

Set the systemd user service to use "mixed" killmode, which lets waybar stop its module scripts itself. This fixes issues where waybar blocks shutdown until systemd sends a SIGKILL to waybar child processes.

This is mostly relevant when waybar is run with custom scripts, but should not have any negative impact otherwise. Also see man pages for `systemd.kill(5)`. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
