### PR TITLE
i3, sway: description and example for font options

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -95,6 +95,12 @@ let
       fonts = mkOption {
         type = with types; either (listOf str) fontOptions;
         default = { };
+        example = {
+          names = [ "DejaVu Sans Mono" "FontAwesome5Free" ];
+          style = "Bold Semi-Condensed";
+          size = 11.0;
+        };
+        description = "Font configuration for this bar.";
       };
 
       extraConfig = mkOption {
@@ -339,6 +345,12 @@ in {
   fonts = mkOption {
     type = with types; either (listOf str) fontOptions;
     default = { };
+    example = {
+      names = [ "DejaVu Sans Mono" "FontAwesome5Free" ];
+      style = "Bold Semi-Condensed";
+      size = 11.0;
+    };
+    description = "Font configuration for window titles, nagbar...";
   };
 
   window = mkOption {

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -95,11 +95,13 @@ let
       fonts = mkOption {
         type = with types; either (listOf str) fontOptions;
         default = { };
-        example = {
-          names = [ "DejaVu Sans Mono" "FontAwesome5Free" ];
-          style = "Bold Semi-Condensed";
-          size = 11.0;
-        };
+        example = literalExample ''
+          {
+            names = [ "DejaVu Sans Mono" "FontAwesome5Free" ];
+            style = "Bold Semi-Condensed";
+            size = 11.0;
+          }
+        '';
         description = "Font configuration for this bar.";
       };
 
@@ -345,11 +347,13 @@ in {
   fonts = mkOption {
     type = with types; either (listOf str) fontOptions;
     default = { };
-    example = {
-      names = [ "DejaVu Sans Mono" "FontAwesome5Free" ];
-      style = "Bold Semi-Condensed";
-      size = 11.0;
-    };
+    example = literalExample ''
+      {
+        names = [ "DejaVu Sans Mono" "FontAwesome5Free" ];
+        style = "Bold Semi-Condensed";
+        size = 11.0;
+      }
+    '';
     description = "Font configuration for window titles, nagbar...";
   };
 


### PR DESCRIPTION
Fixes #1979

### Description

Though the module options themselves had examples, they're unfortunately not reflected individually in the manual (I'm guessing because of `type = with types; either (listOf str) fontOptions;`?), so add examples for both font options

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
