### PR TITLE
Change neovim's init.vim to init.lua

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -20,7 +20,7 @@ let
     options = {
       config = mkOption {
         type = types.lines;
-        description = "vimscript for this plugin to be placed in init.lua";
+        description = "lua for this plugin to be placed in init.lua";
         default = "";
       };
 
@@ -137,7 +137,7 @@ in {
         visible = true;
         readOnly = true;
         description = ''
-          Generated vimscript config.
+          Generated lua config.
         '';
       };
 

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -20,7 +20,7 @@ let
     options = {
       config = mkOption {
         type = types.lines;
-        description = "vimscript for this plugin to be placed in init.vim";
+        description = "vimscript for this plugin to be placed in init.lua";
         default = "";
       };
 
@@ -221,7 +221,7 @@ in {
         '';
         description = ''
           List of vim plugins to install optionally associated with
-          configuration to be placed in init.vim.
+          configuration to be placed in init.lua.
 
           </para><para>
 
@@ -293,7 +293,7 @@ in {
 
     home.packages = [ cfg.finalPackage ];
 
-    xdg.configFile."nvim/init.vim" = mkIf (neovimConfig.neovimRcContent != "") {
+    xdg.configFile."nvim/init.lua" = mkIf (neovimConfig.neovimRcContent != "") {
       text = neovimConfig.neovimRcContent;
     };
     xdg.configFile."nvim/coc-settings.json" = mkIf cfg.coc.enable {

--- a/tests/modules/programs/neovim/no-init.nix
+++ b/tests/modules/programs/neovim/no-init.nix
@@ -15,7 +15,7 @@ with lib;
       extraPython3Packages = (ps: with ps; [ jedi pynvim ]);
     };
     nmt.script = ''
-      vimrc="home-files/.config/nvim/init.vim"
+      vimrc="home-files/.config/nvim/init.lua"
       assertPathNotExists "$vimrc"
     '';
   };

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -23,7 +23,7 @@ with lib;
     };
 
     nmt.script = ''
-      vimrc="$TESTED/home-files/.config/nvim/init.vim"
+      vimrc="$TESTED/home-files/.config/nvim/init.lua"
       vimrcNormalized="$(normalizeStorePaths "$vimrc")"
 
       assertFileExists "$vimrc"


### PR DESCRIPTION
### Description

Now that Neovim's 0.5.0 release has support for lua configurations, I've changed the init.vim file to init.lua to leverage this new feature :)