### PR TITLE
home-manager: pass on `--debug` option

### DIFF
--- a/doc/man-home-manager.xml
+++ b/doc/man-home-manager.xml
@@ -12,47 +12,47 @@
  </refnamediv>
  <refsynopsisdiv>
   <cmdsynopsis>
-   <command>home-manager</command> <group choice="req"> 
+   <command>home-manager</command> <group choice="req">
    <arg choice="plain">
     build
    </arg>
-    
+
    <arg choice="plain">
     instantiate
    </arg>
-    
+
    <arg choice="plain">
     edit
    </arg>
-    
+
    <arg choice="plain">
     expire-generations <replaceable>timestamp</replaceable>
    </arg>
-    
+
    <arg choice="plain">
     generations
    </arg>
-    
+
    <arg choice="plain">
     help
    </arg>
-    
+
    <arg choice="plain">
     news
    </arg>
-    
+
    <arg choice="plain">
     packages
    </arg>
-    
+
    <arg choice="plain">
     remove-generations <replaceable>ID …</replaceable>
    </arg>
-    
+
    <arg choice="plain">
     switch
    </arg>
-    
+
    <arg choice="plain">
     uninstall
    </arg>
@@ -61,63 +61,63 @@
    <arg>
     -A <replaceable>attrPath</replaceable>
    </arg>
-    
+
    <arg>
     -I <replaceable>path</replaceable>
    </arg>
-    
+
    <arg>
     --flake <replaceable>flake-uri</replaceable>
    </arg>
-    
+
    <arg>
     -b <replaceable>ext</replaceable>
    </arg>
-    
+
    <arg>
-    <group choice="req"> 
+    <group choice="req">
     <arg choice="plain">
      -f
     </arg>
-     
+
     <arg choice="plain">
      --file
     </arg>
      </group> <replaceable>path</replaceable>
    </arg>
-    
+
    <arg>
-    <group choice="req"> 
+    <group choice="req">
     <arg choice="plain">
      -h
     </arg>
-     
+
     <arg choice="plain">
      --help
     </arg>
      </group>
    </arg>
-    
+
    <arg>
-    <group choice="req"> 
+    <group choice="req">
     <arg choice="plain">
      -n
     </arg>
-     
+
     <arg choice="plain">
      --dry-run
     </arg>
      </group>
    </arg>
-    
+
    <arg>
     --option <replaceable>name</replaceable> <replaceable>value</replaceable>
    </arg>
-    
+
    <arg>
     --cores <replaceable>number</replaceable>
    </arg>
-    
+
    <arg>
      <group choice="req">
        <arg choice="plain">
@@ -130,29 +130,29 @@
      </group>
      <replaceable>number</replaceable>
    </arg>
-    
+
    <arg>
     --keep-failed
    </arg>
-    
+
    <arg>
     --keep-going
    </arg>
-    
+
    <arg>
     --show-trace
    </arg>
-    
+
    <arg>
     --(no-)substitute
    </arg>
-    
+
    <arg>
-    <group choice="req"> 
+    <group choice="req">
     <arg choice="plain">
      -v
     </arg>
-     
+
     <arg choice="plain">
      --verbose
     </arg>

--- a/doc/man-home-manager.xml
+++ b/doc/man-home-manager.xml
@@ -132,6 +132,10 @@
    </arg>
 
    <arg>
+    --debug
+   </arg>
+
+   <arg>
     --keep-failed
    </arg>
 
@@ -447,6 +451,18 @@
     </term>
     <term>
      <option>--max-jobs <replaceable>number</replaceable></option>
+    </term>
+    <listitem>
+     <para>
+      Passed on to <citerefentry>
+      <refentrytitle>nix-build</refentrytitle>
+      <manvolnum>1</manvolnum> </citerefentry>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--debug</option>
     </term>
     <listitem>
      <para>

--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -285,8 +285,8 @@ _home-manager_completions ()
     #--------------------------#
 
     local Options
-    Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" "--verbose" "--show-trace" \
-              "-j" "--max-jobs" )
+    Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" "--verbose" \
+              "--cores" "--debug" "--keep-failed" "--keep-going" "-j" "--max-jobs" "--no-substitute" "--show-trace" "--substitute")
 
     # ^ « home-manager »'s options.
 

--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -7,6 +7,7 @@ _arguments \
   '-I[search path]:PATH:_files -/' \
   '-b[backup files]:EXT:()' \
   '--cores[cores]:NUM:()' \
+  '--debug[debug]' \
   '--keep-failed[keep failed]' \
   '--keep-going[keep going]' \
   '(-h --help)'{--help,-h}'[help]' \
@@ -42,11 +43,14 @@ case "$state" in
       build|switch)
         _arguments \
           '--cores[cores]:NUM:()' \
+          '--debug[debug]' \
           '--keep-failed[keep failed]' \
           '--keep-going[keep going]' \
           '--max-jobs[max jobs]:NUM:()' \
+          '--no-substitute[no substitute]' \
           '--option[option]:NAME VALUE:()' \
-          '--show-trace[show trace]'
+          '--show-trace[show trace]' \
+          '--substitute[substitute]'
         ;;
     esac
 esac

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -473,6 +473,7 @@ function doHelp() {
     echo
     echo "  --arg(str) NAME VALUE    Override inputs passed to home-manager.nix"
     echo "  --cores NUM"
+    echo "  --debug"
     echo "  --keep-failed"
     echo "  --keep-going"
     echo "  -j, --max-jobs NUM"
@@ -572,7 +573,7 @@ while [[ $# -gt 0 ]]; do
             PASSTHROUGH_OPTS+=("$opt" "$1")
             shift
             ;;
-        --keep-failed|--keep-going|--show-trace\
+        --debug|--keep-failed|--keep-going|--show-trace\
             |--substitute|--no-substitute)
             PASSTHROUGH_OPTS+=("$opt")
             ;;


### PR DESCRIPTION
### Description

Teach `home-manager` to pass on the `--debug` option.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
