### PR TITLE
waybar: make settings a submodule

### DIFF
--- a/doc/release-notes/rl-2105.adoc
+++ b/doc/release-notes/rl-2105.adoc
@@ -158,6 +158,26 @@ qt = {
 };
 ----
 
+* The <<opt-programs.waybar.settings>> option is now an attribute set rather
+than a list of attributes. To migrate, just remove the outermost `[]` from
+your configuration. For example,
++
+[source,nix]
+----
+programs.waybar.settings = [{
+  # your settings
+}];
+----
++
+becomes
++
+[source,nix]
+----
+programs.waybar.settings = {
+  # your settings
+};
+----
+
 [[sec-release-21.05-state-version-changes]]
 === State Version Changes
 

--- a/tests/modules/programs/waybar/settings-complex.nix
+++ b/tests/modules/programs/waybar/settings-complex.nix
@@ -9,7 +9,7 @@ in {
     programs.waybar = {
       inherit package;
       enable = true;
-      settings = [{
+      settings = {
         layer = "top";
         position = "top";
         height = 30;
@@ -47,7 +47,7 @@ in {
             in "${dummyScript}/bin/dummy";
           };
         };
-      }];
+      };
     };
 
     nmt.script = ''

--- a/tests/modules/programs/waybar/warnings-tests.nix
+++ b/tests/modules/programs/waybar/warnings-tests.nix
@@ -9,7 +9,7 @@ in {
     programs.waybar = {
       inherit package;
       enable = true;
-      settings = [{
+      settings = {
         modules-left = [ "custom/my-module" ];
         modules-center =
           [ "this_module_is_not_a_valid_default_module_nor_custom_module" ];
@@ -23,15 +23,15 @@ in {
           "battery#bat1" = { };
           "custom/my-module" = { };
         };
-      }];
+      };
     };
 
     test.asserts.warnings.expected = [
-      "The module 'this_module_is_not_a_valid_default_module_nor_custom_module' defined in 'programs.waybar.settings.[].modules-center' is neither a default module or a custom module declared in 'programs.waybar.settings.[].modules'"
+      "The module 'this_module_is_not_a_valid_default_module_nor_custom_module' defined in 'programs.waybar.settings.modules-center' is neither a default module or a custom module declared in 'programs.waybar.settings.modules'"
 
-      "The module 'custom/this_custom_module_doesn't_have_a_definition_in_modules' defined in 'programs.waybar.settings.[].modules-right' is neither a default module or a custom module declared in 'programs.waybar.settings.[].modules'"
+      "The module 'custom/this_custom_module_doesn't_have_a_definition_in_modules' defined in 'programs.waybar.settings.modules-right' is neither a default module or a custom module declared in 'programs.waybar.settings.modules'"
 
-      "The module 'custom/this_module_is_not_referenced' defined in 'programs.waybar.settings.[].modules' is not referenced in either `modules-left`, `modules-center` or `modules-right` of Waybar's options"
+      "The module 'custom/this_module_is_not_referenced' defined in 'programs.waybar.settings.modules' is not referenced in either `modules-left`, `modules-center` or `modules-right` of Waybar's options"
     ];
 
     nmt.script = ''


### PR DESCRIPTION
### Description

This changes the type of `programs.waybar.settings` from a list of submodules to
a submodule.

As far as I can tell, the only reason this was a list to begin with is that the
underlying/output JSON expects the top-level element to be a list, but I don't
see why we should let this limitation leak into the Nix code. By making this a
submodule instead of a list of submodules we make it much easier for users to
selectively override portions of their settings.


NB: This is a breakign change. I understand I should add an assertion, but I'm
not sure where/how to do it. Help appreciated.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
