### PR TITLE
newsboat: use $XDG_CONFIG_HOME/newsboat

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,6 +104,9 @@
 /modules/programs/ne.nix                              @cwyc
 /tests/modules/programs/ne                            @cwyc
 
+/modules/programs/newsboat.nix                        @sumnerevans
+/tests/modules/programs/newsboat                      @sumnerevans
+
 /modules/programs/noti.nix                            @marsam
 
 /modules/programs/nushell.nix                         @Philipp-M

--- a/doc/release-notes/rl-2105.adoc
+++ b/doc/release-notes/rl-2105.adoc
@@ -179,4 +179,5 @@ The state version in this release includes the changes below. These
 changes are only active if the `home.stateVersion` option is set to
 "21.05" or later.
 
-* Nothing has happened.
+* The `newsboat` module now stores generated configuration in
+  `$XDG_CONFIG_HOME/newsboat`.

--- a/modules/programs/newsboat.nix
+++ b/modules/programs/newsboat.nix
@@ -33,6 +33,8 @@ let
   '';
 
 in {
+  meta.maintainers = [ maintainers.sumnerevans ];
+
   options = {
     programs.newsboat = {
       enable = mkEnableOption "the Newsboat feed reader";

--- a/tests/modules/programs/newsboat/default.nix
+++ b/tests/modules/programs/newsboat/default.nix
@@ -1,4 +1,5 @@
 {
   newsboat-basics = ./newsboat-basics.nix;
   newsboat-basics-2003 = ./newsboat-basics-2003.nix;
+  newsboat-basics-2105 = ./newsboat-basics-2105.nix;
 }

--- a/tests/modules/programs/newsboat/newsboat-basics-2105.nix
+++ b/tests/modules/programs/newsboat/newsboat-basics-2105.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.stateVersion = "21.05";
+
+    programs.newsboat = {
+      enable = true;
+
+      urls = [
+        {
+          url = "http://example.org/feed.xml";
+          tags = [ "tag1" "tag2" ];
+          title = "Cool feed";
+        }
+
+        { url = "http://example.org/feed2.xml"; }
+      ];
+
+      queries = { "foo" = ''rssurl =~ "example.com"''; };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: { newsboat = pkgs.writeScriptBin "dummy-newsboat" ""; })
+    ];
+
+    # The format didn't change since 20.03, just the location.
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/newsboat/urls \
+        ${./newsboat-basics-urls-2003.txt}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

As of Newsboat 2.19, configuration using XDG_CONFIG_HOME/newsboat is supported: https://newsboat.org/releases/2.19/docs/newsboat.html#_xdg_base_directory_support

This is a continuation of #1331 and includes gating logic so that the change doesn't happen until state version 21.05.

Supersedes and Closes #1331

I also added myself as maintainer, please let me know if I should not do this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module (not a new module, but there is no maintainer currently for this module)

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
