### PR TITLE
gpg: can configure scdaemon.conf

### DIFF
--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -15,6 +15,11 @@ let
     listsAsDuplicateKeys = true;
   } cfg.settings;
 
+  scdaemonCfgText = generators.toKeyValue {
+    inherit mkKeyValue;
+    listsAsDuplicateKeys = true;
+  } cfg.scdaemonSettings;
+
   primitiveType = types.oneOf [ types.str types.bool ];
 in
 {
@@ -41,6 +46,20 @@ in
         GnuPG configuration options. Available options are described
         in the gpg manpage:
         <link xlink:href="https://gnupg.org/documentation/manpage.html"/>.
+      '';
+    };
+
+    scdaemonSettings = mkOption {
+      type = types.attrsOf (types.either primitiveType (types.listOf types.str));
+      example = literalExample ''
+        {
+          disable-ccid = true;
+        }
+      '';
+      description = ''
+        SCdaemon configuration options. Available options are described
+        in the gpg scdaemon manpage:
+        <link xlink:href="https://www.gnupg.org/documentation/manuals/gnupg/Scdaemon-Options.html"/>.
       '';
     };
 
@@ -75,11 +94,17 @@ in
       use-agent = mkDefault true;
     };
 
+    programs.gpg.scdaemonSettings = {
+      # no defaults for scdaemon
+    };
+
     home.packages = [ cfg.package ];
     home.sessionVariables = {
       GNUPGHOME = cfg.homedir;
     };
 
     home.file."${cfg.homedir}/gpg.conf".text = cfgText;
+
+    home.file."${cfg.homedir}/scdaemon.conf".text = scdaemonCfgText;
   };
 }


### PR DESCRIPTION
### Description

Related to:
- https://dev.gnupg.org/T4673 (an upcoming change in gnupg-2.3 and eventually 2.4 behavior)

It is useful for users to be able to configure their gnupg's `scdaemon.conf`.

This PR enables this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
