### PR TITLE
ncspot: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,6 +103,8 @@
 /tests/modules/programs/ncmpcpp                       @olmokramer
 /tests/modules/programs/ncmpcpp-linux                 @olmokramer
 
+/modules/programs/ncspot.nix                          @marsam
+
 /modules/programs/ne.nix                              @cwyc
 /tests/modules/programs/ne                            @cwyc
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1951,6 +1951,7 @@ in
         time = "2021-04-27T00:00:00+00:00";
         message = ''
           A new module is available: 'programs.ncspot'.
+        '';
       }
 
     ];

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1936,6 +1936,13 @@ in
           A new service is available: 'services.barrier'.
         '';
       }
+
+      {
+        time = "2021-04-27T00:00:00+00:00";
+        message = ''
+          A new module is available: 'programs.ncspot'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -97,6 +97,7 @@ let
     (loadModule ./programs/msmtp.nix { })
     (loadModule ./programs/mu.nix { })
     (loadModule ./programs/ncmpcpp.nix { })
+    (loadModule ./programs/ncspot.nix { })
     (loadModule ./programs/ne.nix { })
     (loadModule ./programs/neomutt.nix { })
     (loadModule ./programs/neovim.nix { })

--- a/modules/programs/ncspot.nix
+++ b/modules/programs/ncspot.nix
@@ -1,0 +1,50 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.ncspot;
+
+  tomlFormat = pkgs.formats.toml { };
+
+in {
+  meta.maintainers = [ maintainers.marsam ];
+
+  options.programs.ncspot = {
+    enable = mkEnableOption "ncspot";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.ncspot;
+      defaultText = literalExample "pkgs.ncspot";
+      description = "The package to use for ncspot.";
+    };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExample ''
+        {
+          shuffle = true;
+          gapless = true;
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>~/.config/ncspot/config.toml</filename>.
+        </para><para>
+        See <link xlink:href="https://github.com/hrkfdn/ncspot#configuration" />
+        for the full list of options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."ncspot/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "ncspot-config" cfg.settings;
+    };
+  };
+}


### PR DESCRIPTION

### Description

[ncspot](https://github.com/hrkfdn/ncspot) is a ncurses Spotify client written in Rust using librespot.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
