### PR TITLE
sway: add propagate --to-code for modes

### DIFF
--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -179,7 +179,7 @@ let
       ${keybindingsStr { keybindings = keybindingDefaultWorkspace; }}
       ${keybindingsStr { keybindings = keybindingsRest; }}
       ${keycodebindingsStr keycodebindings}
-      ${concatStringsSep "\n" (mapAttrsToList modeStr modes)}
+      ${concatStringsSep "\n" (mapAttrsToList (modeStr false) modes)}
       ${concatStringsSep "\n" (mapAttrsToList assignStr assigns)}
       ${concatStringsSep "\n" (map barStr bars)}
       ${optionalString (gaps != null) gapsStr}

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -37,9 +37,12 @@ rec {
     ];
   barColorSetStr = c: concatStringsSep " " [ c.border c.background c.text ];
 
-  modeStr = name: keybindings: ''
+  modeStr = bindkeysToCode: name: keybindings: ''
     mode "${name}" {
-    ${keybindingsStr { inherit keybindings; }}
+    ${keybindingsStr {
+      inherit keybindings;
+      bindsymArgs = lib.optionalString bindkeysToCode "--to-code";
+    }}
     }
   '';
 

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -300,7 +300,7 @@ let
         mapAttrsToList inputStr input # inputs
         ++ mapAttrsToList outputStr output # outputs
         ++ mapAttrsToList seatStr seat # seats
-        ++ mapAttrsToList modeStr modes # modes
+        ++ mapAttrsToList (modeStr cfg.config.bindkeysToCode) modes # modes
         ++ mapAttrsToList assignStr assigns # assigns
         ++ map barStr bars # bars
         ++ optional (gaps != null) gapsStr # gaps

--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -1,12 +1,13 @@
 {
   sway-bar-focused-colors = ./sway-bar-focused-colors.nix;
+  sway-bindkeys-to-code = ./sway-bindkeys-to-code.nix;
   sway-default = ./sway-default.nix;
-  sway-post-2003 = ./sway-post-2003.nix;
   sway-followmouse = ./sway-followmouse.nix;
   sway-followmouse-legacy = ./sway-followmouse-legacy.nix;
+  sway-modules = ./sway-modules.nix;
   sway-null-config = ./sway-null-config.nix;
   sway-null-package = ./sway-null-package.nix;
-  sway-modules = ./sway-modules.nix;
+  sway-post-2003 = ./sway-post-2003.nix;
   sway-workspace-default = ./sway-workspace-default.nix;
   sway-workspace-output = ./sway-workspace-output.nix;
 }

