### PR TITLE
pantalaimon: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -246,6 +246,9 @@
 
 /modules/services/network-manager-applet.nix          @rycee
 
+/modules/services/pantalaimon.nix                     @jojosch
+/tests/modules/services/pantalaimon                   @jojosch
+
 /modules/services/parcellite.nix                      @gleber
 
 /modules/services/pass-secret-service.nix             @cab404

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2069,6 +2069,14 @@ in
           A new module is available: 'services.xidlehook'.
         '';
       }
+
+      {
+        time = "2021-06-07T20:44:00+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.pantalaimon'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -185,6 +185,7 @@ let
     (loadModule ./services/network-manager-applet.nix { })
     (loadModule ./services/nextcloud-client.nix { })
     (loadModule ./services/owncloud-client.nix { })
+    (loadModule ./services/pantalaimon.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/parcellite.nix { })
     (loadModule ./services/pass-secret-service.nix { condition = hostPlatform.isLinux; })
     (loadModule ./services/password-store-sync.nix { condition = hostPlatform.isLinux; })

--- a/modules/services/pantalaimon.nix
+++ b/modules/services/pantalaimon.nix
@@ -1,0 +1,79 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.pantalaimon;
+
+  iniFmt = pkgs.formats.ini { };
+in {
+  meta.maintainers = [ maintainers.jojosch ];
+
+  options = {
+    services.pantalaimon = {
+      enable = mkEnableOption
+        "Pantalaimon, an E2EE aware proxy daemon for matrix clients";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.pantalaimon;
+        defaultText = literalExample "pkgs.pantalaimon";
+        description =
+          "Package providing the <command>pantalaimon</command> executable to use.";
+      };
+
+      settings = mkOption {
+        type = iniFmt.type;
+        default = { };
+        defaultText = literalExample "{ }";
+        example = literalExample ''
+          {
+            Default = {
+              LogLevel = "Debug";
+              SSL = true;
+            };
+            local-matrix = {
+              Homeserver = "https://matrix.org";
+              ListenAddress = "127.0.0.1";
+              ListenPort = 8008;
+            };
+          }
+        '';
+        description = ''
+          Configuration written to
+          <filename>$XDG_CONFIG_HOME/pantalaimon/pantalaimon.conf</filename>.
+          </para><para>
+          See <link xlink:href="https://github.com/matrix-org/pantalaimon/blob/master/docs/manpantalaimon.5.md" /> or
+          <citerefentry>
+            <refentrytitle>pantalaimon</refentrytitle>
+            <manvolnum>5</manvolnum>
+          </citerefentry>
+          for options.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    systemd.user.services = {
+      pantalaimon = {
+        Unit = {
+          Description =
+            "Pantalaimon - E2EE aware proxy daemon for matrix clients";
+          After = [ "network-online.target" ];
+        };
+
+        Service = {
+          ExecStart = "${cfg.package}/bin/pantalaimon -c ${
+              iniFmt.generate "pantalaimon.conf" cfg.settings
+            }";
+          Restart = "on-failure";
+        };
+
+        Install.WantedBy = [ "default.target" ];
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -113,6 +113,7 @@ import nmt {
     ./modules/services/fluidsynth
     ./modules/services/kanshi
     ./modules/services/lieer
+    ./modules/services/pantalaimon
     ./modules/services/pbgopy
     ./modules/services/playerctld
     ./modules/services/polybar

--- a/tests/modules/services/pantalaimon/basic-configuration.nix
+++ b/tests/modules/services/pantalaimon/basic-configuration.nix
@@ -1,0 +1,29 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.pantalaimon = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-pantalaimon" "" // {
+        outPath = "@pantalaimon@";
+      };
+      settings = {
+        Default = {
+          LogLevel = "Debug";
+          SSL = true;
+        };
+        local-matrix = {
+          Homeserver = "https://matrix.org";
+          ListenAddress = "127.0.0.1";
+          ListenPort = 8008;
+        };
+      };
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/pantalaimon.service
+      assertFileExists $serviceFile
+      assertFileRegex $serviceFile 'ExecStart=@pantalaimon@/bin/pantalaimon -c /nix/store/.*-pantalaimon.conf'
+    '';
+  };
+}

--- a/tests/modules/services/pantalaimon/default.nix
+++ b/tests/modules/services/pantalaimon/default.nix
@@ -1,0 +1,1 @@
+{ pantalaimon-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

Add a module for [pantalaimon](https://github.com/matrix-org/pantalaimon), a E2EE aware proxy daemon for matrix clients.

Tested the new module with [fractal](https://wiki.gnome.org/Apps/Fractal), which doesn't support E2EE by itself.

nixpkgs-PR for the "headless" version: https://github.com/NixOS/nixpkgs/pull/123896#issuecomment-851006235

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.