### PR TITLE
taskwarrior: don't create dataLocation with home.file

### DIFF
--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -98,8 +98,6 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ pkgs.taskwarrior ];
 
-    home.file."${cfg.dataLocation}/.keep".text = "";
-
     home.file.".taskrc".text = ''
       data.location=${cfg.dataLocation}
       ${includeTheme cfg.colorTheme}


### PR DESCRIPTION
### Description
My use-case is having programs.taskwarrior.dataLocation =
/absolute/path (outside of $HOME), but the current implementation
wrongly creates $HOME/absolute/path (due to how home.file is
implemented).

Since taskwarrior creates the dataLocation automatically on first run,
there is actually no need for HM to create that directory.

Additional benefit, the .keep symlink that HM creates as a side-effect
no longer appears in the taskwarrior data directory.

Fixes #2207.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`. I'm still on nixpkgs-20.09 and that command is impure so it fails. I tried with `NIX_PATH=nixpkgs=... nix-shell ...` but then my local overlays leak into the tests breaking them. I patched some (`import <nixpkgs> {}` -> `import <nixpkgs> { config = {}; overlays = []; }` but I guess I didn't catch them all.)

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
