### PR TITLE
xsession: handle parameter passed from display-manager

### DIFF
--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -33,8 +33,13 @@ in {
           in
             "''${xmonad}/bin/xmonad";
         '';
+        default = ''test -n "$1" && eval "$@"'';
         description = ''
-          Window manager start command.
+          Command to use to start the window manager.
+          </para><para>
+          The default value allows integration with NixOS' generated xserver configuration.
+          </para><para>
+          Extra actions and commands can be specified in <option>xsession.initExtra</option>.
         '';
       };
 


### PR DESCRIPTION

### Description
fix: #2122 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
