### PR TITLE
vivid: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -194,6 +194,8 @@
 /modules/programs/topgrade.nix                        @msfjarvis
 /tests/modules/programs/topgrade                      @msfjarvis
 
+/modules/programs/vivid.nix                           @noib3
+
 /modules/programs/waybar.nix                          @berbiche
 /tests/modules/programs/waybar                        @berbiche
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -103,7 +103,7 @@ in
       entries = mkOption {
         internal = true;
         type = types.listOf entryModule;
-        default = [];
+        default = [ ];
         description = "News entries.";
       };
     };
@@ -169,7 +169,7 @@ in
         time = "2017-09-12T13:11:48+00:00";
         condition = (
           config.programs.zsh.enable &&
-          config.programs.zsh.shellAliases != {}
+          config.programs.zsh.shellAliases != { }
         );
         message = ''
           Aliases defined in 'programs.zsh.shellAliases'
@@ -312,7 +312,7 @@ in
       {
         time = "2017-10-20T12:15:27+00:00";
         condition = with config.systemd.user;
-          services != {} || sockets != {} || targets != {} || timers != {};
+          services != { } || sockets != { } || targets != { } || timers != { };
         message = ''
           Home Manager's interaction with systemd is now done using
           'systemctl' from Nixpkgs, not the 'systemctl' in '$PATH'.
@@ -412,7 +412,7 @@ in
       {
         time = "2017-11-14T19:56:49+00:00";
         condition = with config.xsession.windowManager; (
-          i3.enable && i3.config != null && i3.config.startup != []
+          i3.enable && i3.config != null && i3.config.startup != [ ]
         );
         message = ''
           A new 'notification' option was added to
@@ -576,7 +576,7 @@ in
 
       {
         time = "2018-03-25T06:49:57+00:00";
-        condition = with config.programs.ssh; enable && matchBlocks != {};
+        condition = with config.programs.ssh; enable && matchBlocks != { };
         message = ''
           Options set through the 'programs.ssh' module are now placed
           at the end of the SSH configuration file. This was done to
@@ -886,7 +886,7 @@ in
 
       {
         time = "2018-12-04T21:54:38+00:00";
-        condition = config.programs.beets.settings != {};
+        condition = config.programs.beets.settings != { };
         message = ''
           A new option 'programs.beets.enable' has been added.
           Starting with state version 19.03 this option defaults to
@@ -1795,7 +1795,7 @@ in
 
       {
         time = "2021-01-01T08:51:11+00:00";
-        condition = config.pam.sessionVariables != {};
+        condition = config.pam.sessionVariables != { };
         message = ''
           The option 'pam.sessionVariables' will be deprecated in the future.
           This is due to PAM 1.5.0 deprecating reading of the user environment.
@@ -2003,7 +2003,7 @@ in
 
       {
         time = "2021-05-18T12:22:42+00:00";
-        condition = config.services.syncthing != {};
+        condition = config.services.syncthing != { };
         message = ''
           Setting 'services.syncthing.tray' as a boolean will be deprecated in
           the future.
@@ -2131,6 +2131,13 @@ in
         condition = hostPlatform.isLinux;
         message = ''
           A new module is available: 'services.xsettingsd'.
+        '';
+      }
+
+      {
+        time = "2021-07-18T11:10:27+00:00";
+        message = ''
+          A new module is available: 'programs.vivid'.
         '';
       }
     ];

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -6,7 +6,7 @@
   # Whether to enable module type checking.
 , check ? true
 
-# If disabled, the pkgs attribute passed to this function is used instead.
+  # If disabled, the pkgs attribute passed to this function is used instead.
 , useNixpkgsModule ? true
 }:
 
@@ -127,7 +127,7 @@ let
     (loadModule ./programs/rbw.nix { })
     (loadModule ./programs/readline.nix { })
     (loadModule ./programs/rofi.nix { })
-    (loadModule ./programs/rofi-pass.nix {  })
+    (loadModule ./programs/rofi-pass.nix { })
     (loadModule ./programs/rtorrent.nix { })
     (loadModule ./programs/scmpuff.nix { })
     (loadModule ./programs/senpai.nix { })
@@ -144,6 +144,7 @@ let
     (loadModule ./programs/topgrade.nix { })
     (loadModule ./programs/urxvt.nix { })
     (loadModule ./programs/vim.nix { })
+    (loadModule ./programs/vivid.nix { })
     (loadModule ./programs/vscode.nix { })
     (loadModule ./programs/vscode/haskell.nix { })
     (loadModule ./programs/waybar.nix { condition = hostPlatform.isLinux; })
@@ -250,7 +251,8 @@ let
         if versionAtLeast config.home.stateVersion "20.09" then
           pkgs.path
         else
-          <nixpkgs>);
+          <nixpkgs>
+      );
       _module.args.pkgs = lib.mkDefault pkgs;
       _module.check = check;
       lib = lib.hm;
@@ -261,4 +263,4 @@ let
 
 in
 
-  modules ++ [ pkgsModule ]
+modules ++ [ pkgsModule ]

--- a/modules/programs/vivid.nix
+++ b/modules/programs/vivid.nix
@@ -1,0 +1,81 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.programs.vivid;
+  yaml = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = [ maintainers.noib3 ];
+
+  options.programs.vivid = {
+    enable = mkEnableOption "vivid";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.vivid;
+      defaultText = literalExample "pkgs.vivid";
+      description = "The vivid package to install.";
+    };
+
+    filetypes = mkOption {
+      type = yaml.type;
+      default = { };
+      example = literalExample ''
+        {
+          core = {
+            regular_file = [ "$fi" ];
+            directory = [ "$di" ];
+          };
+          text = {
+            readme = [ "README.md" ];
+            licenses = [ "LICENSE" ];
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>~/.config/vivid/filetypes.yml</filename>.
+      '';
+    };
+
+    themes = mkOption {
+      type = types.attrsOf (yaml.type);
+      default = { };
+      example = literalExample ''
+        {
+          mytheme = {
+            colors = {
+              blue = "0000ff";
+            };
+            core = {
+              directory = {
+                foreground = "blue";
+                font-style = "bold";
+              };
+            };
+          };
+        }
+      '';
+      description = ''
+        Theme files written to
+        <filename>~/.config/vivid/themes/<mytheme>.yml</filename>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = {
+      "vivid/filetypes.yml".source =
+        yaml.generate "filetypes.yml" cfg.filetypes;
+    } // mapAttrs'
+      (
+        name: value: nameValuePair
+          ("vivid/themes/${name}.yml")
+          ({ source = yaml.generate "${name}.yml" value; })
+      )
+      cfg.themes;
+  };
+}


### PR DESCRIPTION
A themeable LS_COLORS generator with a rich filetype datebase.

### Description

Added a new module for https://github.com/sharkdp/vivid.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
