### PR TITLE
neovim: fall back to plugin name if pname does not exist

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -44,7 +44,7 @@ let
   # A function to get the configuration string (if any) from an element of 'plugins'
   pluginConfig = p:
     if p ? plugin && (p.config or "") != "" then ''
-      " ${p.plugin.pname} {{{
+      " ${p.plugin.pname or p.plugin.name} {{{
       ${p.config}
       " }}}
     '' else


### PR DESCRIPTION
### Description

I have some ad-hoc neovim plugins in my home-manager config. I don't really care about plugin versions so I prefer to define them with just `name` instead of needing both `pname` and `version`. If you search github for `buildVimPluginFrom2Nix` you'll see lots of others doing the same thing. Right now if you use a package without `pname` with a config snippet you'll get an error about missing `pname` because of this comment in the neovim config labeling the plugin's config. This PR falls back to `name` when `pname` isn't present.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.