### PR TITLE
i3, sway: extract border functionality to common function

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -244,7 +244,13 @@
 
 /modules/services/unison.nix                          @pacien
 
+/modules/services/window-managers/i3-sway/i3.nix      @sumnerevans
+/tests/modules/services/window-managers/i3            @sumnerevans
+
+/modules/services/window-managers/i3-sway/lib         @sumnerevans
+
 /modules/services/window-managers/i3-sway/sway.nix    @alexarice @sumnerevans
+/tests/modules/services/window-managers/sway          @sumnerevans
 
 /modules/services/wlsunset.nix                        @matrss
 /tests/modules/services/wlsunset                      @matrss

--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -140,7 +140,7 @@ let
 
   inherit (commonFunctions)
     keybindingsStr keycodebindingsStr modeStr assignStr barStr gapsStr
-    floatingCriteriaStr windowCommandsStr colorSetStr;
+    floatingCriteriaStr windowCommandsStr colorSetStr windowBorderString;
 
   startupEntryStr = { command, always, notification, workspace, ... }: ''
     ${if always then "exec_always" else "exec"} ${
@@ -157,12 +157,7 @@ let
     with cfg.config; ''
       font pango:${concatStringsSep ", " fonts}
       floating_modifier ${floating.modifier}
-      new_window ${if window.titlebar then "normal" else "pixel"} ${
-        toString window.border
-      }
-      new_float ${if floating.titlebar then "normal" else "pixel"} ${
-        toString floating.border
-      }
+      ${windowBorderString window floating}
       hide_edge_borders ${window.hideEdgeBorders}
       force_focus_wrapping ${if focus.forceWrapping then "yes" else "no"}
       focus_follows_mouse ${if focus.followMouse then "yes" else "no"}

--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -204,6 +204,8 @@ let
     '';
 
 in {
+  meta.maintainers = with maintainers; [ sumnerevans ];
+
   options = {
     xsession.windowManager.i3 = {
       enable = mkEnableOption "i3 window manager.";

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -120,6 +120,15 @@ rec {
     ${optionalString (smartBorders != "off") "smart_borders ${smartBorders}"}
   '';
 
+  windowBorderString = window: floating:
+    let
+      titlebarString = { titlebar, border, ... }:
+        "${if titlebar then "normal" else "pixel"} ${toString border}";
+    in concatStringsSep "\n" [
+      "default_border ${titlebarString window}"
+      "default_floating_border ${titlebarString floating}"
+    ];
+
   floatingCriteriaStr = criteria:
     "for_window ${criteriaStr criteria} floating enable";
   windowCommandsStr = { command, criteria, ... }:

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -245,7 +245,7 @@ let
 
   inherit (commonFunctions)
     keybindingsStr keycodebindingsStr modeStr assignStr barStr gapsStr
-    floatingCriteriaStr windowCommandsStr colorSetStr;
+    floatingCriteriaStr windowCommandsStr colorSetStr windowBorderString;
 
   startupEntryStr = { command, always, ... }: ''
     ${if always then "exec_always" else "exec"} ${command}
@@ -265,12 +265,7 @@ let
     with cfg.config; ''
       font pango:${concatStringsSep ", " fonts}
       floating_modifier ${floating.modifier}
-      default_border ${if window.titlebar then "normal" else "pixel"} ${
-        toString window.border
-      }
-      default_floating_border ${
-        if floating.titlebar then "normal" else "pixel"
-      } ${toString floating.border}
+      ${windowBorderString window floating}
       hide_edge_borders ${window.hideEdgeBorders}
       focus_wrapping ${if focus.forceWrapping then "yes" else "no"}
       focus_follows_mouse ${focus.followMouse}

--- a/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
@@ -1,7 +1,7 @@
 font pango:monospace 8
 floating_modifier Mod1
-new_window normal 2
-new_float normal 2
+default_border normal 2
+default_floating_border normal 2
 hide_edge_borders none
 force_focus_wrapping no
 focus_follows_mouse no

--- a/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
@@ -1,7 +1,7 @@
 font pango:monospace 8
 floating_modifier Mod1
-new_window normal 2
-new_float normal 2
+default_border normal 2
+default_floating_border normal 2
 hide_edge_borders none
 force_focus_wrapping no
 focus_follows_mouse yes


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Converted the i3 module to use `default_border` and `default_floating_border` and extracted that functionality out to be shared between the i3 and sway modules.

Also add myself as maintainer for i3.

Closes #1938

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
