### PR TITLE
gtk: use font.size option in dconf

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -138,8 +138,12 @@ in {
         gtk-icon-theme-name = cfg.iconTheme.name;
       };
 
-    dconfIni = optionalAttrs (cfg.font != null) { font-name = cfg.font.name; }
-      // optionalAttrs (cfg.theme != null) { gtk-theme = cfg.theme.name; }
+    dconfIni = optionalAttrs (cfg.font != null) {
+      font-name = let
+        fontSize =
+          optionalString (cfg.font.size != null) " ${toString cfg.font.size}";
+      in "${cfg.font.name}" + fontSize;
+    } // optionalAttrs (cfg.theme != null) { gtk-theme = cfg.theme.name; }
       // optionalAttrs (cfg.iconTheme != null) {
         icon-theme = cfg.iconTheme.name;
       };


### PR DESCRIPTION
### Description
After #1848, if specified, home-manager will use `gtk.font.size` when writing `.config/gtk-3.0/settings.ini,` but won't when writing Dconf settings.

Simply apply the same change made to the ini attribute.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
