### PR TITLE
i3,sway: default workspace

### DIFF
--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -17,7 +17,7 @@ let
       inherit (commonOptions)
         fonts window floating focus assigns modifier workspaceLayout
         workspaceAutoBackAndForth keycodebindings colors bars startup gaps menu
-        terminal;
+        terminal defaultWorkspace;
 
       keybindings = mkOption {
         type = types.attrsOf (types.nullOr types.str);
@@ -141,7 +141,7 @@ let
   inherit (commonFunctions)
     keybindingsStr keycodebindingsStr modeStr assignStr barStr gapsStr
     floatingCriteriaStr windowCommandsStr colorSetStr windowBorderString
-    fontConfigStr;
+    fontConfigStr keybindingDefaultWorkspace keybindingsRest;
 
   startupEntryStr = { command, always, notification, workspace, ... }: ''
     ${if always then "exec_always" else "exec"} ${
@@ -176,7 +176,8 @@ let
       client.placeholder ${colorSetStr colors.placeholder}
       client.background ${colors.background}
 
-      ${keybindingsStr { inherit keybindings; }}
+      ${keybindingsStr { keybindings = keybindingDefaultWorkspace; }}
+      ${keybindingsStr { keybindings = keybindingsRest; }}
       ${keycodebindingsStr keycodebindings}
       ${concatStringsSep "\n" (mapAttrsToList modeStr modes)}
       ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -8,6 +8,14 @@ rec {
       concatStringsSep " " (mapAttrsToList (k: v: ''${k}="${v}"'') criteria)
     }]";
 
+  keybindingDefaultWorkspace = filterAttrs (n: v:
+    cfg.config.defaultWorkspace != null && v == cfg.config.defaultWorkspace)
+    cfg.config.keybindings;
+
+  keybindingsRest = filterAttrs (n: v:
+    cfg.config.defaultWorkspace == null || v != cfg.config.defaultWorkspace)
+    cfg.config.keybindings;
+
   keybindingsStr = { keybindings, bindsymArgs ? "" }:
     concatStringsSep "\n" (mapAttrsToList (keycomb: action:
       optionalString (action != null) "bindsym ${

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -819,4 +819,16 @@ in {
     description = "Default launcher to use.";
     example = "bemenu-run";
   };
+
+  defaultWorkspace = mkOption {
+    type = types.nullOr types.str;
+    default = null;
+    description = ''
+      The default workspace to show when ${
+        if isSway then "sway" else "i3"
+      } is launched.
+      This must to correspond to the value of the keybinding of the default workspace.
+    '';
+    example = "workspace number 9";
+  };
 }

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -17,7 +17,7 @@ let
       inherit (commonOptions)
         fonts window floating focus assigns workspaceLayout
         workspaceAutoBackAndForth modifier keycodebindings colors bars startup
-        gaps menu terminal;
+        gaps menu terminal defaultWorkspace;
 
       left = mkOption {
         type = types.str;
@@ -246,7 +246,7 @@ let
   inherit (commonFunctions)
     keybindingsStr keycodebindingsStr modeStr assignStr barStr gapsStr
     floatingCriteriaStr windowCommandsStr colorSetStr windowBorderString
-    fontConfigStr;
+    fontConfigStr keybindingDefaultWorkspace keybindingsRest;
 
   startupEntryStr = { command, always, ... }: ''
     ${if always then "exec_always" else "exec"} ${command}
@@ -285,7 +285,12 @@ let
       client.background ${colors.background}
 
       ${keybindingsStr {
-        inherit keybindings;
+        keybindings = keybindingDefaultWorkspace;
+        bindsymArgs =
+          lib.optionalString (cfg.config.bindkeysToCode) "--to-code";
+      }}
+      ${keybindingsStr {
+        keybindings = keybindingsRest;
         bindsymArgs =
           lib.optionalString (cfg.config.bindkeysToCode) "--to-code";
       }}

--- a/tests/modules/services/window-managers/i3/default.nix
+++ b/tests/modules/services/window-managers/i3/default.nix
@@ -4,4 +4,5 @@
   i3-fonts-deprecated = ./i3-fonts-deprecated.nix;
   i3-keybindings = ./i3-keybindings.nix;
   i3-null-config = ./i3-null-config.nix;
+  i3-workspace-default = ./i3-workspace-default.nix;
 }

--- a/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
@@ -17,6 +17,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+
 bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2

--- a/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
@@ -17,6 +17,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+
 bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2

--- a/tests/modules/services/window-managers/i3/i3-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-workspace-default-expected.conf
@@ -4,7 +4,7 @@ default_border normal 2
 default_floating_border normal 2
 hide_edge_borders none
 force_focus_wrapping no
-focus_follows_mouse no
+focus_follows_mouse yes
 focus_on_window_activation smart
 mouse_warping output
 workspace_layout default
@@ -17,9 +17,8 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
-
-bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
 bindsym Mod1+4 workspace number 4

--- a/tests/modules/services/window-managers/i3/i3-workspace-default.nix
+++ b/tests/modules/services/window-managers/i3/i3-workspace-default.nix
@@ -1,0 +1,21 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  config = {
+    xsession.windowManager.i3 = {
+      enable = true;
+
+      config.defaultWorkspace = "workspace number 1";
+    };
+
+    nixpkgs.overlays = [ (import ./i3-overlay.nix) ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/i3/config
+      assertFileContent home-files/.config/i3/config \
+        ${./i3-workspace-default-expected.conf}
+    '';
+  };
+}

--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -6,4 +6,5 @@
   sway-null-config = ./sway-null-config.nix;
   sway-null-package = ./sway-null-package.nix;
   sway-modules = ./sway-modules.nix;
+  sway-workspace-default = ./sway-workspace-default.nix;
 }

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -17,6 +17,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
@@ -17,6 +17,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
@@ -17,6 +17,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-modules.conf
+++ b/tests/modules/services/window-managers/sway/sway-modules.conf
@@ -17,6 +17,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-null-package.conf
+++ b/tests/modules/services/window-managers/sway/sway-null-package.conf
@@ -17,6 +17,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
@@ -1,10 +1,10 @@
 font pango:monospace 8.000000
 floating_modifier Mod1
-default_border normal 2
-default_floating_border normal 2
+default_border pixel 2
+default_floating_border pixel 2
 hide_edge_borders none
-force_focus_wrapping no
-focus_follows_mouse no
+focus_wrapping no
+focus_follows_mouse yes
 focus_on_window_activation smart
 mouse_warping output
 workspace_layout default
@@ -17,8 +17,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
-
-bindsym Mod1+0 workspace number 10
+bindsym Mod1+9 workspace number 9
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -27,12 +26,10 @@ bindsym Mod1+5 workspace number 5
 bindsym Mod1+6 workspace number 6
 bindsym Mod1+7 workspace number 7
 bindsym Mod1+8 workspace number 8
-bindsym Mod1+9 workspace number 9
 bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
-bindsym Mod1+Return exec i3-sensible-terminal
+bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
 bindsym Mod1+Right focus right
-bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3
@@ -47,33 +44,43 @@ bindsym Mod1+Shift+Left move left
 bindsym Mod1+Shift+Right move right
 bindsym Mod1+Shift+Up move up
 bindsym Mod1+Shift+c reload
-bindsym Mod1+Shift+e exec i3-nagbar -t warning -m 'Do you want to exit i3?' -b 'Yes' 'i3-msg exit'
+bindsym Mod1+Shift+e exec swaynag -t warning -m 'You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.' -b 'Yes, exit sway' 'swaymsg exit'
+bindsym Mod1+Shift+h move left
+bindsym Mod1+Shift+j move down
+bindsym Mod1+Shift+k move up
+bindsym Mod1+Shift+l move right
 bindsym Mod1+Shift+minus move scratchpad
 bindsym Mod1+Shift+q kill
-bindsym Mod1+Shift+r restart
 bindsym Mod1+Shift+space floating toggle
 bindsym Mod1+Up focus up
 bindsym Mod1+a focus parent
+bindsym Mod1+b splith
 bindsym Mod1+d exec @dmenu@/bin/dmenu_run
 bindsym Mod1+e layout toggle split
 bindsym Mod1+f fullscreen toggle
-bindsym Mod1+h split h
+bindsym Mod1+h focus left
+bindsym Mod1+j focus down
+bindsym Mod1+k focus up
+bindsym Mod1+l focus right
 bindsym Mod1+minus scratchpad show
 bindsym Mod1+r mode resize
 bindsym Mod1+s layout stacking
 bindsym Mod1+space focus mode_toggle
-bindsym Mod1+v split v
+bindsym Mod1+v splitv
 bindsym Mod1+w layout tabbed
 
 mode "resize" {
-bindsym Down resize grow height 10 px or 10 ppt
+bindsym Down resize grow height 10 px
 bindsym Escape mode default
-bindsym Left resize shrink width 10 px or 10 ppt
+bindsym Left resize shrink width 10 px
 bindsym Return mode default
-bindsym Right resize grow width 10 px or 10 ppt
-bindsym Up resize shrink height 10 px or 10 ppt
+bindsym Right resize grow width 10 px
+bindsym Up resize shrink height 10 px
+bindsym h resize shrink width 10 px
+bindsym j resize grow height 10 px
+bindsym k resize shrink height 10 px
+bindsym l resize grow width 10 px
 }
-
 
 bar {
   
@@ -82,7 +89,7 @@ bar {
   hidden_state hide
   position bottom
   status_command @i3status@/bin/i3status
-  i3bar_command @i3@/bin/i3bar
+  swaybar_command @sway/bin/swaybar
   workspace_buttons yes
   strip_workspace_numbers no
   tray_output primary
@@ -100,7 +107,4 @@ bar {
 }
 
 
-
-
-
-
+exec "systemctl --user import-environment; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-workspace-default.nix
+++ b/tests/modules/services/window-managers/sway/sway-workspace-default.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  dummy-package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out";
+
+in {
+  config = {
+    wayland.windowManager.sway = {
+      enable = true;
+      package = dummy-package // { outPath = "@sway"; };
+      # overriding findutils causes issues
+      config.menu = "${pkgs.dmenu}/bin/dmenu_run";
+      config.defaultWorkspace = "workspace number 9";
+    };
+
+    nixpkgs.overlays = [ (import ./sway-overlay.nix) ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/sway/config
+      assertFileContent home-files/.config/sway/config \
+        ${./sway-workspace-default-expected.conf}
+    '';
+  };
+}


### PR DESCRIPTION
### Description
As offered, in #1967 first split PR for ability to set default-workspace for i3 and now also for i3-sway.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted
