### PR TITLE
mangohud: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,6 +104,9 @@
 
 /modules/programs/matplotlib.nix                      @rprospero
 
+/modules/programs/mangohud.nix                        @ZerataX
+/tests/modules/programs/mangohud                      @ZerataX
+
 /modules/programs/mbsync.nix                          @KarlJoad
 /tests/modules/programs/mbsync                        @KarlJoad
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2077,6 +2077,13 @@ in
           A new module is available: 'services.pantalaimon'.
         '';
       }
+
+      {
+        time = "2021-06-12T05:00:22+00:00";
+        message = ''
+          A new module is available: 'programs.mangohud'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -93,6 +93,7 @@ let
     (loadModule ./programs/lf.nix { })
     (loadModule ./programs/lsd.nix { })
     (loadModule ./programs/man.nix { })
+    (loadModule ./programs/mangohud.nix { condition = hostPlatform.isLinux; })
     (loadModule ./programs/matplotlib.nix { })
     (loadModule ./programs/mbsync.nix { })
     (loadModule ./programs/mcfly.nix { })

--- a/modules/programs/mangohud.nix
+++ b/modules/programs/mangohud.nix
@@ -1,0 +1,105 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.mangohud;
+
+  settingsType = with types;
+    (oneOf [ bool int float str path (listOf (oneOf [ int str ])) ]);
+
+  renderOption = option:
+    rec {
+      int = toString option;
+      float = int;
+      path = int;
+      bool = "false";
+      string = option;
+      list = concatStringsSep "," (lists.forEach option (x: toString x));
+    }.${builtins.typeOf option};
+
+  renderLine = k: v: (if isBool v && v then k else "${k}=${renderOption v}");
+  renderSettings = attrs:
+    strings.concatStringsSep "\n" (attrsets.mapAttrsToList renderLine attrs)
+    + "\n";
+
+in {
+  options = {
+    programs.mangohud = {
+      enable = mkEnableOption "Mangohud";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.mangohud;
+        defaultText = literalExample "pkgs.mangohud";
+        description = "The Mangohud package to install.";
+      };
+
+      enableSessionWide = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Sets environment variables so that 
+          MangoHud is started on any application that supports it.
+        '';
+      };
+
+      settings = mkOption {
+        type = with types; attrsOf settingsType;
+        default = { };
+        example = literalExample ''
+          {
+            output_folder = ~/Documents/mangohud/;
+            full = true;
+          }
+        '';
+        description = ''
+          Configuration written to
+          <filename>~/.config/MangoHud/MangoHud.conf</filename>. See
+          <link xlink:href="https://github.com/flightlessmango/MangoHud/blob/master/bin/MangoHud.conf"/>
+          for the default configuration.
+        '';
+      };
+
+      settingsPerApplication = mkOption {
+        type = with types; attrsOf (attrsOf settingsType);
+        default = { };
+        example = literalExample ''
+          {
+            mpv = {
+              no_display = true;
+            }
+          }
+        '';
+        description = ''
+          Sets MangoHud settings per application.
+          Configuration written to
+          <filename>~/.config/MangoHud/{application_name}.conf</filename>. See
+          <link xlink:href="https://github.com/flightlessmango/MangoHud/blob/master/bin/MangoHud.conf"/>
+          for the default configuration.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      home.packages = [ cfg.package ];
+
+      home.sessionVariables = mkIf cfg.enableSessionWide {
+        MANGOHUD = 1;
+        MANGOHUD_DLSYM = 1;
+      };
+
+      xdg.configFile."MangoHud/MangoHud.conf" =
+        mkIf (cfg.settings != { }) { text = renderSettings cfg.settings; };
+    }
+    {
+      xdg.configFile = mapAttrs'
+        (n: v: nameValuePair "MangoHud/${n}.conf" { text = renderSettings v; })
+        cfg.settingsPerApplication;
+    }
+  ]);
+
+  meta.maintainers = with maintainers; [ zeratax ];
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -101,6 +101,7 @@ import nmt {
     ./modules/programs/foot
     ./modules/programs/getmail
     ./modules/programs/i3status-rust
+    ./modules/programs/mangohud
     ./modules/programs/ncmpcpp-linux
     ./modules/programs/neovim   # Broken package dependency on Darwin.
     ./modules/programs/rbw

--- a/tests/modules/programs/mangohud/basic-configuration-mpv.conf
+++ b/tests/modules/programs/mangohud/basic-configuration-mpv.conf
@@ -1,0 +1,2 @@
+no_display
+output_folder=/home/user/Documents/mpv-mangohud

--- a/tests/modules/programs/mangohud/basic-configuration.conf
+++ b/tests/modules/programs/mangohud/basic-configuration.conf
@@ -1,0 +1,13 @@
+cpu_load_change
+cpu_load_value
+cpu_mhz
+cpu_power
+cpu_stats
+cpu_temp
+cpu_text=CPU
+fps_limit=30,60
+legacy_layout=false
+media_player_name=spotify
+media_player_order=title,artist,album
+output_folder=/home/user/Documents/mangohud
+vsync=0

--- a/tests/modules/programs/mangohud/basic-configuration.nix
+++ b/tests/modules/programs/mangohud/basic-configuration.nix
@@ -1,0 +1,40 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    programs.mangohud = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-mangohud" "";
+      settings = {
+        output_folder = /home/user/Documents/mangohud;
+        fps_limit = [ 30 60 ];
+        vsync = 0;
+        legacy_layout = false;
+        cpu_stats = true;
+        cpu_temp = true;
+        cpu_power = true;
+        cpu_text = "CPU";
+        cpu_mhz = true;
+        cpu_load_change = true;
+        cpu_load_value = true;
+        media_player_name = "spotify";
+        media_player_order = [ "title" "artist" "album" ];
+      };
+      settingsPerApplication = {
+        mpv = {
+          output_folder = /home/user/Documents/mpv-mangohud;
+          no_display = true;
+        };
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/MangoHud/MangoHud.conf
+      assertFileContent home-files/.config/MangoHud/MangoHud.conf \
+          ${./basic-configuration.conf}
+      assertFileExists home-files/.config/MangoHud/mpv.conf
+      assertFileContent home-files/.config/MangoHud/mpv.conf \
+          ${./basic-configuration-mpv.conf}
+    '';
+  };
+}

--- a/tests/modules/programs/mangohud/default.nix
+++ b/tests/modules/programs/mangohud/default.nix
@@ -1,0 +1,1 @@
+{ mangohud-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

since i recently packaged mangohud for nixpkgs seems like a good time to also add a home-manager module
https://github.com/flightlessmango/MangoHud

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

<details>
 <summary>neovim failed, but i have hard time believing that's my fault</summary>

```
--- actual
+++ expected
@@ -1,2 +1,10 @@
 set packpath^=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-vim-pack-dir
 set runtimepath^=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-vim-pack-dir
+
+" vim-commentary {{{
+" This should be present too
+autocmd FileType c setlocal commentstring=//\ %s
+autocmd FileType c setlocal comments=://
+
+" }}}
+" This should be present in vimrc
For further reference please introspect /nix/store/7mmydymjnqv70ifr2rvz6syigxals67g-nmt-report-neovim-plugin-co
```
</details>
 Edit: ah yes it's #2100

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
