### PR TITLE
fzf: option for tmux usage in shell integration

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -88,6 +88,23 @@ in {
       '';
     };
 
+    tmux = {
+      enableShellIntegration = mkEnableOption ''
+        setting <literal>FZF_TMUX=1</literal> which causes shell integration to use fzf-tmux
+      '';
+
+      shellIntegrationOptions = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = literalExample ''[ "-d 40%" ]'';
+        description = ''
+          If <option>programs.fzf.tmux.enableShellIntegration</option> is set to true,
+          shell integration will use these options for fzf-tmux.
+          See <command>fzf-tmux --help</command> for available options.
+        '';
+      };
+    };
+
     enableBashIntegration = mkOption {
       default = true;
       type = types.bool;
@@ -125,6 +142,8 @@ in {
         FZF_CTRL_T_OPTS = cfg.fileWidgetOptions;
         FZF_DEFAULT_COMMAND = cfg.defaultCommand;
         FZF_DEFAULT_OPTS = cfg.defaultOptions;
+        FZF_TMUX = if cfg.tmux.enableShellIntegration then "1" else null;
+        FZF_TMUX_OPTS = cfg.tmux.shellIntegrationOptions;
       });
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -98,7 +98,7 @@ in {
         default = [ ];
         example = literalExample ''[ "-d 40%" ]'';
         description = ''
-          If <option>programs.fzf.tmux.enableShellIntegration</option> is set to true,
+          If <option>programs.fzf.tmux.enableShellIntegration</option> is set to <literal>true</literal>,
           shell integration will use these options for fzf-tmux.
           See <command>fzf-tmux --help</command> for available options.
         '';


### PR DESCRIPTION
### Description

Added options for tmux which will be read by fzf shell integrations.
The env variables are not read by the fzf binary, they only change behaviour of fzf shell integrations.
(Like FZF_CTRL_*_* and FZF_ALT_*_* env variables.)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
(there arent any test cases for fzf)

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
