### PR TITLE
format: remove exception for afew module

### DIFF
--- a/format
+++ b/format
@@ -29,7 +29,6 @@ find . -name '*.nix' \
   ! -path ./modules/misc/nixpkgs.nix \
   ! -path ./modules/misc/xdg.nix \
   ! -path ./modules/modules.nix \
-  ! -path ./modules/programs/afew.nix \
   ! -path ./modules/programs/bash.nix \
   ! -path ./modules/programs/firefox.nix \
   ! -path ./modules/programs/gpg.nix \

--- a/modules/programs/afew.nix
+++ b/modules/programs/afew.nix
@@ -6,9 +6,7 @@ let
 
   cfg = config.programs.afew;
 
-in
-
-{
+in {
   options.programs.afew = {
     enable = mkEnableOption "the afew initial tagging script for Notmuch";
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

See #1953 (feel free to close this and my other formatting PRs if you want to keep the exceptions)

Remove the format script exception for the afew module.

Reasons:

* the PR that touches this module is stale (last activity was in September of 2019) https://github.com/nix-community/home-manager/pull/608
* even if the PR eventually becomes un-stale, it will need to be rebased anyway due to the transition from Travis CI to GitHub Actions.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
