### PR TITLE
home-manager.auto-upgrade: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -292,6 +292,9 @@
 /modules/services/gromit-mpx.nix                      @pjones
 /tests/modules/services/gromit-mpx                    @pjones
 
+/modules/services/home-manager-auto-upgrade.nix       @pinage404
+/tests/modules/services/home-manager-auto-upgrade     @pinage404
+
 /modules/services/hound.nix                           @adisbladis
 
 /modules/services/imapnotify.nix                      @nickhu

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -193,4 +193,10 @@
     githubId = 9267430;
     name = "Philipp Mildenberger";
   };
+  pinage404 = {
+    name = "pinage404";
+    email = "pinage404@gmail.com";
+    github = "pinage404";
+    githubId = 6325757;
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -185,6 +185,7 @@ let
     ./services/gpg-agent.nix
     ./services/grobi.nix
     ./services/gromit-mpx.nix
+    ./services/home-manager-auto-upgrade.nix
     ./services/hound.nix
     ./services/imapnotify.nix
     ./services/kanshi.nix

--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -1,0 +1,69 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  cfg = config.services.home-manager.autoUpgrade;
+
+  homeManagerPackage = pkgs.callPackage ../../home-manager {
+    path = config.programs.home-manager.path;
+  };
+
+in {
+  meta.maintainers = [ lib.hm.maintainers.pinage404 ];
+
+  options = {
+    services.home-manager.autoUpgrade = {
+      enable = lib.mkEnableOption ''
+        the Home Manager upgrade service that periodically updates your Nix
+        channels before running <code>home-manager switch</code>'';
+
+      frequency = lib.mkOption {
+        type = lib.types.str;
+        example = "weekly";
+        description = ''
+          The interval at which the Home Manager auto upgrade is run.
+          This value is passed to the systemd timer configuration
+          as the <code>OnCalendar</code> option.
+          The format is described in
+          <citerefentry>
+            <refentrytitle>systemd.time</refentrytitle>
+            <manvolnum>7</manvolnum>
+          </citerefentry>.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.home-manager.autoUpgrade" pkgs
+        lib.platforms.linux)
+    ];
+
+    systemd.user = {
+      timers.home-manager-auto-upgrade = {
+        Unit.Description = "Home Manager upgrade timer";
+
+        Install.WantedBy = [ "timers.target" ];
+
+        Timer = {
+          OnCalendar = cfg.frequency;
+          Unit = "home-manager-auto-upgrade.service";
+          Persistent = true;
+        };
+      };
+
+      services.home-manager-auto-upgrade = {
+        Unit.Description = "Home Manager upgrade";
+
+        Service.ExecStart = toString
+          (pkgs.writeShellScript "home-manager-auto-upgrade" ''
+            echo "Update Nix's channels"
+            ${pkgs.nix}/bin/nix-channel --update
+            echo "Upgrade Home Manager"
+            ${homeManagerPackage}/bin/home-manager switch
+          '');
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -143,6 +143,7 @@ import nmt {
     ./modules/services/git-sync
     ./modules/services/gpg-agent
     ./modules/services/gromit-mpx
+    ./modules/services/home-manager-auto-upgrade
     ./modules/services/kanshi
     ./modules/services/lieer
     ./modules/services/pantalaimon

--- a/tests/modules/services/home-manager-auto-upgrade/basic-configuration.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/basic-configuration.nix
@@ -1,0 +1,18 @@
+{ config, ... }:
+
+{
+  config = {
+    services.home-manager.autoUpgrade = {
+      enable = true;
+      frequency = "00:00";
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/home-manager-auto-upgrade.service
+      assertFileExists $serviceFile
+
+      timerFile=home-files/.config/systemd/user/home-manager-auto-upgrade.timer
+      assertFileExists $timerFile
+    '';
+  };
+}

--- a/tests/modules/services/home-manager-auto-upgrade/default.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/default.nix
@@ -1,0 +1,1 @@
+{ home-manager-auto-upgrade-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
Hi,

### Description

Add a simple module to periodically upgrade Home Manager (it just runs `home-manager switch` in a SystemD's service)
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.

### Notes

I wrote test, but it might be better

i don't really know neither what and how to test

---

The documentation generation failed on a file that i didn't changed, i don't know how to fix it

```
nix-build -A docs.html
error: attribute 'anything' missing, at /home/pinage404/Project/home-manager/modules/programs/matplotlib.nix:26:28
(use '--show-trace' to show detailed location information)
```

```
nix-build -A docs.manPages
error: attribute 'anything' missing, at /home/pinage404/Project/home-manager/modules/programs/matplotlib.nix:26:28
(use '--show-trace' to show detailed location information)
```

---

The tests are failing on a file that i didn't changed, i don't know how to fix it

```
nix-shell --pure tests -A run.all
error: undefined variable 'isFloat' at /home/pinage404/Project/home-manager/modules/services/window-managers/bspwm/default.nix:20:24
(use '--show-trace' to show detailed location information)
```

---

The new test fail, but i don't understand the error

```
nix-shell --pure tests -A run.home-manager-auto-upgrade-basic-configuration
home-manager-auto-upgrade-basic-configuration: FAILED
Expected home-files/asserts/warnings.actual to be same as /nix/store/fvlxs1c042nl87f8d82ddxjw0l3m2cm7-warnings.expected but were different:
--- actual
+++ expected
@@ -1,14 +0,0 @@
-You are using
-
-  Home Manager version 21.11 and
-  Nixpkgs version 20.09.
-
-Using mismatched versions is likely to cause errors and unexpected
-behavior. It is therefore highly recommended to use a release of Home
-Manager than corresponds with your chosen release of Nixpkgs.
-
-If you insist then you can disable this warning by adding
-
-  home.enableNixpkgsReleaseCheck = false;
-
-to your configuration.
For further reference please introspect /nix/store/wh2wysx6biig4mjrha014iibijvnff5b-nmt-report-home-manager-auto-upgrade-basic-configuration
```

Maybe i have to use NixOS 21.05 to make the tests pass, i'm stuck on 20.09 until this PR will be merged https://nixpk.gs/pr-tracker.html?pr=125224

----

This is my first PR on this repo, i would love to have feedbacks