### PR TITLE
nixos/nix-darwin: switch sharedModules type to anything instead of functionTo

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -68,7 +68,11 @@ in
       };
 
       sharedModules = mkOption {
-        type = with types; listOf (oneOf [ attrs (functionTo attrs) path ]);
+        type = with types;
+          listOf (anything // {
+            inherit (submodule { }) check;
+            description = "Home Manager modules";
+          });
         default = [ ];
         example = literalExample "[ { home.packages = [ nixpkgs-fmt ]; } ]";
         description = ''

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -75,7 +75,11 @@ in {
       };
 
       sharedModules = mkOption {
-        type = with types; listOf (oneOf [ attrs (functionTo attrs) path ]);
+        type = with types;
+          listOf (anything // {
+            inherit (submodule { }) check;
+            description = "Home Manager modules";
+          });
         default = [ ];
         example = literalExample "[ { home.packages = [ nixpkgs-fmt ]; } ]";
         description = ''


### PR DESCRIPTION
functionTo tries to evaluate functions too quickly and prevents sharedModules from accessing the pkgs argument.
Fixes #1878.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
