### PR TITLE
htop: fix deprecation warnings

### DIFF
--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -587,7 +587,7 @@ in {
           warn' = warn
             "htop: programs.htop.${optionKey} is deprecated; please is programs.htop.settings.${settingsKey} instead";
         in if !isNull optionValue then
-          warn' settingsKey optionKey optionValue
+          warn' optionValue
         else if hasAttr settingsKey cfg.settings then
           cfg.settings.${settingsKey}
         else


### PR DESCRIPTION
Previous patch on deprecation warnings broke use of old options due to function
call with too many arguments. This fixes the arguments so deprecation warnings
are properly traced while preserving old configuration options.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
