### PR TITLE
Add flake.lock & workflow to update it

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -1,0 +1,23 @@
+name: Update flake inputs
+on:
+  schedule:
+    # Update every Sunday and Wednesday
+    - cron: "51 3 * * 0,3"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v9
+        with:
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          pr-labels: dependencies

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -13,9 +13,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: cachix/install-nix-action@v17
-        with:
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v9
         with:


### PR DESCRIPTION
### Description

This PR implements suggestions from #1913, adding a flake.lock file so we can `nix run github:nix-community/home-manager` without any hiccups. The nixpkgs input is currently set to track `nixos-unstable`. If you want to test this out, you can run `nix run github:nix-community/home-manager/pull/1934/head`, which should give you the help text.

To keep this file up to date, the PR also adds a GitHub workflow that
- Runs every Sunday and Wednesday at 03:51 (I just picked a random time)
- Runs `nix flake update --commit-lock-file`, committing as a nonexistent user called `flakebot`
- Pushes this commit ~~directly to master~~ to a new branch called `flake-update` with a custom token `FLAKEBOT_TOKEN` (this needs to be added to the repo)
- Opens a PR (or updates an existing PR) to merge this commit to master. This is done with the same custom token so that other workflows can be run against the PR.

Also updates the README to change the section on a flake-based config a bit.

I also wanted to modify the testing workflow to actually run home-manager's tests, but was having a bit of trouble exposing the tests under the `checks` output of the flake, so I will leave that out for now. ~~This means that the update workflow will just regularly push updates to master, whether they pass tests or not.~~

cc @berbiche since we were talking about this in the other PR.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
