### PR TITLE
Revert "foot: add foot binaries to user service's path (#2061)"

### DIFF
--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -66,7 +66,6 @@ in {
         };
 
         Service = {
-          Environment = "PATH=${cfg.package}/bin";
           ExecStart = "${cfg.package}/bin/foot --server";
           Restart = "on-failure";
         };

--- a/tests/modules/programs/foot/systemd-user-service-expected.service
+++ b/tests/modules/programs/foot/systemd-user-service-expected.service
@@ -2,7 +2,6 @@
 WantedBy=graphical-session.target
 
 [Service]
-Environment=PATH=@foot@/bin
 ExecStart=@foot@/bin/foot --server
 Restart=on-failure
 


### PR DESCRIPTION
### Description

This reverts commit cb227dc6c29eb4f768d04958f4fe6d9d3d4aba46 (#2061).

That PR broke usage of foot as a server as `PATH` would be overriden, and shells inside the terminal could not find binaries. Also the workaround for the spawning feature no longer seems necessary: it now is working for me without the patch. 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
