### PR TITLE
msmtp: add extraAccounts option

### DIFF
--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -37,6 +37,8 @@ let
     ${cfg.extraConfig}
 
     ${concatStringsSep "\n\n" (map accountStr mailAccounts)}
+
+    ${cfg.extraAccounts}
   '';
 
 in {
@@ -50,6 +52,15 @@ in {
         default = "";
         description = ''
           Extra configuration lines to add to <filename>~/.msmtprc</filename>.
+          See <link xlink:href="https://marlam.de/msmtp/msmtprc.txt"/> for examples.
+        '';
+      };
+
+      extraAccounts = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Extra configuration lines to add to the end of <filename>~/.msmtprc</filename>.
           See <link xlink:href="https://marlam.de/msmtp/msmtprc.txt"/> for examples.
         '';
       };


### PR DESCRIPTION
It is appended to the end of msmtprc instead of top like extraConfig.

### Description

<!--

Please provide a brief description of your change.

-->
Fix: #1707 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
