### PR TITLE
zsh: add history.ignorePatterns option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -63,7 +63,7 @@ let
       ignorePatterns = mkOption {
         type = types.listOf types.str;
         default = [];
-        example = [ "rm *" "pkill *" ];
+        example = literalExample ''[ "rm *" "pkill *" ]'';
         description = ''
           Do not enter command lines into the history list
           if they match any one of the given shell patterns.

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -505,7 +505,7 @@ in
         # See https://github.com/nix-community/home-manager/issues/177.
         HISTSIZE="${toString cfg.history.size}"
         SAVEHIST="${toString cfg.history.save}"
-        ${if cfg.history.ignorePatterns != [] then "HISTORY_IGNORE=${lib.escapeShellArg "(${lib.concatStringsSep "|" cfg.history.ignorePatterns})"}" else ""}
+        ${optionalString (cfg.history.ignorePatterns != []) "HISTORY_IGNORE=${lib.escapeShellArg "(${lib.concatStringsSep "|" cfg.history.ignorePatterns})"}"}
         ${if versionAtLeast config.home.stateVersion "20.03"
           then ''HISTFILE="${cfg.history.path}"''
           else ''HISTFILE="$HOME/${cfg.history.path}"''}

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -60,6 +60,16 @@ let
         description = "History file location";
       };
 
+      ignorePatterns = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [ "rm *" "pkill *" ];
+        description = ''
+          Do not enter command lines into the history list
+          if they match any one of the given shell patterns.
+        '';
+      };
+
       ignoreDups = mkOption {
         type = types.bool;
         default = true;
@@ -495,6 +505,7 @@ in
         # See https://github.com/nix-community/home-manager/issues/177.
         HISTSIZE="${toString cfg.history.size}"
         SAVEHIST="${toString cfg.history.save}"
+        ${if cfg.history.ignorePatterns != [] then "HISTORY_IGNORE=${lib.escapeShellArg "(${lib.concatStringsSep "|" cfg.history.ignorePatterns})"}" else ""}
         ${if versionAtLeast config.home.stateVersion "20.03"
           then ''HISTFILE="${cfg.history.path}"''
           else ''HISTFILE="$HOME/${cfg.history.path}"''}

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -4,5 +4,6 @@
   zsh-history-path-new-custom = ./history-path-new-custom.nix;
   zsh-history-path-old-default = ./history-path-old-default.nix;
   zsh-history-path-old-custom = ./history-path-old-custom.nix;
+  zsh-history-ignore-pattern = ./history-ignore-pattern.nix;
   zsh-prezto = ./prezto.nix;
 }

--- a/tests/modules/programs/zsh/history-ignore-pattern.nix
+++ b/tests/modules/programs/zsh/history-ignore-pattern.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [
+    ({ ... }: { config.programs.zsh.history.ignorePatterns = [ "echo *" ]; })
+    ({ ... }: { config.programs.zsh.history.ignorePatterns = [ "rm *" ]; })
+  ];
+
+  config = {
+    programs.zsh.enable = true;
+
+    nixpkgs.overlays =
+      [ (self: super: { zsh = pkgs.writeScriptBin "dummy-zsh" ""; }) ];
+
+    nmt.script = ''
+      assertFileContains home-files/.zshrc "HISTORY_IGNORE='(echo *|rm *)'"
+    '';
+  };
+}


### PR DESCRIPTION
### Description

This option allows user to prevent commands matching a specific pattern from going to history.
The corresponding variable is `HISTORY_IGNORE` described in [zshparam(1)](https://man.archlinux.org/man/zshparam.1).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
