### PR TITLE
home-manager: add `home-manager option` (like nixos-option)

### DIFF
--- a/doc/man-home-manager.xml
+++ b/doc/man-home-manager.xml
@@ -42,6 +42,10 @@
    </arg>
 
    <arg choice="plain">
+    option <replaceable>option.name</replaceable>
+   </arg>
+
+   <arg choice="plain">
     packages
    </arg>
 
@@ -247,6 +251,18 @@
      <listitem>
       <para>
        Show news entries in a pager.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <option>option <replaceable>option.name</replaceable></option>
+     </term>
+     <listitem>
+      <para>
+       Inspect the given option name in the home configuration, like <citerefentry>
+       <refentrytitle>nixos-option</refentrytitle>
+       <manvolnum>8</manvolnum> </citerefentry>.
       </para>
      </listitem>
     </varlistentry>

--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -62,6 +62,7 @@
 # generations
 # help
 # news
+# option
 # packages
 # remove-generations
 # switch
@@ -86,6 +87,7 @@
 #
 #   help
 #   edit
+#   option
 #   build
 #   switch
 #   generations
@@ -130,6 +132,9 @@
 #   help         Print this help
 #
 #   edit         Open the home configuration in $EDITOR
+#
+#   option OPTION.NAME
+#                Inspect configuration option named OPTION.NAME.
 #
 #   build        Build configuration into result directory
 #
@@ -278,7 +283,7 @@ _home-manager_completions ()
     #--------------------------#
 
     local Subcommands
-    Subcommands=( "help" "edit" "build" "instantiate" "switch" "generations" "remove-generations" "expire-generations" "packages" "news" "uninstall" )
+    Subcommands=( "help" "edit" "option" "build" "instantiate" "switch" "generations" "remove-generations" "expire-generations" "packages" "news" "uninstall" )
 
     # ^ « home-manager »'s subcommands.
 
@@ -354,4 +359,4 @@ _home-manager_completions ()
 
 complete -F _home-manager_completions -o default home-manager
 
-#complete -W "help edit build switch generations remove-generations expire-generations packages news" home-manager
+#complete -W "help edit option build switch generations remove-generations expire-generations packages news" home-manager

--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -25,6 +25,7 @@ case "$state" in
     _values 'command' \
       'help[help]' \
       'edit[edit]' \
