### PR TITLE
services/pbgopy: add missing options

### DIFF
--- a/modules/services/pbgopy.nix
+++ b/modules/services/pbgopy.nix
@@ -3,13 +3,31 @@
 with lib;
 
 let
+
   cfg = config.services.pbgopy;
   package = pkgs.pbgopy;
+
+  commandLine = concatStringsSep " " ([
+    "${package}/bin/pbgopy serve"
+    "--port ${toString cfg.port}"
+    "--ttl ${cfg.cache.ttl}"
+  ] ++ optional (cfg.httpAuth != null)
+    "--basic-auth ${escapeShellArg cfg.httpAuth}");
+
 in {
   meta.maintainers = [ maintainers.ivar ];
 
   options.services.pbgopy = {
     enable = mkEnableOption "pbgopy";
+
+    port = mkOption {
+      type = types.port;
+      default = 9090;
+      example = 8080;
+      description = ''
+        The port to host the pbgopy server on.
+      '';
+    };
 
     cache.ttl = mkOption {
       type = types.str;
@@ -17,6 +35,16 @@ in {
       example = "10m";
       description = ''
         The TTL for the cache. Use <literal>"0s"</literal> to disable it.
+      '';
+    };
+
+    httpAuth = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "user:pass";
+      description = ''
+        Basic HTTP authentication's username and password. Both the username and
+        password are escaped.
       '';
     };
   };
@@ -31,7 +59,7 @@ in {
         PartOf = [ "graphical-session.target" ];
       };
       Service = {
-        ExecStart = "${package}/bin/pbgopy serve --ttl ${cfg.cache.ttl}";
+        ExecStart = commandLine;
         Restart = "on-abort";
       };
       Install = { WantedBy = [ "graphical-session.target" ]; };

--- a/tests/modules/services/pbgopy/service.nix
+++ b/tests/modules/services/pbgopy/service.nix
@@ -16,7 +16,7 @@
       assertFileExists $serviceFile
 
       assertFileContains $serviceFile \
-        'ExecStart=@pbgopy@/bin/pbgopy serve --ttl 24h'
+        'ExecStart=@pbgopy@/bin/pbgopy serve --port 9090 --ttl 24h'
     '';
   };
 }


### PR DESCRIPTION
### Description
I noticed a few options were missing from the pbgopy module i added a while ago, so i added them.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
