### PR TITLE
programs.neovim: expose generatedConfigViml

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -130,6 +130,15 @@ in {
         '';
       };
 
+      generatedConfigViml = mkOption {
+        type = types.lines;
+        visible = true;
+        readOnly = true;
+        description = ''
+          Generated vimscript config.
+        '';
+      };
+
       package = mkOption {
         type = types.package;
         default = pkgs.neovim-unwrapped;
@@ -238,6 +247,8 @@ in {
         configure.packages.*.start  -> programs.neovim.plugins = [ { plugin = ...; }]
         configure.customRC -> programs.neovim.extraConfig
     '';
+
+    programs.neovim.generatedConfigViml = neovimConfig.neovimRcContent;
 
     home.packages = [ cfg.finalPackage ];
 


### PR DESCRIPTION
Expose the generated viml config, this has 2 advantages:
1/ user can choose to write the generated config to a file of its choice
2/ the user can prepend/append to the config before writing it

    xdg.configFile."nvim/init.vim".text = ''
	" prepend some config
	${programs.neovim.generatedConfigViml}
	" append some config
    '';

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