+      'option[inspect option]' \
       'build[build]' \
       'switch[switch]' \
       'generations[list generations]' \

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -1,4 +1,6 @@
-{ runCommand, lib, bash, coreutils, findutils, gnused, less
+{ runCommand, lib, bash, callPackage, coreutils, findutils, gnused, less
+# used for pkgs.path for nixos-option
+, pkgs
 
 # Extra path to Home Manager. If set then this path will be tried
 # before `$HOME/.config/nixpkgs/home-manager` and
@@ -8,6 +10,9 @@
 let
 
   pathStr = if path == null then "" else path;
+
+  nixos-option =
+    callPackage "${pkgs.path}/nixos/modules/installer/tools/nixos-option" { };
 
 in runCommand "home-manager" {
   preferLocalBuild = true;
@@ -27,6 +32,7 @@ in runCommand "home-manager" {
     --subst-var-by findutils "${findutils}" \
     --subst-var-by gnused "${gnused}" \
     --subst-var-by less "${less}" \
+    --subst-var-by nixos-option "${nixos-option}" \
     --subst-var-by HOME_MANAGER_PATH '${pathStr}'
 
   install -D -m755 ${./completion.bash} \

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -1,7 +1,7 @@
 #!@bash@/bin/bash
 
 # Prepare to use tools from Nixpkgs.
-PATH=@coreutils@/bin:@findutils@/bin:@gnused@/bin:@less@/bin${PATH:+:}$PATH
+PATH=@coreutils@/bin:@findutils@/bin:@gnused@/bin:@less@/bin:@nixos-option@/bin${PATH:+:}$PATH
 
 set -euo pipefail
 
@@ -95,6 +95,46 @@ function setFlakeAttribute() {
         esac
         export FLAKE_CONFIG_URI="$flake#homeConfigurations.\"$name\""
     fi
+}
+
+function doInspectOption() {
+    setFlakeAttribute
+    if [[ -v FLAKE_CONFIG_URI ]]; then
+        errorEcho "Can't inspect options of a flake configuration"
+        exit 1
+    fi
+    setConfigFile
+    setHomeManagerNixPath
+
+    local extraArgs=("$@")
+
+    for p in "${EXTRA_NIX_PATH[@]}"; do
+        extraArgs=("${extraArgs[@]}" "-I" "$p")
+    done
+
+    if [[ -v VERBOSE ]]; then
+        extraArgs=("${extraArgs[@]}" "--show-trace")
+    fi
+
+    local HOME_MANAGER_CONFIG_NIX HOME_MANAGER_CONFIG_ATTRIBUTE_NIX
+    HOME_MANAGER_CONFIG_NIX=${HOME_MANAGER_CONFIG//'\'/'\\'}
+    HOME_MANAGER_CONFIG_NIX=${HOME_MANAGER_CONFIG_NIX//'"'/'\"'}
+    HOME_MANAGER_CONFIG_NIX=${HOME_MANAGER_CONFIG_NIX//$'\n'/$'\\n'}
+    HOME_MANAGER_CONFIG_ATTRIBUTE_NIX=${HOME_MANAGER_CONFIG_ATTRIBUTE//'\'/'\\'}
+    HOME_MANAGER_CONFIG_ATTRIBUTE_NIX=${HOME_MANAGER_CONFIG_ATTRIBUTE_NIX//'"'/'\"'}
+    HOME_MANAGER_CONFIG_ATTRIBUTE_NIX=${HOME_MANAGER_CONFIG_ATTRIBUTE_NIX//$'\n'/$'\\n'}
+    local modulesExpr
+    modulesExpr="let confPath = \"${HOME_MANAGER_CONFIG_NIX}\"; "
+    modulesExpr+="confAttr = \"${HOME_MANAGER_CONFIG_ATTRIBUTE_NIX}\"; in "
+    modulesExpr+="(import <home-manager/modules> {"
+    modulesExpr+=" configuration = if confAttr == \"\" then confPath else (import confPath).\${confAttr};"
+    modulesExpr+=" pkgs = import <nixpkgs> {}; check = true; })"
+
+    nixos-option \
+        --options_expr "$modulesExpr.options" \
+        --config_expr "$modulesExpr.config" \
+        "${extraArgs[@]}" \
+        "${PASSTHROUGH_OPTS[@]}"
 }
 
 function doInstantiate() {
@@ -487,6 +527,9 @@ function doHelp() {
     echo
     echo "  edit         Open the home configuration in \$EDITOR"
     echo
+    echo "  option OPTION.NAME"
+    echo "               Inspect configuration option named OPTION.NAME."
+    echo
     echo "  build        Build configuration into result directory"
     echo
     echo "  instantiate  Instantiate the configuration and print the resulting derivation"
@@ -524,7 +567,7 @@ while [[ $# -gt 0 ]]; do
     opt="$1"
     shift
     case $opt in
-        build|instantiate|edit|expire-generations|generations|help|news|packages|remove-generations|switch|uninstall)
+        build|instantiate|option|edit|expire-generations|generations|help|news|packages|remove-generations|switch|uninstall)
             COMMAND="$opt"
             ;;
         -A)
@@ -586,7 +629,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             case $COMMAND in
-                expire-generations|remove-generations)
+                expire-generations|remove-generations|option)
                     COMMAND_ARGS+=("$opt")
                     ;;
                 *)
@@ -630,6 +673,9 @@ case $COMMAND in
         else
             doExpireGenerations "${COMMAND_ARGS[@]}"
         fi
+        ;;
+    option)
+        doInspectOption "${COMMAND_ARGS[@]}"
         ;;
     packages)
         doListPackages


### PR DESCRIPTION
### Description

Add a `home-manager option` subcommand which acts like `nixos-option` by constructing a home-manager–based invocation of `nixos-option`.

Doesn't work on flake configurations currently.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
