### PR TITLE
Replace references to pkgs.gnome3 by pkgs.gnome

### DIFF
--- a/doc/faq.adoc
+++ b/doc/faq.adoc
@@ -92,7 +92,7 @@ error: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name ca.desrt.
 The solution on NixOS is to add
 
 [source,nix]
-services.dbus.packages = with pkgs; [ gnome3.dconf ];
+services.dbus.packages = with pkgs; [ gnome.dconf ];
 
 to your system configuration.
 

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -33,7 +33,7 @@ let
       package = mkOption {
         type = types.nullOr types.package;
         default = null;
-        example = literalExample "pkgs.gnome3.gnome_themes_standard";
+        example = literalExample "pkgs.gnome.gnome_themes_standard";
         description = ''
           Package providing the theme. This package will be installed
           to your profile. If <literal>null</literal> then the theme

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -315,7 +315,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.gnome3.gnome-terminal ];
+    home.packages = [ pkgs.gnome.gnome-terminal ];
 
     dconf.settings = let dconfPath = "org/gnome/terminal/legacy";
     in {

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -261,7 +261,7 @@ in {
       description = ''
         Path to the terminal which will be used to run console applications
       '';
-      example = "\${pkgs.gnome3.gnome_terminal}/bin/gnome-terminal";
+      example = "\${pkgs.gnome.gnome_terminal}/bin/gnome-terminal";
     };
 
     separator = mkOption {

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -25,7 +25,7 @@ let
     options = {
       package = mkOption {
         type = types.package;
-        example = literalExample "pkgs.gnome3.adwaita-icon-theme";
+        example = literalExample "pkgs.gnome.adwaita-icon-theme";
         description = "Package providing the theme.";
       };
 

--- a/modules/services/gnome-keyring.nix
+++ b/modules/services/gnome-keyring.nix
@@ -36,7 +36,7 @@ in {
           args = concatStringsSep " " ([ "--start" "--foreground" ]
             ++ optional (cfg.components != [ ])
             ("--components=" + concatStringsSep "," cfg.components));
-        in "${pkgs.gnome3.gnome-keyring}/bin/gnome-keyring-daemon ${args}";
+        in "${pkgs.gnome.gnome-keyring}/bin/gnome-keyring-daemon ${args}";
         Restart = "on-abort";
       };
 

--- a/modules/services/pulseeffects.nix
+++ b/modules/services/pulseeffects.nix
@@ -38,7 +38,7 @@ in {
     # "AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files"
     home.packages = [ cfg.package pkgs.at-spi2-core ];
 
-    # Will need to add `services.dbus.packages = with pkgs; [ gnome3.dconf ];`
+    # Will need to add `services.dbus.packages = with pkgs; [ gnome.dconf ];`
     # to /etc/nixos/configuration.nix for daemon to work correctly
 
     systemd.user.services.pulseeffects = {


### PR DESCRIPTION
### Description

To avoid use of gnome3 alias.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.