### PR TITLE
nextcloud-client: add startInBackground option

### DIFF
--- a/modules/services/nextcloud-client.nix
+++ b/modules/services/nextcloud-client.nix
@@ -22,7 +22,7 @@ in {
         type = types.bool;
         default = false;
         defaultText = literalExample "false";
-        description = "Whether to run the nextcloud client in the background.";
+        description = "Whether to start the Nextcloud client in the background.";
       };
     };
   };

--- a/modules/services/nextcloud-client.nix
+++ b/modules/services/nextcloud-client.nix
@@ -18,7 +18,7 @@ in {
         description = "The package to use for the nextcloud client binary.";
       };
 
-      runInBackground = mkOption {
+      startInBackground = mkOption {
         type = types.bool;
         default = false;
         description =
@@ -38,7 +38,7 @@ in {
       Service = {
         Environment = "PATH=${config.home.profileDirectory}/bin";
         ExecStart = "${cfg.package}/bin/nextcloud"
-          + (optionalString cfg.runInBackground " --background");
+          + (optionalString cfg.startInBackground " --background");
       };
 
       Install = { WantedBy = [ "graphical-session.target" ]; };

--- a/modules/services/nextcloud-client.nix
+++ b/modules/services/nextcloud-client.nix
@@ -38,7 +38,7 @@ in {
       Service = {
         Environment = "PATH=${config.home.profileDirectory}/bin";
         ExecStart = "${cfg.package}/bin/nextcloud"
-          + (if cfg.runInBackground then " --background" else "");
+          + (optionalString cfg.runInBackground " --background");
       };
 
       Install = { WantedBy = [ "graphical-session.target" ]; };

--- a/modules/services/nextcloud-client.nix
+++ b/modules/services/nextcloud-client.nix
@@ -6,7 +6,8 @@ let
 
   cfg = config.services.nextcloud-client;
 
-in {
+in
+{
   options = {
     services.nextcloud-client = {
       enable = mkEnableOption "Nextcloud Client";
@@ -21,8 +22,8 @@ in {
       runInBackground = mkOption {
         type = types.bool;
         default = false;
-        defaultText = literalExample "false";
-        description = "Whether to start the Nextcloud client in the background.";
+        description =
+          "Whether to start the Nextcloud client in the background.";
       };
     };
   };

--- a/modules/services/nextcloud-client.nix
+++ b/modules/services/nextcloud-client.nix
@@ -6,8 +6,7 @@ let
 
   cfg = config.services.nextcloud-client;
 
-in
-{
+in {
   options = {
     services.nextcloud-client = {
       enable = mkEnableOption "Nextcloud Client";

--- a/modules/services/nextcloud-client.nix
+++ b/modules/services/nextcloud-client.nix
@@ -17,6 +17,13 @@ in {
         defaultText = literalExample "pkgs.nextcloud-client";
         description = "The package to use for the nextcloud client binary.";
       };
+
+      runInBackground = mkOption {
+        type = types.bool;
+        default = false;
+        defaultText = literalExample "false";
+        description = "Whether to run the nextcloud client in the background.";
+      };
     };
   };
 
@@ -30,7 +37,8 @@ in {
 
       Service = {
         Environment = "PATH=${config.home.profileDirectory}/bin";
-        ExecStart = "${cfg.package}/bin/nextcloud";
+        ExecStart = "${cfg.package}/bin/nextcloud"
+          + (if cfg.runInBackground then " --background" else "");
       };
 
       Install = { WantedBy = [ "graphical-session.target" ]; };


### PR DESCRIPTION
### Description

Added an option that will make nextcloud-client run in the background.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```