### PR TITLE
i3,sway: add bar color options for the focused output

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -103,6 +103,18 @@ rec {
             "separator ${colors.separator}"
           }
           ${
+            optionalString (colors.focusedBackground != null)
+            "focused_background ${colors.focusedBackground}"
+          }
+          ${
+            optionalString (colors.focusedStatusline != null)
+            "focused_statusline ${colors.focusedStatusline}"
+          }
+          ${
+            optionalString (colors.focusedSeparator != null)
+            "focused_separator ${colors.focusedSeparator}"
+          }
+          ${
             optionalString (colors.focusedWorkspace != null)
             "focused_workspace ${barColorSetStr colors.focusedWorkspace}"
           }

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -190,6 +190,30 @@ let
               description = "Text color to be used for the separator.";
             };
 
+            focusedBackground = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description =
+                "Background color of the bar on the currently focused monitor output.";
+              example = "#000000";
+            };
+
+            focusedStatusline = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description =
+                "Text color to be used for the statusline on the currently focused monitor output.";
+              example = "#ffffff";
+            };
+
+            focusedSeparator = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description =
+                "Text color to be used for the separator on the currently focused monitor output.";
+              example = "#666666";
+            };
+
             focusedWorkspace = mkNullableOption {
               type = barColorSetModule;
               default = {

--- a/tests/modules/services/window-managers/i3/default.nix
+++ b/tests/modules/services/window-managers/i3/default.nix
@@ -1,4 +1,5 @@
 {
+  i3-bar-focused-colors = ./i3-bar-focused-colors.nix;
   i3-followmouse = ./i3-followmouse.nix;
   i3-fonts = ./i3-fonts.nix;
   i3-fonts-deprecated = ./i3-fonts-deprecated.nix;

--- a/tests/modules/services/window-managers/i3/i3-bar-focused-colors-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-bar-focused-colors-expected.conf
@@ -1,9 +1,9 @@
 font pango:monospace 8.000000
 floating_modifier Mod1
-default_border pixel 2
-default_floating_border pixel 2
+default_border normal 2
+default_floating_border normal 2
 hide_edge_borders none
-focus_wrapping no
+force_focus_wrapping no
 focus_follows_mouse yes
 focus_on_window_activation smart
 mouse_warping output
@@ -18,6 +18,7 @@ client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
 
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -29,8 +30,9 @@ bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
 bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
-bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym Mod1+Return exec i3-sensible-terminal
 bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3
@@ -45,43 +47,33 @@ bindsym Mod1+Shift+Left move left
 bindsym Mod1+Shift+Right move right
 bindsym Mod1+Shift+Up move up
 bindsym Mod1+Shift+c reload
-bindsym Mod1+Shift+e exec swaynag -t warning -m 'You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.' -b 'Yes, exit sway' 'swaymsg exit'
-bindsym Mod1+Shift+h move left
-bindsym Mod1+Shift+j move down
-bindsym Mod1+Shift+k move up
-bindsym Mod1+Shift+l move right
+bindsym Mod1+Shift+e exec i3-nagbar -t warning -m 'Do you want to exit i3?' -b 'Yes' 'i3-msg exit'
 bindsym Mod1+Shift+minus move scratchpad
 bindsym Mod1+Shift+q kill
+bindsym Mod1+Shift+r restart
 bindsym Mod1+Shift+space floating toggle
 bindsym Mod1+Up focus up
 bindsym Mod1+a focus parent
-bindsym Mod1+b splith
 bindsym Mod1+d exec @dmenu@/bin/dmenu_run
 bindsym Mod1+e layout toggle split
 bindsym Mod1+f fullscreen toggle
-bindsym Mod1+h focus left
-bindsym Mod1+j focus down
-bindsym Mod1+k focus up
-bindsym Mod1+l focus right
+bindsym Mod1+h split h
 bindsym Mod1+minus scratchpad show
 bindsym Mod1+r mode resize
 bindsym Mod1+s layout stacking
 bindsym Mod1+space focus mode_toggle
-bindsym Mod1+v splitv
+bindsym Mod1+v split v
 bindsym Mod1+w layout tabbed
 
 mode "resize" {
-bindsym Down resize grow height 10 px
+bindsym Down resize grow height 10 px or 10 ppt
 bindsym Escape mode default
-bindsym Left resize shrink width 10 px
+bindsym Left resize shrink width 10 px or 10 ppt
 bindsym Return mode default
-bindsym Right resize grow width 10 px
-bindsym Up resize shrink height 10 px
-bindsym h resize shrink width 10 px
-bindsym j resize grow height 10 px
-bindsym k resize shrink height 10 px
-bindsym l resize grow width 10 px
+bindsym Right resize grow width 10 px or 10 ppt
+bindsym Up resize shrink height 10 px or 10 ppt
 }
+
 
 bar {
   
@@ -90,7 +82,7 @@ bar {
   hidden_state hide
   position bottom
   status_command @i3status@/bin/i3status
-  swaybar_command @sway@/bin/swaybar
+  i3bar_command @i3@/bin/i3bar
   workspace_buttons yes
   strip_workspace_numbers no
   tray_output primary
@@ -98,9 +90,9 @@ bar {
     background #000000
     statusline #ffffff
     separator #666666
-    
-    
-    
+    focused_background #ffffff
+    focused_statusline #000000
+    focused_separator #999999
     focused_workspace #4c7899 #285577 #ffffff
     active_workspace #333333 #5f676a #ffffff
     inactive_workspace #333333 #222222 #888888
@@ -111,4 +103,8 @@ bar {
 }
 
 
-exec "systemctl --user import-environment; systemctl --user start sway-session.target"
+
+
+
+
+

--- a/tests/modules/services/window-managers/i3/i3-bar-focused-colors.nix
+++ b/tests/modules/services/window-managers/i3/i3-bar-focused-colors.nix
@@ -1,0 +1,25 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  config = {
+    xsession.windowManager.i3 = {
+      enable = true;
+
+      config.bars = [{
+        colors.focusedBackground = "#ffffff";
+        colors.focusedStatusline = "#000000";
+        colors.focusedSeparator = "#999999";
+      }];
+    };
+
+    nixpkgs.overlays = [ (import ./i3-overlay.nix) ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/i3/config
+      assertFileContent home-files/.config/i3/config \
+        ${./i3-bar-focused-colors-expected.conf}
+    '';
+  };
+}

--- a/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
@@ -90,6 +90,9 @@ bar {
     background #000000
     statusline #ffffff
     separator #666666
+    
+    
+    
     focused_workspace #4c7899 #285577 #ffffff
     active_workspace #333333 #5f676a #ffffff
     inactive_workspace #333333 #222222 #888888

--- a/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
@@ -90,6 +90,9 @@ bar {
     background #000000
     statusline #ffffff
     separator #666666
+    
+    
+    
     focused_workspace #4c7899 #285577 #ffffff
     active_workspace #333333 #5f676a #ffffff
     inactive_workspace #333333 #222222 #888888

--- a/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
@@ -91,6 +91,9 @@ bar {
     background #000000
     statusline #ffffff
     separator #666666
+    
+    
+    
     focused_workspace #4c7899 #285577 #ffffff
     active_workspace #333333 #5f676a #ffffff
     inactive_workspace #333333 #222222 #888888

--- a/tests/modules/services/window-managers/i3/i3-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-workspace-default-expected.conf
@@ -89,6 +89,9 @@ bar {
     background #000000
     statusline #ffffff
     separator #666666
+    
+    
+    
     focused_workspace #4c7899 #285577 #ffffff
     active_workspace #333333 #5f676a #ffffff
     inactive_workspace #333333 #222222 #888888

--- a/tests/modules/services/window-managers/i3/i3-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-workspace-output-expected.conf
@@ -90,6 +90,9 @@ bar {
     background #000000
     statusline #ffffff
     separator #666666
+    
+    
+    
     focused_workspace #4c7899 #285577 #ffffff
     active_workspace #333333 #5f676a #ffffff
     inactive_workspace #333333 #222222 #888888

--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -1,4 +1,5 @@
 {
+  sway-bar-focused-colors = ./sway-bar-focused-colors.nix;
   sway-default = ./sway-default.nix;
   sway-post-2003 = ./sway-post-2003.nix;
   sway-followmouse = ./sway-followmouse.nix;

--- a/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
+++ b/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
@@ -90,7 +90,7 @@ bar {
   hidden_state hide
   position bottom
   status_command @i3status@/bin/i3status
-  swaybar_command @sway@/bin/swaybar
+  swaybar_command @sway/bin/swaybar
   workspace_buttons yes
   strip_workspace_numbers no
   tray_output primary
@@ -98,9 +98,9 @@ bar {
     background #000000
     statusline #ffffff
     separator #666666
-    
-    
-    
+    focused_background #ffffff
+    focused_statusline #000000
+    focused_separator #999999
     focused_workspace #4c7899 #285577 #ffffff
     active_workspace #333333 #5f676a #ffffff
     inactive_workspace #333333 #222222 #888888

--- a/tests/modules/services/window-managers/sway/sway-bar-focused-colors.nix
+++ b/tests/modules/services/window-managers/sway/sway-bar-focused-colors.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  dummy-package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out";
+
+in {
+  config = {
+    wayland.windowManager.sway = {
+      enable = true;
+      package = dummy-package // { outPath = "@sway"; };
+      # overriding findutils causes issues
+      config.menu = "${pkgs.dmenu}/bin/dmenu_run";
+
+      config.bars = [{
+        colors.focusedBackground = "#ffffff";
+        colors.focusedStatusline = "#000000";
+        colors.focusedSeparator = "#999999";
+      }];
+    };
+
+    nixpkgs.overlays = [ (import ./sway-overlay.nix) ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/sway/config
+      assertFileContent home-files/.config/sway/config \
+        ${./sway-bar-focused-colors.conf}
+    '';
+  };
+}

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -98,6 +98,9 @@ bar {
     background #000000
     statusline #ffffff
     separator #666666
+    
+    
+    
     focused_workspace #4c7899 #285577 #ffffff
     active_workspace #333333 #5f676a #ffffff
     inactive_workspace #333333 #222222 #888888

--- a/tests/modules/services/window-managers/sway/sway-modules.conf
+++ b/tests/modules/services/window-managers/sway/sway-modules.conf
@@ -110,6 +110,9 @@ bar {
     background #000000
     statusline #ffffff
     separator #666666
+    
+    
+    
     focused_workspace #4c7899 #285577 #ffffff
     active_workspace #333333 #5f676a #ffffff
     inactive_workspace #333333 #222222 #888888

--- a/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
@@ -97,6 +97,9 @@ bar {
     background #000000
     statusline #ffffff
     separator #666666
+    
+    
+    
     focused_workspace #4c7899 #285577 #ffffff
     active_workspace #333333 #5f676a #ffffff
     inactive_workspace #333333 #222222 #888888

--- a/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
@@ -98,6 +98,9 @@ bar {
     background #000000
     statusline #ffffff
     separator #666666
+    
+    
+    
     focused_workspace #4c7899 #285577 #ffffff
     active_workspace #333333 #5f676a #ffffff
     inactive_workspace #333333 #222222 #888888


### PR DESCRIPTION
### Description

Both i3bar and swaybar can use different colors for the bar on the currently focused monitor output; add color options for this feature.

It is not possible to add these options using `xsession.windowManager.i3.config.bars.*.extraConfig` while using other bar color options at the same time, because all color options must be inside the `colors { ... }` block, so the only way to use `extraConfig` is to move the whole bar color configuration there, losing the convenience of existing options.

New tests added for both i3 and sway, and the expected output for existing tests is adjusted (changes are limited to extra blank lines; avoiding the changes completely would result in much less readable code in `modules/services/window-managers/i3-sway/lib/functions.nix`, which would also be significantly different from the code for existing options).

New options are not defined using `mkNullableOption`, like the existing options are, because `mkNullableOption` sets the default value to non-`null` for state versions < 20.09, and this would break old configs, because these default values would override normal colors that might be configured, so the `null` default is really required.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.