### PR TITLE
nixos: add nix package to activation script path

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -373,6 +373,16 @@ in
       description = "The package containing the complete activation script.";
     };
 
+    home.extraActivationPath = mkOption {
+      internal = true;
+      type = types.listOf types.package;
+      default = [ ];
+      description = ''
+        Extra packages to add to <envar>PATH</envar> within the activation
+        script.
+      '';
+    };
+
     home.extraBuilderCommands = mkOption {
       type = types.lines;
       default = "";
@@ -570,15 +580,17 @@ in
 
         # Programs that always should be available on the activation
         # script's PATH.
-        activationBinPaths = lib.makeBinPath [
-          pkgs.bash
-          pkgs.coreutils
-          pkgs.diffutils        # For `cmp` and `diff`.
-          pkgs.findutils
-          pkgs.gnugrep
-          pkgs.gnused
-          pkgs.ncurses          # For `tput`.
-        ]
+        activationBinPaths = lib.makeBinPath (
+          [
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.diffutils        # For `cmp` and `diff`.
+            pkgs.findutils
+            pkgs.gnugrep
+            pkgs.gnused
+            pkgs.ncurses          # For `tput`.
+          ] ++ config.home.extraActivationPath
+        )
         + optionalString (!cfg.emptyActivationPath) "\${PATH:+:}$PATH";
 
         activationScript = pkgs.writeShellScript "activation-script" ''

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -32,6 +32,10 @@ let
 
           home.username = config.users.users.${name}.name;
           home.homeDirectory = config.users.users.${name}.home;
+
+          # Make activation script use same version of Nix as system as a whole.
+          # This avoids problems with Nix not being in PATH.
+          home.extraActivationPath = [ config.nix.package ];
         };
       })
     ] ++ cfg.sharedModules;


### PR DESCRIPTION
### Description

Explicitly add the system's Nix package to the activation script PATH.

Fixes #2178

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```