### PR TITLE
home-manager: Add --flake option to home-manager

### DIFF
--- a/doc/man-home-manager.xml
+++ b/doc/man-home-manager.xml
@@ -67,6 +67,10 @@
    </arg>
     
    <arg>
+    --flake <replaceable>flake-uri</replaceable>
+   </arg>
+    
+   <arg>
     -b <replaceable>ext</replaceable>
    </arg>
     
@@ -340,6 +344,18 @@
       Home Manager profile using a specific Nixpkgs run <command>home-manager
       -I nixpkgs=/absolute/path/to/nixpkgs build</command>. By default
       <literal>&lt;nixpkgs&gt;</literal> is used.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--flake <replaceable>flake-uri[#name]</replaceable></option>
+    </term>
+    <listitem>
+     <para>
+      Build home-manager configuration from the flake, which must contain the
+      output homeConfigurations.name. If no name is specified it
+      defaults to your username.
      </para>
     </listitem>
    </varlistentry>

--- a/doc/man-home-manager.xml
+++ b/doc/man-home-manager.xml
@@ -354,8 +354,8 @@
     <listitem>
      <para>
       Build Home Manager configuration from the flake, which must contain the
-      output homeConfigurations.name. If no name is specified it
-      defaults to your username.
+      output homeConfigurations.name. If no name is specified it will first try
+      username@hostname and then username.
      </para>
     </listitem>
    </varlistentry>

--- a/doc/man-home-manager.xml
+++ b/doc/man-home-manager.xml
@@ -164,7 +164,7 @@
   <title>Description</title>
   <para>
    This command updates the user environment so that it corresponds to the
-   configuration specified in <filename>~/.config/nixpkgs/home.nix</filename>.
+      configuration specified in <filename>~/.config/nixpkgs/home.nix</filename> or <filename>~/.config/nixpkgs/flake.nix</filename>.
   </para>
   <para>
    All operations using this tool expects a sub-command that indicates the

--- a/doc/man-home-manager.xml
+++ b/doc/man-home-manager.xml
@@ -353,7 +353,7 @@
     </term>
     <listitem>
      <para>
-      Build home-manager configuration from the flake, which must contain the
+      Build Home Manager configuration from the flake, which must contain the
       output homeConfigurations.name. If no name is specified it
       defaults to your username.
      </para>

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -76,11 +76,19 @@ function setHomeManagerNixPath() {
 
 # get activationPackage of homeConfig reference, defaults to $USER if no attr is spedified
 function setFlakeAttribute() {
+    local flake="${1%#*}"
     case $1 in
-        *#*) local name="${1#*#}";;
-        *)   local name="$USER";;
+        *#*)
+            local name="${1#*#}"
+        ;;
+        *)
+            local name="$USER@$(hostname)"
+            if [ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$name\"")" = "false" ]; then
+                name="$USER"
+            fi
+        ;;
     esac
-    export FLAKE_CONFIG_URI="${1%#*}#homeConfigurations.\"${name}\""
+    export FLAKE_CONFIG_URI="$flake#homeConfigurations.\"$name\""
 }
 
 function doInstantiate() {

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -80,7 +80,7 @@ function setFlakeAttribute() {
         *#*) local name="${1#*#}";;
         *)   local name="$USER";;
     esac
-    export FLAKE_CONFIG_URI="${1%#*}#homeConfigurations.${name}"
+    export FLAKE_CONFIG_URI="${1%#*}#homeConfigurations.\"${name}\""
 }
 
 function doInstantiate() {

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -74,7 +74,20 @@ function setHomeManagerNixPath() {
     done
 }
 
+# get activationPackage of homeConfig reference, defaults to $USER if no attr is spedified
+function setFlakeAttribute() {
+    case $1 in
+        *#*) local name="${1#*#}";;
+        *)   local name="$USER";;
+    esac
+    export FLAKE_CONFIG_URI="${1%#*}#homeConfigurations.${name}"
+}
+
 function doInstantiate() {
+    if [[ -v FLAKE_CONFIG_URI ]]; then
+        errorEcho "Can't instantiate a flake configuration"
+        exit 1
+    fi
     setConfigFile
     setHomeManagerNixPath
 
@@ -178,6 +191,16 @@ function doBuild() {
         return 1
     fi
 
+    if [[ -v FLAKE_CONFIG_URI ]]; then
+        local exitCode=0
+        nix build \
+            "${PASSTHROUGH_OPTS[@]}" \
+             ${DRY_RUN+--dry-run} \
+            "$FLAKE_CONFIG_URI.activationPackage" \
+            || exitCode=1
+        return $exitCode
+    fi
+
     setWorkDir
 
     local newsInfo
@@ -194,6 +217,15 @@ function doBuild() {
 }
 
 function doSwitch() {
+    if [[ -v FLAKE_CONFIG_URI ]]; then
+        local exitCode=0
+        nix run \
+            "${PASSTHROUGH_OPTS[@]}" \
+            "$FLAKE_CONFIG_URI.activationPackage" \
+            || exitCode=1
+        return $exitCode
+    fi
+
     setWorkDir
 
     local newsInfo
@@ -409,15 +441,16 @@ function doHelp() {
     echo
     echo "Options"
     echo
-    echo "  -f FILE      The home configuration file."
-    echo "               Default is '~/.config/nixpkgs/home.nix'."
-    echo "  -A ATTRIBUTE Optional attribute that selects a configuration"
-    echo "               expression in the configuration file."
-    echo "  -I PATH      Add a path to the Nix expression search path."
-    echo "  -b EXT       Move existing files to new path rather than fail."
-    echo "  -v           Verbose output"
-    echo "  -n           Do a dry run, only prints what actions would be taken"
-    echo "  -h           Print this help"
+    echo "  -f FILE           The home configuration file."
+    echo "                    Default is '~/.config/nixpkgs/home.nix'."
+    echo "  -A ATTRIBUTE      Optional attribute that selects a configuration"
+    echo "                    expression in the configuration file."
+    echo "  -I PATH           Add a path to the Nix expression search path."
+    echo "  --flake flake-uri Use home-manager configuration at flake-uri"
+    echo "  -b EXT            Move existing files to new path rather than fail."
+    echo "  -v                Verbose output"
+    echo "  -n                Do a dry run, only prints what actions would be taken"
+    echo "  -h                Print this help"
     echo
     echo "Options passed on to nix-build(1)"
     echo
@@ -489,6 +522,21 @@ while [[ $# -gt 0 ]]; do
         -f|--file)
             HOME_MANAGER_CONFIG="$1"
             shift
+            ;;
+        --flake)
+            setFlakeAttribute "$1"
+            shift
+            ;;
+        --recreate-lock-file|--no-update-lock-file|--no-write-lock-file|--no-registries|--commit-lock-file)
+            PASSTHROUGH_OPTS+=("$opt")
+            ;;
+        --update-input)
+            PASSTHROUGH_OPTS+=("$opt" "$1")
+            shift
+            ;;
+        --override-input)
+            PASSTHROUGH_OPTS+=("$opt" "$1" "$2")
+            shift 2
             ;;
         -h|--help)
             doHelp

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -74,24 +74,31 @@ function setHomeManagerNixPath() {
     done
 }
 
