### PR TITLE
systemd: bring more in line with upstream

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -53,7 +53,7 @@ in
         # Paths that should be forcibly overwritten by Home Manager.
         # Caveat emptor!
         forcedPaths =
-          concatMapStringsSep " " (p: ''"$HOME/${p}"'')
+          concatMapStringsSep " " (p: ''"$HOME"/${escapeShellArg p}'')
             (mapAttrsToList (n: v: v.target)
             (filterAttrs (n: v: v.force) cfg));
 
@@ -62,7 +62,7 @@ in
 
           # A symbolic link whose target path matches this pattern will be
           # considered part of a Home Manager generation.
-          homeFilePattern="$(readlink -e "${builtins.storeDir}")/*-home-manager-files/*"
+          homeFilePattern="$(readlink -e ${escapeShellArg builtins.storeDir})/*-home-manager-files/*"
 
           forcedPaths=(${forcedPaths})
 
@@ -160,7 +160,7 @@ in
 
           # A symbolic link whose target path matches this pattern will be
           # considered part of a Home Manager generation.
-          homeFilePattern="$(readlink -e "${builtins.storeDir}")/*-home-manager-files/*"
+          homeFilePattern="$(readlink -e ${escapeShellArg builtins.storeDir})/*-home-manager-files/*"
 
           newGenFiles="$1"
           shift 1
@@ -245,9 +245,9 @@ in
         }
         declare -A changedFiles
       '' + concatMapStrings (v: ''
-        _cmp "${sourceStorePath v}" "${homeDirectory}/${v.target}" \
-          && changedFiles["${v.target}"]=0 \
-          || changedFiles["${v.target}"]=1
+        _cmp ${escapeShellArg (sourceStorePath v)} ${escapeShellArg homeDirectory}/${escapeShellArg v.target} \
+          && changedFiles[${escapeShellArg v.target}]=0 \
+          || changedFiles[${escapeShellArg v.target}]=1
       '') (filter (v: v.onChange != "") (attrValues cfg))
       + ''
         unset -f _cmp
@@ -256,7 +256,7 @@ in
 
     home.activation.onFilesChange = hm.dag.entryAfter ["linkGeneration"] (
       concatMapStrings (v: ''
-        if [[ ${"$\{changedFiles"}["${v.target}"]} -eq 1 ]]; then
+        if [[ ''${changedFiles[${escapeShellArg v.target}]} -eq 1 ]]; then
           ${v.onChange}
         fi
       '') (filter (v: v.onChange != "") (attrValues cfg))

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -16,6 +16,7 @@ let
       || cfg.timers != {}
       || cfg.paths != {}
       || cfg.mounts != {}
+      || cfg.automounts != {}
       || cfg.sessionVariables != {};
 
   toSystemdIni = lib.generators.toINI {
@@ -170,6 +171,13 @@ in
         example = unitExample "Mount";
       };
 
+      automounts = mkOption {
+        default = {};
+        type = unitType "automount";
+        description = unitDescription "automount";
+        example = unitExample "Automount";
+      };
+
       startServices = mkOption {
         default = "suggest";
         type = with types; either bool (enum ["suggest" "legacy" "sd-switch"]);
@@ -275,6 +283,8 @@ in
           (buildServices "path" cfg.paths)
           ++
           (buildServices "mount" cfg.mounts)
+          ++
+          (buildServices "automount" cfg.automounts)
           ))
 
           sessionVariables


### PR DESCRIPTION
### Description

Robust escaping & automounts.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
