### PR TITLE
fish: remove `promptInit` in favor of `interactiveShellInit`

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -214,13 +214,6 @@ in {
           initialisation.
         '';
       };
-
-      promptInit = mkOption {
-        type = types.lines;
-        default = "";
-        description = ''
-          Shell script code used to initialise fish prompt.
-        '';
       };
     };
 
@@ -381,9 +374,6 @@ in {
 
           # Aliases
           ${aliasesStr}
-
-          # Prompt initialisation
-          ${cfg.promptInit}
 
           # Interactive shell intialisation
           ${cfg.interactiveShellInit}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

`promptInit` does nothing special and can already be implemented via `interactiveShellInit`, so I suggest just keep the latter.

However there are some things I'm not too sure:

- This may break some people's config. I don't know the process of deprecating an option in Home Manager, so help welcome.
- There is already a `programs.fish.interactiveShellInit` (which "add completions generated by Home Manager to $fish_complete_path") config, but is it a default value? Will it take effect if users provide a custom `interactiveShellInit`? If that's the case then it should be fixed (and the code looks horrible to me, so we may also have a chance to rewrite it at the same time).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
