### PR TITLE
irssi: add ssl_cert option for servers

### DIFF
--- a/modules/programs/irssi.nix
+++ b/modules/programs/irssi.nix
@@ -35,6 +35,9 @@ let
           use_ssl = "${boolStr v.server.ssl.enable}";
           ssl_verify = "${boolStr v.server.ssl.verify}";
           autoconnect = "${boolStr v.server.autoConnect}";
+          ${lib.optionalString (v.server.ssl.certificateFile != null) ''
+          ssl_cert = "${v.server.ssl.certificateFile}";
+          ''}
         }
       ''));
 
@@ -117,6 +120,15 @@ let
             type = types.bool;
             default = true;
             description = "Whether the SSL certificate should be verified.";
+          };
+
+          certificateFile = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            description = ''
+              Path to a file containing the certificate used for
+              client authentication to the server.
+            '';
           };
         };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -55,6 +55,7 @@ import nmt {
     ./modules/programs/gpg
     ./modules/programs/htop
     ./modules/programs/i3status
+    ./modules/programs/irsii
     ./modules/programs/kakoune
     ./modules/programs/kitty
     ./modules/programs/lf

--- a/tests/modules/programs/irsii/default.nix
+++ b/tests/modules/programs/irsii/default.nix
@@ -1,0 +1,1 @@
+{ irsii-example-settings = ./example-settings.nix; }

--- a/tests/modules/programs/irsii/example-settings-expected.config
+++ b/tests/modules/programs/irsii/example-settings-expected.config
@@ -1,0 +1,43 @@
+settings = {
+  core = {
+    settings_autosave = "no";
+  };
+};
+
+aliases = {
+
+};
+
+chatnets = {
+oftc = {
+  type = "IRC";
+  nick = "nick";
+  autosendcmd = "";
+};
+
+};
+
+servers = (
+{
+  chatnet = "oftc";
+  address = "irc.oftc.net";
+  port = "6697";
+  use_ssl = "yes";
+  ssl_verify = "yes";
+  autoconnect = "yes";
+  ssl_cert = "/home/hm-user/.irssi/certs/nick.pem";
+
+}
+
+);
+
+channels = (
+{
+  chatnet = "oftc";
+  name = "home-manager";
+  autojoin = "yes";
+}
+
+);
+
+

--- a/tests/modules/programs/irsii/example-settings.nix
+++ b/tests/modules/programs/irsii/example-settings.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.irssi = {
+      enable = true;
+      networks.oftc = {
+        nick = "nick";
+        server = {
+          address = "irc.oftc.net";
+          port = 6697;
+          autoConnect = true;
+          ssl.certificateFile =
+            "${config.home.homeDirectory}/.irssi/certs/nick.pem";
+        };
+        channels.home-manager.autoJoin = true;
+      };
+    };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.irssi/config \
+        ${./example-settings-expected.config}
+    '';
+
+    nixpkgs.overlays =
+      [ (self: super: { irsii = pkgs.writeScriptBin "dummy-irsii" ""; }) ];
+  };
+}


### PR DESCRIPTION
### Description

I was following [these instructions](https://www.oftc.net/NickServ/CertFP/ ) and found that the `/server add -ssl_cert` option was needed.

This patch therefore adds an optional `programs.irssi.networks.<name>.server.ssl.certificateFile` path.

Perhaps this could also be done with a `settings` attribute, but that would probably require most of this module to be reworked.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`.
- [x] Test cases updated/added.
- [x] Commit messages are formatted correctly
