### PR TITLE
texlive: add `packageSet` option

### DIFF
--- a/modules/programs/texlive.nix
+++ b/modules/programs/texlive.nix
@@ -13,7 +13,7 @@ in {
 
   options = {
     programs.texlive = {
-      enable = mkEnableOption "Texlive";
+      enable = mkEnableOption "TeX Live";
 
       extraPackages = mkOption {
         default = tpkgs: { inherit (tpkgs) collection-basic; };
@@ -21,12 +21,12 @@ in {
         example = literalExample ''
           tpkgs: { inherit (tpkgs) collection-fontsrecommended algorithms; }
         '';
-        description = "Extra packages available to Texlive.";
+        description = "Extra packages available to TeX Live.";
       };
 
       package = mkOption {
         type = types.package;
-        description = "Resulting customized Texlive package.";
+        description = "Resulting customized TeX Live package.";
         readOnly = true;
       };
     };

--- a/modules/programs/texlive.nix
+++ b/modules/programs/texlive.nix
@@ -6,7 +6,8 @@ let
 
   cfg = config.programs.texlive;
 
-  texlivePkgs = cfg.extraPackages pkgs.texlive;
+  texlive = cfg.packageSet;
+  texlivePkgs = cfg.extraPackages texlive;
 
 in {
   meta.maintainers = [ maintainers.rycee ];
@@ -14,6 +15,12 @@ in {
   options = {
     programs.texlive = {
       enable = mkEnableOption "TeX Live";
+
+      packageSet = mkOption {
+        default = pkgs.texlive;
+        defaultText = literalExample "pkgs.texlive";
+        description = "TeX Live package set to use.";
+      };
 
       extraPackages = mkOption {
         default = tpkgs: { inherit (tpkgs) collection-basic; };
@@ -41,6 +48,6 @@ in {
 
     home.packages = [ cfg.package ];
 
-    programs.texlive.package = pkgs.texlive.combine texlivePkgs;
+    programs.texlive.package = texlive.combine texlivePkgs;
   };
 }


### PR DESCRIPTION
### Description

I've at least personally had the need to swap out `pkgs.texlive`. This is basically a `package` option.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
