### PR TITLE
neomutt: Allow named mailboxes

### DIFF
--- a/modules/programs/neomutt-accounts.nix
+++ b/modules/programs/neomutt-accounts.nix
@@ -2,7 +2,25 @@
 
 with lib;
 
-{
+let
+  extraMailboxOptions = {
+    options = {
+      mailbox = mkOption {
+        type = types.str;
+        example = "Sent";
+        description = "Name of mailbox folder to be included";
+      };
+
+      name = mkOption {
+        type = types.nullOr types.str;
+        example = "Junk";
+        default = null;
+        description = "Name to display";
+      };
+    };
+  };
+
+in {
   options.neomutt = {
     enable = mkEnableOption "NeoMutt";
 
@@ -31,6 +49,19 @@ with lib;
       description = ''
         Extra lines to add to the folder hook for this account.
       '';
+    };
+
+    mailboxName = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "==== <mailbox-name> ===";
+      description = "Use a different name as mailbox name";
+    };
+
+    extraMailboxes = mkOption {
+      type = with types; listOf (either str (submodule extraMailboxOptions));
+      default = [ ];
+      description = "List of extra mailboxes";
     };
   };
 }

--- a/tests/modules/programs/neomutt/default.nix
+++ b/tests/modules/programs/neomutt/default.nix
@@ -8,4 +8,5 @@
     ./neomutt-with-binds-invalid-settings.nix;
   neomutt-with-gpg = ./neomutt-with-gpg.nix;
   neomutt-no-folder-change = ./neomutt-no-folder-change.nix;
+  neomutt-with-named-mailboxes = ./neomutt-with-named-mailboxes.nix;
 }

--- a/tests/modules/programs/neomutt/neomutt-not-primary-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-not-primary-expected.conf
@@ -19,6 +19,7 @@ set delete = yes
 # Register accounts
 # register account hm-account
 mailboxes "/home/hm-user/Mail/hm-account/Inbox"
+
 folder-hook /home/hm-user/Mail/hm-account/ " \
     source /home/hm-user/.config/neomutt/hm-account "
 

--- a/tests/modules/programs/neomutt/neomutt-with-binds-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-with-binds-expected.conf
@@ -21,6 +21,7 @@ macro index,pager c "<change-folder>?<change-dir><home>^K=<enter><tab>"
 # Register accounts
 # register account hm@example.com
 mailboxes "/home/hm-user/Mail/hm@example.com/Inbox"
+
 folder-hook /home/hm-user/Mail/hm@example.com/ " \
     source /home/hm-user/.config/neomutt/hm@example.com "
 

--- a/tests/modules/programs/neomutt/neomutt-with-named-mailboxes-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-with-named-mailboxes-expected.conf
@@ -18,8 +18,10 @@ set delete = yes
 
 # Register accounts
 # register account hm@example.com
-mailboxes "/home/hm-user/Mail/hm@example.com/Inbox"
-
+named-mailboxes "someCustomName" "/home/hm-user/Mail/hm@example.com/Inbox"
+mailboxes "/home/hm-user/Mail/hm@example.com/Sent"
+named-mailboxes "Spam" "/home/hm-user/Mail/hm@example.com/Junk Email"
+mailboxes "/home/hm-user/Mail/hm@example.com/Trash"
 folder-hook /home/hm-user/Mail/hm@example.com/ " \
     source /home/hm-user/.config/neomutt/hm@example.com "
 

--- a/tests/modules/programs/neomutt/neomutt-with-named-mailboxes.nix
+++ b/tests/modules/programs/neomutt/neomutt-with-named-mailboxes.nix
@@ -1,0 +1,50 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  config = {
+    accounts.email.accounts = {
+      "hm@example.com" = {
+        notmuch.enable = true;
+        neomutt = {
+          enable = true;
+          extraConfig = ''
+            color status cyan default
+          '';
+          mailboxName = "someCustomName";
+          extraMailboxes = [
+            "Sent"
+            {
+              mailbox = "Junk Email";
+              name = "Spam";
+            }
+            { mailbox = "Trash"; }
+          ];
+        };
+        imap.port = 993;
+      };
+    };
+
+    programs.neomutt = {
+      enable = true;
+      vimKeys = false;
+    };
+
+    nixpkgs.overlays =
+      [ (self: super: { neomutt = pkgs.writeScriptBin "dummy-neomutt" ""; }) ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/neomutt/neomuttrc
+      assertFileExists home-files/.config/neomutt/hm@example.com
+      assertFileContent home-files/.config/neomutt/neomuttrc ${
+        ./neomutt-with-named-mailboxes-expected.conf
+      }
+      assertFileContent home-files/.config/neomutt/hm@example.com ${
+        ./hm-example.com-expected
+      }
+    '';
+  };
+}


### PR DESCRIPTION
### Description

These options allow to add other folders than the inbox, for example the
Trash, Spam folder or Drafts to be added on a per-account basis. Using
extraOptions is not possible here, as those are lazily loaded on mailbox
open and thus would appear at the bottom and not sorted by account.

This commit also changes the default sidebar format string to use %D
instead of %B because %B will ignore named mailboxes and show the folder
name instead.

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
