### PR TITLE
topgrade: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -150,6 +150,9 @@
 
 /modules/programs/texlive.nix                         @rycee
 
+/modules/programs/topgrade.nix                        @msfjarvis
+/tests/modules/programs/topgrade                      @msfjarvis
+
 /modules/programs/waybar.nix                          @berbiche
 /tests/modules/programs/waybar                        @berbiche
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -71,4 +71,14 @@
     githubId = 46252070;
     name = "Sara Johnsson";
   };
+  msfjarvis = {
+    email = "me@msfjarvis.dev";
+    github = "msfjarvis";
+    githubId = "13348378";
+    name = "Harsh Shandilya";
+    keys = [{
+      longkeyid = "rsa4096/0xB7843F823355E9B9";
+      fingerprint = "8F87 050B 0F9C B841 1515  7399 B784 3F82 3355 E9B9";
+    }];
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1914,6 +1914,12 @@ in
         '';
       }
 
+      {
+        time = "2021-04-28T06:03:52+00:00";
+        message = ''
+          A new module is available: 'programs.topgrade'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -127,6 +127,7 @@ let
     (loadModule ./programs/termite.nix { })
     (loadModule ./programs/texlive.nix { })
     (loadModule ./programs/tmux.nix { })
+    (loadModule ./programs/topgrade.nix { })
     (loadModule ./programs/urxvt.nix { })
     (loadModule ./programs/vim.nix { })
     (loadModule ./programs/vscode.nix { })

--- a/modules/programs/topgrade.nix
+++ b/modules/programs/topgrade.nix
@@ -10,6 +10,8 @@ let
 
 in {
 
+  meta.maintainers = [ hm.maintainers.msfjarvis ];
+
   options.programs.topgrade = {
     enable = mkEnableOption "topgrade";
 

--- a/modules/programs/topgrade.nix
+++ b/modules/programs/topgrade.nix
@@ -1,0 +1,58 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.topgrade;
+
+  tomlFormat = pkgs.formats.toml { };
+
+in {
+
+  options.programs.topgrade = {
+    enable = mkEnableOption "topgrade";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.topgrade;
+      defaultText = literalExample "pkgs.topgrade";
+      description = "The package to use for the topgrade binary.";
+    };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      defaultText = literalExample "{ }";
+      example = literalExample ''
+        {
+          assume_yes = true;
+          disable = [
+            "flutter"
+            "node"
+          ];
+          set_title = false;
+          cleanup = true;
+          commands = {
+            "Run garbage collection on Nix store" = "nix-collect-garbage";
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>~/.config/topgrade.toml</filename>.
+        </para><para>
+        See <link xlink:href="https://github.com/r-darwish/topgrade/wiki/Step-list" /> for the full list
+        of options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."topgrade.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "topgrade-config" cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -76,6 +76,7 @@ import nmt {
     ./modules/programs/starship
     ./modules/programs/texlive
     ./modules/programs/tmux
+    ./modules/programs/topgrade
     ./modules/programs/vscode
     ./modules/programs/zplug
     ./modules/programs/zsh

--- a/tests/modules/programs/topgrade/default.nix
+++ b/tests/modules/programs/topgrade/default.nix
@@ -1,0 +1,1 @@
+{ topgrade-settings = ./settings.nix; }

--- a/tests/modules/programs/topgrade/settings-expected.toml
+++ b/tests/modules/programs/topgrade/settings-expected.toml
@@ -1,0 +1,8 @@
+cleanup = true
+disable = ["sdkman", "flutter", "node", "nix", "home_manager"]
+remote_topgrade_path = "bin/topgrade"
+remote_topgrades = ["backup", "ci"]
+set_title = false
+
+[commands]
+"Purge unused APT packages" = "sudo apt autoremove"

--- a/tests/modules/programs/topgrade/settings.nix
+++ b/tests/modules/programs/topgrade/settings.nix
@@ -1,0 +1,38 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.topgrade = {
+      enable = true;
+
+      settings = mkMerge [
+        {
+          disable = [ "sdkman" "flutter" "node" "nix" "home_manager" ];
+
+          remote_topgrades = [ "backup" "ci" ];
+
+          remote_topgrade_path = "bin/topgrade";
+        }
+
+        {
+          set_title = false;
+          cleanup = true;
+
+          commands = { "Purge unused APT packages" = "sudo apt autoremove"; };
+        }
+      ];
+    };
+
+    nixpkgs.overlays = [
+      (self: super: { topgrade = pkgs.writeScriptBin "dummy-topgrade" ""; })
+    ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/topgrade.toml \
+        ${./settings-expected.toml}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

[topgrade](https://github.com/r-darwish/topgrade) is a CLI tool written in Rust that can detect and upgrade packages across nearly all package managers that can be present on a device.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
