### PR TITLE
files: fix use of onChange with directory source

### DIFF
--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -82,6 +82,9 @@ with lib;
             generations. The script will be run
             <emphasis>after</emphasis> the new files have been linked
             into place.
+            </para><para>
+            Note, this option cannot be used when <literal>recursive</literal>
+            is enabled.
           '';
         };
 


### PR DESCRIPTION
### Description

Previously, the comparison would not handle directory comparison correctly, always finding that the source and target differed. This would trigger the `onChange` script on each activation.

Fixes #2004

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```