### PR TITLE
direnv: add enableFlakes option for enableNixDirenvIntegration (#2089) (backport to release-21.05)

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -9,6 +9,14 @@ let
   tomlFormat = pkgs.formats.toml { };
 
 in {
+  imports = [
+    (mkRenamedOptionModule [
+      "programs"
+      "direnv"
+      "enableNixDirenvIntegration"
+    ] [ "programs" "direnv" "nix-direnv" "enable" ])
+  ];
+
   meta.maintainers = [ maintainers.rycee ];
 
   options.programs.direnv = {
@@ -63,10 +71,14 @@ in {
       '';
     };
 
-    enableNixDirenvIntegration = mkEnableOption ''
-      <link
-          xlink:href="https://github.com/nix-community/nix-direnv">nix-direnv</link>,
-          a fast, persistent use_nix implementation for direnv'';
+    nix-direnv = {
+      enable = mkEnableOption ''
+        <link
+            xlink:href="https://github.com/nix-community/nix-direnv">nix-direnv</link>,
+            a fast, persistent use_nix implementation for direnv'';
+      enableFlakes = mkEnableOption "Flake support in nix-direnv";
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -77,9 +89,11 @@ in {
     };
 
     xdg.configFile."direnv/direnvrc" = let
+      package =
+        pkgs.nix-direnv.override { inherit (cfg.nix-direnv) enableFlakes; };
       text = concatStringsSep "\n" (optional (cfg.stdlib != "") cfg.stdlib
-        ++ optional cfg.enableNixDirenvIntegration
-        "source ${pkgs.nix-direnv}/share/nix-direnv/direnvrc");
+        ++ optional cfg.nix-direnv.enable
+        "source ${package}/share/nix-direnv/direnvrc");
     in mkIf (text != "") { inherit text; };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (

--- a/tests/modules/programs/direnv/nix-direnv.nix
+++ b/tests/modules/programs/direnv/nix-direnv.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     programs.bash.enable = true;
     programs.direnv.enable = true;
-    programs.direnv.enableNixDirenvIntegration = true;
+    programs.direnv.nix-direnv.enable = true;
 
     nmt.script = ''
       assertFileExists home-files/.bashrc

--- a/tests/modules/programs/direnv/stdlib-and-nix-direnv.nix
+++ b/tests/modules/programs/direnv/stdlib-and-nix-direnv.nix
@@ -7,7 +7,7 @@ in {
   config = {
     programs.bash.enable = true;
     programs.direnv.enable = true;
-    programs.direnv.enableNixDirenvIntegration = true;
+    programs.direnv.nix-direnv.enable = true;
     programs.direnv.stdlib = expectedContent;
 
     nmt.script = ''


### PR DESCRIPTION
### Description
Backport #2089 to ``release-21.05`` branch

### Checklist
- [ ] Change is backwards compatible.
- [X] Code formatted with ``./format``.
- [X] Code tested through ``nix-shell --pure tests -A run.all``.
- [ ] Test cases updated/added.
- [X] Commit messages are formatted like
```
{component}: {description}
{long description}
```
