### PR TITLE
Revert "status-notifier-watcher: introduce unit start delay"

### DIFF
--- a/modules/services/status-notifier-watcher.nix
+++ b/modules/services/status-notifier-watcher.nix
@@ -34,14 +34,7 @@ in {
         Before = [ "taffybar.service" ];
       };
 
-      Service = {
-        ExecStart = "${cfg.package}/bin/status-notifier-watcher";
-        # Delay the unit start a bit to allow the program to get fully
-        # set up before letting dependent services start. This is
-        # brittle and a better solution using, e.g., `BusName=` might
-        # be possible.
-        ExecStartPost = "${pkgs.coreutils}/bin/sleep 1";
-      };
+      Service = { ExecStart = "${cfg.package}/bin/status-notifier-watcher"; };
 
       Install = {
         WantedBy = [ "graphical-session.target" "taffybar.service" ];


### PR DESCRIPTION
This reverts commit 02c1f8d416d55d8bc8d4de62f65f62fef40e5e80.

As I described in #1480, this causes more issues than it fixes for me.

To recap, there is some kind of timings issue with status-notifier-watcher and various system tray icons on startup. This was first identified to affect flameshot in #1312. The proposed fix in that PR was to introduce a pre unit start delay for flameshot, but instead 
a post unit start delay for status-notifier-watcher was adopted.

Following this, the following system tray icons fail to show on startup without manually restarting them:

* pasystray
* udiskie
* network-manager-applet
* blueman-applet (@meck could you check this please? I don't use this)

It would be helpful if someone could verify the behaviour of flameshot with and without this commit reverted also.