### PR TITLE
xresources: load .Xresources in xsession.initExtra

### DIFF
--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -23,6 +23,8 @@ let
           toString v;
     in "${n}: ${formatValue v}";
 
+  xrdbMerge = "${pkgs.xorg.xrdb}/bin/xrdb -merge ~/.Xresources";
+
 in {
   meta.maintainers = [ maintainers.rycee ];
 
@@ -45,7 +47,7 @@ in {
         X server resources that should be set.
         Booleans are formatted as "true" or "false" respectively.
         List elements are recursively formatted as a string and joined by commas.
-        All other values are directly formatted using builtins.toString. 
+        All other values are directly formatted using builtins.toString.
         Note, that 2-dimensional lists are not supported and specifying one will throw an exception.
         If this and all other xresources options are
         <code>null</code>, then this feature is disabled and no
@@ -84,9 +86,11 @@ in {
           (mapAttrsToList formatLine cfg.properties)) + "\n";
         onChange = ''
           if [[ -v DISPLAY ]] ; then
-            $DRY_RUN_CMD ${pkgs.xorg.xrdb}/bin/xrdb -merge $HOME/.Xresources
+            $DRY_RUN_CMD ${xrdbMerge}
           fi
         '';
       };
+
+      xsession.initExtra = xrdbMerge;
     };
 }


### PR DESCRIPTION
### Description

Adds an `xrdb` call to `xsession.initExtra`, so that X resources are loaded on startup for people using `startx` (or a display manager that doesn't automatically load `~/.Xresources`).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

