### PR TITLE
pet: Add support for tags in snippets

### DIFF
--- a/modules/programs/pet.nix
+++ b/modules/programs/pet.nix
@@ -36,6 +36,15 @@ let
           Example output of the command.
         '';
       };
+
+      tag = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = literalExample ''["git" "nixpkgs"]'';
+        description = ''
+          List of tags attached to the command.
+        '';
+      };
     };
   };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -65,6 +65,7 @@ import nmt {
     ./modules/programs/neomutt
     ./modules/programs/newsboat
     ./modules/programs/nushell
+    ./modules/programs/pet
     ./modules/programs/powerline-go
     ./modules/programs/qutebrowser
     ./modules/programs/readline

--- a/tests/modules/programs/pet/default.nix
+++ b/tests/modules/programs/pet/default.nix
@@ -1,0 +1,1 @@
+{ pet-snippets = ./snippets.nix; }

--- a/tests/modules/programs/pet/snippet.toml
+++ b/tests/modules/programs/pet/snippet.toml
@@ -1,0 +1,5 @@
+[[snippets]]
+command = "git log -p -G <regex>"
+description = "git: search full history for regex"
+output = ""
+tag = ["git", "regex"]

--- a/tests/modules/programs/pet/snippets.nix
+++ b/tests/modules/programs/pet/snippets.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.pet = {
+      enable = true;
+      selectcmdPackage = pkgs.writeScriptBin "pet-cmd" "" // {
+        outPath = "@pet-cmd@";
+      };
+      snippets = [{
+        description = "git: search full history for regex";
+        command = "git log -p -G <regex>";
+        tag = [ "git" "regex" ];
+      }];
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        pet = pkgs.writeScriptBin "pet" "" // { outPath = "@pet@"; };
+      })
+    ];
+
+    nmt.script = ''
+      assertFileContent home-files/.config/pet/snippet.toml ${./snippet.toml}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Add missing `tag` option for elements of `programs.pet.snippets`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
