### PR TITLE
xsession: Add profilePath configuration option

### DIFF
--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -18,8 +18,18 @@ in {
         default = ".xsession";
         example = ".xsession-hm";
         description = ''
-          Path, relative <envar>HOME</envar>, where Home Manager
+          Path, relative to <envar>HOME</envar>, where Home Manager
           should write the X session script.
+        '';
+      };
+
+      profilePath = mkOption {
+        type = types.str;
+        default = ".xprofile";
+        example = ".xprofile-hm";
+        description = ''
+          Path, relative to <envar>HOME</envar>, where Home Manager
+          should write the X profile script.
         '';
       };
 
@@ -129,7 +139,7 @@ in {
       };
     };
 
-    home.file.".xprofile".text = ''
+    home.file.${cfg.profilePath}.text = ''
       . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
       if [ -e "$HOME/.profile" ]; then
@@ -154,7 +164,7 @@ in {
       executable = true;
       text = ''
         if [ -z "$HM_XPROFILE_SOURCED" ]; then
-          . ~/.xprofile
+          . "${config.home.homeDirectory}/${cfg.profilePath}"
         fi
         unset HM_XPROFILE_SOURCED
 

--- a/tests/modules/misc/xsession/basic-xsession-expected.txt
+++ b/tests/modules/misc/xsession/basic-xsession-expected.txt
@@ -1,5 +1,5 @@
 if [ -z "$HM_XPROFILE_SOURCED" ]; then
-  . ~/.xprofile
+  . "/home/hm-user/.xprofile"
 fi
 unset HM_XPROFILE_SOURCED
 


### PR DESCRIPTION
### Description

This allows the user to move .xprofile somewhere else, which can help with decluttering their home directory.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
