### PR TITLE
programs.ssh: Use nullable types for optional forward attrs

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -26,7 +26,8 @@ let
     };
 
     port = mkOption {
-      type = types.port;
+      type = types.nullOr types.port;
+      default = null;
       example = 8080;
       description = "Specifies port number to bind on bind address.";
     };
@@ -42,13 +43,15 @@ let
 
       host = {
         address = mkOption {
-          type = types.str;
+          type = types.nullOr types.str;
+          default = null;
           example = "example.org";
           description = "The address where to forward the traffic to.";
         };
 
         port = mkOption {
-          type = types.port;
+          type = types.nullOr types.port;
+          default = null;
           example = 80;
           description = "Specifies port number to forward the traffic to.";
         };
@@ -450,7 +453,7 @@ in
             any' = pred: items: if items == [] then true else any pred items;
             # Check that if `entry.address` is defined, and is a path, that `entry.port` has not
             # been defined.
-            noPathWithPort =  entry: entry ? address && isPath entry.address -> !(entry ? port);
+            noPathWithPort =  entry: entry.address != null && isPath entry.address -> entry.port == null;
             checkDynamic = block: any' noPathWithPort block.dynamicForwards;
             checkBindAndHost = fwd: noPathWithPort fwd.bind && noPathWithPort fwd.host;
             checkLocal = block: any' checkBindAndHost block.localForwards;


### PR DESCRIPTION
Attempting to build a flake configuration using `ssh.remoteForwards` results in
evaluation errors when `port` is undefined, as `!(entry ? port)` evaluates to
false. This was verified in the nix repl, and also occurs for `nix flake
check`.

Set optional attrs in `bindOptions` and `forwardModule` to `null` by default
and adjust the assertion to check for `null` instead of attr definitions.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
