### PR TITLE
xsession.pointerCursor: .icons file for AwesomeWM

### DIFF
--- a/modules/xcursor.nix
+++ b/modules/xcursor.nix
@@ -79,5 +79,14 @@ in {
       "gtk-cursor-theme-size" = cfg.size;
     };
 
+    # Set name in icons theme, for compatibility with AwesomeWM etc. See:
+    # https://github.com/nix-community/home-manager/issues/2081
+    # https://wiki.archlinux.org/title/Cursor_themes#XDG_specification
+    home.file.".icons/default/index.theme".text = ''
+      [icon theme]
+      Name=Default
+      Comment=Default Cursor Theme
+      Inherits=${cfg.name}
+    '';
   };
 }


### PR DESCRIPTION
closes #2081

### Description

Writes the file `~/.icons/default/index.theme`, which allows AwesomeWM (perhaps others?) to use the pointerCursor setting.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible. **(Unless a user is writing that file from their own config.)**

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef). **(There isn't a test case for this module yet.)**

- [x] Commit messages are formatted like **(I didn't use a long description, but referenced the reported issue instead)**

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR ~~adds a new module~~

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
