### PR TITLE
brave: fix config dir path

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -114,10 +114,12 @@ let
         brave = "BraveSoftware/Brave-Browser";
       };
 
+      linuxDirs = { brave = "BraveSoftware/Brave-Browser"; };
+
       configDir = if pkgs.stdenv.isDarwin then
-        "Library/Application Support/${getAttr browser darwinDirs}"
+        "Library/Application Support/" + (darwinDirs."${browser}" or browser)
       else
-        "${config.xdg.configHome}/${browser}";
+        "${config.xdg.configHome}/" + (linuxDirs."${browser}" or browser);
 
       extensionJson = ext:
         assert ext.crxPath != null -> ext.version != null;


### PR DESCRIPTION
### Description

<!--

Adding extensions through `programs.brave` doesn't work on linux because the extensions are linked to `~/.config/brave` when it should be `~/.config/BraveSoftware/Brave-Browser`. Not sure when this changed upstream.

See: https://support.brave.com/hc/en-us/articles/360017914832-Why-am-I-seeing-the-message-extensions-disabled-by-Brave-

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

Not if the user overrides `programs.brave.package` with an older version of Brave.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
