### PR TITLE
gpg-agent: Use $TTY instead of $(tty)

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -7,7 +7,7 @@ let
   cfg = config.services.gpg-agent;
 
   gpgInitStr = ''
-    GPG_TTY="$(tty)"
+    GPG_TTY="$TTY"
     export GPG_TTY
   ''
   + optionalString cfg.enableSshSupport


### PR DESCRIPTION
### Description

tty command may return `not a tty` when stdin is redirected(often occured when using powerlevel10k theme)

https://unix.stackexchange.com/a/608921

so I think there is no reason to use `tty`

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
