### PR TITLE
fish: provide different examples for `shellAliases`

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -164,8 +164,8 @@ in {
         default = { };
         example = literalExample ''
           {
-            ll = "ls -l";
-            ".." = "cd ..";
+            g = "git";
+            "..." = "cd ../..";
           }
         '';
         description = ''


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This is a very opinionated change so it's OK to keep it as-is.

I think the examples provided in `shellAliases` are bad because they are provided by Fish out of the box.

- `ll` is aliased to `ls -lh` by default.
- `cd` can be omitted when changing directories. That is, `..` is equivalent to `cd ..`.

I replaced them with two different examples but if there's better one, suggestions welcome.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
