### PR TITLE
xcape: run xcape after setxkbmap (#2198)

### DIFF
--- a/modules/services/xcape.nix
+++ b/modules/services/xcape.nix
@@ -59,11 +59,16 @@ in {
     ];
 
     systemd.user.services.xcape = {
-      Unit = {
-        Description = "xcape";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
-      };
+      Unit = mkMerge [
+        {
+          Description = "xcape";
+          After = [ "graphical-session-pre.target" ];
+          PartOf = [ "graphical-session.target" ];
+        }
+        (mkIf (config.home.keyboard != null && config.home.keyboard != { }) {
+          After = [ "graphical-session-pre.target" "setxkbmap.service" ];
+        })
+      ];
 
       Service = {
         Type = "forking";


### PR DESCRIPTION
### Description

Add `setxkbmap.service` to `After` of `xcape`, if keyboard options are set. Fixes #2198 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
