### PR TITLE
format: removed exceptions already formatted files

### DIFF
--- a/format
+++ b/format
@@ -33,7 +33,6 @@ find . -name '*.nix' \
   ! -path ./modules/programs/bash.nix \
   ! -path ./modules/programs/firefox.nix \
   ! -path ./modules/programs/gpg.nix \
-  ! -path ./modules/programs/lesspipe.nix \
   ! -path ./modules/programs/ssh.nix \
   ! -path ./modules/programs/tmux.nix \
   ! -path ./modules/programs/zsh.nix \
@@ -42,11 +41,9 @@ find . -name '*.nix' \
   ! -path ./modules/services/keybase.nix \
   ! -path ./modules/services/mpd.nix \
   ! -path ./modules/services/sxhkd.nix \
-  ! -path ./modules/services/window-managers/i3.nix \
   ! -path ./modules/systemd.nix \
   ! -path ./nix-darwin/default.nix \
   ! -path ./tests/default.nix \
-  ! -path ./tests/modules/home-environment/default.nix \
   ! -path ./tests/modules/home-environment/session-variables.nix \
   ! -path ./tests/modules/programs/gpg/override-defaults.nix \
   ! -path ./tests/modules/programs/zsh/session-variables.nix \


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Starts work on #1953 by removing exceptions that don't do anything.

Removed format exclusion exceptions for modules that are already
formatted correctly (that is, when running nixfmt, no changes happen) or
have been moved (in the case of i3.nix).

**Note** I wasn't sure what to call the component, so I used `format`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
