### PR TITLE
neovim: drop python2 support

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -6,14 +6,6 @@ let
 
   cfg = config.programs.neovim;
 
-  extraPythonPackageType = mkOptionType {
-    name = "extra-python-packages";
-    description = "python packages in python.withPackages format";
-    check = with types;
-      (x: if isFunction x then isList (x pkgs.pythonPackages) else false);
-    merge = mergeOneOption;
-  };
-
   extraPython3PackageType = mkOptionType {
     name = "extra-python3-packages";
     description = "python3 packages in python.withPackages format";
@@ -67,6 +59,13 @@ let
     ''--suffix PATH : "${lib.makeBinPath cfg.extraPackages}"'';
 
 in {
+  imports = [
+    (mkRemovedOptionModule [ "programs" "neovim" "withPython" ]
+      "Python2 support has been removed from neovim.")
+    (mkRemovedOptionModule [ "programs" "neovim" "extraPythonPackages" ]
+      "Python2 support has been removed from neovim.")
+  ];
+
   options = {
     programs.neovim = {
       enable = mkEnableOption "Neovim";
@@ -101,26 +100,6 @@ in {
         description = ''
           Enable node provider. Set to <literal>true</literal> to
           use Node plugins.
-        '';
-      };
-
-      withPython = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Enable Python 2 provider. Set to <literal>true</literal> to
-          use Python 2 plugins.
-        '';
-      };
-
-      extraPythonPackages = mkOption {
-        type = with types; either extraPythonPackageType (listOf package);
-        default = (_: [ ]);
-        defaultText = "ps: []";
-        example = literalExample "(ps: with ps; [ pandas jedi ])";
-        description = ''
-          A function in python.withPackages format, which returns a
-          list of Python 2 packages required for your plugins to work.
         '';
       };
 
@@ -245,8 +224,7 @@ in {
   config = let
     neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
       inherit (cfg)
-        extraPython3Packages withPython3 extraPythonPackages withPython
-        withNodeJs withRuby viAlias vimAlias;
+        extraPython3Packages withPython3 withNodeJs withRuby viAlias vimAlias;
       configure = cfg.configure // moduleConfigure;
       plugins = cfg.plugins;
     };


### PR DESCRIPTION
### Description
Nixpkgs did the same in https://github.com/NixOS/nixpkgs/pull/121339.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
