### PR TITLE
flavours: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,9 @@
 
 /modules/programs/firefox.nix                         @rycee
 
+/modules/programs/flavours.nix                        @misterio77
+/tests/modules/programs/flavours                      @misterio77
+
 /modules/programs/foot.nix                            @plabadens
 /tests/modules/programs/foot                          @plabadens
 

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -11,8 +11,8 @@ let
 
   pathStr = if path == null then "" else path;
 
-  nixos-option =
-    callPackage (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { };
+  nixos-option = pkgs.nixos-option or callPackage
+    (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { };
 
 in runCommand "home-manager" {
   preferLocalBuild = true;

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -11,8 +11,8 @@ let
 
   pathStr = if path == null then "" else path;
 
-  nixos-option = pkgs.nixos-option or callPackage
-    (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { };
+  nixos-option =
+    callPackage (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { };
 
 in runCommand "home-manager" {
   preferLocalBuild = true;

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -11,8 +11,8 @@ let
 
   pathStr = if path == null then "" else path;
 
-  nixos-option = pkgs.nixos-option or callPackage
-    (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { };
+  nixos-option = pkgs.nixos-option or (callPackage
+    (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { });
 
 in runCommand "home-manager" {
   preferLocalBuild = true;

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -115,4 +115,14 @@
     githubId = 56614642;
     name = "Ilan Joselevich";
   };
+  misterio77 = {
+    email = "eu@misterio.me";
+    github = "Misterio77";
+    githubId = 5727578;
+    name = "Gabriel Fontes";
+    keys = [{
+      longkeyid = "rsa3072/0x245CAB70B4C225E9";
+      fingerprint = "7088 C742 1873 E0DB 97FF 17C2 245C AB70 B4C2 25E9";
+    }];
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2118,6 +2118,13 @@ in
           A new module is available: 'programs.himalaya'.
         '';
       }
+
+      {
+        time = "2021-07-07T00:58:43+00:00";
+        message = ''
+          A new module is available: 'programs.flavours'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -70,6 +70,7 @@ let
     (loadModule ./programs/feh.nix { })
     (loadModule ./programs/firefox.nix { })
     (loadModule ./programs/fish.nix { })
+    (loadModule ./programs/flavours.nix { })
     (loadModule ./programs/foot.nix { condition = hostPlatform.isLinux; })
     (loadModule ./programs/fzf.nix { })
     (loadModule ./programs/getmail.nix { condition = hostPlatform.isLinux; })

--- a/modules/programs/flavours.nix
+++ b/modules/programs/flavours.nix
@@ -12,7 +12,7 @@ in {
   meta.maintainers = [ maintainers.misterio77 ];
 
   options.programs.flavours = {
-    enable = mkEnableOption "Flavours";
+    enable = mkEnableOption "Flavours, a base16 manager";
 
     package = mkOption {
       type = types.package;

--- a/modules/programs/flavours.nix
+++ b/modules/programs/flavours.nix
@@ -1,0 +1,64 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.flavours;
+
+  tomlFormat = pkgs.formats.toml { };
+
+in {
+  meta.maintainers = [ maintainers.misterio77 ];
+
+  options.programs.flavours = {
+    enable = mkEnableOption "Flavours";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.flavours;
+      defaultText = literalExample "pkgs.flavours";
+      description = "The package to use for the flavours binary.";
+    };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      defaultText = literalExample "{ }";
+      example = literalExample ''
+        {
+          shell = "bash -c '{}'";
+          item = [
+            {
+              file = "~/.config/alacritty/colors.yml";
+              template = "alacritty";
+              subtemplate = "default-256";
+              rewrite = true;
+            }
+            {
+              file = "~/.config/sway/colors";
+              template = "sway";
+              subtemplate = "colors";
+              hook = "swaymsg reload";
+              rewrite = true;
+            }
+          ];
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>~/.config/flavours/config.toml</filename>.
+        </para><para>
+        See <link xlink:href="https://github.com/Misterio77/flavours#setup" /> for all options
+        and some examples.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    xdg.configFile."flavours/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "flavours-config" cfg.settings;
+    };
+  };
+}

--- a/modules/programs/flavours.nix
+++ b/modules/programs/flavours.nix
@@ -47,7 +47,7 @@ in {
       '';
       description = ''
         Configuration written to
-        <filename>~/.config/flavours/config.toml</filename>.
+        <filename>$XDG_CONFIG_HOME/flavours/config.toml</filename>.
         </para><para>
         See <link xlink:href="https://github.com/Misterio77/flavours#setup" /> for all options
         and some examples.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -50,6 +50,7 @@ import nmt {
     ./modules/programs/direnv
     ./modules/programs/feh
     ./modules/programs/fish
+    ./modules/programs/flavours
     ./modules/programs/gh
     ./modules/programs/git
     ./modules/programs/gpg

--- a/tests/modules/programs/flavours/default.nix
+++ b/tests/modules/programs/flavours/default.nix
@@ -1,0 +1,1 @@
+{ flavours-settings = ./settings.nix; }

--- a/tests/modules/programs/flavours/settings-expected.toml
+++ b/tests/modules/programs/flavours/settings-expected.toml
@@ -1,0 +1,19 @@
+shell = "bash -c '{}'"
+[[item]]
+file = "~/.config/sway/config"
+hook = "swaymsg reload"
+light = false
+subtemplate = "colors"
+template = "sway"
+
+[[item]]
+file = "~/.config/waybar/colors.css"
+rewrite = true
+template = "waybar"
+
+[[item]]
+end = "/* End Flavours */"
+file = "~/.config/beautifuldiscord/style.css"
+start = "/* Start Flavours */"
+subtemplate = "css-variables"
+template = "styles"

--- a/tests/modules/programs/flavours/settings.nix
+++ b/tests/modules/programs/flavours/settings.nix
@@ -1,0 +1,46 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.flavours = {
+      enable = true;
+
+      settings = {
+        shell = "bash -c '{}'";
+        item = [
+          {
+            file = "~/.config/sway/config";
+            template = "sway";
+            subtemplate = "colors";
+            hook = "swaymsg reload";
+            light = false;
+          }
+          {
+            file = "~/.config/waybar/colors.css";
+            template = "waybar";
+            rewrite = true;
+          }
+          {
+            file = "~/.config/beautifuldiscord/style.css";
+            template = "styles";
+            subtemplate = "css-variables";
+            start = "/* Start Flavours */";
+            end = "/* End Flavours */";
+          }
+        ];
+      };
+    };
+
+    nixpkgs.overlays = [
+      (self: super: { flavours = pkgs.writeScriptBin "dummy-flavours" ""; })
+    ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/flavours/config.toml \
+        ${./settings-expected.toml}
+    '';
+  };
+}

--- a/tests/modules/programs/xmobar/basic-configuration.nix
+++ b/tests/modules/programs/xmobar/basic-configuration.nix
@@ -6,6 +6,7 @@ with lib;
   config = {
     programs.xmobar = {
       enable = true;
+      package = pkgs.writeScriptBin "dummy" "";
       extraConfig = ''
         Config
           { font        = "Fira Code"


### PR DESCRIPTION
### Description

[flavours](https://github.com/misterio77/flavours) is a [base16](https://github.com/chriskempson/base16) manager. It allows you to instantly theme any supported configuration file (using [base16 templates](https://github.com/chriskempson/base16#template-repositories)) with more than 180 existing [base16 schemes](https://github.com/chriskempson/base16#scheme-repositories), or even generate these from images.

Please let me know if there's anything missing, i'm still learning about Home Manager and Nix :D

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
