### PR TITLE
i3,sway: break documentation dependency on configuration

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -79,17 +79,13 @@ let
     options = let
       versionAtLeast2009 = versionAtLeast config.home.stateVersion "20.09";
       mkNullableOption = { type, default, ... }@args:
-        mkOption (args // optionalAttrs versionAtLeast2009 {
+        mkOption (args // {
           type = types.nullOr type;
-          default = null;
-          example = default;
-        } // {
+          default = if versionAtLeast2009 then null else default;
           defaultText = literalExample ''
-            ${
-              if isString default then default else "See code"
-            } for state version < 20.09,
-            null for state version ≥ 20.09
+            null for state version ≥ 20.09, as example otherwise
           '';
+          example = default;
         });
     in {
       fonts = mkOption {
@@ -167,11 +163,9 @@ let
           "\${pkgs.waybar}/bin/waybar";
       };
 
-      statusCommand = mkOption {
-        type = types.nullOr types.str;
-        default =
-          if versionAtLeast2009 then null else "${pkgs.i3status}/bin/i3status";
-        example = "i3status";
+      statusCommand = mkNullableOption {
+        type = types.str;
+        default = "${pkgs.i3status}/bin/i3status";
         description = "Command that will be used to get status lines.";
       };
 
@@ -687,6 +681,7 @@ in {
       };
     }] else
       [ { } ];
+    defaultText = literalExample "see code";
     description = ''
       ${capitalModuleName} bars settings blocks. Set to empty list to remove bars completely.
     '';


### PR DESCRIPTION
### Description

Before the documentation for a number of options had a dependency on the configuration.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.