### PR TITLE
Add a separate tray.target for systemd units which require a system tray

### DIFF
--- a/modules/services/blueman-applet.nix
+++ b/modules/services/blueman-applet.nix
@@ -24,7 +24,8 @@ with lib;
     systemd.user.services.blueman-applet = {
       Unit = {
         Description = "Blueman applet";
-        After = [ "graphical-session-pre.target" ];
+        Requires = [ "tray.target" ];
+        After = [ "graphical-session-pre.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/cbatticon.nix
+++ b/modules/services/cbatticon.nix
@@ -103,7 +103,8 @@ in {
     systemd.user.services.cbatticon = {
       Unit = {
         Description = "cbatticon system tray battery icon";
-        After = [ "graphical-session-pre.target" ];
+        Requires = [ "tray.target" ];
+        After = [ "graphical-session-pre.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/flameshot.nix
+++ b/modules/services/flameshot.nix
@@ -18,12 +18,8 @@ in {
     systemd.user.services.flameshot = {
       Unit = {
         Description = "Flameshot screenshot tool";
-        After = [
-          "graphical-session-pre.target"
-          "polybar.service"
-          "stalonetray.service"
-          "taffybar.service"
-        ];
+        Requires = [ "tray.target" ];
+        After = [ "graphical-session-pre.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/network-manager-applet.nix
+++ b/modules/services/network-manager-applet.nix
@@ -19,7 +19,8 @@ in {
     systemd.user.services.network-manager-applet = {
       Unit = {
         Description = "Network Manager applet";
-        After = [ "graphical-session-pre.target" ];
+        Requires = [ "tray.target" ];
+        After = [ "graphical-session-pre.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/parcellite.nix
+++ b/modules/services/parcellite.nix
@@ -27,7 +27,8 @@ in {
     systemd.user.services.parcellite = {
       Unit = {
         Description = "Lightweight GTK+ clipboard manager";
-        After = [ "graphical-session-pre.target" ];
+        Requires = [ "tray.target" ];
+        After = [ "graphical-session-pre.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/pasystray.nix
+++ b/modules/services/pasystray.nix
@@ -13,7 +13,8 @@ with lib;
     systemd.user.services.pasystray = {
       Unit = {
         Description = "PulseAudio system tray";
-        After = [ "graphical-session-pre.target" ];
+        Requires = [ "tray.target" ];
+        After = [ "graphical-session-pre.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -197,8 +197,7 @@ in {
     systemd.user.services.polybar = {
       Unit = {
         Description = "Polybar status bar";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        PartOf = [ "tray.target" ];
         X-Restart-Triggers =
           [ "${config.xdg.configFile."polybar/config".source}" ];
       };
@@ -212,7 +211,7 @@ in {
         Restart = "on-failure";
       };
 
-      Install = { WantedBy = [ "graphical-session.target" ]; };
+      Install = { WantedBy = [ "tray.target" ]; };
     };
   };
 

--- a/modules/services/stalonetray.nix
+++ b/modules/services/stalonetray.nix
@@ -56,11 +56,10 @@ in {
       systemd.user.services.stalonetray = {
         Unit = {
           Description = "Stalonetray system tray";
-          After = [ "graphical-session-pre.target" ];
-          PartOf = [ "graphical-session.target" ];
+          PartOf = [ "tray.target" ];
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = { WantedBy = [ "tray.target" ]; };
 
         Service = {
           ExecStart = "${cfg.package}/bin/stalonetray";

--- a/modules/services/status-notifier-watcher.nix
+++ b/modules/services/status-notifier-watcher.nix
@@ -29,16 +29,17 @@ in {
     systemd.user.services.status-notifier-watcher = {
       Unit = {
         Description = "SNI watcher";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        PartOf = [ "tray.target" ];
         Before = [ "taffybar.service" ];
       };
 
-      Service = { ExecStart = "${cfg.package}/bin/status-notifier-watcher"; };
-
-      Install = {
-        WantedBy = [ "graphical-session.target" "taffybar.service" ];
+      Service = {
+        Type = "dbus";
+        BusName = "org.kde.StatusNotifierWatcher";
+        ExecStart = "${cfg.package}/bin/status-notifier-watcher";
       };
+
+      Install = { WantedBy = [ "tray.target" "taffybar.service" ]; };
     };
   };
 }

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -74,12 +74,8 @@ with lib;
           ${config.services.syncthing.tray.package.pname} = {
             Unit = {
               Description = config.services.syncthing.tray.package.pname;
-              After = [
-                "graphical-session-pre.target"
-                "polybar.service"
-                "taffybar.service"
-                "stalonetray.service"
-              ];
+              Requires = [ "tray.target" ];
+              After = [ "graphical-session-pre.target" "tray.target" ];
               PartOf = [ "graphical-session.target" ];
             };
 
@@ -100,12 +96,8 @@ with lib;
           "syncthingtray" = {
             Unit = {
               Description = "syncthingtray";
-              After = [
-                "graphical-session-pre.target"
-                "polybar.service"
-                "taffybar.service"
-                "stalonetray.service"
-              ];
+              Requires = [ "tray.target" ];
+              After = [ "graphical-session-pre.target" "tray.target" ];
               PartOf = [ "graphical-session.target" ];
             };
 

--- a/modules/services/taffybar.nix
+++ b/modules/services/taffybar.nix
@@ -27,16 +27,17 @@ in {
     systemd.user.services.taffybar = {
       Unit = {
         Description = "Taffybar desktop bar";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        PartOf = [ "tray.target" ];
       };
 
       Service = {
+        Type = "dbus";
+        BusName = "org.taffybar.Bar";
         ExecStart = "${cfg.package}/bin/taffybar";
         Restart = "on-failure";
       };
 
-      Install = { WantedBy = [ "graphical-session.target" ]; };
+      Install = { WantedBy = [ "tray.target" ]; };
     };
 
     xsession.importedVariables = [ "GDK_PIXBUF_MODULE_FILE" ];

--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -77,7 +77,8 @@ in {
     systemd.user.services.udiskie = {
       Unit = {
         Description = "udiskie mount daemon";
-        After = [ "graphical-session-pre.target" ];
+        Requires = [ "tray.target" ];
+        After = [ "graphical-session-pre.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -110,12 +110,21 @@ in {
         };
       };
 
-      # A basic graphical session target for Home Manager.
-      targets.hm-graphical-session = {
-        Unit = {
-          Description = "Home Manager X session";
-          Requires = [ "graphical-session-pre.target" ];
-          BindsTo = [ "graphical-session.target" ];
+      targets = {
+        # A basic graphical session target for Home Manager.
+        hm-graphical-session = {
+          Unit = {
+            Description = "Home Manager X session";
+            Requires = [ "graphical-session-pre.target" ];
+            BindsTo = [ "graphical-session.target" "tray.target" ];
+          };
+        };
+
+        tray = {
+          Unit = {
+            Description = "Home Manager System Tray";
+            Requires = [ "graphical-session-pre.target" ];
+          };
         };
       };
     };


### PR DESCRIPTION
### Description

Previously, we had some units have

```
After = [ ... "taffybar.service" "polybar.service" "stalonetray.service" ];
```

This is my attempt to abstract over system trays by adding a new `tray.target`.

I also fixed `taffybar.service`: because of the way it works, (due to dyre) when the taffybar binary is launched, systemd considers it active, and only after that does it actually launch your compiled taffybar binary in `~/.cache/taffybar/`. This was causing a bunch of race issues, because units set to run after `taffybar.service` would be immediately started before the locally compiled taffybar runs, and was ready to accept tray icons.

This caused the following issues:

* #1312
* #1480
* #2020

I made it a dbus unit, so now systemd only considers it active when `org.taffybar.Bar` comes up on dbus. I also made a similar change for status-notifier-watcher (probably unnecessary, but I think it's more correct for it to be a dbus unit too).

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

