### PR TITLE
i3, sway: replace fonts with submodule

### DIFF
--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -15,7 +15,7 @@ let
   configModule = types.submodule {
     options = {
       inherit (commonOptions)
-        font window floating focus assigns modifier workspaceLayout
+        fonts window floating focus assigns modifier workspaceLayout
         workspaceAutoBackAndForth keycodebindings colors bars startup gaps menu
         terminal;
 
@@ -156,7 +156,7 @@ let
 
   configFile = pkgs.writeText "i3.conf" ((if cfg.config != null then
     with cfg.config; ''
-      ${fontConfigStr font}
+      ${fontConfigStr fonts}
       floating_modifier ${floating.modifier}
       ${windowBorderString window floating}
       hide_edge_borders ${window.hideEdgeBorders}
@@ -257,6 +257,15 @@ in {
       xsession.windowManager.i3.package =
         mkDefault (if (cfg.config.gaps != null) then pkgs.i3-gaps else pkgs.i3);
     })
+
+    {
+      warnings = (optional (isList cfg.config.fonts)
+        "Specifying i3.config.fonts as a list is deprecated. Use the attrset version instead.")
+        ++ flatten (map (b:
+          optional (isList b.fonts)
+          "Specifying i3.config.bars[].fonts as a list is deprecated. Use the attrset version instead.")
+          cfg.config.bars);
+    }
 
     (mkIf (cfg.config != null
       && (any (s: s.workspace != null) cfg.config.startup)) {

--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -15,9 +15,9 @@ let
   configModule = types.submodule {
     options = {
       inherit (commonOptions)
-        fonts window floating focus assigns modifier workspaceLayout
-        workspaceAutoBackAndForth keycodebindings colors bars startup gaps menu
-        terminal;
+        fontNames fontSize window floating focus assigns modifier
+        workspaceLayout workspaceAutoBackAndForth keycodebindings colors bars
+        startup gaps menu terminal;
 
       keybindings = mkOption {
         type = types.attrsOf (types.nullOr types.str);
@@ -140,7 +140,8 @@ let
 
   inherit (commonFunctions)
     keybindingsStr keycodebindingsStr modeStr assignStr barStr gapsStr
-    floatingCriteriaStr windowCommandsStr colorSetStr windowBorderString;
+    floatingCriteriaStr windowCommandsStr colorSetStr windowBorderString
+    fontConfigStr;
 
   startupEntryStr = { command, always, notification, workspace, ... }: ''
     ${if always then "exec_always" else "exec"} ${
@@ -155,7 +156,7 @@ let
 
   configFile = pkgs.writeText "i3.conf" ((if cfg.config != null then
     with cfg.config; ''
-      font pango:${concatStringsSep ", " fonts}
+      ${fontConfigStr fontNames fontSize}
       floating_modifier ${floating.modifier}
       ${windowBorderString window floating}
       hide_edge_borders ${window.hideEdgeBorders}

--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -15,9 +15,9 @@ let
   configModule = types.submodule {
     options = {
       inherit (commonOptions)
-        fontNames fontSize window floating focus assigns modifier
-        workspaceLayout workspaceAutoBackAndForth keycodebindings colors bars
-        startup gaps menu terminal;
+        font window floating focus assigns modifier workspaceLayout
+        workspaceAutoBackAndForth keycodebindings colors bars startup gaps menu
+        terminal;
 
       keybindings = mkOption {
         type = types.attrsOf (types.nullOr types.str);
@@ -156,7 +156,7 @@ let
 
   configFile = pkgs.writeText "i3.conf" ((if cfg.config != null then
     with cfg.config; ''
-      ${fontConfigStr fontNames fontSize}
+      ${fontConfigStr font}
       floating_modifier ${floating.modifier}
       ${windowBorderString window floating}
       hide_edge_borders ${window.hideEdgeBorders}

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -39,17 +39,18 @@ rec {
     concatStringsSep "\n"
     (map (c: "assign ${criteriaStr c} ${workspace}") criteria);
 
-  barStr = { id, fonts, mode, hiddenState, position, workspaceButtons
-    , workspaceNumbers, command, statusCommand, colors, trayOutput, extraConfig
-    , ... }:
+  fontConfigStr = fontNames: fontSize:
+    optionalString (fontNames != [ ])
+    "font pango:${concatStringsSep ", " fontNames} ${toString fontSize}";
+
+  barStr = { id, fontNames, fontSize, mode, hiddenState, position
+    , workspaceButtons, workspaceNumbers, command, statusCommand, colors
+    , trayOutput, extraConfig, ... }:
     let colorsNotNull = lib.filterAttrs (n: v: v != null) colors != { };
     in ''
       bar {
         ${optionalString (id != null) "id ${id}"}
-        ${
-          optionalString (fonts != [ ])
-          "font pango:${concatStringsSep ", " fonts}"
-        }
+        ${fontConfigStr fontNames fontSize}
         ${optionalString (mode != null) "mode ${mode}"}
         ${optionalString (hiddenState != null) "hidden_state ${hiddenState}"}
         ${optionalString (position != null) "position ${position}"}

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -39,22 +39,31 @@ rec {
     concatStringsSep "\n"
     (map (c: "assign ${criteriaStr c} ${workspace}") criteria);
 
-  fontConfigStr = { names, style, size }:
-    optionalString (names != [ ]) concatStringsSep " " (filter (x: x != "") [
-      "font"
-      "pango:${concatStringsSep ", " names}"
-      style
-      (toString size)
-    ]);
+  fontConfigStr = let
+    toFontStr = { names, style ? "", size ? "" }:
+      optionalString (names != [ ]) concatStringsSep " " (filter (x: x != "") [
+        "font"
+        "pango:${concatStringsSep ", " names}"
+        style
+        size
+      ]);
+  in fontCfg:
+  if isList fontCfg then
+    toFontStr { names = fontCfg; }
+  else
+    toFontStr {
+      inherit (fontCfg) names style;
+      size = toString fontCfg.size;
+    };
 
-  barStr = { id, font, mode, hiddenState, position, workspaceButtons
+  barStr = { id, fonts, mode, hiddenState, position, workspaceButtons
     , workspaceNumbers, command, statusCommand, colors, trayOutput, extraConfig
     , ... }:
     let colorsNotNull = lib.filterAttrs (n: v: v != null) colors != { };
     in ''
       bar {
         ${optionalString (id != null) "id ${id}"}
-        ${fontConfigStr font}
+        ${fontConfigStr fonts}
         ${optionalString (mode != null) "mode ${mode}"}
         ${optionalString (hiddenState != null) "hidden_state ${hiddenState}"}
         ${optionalString (position != null) "position ${position}"}

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -39,18 +39,22 @@ rec {
     concatStringsSep "\n"
     (map (c: "assign ${criteriaStr c} ${workspace}") criteria);
 
-  fontConfigStr = fontNames: fontSize:
-    optionalString (fontNames != [ ])
-    "font pango:${concatStringsSep ", " fontNames} ${toString fontSize}";
+  fontConfigStr = { names, style, size }:
+    optionalString (names != [ ]) concatStringsSep " " (filter (x: x != "") [
+      "font"
+      "pango:${concatStringsSep ", " names}"
+      style
+      (toString size)
+    ]);
 
-  barStr = { id, fontNames, fontSize, mode, hiddenState, position
-    , workspaceButtons, workspaceNumbers, command, statusCommand, colors
-    , trayOutput, extraConfig, ... }:
+  barStr = { id, font, mode, hiddenState, position, workspaceButtons
+    , workspaceNumbers, command, statusCommand, colors, trayOutput, extraConfig
+    , ... }:
     let colorsNotNull = lib.filterAttrs (n: v: v != null) colors != { };
     in ''
       bar {
         ${optionalString (id != null) "id ${id}"}
-        ${fontConfigStr fontNames fontSize}
+        ${fontConfigStr font}
         ${optionalString (mode != null) "mode ${mode}"}
         ${optionalString (hiddenState != null) "hidden_state ${hiddenState}"}
         ${optionalString (position != null) "position ${position}"}

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -7,14 +7,23 @@ let
   isI3 = moduleName == "i3";
   isSway = !isI3;
 
-  fonts = mkOption {
+  fontNames = mkOption {
     type = types.listOf types.str;
-    default = [ "monospace 8" ];
+    default = [ "monospace" ];
     description = ''
       Font list used for window titles. Only FreeType fonts are supported.
       The order here is important (e.g. icons font should go before the one used for text).
     '';
-    example = [ "FontAwesome 10" "Terminus 10" ];
+    example = [ "FontAwesome" "Terminus" ];
+  };
+
+  fontSize = mkOption {
+    type = types.float;
+    default = 8.0;
+    description = ''
+      The font size to use for window titles.
+    '';
+    example = 11.5;
   };
 
   startupModule = types.submodule {
@@ -69,7 +78,8 @@ let
           '';
         });
     in {
-      fonts = fonts // optionalAttrs versionAtLeast2009 { default = [ ]; };
+      fontNames = fontNames;
+      fontSize = fontSize;
 
       extraConfig = mkOption {
         type = types.lines;
@@ -310,7 +320,7 @@ let
 
   criteriaModule = types.attrsOf types.str;
 in {
-  inherit fonts;
+  inherit fontNames fontSize;
 
   window = mkOption {
     type = types.submodule {
@@ -605,7 +615,8 @@ in {
       workspaceButtons = true;
       workspaceNumbers = true;
       statusCommand = "${pkgs.i3status}/bin/i3status";
-      fonts = [ "monospace 8" ];
+      fontNames = [ "monospace" ];
+      fontSize = 8.0;
       trayOutput = "primary";
       colors = {
         background = "#000000";

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -92,8 +92,8 @@ let
           '';
         });
     in {
-      font = mkOption {
-        type = fontOptions;
+      fonts = mkOption {
+        type = with types; either (listOf str) fontOptions;
         default = { };
       };
 
@@ -336,8 +336,8 @@ let
 
   criteriaModule = types.attrsOf types.str;
 in {
-  font = mkOption {
-    type = fontOptions;
+  fonts = mkOption {
+    type = with types; either (listOf str) fontOptions;
     default = { };
   };
 
@@ -634,7 +634,7 @@ in {
       workspaceButtons = true;
       workspaceNumbers = true;
       statusCommand = "${pkgs.i3status}/bin/i3status";
-      font = {
+      fonts = {
         names = [ "monospace" ];
         size = 8.0;
       };

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -7,23 +7,37 @@ let
   isI3 = moduleName == "i3";
   isSway = !isI3;
 
-  fontNames = mkOption {
-    type = types.listOf types.str;
-    default = [ "monospace" ];
-    description = ''
-      Font list used for window titles. Only FreeType fonts are supported.
-      The order here is important (e.g. icons font should go before the one used for text).
-    '';
-    example = [ "FontAwesome" "Terminus" ];
-  };
+  fontOptions = types.submodule {
+    options = {
+      names = mkOption {
+        type = types.listOf types.str;
+        default = [ "monospace" ];
+        defaultText = literalExample ''[ "monospace" ]'';
+        description = ''
+          List of font names list used for window titles. Only FreeType fonts are supported.
+          The order here is important (e.g. icons font should go before the one used for text).
+        '';
+        example = literalExample ''[ "FontAwesome" "Terminus" ]'';
+      };
 
-  fontSize = mkOption {
-    type = types.float;
-    default = 8.0;
-    description = ''
-      The font size to use for window titles.
-    '';
-    example = 11.5;
+      style = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          The font style to use for window titles.
+        '';
+        example = "Bold Semi-Condensed";
+      };
+
+      size = mkOption {
+        type = types.float;
+        default = 8.0;
+        description = ''
+          The font size to use for window titles.
+        '';
+        example = 11.5;
+      };
+    };
   };
 
   startupModule = types.submodule {
@@ -78,8 +92,10 @@ let
           '';
         });
     in {
-      fontNames = fontNames;
-      fontSize = fontSize;
+      font = mkOption {
+        type = fontOptions;
+        default = { };
+      };
 
       extraConfig = mkOption {
         type = types.lines;
@@ -320,7 +336,10 @@ let
 
   criteriaModule = types.attrsOf types.str;
 in {
-  inherit fontNames fontSize;
+  font = mkOption {
+    type = fontOptions;
+    default = { };
+  };
 
   window = mkOption {
     type = types.submodule {
@@ -615,8 +634,10 @@ in {
       workspaceButtons = true;
       workspaceNumbers = true;
       statusCommand = "${pkgs.i3status}/bin/i3status";
-      fontNames = [ "monospace" ];
-      fontSize = 8.0;
+      font = {
+        names = [ "monospace" ];
+        size = 8.0;
+      };
       trayOutput = "primary";
       colors = {
         background = "#000000";

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -15,7 +15,7 @@ let
   configModule = types.submodule {
     options = {
       inherit (commonOptions)
-        fontNames fontSize window floating focus assigns workspaceLayout
+        font window floating focus assigns workspaceLayout
         workspaceAutoBackAndForth modifier keycodebindings colors bars startup
         gaps menu terminal;
 
@@ -264,7 +264,7 @@ let
 
   configFile = pkgs.writeText "sway.conf" ((if cfg.config != null then
     with cfg.config; ''
-      ${fontConfigStr fontNames fontSize}
+      ${fontConfigStr font}
       floating_modifier ${floating.modifier}
       ${windowBorderString window floating}
       hide_edge_borders ${window.hideEdgeBorders}

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -15,7 +15,7 @@ let
   configModule = types.submodule {
     options = {
       inherit (commonOptions)
-        fonts window floating focus assigns workspaceLayout
+        fontNames fontSize window floating focus assigns workspaceLayout
         workspaceAutoBackAndForth modifier keycodebindings colors bars startup
         gaps menu terminal;
 
@@ -245,7 +245,8 @@ let
 
   inherit (commonFunctions)
     keybindingsStr keycodebindingsStr modeStr assignStr barStr gapsStr
-    floatingCriteriaStr windowCommandsStr colorSetStr windowBorderString;
+    floatingCriteriaStr windowCommandsStr colorSetStr windowBorderString
+    fontConfigStr;
 
   startupEntryStr = { command, always, ... }: ''
     ${if always then "exec_always" else "exec"} ${command}
@@ -263,7 +264,7 @@ let
 
   configFile = pkgs.writeText "sway.conf" ((if cfg.config != null then
     with cfg.config; ''
-      font pango:${concatStringsSep ", " fonts}
+      ${fontConfigStr fontNames fontSize}
       floating_modifier ${floating.modifier}
       ${windowBorderString window floating}
       hide_edge_borders ${window.hideEdgeBorders}

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -15,7 +15,7 @@ let
   configModule = types.submodule {
     options = {
       inherit (commonOptions)
-        font window floating focus assigns workspaceLayout
+        fonts window floating focus assigns workspaceLayout
         workspaceAutoBackAndForth modifier keycodebindings colors bars startup
         gaps menu terminal;
 
@@ -264,7 +264,7 @@ let
 
   configFile = pkgs.writeText "sway.conf" ((if cfg.config != null then
     with cfg.config; ''
-      ${fontConfigStr font}
+      ${fontConfigStr fonts}
       floating_modifier ${floating.modifier}
       ${windowBorderString window floating}
       hide_edge_borders ${window.hideEdgeBorders}
@@ -411,6 +411,13 @@ in {
   };
 
   config = mkIf cfg.enable {
+    warnings = (optional (isList cfg.config.fonts)
+      "Specifying sway.config.fonts as a list is deprecated. Use the attrset version instead.")
+      ++ flatten (map (b:
+        optional (isList b.fonts)
+        "Specifying sway.config.bars[].fonts as a list is deprecated. Use the attrset version instead.")
+        cfg.config.bars);
+
     home.packages = optional (cfg.package != null) cfg.package
       ++ optional cfg.xwayland pkgs.xwayland;
     xdg.configFile."sway/config" = {

--- a/tests/modules/services/window-managers/i3/default.nix
+++ b/tests/modules/services/window-managers/i3/default.nix
@@ -1,4 +1,5 @@
 {
   i3-followmouse = ./i3-followmouse.nix;
+  i3-fonts = ./i3-fonts.nix;
   i3-keybindings = ./i3-keybindings.nix;
 }

--- a/tests/modules/services/window-managers/i3/default.nix
+++ b/tests/modules/services/window-managers/i3/default.nix
@@ -1,5 +1,6 @@
 {
   i3-followmouse = ./i3-followmouse.nix;
   i3-fonts = ./i3-fonts.nix;
+  i3-fonts-deprecated = ./i3-fonts-deprecated.nix;
   i3-keybindings = ./i3-keybindings.nix;
 }

--- a/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
@@ -1,4 +1,4 @@
-font pango:monospace 8
+font pango:monospace 8.000000
 floating_modifier Mod1
 default_border normal 2
 default_floating_border normal 2
@@ -76,7 +76,7 @@ bindsym Up resize shrink height 10 px or 10 ppt
 
 bar {
   
-  font pango:monospace 8
+  font pango:monospace 8.000000
   mode dock
   hidden_state hide
   position bottom

--- a/tests/modules/services/window-managers/i3/i3-fonts-deprecated.nix
+++ b/tests/modules/services/window-managers/i3/i3-fonts-deprecated.nix
@@ -8,17 +8,8 @@ with lib;
       enable = true;
 
       config = {
-        bars = [{
-          fonts = {
-            names = [ "FontAwesome" "Iosevka" ];
-            size = 11.5;
-          };
-        }];
-        fonts = {
-          names = [ "DejaVuSansMono" "Terminus" ];
-          style = "Bold Semi-Condensed";
-          size = 13.5;
-        };
+        bars = [{ fonts = [ "FontAwesome" "Iosevka 11.500000" ]; }];
+        fonts = [ "DejaVuSansMono" "Terminus Bold Semi-Condensed 13.500000" ];
       };
     };
 
@@ -39,5 +30,10 @@ with lib;
       assertFileContent home-files/.config/i3/config \
         ${./i3-fonts-expected.conf}
     '';
+
+    test.asserts.warnings.expected = [
+      "Specifying i3.config.fonts as a list is deprecated. Use the attrset version instead."
+      "Specifying i3.config.bars[].fonts as a list is deprecated. Use the attrset version instead."
+    ];
   };
 }

--- a/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
@@ -1,0 +1,105 @@
+font pango:DejaVuSansMono, Terminus Bold Semi-Condensed 13.500000
+floating_modifier Mod1
+default_border normal 2
+default_floating_border normal 2
+hide_edge_borders none
+force_focus_wrapping no
+focus_follows_mouse yes
+focus_on_window_activation smart
+mouse_warping output
+workspace_layout default
+workspace_auto_back_and_forth no
+
+client.focused #4c7899 #285577 #ffffff #2e9ef4 #285577
+client.focused_inactive #333333 #5f676a #ffffff #484e50 #5f676a
+client.unfocused #333333 #222222 #888888 #292d2e #222222
+client.urgent #2f343a #900000 #ffffff #900000 #900000
+client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
+client.background #ffffff
+
+bindsym Mod1+0 workspace number 10
+bindsym Mod1+1 workspace number 1
+bindsym Mod1+2 workspace number 2
+bindsym Mod1+3 workspace number 3
+bindsym Mod1+4 workspace number 4
+bindsym Mod1+5 workspace number 5
+bindsym Mod1+6 workspace number 6
+bindsym Mod1+7 workspace number 7
+bindsym Mod1+8 workspace number 8
+bindsym Mod1+9 workspace number 9
+bindsym Mod1+Down focus down
+bindsym Mod1+Left focus left
+bindsym Mod1+Return exec i3-sensible-terminal
+bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+Shift+1 move container to workspace number 1
+bindsym Mod1+Shift+2 move container to workspace number 2
+bindsym Mod1+Shift+3 move container to workspace number 3
+bindsym Mod1+Shift+4 move container to workspace number 4
+bindsym Mod1+Shift+5 move container to workspace number 5
+bindsym Mod1+Shift+6 move container to workspace number 6
+bindsym Mod1+Shift+7 move container to workspace number 7
+bindsym Mod1+Shift+8 move container to workspace number 8
+bindsym Mod1+Shift+9 move container to workspace number 9
+bindsym Mod1+Shift+Down move down
+bindsym Mod1+Shift+Left move left
+bindsym Mod1+Shift+Right move right
+bindsym Mod1+Shift+Up move up
+bindsym Mod1+Shift+c reload
+bindsym Mod1+Shift+e exec i3-nagbar -t warning -m 'Do you want to exit i3?' -b 'Yes' 'i3-msg exit'
+bindsym Mod1+Shift+minus move scratchpad
+bindsym Mod1+Shift+q kill
+bindsym Mod1+Shift+r restart
+bindsym Mod1+Shift+space floating toggle
+bindsym Mod1+Up focus up
+bindsym Mod1+a focus parent
+bindsym Mod1+d exec @dmenu@/bin/dmenu_run
+bindsym Mod1+e layout toggle split
+bindsym Mod1+f fullscreen toggle
+bindsym Mod1+h split h
+bindsym Mod1+minus scratchpad show
+bindsym Mod1+r mode resize
+bindsym Mod1+s layout stacking
+bindsym Mod1+space focus mode_toggle
+bindsym Mod1+v split v
+bindsym Mod1+w layout tabbed
+
+mode "resize" {
+bindsym Down resize grow height 10 px or 10 ppt
+bindsym Escape mode default
+bindsym Left resize shrink width 10 px or 10 ppt
+bindsym Return mode default
+bindsym Right resize grow width 10 px or 10 ppt
+bindsym Up resize shrink height 10 px or 10 ppt
+}
+
+
+bar {
+  
+  font pango:FontAwesome, Iosevka 11.500000
+  mode dock
+  hidden_state hide
+  position bottom
+  status_command @i3status@/bin/i3status
+  i3bar_command @i3@/bin/i3bar
+  workspace_buttons yes
+  strip_workspace_numbers no
+  tray_output primary
+  colors {
+    background #000000
+    statusline #ffffff
+    separator #666666
+    focused_workspace #4c7899 #285577 #ffffff
+    active_workspace #333333 #5f676a #ffffff
+    inactive_workspace #333333 #222222 #888888
+    urgent_workspace #2f343a #900000 #ffffff
+    binding_mode #2f343a #900000 #ffffff
+  }
+  
+}
+
+
+
+
+
+

--- a/tests/modules/services/window-managers/i3/i3-fonts.nix
+++ b/tests/modules/services/window-managers/i3/i3-fonts.nix
@@ -1,0 +1,43 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  config = {
+    xsession.windowManager.i3 = {
+      enable = true;
+
+      config = {
+        bars = [{
+          font = {
+            names = [ "FontAwesome" "Iosevka" ];
+            size = 11.5;
+          };
+        }];
+        font = {
+          names = [ "DejaVuSansMono" "Terminus" ];
+          style = "Bold Semi-Condensed";
+          size = 13.5;
+        };
+      };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        dmenu = super.dmenu // { outPath = "@dmenu@"; };
+
+        i3 = super.writeScriptBin "i3" "" // { outPath = "@i3@"; };
+
+        i3-gaps = super.writeScriptBin "i3" "" // { outPath = "@i3-gaps@"; };
+
+        i3status = super.i3status // { outPath = "@i3status@"; };
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/i3/config
+      assertFileContent home-files/.config/i3/config \
+        ${./i3-fonts-expected.conf}
+    '';
+  };
+}

--- a/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
@@ -1,4 +1,4 @@
-font pango:monospace 8
+font pango:monospace 8.000000
 floating_modifier Mod1
 default_border normal 2
 default_floating_border normal 2
@@ -77,7 +77,7 @@ bindsym Up resize shrink height 10 px or 10 ppt
 
 bar {
   
-  font pango:monospace 8
+  font pango:monospace 8.000000
   mode dock
   hidden_state hide
   position bottom

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -1,4 +1,4 @@
-font pango:monospace 8
+font pango:monospace 8.000000
 floating_modifier Mod1
 default_border pixel 2
 default_floating_border pixel 2
@@ -84,7 +84,7 @@ bindsym l resize grow width 10 px
 
 bar {
   
-  font pango:monospace 8
+  font pango:monospace 8.000000
   mode dock
   hidden_state hide
   position bottom

--- a/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
@@ -1,4 +1,4 @@
-font pango:monospace 8
+font pango:monospace 8.000000
 floating_modifier Mod1
 default_border pixel 2
 default_floating_border pixel 2

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
@@ -1,4 +1,4 @@
-font pango:monospace 8
+font pango:monospace 8.000000
 floating_modifier Mod1
 default_border pixel 2
 default_floating_border pixel 2

--- a/tests/modules/services/window-managers/sway/sway-modules.conf
+++ b/tests/modules/services/window-managers/sway/sway-modules.conf
@@ -1,4 +1,4 @@
-font pango:monospace 8
+font pango:monospace 8.000000
 floating_modifier Mod1
 default_border pixel 2
 default_floating_border pixel 2
@@ -96,7 +96,7 @@ bindsym l resize grow width 10 px
 
 bar {
   
-  font pango:monospace 8
+  font pango:monospace 8.000000
   mode dock
   hidden_state hide
   position bottom

--- a/tests/modules/services/window-managers/sway/sway-null-package.conf
+++ b/tests/modules/services/window-managers/sway/sway-null-package.conf
@@ -1,4 +1,4 @@
-font pango:monospace 8
+font pango:monospace 8.000000
 floating_modifier Mod1
 default_border pixel 2
 default_floating_border pixel 2
@@ -84,7 +84,7 @@ bindsym l resize grow width 10 px
 
 bar {
   
-  font pango:monospace 8
+  font pango:monospace 8.000000
   mode dock
   hidden_state hide
   position bottom


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
This applies to both the root-level and the bar configs.

Closes #1937.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
