### PR TITLE
dunst: fix systemd user service for cannot open display

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -155,8 +155,11 @@ in {
           Type = "dbus";
           BusName = "org.freedesktop.Notifications";
           ExecStart = "${cfg.package}/bin/dunst";
-          Environment = optionalString (cfg.waylandDisplay != "")
-            "WAYLAND_DISPLAY=${cfg.waylandDisplay}";
+          Environment = [
+            "DISPLAY:=0"
+            (optionalString (cfg.waylandDisplay != "")
+              "WAYLAND_DISPLAY=${cfg.waylandDisplay}")
+          ];
         };
       };
     }


### PR DESCRIPTION
This is a very small change to make it work for X11 as well.

The systemd user service results in a failed start with "Cannot open the X11 display".

Without this change the following works

```shellsession
systemctl --user set-environment DISPLAY:=0
systemctl --user start dunst
```

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.
    - Some unrelated test fails with output 
```shellsession
neovim-plugin-config: FAILED
Expected /nix/store/7mmydymjnqv70ifr2rvz6syigxals67g-nmt-report-neovim-plugin-config/generated.vim to be same as /nix/store/ab8l2mg40bf05y2w2zqp7id3061pv89f-plugin-config.vim but were different:
--- actual
+++ expected
@@ -1,2 +1,10 @@
 set packpath^=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-vim-pack-dir
 set runtimepath^=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-vim-pack-dir
+
+" vim-commentary {{{
+" This should be present too
+autocmd FileType c setlocal commentstring=//\ %s
+autocmd FileType c setlocal comments=://
+
+" }}}
+" This should be present in vimrc
For further reference please introspect /nix/store/7mmydymjnqv70ifr2rvz6syigxals67g-nmt-report-neovim-plugin-config
```

- [ ] ~~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~~

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

