### PR TITLE
Fix --flake URI parsing when URI contains dots

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -93,7 +93,7 @@ function setFlakeAttribute() {
                 fi
             ;;
         esac
-        export FLAKE_CONFIG_URI="$flake#homeConfigurations.\"$name\""
+        export FLAKE_CONFIG_URI="$flake#homeConfigurations.$name"
     fi
 }
 
@@ -212,7 +212,7 @@ function doBuild() {
         nix build \
             "${PASSTHROUGH_OPTS[@]}" \
              ${DRY_RUN+--dry-run} \
-            "$FLAKE_CONFIG_URI.activationPackage" \
+            "'$FLAKE_CONFIG_URI.activationPackage'" \
             || exitCode=1
         return $exitCode
     fi

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -82,12 +82,13 @@ function setFlakeAttribute() {
 
     if [[ -n "$FLAKE_ARG" ]]; then
         local flake="${FLAKE_ARG%#*}"
+        local name
         case $FLAKE_ARG in
             *#*)
-                local name="${FLAKE_ARG#*#}"
+                name="${FLAKE_ARG#*#}"
             ;;
             *)
-                local name="$USER@$(hostname)"
+                name="$USER@$(hostname)"
                 if [ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$name\"")" = "false" ]; then
                     name="$USER"
                 fi
@@ -298,7 +299,7 @@ function doRmGenerations() {
             errorEcho "Cannot remove the current generation $generationId"
         else
             echo Removing generation $generationId
-            $DRY_RUN_CMD rm $VERBOSE_ARG $linkName
+            $DRY_RUN_CMD rm "$VERBOSE_ARG" "$linkName"
         fi
     done
 
@@ -306,7 +307,7 @@ function doRmGenerations() {
 }
 
 function doRmAllGenerations() {
-    $DRY_RUN_CMD rm $VERBOSE_ARG \
+    $DRY_RUN_CMD rm "$VERBOSE_ARG" \
         "$NIX_STATE_DIR/profiles/per-user/$USER/home-manager"*
 }
 
@@ -423,9 +424,9 @@ function doUninstall() {
             doSwitch
             $DRY_RUN_CMD nix-env -e home-manager-path || true
             rm "$HOME_MANAGER_CONFIG"
-            $DRY_RUN_CMD rm $VERBOSE_ARG -r \
+            $DRY_RUN_CMD rm "$VERBOSE_ARG" -r \
                 "${XDG_DATA_HOME:-$HOME/.local/share}/home-manager"
-            $DRY_RUN_CMD rm $VERBOSE_ARG \
+            $DRY_RUN_CMD rm "$VERBOSE_ARG" \
                 "$NIX_STATE_DIR/gcroots/per-user/$USER/current-home"
             ;;
         *)
@@ -648,3 +649,4 @@ case $COMMAND in
         exit 1
         ;;
 esac
+


### PR DESCRIPTION
### Description
Currently `home-manager --flake .#x86_64-linux.linux-desktop switch` fails due to:
```
error: cannot find flake attribute 'path:/path/to/flake#homeConfigurations."x86_64-linux.linux-desktop".activationPackage'
```
Because "x86_64-linux.linux-desktop" is treated as the name of the attribute, dots included. This PR fixes that.

I also ran the script through ShellCheck and blindly incorporated the suggestions.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

Technically no if someone really did have an attribute with dots in it. They would have to add additional quotes.

- [ ] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
