### PR TITLE
neovim: Add coc support

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -6,6 +6,8 @@ let
 
   cfg = config.programs.neovim;
 
+  jsonFormat = pkgs.formats.json { };
+
   extraPython3PackageType = mkOptionType {
     name = "extra-python3-packages";
     description = "python3 packages in python.withPackages format";
@@ -222,9 +224,9 @@ in {
         enable = mkEnableOption "Coc";
 
         extraConfig = mkOption {
-          type = types.lines;
-          default = "";
-          example = ''
+          type = jsonFormat.type;
+          default = { };
+          example = literalExample ''
             {
               "suggest.noselect": true,
               "suggest.enablePreview": true,
@@ -277,8 +279,9 @@ in {
     xdg.configFile."nvim/init.vim" = mkIf (neovimConfig.neovimRcContent != "") {
       text = neovimConfig.neovimRcContent;
     };
-    xdg.configFile."nvim/coc-settings.json" =
-      mkIf cfg.coc.enable { text = cfg.coc.extraConfig; };
+    xdg.configFile."nvim/coc-settings.json" = mkIf cfg.coc.enable {
+      source = jsonFormat.generate "coc-settings.json" cfg.coc.extraConfig;
+    };
 
     programs.neovim.finalPackage = pkgs.wrapNeovimUnstable cfg.package
       (neovimConfig // {

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -223,7 +223,7 @@ in {
       coc = {
         enable = mkEnableOption "Coc";
 
-        extraConfig = mkOption {
+        settings = mkOption {
           type = jsonFormat.type;
           default = { };
           example = literalExample ''
@@ -280,7 +280,7 @@ in {
       text = neovimConfig.neovimRcContent;
     };
     xdg.configFile."nvim/coc-settings.json" = mkIf cfg.coc.enable {
-      source = jsonFormat.generate "coc-settings.json" cfg.coc.extraConfig;
+      source = jsonFormat.generate "coc-settings.json" cfg.coc.settings;
     };
 
     programs.neovim.finalPackage = pkgs.wrapNeovimUnstable cfg.package

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -266,7 +266,7 @@ in {
         extraPython3Packages withPython3 withNodeJs withRuby viAlias vimAlias;
       configure = cfg.configure // moduleConfigure;
       plugins = cfg.plugins
-        ++ (if cfg.coc.enable then [ pkgs.vimPlugins.coc-nvim ] else [ ]);
+        ++ optionals cfg.coc.enable [ pkgs.vimPlugins.coc-nvim ];
       customRC = cfg.extraConfig;
     };
 

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -226,22 +226,26 @@ in {
         settings = mkOption {
           type = jsonFormat.type;
           default = { };
-          example = literalExample ''
-            {
-              "suggest.noselect": true,
-              "suggest.enablePreview": true,
-              "suggest.enablePreselect":false,
-              "suggest.disableKind": true,
-              "languageserver": {
-                "haskell": {
-                  "command": "haskell-language-server-wrapper",
-                  "args": ["--lsp"],
-                  "rootPatterns": ["*.cabal", "stack.yaml", "cabal.project", "package.yaml", "hie.yaml"],
-                  "filetypes": ["haskell", "lhaskell"]
-                }
-              }
-            }
-          '';
+          example = {
+            "suggest.noselect" = true;
+            "suggest.enablePreview" = true;
+            "suggest.enablePreselect" = false;
+            "suggest.disableKind" = true;
+            languageserver = {
+              haskell = {
+                command = "haskell-language-server-wrapper";
+                args = [ "--lsp" ];
+                rootPatterns = [
+                  "*.cabal"
+                  "stack.yaml"
+                  "cabal.project"
+                  "package.yaml"
+                  "hie.yaml"
+                ];
+                filetypes = [ "haskell" "lhaskell" ];
+              };
+            };
+          };
           description = ''
             Extra configuration lines to add to
             <filename>$XDG_CONFIG_HOME/nvim/coc-settings.json</filename>

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -226,26 +226,28 @@ in {
         settings = mkOption {
           type = jsonFormat.type;
           default = { };
-          example = {
-            "suggest.noselect" = true;
-            "suggest.enablePreview" = true;
-            "suggest.enablePreselect" = false;
-            "suggest.disableKind" = true;
-            languageserver = {
-              haskell = {
-                command = "haskell-language-server-wrapper";
-                args = [ "--lsp" ];
-                rootPatterns = [
-                  "*.cabal"
-                  "stack.yaml"
-                  "cabal.project"
-                  "package.yaml"
-                  "hie.yaml"
-                ];
-                filetypes = [ "haskell" "lhaskell" ];
+          example = literalExample ''
+            {
+              "suggest.noselect" = true;
+              "suggest.enablePreview" = true;
+              "suggest.enablePreselect" = false;
+              "suggest.disableKind" = true;
+              languageserver = {
+                haskell = {
+                  command = "haskell-language-server-wrapper";
+                  args = [ "--lsp" ];
+                  rootPatterns = [
+                    "*.cabal"
+                    "stack.yaml"
+                    "cabal.project"
+                    "package.yaml"
+                    "hie.yaml"
+                  ];
+                  filetypes = [ "haskell" "lhaskell" ];
+                };
               };
             };
-          };
+          '';
           description = ''
             Extra configuration lines to add to
             <filename>$XDG_CONFIG_HOME/nvim/coc-settings.json</filename>

--- a/tests/modules/programs/neovim/coc-config.expected
+++ b/tests/modules/programs/neovim/coc-config.expected
@@ -1,4 +1,3 @@
 {
-  // my variable
   "foo": "bar"
 }

--- a/tests/modules/programs/neovim/coc-config.expected
+++ b/tests/modules/programs/neovim/coc-config.expected
@@ -1,0 +1,4 @@
+{
+  // my variable
+  "foo": "bar"
+}

--- a/tests/modules/programs/neovim/coc-config.nix
+++ b/tests/modules/programs/neovim/coc-config.nix
@@ -8,12 +8,10 @@ with lib;
       enable = true;
       coc = {
         enable = true;
-        extraConfig = ''
-          {
-            // my variable
-            "foo": "bar"
-          }
-        '';
+        extraConfig = {
+          # my variable
+          foo = "bar";
+        };
       };
     };
 

--- a/tests/modules/programs/neovim/coc-config.nix
+++ b/tests/modules/programs/neovim/coc-config.nix
@@ -8,7 +8,7 @@ with lib;
       enable = true;
       coc = {
         enable = true;
-        extraConfig = {
+        settings = {
           # my variable
           foo = "bar";
         };

--- a/tests/modules/programs/neovim/coc-config.nix
+++ b/tests/modules/programs/neovim/coc-config.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.neovim = {
+      enable = true;
+      coc = {
+        enable = true;
+        extraConfig = ''
+          {
+            // my variable
+            "foo": "bar"
+          }
+        '';
+      };
+    };
+
+    nmt.script = ''
+      cocSettings="$TESTED/home-files/.config/nvim/coc-settings.json"
+      cocSettingsNormalized="$(normalizeStorePaths "$cocSettings")"
+
+      assertFileExists "$cocSettings"
+      assertFileContent "$cocSettingsNormalized" "${./coc-config.expected}"
+    '';
+  };
+}
+

--- a/tests/modules/programs/neovim/default.nix
+++ b/tests/modules/programs/neovim/default.nix
@@ -1,5 +1,6 @@
 {
   neovim-plugin-config = ./plugin-config.nix;
+  neovim-coc-config = ./coc-config.nix;
   # waiting for a nixpkgs patch
   # neovim-no-init = ./no-init.nix;
 }


### PR DESCRIPTION
### Description

Adds options to enable [coc](https://github.com/neoclide/coc.nvim) and provide content of `coc-settings.json`

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
