### PR TITLE
neovim: add `extraLuaPackages` to neovim, fixes #1964.

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -175,8 +175,8 @@ in {
 
       extraLuaPackages = mkOption {
         type = with types; either extraLua51PackageType (listOf package);
-        default = (_: [ ]);
-        defaultText = "ps: []";
+        default = [ ];
+        defaultText = "[]";
         example = literalExample "(ps: with ps; [ luautf8 ])";
         description = ''
           A function in lua5_1.withPackages format, which returns a

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -22,6 +22,10 @@ let
     merge = mergeOneOption;
   };
 
+
+  # Currently, upstream Neovim is pinned on Lua 5.1 for LuaJIT support.
+  # This will need to be updated if Neovim ever migrates to a newer
+  # version of Lua.
   extraLua51PackageType = mkOptionType {
     name = "extra-lua51-packages";
     description = "lua5.1 packages in lua5_1.withPackages format";

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -22,7 +22,6 @@ let
     merge = mergeOneOption;
   };
 
-
   # Currently, upstream Neovim is pinned on Lua 5.1 for LuaJIT support.
   # This will need to be updated if Neovim ever migrates to a newer
   # version of Lua.

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -20,6 +20,9 @@ with lib;
           '';
         }
       ];
+      extraLuaPackages = [
+        pkgs.lua51Packages.luautf8
+      ];
     };
 
     nmt.script = ''


### PR DESCRIPTION
### Description

Extend neovim program to allow specifying additional lua libraries that will become available to neovim at runtime.  See #1964 for further details.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.  The tests die on my machine, but aparently for the reasons that has nothing to do with my changes.  I hope that github's CI would pick it up so we can discuss what's going on.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).  I am not sure whether this change needs any tests.  Does it?

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
