### PR TITLE
targets.generic-linux: add system fpaths

### DIFF
--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -52,6 +52,24 @@ in {
       . "${pkgs.nix}/etc/profile.d/nix.sh"
       . "${profileDirectory}/etc/profile.d/hm-session-vars.sh"
     '';
+    
+    programs.zsh.envExtra = ''
+      # Make system functions available to zsh
+      () {
+        setopt LOCAL_OPTIONS CASE_GLOB EXTENDED_GLOB
+
+        local system_fpaths=(
+            # Package default
+            /usr/share/zsh/site-functions(/-N)
+
+            # Debian 
+            /usr/share/zsh/functions/**/*(/-N)
+            /usr/share/zsh/vendor-completions/(/-N) 
+            /usr/share/zsh/vendor-functions/(/-N)
+        )
+        fpath=(''${fpath} ''${system_fpaths})
+      }
+    '';
 
     systemd.user.sessionVariables = let
       # https://github.com/archlinux/svntogit-packages/blob/packages/ncurses/trunk/PKGBUILD


### PR DESCRIPTION
### Description

The nixpkgs-provided ZSH doesn't look in /etc for `fpath` entries by default. This means any system-level functions, including completions, won't get picked up. This PR fixes that for unmodified system ZSH installs (e.g. Arch Linux) and Debian (which uses custom directories).

EDIT: For those unfamiliar with ZSH, `fpath` serves the same purpose as `PATH` except for shell functions.
EDIT2: It also only adds those directories to `fpath` if they exist (done by the glob modifier `(/-N)`) and adds those entries the end of `fpath`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
