### PR TITLE
git: install delta when it's enabled

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -354,6 +354,8 @@ in {
     })
 
     (mkIf cfg.delta.enable {
+      home.packages = [ pkgs.delta ];
+
       programs.git.iniContent = let deltaCommand = "${pkgs.delta}/bin/delta";
       in {
         core.pager = deltaCommand;


### PR DESCRIPTION
### Description

Install delta when it's enabled, similar to `git-lfs` a few lines above. Without this change, `delta` isn't available outside `git` (running `delta` outputs: `The program ‘delta’ is currently not installed`)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.