### PR TITLE
flake.nix: Add packages and defaultPackage outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,26 +1,43 @@
 {
   description = "Home Manager for Nix";
 
-  outputs = { self, nixpkgs }: rec {
-    nixosModules.home-manager = import ./nixos;
-    nixosModule = self.nixosModules.home-manager;
+  outputs = { self, nixpkgs }:
+    let
+      # List of systems supported by home-manager binary
+      supportedSystems = nixpkgs.lib.platforms.unix;
 
-    darwinModules.home-manager = import ./nix-darwin;
-    darwinModule = self.darwinModules.home-manager;
+      # Function to generate a set based on supported systems
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs supportedSystems (system: f system);
 
-    lib = {
-      hm = import ./modules/lib { lib = nixpkgs.lib; };
-      homeManagerConfiguration = { configuration, system, homeDirectory
-        , username, extraSpecialArgs ? { }
-        , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
-        , check ? true }@args:
-        import ./modules {
-          inherit pkgs check extraSpecialArgs;
-          configuration = { ... }: {
-            imports = [ configuration ];
-            home = { inherit homeDirectory username; };
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in rec {
+      nixosModules.home-manager = import ./nixos;
+      nixosModule = self.nixosModules.home-manager;
+
+      darwinModules.home-manager = import ./nix-darwin;
+      darwinModule = self.darwinModules.home-manager;
+
+      packages = forAllSystems (system: {
+        home-manager = nixpkgsFor.${system}.callPackage ./home-manager { };
+      });
+
+      defaultPackage =
+        forAllSystems (system: self.packages.${system}.home-manager);
+
+      lib = {
+        hm = import ./modules/lib { lib = nixpkgs.lib; };
+        homeManagerConfiguration = { configuration, system, homeDirectory
+          , username, extraSpecialArgs ? { }
+          , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
+          , check ? true }@args:
+          import ./modules {
+            inherit pkgs check extraSpecialArgs;
+            configuration = { ... }: {
+              imports = [ configuration ];
+              home = { inherit homeDirectory username; };
+            };
           };
-        };
+      };
     };
-  };
 }


### PR DESCRIPTION
### Description

Modify flake.nix to provide the the `home-manager` binary for each supported platform as mentioned in https://github.com/nix-community/home-manager/pull/1856#issuecomment-815077415. "Supported platforms" is equivalent to the set provided in `meta.platforms` in the home-manager derivation, `lib.platforms.unix`.

**One problem**: `nix run github:nix-community/home-manager/pull/1913/head` does not run because nix wants to write a lock file. Passing `--no-write-lock-file` fixes this, but this must be passed on each invocation of `nix run`. To fix this, we could start to track `flake.lock` (and I think this will be necessary if we want to provide a package output), but I'm hesitant to do so mostly because it would have to be updated every so often. Probably worth discussing before merging this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
