### PR TITLE
home-manager: add command line argument: --impure

### DIFF
--- a/docs/man-home-manager.xml
+++ b/docs/man-home-manager.xml
@@ -140,6 +140,10 @@
    </arg>
 
    <arg>
+    --impure
+   </arg>
+
+   <arg>
     --keep-failed
    </arg>
 
@@ -483,6 +487,18 @@
    <varlistentry>
     <term>
      <option>--debug</option>
+    </term>
+    <listitem>
+     <para>
+      Passed on to <citerefentry>
+      <refentrytitle>nix-build</refentrytitle>
+      <manvolnum>1</manvolnum> </citerefentry>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--impure</option>
     </term>
     <listitem>
      <para>

--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -290,10 +290,10 @@ _home-manager_completions ()
     #--------------------------#
 
     local Options
-    Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" "--verbose" \
-              "--cores" "--debug" "--keep-failed" "--keep-going" "-j" "--max-jobs" \
-              "--no-substitute" "--no-out-link" "--show-trace" "--substitute" \
-              "--builders")
+    Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" \
+              "--verbose" "--cores" "--debug" "--impure" "--keep-failed" \
+              "--keep-going" "-j" "--max-jobs" "--no-substitute" "--no-out-link" \
+              "--show-trace" "--substitute" "--builders")
 
     # ^ « home-manager »'s options.
 

--- a/home-manager/completion.fish
+++ b/home-manager/completion.fish
@@ -53,6 +53,7 @@ complete -c home-manager -x -l "arg" -d "Override inputs passed to home-manager.
 complete -c home-manager -x -l "argstr" -d "Like --arg but the value is a string"
 complete -c home-manager -x -l "cores" -d "Threads per job (e.g. -j argument to make)"
 complete -c home-manager -x -l "debug"
+complete -c home-manager -x -l "impure"
 complete -c home-manager -f -l "keep-failed" -d "Keep temporary directory used by failed builds"
 complete -c home-manager -f -l "keep-going" -d "Keep going in case of failed builds"
 complete -c home-manager -x -s j -l "max-jobs" -d "Max number of build jobs in parallel"

--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -8,6 +8,7 @@ _arguments \
   '-b[backup files]:EXT:()' \
   '--cores[cores]:NUM:()' \
   '--debug[debug]' \
+  '--impure[impure]' \
   '--keep-failed[keep failed]' \
   '--keep-going[keep going]' \
   '(-h --help)'{--help,-h}'[help]' \
@@ -46,6 +47,7 @@ case "$state" in
         _arguments \
           '--cores[cores]:NUM:()' \
           '--debug[debug]' \
+          '--impure[impure]' \
           '--keep-failed[keep failed]' \
           '--keep-going[keep going]' \
           '--max-jobs[max jobs]:NUM:()' \

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -516,6 +516,7 @@ function doHelp() {
     echo "  --arg(str) NAME VALUE    Override inputs passed to home-manager.nix"
     echo "  --cores NUM"
     echo "  --debug"
+    echo "  --impure"
     echo "  --keep-failed"
     echo "  --keep-going"
     echo "  -j, --max-jobs NUM"
@@ -624,7 +625,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --debug|--keep-failed|--keep-going|--show-trace\
-            |--substitute|--no-substitute)
+            |--substitute|--no-substitute|--impure)
             PASSTHROUGH_OPTS+=("$opt")
             ;;
         -v|--verbose)


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

In macOS, I'm trying use flake with home-manager, then I encountered error: 

```
error: access to path '/System/Volumes/Data/nix/store/2kn3jicr9rab7j4d0mgajz6fcnydcmlh-source/nix/flake.nix' is forbidden in restricted mode
```

I investigated the error, it seems like a bug of flake., it can not use the directory other than `/nix/store`, in order to avoid this problem, I need to use `nix build --impure`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
