### PR TITLE
chromium: remove 'extensions' option for proprietary Chrome versions

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -5,7 +5,9 @@ with lib;
 let
 
   browserModule = defaultPkg: name: visible:
-    let browser = (builtins.parseDrvName defaultPkg.name).name;
+    let
+      browser = (builtins.parseDrvName defaultPkg.name).name;
+      isProprietaryChrome = hasPrefix "Google Chrome" name;
     in {
       enable = mkOption {
         inherit visible;
@@ -22,7 +24,9 @@ let
         defaultText = literalExample "pkgs.${browser}";
         description = "The ${name} package to use.";
       };
-
+    } // optionalAttrs (!isProprietaryChrome) {
+      # Extensions do not work with Google Chrome
+      # see https://github.com/nix-community/home-manager/issues/1383
       extensions = mkOption {
         inherit visible;
         type = with types;
@@ -129,10 +133,19 @@ let
 
     in mkIf cfg.enable {
       home.packages = [ cfg.package ];
-      home.file = listToAttrs (map extensionJson cfg.extensions);
+      home.file = listToAttrs (map extensionJson (cfg.extensions or [ ]));
     };
 
 in {
+  # Extensions do not work with the proprietary Google Chrome version
+  # see https://github.com/nix-community/home-manager/issues/1383
+  imports = map (flip mkRemovedOptionModule
+    "The `extensions` option does not work on Google Chrome anymore.") [
+      [ "programs" "google-chrome" "extensions" ]
+      [ "programs" "google-chrome-beta" "extensions" ]
+      [ "programs" "google-chrome-dev" "extensions" ]
+    ];
+
   options.programs = {
     chromium = browserModule pkgs.chromium "Chromium" true;
     google-chrome = browserModule pkgs.google-chrome "Google Chrome" false;


### PR DESCRIPTION
### Description

Fixes #1383 by removing the `extensions` option for proprietary Chromium versions (Google Chrome, Google Chrome Beta, Google Chrome Dev).

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.


cc @bb2020 @ivankovnatsky