### PR TITLE
jq: Use default upstream values for colors

### DIFF
--- a/modules/programs/jq.nix
+++ b/modules/programs/jq.nix
@@ -51,12 +51,12 @@ in {
 
         default = {
           null = "1;30";
-          false = "0;39";
-          true = "0;39";
-          numbers = "0;39";
+          false = "0;37";
+          true = "0;37";
+          numbers = "0;37";
           strings = "0;32";
-          arrays = "1;39";
-          objects = "1;39";
+          arrays = "1;37";
+          objects = "1;37";
         };
 
         type = colorsType;


### PR DESCRIPTION
### Description

As documented here: https://stedolan.github.io/jq/manual/#Colors

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.