### PR TITLE
terminator: added

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -178,6 +178,8 @@
 
 /modules/programs/starship.nix                        @marsam
 
+/modules/programs/terminator.nix                      @chisui
+
 /modules/programs/texlive.nix                         @rycee
 
 /modules/programs/topgrade.nix                        @msfjarvis

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -25,6 +25,12 @@
     github = "cwyc";
     githubId = 16950437;
   };
+  chisui = {
+    name = "Philipp Dargel";
+    email = "chisui@users.noreply.github.com";
+    github = "chisui";
+    githubId = 4526429;
+  };
   olmokramer = {
     name = "Olmo Kramer";
     email = "olmokramer@users.noreply.github.com";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -137,6 +137,7 @@ let
     (loadModule ./programs/termite.nix { })
     (loadModule ./programs/texlive.nix { })
     (loadModule ./programs/tmux.nix { })
+    (loadModule ./programs/terminator.nix { condition = hostPlatform.isLinux; })
     (loadModule ./programs/topgrade.nix { })
     (loadModule ./programs/urxvt.nix { })
     (loadModule ./programs/vim.nix { })

--- a/modules/programs/terminator.nix
+++ b/modules/programs/terminator.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.terminator;
+
+  toValue = val:
+    if val == null then
+      "None"
+    else if val == true then
+      "True"
+    else if val == false then
+      "False"
+    else
+      ''"${toString val}"'';
+
+  toConfigObject = let
+    toKey = depth: key:
+      if depth == 0 then key else toKey (depth - 1) "[${key}]";
+    toConfigObjectLevel = depth: obj:
+      flatten (mapAttrsToList (key: val:
+        if isAttrs val then
+          [ (toKey depth key) ] ++ toConfigObjectLevel (depth + 1) val
+        else
+          [ "${key} = ${toValue val}" ]) obj);
+  in obj: concatStringsSep "\n" (toConfigObjectLevel 1 obj);
+
+in {
+  meta.maintainers = [ maintainers.chisui ];
+
+  options.programs.terminator = {
+    enable = mkEnableOption "terminator, a tiling terminal emulator";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.terminator;
+      example = literalExample "pkgs.terminator";
+      description = "terminator package to install.";
+    };
+
+    config = mkOption {
+      default = { };
+      description = ''
+        configuration for terminator.
+        </para><para>
+        For a list of all possible options refer to the
+        <citerefentry>
+          <refentrytitle>terminator_config</refentrytitle>
+          <manvolnum>5</manvolnum>
+        </citerefentry>
+        man page.
+      '';
+      type = types.attrsOf types.anything;
+      example = literalExample ''
+        {
+          global_config.borderless = true;
+          profiles.default.background_color = "#002b36";
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    xdg.configFile."terminator/config" =
+      mkIf (cfg.config != { }) { text = toConfigObject cfg.config; };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -108,6 +108,7 @@ import nmt {
     ./modules/programs/rbw
     ./modules/programs/rofi
     ./modules/programs/rofi-pass
+    ./modules/programs/terminator
     ./modules/programs/waybar
     ./modules/services/barrier
     ./modules/services/dropbox

--- a/tests/modules/programs/terminator/config-file.nix
+++ b/tests/modules/programs/terminator/config-file.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }: {
+  config = {
+    programs.terminator = {
+      enable = true;
+      config = {
+        global_config.borderless = true;
+        profiles.default.background_color = "#002b36";
+      };
+    };
+
+    nmt.script = ''
+      assertFileContent home-files/.config/terminator/config ${
+        pkgs.writeText "expected" ''
+          [global_config]
+          borderless = True
+          [profiles]
+          [[default]]
+          background_color = "#002b36"''
+      }
+    '';
+  };
+}

--- a/tests/modules/programs/terminator/default.nix
+++ b/tests/modules/programs/terminator/default.nix
@@ -1,0 +1,1 @@
+{ terminator-config-file = ./config-file.nix; }


### PR DESCRIPTION
### Description

Added configuration for terminator.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
