### PR TITLE
kitty: use dummy package in test

### DIFF
--- a/tests/modules/programs/kitty/example-settings.nix
+++ b/tests/modules/programs/kitty/example-settings.nix
@@ -6,7 +6,6 @@ with lib;
   config = {
     programs.kitty = {
       enable = true;
-      package = pkgs.writeScriptBin "dummy-kitty" "";
       settings = {
         scrollback_lines = 10000;
         enable_audio_bell = false;
@@ -21,6 +20,9 @@ with lib;
         "ctrl+f>2" = "set_font_size 20";
       };
     };
+
+    nixpkgs.overlays =
+      [ (self: super: { kitty = pkgs.writeScriptBin "dummy-kitty" ""; }) ];
 
     nmt.script = ''
       assertFileExists home-files/.config/kitty/kitty.conf


### PR DESCRIPTION
Also remove assignment to non-existent option `programs.kitty.package`.