### PR TITLE
github: configure probot/stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,75 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+daysUntilStale: 90
+daysUntilClose: 7
+staleLabel: "status: stale"
+closeComment: false
+issues:
+  markComment: |
+    <p>
+      Thank you for your contribution!
+      I marked this issue as stale due to inactivity.
+      If this remains inactive for another 7 days, I will close this issue.
+      <b>Please read the relevant sections below before commenting.</b>
+    </p>
+
+    <details>
+    <summary><b>If you are the original author of the issue</b></summary>
+    <p>
+
+    * If this is resolved, please consider closing it so that the maintainers know not to focus on this.
+    * If this might still be an issue, but you are not interested in promoting its resolution, please consider closing it while encouraging others to take over and reopen an issue if they care enough.
+    * If you know how to solve the issue, please consider submitting a Pull Request that addresses this issue.
+
+    </p>
+    </details>
+
+    <details>
+    <summary><b>If you are <i>not</i> the original author of the issue</b></summary>
+    <p>
+
+    * If you are also experiencing this issue, please add details of your situation to help with the debugging process.
+    * If you know how to solve the issue, please consider submitting a Pull Request that addresses this issue.
+
+    </p>
+    </details>
+
+    <details>
+    <summary><b>Memorandum on closing issues</b></summary>
+    <p>
+      If you have nothing of substance to add, please refrain from commenting and allow the bot close the issue.
+      Also, don't be afraid to manually close an issue, even if it holds valuable information.
+    </p>
+    <p>
+      Closed issues stay in the system for people to search, read, cross-reference, or even reopen--nothing is lost!
+      Closing obsolete issues is an important way to help maintainers focus their time and effort.
+    </p>
+    </details>
+pulls:
+  markComment: |
+    <p>
+      Thank you for your contribution!
+      I marked this pull request as stale due to inactivity.
+      If this remains inactive for another 7 days, I will close this PR.
+      <b>Please read the relevant sections below before commenting.</b>
+    </p>
+
+    <details>
+    <summary><b>If you are the original author of the PR</b></summary>
+    <p>
+
+    * GitHub sometimes doesn't notify people who commented / reviewed a PR previously, when you (force) push commits. *If you have addressed the reviews* you can [officially ask for a review](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review) from those who commented to you or anyone else.
+    * If it is unfinished but you plan to finish it, please mark it as a draft.
+    * If you don't expect to work on it any time soon, please consider closing it with a short comment encouraging someone else to pick up your work.
+    * To get things rolling again, rebase the PR against the target branch and address valid comments.
+
+    </p>
+    </details>
+
+    <details>
+    <summary><b>If you are <i>not</i> the original author of the issue</b></summary>
+    <p>
+
+    * If you want to pick up the work on this PR, please create a new PR and indicate that it supercedes and closes this PR.
+
+    </p>
+    </details>


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Closes #1957 

This PR adds configuration for [probot/stale](https://github.com/probot/stale) to the repository. The configuration is as follows:

* Issues & PRs get marked as stale after 60 days.
* After 7 days in the stale state, the issue/PR is closed.
* The message from the stalebot when it marks issues as stale looks like this: https://github.com/sumnerevans/sumnerevans/issues/1#issuecomment-828588816
* The message from the stalebot when it marks PRs as stale looks like this: https://github.com/sumnerevans/sumnerevans/issues/1#issuecomment-828638816
* Both of the messages were inspired by the text here: https://github.com/NixOS/nixpkgs/blob/master/.github/STALE-BOT.md

#### Things that need to be done before merging this PR:

- [x] Somebody with permission needs to add probot/stale to the repo
- [x] Somebody with permission needs to add the  `status: stale` label

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
