### PR TITLE
tmux: use xdg config path

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -109,7 +109,7 @@ let
         }
     )];
 
-    home.file.".tmux.conf".text = ''
+    xdg.configFile."tmux/tmux.conf".text = ''
       # ============================================= #
       # Load plugins with Home Manager                #
       # --------------------------------------------- #
@@ -335,10 +335,9 @@ in
         };
       })
 
-      # config file ~/.tmux.conf
-      { home.file.".tmux.conf".text = mkBefore tmuxConf; }
+      { xdg.configFile."tmux/tmux.conf".text = mkBefore tmuxConf; }
       (mkIf (cfg.plugins != []) configPlugins)
-      { home.file.".tmux.conf".text = mkAfter cfg.extraConfig; }
+      { xdg.configFile."tmux/tmux.conf".text = mkAfter cfg.extraConfig; }
     ])
   );
 }

--- a/tests/modules/programs/tmux/default-shell.nix
+++ b/tests/modules/programs/tmux/default-shell.nix
@@ -19,8 +19,8 @@ in {
     };
 
     nmt.script = ''
-      assertFileExists home-files/.tmux.conf
-      assertFileContent home-files/.tmux.conf \
+      assertFileExists home-files/.config/tmux/tmux.conf
+      assertFileContent home-files/.config/tmux/tmux.conf \
         ${substituteExpected ./default-shell.conf}
     '';
   };

--- a/tests/modules/programs/tmux/disable-confirmation-prompt.nix
+++ b/tests/modules/programs/tmux/disable-confirmation-prompt.nix
@@ -18,8 +18,8 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.tmux.conf
-      assertFileContent home-files/.tmux.conf \
+      assertFileExists home-files/.config/tmux/tmux.conf
+      assertFileContent home-files/.config/tmux/tmux.conf \
         ${./disable-confirmation-prompt.conf}
     '';
   };

--- a/tests/modules/programs/tmux/emacs-with-plugins.nix
+++ b/tests/modules/programs/tmux/emacs-with-plugins.nix
@@ -42,8 +42,10 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.tmux.conf
-      assertFileContent home-files/.tmux.conf ${./emacs-with-plugins.conf}
+      assertFileExists home-files/.config/tmux/tmux.conf
+      assertFileContent home-files/.config/tmux/tmux.conf ${
+        ./emacs-with-plugins.conf
+      }
     '';
   };
 }

--- a/tests/modules/programs/tmux/not-enabled.nix
+++ b/tests/modules/programs/tmux/not-enabled.nix
@@ -7,7 +7,7 @@ with lib;
     programs.tmux = { enable = false; };
 
     nmt.script = ''
-      assertPathNotExists home-files/.tmux.conf
+      assertPathNotExists home-files/.config/tmux/tmux.conf
     '';
   };
 }

--- a/tests/modules/programs/tmux/prefix.nix
+++ b/tests/modules/programs/tmux/prefix.nix
@@ -18,8 +18,8 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.tmux.conf
-      assertFileContent home-files/.tmux.conf \
+      assertFileExists home-files/.config/tmux/tmux.conf
+      assertFileContent home-files/.config/tmux/tmux.conf \
         ${./prefix.conf}
     '';
   };

--- a/tests/modules/programs/tmux/shortcut-without-prefix.nix
+++ b/tests/modules/programs/tmux/shortcut-without-prefix.nix
@@ -19,8 +19,8 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.tmux.conf
-      assertFileContent home-files/.tmux.conf \
+      assertFileExists home-files/.config/tmux/tmux.conf
+      assertFileContent home-files/.config/tmux/tmux.conf \
         ${./shortcut-without-prefix.conf}
     '';
   };

--- a/tests/modules/programs/tmux/vi-all-true.nix
+++ b/tests/modules/programs/tmux/vi-all-true.nix
@@ -22,8 +22,8 @@ with lib;
     ];
 
     nmt.script = ''
-      assertFileExists home-files/.tmux.conf
-      assertFileContent home-files/.tmux.conf ${./vi-all-true.conf}
+      assertFileExists home-files/.config/tmux/tmux.conf
+      assertFileContent home-files/.config/tmux/tmux.conf ${./vi-all-true.conf}
     '';
   };
 }


### PR DESCRIPTION
### Description

[Tmux 3.2](https://github.com/tmux/tmux/raw/3.2/CHANGES) includes support to use `$XDG_CONFIG_HOME/tmux/tmux.conf` as
well as `~/.config/tmux/tmux.conf` for configuration file.

Fixes https://github.com/nix-community/home-manager/issues/1558
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
