### PR TITLE
dircolors: apply extraConfig after settings

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1880,6 +1880,13 @@ in
           https://no-color.org/.
         '';
       }
+      {
+        time = "2021-03-29T21:05:50+00:00";
+        message = ''
+          Configuration specified by 'programs.dircolors.extraConfig' is now
+          applied after 'programs.dircolors.settings'.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -204,8 +204,8 @@ in {
     };
 
     home.file.".dir_colors".text = concatStringsSep "\n" ([ ]
-      ++ optional (cfg.extraConfig != "") cfg.extraConfig
-      ++ mapAttrsToList formatLine cfg.settings) + "\n";
+      ++ mapAttrsToList formatLine cfg.settings ++ [ "" ]
+      ++ optional (cfg.extraConfig != "") cfg.extraConfig);
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       eval $(${pkgs.coreutils}/bin/dircolors -b ~/.dir_colors)

--- a/tests/modules/programs/dircolors/settings-expected.conf
+++ b/tests/modules/programs/dircolors/settings-expected.conf
@@ -1,5 +1,3 @@
-# Extra dircolors configuration.
-
 .7z 01;31
 .aac 00;36
 .ace 01;31
@@ -131,3 +129,5 @@ SETUID 37;41
 SOCK 01;35
 STICKY 37;44
 STICKY_OTHER_WRITABLE 30;42
+
+# Extra dircolors configuration.


### PR DESCRIPTION
### Description

This patch changes the `dircolors` module so that `dircolors.extraConfig` is applied after `dircolors.settings`. This allows `extraConfig` to override the default settings.

Previously if a colour was set in both `settings` and `extraConfig`, `settings` would take precedence. The reverse is now the case and so this is a **breaking change**. Consequently, I have added a news entry. The impact should be fairly minor: I don't see how this could break an existing config, just slightly modify the behaviour for a config that was arguably ill-formed in the first place. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

I have not run all test cases, but I have updated the `dircolors-settings` test case to make sure it passes.
