### PR TITLE
xsession: don't reset the inherited keyboard options

### DIFF
--- a/docs/release-notes/rl-2111.adoc
+++ b/docs/release-notes/rl-2111.adoc
@@ -44,4 +44,4 @@ The state version in this release includes the changes below. These
 changes are only active if the `home.stateVersion` option is set to
 "21.11" or later.
 
-* Nothing has happened.
+* The <<opt-home.keyboard>> option now defaults to `null`, meaning that Home Manager won't do any keyboard layout management. For example, `setxkbmap` won't be run in X sessions.

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -4,6 +4,8 @@ with lib;
 
 let
 
+  inherit (config.home) stateVersion;
+
   cfg = config.home;
 
   languageSubModule = types.submodule {
@@ -220,7 +222,11 @@ in
 
     home.keyboard = mkOption {
       type = types.nullOr keyboardSubModule;
-      default = {};
+      default = if versionAtLeast stateVersion "21.11" then null else { };
+      defaultText = literalExpression ''
+        "{ }"  for state version < 21.11,
+        "null" for state version ≥ 21.11
+      '';
       description = ''
         Keyboard configuration. Set to <literal>null</literal> to
         disable Home Manager keyboard management.


### PR DESCRIPTION
### Description

If the keyboard configuration is an empty set, don't run the setxkbmap service.

The default values for all keyboard options are null or empty so long as the state version is set to 19.09 or higher (21.05 being the
latest version).

Fixes #2219 

CC; @sigprof @dschrempf 

If you need guidance to test this PR, let me know.

### Checklist


- [ ] Change is backwards compatible. **Maybe?**

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
