### PR TITLE
easyeffects: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -227,6 +227,8 @@
 
 /modules/services/dunst.nix                           @rycee
 
+/modules/services/easyeffects.nix                     @fufexan
+
 /modules/services/emacs.nix                           @tadfisher
 
 /modules/services/etesync-dav.nix                     @Valodim

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2164,6 +2164,14 @@ in
           A new module is available: 'programs.java'.
         '';
       }
+
+      {
+        time = "2021-08-11T13:55:51+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.easyeffects'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -157,6 +157,7 @@ let
     ./services/dropbox.nix
     ./services/dunst.nix
     ./services/dwm-status.nix
+    ./services/easyeffects.nix
     ./services/emacs.nix
     ./services/etesync-dav.nix
     ./services/flameshot.nix

--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.easyeffects;
+
+  presetOpts = optionalString (cfg.preset != "") "--load-preset ${cfg.preset}";
+
+in {
+  meta.maintainers = [ maintainers.fufexan ];
+
+  options.services.easyeffects = {
+    enable = mkEnableOption ''
+      Easyeffects daemon.
+      Note, it is necessary to add
+      <programlisting language="nix">
+      services.dbus.packages = with pkgs; [ gnome.dconf ];
+      </programlisting>
+      to your system configuration for the daemon to work correctly
+    '';
+
+    preset = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        Which preset to use when starting easyeffects.
+        Will likely need to launch easyeffects to initially create preset.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.easyeffects" pkgs platforms.linux)
+    ];
+
+    # running easyeffects will just attach itself to gapplication service
+    # at-spi2-core is to minimize journalctl noise of:
+    # "AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files"
+    home.packages = with pkgs; [ easyeffects at-spi2-core ];
+
+    systemd.user.services.easyeffects = {
+      Unit = {
+        Description = "Easyeffects daemon";
+        Requires = [ "dbus.service" ];
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" "pipewire.service" ];
+      };
+
+      Install.WantedBy = [ "graphical-session.target" ];
+
+      Service = {
+        ExecStart =
+          "${pkgs.easyeffects}/bin/easyeffects --gapplication-service ${presetOpts}";
+        ExecStop = "${pkgs.easyeffects}/bin/easyeffects --quit";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    };
+  };
+}

--- a/modules/services/pulseeffects.nix
+++ b/modules/services/pulseeffects.nix
@@ -16,10 +16,9 @@ in {
 
     package = mkOption {
       type = types.package;
-      default = pkgs.pulseeffects;
-      defaultText = literalExample "pkgs.pulseeffects";
+      default = pkgs.pulseeffects-legacy;
+      defaultText = literalExample "pkgs.pulseeffects-legacy";
       description = "Pulseeffects package to use.";
-      example = literalExample "pkgs.pulseeffects-pw";
     };
 
     preset = mkOption {


### PR DESCRIPTION
### Description

Added `services.easyeffects` as a PipeWire replacement for `services.pulseeffects`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
