### PR TITLE
ci: remove cachix from test pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,6 @@ jobs:
     - uses: cachix/install-nix-action@v13
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - uses: cachix/cachix-action@v10
-      with:
-        name: nix-community
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: ./format -c
     - run: nix-shell . -A install
     - run: nix-shell --pure tests -A run.all


### PR DESCRIPTION
The tests produce many small files that are quick to build and take long to upload. Using cachix is therefore increases the pipeline run time.