### PR TITLE
programs.neovim: fix tests + swap extraConfig and pluginconfig

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -51,8 +51,8 @@ let
         (map (x: if x ? plugin && x.optional == true then x.plugin else null)
           cfg.plugins);
     };
-    customRC = cfg.extraConfig
-      + pkgs.lib.concatMapStrings pluginConfig cfg.plugins;
+    customRC = pkgs.lib.concatMapStrings pluginConfig cfg.plugins
+      + cfg.extraConfig;
   };
 
   extraMakeWrapperArgs = lib.optionalString (cfg.extraPackages != [ ])

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -24,11 +24,11 @@ with lib;
 
     nmt.script = ''
       vimrc="$TESTED/home-files/.config/nvim/init.vim"
+      ${pkgs.perl}/bin/perl -pe "s|\Q$NIX_STORE\E/[a-z0-9]{32}-|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" < "$vimrc" > $out/generated.vim
       assertFileExists home-files/.config/nvim/init.vim
       # We need to remove the unkown store paths in the config
       TESTED="" assertFileContent \
-        <( ${pkgs.perl}/bin/perl -pe "s|\Q$NIX_STORE\E/[a-z0-9]{32}-|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" < "$vimrc"
-         ) \
+         $out/generated.vim \
         "${./plugin-config.vim}"
     '';
   };

--- a/tests/modules/programs/neovim/plugin-config.vim
+++ b/tests/modules/programs/neovim/plugin-config.vim
@@ -4,10 +4,10 @@ set nocompatible
 set packpath^=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-vim-pack-dir
 set runtimepath^=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-vim-pack-dir
 
-" This should be present in vimrc
 " vim-commentary {{{
 " This should be present too
 autocmd FileType c setlocal commentstring=//\ %s
 autocmd FileType c setlocal comments=://
 
 " }}}
+" This should be present in vimrc


### PR DESCRIPTION
makes more sense to have extraConfig afterwards in case use want to override config

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
