### PR TITLE
offlineimap: Strip newlines from offlineimap passwordcommand

### DIFF
--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -65,7 +65,7 @@ let
       remotePassEval =
         let arglist = concatMapStringsSep "," (x: "'${x}'") passwordCommand;
         in optionalAttrs (passwordCommand != null) {
-          remotepasseval = ''get_pass("${name}", [${arglist}])'';
+          remotepasseval = ''get_pass("${name}", [${arglist}]).strip("\n")'';
         };
     in toIni {
       "Account ${name}" = {


### PR DESCRIPTION

### Description

This allows me to use offlineimap with passwordstore. I guess nobody uses a newline in their password?


### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

Tests seem to be broken atm? `attribute 'anything' missing`

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
