### PR TITLE
gh: add options for "pager" and "prompt" to gh.nix

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -42,13 +42,32 @@ in {
         The protocol to use when performing Git operations.
       '';
     };
+
+    pager = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        A pager program to send command output to, e.g. "less".
+        Set the value to "cat" to disable the pager.
+        '';
+    };
+
+    prompt = mkOption {
+      type = types.enum [ "enabled" "disabled" ];
+      default = "enabled";
+      description = ''
+        When to interactively prompt.
+        This is a global config that cannot be overridden by hostname.
+        Supported values: enabled, disabled.
+        '';
+    };
   };
 
   config = mkIf cfg.enable {
     home.packages = [ pkgs.gh ];
 
     xdg.configFile."gh/config.yml".text = builtins.toJSON {
-      inherit (cfg) aliases editor;
+      inherit (cfg) aliases editor pager prompt;
       git_protocol = cfg.gitProtocol;
     };
   };

--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -49,7 +49,7 @@ in {
       description = ''
         A pager program to send command output to, e.g. "less".
         Set the value to "cat" to disable the pager.
-        '';
+      '';
     };
 
     prompt = mkOption {
@@ -59,7 +59,7 @@ in {
         When to interactively prompt.
         This is a global config that cannot be overridden by hostname.
         Supported values: enabled, disabled.
-        '';
+      '';
     };
   };
 


### PR DESCRIPTION

### Description

<!--

Please provide a brief description of your change.

-->
These two options are present in the config.yml file generated by
"gh auth login" with browser authentication. This change allows
gh.nix to generate a config.yml file that includes these options.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
