### PR TITLE
Partially revert "xdg.systemDirs: init module"

### DIFF
--- a/modules/misc/xdg-system-dirs.nix
+++ b/modules/misc/xdg-system-dirs.nix
@@ -37,11 +37,17 @@ in {
 
   config = mkMerge [
     (mkIf (cfg.config != [ ]) {
+      home.sessionVariables.XDG_CONFIG_DIRS =
+        "${configDirs}\${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}";
+
       systemd.user.sessionVariables.XDG_CONFIG_DIRS =
         "${configDirs}\${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}";
     })
 
     (mkIf (cfg.data != [ ]) {
+      home.sessionVariables.XDG_DATA_DIRS =
+        "${dataDirs}\${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}";
+
       systemd.user.sessionVariables.XDG_DATA_DIRS =
         "${dataDirs}\${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}";
     })

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -333,11 +333,6 @@ in
             unset systemdStatus
           ''
       );
-
-      # Export environment variables in systemd.user.sessionVariables to login shells.
-      home.sessionVariablesExtra = optionalString (cfg.sessionVariables != {}) ''
-        export $(${pkgs.systemd}/lib/systemd/user-environment-generators/30-systemd-environment-d-generator)
-      '';
     })
   ];
 }

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -15,7 +15,6 @@ let
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
-    export $(${pkgs.systemd}/lib/systemd/user-environment-generators/30-systemd-environment-d-generator)
   '';
 
   darwinExpected = ''

--- a/tests/modules/misc/xdg/system-dirs.nix
+++ b/tests/modules/misc/xdg/system-dirs.nix
@@ -19,7 +19,9 @@
       sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
       assertFileExists $sessionVarsFile
       assertFileContains $sessionVarsFile \
-        'export $(${pkgs.systemd}/lib/systemd/user-environment-generators/30-systemd-environment-d-generator)'
+        'export XDG_CONFIG_DIRS="/etc/xdg:/foo/bar''${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}"'
+      assertFileContains $sessionVarsFile \
+        'export XDG_DATA_DIRS="/usr/local/share:/usr/share:/baz/quux''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"'
     '';
   };
 }

--- a/tests/modules/systemd/session-variables.nix
+++ b/tests/modules/systemd/session-variables.nix
@@ -15,11 +15,6 @@
         V_int=1
         V_str=2
       ''}
-
-      sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
-      assertFileExists $sessionVarsFile
-      assertFileContains $sessionVarsFile \
-        'export $(${pkgs.systemd}/lib/systemd/user-environment-generators/30-systemd-environment-d-generator)'
     '';
   };
 }


### PR DESCRIPTION
Reverts nix-community/home-manager#1797

See #1999 ; in addition, since updating to latest nixpkgs-master, I've lost XDG_RUNTIME_DIR with this change.