### PR TITLE
setxkbmap: reset options before setting new ones

### DIFF
--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -114,7 +114,7 @@ in {
                 args = optional (layout != null) "-layout '${layout}'"
                   ++ optional (variant != null) "-variant '${variant}'"
                   ++ optional (model != null) "-model '${model}'"
-                  ++ map (v: "-option '${v}'") options;
+                  ++ [ "-option ''" ] ++ map (v: "-option '${v}'") options;
               in "${pkgs.xorg.setxkbmap}/bin/setxkbmap ${toString args}";
           };
         };

--- a/tests/modules/misc/xsession/basic-setxkbmap-expected.service
+++ b/tests/modules/misc/xsession/basic-setxkbmap-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@setxkbmap@/bin/setxkbmap -layout 'us' -variant ''
+ExecStart=@setxkbmap@/bin/setxkbmap -layout 'us' -variant '' -option ''
 RemainAfterExit=true
 Type=oneshot
 

--- a/tests/modules/misc/xsession/keyboard-without-layout-expected.service
+++ b/tests/modules/misc/xsession/keyboard-without-layout-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@setxkbmap@/bin/setxkbmap -option 'ctrl:nocaps' -option 'altwin:no_win'
+ExecStart=@setxkbmap@/bin/setxkbmap -option '' -option 'ctrl:nocaps' -option 'altwin:no_win'
 RemainAfterExit=true
 Type=oneshot
 


### PR DESCRIPTION
### Description

Resets setxkbmap options before setting new ones. Quoting `setxkbmap(1)`:

> Note that setxkbmap adds options specified in the command line to the options that were set before (as saved in root window properties). If you want to replace all previously specified options, use the -option flag with an empty argument first.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
