### PR TITLE
home-manager: add basic i18n support

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -1,4 +1,4 @@
-{ runCommand, lib, bash, coreutils, findutils, gnused, less
+{ runCommand, lib, bash, coreutils, findutils, gettext, gnused, less
 
 # Extra path to Home Manager. If set then this path will be tried
 # before `$HOME/.config/nixpkgs/home-manager` and
@@ -12,6 +12,7 @@ let
 in runCommand "home-manager" {
   preferLocalBuild = true;
   allowSubstitutes = false;
+  nativeBuildInputs = [ gettext ];
   meta = with lib; {
     description = "A user environment configurator";
     maintainers = [ maintainers.rycee ];
@@ -25,12 +26,17 @@ in runCommand "home-manager" {
     --subst-var-by bash "${bash}" \
     --subst-var-by coreutils "${coreutils}" \
     --subst-var-by findutils "${findutils}" \
+    --subst-var-by gettext "${gettext}" \
     --subst-var-by gnused "${gnused}" \
     --subst-var-by less "${less}" \
-    --subst-var-by HOME_MANAGER_PATH '${pathStr}'
+    --subst-var-by HOME_MANAGER_PATH '${pathStr}' \
+    --subst-var-by TEXTDOMAINDIR "$out/share/locale"
 
   install -D -m755 ${./completion.bash} \
     $out/share/bash-completion/completions/home-manager
   install -D -m755 ${./completion.zsh} \
     $out/share/zsh/site-functions/_home-manager
+
+  mkdir -p $out/share/locale/sv/LC_MESSAGES
+  msgfmt -o $out/share/locale/sv/LC_MESSAGES/home-manager.mo ${./po/sv.po}
 ''

--- a/home-manager/hm-xgettext
+++ b/home-manager/hm-xgettext
@@ -1,0 +1,10 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -I https://github.com/NixOS/nixpkgs/archive/05f0934825c2a0750d4888c4735f9420c906b388.tar.gz -i bash -p gettext
+
+xgettext --package-name='Home Manager' \
+         --copyright-holder='Home Manager contributors' \
+         --msgid-bugs-address=https://github.com/nix-community/home-manager/issues \
+         -L Shell -k \
+         -k_echo:1 --flag=_echo:1:c-format \
+         -k_echop:1,2 --flag=_echop:1:c-format --flag=_echop:2:c-format \
+         -o po/home-manager.pot -d home-manager home-manager

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -3,7 +3,27 @@
 # Prepare to use tools from Nixpkgs.
 PATH=@coreutils@/bin:@findutils@/bin:@gnused@/bin:@less@/bin${PATH:+:}$PATH
 
+export TEXTDOMAINDIR=@TEXTDOMAINDIR@
+
 set -euo pipefail
+
+function _echo() {
+    local msgid="$1"
+    shift
+
+    # shellcheck disable=2059
+    printf "$(@gettext@/bin/gettext -e "home-manager" "$msgid")\n" "$@"
+}
+
+function _echop() {
+    local msgid="$1"
+    local msgidPlural="$2"
+    local count="$3"
+    shift 3
+
+    # shellcheck disable=2059
+    printf "$(@gettext@/bin/ngettext -e "home-manager" "$msgid" "$msgidPlural" "$count")\n" "$@"
+}
 
 function errorEcho() {
     # shellcheck disable=2048,2086
@@ -39,7 +59,8 @@ function setWorkDir() {
 function setConfigFile() {
     if [[ -v HOME_MANAGER_CONFIG ]] ; then
         if [[ ! -e "$HOME_MANAGER_CONFIG" ]] ; then
-            errorEcho "No configuration file found at $HOME_MANAGER_CONFIG"
+            _echo "No configuration file found at %s" \
+               "$HOME_MANAGER_CONFIG" >&2
             exit 1
         fi
 
@@ -57,8 +78,8 @@ function setConfigFile() {
         fi
     done
 
-    errorEcho "No configuration file found." \
-         "Please create one at $defaultConfFile"
+    _echo "No configuration file found. Please create one at %s" \
+       "$defaultConfFile" >&2
     exit 1
 }
 
@@ -100,7 +121,7 @@ function setFlakeAttribute() {
 function doInstantiate() {
     setFlakeAttribute
     if [[ -v FLAKE_CONFIG_URI ]]; then
-        errorEcho "Can't instantiate a flake configuration"
+        _echo "Can't instantiate a flake configuration" >&2
         exit 1
     fi
     setConfigFile
@@ -160,20 +181,16 @@ function presentNews() {
     elif [[ "$newsDisplay" == "silent" ]]; then
         return
     elif [[ "$newsDisplay" == "notify" ]]; then
-        local msg
-        if [[ $newsNumUnread -eq 1 ]]; then
-            msg="There is an unread and relevant news item.\n"
-            msg+="Read it by running the command '$(basename "$0") news'."
-        else
-            msg="There are $newsNumUnread unread and relevant news items.\n"
-            msg+="Read them by running the command '$(basename "$0") news'."
-        fi
+        local cmd msg
+        cmd="$(basename "$0")"
+        msg="$(_echop \
+                $'There is %d unread and relevant news item.\nRead it by running the command "%s news".' \
+                $'There are %d unread and relevant news items.\nRead them by running the command "%s news".' \
+                "$newsNumUnread" "$newsNumUnread" "$cmd")"
 
         # Not actually an error but here stdout is reserved for
         # nix-build output.
-        errorEcho
-        errorEcho -e "$msg"
-        errorEcho
+        echo $'\n'"$msg"$'\n' >&2
 
         if [[ -v DISPLAY ]] && type -P notify-send > /dev/null; then
             notify-send "Home Manager" "$msg"
@@ -181,13 +198,14 @@ function presentNews() {
     elif [[ "$newsDisplay" == "show" ]]; then
         doShowNews --unread
     else
-        errorEcho "Unknown 'news.display' setting '$newsDisplay'."
+        _echo 'Unknown "news.display" setting "%s".' "$newsDisplay" >&2
     fi
 }
 
 function doEdit() {
     if [[ ! -v EDITOR || -z $EDITOR ]]; then
-        errorEcho "Please set the \$EDITOR environment variable"
+        # shellcheck disable=2016
+        _echo 'Please set the $EDITOR environment variable' >&2
         return 1
     fi
 
@@ -202,7 +220,7 @@ function doEdit() {
 
 function doBuild() {
     if [[ ! -w . ]]; then
-        errorEcho "Cannot run build in read-only directory";
+        _echo 'Cannot run build in read-only directory' >&2
         return 1
     fi
 
@@ -293,9 +311,9 @@ function doRmGenerations() {
         local linkName="home-manager-$generationId-link"
 
         if [[ ! -e $linkName ]]; then
-            errorEcho "No generation with ID $generationId"
+            _echo 'No generation with ID %s' "$generationId" >&2
         elif [[ $linkName == $(readlink home-manager) ]]; then
-            errorEcho "Cannot remove the current generation $generationId"
+            _echo 'Cannot remove the current generation %s' "$generationId" >&2
         else
             echo Removing generation $generationId
             $DRY_RUN_CMD rm $VERBOSE_ARG $linkName
@@ -323,7 +341,7 @@ function doExpireGenerations() {
         # shellcheck disable=2086
         doRmGenerations $generations
     elif [[ -v VERBOSE ]]; then
-        echo "No generations to expire"
+        _echo "No generations to expire"
     fi
 }
 
@@ -333,7 +351,7 @@ function doListPackages() {
     if [[ -n "$outPath" ]] ; then
         nix-store -q --references "$outPath" | sed 's/[^-]*-//'
     else
-        errorEcho "No home-manager packages seem to be installed."
+        _echo 'No home-manager packages seem to be installed.' >&2
     fi
 }
 
@@ -390,7 +408,7 @@ function doShowNews() {
             ${PAGER:-less} "$newsFileUnread"
             ;;
         *)
-            errorEcho "Unknown argument $1"
+            _echo 'Unknown argument %s' "$1"
             return 1
     esac
 
@@ -405,19 +423,19 @@ function doShowNews() {
 function doUninstall() {
     setVerboseAndDryRun
 
-    echo "This will remove Home Manager from your system."
+    _echo 'This will remove Home Manager from your system.'
 
     if [[ -v DRY_RUN ]]; then
-        echo "This is a dry run, nothing will actually be uninstalled."
+        _echo 'This is a dry run, nothing will actually be uninstalled.'
     fi
 
     local confirmation
-    read -r -n 1 -p "Really uninstall Home Manager? [y/n] " confirmation
+    read -r -n 1 -p "$(_echo 'Really uninstall Home Manager?') [y/n] " confirmation
     echo
 
     case $confirmation in
         y|Y)
-            echo "Switching to empty Home Manager configuration..."
+            _echo "Switching to empty Home Manager configuration..."
             HOME_MANAGER_CONFIG="$(mktemp --tmpdir home-manager.XXXXXXXXXX)"
             echo "{ lib, ... }: { home.file = lib.mkForce {}; }" > "$HOME_MANAGER_CONFIG"
             doSwitch
@@ -429,28 +447,28 @@ function doUninstall() {
                 "$NIX_STATE_DIR/gcroots/per-user/$USER/current-home"
             ;;
         *)
-            echo "Yay!"
+            _echo "Yay!"
             exit 0
             ;;
     esac
 
     local deleteProfiles
     read -r -n 1 \
-         -p 'Remove all Home Manager generations? [y/n] ' \
+         -p "$(_echo 'Remove all Home Manager generations?') [y/n] " \
          deleteProfiles
     echo
 
     case $deleteProfiles in
         y|Y)
             doRmAllGenerations
-            echo "All generations are now eligible for garbage collection."
+            _echo 'All generations are now eligible for garbage collection.'
             ;;
         *)
-            echo "Leaving generations but they may still be garbage collected."
+            _echo 'Leaving generations but they may still be garbage collected.'
             ;;
     esac
 
-    echo "Home Manager is uninstalled but your home.nix is left untouched."
+    _echo "Home Manager is uninstalled but your home.nix is left untouched."
 }
 
 function doHelp() {
@@ -589,8 +607,8 @@ while [[ $# -gt 0 ]]; do
                     COMMAND_ARGS+=("$opt")
                     ;;
                 *)
-                    errorEcho "$0: unknown option '$opt'"
-                    errorEcho "Run '$0 --help' for usage help"
+                    _echo "%s: unknown option '%s'" "$0" "$opt" >&2
+                    _echo "Run '%s --help' for usage help" "$0" >&2
                     exit 1
                     ;;
             esac
@@ -624,7 +642,7 @@ case $COMMAND in
         ;;
     expire-generations)
         if [[ ${#COMMAND_ARGS[@]} != 1 ]]; then
-            errorEcho "expire-generations expects one argument, got ${#COMMAND_ARGS[@]}."
+            _echo 'expire-generations expects one argument, got %d.' "${#COMMAND_ARGS[@]}" >&2
             exit 1
         else
             doExpireGenerations "${COMMAND_ARGS[@]}"
@@ -643,7 +661,7 @@ case $COMMAND in
         doHelp
         ;;
     *)
-        errorEcho "Unknown command: $COMMAND"
+        _echo 'Unknown command: %s' "$COMMAND" >&2
         doHelp >&2
         exit 1
         ;;

--- a/home-manager/po/home-manager.pot
+++ b/home-manager/po/home-manager.pot
@@ -1,0 +1,126 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Home Manager contributors
+# This file is distributed under the same license as the Home Manager package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Home Manager\n"
+"Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
+"POT-Creation-Date: 2021-05-18 22:53+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: home-manager:62
+msgid "No configuration file found at %s"
+msgstr ""
+
+#: home-manager:81
+msgid "No configuration file found. Please create one at %s"
+msgstr ""
+
+#: home-manager:124
+msgid "Can't instantiate a flake configuration"
+msgstr ""
+
+#: home-manager:187
+msgid ""
+"There is %d unread and relevant news item.\n"
+"Read it by running the command \"%s news\"."
+msgid_plural ""
+"There are %d unread and relevant news items.\n"
+"Read them by running the command \"%s news\"."
+msgstr[0] ""
+msgstr[1] ""
+
+#: home-manager:201
+msgid "Unknown \"news.display\" setting \"%s\"."
+msgstr ""
+
+#: home-manager:208
+#, sh-format
+msgid "Please set the $EDITOR environment variable"
+msgstr ""
+
+#: home-manager:223
+msgid "Cannot run build in read-only directory"
+msgstr ""
+
+#: home-manager:314
+msgid "No generation with ID %s"
+msgstr ""
+
+#: home-manager:316
+msgid "Cannot remove the current generation %s"
+msgstr ""
+
+#: home-manager:344
+msgid "No generations to expire"
+msgstr ""
+
+#: home-manager:354
+msgid "No home-manager packages seem to be installed."
+msgstr ""
+
+#: home-manager:411
+msgid "Unknown argument %s"
+msgstr ""
+
+#: home-manager:426
+msgid "This will remove Home Manager from your system."
+msgstr ""
+
+#: home-manager:429
+msgid "This is a dry run, nothing will actually be uninstalled."
+msgstr ""
+
+#: home-manager:433
+msgid "Really uninstall Home Manager?"
+msgstr ""
+
+#: home-manager:438
+msgid "Switching to empty Home Manager configuration..."
+msgstr ""
+
+#: home-manager:450
+msgid "Yay!"
+msgstr ""
+
+#: home-manager:457
+msgid "Remove all Home Manager generations?"
+msgstr ""
+
+#: home-manager:464
+msgid "All generations are now eligible for garbage collection."
+msgstr ""
+
+#: home-manager:467
+msgid "Leaving generations but they may still be garbage collected."
+msgstr ""
+
+#: home-manager:471
+msgid "Home Manager is uninstalled but your home.nix is left untouched."
+msgstr ""
+
+#: home-manager:610
+msgid "%s: unknown option '%s'"
+msgstr ""
+
+#: home-manager:611
+msgid "Run '%s --help' for usage help"
+msgstr ""
+
+#: home-manager:645
+msgid "expire-generations expects one argument, got %d."
+msgstr ""
+
+#: home-manager:664
+msgid "Unknown command: %s"
+msgstr ""

--- a/home-manager/po/sv.po
+++ b/home-manager/po/sv.po
@@ -1,0 +1,131 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Home Manager\n"
+"Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/"
+"issues\n"
+"POT-Creation-Date: 2021-05-18 22:53+0200\n"
+"PO-Revision-Date: 2021-05-18 22:54+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.4.1\n"
+
+#: home-manager:62
+msgid "No configuration file found at %s"
+msgstr "Det finns ingen konfigurationsfil i %s"
+
+#: home-manager:81
+msgid "No configuration file found. Please create one at %s"
+msgstr "Hittade ingen konfigurationsfil. Skapa en i %s"
+
+#: home-manager:124
+msgid "Can't instantiate a flake configuration"
+msgstr "Kan inte instansera en flake-konfiguration"
+
+#: home-manager:187
+msgid ""
+"There is %d unread and relevant news item.\n"
+"Read it by running the command \"%s news\"."
+msgid_plural ""
+"There are %d unread and relevant news items.\n"
+"Read them by running the command \"%s news\"."
+msgstr[0] ""
+"Det finns %d oläst och relevant nyhet.\n"
+"Läs den genom att köra kommandot \"%s news\"."
+msgstr[1] ""
+"Det finns %d olästa och relevanta nyheter.\\nLäs dem genom att köra "
+"kommandot \"%s news\"."
+
+#: home-manager:201
+msgid "Unknown \"news.display\" setting \"%s\"."
+msgstr "Okänt \"news.display\"-värde \"%s\"."
+
+#: home-manager:208
+#, sh-format
+msgid "Please set the $EDITOR environment variable"
+msgstr "Vänligen tilldela miljövariablen $EDITOR"
+
+#: home-manager:223
+msgid "Cannot run build in read-only directory"
+msgstr "Kan inte bygga i katalog med bara läsrättigheter"
+
+#: home-manager:314
+msgid "No generation with ID %s"
+msgstr "Ingen generation med ID %s"
+
+#: home-manager:316
+msgid "Cannot remove the current generation %s"
+msgstr "Kan inte ta bort nuvarande generation %s"
+
+#: home-manager:344
+msgid "No generations to expire"
+msgstr "Ingen generation att förfalla"
+
+#: home-manager:354
+msgid "No home-manager packages seem to be installed."
+msgstr "Paketet home-manager verkar inte vara installerat."
+
+#: home-manager:411
+msgid "Unknown argument %s"
+msgstr "Okänt argument %s"
+
+#: home-manager:426
+msgid "This will remove Home Manager from your system."
+msgstr "Detta kommer att ta bort Home Manager från ditt system."
+
+#: home-manager:429
+msgid "This is a dry run, nothing will actually be uninstalled."
+msgstr "Detta är en testkörning, inget kommer att bli avinstallerat."
+
+#: home-manager:433
+msgid "Really uninstall Home Manager?"
+msgstr "Verkligen avinstallera Home Manager?"
+
+#: home-manager:438
+msgid "Switching to empty Home Manager configuration..."
+msgstr "Byter till tom Home Manager-konfiguration..."
+
+#: home-manager:450
+msgid "Yay!"
+msgstr "Hurra!"
+
+#: home-manager:457
+msgid "Remove all Home Manager generations?"
+msgstr "Ta bort alla Home Manager-generationer?"
+
+#: home-manager:464
+msgid "All generations are now eligible for garbage collection."
+msgstr "Alla generationer kan nu skräpsamlas."
+
+#: home-manager:467
+msgid "Leaving generations but they may still be garbage collected."
+msgstr "Låter generationer vara kvar men de kan fortfarande skräpsamlas."
+
+#: home-manager:471
+msgid "Home Manager is uninstalled but your home.nix is left untouched."
+msgstr "Home Manager är avinstallerad men din home.nix är orörd."
+
+#: home-manager:610
+msgid "%s: unknown option '%s'"
+msgstr "%s: okänt val '%s'"
+
+#: home-manager:611
+msgid "Run '%s --help' for usage help"
+msgstr "Kör '%s --help' för användarhjälp"
+
+#: home-manager:645
+msgid "expire-generations expects one argument, got %d."
+msgstr "expect-generations förväntar sig ett argument, fick %d."
+
+#: home-manager:664
+msgid "Unknown command: %s"
+msgstr "Okänd kommando: %s"


### PR DESCRIPTION
### Description

Experimental support for i18n.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
