### PR TITLE
firefox: fix package override config

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -300,7 +300,7 @@ in
           if isDarwin then
             cfg.package
           else if versionAtLeast config.home.stateVersion "19.09" then
-            cfg.package.override (old: { cfg = old.cfg or {} // fcfg; })
+            cfg.package.override (old: old // { cfg = old.cfg or {} // fcfg; })
           else
             (pkgs.wrapFirefox.override { config = bcfg; }) cfg.package { };
       in


### PR DESCRIPTION
### Description

Fix #2010.

cc @ambroisie 

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
