### PR TITLE
Add git-sync

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -238,6 +238,8 @@
 
 /modules/services/fluidsynth.nix                      @Valodim
 
+/modules/services/git-sync.nix                        @IvanMalison
+
 /modules/services/gnome-keyring.nix                   @rycee
 
 /modules/services/gpg-agent.nix                       @rycee

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2172,6 +2172,14 @@ in
           A new module is available: 'services.easyeffects'.
         '';
       }
+
+      {
+        time = "2021-08-16T21:59:02+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.git-sync'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -163,6 +163,7 @@ let
     ./services/flameshot.nix
     ./services/fluidsynth.nix
     ./services/getmail.nix
+    ./services/git-sync.nix
     ./services/gnome-keyring.nix
     ./services/gpg-agent.nix
     ./services/grobi.nix

--- a/modules/services/git-sync.nix
+++ b/modules/services/git-sync.nix
@@ -1,0 +1,100 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.git-sync;
+
+  mkUnit = name: repo: {
+    Unit.Description = "Git Sync ${name}";
+
+    Install.WantedBy = [ "default.target" ];
+
+    Service = {
+      Environment = [
+        "GIT_SYNC_DIRECTORY=${repo.path}"
+        "GIT_SYNC_COMMAND=${cfg.package}/bin/git-sync"
+        "GIT_SYNC_REPOSITORY=${repo.uri}"
+        "GIT_SYNC_INTERVAL=${toString repo.interval}"
+      ];
+      ExecStart = "${cfg.package}/bin/git-sync-on-inotify";
+      Restart = "on-abort";
+    };
+  };
+
+  services = mapAttrs' (name: repo: {
+    name = "git-sync-${name}";
+    value = mkUnit name repo;
+  }) cfg.repositories;
+
+  repositoryType = types.submodule ({ name, ... }: {
+    options = {
+      name = mkOption {
+        internal = true;
+        default = name;
+        type = types.str;
+        description = "The name that should be given to this unit.";
+      };
+
+      path = mkOption {
+        type = types.path;
+        description = "The path at which to sync the repository";
+      };
+
+      uri = mkOption {
+        type = types.str;
+        example = "git+ssh://user@example.com:/~[user]/path/to/repo.git";
+        description = ''
+          The URI of the remote to be synchronized. This is only used in the
+          event that the directory does not already exist. See
+          <link xlink:href="https://git-scm.com/docs/git-clone#_git_urls"/>
+          for the supported URIs.
+        '';
+      };
+
+      interval = mkOption {
+        type = types.int;
+        default = 500;
+        description = ''
+          The interval, specified in seconds, at which the synchronization will
+          be triggered even without filesystem changes.
+        '';
+      };
+    };
+  });
+
+in {
+  meta.maintainers = [ maintainers.imalison ];
+
+  options = {
+    services.git-sync = {
+      enable = mkEnableOption "git-sync services";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.git-sync;
+        defaultText = literalExample "pkgs.git-sync";
+        description = ''
+          Package containing the <command>git-sync</command> program.
+        '';
+      };
+
+      repositories = mkOption {
+        type = with types; attrsOf repositoryType;
+        description = ''
+          The repositories that should be synchronized.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.git-sync" pkgs
+        lib.platforms.linux)
+    ];
+
+    systemd.user.services = services;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -120,6 +120,7 @@ import nmt {
     ./modules/services/dropbox
     ./modules/services/emacs
     ./modules/services/fluidsynth
+    ./modules/services/git-sync
     ./modules/services/kanshi
     ./modules/services/lieer
     ./modules/services/pantalaimon

--- a/tests/modules/services/git-sync/basic.nix
+++ b/tests/modules/services/git-sync/basic.nix
@@ -1,0 +1,37 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.git-sync = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy" "" // { outPath = "@git-sync@"; };
+      repositories.test = {
+        path = "/a/path";
+        uri = "git+ssh://user@example.com:/~user/path/to/repo.git";
+      };
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/git-sync-test.service
+
+      assertFileExists $serviceFile
+      assertFileContent $serviceFile ${
+        builtins.toFile "expected" ''
+          [Install]
+          WantedBy=default.target
+
+          [Service]
+          Environment=GIT_SYNC_DIRECTORY=/a/path
+          Environment=GIT_SYNC_COMMAND=@git-sync@/bin/git-sync
+          Environment=GIT_SYNC_REPOSITORY=git+ssh://user@example.com:/~user/path/to/repo.git
+          Environment=GIT_SYNC_INTERVAL=500
+          ExecStart=@git-sync@/bin/git-sync-on-inotify
+          Restart=on-abort
+
+          [Unit]
+          Description=Git Sync test
+        ''
+      }
+    '';
+  };
+}

--- a/tests/modules/services/git-sync/default.nix
+++ b/tests/modules/services/git-sync/default.nix
@@ -1,0 +1,1 @@
+{ git-sync = ./basic.nix; }


### PR DESCRIPTION
### Description

This service module uses git-sync-on-inotify to automatically keep a git repository in sync by
- Auto committing any changes it detects from its inotifywait
- Periodically synchronizing a configurable amount with the remote 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
