### PR TITLE
Remove some usage of config.lib.dag

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -6,8 +6,6 @@ let
 
   cfg = config.xdg;
 
-  dag = config.lib.dag;
-
   fileType = (import ../lib/file-type.nix {
     inherit (config.home) homeDirectory;
     inherit lib pkgs;

--- a/modules/programs/home-manager.nix
+++ b/modules/programs/home-manager.nix
@@ -6,8 +6,6 @@ let
 
   cfg = config.programs.home-manager;
 
-  dag = config.lib.dag;
-
 in {
   meta.maintainers = [ maintainers.rycee ];
 

--- a/tests/lib/types/dag-merge.nix
+++ b/tests/lib/types/dag-merge.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
 
-  dag = config.lib.dag;
+  dag = lib.hm.dag;
 
   result = let
     sorted = dag.topoSort config.tested.dag;

--- a/tests/lib/types/dag-submodule.nix
+++ b/tests/lib/types/dag-submodule.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
 
-  dag = config.lib.dag;
+  dag = lib.hm.dag;
 
   result = let
     sorted = dag.topoSort config.tested.dag;

--- a/tests/lib/types/list-or-dag-merge.nix
+++ b/tests/lib/types/list-or-dag-merge.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
 
-  dag = config.lib.dag;
+  dag = lib.hm.dag;
 
   result = let
     sorted = dag.topoSort config.tested.dag;


### PR DESCRIPTION
The `lib.hm.dag` attribute set should always be preferred.