### PR TITLE
firefox: do not override other attributes in 'cfg'

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -282,7 +282,7 @@ in
           if isDarwin then
             cfg.package
           else if versionAtLeast config.home.stateVersion "19.09" then
-            cfg.package.override { cfg = fcfg; }
+            cfg.package.override (old: { cfg = old.cfg or {} // fcfg; })
           else
             (pkgs.wrapFirefox.override { config = bcfg; }) cfg.package { };
       in


### PR DESCRIPTION
Closes #1962.

### Description

This commit changes the module so that it only overrides *some* of the attributes in `cfg` of the firefox wrapper. This allows the user to enable other features by providing the appropriate `package` option, like so:

```nix
config.programs.firefox = {
  enable = true;

  package = pkgs.firefox.override {
    cfg = {
      enableTridactylNative = cfg.tridactyl.enable;
    };
  };
};
```

### Checklist


- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
