### PR TITLE
neomutt: Add encryptByDefault support

### DIFF
--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -189,6 +189,7 @@ let
       # GPG section
       set crypt_use_gpgme = yes
       set crypt_autosign = ${yesno (gpg.signByDefault or false)}
+      set crypt_opportunistic_encrypt = ${yesno (gpg.encryptByDefault or false)}
       set pgp_use_gpg_agent = yes
       set mbox_type = ${if maildir != null then "Maildir" else "mbox"}
       set sort = "${cfg.sort}"

--- a/tests/modules/programs/neomutt/default.nix
+++ b/tests/modules/programs/neomutt/default.nix
@@ -6,4 +6,5 @@
   neomutt-with-binds-with-warning = ./neomutt-with-binds-with-warning.nix;
   neomutt-with-binds-invalid-settings =
     ./neomutt-with-binds-invalid-settings.nix;
+  neomutt-with-gpg = ./neomutt-with-gpg.nix;
 }

--- a/tests/modules/programs/neomutt/hm-example.com-gpg-expected.conf
+++ b/tests/modules/programs/neomutt/hm-example.com-gpg-expected.conf
@@ -4,8 +4,8 @@ set certificate_file=/etc/ssl/certs/ca-certificates.crt
 
 # GPG section
 set crypt_use_gpgme = yes
-set crypt_autosign = no
-set crypt_opportunistic_encrypt = no
+set crypt_autosign = yes
+set crypt_opportunistic_encrypt = yes
 set pgp_use_gpg_agent = yes
 set mbox_type = Maildir
 set sort = "threads"
@@ -29,8 +29,4 @@ set trash='+Trash'
 
 
 # Extra configuration
-color status cyan default
 
-# notmuch section
-set nm_default_uri = "notmuch:///home/hm-user/Mail"
-virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"

--- a/tests/modules/programs/neomutt/hm-example.com-msmtp-expected.conf
+++ b/tests/modules/programs/neomutt/hm-example.com-msmtp-expected.conf
@@ -5,6 +5,7 @@ set certificate_file=/etc/ssl/certs/ca-certificates.crt
 # GPG section
 set crypt_use_gpgme = yes
 set crypt_autosign = no
+set crypt_opportunistic_encrypt = no
 set pgp_use_gpg_agent = yes
 set mbox_type = Maildir
 set sort = "threads"

--- a/tests/modules/programs/neomutt/neomutt-with-gpg.nix
+++ b/tests/modules/programs/neomutt/neomutt-with-gpg.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+with lib; {
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  config = {
+    accounts.email.accounts = {
+      "hm@example.com" = {
+        gpg = {
+          encryptByDefault = true;
+          signByDefault = true;
+        };
+        neomutt.enable = true;
+        imap.port = 993;
+      };
+    };
+
+    programs.neomutt.enable = true;
+
+    nixpkgs.overlays =
+      [ (self: super: { neomutt = pkgs.writeScriptBin "dummy-neomutt" ""; }) ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/neomutt/neomuttrc
+      assertFileExists home-files/.config/neomutt/hm@example.com
+      assertFileContent home-files/.config/neomutt/neomuttrc ${
+        ./neomutt-expected.conf
+      }
+      assertFileContent home-files/.config/neomutt/hm@example.com ${
+        ./hm-example.com-gpg-expected.conf
+      }
+    '';
+  };
+}


### PR DESCRIPTION
Adds support for `encryptByDefault` to the neomutt module using the `crypt_opportunistic_encrypt` option.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
