### PR TITLE
qutebrowser: add quickmark support

### DIFF
--- a/tests/modules/programs/qutebrowser/default.nix
+++ b/tests/modules/programs/qutebrowser/default.nix
@@ -1,4 +1,5 @@
 {
   qutebrowser-settings = ./settings.nix;
   qutebrowser-keybindings = ./keybindings.nix;
+  qutebrowser-quickmarks = ./quickmarks.nix;
 }

--- a/tests/modules/programs/qutebrowser/quickmarks.nix
+++ b/tests/modules/programs/qutebrowser/quickmarks.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.qutebrowser = {
+      enable = true;
+
+      quickmarks = {
+        nixpkgs = "https://github.com/NixOS/nixpkgs";
+        home-manager = "https://github.com/nix-community/home-manager";
+      };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        qutebrowser = pkgs.writeScriptBin "dummy-qutebrowser" "";
+      })
+    ];
+
+    nmt.script = let
+      quickmarksFile = if pkgs.stdenv.hostPlatform.isDarwin then
+        ".qutebrowser/quickmarks"
+      else
+        ".config/qutebrowser/quickmarks";
+    in ''
+      assertFileContent \
+        home-files/${quickmarksFile} \
+        ${
+          pkgs.writeText "qutebrowser-expected-quickmarks" ''
+            home-manager https://github.com/nix-community/home-manager
+            nixpkgs https://github.com/NixOS/nixpkgs''
+        }
+    '';
+  };
+}


### PR DESCRIPTION
Closes: https://github.com/nix-community/home-manager/issues/1230

### Description
This allows the qutebrowser derivation to parse quickmarks, which I've been wanting to use for a while. If unset, qutebrowser will manage the file instead of home-manager. 

When quickmarks are set through home-manager, they cannot be edited at runtime.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
