### PR TITLE
programs.gnome-terminal: terminal options

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,7 +77,7 @@
 
 /modules/programs/git.nix                             @rycee
 
-/modules/programs/gnome-terminal.nix                  @rycee
+/modules/programs/gnome-terminal.nix                  @kamadorueda @rycee
 
 /modules/programs/go.nix                              @rvolosatovs
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -37,6 +37,16 @@
     github = "kalhauge";
     githubId = 1182166;
   };
+  kamadorueda = {
+    name = "Kevin Amado";
+    email = "kamadorueda@gmail.com";
+    github = "kamadorueda";
+    githubId = 47480384;
+    keys = [{
+      longkeyid = "rsa4096/0x04D0CEAF916A9A40";
+      fingerprint = "2BE3 BAFD 793E A349 ED1F  F00F 04D0 CEAF 916A 9A40";
+    }];
+  };
   kubukoz = {
     name = "Jakub Kozłowski";
     email = "kubukoz@users.noreply.github.com";

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -187,6 +187,12 @@ let
         '';
       };
 
+      boldIsBright = mkOption {
+        default = null;
+        type = types.nullOr types.bool;
+        description = "Whether bold text is shown in bright colors.";
+      };
+
       deleteBinding = mkOption {
         default = "delete-sequence";
         type = eraseBinding;
@@ -234,6 +240,12 @@ let
         type = types.bool;
         description = "Turn on/off the terminal's bell.";
       };
+
+      transparencyPercent = mkOption {
+        default = null;
+        type = types.nullOr (types.ints.between 0 100);
+        description = "Background transparency in percent.";
+      };
     };
   });
 
@@ -241,6 +253,7 @@ let
     {
       audible-bell = pcfg.audibleBell;
       visible-name = pcfg.visibleName;
+      scroll-on-output = pcfg.scrollOnOutput;
       scrollbar-policy = if pcfg.showScrollbar then "always" else "never";
       scrollback-lines = pcfg.scrollbackLines;
       cursor-shape = pcfg.cursorShape;
@@ -273,7 +286,9 @@ let
       } else {
         bold-color-same-as-fg = false;
         bold-color = pcfg.colors.boldColor;
-      }) // (if (pcfg.colors.cursor != null) then {
+      }) // optionalAttrs (pcfg.boldIsBright != null) {
+        bold-is-bright = pcfg.boldIsBright;
+      } // (if (pcfg.colors.cursor != null) then {
         cursor-colors-set = true;
         cursor-foreground-color = pcfg.colors.cursor.foreground;
         cursor-background-color = pcfg.colors.cursor.background;
@@ -285,10 +300,14 @@ let
         highlight-background-color = pcfg.colors.highlight.background;
       } else {
         highlight-colors-set = false;
-      })));
+      }) // optionalAttrs (pcfg.transparencyPercent != null) {
+        background-transparency-percent = pcfg.transparencyPercent;
+        use-theme-transparency = false;
+        use-transparent-background = true;
+      }));
 
 in {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = with maintainers; [ kamadorueda rycee ];
 
   options = {
     programs.gnome-terminal = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -100,6 +100,7 @@ import nmt {
     ./modules/programs/firefox
     ./modules/programs/foot
     ./modules/programs/getmail
+    ./modules/programs/gnome-terminal
     ./modules/programs/i3status-rust
     ./modules/programs/mangohud
     ./modules/programs/ncmpcpp-linux

--- a/tests/modules/programs/gnome-terminal/default.nix
+++ b/tests/modules/programs/gnome-terminal/default.nix
@@ -1,0 +1,1 @@
+{ gnome-terminal-1 = ./gnome-terminal-1.nix; }

--- a/tests/modules/programs/gnome-terminal/gnome-terminal-1.conf
+++ b/tests/modules/programs/gnome-terminal/gnome-terminal-1.conf
@@ -1,0 +1,34 @@
+[org/gnome/terminal/legacy]
+default-show-menubar=false
+schema-version=3
+theme-variant='default'
+
+[org/gnome/terminal/legacy/profiles:]
+default='e0b782ed-6aca-44eb-8c75-62b3706b6220'
+list=@as ['e0b782ed-6aca-44eb-8c75-62b3706b6220']
+
+[org/gnome/terminal/legacy/profiles:/:e0b782ed-6aca-44eb-8c75-62b3706b6220]
+allow-bold=true
+audible-bell=true
+background-color='#2E3436'
+background-transparency-percent=5
+backspace-binding='ascii-delete'
+bold-color-same-as-fg=true
+bold-is-bright=true
+cursor-blink-mode='off'
+cursor-colors-set=false
+cursor-shape='underline'
+delete-binding='delete-sequence'
+foreground-color='#D3D7C1'
+highlight-colors-set=false
+login-shell=false
+palette=@as ['#000000','#AA0000','#00AA00','#AA5500','#0000AA','#AA00AA','#00AAAA','#AAAAAA','#555555','#FF5555','#55FF55','#FFFF55','#5555FF','#FF55FF','#55FFFF','#FFFFFF']
+scroll-on-output=false
+scrollback-lines=1000000
+scrollbar-policy='never'
+use-custom-command=false
+use-system-font=true
+use-theme-colors=false
+use-theme-transparency=false
+use-transparent-background=true
+visible-name='kamadorueda'

--- a/tests/modules/programs/gnome-terminal/gnome-terminal-1.nix
+++ b/tests/modules/programs/gnome-terminal/gnome-terminal-1.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    nixpkgs.overlays = [
+      (self: super: {
+        gnome.gnome-terminal =
+          pkgs.writeScriptBin "dummy-gnome3-gnome-terminal" "";
+      })
+    ];
+
+    programs.gnome-terminal = {
+      enable = true;
+      profile = {
+        "e0b782ed-6aca-44eb-8c75-62b3706b6220" = {
+          allowBold = true;
+          audibleBell = true;
+          backspaceBinding = "ascii-delete";
+          boldIsBright = true;
+          colors = {
+            backgroundColor = "#2E3436";
+            foregroundColor = "#D3D7C1";
+            palette = [
+              "#000000"
+              "#AA0000"
+              "#00AA00"
+              "#AA5500"
+              "#0000AA"
+              "#AA00AA"
+              "#00AAAA"
+              "#AAAAAA"
+              "#555555"
+              "#FF5555"
+              "#55FF55"
+              "#FFFF55"
+              "#5555FF"
+              "#FF55FF"
+              "#55FFFF"
+              "#FFFFFF"
+            ];
+          };
+          cursorBlinkMode = "off";
+          cursorShape = "underline";
+          default = true;
+          deleteBinding = "delete-sequence";
+          scrollbackLines = 1000000;
+          scrollOnOutput = false;
+          showScrollbar = false;
+          transparencyPercent = 5;
+          visibleName = "kamadorueda";
+        };
+      };
+      showMenubar = false;
+    };
+
+    nmt.script = ''
+      dconfIni=$(grep -oPm 1 '/nix/store/[a-z0-9]*?-hm-dconf.ini' $TESTED/activate)
+      TESTED= assertFileContent $dconfIni ${./gnome-terminal-1.conf}
+    '';
+  };
+}


### PR DESCRIPTION
- Add support for showing bold as bright colors
- Add support to configure the background transparency
- Fix the scrollOnOutput, it was not being dumped to the config
- Add tests!
- Add myself as maintainer
- ![image](https://user-images.githubusercontent.com/47480384/120058374-03299a80-c010-11eb-9e01-1714103b8b4a.png)
- ![demo](https://user-images.githubusercontent.com/47480384/120057273-81357380-c007-11eb-8bad-1ecee927cc36.gif)

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
