### PR TITLE
pass-secret-service: fix systemd unit install option

### DIFF
--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -18,11 +18,11 @@ in {
     systemd.user.services.pass-secret-service = {
       Unit = { Description = "Pass libsecret service"; };
       Service = {
-        Install = { WantedBy = [ "default.target" ]; };
         # pass-secret-service doesn't use environment variables for some reason.
         ExecStart =
           "${pkgs.pass-secret-service}/bin/pass_secret_service --path ${config.programs.password-store.settings.PASSWORD_STORE_DIR}";
       };
+      Install = { WantedBy = [ "default.target" ]; };
     };
   };
 }


### PR DESCRIPTION
### Description

Fixes https://github.com/nix-community/home-manager/pull/1898#issuecomment-827879711

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
