### PR TITLE
fzf: also use custom package for shell integrations

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -148,20 +148,20 @@ in {
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
-        . ${pkgs.fzf}/share/fzf/completion.bash
-        . ${pkgs.fzf}/share/fzf/key-bindings.bash
+        . ${cfg.package}/share/fzf/completion.bash
+        . ${cfg.package}/share/fzf/key-bindings.bash
       fi
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
       if [[ $options[zle] = on ]]; then
-        . ${pkgs.fzf}/share/fzf/completion.zsh
-        . ${pkgs.fzf}/share/fzf/key-bindings.zsh
+        . ${cfg.package}/share/fzf/completion.zsh
+        . ${cfg.package}/share/fzf/key-bindings.zsh
       fi
     '';
 
     programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
-      source ${pkgs.fzf}/share/fzf/key-bindings.fish && fzf_key_bindings
+      source ${cfg.package}/share/fzf/key-bindings.fish && fzf_key_bindings
     '';
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Previously, if the user customised `programs.fzf.package`, that package
is only put into `home.packages`, and the shell integration hooks use
the files from `pkgs.fzf`.  If a different package is needed for the
shell integration, the user would need to manually source it into their
shell configuration.  With this PR, `cfg.package` is used throughout.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
