### PR TITLE
bash: do not use writeShellScript for initialisation files

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -168,8 +168,15 @@ in
             HISTIGNORE = concatStringsSep ":" cfg.historyIgnore;
           }
         ));
+
+      writeShellText = name: script:
+        (pkgs.writeText name script).overrideAttrs (_: {
+          checkPhase = ''
+            ${pkgs.bash}/bin/bash -n -O extglob "$out"
+          '';
+        });
     in mkIf cfg.enable {
-      home.file.".bash_profile".source = pkgs.writeShellScript "bash_profile" ''
+      home.file.".bash_profile".source = writeShellText "bash_profile" ''
         # include .profile if it exists
         [[ -f ~/.profile ]] && . ~/.profile
 
@@ -177,7 +184,7 @@ in
         [[ -f ~/.bashrc ]] && . ~/.bashrc
       '';
 
-      home.file.".profile".source = pkgs.writeShellScript "profile" ''
+      home.file.".profile".source = writeShellText "profile" ''
         . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
         ${sessionVarsStr}
@@ -185,7 +192,7 @@ in
         ${cfg.profileExtra}
       '';
 
-      home.file.".bashrc".source = pkgs.writeShellScript "bashrc" ''
+      home.file.".bashrc".source = writeShellText "bashrc" ''
         ${cfg.bashrcExtra}
 
         # Commands that should be applied only for interactive shells.
@@ -201,7 +208,7 @@ in
       '';
 
       home.file.".bash_logout" = mkIf (cfg.logoutExtra != "") {
-        source = pkgs.writeShellScript "bash_logout" cfg.logoutExtra;
+        source = writeShellText "bash_logout" cfg.logoutExtra;
       };
     }
   );

--- a/tests/modules/programs/bash/logout.nix
+++ b/tests/modules/programs/bash/logout.nix
@@ -17,7 +17,7 @@ with lib;
       assertFileContent \
         home-files/.bash_logout \
         ${
-          pkgs.writeShellScript "logout-expected" ''
+          pkgs.writeText "logout-expected" ''
             clear-console
           ''
         }

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -18,7 +18,7 @@ with lib;
       assertFileContent \
         home-files/.profile \
         ${
-          pkgs.writeShellScript "session-variables-expected" ''
+          pkgs.writeText "session-variables-expected" ''
             . "/home/hm-user/.nix-profile/etc/profile.d/hm-session-vars.sh"
 
             export V1="v1"


### PR DESCRIPTION
### Description

This solves the issue described at https://github.com/NixOS/nixpkgs/issues/126344. TL;DR: `writeShellScript` checks syntax using `bash -n`, which rejects scripts that use extglob even if they enable it.

Bash initialisation (and logout) files are not supposed to be executed, but sourced.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
