### PR TITLE
home-environment: use `declare -gr` in activation init

### DIFF
--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -5,9 +5,9 @@ function setupVars() {
     local profilesPath="$nixStateDir/profiles/per-user/$USER"
     local gcPath="$nixStateDir/gcroots/per-user/$USER"
 
-    genProfilePath="$profilesPath/home-manager"
-    newGenPath="@GENERATION_DIR@";
-    newGenGcPath="$gcPath/current-home"
+    declare -gr genProfilePath="$profilesPath/home-manager"
+    declare -gr newGenPath="@GENERATION_DIR@";
+    declare -gr newGenGcPath="$gcPath/current-home"
 
     local greatestGenNum
     greatestGenNum=$( \
@@ -16,14 +16,15 @@ function setupVars() {
             | sed -E 's/ *([[:digit:]]+) .*/\1/')
 
     if [[ -n $greatestGenNum ]] ; then
-        oldGenNum=$greatestGenNum
-        newGenNum=$((oldGenNum + 1))
+        declare -gr oldGenNum=$greatestGenNum
+        declare -gr newGenNum=$((oldGenNum + 1))
     else
-        newGenNum=1
+        declare -gr newGenNum=1
     fi
 
     if [[ -e $profilesPath/home-manager ]] ; then
         oldGenPath="$(readlink -e "$profilesPath/home-manager")"
+        declare -gr oldGenPath
     fi
 
     $VERBOSE_ECHO "Sanity checking oldGenNum and oldGenPath"


### PR DESCRIPTION
### Description

This marks the setup variables as read-only. Just to add a bit extra safety.

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.