### PR TITLE
xresources: Add path configuration option

### DIFF
--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -23,7 +23,7 @@ let
           toString v;
     in "${n}: ${formatValue v}";
 
-  xrdbMerge = "${pkgs.xorg.xrdb}/bin/xrdb -merge ~/.Xresources";
+  xrdbMerge = "${pkgs.xorg.xrdb}/bin/xrdb -merge ${cfg.path}";
 
 in {
   meta.maintainers = [ maintainers.rycee ];
@@ -75,11 +75,18 @@ in {
         <filename>~/.Xresources</filename> link is produced.
       '';
     };
+
+    xresources.path = mkOption {
+      type = types.str;
+      default = "${config.home.homeDirectory}/.Xresources";
+      defaultText = "$HOME/.Xresources";
+      description = "Path to generate the .Xresources file to.";
+    };
   };
 
   config = mkIf ((cfg.properties != null && cfg.properties != { })
     || cfg.extraConfig != "") {
-      home.file.".Xresources" = {
+      home.file.${cfg.path} = {
         text = concatStringsSep "\n" ([ ]
           ++ optional (cfg.extraConfig != "") cfg.extraConfig
           ++ optionals (cfg.properties != null)

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -80,7 +80,7 @@ in {
       type = types.str;
       default = "${config.home.homeDirectory}/.Xresources";
       defaultText = "$HOME/.Xresources";
-      description = "Path to generate the .Xresources file to.";
+      description = "Path where Home Manager should link the <filename>.Xresources</filename> file.";
     };
   };
 

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -80,7 +80,8 @@ in {
       type = types.str;
       default = "${config.home.homeDirectory}/.Xresources";
       defaultText = "$HOME/.Xresources";
-      description = "Path where Home Manager should link the <filename>.Xresources</filename> file.";
+      description =
+        "Path where Home Manager should link the <filename>.Xresources</filename> file.";
     };
   };
 


### PR DESCRIPTION
### Description

This allows the user to move .Xresources somewhere else, which can help with decluttering their home directory.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
