### PR TITLE
foot: add foot binaries to user service's path

### DIFF
--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -66,6 +66,7 @@ in {
         };
 
         Service = {
+          Environment = "PATH=${cfg.package}/bin";
           ExecStart = "${cfg.package}/bin/foot --server";
           Restart = "on-failure";
         };

--- a/tests/modules/programs/foot/systemd-user-service-expected.service
+++ b/tests/modules/programs/foot/systemd-user-service-expected.service
@@ -2,6 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
+Environment=PATH=@foot@/bin
 ExecStart=@foot@/bin/foot --server
 Restart=on-failure
 


### PR DESCRIPTION
### Description

`foot`'s terminal spawning feature (`Control+Shift+n` by default) does not work with the `foot` user service supplied with the `foot` module. The error in the system journal is:
```
Jun 01 18:09:17 foureightynine foot[30948]:  err: spawn.c:89: footclient: failed to spawn: No such file or directory
Jun 01 18:09:17 foureightynine foot[30948]: spawn: footclient: failed to spawn: No such file or directory
```
Adding foot's `bin` folder to the services path fixes this issue.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
