### PR TITLE
home-environment: extra message on nix-env error

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -493,7 +493,24 @@ in
         ''
       else
         ''
-          $DRY_RUN_CMD nix-env -i ${cfg.path}
+          if ! $DRY_RUN_CMD nix-env -i ${cfg.path} ; then
+            cat <<EOF
+
+          Oops, nix-env failed to install your new Home Manager profile!
+
+          Perhaps there is a conflict with a package that was installed using
+          'nix-env -i'? Try running
+
+              nix-env -q
+
+          and if there is a conflicting package you can remove it with
+
+              nix-env -e {package name}
+
+          Then try activating your Home Manager configuration again.
+          EOF
+            exit 1
+          fi
         ''
     );
 


### PR DESCRIPTION
### Description

When profile installation fails during activation we'll print an extra message that explain that, if the error is due to conflicting packages, then it may be that the user has a manually installed copy of the package.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.