-# get activationPackage of homeConfig reference, defaults to $USER if no attr is spedified
 function setFlakeAttribute() {
-    local flake="${1%#*}"
-    case $1 in
-        *#*)
-            local name="${1#*#}"
-        ;;
-        *)
-            local name="$USER@$(hostname)"
-            if [ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$name\"")" = "false" ]; then
-                name="$USER"
-            fi
-        ;;
-    esac
-    export FLAKE_CONFIG_URI="$flake#homeConfigurations.\"$name\""
+    local configFlake="${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/flake.nix"
+    if [[ -z $FLAKE_ARG && ! -v HOME_MANAGER_CONFIG && -e "$configFlake" ]]; then
+        FLAKE_ARG="$(dirname "$(readlink -f "$configFlake")")"
+    fi
+
+    if [[ -n "$FLAKE_ARG" ]]; then
+        local flake="${FLAKE_ARG%#*}"
+        case $FLAKE_ARG in
+            *#*)
+                local name="${FLAKE_ARG#*#}"
+            ;;
+            *)
+                local name="$USER@$(hostname)"
+                if [ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$name\"")" = "false" ]; then
+                    name="$USER"
+                fi
+            ;;
+        esac
+        export FLAKE_CONFIG_URI="$flake#homeConfigurations.\"$name\""
+    fi
 }
 
 function doInstantiate() {
+    setFlakeAttribute
     if [[ -v FLAKE_CONFIG_URI ]]; then
         errorEcho "Can't instantiate a flake configuration"
         exit 1
@@ -199,6 +206,7 @@ function doBuild() {
         return 1
     fi
 
+    setFlakeAttribute
     if [[ -v FLAKE_CONFIG_URI ]]; then
         local exitCode=0
         nix build \
@@ -225,6 +233,7 @@ function doBuild() {
 }
 
 function doSwitch() {
+    setFlakeAttribute
     if [[ -v FLAKE_CONFIG_URI ]]; then
         local exitCode=0
         nix run \
@@ -507,6 +516,7 @@ HOME_MANAGER_CONFIG_ATTRIBUTE=""
 PASSTHROUGH_OPTS=()
 COMMAND=""
 COMMAND_ARGS=()
+FLAKE_ARG=""
 
 while [[ $# -gt 0 ]]; do
     opt="$1"
@@ -532,7 +542,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --flake)
-            setFlakeAttribute "$1"
+            FLAKE_ARG="$1"
             shift
             ;;
         --recreate-lock-file|--no-update-lock-file|--no-write-lock-file|--no-registries|--commit-lock-file)

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -552,6 +552,9 @@ in
 
             cp ${activationScript} $out/activate
 
+            mkdir $out/bin
+            ln -s $out/activate $out/bin/home-manager-generation
+
             substituteInPlace $out/activate \
               --subst-var-by GENERATION_DIR $out
 


### PR DESCRIPTION
Improves on #1828. Afer looking at the home-manager script I realized it wouldn't actually be too much work to just implement a flake option to home-manager. `home-manager build/switch --flake uri[#name]` now builds/switches to the
`homeConfigurations.<name>` output of the flake located at `uri` (name defaults to username). The lock-file options should also work*.
Hasn't been implemented for:
* Instantiate: NixOS/nix#3908. Shouldn't (?) be implemented.
* Edit: Not sure if it can be done in a nice way, `nix edit` currently opens a read-only version even if the flake uri is a path.
* News: Shouldn't be too difficult, but I'm not quite sure how the news output works.

I have also added an entry to man page, but it doesn't mention the lock-file options (`man nixos-rebuild` doesn't mention them either, so I wasn't sure if it should). The completions scripts also haven't been updated (I have no idea how those work).

Also, should I add a news entry?

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```