### PR TITLE
meta: github: fix issue template assignees

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Ask for a new feature to be added (module, program, etc.)
 title: ''
 labels: feature request
-assignees: nix-community/home-manager
+assignees: rycee, berbiche, sumnerevans
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -3,8 +3,9 @@ description: File a bug/issue
 title: 'bug: '
 labels: [bug, triage]
 
-assignees:
-- nix-community/home-manager
+# We cannot use nix-community/home-manager
+# See https://github.com/dear-github/dear-github/issues/170
+assignees: [rycee, berbiche, sumnerevans]
 
 body:
 - type: checkboxes


### PR DESCRIPTION
### Description

We cannot assign teams to issues yet.
See <https://github.com/dear-github/dear-github/issues/170>.

The current list of assignees is me, @rycee and @sumnerevans.
If you do not wish to be pinged, please indicate it here.

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
