### PR TITLE
jq: add `package` option

### DIFF
--- a/modules/programs/jq.nix
+++ b/modules/programs/jq.nix
@@ -30,6 +30,13 @@ in {
     programs.jq = {
       enable = mkEnableOption "the jq command-line JSON processor";
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.jq;
+        defaultText = literalExample "pkgs.jq";
+        description = "jq package to use.";
+      };
+
       colors = mkOption {
         description = ''
           The colors used in colored JSON output.</para>
@@ -65,7 +72,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.jq ];
+    home.packages = [ cfg.package ];
 
     home.sessionVariables = let c = cfg.colors;
     in {


### PR DESCRIPTION
### Description

Sometimes, I use a different jq build.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
