### PR TITLE
exa: Add exa module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,6 +57,8 @@
 
 /modules/programs/emacs.nix                           @rycee
 
+/modules/programs/exa.nix                             @kalhauge
+
 /modules/programs/firefox.nix                         @rycee
 
 /modules/programs/gh.nix                              @Gerschtli

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -31,6 +31,12 @@
     github = "olmokramer";
     githubId = 3612514;
   };
+  kalhauge = {
+    name = "Christian Gram Kalhauge";
+    email = "kalhauge@users.noreply.github.com";
+    github = "kalhauge";
+    githubId = 1182166;
+  };
   kubukoz = {
     name = "Jakub Kozłowski";
     email = "kubukoz@users.noreply.github.com";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1863,6 +1863,7 @@ in
           lists to polybar-style 'foo-0, foo-1, ...' lists.
         '';
       }
+
       {
         time = "2021-02-25T22:36:43+00:00";
         condition = config.programs.git.enable && any (msmtp: msmtp.enable)
@@ -1873,6 +1874,7 @@ in
           'accounts.email.accounts.<name>.msmtp.enable' is true.
         '';
       }
+
       {
         time = "2021-03-03T22:16:05+00:00";
         message = ''
@@ -1880,11 +1882,19 @@ in
           https://no-color.org/.
         '';
       }
+
       {
         time = "2021-03-29T21:05:50+00:00";
         message = ''
           Configuration specified by 'programs.dircolors.extraConfig' is now
           applied after 'programs.dircolors.settings'.
+        '';
+      }
+
+      {
+        time = "2021-04-11T20:44:54+00:00";
+        message = ''
+          A new module is available: 'programs.exa'.
         '';
       }
     ];

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -63,6 +63,7 @@ let
     (loadModule ./programs/direnv.nix { })
     (loadModule ./programs/eclipse.nix { })
     (loadModule ./programs/emacs.nix { })
+    (loadModule ./programs/exa.nix { })
     (loadModule ./programs/feh.nix { })
     (loadModule ./programs/firefox.nix { })
     (loadModule ./programs/fish.nix { })

--- a/modules/programs/exa.nix
+++ b/modules/programs/exa.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.exa;
+
+  aliases = {
+    ls = "${pkgs.exa}/bin/exa";
+    ll = "${pkgs.exa}/bin/exa -l";
+    la = "${pkgs.exa}/bin/exa -a";
+    lt = "${pkgs.exa}/bin/exa --tree";
+    lla = "${pkgs.exa}/bin/exa -la";
+  };
+
+in {
+  meta.maintainers = [ maintainers.kalhauge ];
+
+  options.programs.exa = {
+    enable =
+      mkEnableOption "exa, a modern replacement for <command>ls</command>";
+    enableAliases = mkEnableOption "recommended exa aliases";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.exa ];
+
+    programs.bash.shellAliases = mkIf cfg.enableAliases aliases;
+
+    programs.zsh.shellAliases = mkIf cfg.enableAliases aliases;
+
+    programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
+
+  };
+}


### PR DESCRIPTION
### Description

Add the exa program as a module: 

Exa is a ls replacement, which have a saner colors cheme than lsd on white backgrounds.
https://github.com/ogham/exa

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

No tests needed, very simple configurations alike 'lsd'.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
