### PR TITLE
services/barrier: Add service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -164,6 +164,9 @@
 
 /modules/programs/zsh/prezto.nix                      @NickHu
 
+/modules/services/barrier.nix                         @Kritnich
+/tests/modules/services/barrier                       @Kritnich
+
 /modules/services/caffeine.nix                        @uvNikita
 
 /modules/services/cbatticon.nix                       @pmiddend

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1929,6 +1929,13 @@ in
         '';
       }
 
+      {
+        time = "2021-04-30T22:05:01+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new service is available: 'services.barrier'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -139,6 +139,7 @@ let
     (loadModule ./programs/zplug.nix { })
     (loadModule ./programs/zsh.nix { })
     (loadModule ./programs/zsh/prezto.nix { })
+    (loadModule ./services/barrier.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/blueman-applet.nix { })
     (loadModule ./services/caffeine.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/cbatticon.nix { condition = hostPlatform.isLinux; })

--- a/modules/services/barrier.nix
+++ b/modules/services/barrier.nix
@@ -1,0 +1,71 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.services.barrier;
+in {
+
+  meta.maintainers = with maintainers; [ kritnich ];
+
+  options.services.barrier = {
+
+    client = {
+
+      enable = mkEnableOption "Barrier Client daemon";
+
+      name = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Screen name of client. Defaults to hostname.
+        '';
+      };
+
+      server = mkOption {
+        type = types.str;
+        description = ''
+          Server to connect to formatted as
+          <literal>&lt;host&gt;[:&lt;port&gt;]</literal>.
+          Port defaults to <literal>24800</literal>.
+        '';
+      };
+
+      tray = mkEnableOption "the system tray icon" // { default = true; };
+
+      enableCrypto = mkEnableOption "crypto (SSL) plugin" // {
+        default = true;
+      };
+
+      enableDragDrop = mkEnableOption "file drag &amp; drop";
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [ "-f" ];
+        defaultText = literalExample ''[ "-f" ]'';
+        description = ''
+          Additional flags to pass to <command>barrierc</command>.
+          See <command>barrierc --help</command>.
+        '';
+      };
+
+    };
+  };
+
+  config = mkIf cfg.client.enable {
+    systemd.user.services.barrierc = {
+      Unit = {
+        Description = "Barrier Client daemon";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+      Install.WantedBy = [ "graphical-session.target" ];
+      Service.ExecStart = with cfg.client;
+        toString ([ "${pkgs.barrier}/bin/barrierc" ]
+          ++ optional (name != null) "--name ${name}"
+          ++ optional (!tray) "--no-tray"
+          ++ optional enableCrypto "--enable-crypto"
+          ++ optional enableDragDrop "--enable-drag-drop" ++ extraFlags
+          ++ [ server ]);
+    };
+  };
+
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -102,6 +102,7 @@ import nmt {
     ./modules/programs/rofi
     ./modules/programs/rofi-pass
     ./modules/programs/waybar
+    ./modules/services/barrier
     ./modules/services/dropbox
     ./modules/services/emacs
     ./modules/services/fluidsynth

--- a/tests/modules/services/barrier/basic-configuration.nix
+++ b/tests/modules/services/barrier/basic-configuration.nix
@@ -1,0 +1,20 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.barrier.client = {
+      enable = true;
+      server = "testServer";
+    };
+
+    nixpkgs.overlays =
+      [ (self: super: { barrier = pkgs.writeScriptBin "dummy-barrier" ""; }) ];
+
+    nmt.script = ''
+      clientServiceFile=home-files/.config/systemd/user/barrierc.service
+
+      assertFileExists $clientServiceFile
+      assertFileRegex $clientServiceFile 'ExecStart=.*/bin/barrierc --enable-crypto -f testServer'
+    '';
+  };
+}

--- a/tests/modules/services/barrier/default.nix
+++ b/tests/modules/services/barrier/default.nix
@@ -1,0 +1,1 @@
+{ barrier-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

Adds a background service for the Barrier client. Partially closes #712

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
