### PR TITLE
lsd: add support for config file 

### DIFF
--- a/modules/programs/lsd.nix
+++ b/modules/programs/lsd.nix
@@ -6,6 +6,8 @@ let
 
   cfg = config.programs.lsd;
 
+  yamlFormat = pkgs.formats.yaml { };
+
   aliases = {
     ls = "${pkgs.lsd}/bin/lsd";
     ll = "ls -l";
@@ -27,6 +29,21 @@ in {
         Whether to enable recommended lsd aliases.
       '';
     };
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = {
+        date = "relative";
+        ignore-globs = [ ".git" ".hg" ];
+      };
+      description = ''
+        Configuration written to
+        <filename>~/.config/lsd/config.yaml</filename>. See
+        <link xlink:href="https://github.com/Peltoche/lsd#config-file-content"/>
+        for supported values.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -37,5 +54,9 @@ in {
     programs.zsh.shellAliases = mkIf cfg.enableAliases aliases;
 
     programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
+
+    xdg.configFile."lsd/config.yaml" = mkIf (cfg.settings != { }) {
+      source = yamlFormat.generate "lsd-config" cfg.settings;
+    };
   };
 }

--- a/modules/programs/lsd.nix
+++ b/modules/programs/lsd.nix
@@ -10,10 +10,10 @@ let
 
   aliases = {
     ls = "${pkgs.lsd}/bin/lsd";
-    ll = "ls -l";
-    la = "ls -a";
-    lt = "ls --tree";
-    lla = "ls -la";
+    ll = "${pkgs.lsd}/bin/lsd -l";
+    la = "${pkgs.lsd}/bin/lsd -a";
+    lt = "${pkgs.lsd}/bin/lsd --tree";
+    lla = "${pkgs.lsd}/bin/lsd -la";
   };
 
 in {


### PR DESCRIPTION
### Description
lsd 0.19.0 added support for a configuration file

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.


Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