--- a/tests/modules/services/window-managers/sway/sway-bindkeys-to-code.conf
+++ b/tests/modules/services/window-managers/sway/sway-bindkeys-to-code.conf
@@ -1,0 +1,114 @@
+font pango:monospace 8.000000
+floating_modifier Mod1
+default_border pixel 2
+default_floating_border pixel 2
+hide_edge_borders none
+focus_wrapping no
+focus_follows_mouse yes
+focus_on_window_activation smart
+mouse_warping output
+workspace_layout default
+workspace_auto_back_and_forth no
+
+client.focused #4c7899 #285577 #ffffff #2e9ef4 #285577
+client.focused_inactive #333333 #5f676a #ffffff #484e50 #5f676a
+client.unfocused #333333 #222222 #888888 #292d2e #222222
+client.urgent #2f343a #900000 #ffffff #900000 #900000
+client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
+client.background #ffffff
+
+
+bindsym --to-code Mod1+1 workspace number 1
+bindsym --to-code Mod1+2 workspace number 2
+bindsym --to-code Mod1+3 workspace number 3
+bindsym --to-code Mod1+4 workspace number 4
+bindsym --to-code Mod1+5 workspace number 5
+bindsym --to-code Mod1+6 workspace number 6
+bindsym --to-code Mod1+7 workspace number 7
+bindsym --to-code Mod1+8 workspace number 8
+bindsym --to-code Mod1+9 workspace number 9
+bindsym --to-code Mod1+Down focus down
+bindsym --to-code Mod1+Left focus left
+bindsym --to-code Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym --to-code Mod1+Right focus right
+bindsym --to-code Mod1+Shift+1 move container to workspace number 1
+bindsym --to-code Mod1+Shift+2 move container to workspace number 2
+bindsym --to-code Mod1+Shift+3 move container to workspace number 3
+bindsym --to-code Mod1+Shift+4 move container to workspace number 4
+bindsym --to-code Mod1+Shift+5 move container to workspace number 5
+bindsym --to-code Mod1+Shift+6 move container to workspace number 6
+bindsym --to-code Mod1+Shift+7 move container to workspace number 7
+bindsym --to-code Mod1+Shift+8 move container to workspace number 8
+bindsym --to-code Mod1+Shift+9 move container to workspace number 9
+bindsym --to-code Mod1+Shift+Down move down
+bindsym --to-code Mod1+Shift+Left move left
+bindsym --to-code Mod1+Shift+Right move right
+bindsym --to-code Mod1+Shift+Up move up
+bindsym --to-code Mod1+Shift+c reload
+bindsym --to-code Mod1+Shift+e exec swaynag -t warning -m 'You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.' -b 'Yes, exit sway' 'swaymsg exit'
+bindsym --to-code Mod1+Shift+h move left
+bindsym --to-code Mod1+Shift+j move down
+bindsym --to-code Mod1+Shift+k move up
+bindsym --to-code Mod1+Shift+l move right
+bindsym --to-code Mod1+Shift+minus move scratchpad
+bindsym --to-code Mod1+Shift+q kill
+bindsym --to-code Mod1+Shift+space floating toggle
+bindsym --to-code Mod1+Up focus up
+bindsym --to-code Mod1+a focus parent
+bindsym --to-code Mod1+b splith
+bindsym --to-code Mod1+d exec @dmenu@/bin/dmenu_run
+bindsym --to-code Mod1+e layout toggle split
+bindsym --to-code Mod1+f fullscreen toggle
+bindsym --to-code Mod1+h focus left
+bindsym --to-code Mod1+j focus down
+bindsym --to-code Mod1+k focus up
+bindsym --to-code Mod1+l focus right
+bindsym --to-code Mod1+minus scratchpad show
+bindsym --to-code Mod1+r mode resize
+bindsym --to-code Mod1+s layout stacking
+bindsym --to-code Mod1+space focus mode_toggle
+bindsym --to-code Mod1+v splitv
+bindsym --to-code Mod1+w layout tabbed
+
+mode "resize" {
+bindsym --to-code Down resize grow height 10 px
+bindsym --to-code Escape mode default
+bindsym --to-code Left resize shrink width 10 px
+bindsym --to-code Return mode default
+bindsym --to-code Right resize grow width 10 px
+bindsym --to-code Up resize shrink height 10 px
+bindsym --to-code h resize shrink width 10 px
+bindsym --to-code j resize grow height 10 px
+bindsym --to-code k resize shrink height 10 px
+bindsym --to-code l resize grow width 10 px
+}
+
+bar {
+  
+  font pango:monospace 8.000000
+  mode dock
+  hidden_state hide
+  position bottom
+  status_command @i3status@/bin/i3status
+  swaybar_command @sway/bin/swaybar
+  workspace_buttons yes
+  strip_workspace_numbers no
+  tray_output primary
+  colors {
+    background #000000
+    statusline #ffffff
+    separator #666666
+    
+    
+    
+    focused_workspace #4c7899 #285577 #ffffff
+    active_workspace #333333 #5f676a #ffffff
+    inactive_workspace #333333 #222222 #888888
+    urgent_workspace #2f343a #900000 #ffffff
+    binding_mode #2f343a #900000 #ffffff
+  }
+  
+}
+
+
+exec "systemctl --user import-environment; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-bindkeys-to-code.nix
+++ b/tests/modules/services/window-managers/sway/sway-bindkeys-to-code.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  dummy-package = pkgs.runCommandLocal "dummy-package" { } "mkdir $out";
+
+in {
+  config = {
+    wayland.windowManager.sway = {
+      enable = true;
+      package = dummy-package // { outPath = "@sway"; };
+      # overriding findutils causes issues
+      config.menu = "${pkgs.dmenu}/bin/dmenu_run";
+      config.bindkeysToCode = true;
+    };
+
+    nixpkgs.overlays = [ (import ./sway-overlay.nix) ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/sway/config
+      assertFileContent home-files/.config/sway/config \
+        ${./sway-bindkeys-to-code.conf}
+    '';
+  };
+}


### PR DESCRIPTION

### Description

Propagates the `bindkeysToCode` setting which adds `--to-code` to the keybinding to mode configs.

Closes #2174

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
