### PR TITLE
gpg-agent: add GNUPG_HOMEDIR to environment

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -240,6 +240,7 @@ in
           ExecStart = "${pkgs.gnupg}/bin/gpg-agent --supervised"
             + optionalString cfg.verbose " --verbose";
           ExecReload = "${pkgs.gnupg}/bin/gpgconf --reload gpg-agent";
+          Environment = "GNUPGHOME=${homedir}";
         };
       };
 


### PR DESCRIPTION
### Description

this fixes #1931: if `programs.gpg.homedir` was not set to default, calls to
`gpg` would fail to pick up anything related to secrets.

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.