### PR TITLE
Use formats.toml to generate configurations

### DIFF
--- a/modules/programs/broot.nix
+++ b/modules/programs/broot.nix
@@ -6,16 +6,7 @@ let
 
   cfg = config.programs.broot;
 
-  configFile = config:
-    pkgs.runCommand "conf.toml" {
-      buildInputs = [ pkgs.remarshal ];
-      preferLocalBuild = true;
-      allowSubstitutes = false;
-    } ''
-      remarshal -if json -of toml \
-        < ${pkgs.writeText "verbs.json" (builtins.toJSON config)} \
-        > $out
-    '';
+  tomlFormat = pkgs.formats.toml { };
 
   brootConf = {
     verbs = cfg.verbs;
@@ -194,7 +185,8 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."broot/conf.toml".source = configFile brootConf;
+    xdg.configFile."broot/conf.toml".source =
+      tomlFormat.generate "broot-config" brootConf;
 
     # Dummy file to prevent broot from trying to reinstall itself
     xdg.configFile."broot/launcher/installed-v1".text = "";

--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -6,16 +6,7 @@ let
 
   cfg = config.programs.nushell;
 
-  configFile = config:
-    pkgs.runCommand "config.toml" {
-      buildInputs = [ pkgs.remarshal ];
-      preferLocalBuild = true;
-      allowSubstitutes = false;
-    } ''
-      remarshal -if json -of toml \
-        < ${pkgs.writeText "config.json" (builtins.toJSON config)} \
-        > $out
-    '';
+  tomlFormat = pkgs.formats.toml { };
 
 in {
   meta.maintainers = [ maintainers.Philipp-M ];
@@ -62,7 +53,8 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."nu/config.toml" =
-      mkIf (cfg.settings != { }) { source = configFile cfg.settings; };
+    xdg.configFile."nu/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "nushell-config" cfg.settings;
+    };
   };
 }

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -6,16 +6,7 @@ let
 
   cfg = config.programs.starship;
 
-  configFile = config:
-    pkgs.runCommand "config.toml" {
-      buildInputs = [ pkgs.remarshal ];
-      preferLocalBuild = true;
-      allowSubstitutes = false;
-    } ''
-      remarshal -if json -of toml \
-        < ${pkgs.writeText "config.json" (builtins.toJSON config)} \
-        > $out
-    '';
+  tomlFormat = pkgs.formats.toml { };
 
 in {
   meta.maintainers = [ maintainers.marsam ];
@@ -93,8 +84,9 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."starship.toml" =
-      mkIf (cfg.settings != { }) { source = configFile cfg.settings; };
+    xdg.configFile."starship.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "starship-config" cfg.settings;
+    };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then


### PR DESCRIPTION
### Description

Use [`formats.toml`](https://nixos.org/manual/nixos/stable/#sec-settings-nix-representable) to build configurations

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
