### PR TITLE
rbw: use pientry.binaryPath when available

### DIFF
--- a/modules/programs/rbw.nix
+++ b/modules/programs/rbw.nix
@@ -60,7 +60,7 @@ let
             if builtins.isString val then
               "${pkgs.pinentry.${val}}/bin/pinentry"
             else
-              "${val}/bin/pinentry";
+              "${val}/${val.binaryPath or "bin/pinentry"}";
         };
       };
     };


### PR DESCRIPTION
### Description

`pinentry_mac` does not use bin/pientry as path for its binary, instead
it sets `binaryPath` pointing to its binary.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.