### PR TITLE
Make Git signing key id be optional

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -62,7 +62,6 @@ let
     options = {
       key = mkOption {
         type = types.nullOr types.str;
-        default = null;
         description = "The default GPG signing key fingerprint.";
       };
 

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -62,7 +62,12 @@ let
     options = {
       key = mkOption {
         type = types.nullOr types.str;
-        description = "The default GPG signing key fingerprint.";
+        description = ''
+          The default GPG signing key fingerprint.
+          </para><para>
+          Set to <literal>null</literal> to let GnuPG decide what signing key
+          to use depending on commit’s author.
+        '';
       };
 
       signByDefault = mkOption {

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -61,7 +61,8 @@ let
   signModule = types.submodule {
     options = {
       key = mkOption {
-        type = types.str;
+        type = types.nullOr types.str;
+        default = null;
         description = "The default GPG signing key fingerprint.";
       };
 
@@ -303,7 +304,7 @@ in {
 
     (mkIf (cfg.signing != null) {
       programs.git.iniContent = {
-        user.signingKey = cfg.signing.key;
+        user.signingKey = mkIf (cfg.signing.key != null) cfg.signing.key;
         commit.gpgSign = cfg.signing.signByDefault;
         gpg.program = cfg.signing.gpgPath;
       };

--- a/tests/modules/programs/git/default.nix
+++ b/tests/modules/programs/git/default.nix
@@ -3,4 +3,6 @@
   git-with-most-options = ./git.nix;
   git-with-msmtp = ./git-with-msmtp.nix;
   git-with-str-extra-config = ./git-with-str-extra-config.nix;
+  git-with-signing-key-id = ./git-with-signing-key-id.nix;
+  git-without-signing-key-id = ./git-without-signing-key-id.nix;
 }

--- a/tests/modules/programs/git/git-with-signing-key-id-expected.conf
+++ b/tests/modules/programs/git/git-with-signing-key-id-expected.conf
@@ -1,0 +1,10 @@
+[commit]
+	gpgSign = true
+
+[gpg]
+	program = "path-to-gpg"
+
+[user]
+	email = "user@example.org"
+	name = "John Doe"
+	signingKey = "00112233445566778899AABBCCDDEEFF"

--- a/tests/modules/programs/git/git-with-signing-key-id.nix
+++ b/tests/modules/programs/git/git-with-signing-key-id.nix
@@ -1,5 +1,4 @@
-{ pkgs, ... }:
-{
+{ pkgs, ... }: {
   config = {
     programs.git = {
       enable = true;

--- a/tests/modules/programs/git/git-with-signing-key-id.nix
+++ b/tests/modules/programs/git/git-with-signing-key-id.nix
@@ -1,0 +1,23 @@
+{ pkgs, ... }:
+{
+  config = {
+    programs.git = {
+      enable = true;
+      userName = "John Doe";
+      userEmail = "user@example.org";
+
+      signing = {
+        gpgPath = "path-to-gpg";
+        key = "00112233445566778899AABBCCDDEEFF";
+        signByDefault = true;
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/git/config
+      assertFileContent home-files/.config/git/config ${
+        ./git-with-signing-key-id-expected.conf
+      }
+    '';
+  };
+}

--- a/tests/modules/programs/git/git-without-signing-key-id-expected.conf
+++ b/tests/modules/programs/git/git-without-signing-key-id-expected.conf
@@ -1,0 +1,9 @@
+[commit]
+	gpgSign = true
+
+[gpg]
+	program = "path-to-gpg"
+
+[user]
+	email = "user@example.org"
+	name = "John Doe"

--- a/tests/modules/programs/git/git-without-signing-key-id.nix
+++ b/tests/modules/programs/git/git-without-signing-key-id.nix
@@ -7,6 +7,7 @@
 
       signing = {
         gpgPath = "path-to-gpg";
+        key = null;
         signByDefault = true;
       };
     };

--- a/tests/modules/programs/git/git-without-signing-key-id.nix
+++ b/tests/modules/programs/git/git-without-signing-key-id.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+{
+  config = {
+    programs.git = {
+      enable = true;
+      userName = "John Doe";
+      userEmail = "user@example.org";
+
+      signing = {
+        gpgPath = "path-to-gpg";
+        signByDefault = true;
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/git/config
+      assertFileContent home-files/.config/git/config ${
+        ./git-without-signing-key-id-expected.conf
+      }
+    '';
+  };
+}

--- a/tests/modules/programs/git/git-without-signing-key-id.nix
+++ b/tests/modules/programs/git/git-without-signing-key-id.nix
@@ -1,5 +1,4 @@
-{ pkgs, ... }:
-{
+{ pkgs, ... }: {
   config = {
     programs.git = {
       enable = true;


### PR DESCRIPTION

### Description

Thus by default the signing key is selected by commit’s author.

Imagine you have 2 PGP keys with these UIDs:

1. `John Smith <john.smith@foo.bar>`
2. `John Smith <john.smith@at.work>`

By default you set Git `user.name` as `John Smith` and `user.email` as `john.smith@foo.bar` (e.g. via Home Manager). But in some repo you do `git config user.email 'john.smith@at.work'`. If you provide a signing key in `home-manager.users.USERNAME.programs.git.signing.key` (which is currently a required field, before this MR) your commits will be signed with that key in all the repos by default. Even in that one where you changed `user.email`, you would have to pay attention to not forget to change the signing key explicitly in that repo too along with the email. But with this change if you don’t set that field (`null` is used by default) the proper signing key will be chosen automatically by Git commit author’s email.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~~If this PR adds a new module~~ *[it does not]*

  - [ ] ~~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~~

  - [ ] ~~Added myself and the module files to `.github/CODEOWNERS`.~~
