### PR TITLE
qutebrowser: fix config location on darwin

### DIFF
--- a/tests/modules/programs/qutebrowser/keybindings.nix
+++ b/tests/modules/programs/qutebrowser/keybindings.nix
@@ -24,9 +24,14 @@ with lib;
       })
     ];
 
-    nmt.script = ''
+    nmt.script = let
+      qutebrowserConfig = if pkgs.stdenv.hostPlatform.isDarwin then
+        ".qutebrowser/config.py"
+      else
+        ".config/qutebrowser/config.py";
+    in ''
       assertFileContent \
-        home-files/.config/qutebrowser/config.py \
+        home-files/${qutebrowserConfig} \
         ${
           pkgs.writeText "qutebrowser-expected-config.py" ''
             config.load_autoconfig(False)

--- a/tests/modules/programs/qutebrowser/settings.nix
+++ b/tests/modules/programs/qutebrowser/settings.nix
@@ -30,9 +30,14 @@ with lib;
       })
     ];
 
-    nmt.script = ''
+    nmt.script = let
+      qutebrowserConfig = if pkgs.stdenv.hostPlatform.isDarwin then
+        ".qutebrowser/config.py"
+      else
+        ".config/qutebrowser/config.py";
+    in ''
       assertFileContent \
-        home-files/.config/qutebrowser/config.py \
+        home-files/${qutebrowserConfig} \
         ${
           pkgs.writeText "qutebrowser-expected-config.py" ''
             config.load_autoconfig(False)


### PR DESCRIPTION
### Description
<!--

Please provide a brief description of your change.

-->
Fix #1897 
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
