### PR TITLE
home-manager: allow overriding pkgs with --arg(str)

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -421,6 +421,7 @@ function doHelp() {
     echo
     echo "Options passed on to nix-build(1)"
     echo
+    echo "  --arg(str) NAME VALUE    Override inputs passed to home-manager.nix"
     echo "  --cores NUM"
     echo "  --keep-failed"
     echo "  --keep-going"
@@ -497,7 +498,7 @@ while [[ $# -gt 0 ]]; do
         -n|--dry-run)
             export DRY_RUN=1
             ;;
-        --option)
+        --option|--arg|--argstr)
             PASSTHROUGH_OPTS+=("$opt" "$1" "$2")
             shift 2
             ;;


### PR DESCRIPTION
### Description

This is required to use nixpkgs provided by niv instead of the nixpkgs channel.

Tested with ``home-manager build --arg pkgs "import (import $HOME/.config/nixpkgs/nix/sources.nix {}).nixpkgs {}"``.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
