### PR TITLE
termite: add option to enable VTE integration

### DIFF
--- a/modules/programs/termite.nix
+++ b/modules/programs/termite.nix
@@ -6,13 +6,6 @@ let
 
   cfg = config.programs.termite;
 
-  vteInitStr = ''
-    # See https://github.com/thestinger/termite#id1
-    if [[ $TERM == xterm-termite ]]; then
-      . ${pkgs.termite.vte-ng}/etc/profile.d/vte.sh
-    fi
-  '';
-
 in {
   options = {
     programs.termite = {
@@ -48,6 +41,10 @@ in {
           Settings dynamic title allows the terminal and the shell to
           update the terminal's title.
         '';
+      };
+
+      enableVteIntegration = mkEnableOption "Shell VTE integration" // {
+        default = true;
       };
 
       fullscreen = mkOption {
@@ -381,7 +378,7 @@ in {
       ${cfg.hintsExtra}
     '';
 
-    programs.bash.initExtra = vteInitStr;
-    programs.zsh.initExtra = vteInitStr;
+    programs.bash.enableVteIntegration = lib.mkDefault cfg.enableVteIntegration;
+    programs.zsh.enableVteIntegration = lib.mkDefault cfg.enableVteIntegration;
   });
 }


### PR DESCRIPTION
### Description

Instead of having an unconditional and undocumented addition to both `bash` and `zsh` to source the VTE integration, declare an option and make it use the VTE module directly. This allows bug fixes regarding VTE integration to be done at a single module.

I wasn't sure if `mkDefault` is needed for those options, so I omitted them for now.

Closes #1909.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`: I could not run them because `types.anything` does not exist.

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
