### PR TITLE
xmonad: use compiled configuration when config is not null

### DIFF
--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -132,12 +132,12 @@ in {
       }/bin/xmonad-${pkgs.hostPlatform.system}";
 
   in mkIf cfg.enable (mkMerge [
-    {
-      home.packages = [ (lowPrio xmonad) ];
-      xsession.windowManager.command = xmonadBin;
-    }
-
+    { home.packages = [ (lowPrio xmonad) ]; }
+    (mkIf (cfg.config == null) {
+      xsession.windowManager.command = "${xmonad}/bin/xmonad";
+    })
     (mkIf (cfg.config != null) {
+      xsession.windowManager.command = xmonadBin;
       home.file.".xmonad/xmonad.hs".source = cfg.config;
       home.file.".xmonad/xmonad-${pkgs.hostPlatform.system}" = {
         source = xmonadBin;


### PR DESCRIPTION
### Description

Fixes #1891 

If the configuration is `null`, the compiled configuration`xmonadBin` should not be used and instead the WM startup command should be set to the bare `xmonad` binary.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
