### PR TITLE
xmonad: document recompilation issue

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2084,6 +2084,25 @@ in
           A new module is available: 'programs.mangohud'.
         '';
       }
+
+      {
+        time = "2021-06-16T01:26:16+00:00";
+        message = ''
+          The xmonad module now compiles the configuration before
+          linking the binary to the place xmonad expects to find
+          the compiled configuration (the binary).
+
+          This breaks recompilation of xmonad (i.e. the 'q' binding or
+          'xmonad --recompile').
+
+          If this behavior is undesirable, do not use the
+          'xsession.windowManager.xmonad.config' option. Instead, set the
+          contents of the configuration file with
+          'home.file.".xmonad/config.hs".text = "content of the file"'
+          or 'home.file.".xmonad/config.hs".source = ./path-to-config'.
+        '';
+      }
+
     ];
   };
 }

--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -73,6 +73,11 @@ in {
           an absolute path or <literal>null</literal> in which case
           <filename>~/.xmonad/xmonad.hs</filename> will not be managed
           by Home Manager.
+          </para>
+          <para>
+          If this option is set to a non-<literal>null</literal> value,
+          recompilation of xmonad outside of Home Manager (e.g. via
+          <command>xmonad --recompile</command>) will fail.
         '';
       };
 


### PR DESCRIPTION
### Description

- xmonad: document breakage of recompilation
- news: add warning about xmonad recompilation

Whether this fixes #1895 is up to the author.

cc: @dnaq @markusscherer @woffs

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
