### PR TITLE
For nix darwin need a valid user

### DIFF
--- a/doc/installation.adoc
+++ b/doc/installation.adoc
@@ -226,7 +226,7 @@ For example, a nix-darwin configuration may include the lines
 ----
 user.users.eve = {
   name = "eve";
-  home = /Users/eve ;
+  home = "/Users/eve";
 }
 home-manager.users.eve = { pkgs, ... }: {
   home.packages = [ pkgs.atool pkgs.httpie ];

--- a/doc/installation.adoc
+++ b/doc/installation.adoc
@@ -224,6 +224,10 @@ For example, a nix-darwin configuration may include the lines
 
 [source,nix]
 ----
+user.users.eve = {
+  name = "eve";
+  home = /Users/eve ;
+}
 home-manager.users.eve = { pkgs, ... }: {
   home.packages = [ pkgs.atool pkgs.httpie ];
   programs.bash.enable = true;


### PR DESCRIPTION
### Description

Fixing documentation for *nix-darwin module*, you must specify a user in your darwin config or home-manager will fail.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
