### PR TITLE
gnupg/gpg-agent: gnupg package is configurable

### DIFF
--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -21,6 +21,14 @@ in
   options.programs.gpg = {
     enable = mkEnableOption "GnuPG";
 
+    package = mkOption {
+      type = types.package;
+      default = pkgs.gnupg;
+      defaultText = literalExample "pkgs.gnupg";
+      example = literalExample "pkgs.gnupg23";
+      description = "The Gnupg package to use (also used the gpg-agent service).";
+    };
+
     settings = mkOption {
       type = types.attrsOf (types.either primitiveType (types.listOf types.str));
       example = literalExample ''
@@ -67,7 +75,7 @@ in
       use-agent = mkDefault true;
     };
 
-    home.packages = [ pkgs.gnupg ];
+    home.packages = [ cfg.package ];
     home.sessionVariables = {
       GNUPGHOME = cfg.homedir;
     };

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -5,6 +5,7 @@ with lib;
 let
 
   cfg = config.services.gpg-agent;
+  gpgPkg = config.programs.gpg.package;
 
   homedir = config.programs.gpg.homedir;
 
@@ -13,7 +14,7 @@ let
     export GPG_TTY
   ''
   + optionalString cfg.enableSshSupport
-      "${pkgs.gnupg}/bin/gpg-connect-agent updatestartuptty /bye > /dev/null";
+      "${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye > /dev/null";
 
   # mimic `gpgconf` output for use in `systemd` unit definitions.
   # we cannot use `gpgconf` directly because it heavily depends on system
@@ -204,7 +205,7 @@ in
 
       home.sessionVariables =
         optionalAttrs cfg.enableSshSupport {
-          SSH_AUTH_SOCK = "$(${pkgs.gnupg}/bin/gpgconf --list-dirs agent-ssh-socket)";
+          SSH_AUTH_SOCK = "$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)";
         };
 
       programs.bash.initExtra = gpgInitStr;
@@ -222,7 +223,7 @@ in
     # The systemd units below are direct translations of the
     # descriptions in the
     #
-    #   ${pkgs.gnupg}/share/doc/gnupg/examples/systemd-user
+    #   ${gpgPkg}/share/doc/gnupg/examples/systemd-user
     #
     # directory.
     {
@@ -237,9 +238,9 @@ in
         };
 
         Service = {
-          ExecStart = "${pkgs.gnupg}/bin/gpg-agent --supervised"
+          ExecStart = "${gpgPkg}/bin/gpg-agent --supervised"
             + optionalString cfg.verbose " --verbose";
-          ExecReload = "${pkgs.gnupg}/bin/gpgconf --reload gpg-agent";
+          ExecReload = "${gpgPkg}/bin/gpgconf --reload gpg-agent";
           Environment = "GNUPGHOME=${homedir}";
         };
       };


### PR DESCRIPTION
### Description

This allows for the gnupg package to be configurable.

I am using this, and now my agent and cli tools are running 2.3.1 (using this commit on nixpkgs to provide the gnupg23 package: https://github.com/colemickens/nixpkgs/commit/3989c71f5cb0eca2764f9025dfe848f7143d2103)

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
