### PR TITLE
zsh: break configuration dependency in documentation

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -56,6 +56,10 @@ let
         default = if versionAtLeast stateVersion "20.03"
           then "$HOME/.zsh_history"
           else relToDotDir ".zsh_history";
+        defaultText = literalExample ''
+          "$HOME/.zsh_history" if state version ≥ 20.03,
+          "$ZDOTDIR/.zsh_history" otherwise
+        '';
         example = literalExample ''"''${config.xdg.dataHome}/zsh/zsh_history"'';
         description = "History file location";
       };


### PR DESCRIPTION
### Description

Before the documentation for the `programs.zsh.history.path` had a dependency on the configuration.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.