### PR TITLE
i3status: add `package` option

### DIFF
--- a/modules/programs/i3status.nix
+++ b/modules/programs/i3status.nix
@@ -138,6 +138,13 @@ in {
         }
       '';
     };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.i3status;
+      defaultText = literalExample "pkgs.i3status";
+      description = "The i3status package to use.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -197,7 +204,7 @@ in {
       };
     };
 
-    home.packages = [ pkgs.i3status ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."i3status/config".text = concatStringsSep "\n" ([ ]
       ++ optional (cfg.general != { }) (formatModule "general" cfg.general)

--- a/modules/programs/jq.nix
+++ b/modules/programs/jq.nix
@@ -34,7 +34,7 @@ in {
         type = types.package;
         default = pkgs.jq;
         defaultText = literalExpression "pkgs.jq";
-        description = "jq package to use.";
+        description = "The jq package to use.";
       };
 
       colors = mkOption {

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -165,7 +165,9 @@ let
 
       statusCommand = mkNullableOption {
         type = types.str;
-        default = "${pkgs.i3status}/bin/i3status";
+        default = "${config.programs.i3status.package}/bin/i3status";
+        defaultText = literalExample
+          ''"''${config.programs.i3status.package}/bin/i3status"'';
         description = "Command that will be used to get status lines.";
       };
 
@@ -676,7 +678,7 @@ in {
       position = "bottom";
       workspaceButtons = true;
       workspaceNumbers = true;
-      statusCommand = "${pkgs.i3status}/bin/i3status";
+      statusCommand = "${config.programs.i3status.package}/bin/i3status";
       fonts = {
         names = [ "monospace" ];
         size = 8.0;


### PR DESCRIPTION
### Description

Declare package option `option.programs.i3status.package`. This is mostly so I can reference `config.programs.i3status.package` anywhere for the same `i3status`, e.g. from `xsession.windowManager.i3.config.bars.*.statusCommand`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.