### PR TITLE
programs.neomutt: Make manual configuration have higher precedence than generated settings

### DIFF
--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -312,16 +312,16 @@ in {
         ${optionalString cfg.vimKeys
         "source ${pkgs.neomutt}/share/doc/neomutt/vim-keys/vim-keys.rc"}
 
-        # Extra configuration
-        ${optionsStr cfg.settings}
-
-        ${cfg.extraConfig}
-
         # Register accounts
         ${concatMapStringsSep "\n" registerAccount neomuttAccounts}
 
         # Source primary account
         source ${accountFilename primary}
+
+        # Extra configuration
+        ${optionsStr cfg.settings}
+
+        ${cfg.extraConfig}
       '';
     };
 

--- a/tests/modules/programs/neomutt/neomutt-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-expected.conf
@@ -16,11 +16,6 @@ set delete = yes
 
 
 
-# Extra configuration
-
-
-
-
 # Register accounts
 # register account hm@example.com
 mailboxes "/home/hm-user/Mail/hm@example.com/Inbox"
@@ -30,3 +25,8 @@ folder-hook /home/hm-user/Mail/hm@example.com/ " \
 
 # Source primary account
 source /home/hm-user/.config/neomutt/hm@example.com
+
+# Extra configuration
+
+
+

--- a/tests/modules/programs/neomutt/neomutt-not-primary-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-not-primary-expected.conf
@@ -16,11 +16,6 @@ set delete = yes
 
 
 
-# Extra configuration
-
-
-
-
 # Register accounts
 # register account hm-account
 mailboxes "/home/hm-user/Mail/hm-account/Inbox"
@@ -30,3 +25,8 @@ folder-hook /home/hm-user/Mail/hm-account/ " \
 
 # Source primary account
 source /home/hm-user/.config/neomutt/hm-account
+
+# Extra configuration
+
+
+

--- a/tests/modules/programs/neomutt/neomutt-with-binds-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-with-binds-expected.conf
@@ -18,11 +18,6 @@ macro index,pager c "<change-folder>?<change-dir><home>^K=<enter><tab>"
 
 
 
-# Extra configuration
-
-
-
-
 # Register accounts
 # register account hm@example.com
 mailboxes "/home/hm-user/Mail/hm@example.com/Inbox"
@@ -32,3 +27,8 @@ folder-hook /home/hm-user/Mail/hm@example.com/ " \
 
 # Source primary account
 source /home/hm-user/.config/neomutt/hm@example.com
+
+# Extra configuration
+
+
+


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
I need to set `$folder` manually because I'd like to use multiple accounts with neomutt. `home-manager` just sets `$folder` to the location of the primary account, which makes sense if you only want to use one account, but messes up the way mailboxes are displayed if you use multiple accounts. This PR makes it possible to override settings already configured by home-manager, such as `$folder`.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
