### PR TITLE
msmtp: add note about account commands in extraConfig

### DIFF
--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -53,6 +53,11 @@ in {
         description = ''
           Extra configuration lines to add to <filename>~/.msmtprc</filename>.
           See <link xlink:href="https://marlam.de/msmtp/msmtprc.txt"/> for examples.
+          </para><para>
+          Note, if running msmtp fails with the error message "account default
+          was already defined" then you probably have an account command here.
+          Account commands should be placed in
+          <xref linkend="opt-accounts.email.accounts._name_.msmtp.extraConfig"/>.
         '';
       };
 


### PR DESCRIPTION
### Description

Fixes #1975.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.