### PR TITLE
waybar: Fix systemd service

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -370,14 +370,13 @@ in {
             "Highly customizable Wayland bar for Sway and Wlroots based compositors.";
           Documentation = "https://github.com/Alexays/Waybar/wiki";
           PartOf = [ "graphical-session.target" ];
+          After = [ "graphical-session.target" ];
         };
 
         Service = {
-          Type = "dbus";
-          BusName = "fr.arouillard.waybar";
           ExecStart = "${cfg.package}/bin/waybar";
-          Restart = "always";
-          RestartSec = "1sec";
+          ExecReload = "kill -SIGUSR2 $MAINPID";
+          Restart = "on-failure";
           KillMode = "mixed";
         };
 

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -2,14 +2,13 @@
 WantedBy=graphical-session.target
 
 [Service]
-BusName=fr.arouillard.waybar
+ExecReload=kill -SIGUSR2 $MAINPID
 ExecStart=@waybar@/bin/waybar
 KillMode=mixed
-Restart=always
-RestartSec=1sec
-Type=dbus
+Restart=on-failure
 
 [Unit]
+After=graphical-session.target
 Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
 Documentation=https://github.com/Alexays/Waybar/wiki
 PartOf=graphical-session.target


### PR DESCRIPTION
I've gone ahead and [ported over the systemd service changes from upstream](https://github.com/Alexays/Waybar/blob/ef38061edd52a09222a187459bd0b5407e0beffe/resources/waybar.service.in).

In particular:

- After specifies so that the waybar starts after sway finishes booting up. Without this clause, waybar would start in parallel and would race with the systemd integration line in the config. waybar would then start before `xdg-portal`, timeout after 25s, then successfully start. (Essentially https://github.com/swaywm/sway/wiki#gtk-applications-take-20-seconds-to-start -- [this line](https://github.com/archseer/home-manager/blob/db8044cc18eb9c4a41a18ffa49af97d83559dd05/modules/services/window-managers/i3-sway/sway.nix#L313) already fixes the issue but waybar would start before that)

- Type: dbus was removed upstream since the service isn't a dbus service, it's simply a consumer.

- A reload hook was added to play nice with sway reloads.