### PR TITLE
dunst: add service package option

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -57,6 +57,13 @@ in {
     services.dunst = {
       enable = mkEnableOption "the dunst notification daemon";
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.dunst;
+        defaultText = literalExample "pkgs.dunst";
+        description = "Package providing <command>dunst</command>.";
+      };
+
       iconTheme = mkOption {
         type = themeType;
         default = hicolorTheme;
@@ -140,7 +147,7 @@ in {
         Service = {
           Type = "dbus";
           BusName = "org.freedesktop.Notifications";
-          ExecStart = "${pkgs.dunst}/bin/dunst";
+          ExecStart = "${cfg.package}/bin/dunst";
         };
       };
     }

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -70,6 +70,13 @@ in {
         description = "Set the icon theme.";
       };
 
+      waylandDisplay = mkOption {
+        type = types.str;
+        default = "";
+        description =
+          "Set the service's <envar>WAYLAND_DISPLAY</envar> environment variable.";
+      };
+
       settings = mkOption {
         type = with types; attrsOf (attrsOf eitherStrBoolIntList);
         default = { };
@@ -148,6 +155,8 @@ in {
           Type = "dbus";
           BusName = "org.freedesktop.Notifications";
           ExecStart = "${cfg.package}/bin/dunst";
+          Environment = optionalString (cfg.waylandDisplay != "")
+            "WAYLAND_DISPLAY=${cfg.waylandDisplay}";
         };
       };
     }


### PR DESCRIPTION
### Description

Supercedes and Closes #1796 

Adds `package` and `waylandDisplay` options to the dunst module.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
