### PR TITLE
htop: fix preserving the order of meters (backport to 21.05)

### DIFF
--- a/tests/modules/programs/htop/example-settings.nix
+++ b/tests/modules/programs/htop/example-settings.nix
@@ -27,18 +27,14 @@ with lib;
       highlight_megabytes = 1;
       highlight_threads = 1;
     } // (with config.lib.htop;
-      leftMeters {
-        AllCPUs2 = modes.Bar;
-        Memory = modes.Bar;
-        Swap = modes.Bar;
-        Zram = modes.Text;
-      }) // (with config.lib.htop;
-        rightMeters {
-          Tasks = modes.Text;
-          LoadAverage = modes.Text;
-          Uptime = modes.Text;
-          Systemd = modes.Text;
-        });
+      leftMeters [ (bar "AllCPUs2") (bar "Memory") (bar "Swap") (text "Zram") ])
+      // (with config.lib.htop;
+        rightMeters [
+          (text "Tasks")
+          (text "LoadAverage")
+          (text "Uptime")
+          (text "Systemd")
+        ]);
 
     nmt.script = ''
       assertFileExists home-files/.config/htop/htoprc


### PR DESCRIPTION
Pass meters for formatting in a list of attrsets so that ordering can be
preserved. In addition provide some mode-specific functions to create these
attrsets, to make for a bit nicer config.

This fixes #2060 on 21.05. See #2065 for these fixes on master.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
