### PR TITLE
syncthing: fix news link

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2016,7 +2016,7 @@ in
 
           See
 
-            https://github.com/nix-community/home-manager/pulls/1257
+            https://github.com/nix-community/home-manager/pull/1257
 
           for discussion.
         '';


### PR DESCRIPTION
https://github.com/nix-community/home-manager/pulls/1257 (goes to search page)

vs.

https://github.com/nix-community/home-manager/pull/1257 (goes to PR)
