### PR TITLE
bspwm: re-add support for lists as config option values

### DIFF
--- a/modules/services/window-managers/bspwm/options.nix
+++ b/modules/services/window-managers/bspwm/options.nix
@@ -157,7 +157,7 @@ in {
     settings = mkOption {
       type = with types;
         let primitive = either bool (either int (either float str));
-        in attrsOf primitive;
+        in attrsOf (either primitive (listOf primitive));
       default = { };
       description = "General settings given to <literal>bspc config</literal>.";
       example = {

--- a/tests/modules/services/window-managers/bspwm/bspwmrc
+++ b/tests/modules/services/window-managers/bspwm/bspwmrc
@@ -1,9 +1,10 @@
 bspc monitor 'focused' -d 'desktop 1' 'd'\''esk top'
 
-bspc config 'border_width' 2
+bspc config 'border_width' '2'
 bspc config 'external_rules_command' '/path/to/external rules command'
-bspc config 'gapless_monocle' true
-bspc config 'split_ratio' 0.520000
+bspc config 'gapless_monocle' 'on'
+bspc config 'ignore_ewmh_fullscreen' 'enter,exit'
+bspc config 'split_ratio' '0.520000'
 
 bspc rule -r '*'
 bspc rule -a '*' 'center=off' 'desktop=d'\''esk top#next' 'split_dir=north' 'sticky=on'

--- a/tests/modules/services/window-managers/bspwm/configuration.nix
+++ b/tests/modules/services/window-managers/bspwm/configuration.nix
@@ -13,6 +13,7 @@ with lib;
         split_ratio = 0.52;
         gapless_monocle = true;
         external_rules_command = "/path/to/external rules command";
+        ignore_ewmh_fullscreen = [ "enter" "exit" ];
       };
       rules."*" = {
         sticky = true;


### PR DESCRIPTION
Removed by mistake in e70524c, but `ignore_ewmh_fullscreen` still needs it.

cc @berbiche 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

