### PR TITLE
lazygit: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,6 +78,8 @@
 
 /modules/programs/keychain.nix                        @marsam
 
+/modules/programs/lazygit.nix                         @kalhauge
+
 /modules/programs/lesspipe.nix                        @rycee
 
 /modules/programs/lf.nix                              @owm111

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -116,6 +116,9 @@ in
     #
     #     date --iso-8601=second --universal
     #
+    # On darwin (or BSD like systems) use
+    #
+    #     date -u +'%Y-%m-%dT%H:%M:%S+00:00'
     news.entries = [
       {
         time = "2017-09-01T10:56:28+00:00";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1936,6 +1936,13 @@ in
           A new service is available: 'services.barrier'.
         '';
       }
+
+      {
+        time = "2021-05-01T15:16:08+00:00";
+        message = ''
+          A new module is available: 'programs.lazygit'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -85,6 +85,7 @@ let
     (loadModule ./programs/kakoune.nix { })
     (loadModule ./programs/keychain.nix { })
     (loadModule ./programs/kitty.nix { })
+    (loadModule ./programs/lazygit.nix { })
     (loadModule ./programs/lesspipe.nix { })
     (loadModule ./programs/lf.nix { })
     (loadModule ./programs/lsd.nix { })

--- a/modules/programs/lazygit.nix
+++ b/modules/programs/lazygit.nix
@@ -1,0 +1,56 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.lazygit;
+
+  yamlFormat = pkgs.formats.yaml { };
+
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+in {
+  meta.maintainers = [ maintainers.kalhauge ];
+
+  options.programs.lazygit = {
+    enable = mkEnableOption "lazygit, a simple terminal UI for git commands";
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      defaultText = literalExample "{ }";
+      example = literalExample ''
+        {
+          gui.theme = {
+            lightTheme = true;
+            activeBorderColor = [ "blue" "bold" ];
+            inactiveBorderColor = [ "black" ];
+            selectedLineBgColor = [ "default" ];
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>~/.config/lazygit/config.yml</filename> on Linux
+        or <filename>~/Library/Application Support/lazygit/config.yml</filename> on Darwin. See
+        <link xlink:href="https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md"/>
+        for supported values.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.lazygit ];
+
+    home.file."Library/Application Support/lazygit/config.yml" =
+      mkIf (cfg.settings != { } && isDarwin) {
+        source = yamlFormat.generate "lazygit-config" cfg.settings;
+      };
+
+    xdg.configFile."lazygit/config.yml" =
+      mkIf (cfg.settings != { } && !isDarwin) {
+        source = yamlFormat.generate "lazygit-config" cfg.settings;
+      };
+  };
+}


### PR DESCRIPTION
lazygit uses different configuration folders for mac and for linux.

### Description

lazygit is a interactive program for working with git. If you are using a light colored terminal, then 
the suggested configuration is crucial for a good experience.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
   I'm unsure how to test this module.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
