### PR TITLE
Multi mpd

### DIFF
--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -36,6 +36,14 @@ let
       '';
     };
 
+    autoStart = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether this instance should be started automatically.
+      '';
+    };
+
     musicDirectory = mkOption {
       type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
       default = "${config.home.homeDirectory}/music";
@@ -130,7 +138,7 @@ let
       Description = "Music Player Daemon";
     };
 
-    Install = mkIf (!cfg'.network.startWhenNeeded) {
+    Install = mkIf (!cfg'.network.startWhenNeeded && cfg'.autoStart) {
       WantedBy = [ "default.target" ];
     };
 

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -27,18 +27,6 @@ let
 
   mpdOptions = cfg: {
 
-  };
-
-in {
-
-  ###### interface
-
-  options = {
-
-    services.mpd = {
-
-      enable = mkEnableOption "MPD, the music player daemon";
-
       package = mkOption {
         type = types.package;
         default = pkgs.mpd;
@@ -133,6 +121,18 @@ in {
           configuration.
         '';
       };
+
+  };
+
+in {
+
+  ###### interface
+
+  options = {
+
+    services.mpd = {
+
+      enable = mkEnableOption "MPD, the music player daemon";
 
     } // mpdOptions cfg;
 

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -33,13 +33,7 @@ in {
 
     services.mpd = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable MPD, the music player daemon.
-        '';
-      };
+      enable = mkEnableOption "MPD, the music player daemon";
 
       package = mkOption {
         type = types.package;

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -36,15 +36,15 @@ let
       '';
     };
 
-      musicDirectory = mkOption {
-        type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
-        default = "${config.home.homeDirectory}/music";
-        defaultText = "$HOME/music";
-        apply = toString;       # Prevent copies to Nix store.
-        description = ''
-          The directory where mpd reads music from.
-        '';
-      };
+    musicDirectory = mkOption {
+      type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
+      default = "${config.home.homeDirectory}/music";
+      defaultText = "$HOME/music";
+      apply = toString;       # Prevent copies to Nix store.
+      description = ''
+        The directory where mpd reads music from.
+      '';
+    };
 
     playlistDirectory = mkOption {
       type = with types; either path str;
@@ -56,20 +56,20 @@ let
       '';
     };
 
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "";
-        description = ''
-          Extra directives added to to the end of MPD's configuration
-          file, <filename>mpd.conf</filename>. Basic configuration
-          like file location and uid/gid is added automatically to the
-          beginning of the file. For available options see
-          <citerefentry>
-            <refentrytitle>mpd.conf</refentrytitle>
-            <manvolnum>5</manvolnum>
-          </citerefentry>.
-        '';
-      };
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra directives added to to the end of MPD's configuration
+        file, <filename>mpd.conf</filename>. Basic configuration
+        like file location and uid/gid is added automatically to the
+        beginning of the file. For available options see
+        <citerefentry>
+          <refentrytitle>mpd.conf</refentrytitle>
+          <manvolnum>5</manvolnum>
+        </citerefentry>.
+      '';
+    };
 
     dataDir = mkOption {
       type = with types; either path str;
@@ -82,14 +82,14 @@ let
       '';
     };
 
-      network = {
-        startWhenNeeded = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-           Enable systemd socket activation.
-          '';
-        };
+    network = {
+      startWhenNeeded = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable systemd socket activation.
+        '';
+      };
 
       listenAddress = mkOption {
         type = types.str;
@@ -101,13 +101,13 @@ let
         '';
       };
 
-        port = mkOption {
-          type = types.port;
-          default = 6600;
-          description = ''
-            The TCP port on which the the daemon will listen.
-          '';
-        };
+      port = mkOption {
+        type = types.port;
+        default = 6600;
+        description = ''
+          The TCP port on which the the daemon will listen.
+        '';
+      };
 
     };
 

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -27,14 +27,14 @@ let
 
   mpdOptions = cfg: {
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.mpd;
-        defaultText = "pkgs.mpd";
-        description = ''
-          The MPD package to run.
-        '';
-      };
+    package = mkOption {
+      type = types.package;
+      default = pkgs.mpd;
+      defaultText = "pkgs.mpd";
+      description = ''
+        The MPD package to run.
+      '';
+    };
 
       musicDirectory = mkOption {
         type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
@@ -46,15 +46,15 @@ let
         '';
       };
 
-      playlistDirectory = mkOption {
-        type = with types; either path str;
-        default = "${cfg.dataDir}/playlists";
-        defaultText = ''''${dataDir}/playlists'';
-        apply = toString;       # Prevent copies to Nix store.
-        description = ''
-          The directory where mpd stores playlists.
-        '';
-      };
+    playlistDirectory = mkOption {
+      type = with types; either path str;
+      default = "${cfg.dataDir}/playlists";
+      defaultText = ''''${dataDir}/playlists'';
+      apply = toString;       # Prevent copies to Nix store.
+      description = ''
+        The directory where mpd stores playlists.
+      '';
+    };
 
       extraConfig = mkOption {
         type = types.lines;
@@ -71,16 +71,16 @@ let
         '';
       };
 
-      dataDir = mkOption {
-        type = with types; either path str;
-        default = "${config.xdg.dataHome}/${name}";
-        defaultText = "$XDG_DATA_HOME/mpd";
-        apply = toString;       # Prevent copies to Nix store.
-        description = ''
-          The directory where MPD stores its state, tag cache,
-          playlists etc.
-        '';
-      };
+    dataDir = mkOption {
+      type = with types; either path str;
+      default = "${config.xdg.dataHome}/${name}";
+      defaultText = "$XDG_DATA_HOME/mpd";
+      apply = toString;       # Prevent copies to Nix store.
+      description = ''
+        The directory where MPD stores its state, tag cache,
+        playlists etc.
+      '';
+    };
 
       network = {
         startWhenNeeded = mkOption {
@@ -91,15 +91,15 @@ let
           '';
         };
 
-        listenAddress = mkOption {
-          type = types.str;
-          default = "127.0.0.1";
-          example = "any";
-          description = ''
-            The address for the daemon to listen on.
-            Use <literal>any</literal> to listen on all addresses.
-          '';
-        };
+      listenAddress = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        example = "any";
+        description = ''
+          The address for the daemon to listen on.
+          Use <literal>any</literal> to listen on all addresses.
+        '';
+      };
 
         port = mkOption {
           type = types.port;
@@ -109,18 +109,18 @@ let
           '';
         };
 
-      };
+    };
 
-      dbFile = mkOption {
-        type = types.nullOr types.str;
-        default = "${cfg.dataDir}/tag_cache";
-        defaultText = ''''${dataDir}/tag_cache'';
-        description = ''
-          The path to MPD's database. If set to
-          <literal>null</literal> the parameter is omitted from the
-          configuration.
-        '';
-      };
+    dbFile = mkOption {
+      type = types.nullOr types.str;
+      default = "${cfg.dataDir}/tag_cache";
+      defaultText = ''''${dataDir}/tag_cache'';
+      description = ''
+        The path to MPD's database. If set to
+        <literal>null</literal> the parameter is omitted from the
+        configuration.
+      '';
+    };
 
   };
 

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -8,22 +8,26 @@ let
 
   cfg = config.services.mpd;
 
