### PR TITLE
sharedModules: add `pkgs` to module args

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -75,7 +75,7 @@ in {
       };
 
       sharedModules = mkOption {
-        type = with types; listOf (oneOf [ attrs (functionTo attrs) path ]);
+        type = with types; listOf anything;
         default = [ ];
         example = literalExample "[ { home.packages = [ nixpkgs-fmt ]; } ]";
         description = ''


### PR DESCRIPTION
Fixes #1878.

### Description

See the linked issue for context. Opting for a minimal solution.

### Todo
- [x] fix for NixOS module
- [ ] consider removing `useGlobalPackages` altogether and always opt for NixOS systems `pkgs`.
- [ ] check nix-darwin module for similar issue and fix if found
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```