### PR TITLE
gtk: add onChange theme reload

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -178,14 +178,8 @@ in {
 
     home.sessionVariables.GTK2_RC_FILES = cfg2.configLocation;
 
-    xdg.configFile."gtk-3.0/settings.ini" = {
-      text = toGtk3Ini { Settings = ini // cfg3.extraConfig; };
-      onChange = mkIf (cfg.theme != null)
-        (let gsettings = "${pkgs.glib}/bin/gsettings";
-        in ''
-          ${gsettings} set org.gnome.desktop.interface gtk-theme ${cfg.theme.name} || true
-        '');
-    };
+    xdg.configFile."gtk-3.0/settings.ini".text =
+      toGtk3Ini { Settings = ini // cfg3.extraConfig; };
 
     xdg.configFile."gtk-3.0/gtk.css".text = cfg3.extraCss;
 

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -172,7 +172,7 @@ in {
       onChange = mkIf (cfg.theme != null)
         (let xsettingsd = "${pkgs.xsettingsd}/bin/xsettingsd";
         in ''
-          timeout 2 ${xsettingsd} -c <(echo 'Net/ThemeName "${cfg.theme.name}"') & true
+          timeout 2 ${xsettingsd} -c <(echo 'Net/ThemeName "${cfg.theme.name}"') &> /dev/null &
         '');
     };
 


### PR DESCRIPTION
### Description

EDIT: Mostly done, just waiting on #2147 and #2239 and more feedback

I'm interested in getting `onChange` into more modules. This is related to https://github.com/nix-community/home-manager/issues/361.

This one reloads gtk themes (using `gsettings` and `xsettingsd`) when changed. I'm using sway and everything seems to work nicely (even without any actual gnome apps on my environment), but i'm not sure if it works across all WMs and DEs. I'd love some input regarding this.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.