-  mpdConf = pkgs.writeText "mpd.conf" ''
-    music_directory     "${cfg.musicDirectory}"
-    playlist_directory  "${cfg.playlistDirectory}"
-    ${lib.optionalString (cfg.dbFile != null) ''
-      db_file             "${cfg.dbFile}"
+  mpdConf = cfg': pkgs.writeText "mpd.conf" ''
+    music_directory     "${cfg'.musicDirectory}"
+    playlist_directory  "${cfg'.playlistDirectory}"
+    ${lib.optionalString (cfg'.dbFile != null) ''
+      db_file             "${cfg'.dbFile}"
     ''}
-    state_file          "${cfg.dataDir}/state"
-    sticker_file        "${cfg.dataDir}/sticker.sql"
+    state_file          "${cfg'.dataDir}/state"
+    sticker_file        "${cfg'.dataDir}/sticker.sql"
 
-    ${optionalString (cfg.network.listenAddress != "any")
-      ''bind_to_address "${cfg.network.listenAddress}"''}
-    ${optionalString (cfg.network.port != 6600)
-      ''port "${toString cfg.network.port}"''}
+    ${optionalString (cfg'.network.listenAddress != "any")
+      ''bind_to_address "${cfg'.network.listenAddress}"''}
+    ${optionalString (cfg'.network.port != 6600)
+      ''port "${toString cfg'.network.port}"''}
 
-    ${cfg.extraConfig}
+    ${cfg'.extraConfig}
   '';
+
+  mpdOptions = cfg: {
+
+  };
 
 in {
 
@@ -129,7 +133,8 @@ in {
           configuration.
         '';
       };
-    };
+
+    } // mpdOptions cfg;
 
   };
 
@@ -150,7 +155,7 @@ in {
 
       Service = {
         Environment = "PATH=${config.home.profileDirectory}/bin";
-        ExecStart = "${cfg.package}/bin/mpd --no-daemon ${mpdConf}";
+        ExecStart = "${cfg.package}/bin/mpd --no-daemon ${mpdConf cfg}";
         Type = "notify";
         ExecStartPre = ''${pkgs.bash}/bin/bash -c "${pkgs.coreutils}/bin/mkdir -p '${cfg.dataDir}' '${cfg.playlistDirectory}'"'';
       };

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -51,7 +51,7 @@ in {
       };
 
       musicDirectory = mkOption {
-        type = with types; either path str;
+        type = with types; either path (strMatching "(http|https|nfs|smb)://.+");
         default = "${config.home.homeDirectory}/music";
         defaultText = "$HOME/music";
         apply = toString;       # Prevent copies to Nix store.
@@ -61,7 +61,7 @@ in {
       };
 
       playlistDirectory = mkOption {
-        type = types.path;
+        type = with types; either path str;
         default = "${cfg.dataDir}/playlists";
         defaultText = ''''${dataDir}/playlists'';
         apply = toString;       # Prevent copies to Nix store.
@@ -86,7 +86,7 @@ in {
       };
 
       dataDir = mkOption {
-        type = types.path;
+        type = with types; either path str;
         default = "${config.xdg.dataHome}/${name}";
         defaultText = "$XDG_DATA_HOME/mpd";
         apply = toString;       # Prevent copies to Nix store.

--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -124,31 +124,31 @@ let
 
   };
 
-  mpdService = cfg: {
-      Unit = {
-        After = [ "network.target" "sound.target" ];
-        Description = "Music Player Daemon";
-      };
+  mpdService = cfg': {
+    Unit = {
+      After = [ "network.target" "sound.target" ];
+      Description = "Music Player Daemon";
+    };
 
-      Install = mkIf (!cfg.network.startWhenNeeded) {
-        WantedBy = [ "default.target" ];
-      };
+    Install = mkIf (!cfg'.network.startWhenNeeded) {
+      WantedBy = [ "default.target" ];
+    };
 
-      Service = {
-        Environment = "PATH=${config.home.profileDirectory}/bin";
-        ExecStart = "${cfg.package}/bin/mpd --no-daemon ${mpdConf cfg}";
-        Type = "notify";
-        ExecStartPre = ''${pkgs.bash}/bin/bash -c "${pkgs.coreutils}/bin/mkdir -p '${cfg.dataDir}' '${cfg.playlistDirectory}'"'';
-      };
+    Service = {
+      Environment = "PATH=${config.home.profileDirectory}/bin";
+      ExecStart = "${cfg'.package}/bin/mpd --no-daemon ${mpdConf cfg'}";
+      Type = "notify";
+      ExecStartPre = ''${pkgs.bash}/bin/bash -c "${pkgs.coreutils}/bin/mkdir -p '${cfg'.dataDir}' '${cfg'.playlistDirectory}'"'';
+    };
   };
 
-  mpdSocket = cfg: mkIf cfg.network.startWhenNeeded {
+  mpdSocket = cfg': mkIf cfg'.network.startWhenNeeded {
       Socket = {
         ListenStream = let
           listen =
-            if cfg.network.listenAddress == "any"
-            then toString cfg.network.port
-            else "${cfg.network.listenAddress}:${toString cfg.network.port}";
+            if cfg'.network.listenAddress == "any"
+            then toString cfg'.network.port
+            else "${cfg'.network.listenAddress}:${toString cfg'.network.port}";
         in [ listen "%t/mpd/socket" ];
 
         Backlog = 5;

--- a/tests/modules/programs/ncmpcpp-linux/ncmpcpp-use-mpd-config.nix
+++ b/tests/modules/programs/ncmpcpp-linux/ncmpcpp-use-mpd-config.nix
@@ -4,8 +4,8 @@
   config = {
     programs.ncmpcpp.enable = true;
 
-    services.mpd.enable = true;
-    services.mpd.musicDirectory = "/home/user/music";
+    services.mpd.daemons.default.enable = true;
+    services.mpd.daemons.default.musicDirectory = "/home/user/music";
 
     nixpkgs.overlays = [
       (self: super: {


### PR DESCRIPTION
### Description

Retools `services.mpd` to work off of a set of daemon configurations instead of just one, allowing for setups like multiple music dirs nicely. Path configuration is also fixed up so you don't end up copying entire music directory hierarchies into the store, unless you really want to.

Check the commit message for an example transition from old style to new and some reasoning on `daemons.<name>.default`.

Succeeds #528.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.