### PR TITLE
NixOS: remove indirection via activate-${username}, fixes #2191

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -144,11 +144,8 @@ in {
 
           # The activation script is run by a login shell to make sure
           # that the user is given a sane Nix environment.
-          ExecStart = pkgs.writeScript "activate-${username}" ''
-            #! ${pkgs.runtimeShell} -el
-            echo Activating home-manager configuration for ${username}
-            exec ${usercfg.home.activationPackage}/activate
-          '';
+          ExecStart =
+            "${pkgs.runtimeShell} -l ${usercfg.home.activationPackage}/activate";
         };
       }) cfg.users;
   };


### PR DESCRIPTION
### Description

Fixes #2191.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
