### PR TITLE
sxhkd: stop scope before creating

### DIFF
--- a/modules/services/sxhkd.nix
+++ b/modules/services/sxhkd.nix
@@ -73,6 +73,7 @@ in
     ];
 
     xsession.initExtra = ''
+      systemctl --user stop sxhkd.scope 2> /dev/null || true
       systemd-cat -t sxhkd systemd-run --user --scope -u sxhkd \
         ${cfg.package}/bin/sxhkd ${toString cfg.extraOptions} &
     '';

--- a/tests/modules/services/sxhkd/service.nix
+++ b/tests/modules/services/sxhkd/service.nix
@@ -2,8 +2,9 @@
 
 let 
   expectedFileRegex = ''
-      systemd-cat -t sxhkd systemd-run --user --scope -u sxhkd \
-       @sxhkd@/bin/sxhkd -m 1 &
+    systemctl --user stop sxhkd.scope 2> /dev/null || true
+    systemd-cat -t sxhkd systemd-run --user --scope -u sxhkd \
+     @sxhkd@/bin/sxhkd -m 1 &
   '';
 in
 


### PR DESCRIPTION
### Description
This allows relogging into graphical session.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
