### PR TITLE
sm64ex: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -180,6 +180,9 @@
 
 /modules/programs/senpai.nix                          @malte-v
 
+/modules/programs/sm64ex.nix                          @ivarwithoutbones
+/tests/modules/programs/sm64ex                        @ivarwithoutbones
+
 /modules/programs/ssh.nix                             @rycee
 
 /modules/programs/starship.nix                        @marsam

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2118,6 +2118,13 @@ in
           A new module is available: 'programs.himalaya'.
         '';
       }
+
+      {
+        time = "2021-07-11T17:45:56+00:00";
+        message = ''
+          A new module is available: 'programs.sm64ex'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -132,6 +132,7 @@ let
     (loadModule ./programs/scmpuff.nix { })
     (loadModule ./programs/senpai.nix { })
     (loadModule ./programs/skim.nix { })
+    (loadModule ./programs/sm64ex.nix { })
     (loadModule ./programs/starship.nix { })
     (loadModule ./programs/sbt.nix { })
     (loadModule ./programs/ssh.nix { })

--- a/modules/programs/sm64ex.nix
+++ b/modules/programs/sm64ex.nix
@@ -1,0 +1,128 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.sm64ex;
+
+  # This is required for tests, we cannot overwrite the dummy package.
+  package = if cfg.region == null && cfg.baserom == null
+  && cfg.extraCompileFlags == null then
+    cfg.package
+
+  else
+    cfg.package.override (attrs:
+      { } // optionalAttrs (cfg.region != null) { region = cfg.region; }
+      // optionalAttrs (cfg.baserom != null) { baseRom = cfg.baserom; }
+      // optionalAttrs (cfg.extraCompileFlags != null) {
+        compileFlags = cfg.extraCompileFlags;
+      });
+
+  mkConfig = key: value:
+    let
+      generatedValue = if isBool value then
+        (if value then "true" else "false")
+      else if isList value then
+        concatStringsSep " " value
+      else
+        toString value;
+    in "${key} ${generatedValue}";
+
+in {
+  meta.maintainers = [ maintainers.ivar ];
+
+  options.programs.sm64ex = {
+    enable = mkEnableOption "sm64ex";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.sm64ex;
+      description = "The sm64ex package to use.";
+    };
+
+    region = mkOption {
+      type = types.nullOr (types.enum [ "us" "eu" "jp" ]);
+      default = null;
+      defaultText =
+        literalExample "us"; # This is set both in nixpkgs and upstream
+      description = ''
+        Your baserom's region. Note that only "us", "eu", and "jp" are supported.
+      '';
+      example = literalExample "jp";
+    };
+
+    baserom = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description =
+        "The path to the Super Mario 64 baserom to extract assets from.";
+      example = literalExample "/home/foo/baserom.us.z64";
+    };
+
+    extraCompileFlags = mkOption {
+      type = with types; nullOr (listOf str);
+      default = null;
+      description = ''
+        Extra flags to pass to the compiler. See
+        <link xlink:href="https://github.com/sm64pc/sm64ex/wiki/Build-options"/>
+        for more information.
+      '';
+      example = literalExample ''
+        [
+          "BETTERCAMERA=1"
+          "NODRAWINGDISTANCE=1"
+        ];
+      '';
+    };
+
+    settings = mkOption {
+      type = with types;
+        nullOr (attrsOf (either str (either int (either bool (listOf str)))));
+      default = null;
+      description =
+        "Settings for sm64ex's <filename>~/.local/share/sm64pc/sm64config.txt</filename> file.";
+      example = literalExample ''
+        {
+          fullscreen = false;
+          window_x = 0;
+          window_y = 0;
+          window_w = 1920;
+          window_h = 1080;
+          vsync = 1;
+          texture_filtering = 1;
+          master_volume = 127;
+          music_volume = 127;
+          sfx_volume = 127;
+          env_volume = 127;
+          key_a = [ "0026" "1000" "1103" ];
+          key_b = [ "0033" "1002" "1101" ];
+          key_start = [ "0039" "1006" "ffff" ];
+          key_l = [ "0034" "1007" "1104" ];
+          key_r = [ "0036" "100a" "1105" ];
+          key_z = [ "0025" "1009" "1102" ];
+          key_cup = [ "100b" "ffff" "ffff" ];
+          key_cdown = [ "100c" "ffff" "ffff" ];
+          key_cleft = [ "100d" "ffff" "ffff" ];
+          key_cright = [ "100e" "ffff" "ffff" ];
+          key_stickup = [ "0011" "ffff" "ffff" ];
+          key_stickdown = [ "001f" "ffff" "ffff" ];
+          key_stickleft = [ "001e" "ffff" "ffff" ];
+          key_stickright = [ "0020" "ffff" "ffff" ];
+          stick_deadzone = 16;
+          rumble_strength = 10;
+          skip_intro = 1;
+        };
+      '';
+    };
+  };
+
+  config = let
+    configFile = optionals (cfg.settings != null)
+      (concatStringsSep "\n" ((mapAttrsToList mkConfig cfg.settings)));
+  in mkIf cfg.enable {
+    home.packages = [ package ];
+
+    xdg.dataFile."sm64pc/sm64config.txt" =
+      mkIf (cfg.settings != null) { text = configFile; };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -76,6 +76,7 @@ import nmt {
     ./modules/programs/readline
     ./modules/programs/sbt
     ./modules/programs/scmpuff
+    ./modules/programs/sm64ex
     ./modules/programs/ssh
     ./modules/programs/starship
     ./modules/programs/texlive

--- a/tests/modules/programs/sm64ex/default.nix
+++ b/tests/modules/programs/sm64ex/default.nix
@@ -1,0 +1,1 @@
+{ sm64ex = import ./settings.nix; }

--- a/tests/modules/programs/sm64ex/settings.nix
+++ b/tests/modules/programs/sm64ex/settings.nix
@@ -1,0 +1,81 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.sm64ex = {
+      enable = true;
+
+      settings = {
+        fullscreen = true;
+        window_x = 0;
+        window_y = 0;
+        window_w = 1920;
+        window_h = 1080;
+        vsync = 1;
+        texture_filtering = 1;
+        master_volume = 127;
+        music_volume = 127;
+        sfx_volume = 127;
+        env_volume = 127;
+        key_a = [ "0026" "1000" "1103" ];
+        key_b = [ "0033" "1002" "1101" ];
+        key_start = [ "0039" "1006" "ffff" ];
+        key_l = [ "0034" "1007" "1104" ];
+        key_r = [ "0036" "100a" "1105" ];
+        key_z = [ "0025" "1009" "1102" ];
+        key_cup = [ "100b" "ffff" "ffff" ];
+        key_cdown = [ "100c" "ffff" "ffff" ];
+        key_cleft = [ "100d" "ffff" "ffff" ];
+        key_cright = [ "100e" "ffff" "ffff" ];
+        key_stickup = [ "0011" "ffff" "ffff" ];
+        key_stickdown = [ "001f" "ffff" "ffff" ];
+        key_stickleft = [ "001e" "ffff" "ffff" ];
+        key_stickright = [ "0020" "ffff" "ffff" ];
+        stick_deadzone = 16;
+        rumble_strength = 10;
+        skip_intro = 1;
+      };
+    };
+
+    nixpkgs.overlays =
+      [ (self: super: { sm64ex = pkgs.writeScriptBin "dummy-sm64ex" ""; }) ];
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.local/share/sm64pc/sm64config.txt \
+        ${
+          pkgs.writeText "sm64ex-expected-settings" ''
+            env_volume 127
+            fullscreen true
+            key_a 0026 1000 1103
+            key_b 0033 1002 1101
+            key_cdown 100c ffff ffff
+            key_cleft 100d ffff ffff
+            key_cright 100e ffff ffff
+            key_cup 100b ffff ffff
+            key_l 0034 1007 1104
+            key_r 0036 100a 1105
+            key_start 0039 1006 ffff
+            key_stickdown 001f ffff ffff
+            key_stickleft 001e ffff ffff
+            key_stickright 0020 ffff ffff
+            key_stickup 0011 ffff ffff
+            key_z 0025 1009 1102
+            master_volume 127
+            music_volume 127
+            rumble_strength 10
+            sfx_volume 127
+            skip_intro 1
+            stick_deadzone 16
+            texture_filtering 1
+            vsync 1
+            window_h 1080
+            window_w 1920
+            window_x 0
+            window_y 0''
+        }
+    '';
+  };
+}


### PR DESCRIPTION
### Description
This adds a module for sm64ex, in which you can configure compile-time options, and also run-time options.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
