### PR TITLE
sway: add seat config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -236,7 +236,7 @@
 
 /modules/services/unison.nix                          @pacien
 
-/modules/services/window-managers/i3-sway/sway.nix    @alexarice
+/modules/services/window-managers/i3-sway/sway.nix    @alexarice @sumnerevans
 
 /modules/services/wlsunset.nix                        @matrss
 /tests/modules/services/wlsunset                      @matrss

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -322,7 +322,7 @@ let
   };
 
 in {
-  meta.maintainers = [ maintainers.alexarice ];
+  meta.maintainers = with maintainers; [ alexarice sumnerevans ];
 
   options.wayland.windowManager.sway = {
     enable = mkEnableOption "sway wayland compositor";

--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -4,4 +4,5 @@
   sway-followmouse = ./sway-followmouse.nix;
   sway-followmouse-legacy = ./sway-followmouse-legacy.nix;
   sway-null-package = ./sway-null-package.nix;
+  sway-modules = ./sway-modules.nix;
 }

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -69,8 +69,6 @@ bindsym Mod1+space focus mode_toggle
 bindsym Mod1+v splitv
 bindsym Mod1+w layout tabbed
 
-
-
 mode "resize" {
 bindsym Down resize grow height 10 px
 bindsym Escape mode default
@@ -83,7 +81,6 @@ bindsym j resize grow height 10 px
 bindsym k resize shrink height 10 px
 bindsym l resize grow width 10 px
 }
-
 
 bar {
   
@@ -108,10 +105,6 @@ bar {
   }
   
 }
-
-
-
-
 
 
 exec "systemctl --user import-environment; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
@@ -69,8 +69,6 @@ bindsym Mod1+space focus mode_toggle
 bindsym Mod1+v splitv
 bindsym Mod1+w layout tabbed
 
-
-
 mode "resize" {
 bindsym Down resize grow height 10 px
 bindsym Escape mode default
@@ -83,12 +81,6 @@ bindsym j resize grow height 10 px
 bindsym k resize shrink height 10 px
 bindsym l resize grow width 10 px
 }
-
-
-
-
-
-
 
 
 exec "systemctl --user import-environment; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
@@ -69,8 +69,6 @@ bindsym Mod1+space focus mode_toggle
 bindsym Mod1+v splitv
 bindsym Mod1+w layout tabbed
 
-
-
 mode "resize" {
 bindsym Down resize grow height 10 px
 bindsym Escape mode default
@@ -83,12 +81,6 @@ bindsym j resize grow height 10 px
 bindsym k resize shrink height 10 px
 bindsym l resize grow width 10 px
 }
-
-
-
-
-
-
 
 
 exec "systemctl --user import-environment; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-modules.conf
+++ b/tests/modules/services/window-managers/sway/sway-modules.conf
@@ -69,6 +69,18 @@ bindsym Mod1+space focus mode_toggle
 bindsym Mod1+v splitv
 bindsym Mod1+w layout tabbed
 
+input "*" {
+xkb_variant dvorak
+}
+
+output "HDMI-A-2" {
+bg ~/path/to/background.png fill
+}
+
+seat "*" {
+hide_cursor when-typing enable
+}
+
 mode "resize" {
 bindsym Down resize grow height 10 px
 bindsym Escape mode default
@@ -89,7 +101,7 @@ bar {
   hidden_state hide
   position bottom
   status_command @i3status@/bin/i3status
-  swaybar_command @sway@/bin/swaybar
+  swaybar_command @sway/bin/swaybar
   workspace_buttons yes
   strip_workspace_numbers no
   tray_output primary

--- a/tests/modules/services/window-managers/sway/sway-modules.nix
+++ b/tests/modules/services/window-managers/sway/sway-modules.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  dummy-package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out";
+
+in {
+  config = {
+    wayland.windowManager.sway = {
+      enable = true;
+      package = dummy-package // { outPath = "@sway"; };
+      # overriding findutils causes issues
+      config = {
+        menu = "${pkgs.dmenu}/bin/dmenu_run";
+
+        input = { "*" = { xkb_variant = "dvorak"; }; };
+        output = { "HDMI-A-2" = { bg = "~/path/to/background.png fill"; }; };
+        seat = { "*" = { hide_cursor = "when-typing enable"; }; };
+      };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        dmenu = dummy-package // { outPath = "@dmenu@"; };
+        rxvt-unicode-unwrapped = dummy-package // {
+          outPath = "@rxvt-unicode-unwrapped@";
+        };
+        i3status = dummy-package // { outPath = "@i3status@"; };
+        sway = dummy-package // { outPath = "@sway@"; };
+        xwayland = dummy-package // { outPath = "@xwayland@"; };
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/sway/config
+      assertFileContent home-files/.config/sway/config \
+        ${./sway-modules.conf}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Supersedes and Closes #1663

* Added seat configuration to sway config. Also improved the way that the configuration is generated to reduce superfluous whitespace.

* I also added myself as a maintainer of the sway module. Please let me know if I'm not allowed to do this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module (this is not a new module, but I added myself anyway)

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
