### PR TITLE
foot: Always create config file

### DIFF
--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -51,7 +51,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."foot/foot.ini" = mkIf (cfg.settings != { }) {
+    xdg.configFile."foot/foot.ini" = {
       source = iniFormat.generate "foot.ini" cfg.settings;
     };
 

--- a/tests/modules/programs/foot/empty-settings.nix
+++ b/tests/modules/programs/foot/empty-settings.nix
@@ -10,7 +10,10 @@ with lib;
       [ (self: super: { foot = pkgs.writeScriptBin "dummy-foot" ""; }) ];
 
     nmt.script = ''
-      assertPathNotExists home-files/.config/foot
+      assertFileExists home-files/.config/foot/foot.ini
+      assertFileContent \
+        home-files/.config/foot/foot.ini \
+        ${builtins.toFile "test" ""}
     '';
   };
 }

--- a/tests/modules/programs/foot/systemd-user-service.nix
+++ b/tests/modules/programs/foot/systemd-user-service.nix
@@ -11,7 +11,10 @@ in {
     };
 
     nmt.script = ''
-      assertPathNotExists home-files/.config/foot/foot.ini
+      assertFileExists home-files/.config/foot/foot.ini
+      assertFileContent \
+        home-files/.config/foot/foot.ini \
+        ${builtins.toFile "test" ""}
 
       assertFileContent \
         home-files/.config/systemd/user/foot.service \


### PR DESCRIPTION
### Description
<!--

Please provide a brief description of your change.
Always write foots config file if foot is enabled.
-->
Fixes #2090 
Creates foots config file at `xdg.configFile."foot/foot.ini"` as long as `programs.foot.enable` is `true`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
