### PR TITLE
firefox: deprecate 'enableGnomeExtensions'

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -86,6 +86,17 @@ in
           then pkgs.firefox
           else pkgs.firefox-unwrapped;
         defaultText = literalExample "pkgs.firefox";
+        example = literalExample ''
+          pkgs.firefox.override {
+            # See nixpkgs' firefox/wrapper.nix to check which options you can use
+            cfg = {
+              # Gnome shell native connector
+              enableGnomeExtensions = true;
+              # Tridactyl native connector
+              enableTridactylNative = true;
+            };
+          }
+        '';
         description = ''
           The Firefox package to use. If state version ≥ 19.09 then
           this should be a wrapped Firefox package. For earlier state
@@ -263,6 +274,13 @@ in
         }
       )
     ];
+
+    warnings = optional (cfg.enableGnomeExtensions or false) ''
+      Using 'programs.firefox.enableGnomeExtensions' has been deprecated and
+      will be removed in the future. Please change to overriding the package
+      configuration using 'programs.firefox.package' instead. You can refer to
+      its example for how to do this.
+    '';
 
     home.packages =
       let

--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -1,4 +1,5 @@
 {
   firefox-profile-settings = ./profile-settings.nix;
   firefox-state-version-19_09 = ./state-version-19_09.nix;
+  firefox-deprecated-native-messenger = ./deprecated-native-messenger.nix;
 }

--- a/tests/modules/programs/firefox/deprecated-native-messenger.nix
+++ b/tests/modules/programs/firefox/deprecated-native-messenger.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.firefox = {
+      enable = true;
+      enableGnomeExtensions = true;
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        firefox-unwrapped = pkgs.runCommand "firefox-0" {
+          meta.description = "I pretend to be Firefox";
+          preferLocalBuild = true;
+          allowSubstitutes = false;
+        } ''
+          mkdir -p "$out/bin"
+          touch "$out/bin/firefox"
+          chmod 755 "$out/bin/firefox"
+        '';
+      })
+    ];
+
+    test.asserts.warnings.expected = [''
+      Using 'programs.firefox.enableGnomeExtensions' has been deprecated and
+      will be removed in the future. Please change to overriding the package
+      configuration using 'programs.firefox.package' instead. You can refer to
+      its example for how to do this.
+    ''];
+  };
+}


### PR DESCRIPTION
Fixes #1990.

### Description

As discussed in #1990.

I did not add a `mkRemovedOptionModule` because the option has only been deprecated, and is not yet removed.

I have not touched the `browserpass` module even though it is a native messenger extension because it only adds files to the home directory, not touching the browser packages in any way.

### Checklist

- [X] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
