### PR TITLE
i3status-rust: Fix formatting

### DIFF
--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -85,7 +85,7 @@ in {
                   on_click = "pavucontrol --tab=3";
                   mappings = {
                    "alsa_output.pci-0000_00_1f.3.analog-stereo" = "";
-                   "bluez_sink.70_26_05_DA_27_A4.a2dp_sink" = ""
+                   "bluez_sink.70_26_05_DA_27_A4.a2dp_sink" = "";
                   };
                 }
               ];


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
