### PR TITLE
nixos: set stopIfChanged to false

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -130,6 +130,8 @@ in {
 
         unitConfig = { RequiresMountsFor = usercfg.home.homeDirectory; };
 
+        stopIfChanged = false;
+
         serviceConfig = {
           User = usercfg.home.username;
           Type = "oneshot";


### PR DESCRIPTION
### Description

Sets `systemd.services.home-manager-${user}.stopIfChanged` to false in the NixOS module. The service has no `ExecStop`, so I don't think there's a point in stopping it in the old configuration and starting it in the new, we can just restart it.

One more line of code for one less line of logs seems like a good deal to me.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

