### PR TITLE
xmonad: remove xmonad config files from home

### DIFF
--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -73,6 +73,10 @@ in {
           an absolute path or <literal>null</literal> in which case
           <filename>~/.xmonad/xmonad.hs</filename> will not be managed
           by Home Manager.
+
+          If this option is set to a non-<literal>null</literal> value,
+          recompilation of xmonad outside of home-manager (e.g. via
+          <command>xmonad --recompile</command>) will fail.
         '';
       };
 
@@ -138,7 +142,6 @@ in {
     })
     (mkIf (cfg.config != null) {
       xsession.windowManager.command = xmonadBin;
-      home.file.".xmonad/xmonad.hs".source = cfg.config;
       home.file.".xmonad/xmonad-${pkgs.hostPlatform.system}" = {
         source = xmonadBin;
         onChange = ''
@@ -150,11 +153,5 @@ in {
         '';
       };
     })
-
-    {
-      home.file = mapAttrs' (name: value:
-        attrsets.nameValuePair (".xmonad/lib/" + name) { source = value; })
-        cfg.libFiles;
-    }
   ]);
 }


### PR DESCRIPTION
If these files are present, xmonad recompilation (triggered e.g. via
`xmonad --recompile`) will overwrite the executable generated by
home-manager, which will make `home-manager switch` fail when it is
invoked the next time.

If these files are missing, recompilation will fail, which is not nice,
but at least won't mess up the configuration.

Mitigates #1895

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
