### PR TITLE
direnv: add enableFlakes option for enableNixDirenvIntegration

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -9,6 +9,14 @@ let
   tomlFormat = pkgs.formats.toml { };
 
 in {
+  imports = [
+    (mkRenamedOptionModule [
+      "programs"
+      "direnv"
+      "enableNixDirenvIntegration"
+    ] [ "programs" "direnv" "nix-direnv" "enable" ])
+  ];
+
   meta.maintainers = [ maintainers.rycee ];
 
   options.programs.direnv = {
@@ -63,10 +71,14 @@ in {
       '';
     };
 
-    enableNixDirenvIntegration = mkEnableOption ''
-      <link
-          xlink:href="https://github.com/nix-community/nix-direnv">nix-direnv</link>,
-          a fast, persistent use_nix implementation for direnv'';
+    nix-direnv = {
+      enable = mkEnableOption ''
+        <link
+            xlink:href="https://github.com/nix-community/nix-direnv">nix-direnv</link>,
+            a fast, persistent use_nix implementation for direnv'';
+      enableFlakes = mkEnableOption "Flake support in nix-direnv";
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -77,9 +89,11 @@ in {
     };
 
     xdg.configFile."direnv/direnvrc" = let
+      package =
+        pkgs.nix-direnv.override { inherit (cfg.nix-direnv) enableFlakes; };
       text = concatStringsSep "\n" (optional (cfg.stdlib != "") cfg.stdlib
-        ++ optional cfg.enableNixDirenvIntegration
-        "source ${pkgs.nix-direnv}/share/nix-direnv/direnvrc");
+        ++ optional cfg.nix-direnv.enable
+        "source ${package}/share/nix-direnv/direnvrc");
     in mkIf (text != "") { inherit text; };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (

--- a/tests/modules/programs/direnv/nix-direnv.nix
+++ b/tests/modules/programs/direnv/nix-direnv.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     programs.bash.enable = true;
     programs.direnv.enable = true;
-    programs.direnv.enableNixDirenvIntegration = true;
+    programs.direnv.nix-direnv.enable = true;
 
     nmt.script = ''
       assertFileExists home-files/.bashrc

--- a/tests/modules/programs/direnv/stdlib-and-nix-direnv.nix
+++ b/tests/modules/programs/direnv/stdlib-and-nix-direnv.nix
@@ -7,7 +7,7 @@ in {
   config = {
     programs.bash.enable = true;
     programs.direnv.enable = true;
-    programs.direnv.enableNixDirenvIntegration = true;
+    programs.direnv.nix-direnv.enable = true;
     programs.direnv.stdlib = expectedContent;
 
     nmt.script = ''


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

NixOS/nixpkgs@03310df843a344215b45b2e8aef11ae9402a40e2 disabled flake
support by default, so we now need to build a custom package and use it
if the user wants to `use flake` successfully.  This should fix #2087.

I'm not wedded to the backwards-incompatible change to the configuration,
but adding a `programs.direnv.enableNixDirenvFlakeIntegration` option
seemed excessively unwieldy.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
