### PR TITLE
i3status-rust: replace deprecated memory format keys

### DIFF
--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -42,8 +42,8 @@ in {
               {
                 block = "memory";
                 display_type = "memory";
-                format_mem = "{Mup}%";
-                format_swap = "{SUp}%";
+                format_mem = "{mem_used_percents}";
+                format_swap = "{swap_used_percents}";
               }
               {
                 block = "cpu";
@@ -205,8 +205,8 @@ in {
              {
                block = "memory";
                display_type = "memory";
-               format_mem = "{Mup}%";
-               format_swap = "{SUp}%";
+               format_mem = "{mem_used_percents}";
+               format_swap = "{swap_used_percents}";
              }
              {
                block = "cpu";


### PR DESCRIPTION
### Description

The format keys have changed in `i3status-rust` ([source](https://github.com/greshake/i3status-rust/blob/master/doc/blocks.md#removed-format-keys)), resulting in an error when using the default configuration.

### Checklist

- [ ] Change is backwards compatible. (I’m not sure about this: if someone uses an old `i3status-rust` version, then it’s not backwards compatible)

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
