### PR TITLE
fish: simplify config guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Currently the easiest way to install Home Manager is as follows:
 
     file in your shell configuration. This file can be sourced
     directly by POSIX.2-like shells such as [Bash][] or [Z shell][].
+    [Fish][] users can use utilities such as [foreign-env][] or
+    [babelfish][].
 
     For example, if you use Bash then add
 
@@ -123,9 +125,7 @@ Currently the easiest way to install Home Manager is as follows:
     . "/etc/profiles/per-user/$USER/etc/profile.d/hm-session-vars.sh"
     ```
 
-    to your `~/.profile` file. For fish shell, it is possible to use
-    [foreign-env](https://github.com/oh-my-fish/plugin-foreign-env) to
-    source the file.
+    to your `~/.profile` file.
 
 If instead of using channels you want to run Home Manager from a Git
 checkout of the repository then you can use the
@@ -385,3 +385,6 @@ an issue.
 [samueldr]: https://github.com/samueldr/
 [Nix Pills]: https://nixos.org/nixos/nix-pills/
 [Nix Flakes]: https://nixos.wiki/wiki/Flakes
+[Fish]: https://fishshell.com
+[foreign-env]: https://github.com/oh-my-fish/plugin-foreign-env
+[babelfish]: https://github.com/bouk/babelfish

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -88,7 +88,10 @@ when managing home configuration together with system configuration.
 +
 This file can be sourced directly by POSIX.2-like shells such as
 https://www.gnu.org/software/bash/[Bash] or
-http://zsh.sourceforge.net/[Z shell].
+http://zsh.sourceforge.net/[Z shell]. https://fishshell.com[Fish]
+users can use utilities such as
+https://github.com/oh-my-fish/plugin-foreign-env[foreign-env] or
+https://github.com/bouk/babelfish[babelfish].
 +
 For example, if you use Bash then add
 +
@@ -97,9 +100,7 @@ For example, if you use Bash then add
 . "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
 ----
 +
-to your `~/.profile` file. For fish shell, it is possible to use
-https://github.com/oh-my-fish/plugin-foreign-env[foreign-env] to
-source the file.
+to your `~/.profile` file.
 
 If instead of using channels you want to run Home Manager from a Git
 checkout of the repository then you can use the

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -340,41 +340,24 @@ in {
         # ~/.config/fish/config.fish: DO NOT EDIT -- this file has been generated
         # automatically by home-manager.
 
-        # if we haven't sourced the general config, do it
-        if not set -q __fish_general_config_sourced
+        # Only execute this file once per shell.
+        set -q __fish_home_manager_config_sourced; and exit
+        set -g __fish_home_manager_config_sourced 1
 
-          set --prepend fish_function_path ${
-            if pkgs ? fishPlugins && pkgs.fishPlugins ? foreign-env then
-              "${pkgs.fishPlugins.foreign-env}/share/fish/vendor_functions.d"
-            else
-              "${pkgs.fish-foreign-env}/share/fish-foreign-env/functions"
-          }
-          fenv source ${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh > /dev/null
-          set -e fish_function_path[1]
+        set --prepend fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish/vendor_functions.d
+        fenv source ${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh > /dev/null
+        set -e fish_function_path[1]
 
-          ${cfg.shellInit}
-          # and leave a note so we don't source this config section again from
-          # this very shell (children will source the general config anew)
-          set -g __fish_general_config_sourced 1
+        ${cfg.shellInit}
 
-        end
-
-        # if we haven't sourced the login config, do it
-        status --is-login; and not set -q __fish_login_config_sourced
-        and begin
+        status --is-login; and begin
 
           # Login shell initialisation
           ${cfg.loginShellInit}
 
-          # and leave a note so we don't source this config section again from
-          # this very shell (children will source the general config anew)
-          set -g __fish_login_config_sourced 1
-
         end
 
-        # if we haven't sourced the interactive config, do it
-        status --is-interactive; and not set -q __fish_interactive_config_sourced
-        and begin
+        status --is-interactive; and begin
 
           # Abbreviations
           ${abbrsStr}
@@ -387,11 +370,6 @@ in {
 
           # Interactive shell intialisation
           ${cfg.interactiveShellInit}
-
-          # and leave a note so we don't source this config section again from
-          # this very shell (children will source the general config anew,
-          # allowing configuration changes in, e.g, aliases, to propagate)
-          set -g __fish_interactive_config_sourced 1
 
         end
       '';


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

`config.fish` generated by Home Manager have superfluous config guards, at least to my eyes.

We don't have them in neither bash and zsh config. And even if the guard does make sense, there's no need to use separate variables for each section.

These are present when Fish module is added, ~~we may never the reason behind it~~ (edit: it seems inherited from the corresponding Nixpkgs/NixOS module), but it doesn't affect the fact theses are unnecessary and can be removed safely.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
