### PR TITLE
Revert "Revert "home-manager: use nixos-option from pkgs""

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -11,8 +11,8 @@ let
 
   pathStr = if path == null then "" else path;
 
-  nixos-option =
-    callPackage (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { };
+  nixos-option = pkgs.nixos-option or callPackage
+    (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { };
 
 in runCommand "home-manager" {
   preferLocalBuild = true;

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -11,8 +11,8 @@ let
 
   pathStr = if path == null then "" else path;
 
-  nixos-option = pkgs.nixos-option or callPackage
-    (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { };
+  nixos-option = pkgs.nixos-option or (callPackage
+    (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { });
 
 in runCommand "home-manager" {
   preferLocalBuild = true;


### PR DESCRIPTION
This reverts commit 2c9fe368c1b5d79d504e3111ebaa97e90192fbb4.

### Description

In I accidentally pushed to master which I believed was my own fork:

https://github.com/nix-community/home-manager/commit/2c9fe368c1b5d79d504e3111ebaa97e90192fbb4

However since it also broke home-manager according to my information, this might have been a good thing.
However here is the revert of the revert just in case

Note if this PR is applied evaluation on my system fails as follows:

```
Exception: error: attempt to call something which is not a function but a set at /nix/store/wg5hvwq8p85872am5wjslnvrjzbb0mjh-source/home-manager/default.nix:14:18: 13| 14| nixos-option = pkgs.nixos-option or callPackage | ^ 15| (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { };; type: nix::TypeError
```