### PR TITLE
barrier: remove `tray` option

### DIFF
--- a/modules/services/barrier.nix
+++ b/modules/services/barrier.nix
@@ -6,6 +6,12 @@ in {
 
   meta.maintainers = with maintainers; [ kritnich ];
 
+  imports = [
+    (mkRemovedOptionModule [ "services" "barrier" "client" "tray" ] ''
+      The tray option is non-functional and has been removed.
+    '')
+  ];
+
   options.services.barrier = {
 
     client = {
@@ -28,8 +34,6 @@ in {
           Port defaults to <literal>24800</literal>.
         '';
       };
-
-      tray = mkEnableOption "the system tray icon" // { default = true; };
 
       enableCrypto = mkEnableOption "crypto (SSL) plugin" // {
         default = true;
@@ -66,7 +70,6 @@ in {
       Service.ExecStart = with cfg.client;
         toString ([ "${pkgs.barrier}/bin/barrierc" ]
           ++ optional (name != null) "--name ${name}"
-          ++ optional (!tray) "--no-tray"
           ++ optional enableCrypto "--enable-crypto"
           ++ optional enableDragDrop "--enable-drag-drop" ++ extraFlags
           ++ [ server ]);


### PR DESCRIPTION
### Description

Closes #2066 by removing the non-functional `tray` option

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
