### PR TITLE
files: assert that target files are unique

### DIFF
--- a/tests/modules/files/default.nix
+++ b/tests/modules/files/default.nix
@@ -3,6 +3,7 @@
   files-hidden-source = ./hidden-source.nix;
   files-out-of-store-symlink = ./out-of-store-symlink.nix;
   files-source-with-spaces = ./source-with-spaces.nix;
+  files-target-conflict = ./target-conflict.nix;
   files-target-with-shellvar = ./target-with-shellvar.nix;
   files-text = ./text.nix;
 }

--- a/tests/modules/files/target-conflict.nix
+++ b/tests/modules/files/target-conflict.nix
@@ -1,0 +1,26 @@
+{ ... }:
+
+{
+  config = {
+    home.file = {
+      conflict1 = {
+        text = "";
+        target = "baz";
+      };
+      conflict2 = {
+        source = ./target-conflict.nix;
+        target = "baz";
+      };
+    };
+
+    test.asserts.assertions.expected = [''
+      Conflicting managed target files: baz
+
+      This may happen, for example, if you have a configuration similar to
+
+          home.file = {
+            conflict1 = { source = ./foo.nix; target = "baz"; };
+            conflict2 = { source = ./bar.nix; target = "baz"; };
+          }''];
+  };
+}


### PR DESCRIPTION
### Description

Improve error handling of conflicting target files.

Fixes #1807

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```