### PR TITLE
 programs.foot: revert always create config file (#2091) 

### DIFF
--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -51,7 +51,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."foot/foot.ini" = {
+    xdg.configFile."foot/foot.ini" = mkIf (cfg.settings != { }) {
       source = iniFormat.generate "foot.ini" cfg.settings;
     };
 

--- a/tests/modules/programs/foot/empty-settings.nix
+++ b/tests/modules/programs/foot/empty-settings.nix
@@ -10,10 +10,7 @@ with lib;
       [ (self: super: { foot = pkgs.writeScriptBin "dummy-foot" ""; }) ];
 
     nmt.script = ''
-      assertFileExists home-files/.config/foot/foot.ini
-      assertFileContent \
-        home-files/.config/foot/foot.ini \
-        ${builtins.toFile "test" ""}
+      assertPathNotExists home-files/.config/foot
     '';
   };
 }

--- a/tests/modules/programs/foot/systemd-user-service.nix
+++ b/tests/modules/programs/foot/systemd-user-service.nix
@@ -11,10 +11,7 @@ in {
     };
 
     nmt.script = ''
-      assertFileExists home-files/.config/foot/foot.ini
-      assertFileContent \
-        home-files/.config/foot/foot.ini \
-        ${builtins.toFile "test" ""}
+      assertPathNotExists home-files/.config/foot/foot.ini
 
       assertFileContent \
         home-files/.config/systemd/user/foot.service \


### PR DESCRIPTION
This reverts commit 666eee4f72979b0ebbd2e065a3846d7a8a16895c. ( aka #2091 )

### Description
As of https://github.com/NixOS/nixpkgs/pull/128121 we don't need to generate this file if there is no config.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
