### PR TITLE
Add option "plugins" to Rofi module

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -207,6 +207,17 @@ in {
       '';
     };
 
+    plugins = mkOption {
+      default = [ ];
+      type = types.listOf types.package;
+      description = ''
+        List of rofi plugins to be installed.
+      '';
+      example = literalExample ''
+        [ pkgs.rofi-calc ];
+      '';
+    };
+
     width = mkOption {
       default = null;
       type = types.nullOr types.int;
@@ -405,7 +416,10 @@ in {
       inherit value;
     };
 
-    home.packages = [ cfg.package ];
+    home.packages = let
+      rofiWithPlugins = cfg.package.override
+        (old: rec { plugins = (old.plugins or [ ]) ++ cfg.plugins; });
+    in [ rofiWithPlugins ];
 
     home.file."${cfg.configPath}".text = toRasi {
       configuration = ({

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -417,7 +417,10 @@ in {
     home.packages = let
       rofiWithPlugins = cfg.package.override
         (old: rec { plugins = (old.plugins or [ ]) ++ cfg.plugins; });
-    in [ rofiWithPlugins ];
+    in if builtins.hasAttr "override" cfg.package then
+      [ rofiWithPlugins ]
+    else
+      [ cfg.package ];
 
     home.file."${cfg.configPath}".text = toRasi {
       configuration = ({

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -417,10 +417,11 @@ in {
     home.packages = let
       rofiWithPlugins = cfg.package.override
         (old: rec { plugins = (old.plugins or [ ]) ++ cfg.plugins; });
-    in if builtins.hasAttr "override" cfg.package then
-      [ rofiWithPlugins ]
-    else
-      [ cfg.package ];
+      rofiPackage = if builtins.hasAttr "override" cfg.package then
+        rofiWithPlugins
+      else
+        cfg.package;
+    in [ rofiPackage ];
 
     home.file."${cfg.configPath}".text = toRasi {
       configuration = ({

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -213,7 +213,7 @@ in {
       description = ''
         List of rofi plugins to be installed.
       '';
-      example = literalExample ''[ pkgs.rofi-calc ]'';
+      example = literalExample "[ pkgs.rofi-calc ]";
     };
 
     width = mkOption {

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -213,9 +213,7 @@ in {
       description = ''
         List of rofi plugins to be installed.
       '';
-      example = literalExample ''
-        [ pkgs.rofi-calc ];
-      '';
+      example = literalExample ''[ pkgs.rofi-calc ]'';
     };
 
     width = mkOption {


### PR DESCRIPTION
### Description

It was possible to add plugins to `rofi` only via overriding package in `package` option. Adds option to list plugins in separate `plugins` option.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
