### PR TITLE
format: remove exception for keybase and kbfs modules

### DIFF
--- a/format
+++ b/format
@@ -36,8 +36,6 @@ find . -name '*.nix' \
   ! -path ./modules/programs/tmux.nix \
   ! -path ./modules/programs/zsh.nix \
   ! -path ./modules/services/gpg-agent.nix \
-  ! -path ./modules/services/kbfs.nix \
-  ! -path ./modules/services/keybase.nix \
   ! -path ./modules/services/mpd.nix \
   ! -path ./modules/services/sxhkd.nix \
   ! -path ./modules/systemd.nix \

--- a/modules/services/kbfs.nix
+++ b/modules/services/kbfs.nix
@@ -6,9 +6,7 @@ let
 
   cfg = config.services.kbfs;
 
-in
-
-{
+in {
   options = {
     services.kbfs = {
       enable = mkEnableOption "Keybase File System";
@@ -24,11 +22,8 @@ in
 
       extraFlags = mkOption {
         type = types.listOf types.str;
-        default = [];
-        example = [
-          "-label kbfs"
-          "-mount-type normal"
-        ];
+        default = [ ];
+        example = [ "-label kbfs" "-mount-type normal" ];
         description = ''
           Additional flags to pass to the Keybase filesystem on launch.
         '';
@@ -44,21 +39,18 @@ in
         After = [ "keybase.service" ];
       };
 
-      Service =
-        let
-          mountPoint = "\"%h/${cfg.mountPoint}\"";
-        in {
-          Environment = "PATH=/run/wrappers/bin KEYBASE_SYSTEMD=1";
-          ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${mountPoint}";
-          ExecStart ="${pkgs.kbfs}/bin/kbfsfuse ${toString cfg.extraFlags} ${mountPoint}";
-          ExecStopPost = "/run/wrappers/bin/fusermount -u ${mountPoint}";
-          Restart = "on-failure";
-          PrivateTmp = true;
-        };
-
-      Install = {
-        WantedBy = [ "default.target" ];
+      Service = let mountPoint = ''"%h/${cfg.mountPoint}"'';
+      in {
+        Environment = "PATH=/run/wrappers/bin KEYBASE_SYSTEMD=1";
+        ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${mountPoint}";
+        ExecStart =
+          "${pkgs.kbfs}/bin/kbfsfuse ${toString cfg.extraFlags} ${mountPoint}";
+        ExecStopPost = "/run/wrappers/bin/fusermount -u ${mountPoint}";
+        Restart = "on-failure";
+        PrivateTmp = true;
       };
+
+      Install.WantedBy = [ "default.target" ];
     };
 
     home.packages = [ pkgs.kbfs ];

--- a/modules/services/keybase.nix
+++ b/modules/services/keybase.nix
@@ -6,22 +6,14 @@ let
 
   cfg = config.services.keybase;
 
-in
-
-{
-  options = {
-    services.keybase = {
-      enable = mkEnableOption "Keybase";
-    };
-  };
+in {
+  options.services.keybase.enable = mkEnableOption "Keybase";
 
   config = mkIf cfg.enable {
     home.packages = [ pkgs.keybase ];
 
     systemd.user.services.keybase = {
-      Unit = {
-        Description = "Keybase service";
-      };
+      Unit.Description = "Keybase service";
 
       Service = {
         ExecStart = "${pkgs.keybase}/bin/keybase service --auto-forked";
@@ -29,9 +21,7 @@ in
         PrivateTmp = true;
       };
 
-      Install = {
-        WantedBy = [ "default.target" ];
-      };
+      Install.WantedBy = [ "default.target" ];
     };
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
See #1953 (feel free to close this and my other formatting PRs if you want to keep the exceptions)

Remove the format script exception for the afew module.

Reasons:

* the PR that touches this module is stale (last activity in April of 2020) #973
* even if the PR eventually becomes un-stale, it will need to be rebased anyway due to:
  * existing merge conflicts
  * the transition from Travis CI to GitHub Actions

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
