### PR TITLE
polybar: use recursive config type

### DIFF
--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -112,7 +112,9 @@ in {
       };
 
       settings = mkOption {
-        type = types.attrsOf types.attrs;
+        type = with types;
+          let ty = oneOf [ bool int float str (listOf ty) (attrsOf ty) ];
+          in attrsOf (attrsOf ty // { description = "attribute sets"; });
         description = ''
           Polybar configuration. This takes a nix attrset and converts it to the
           strange data format that polybar uses.


### PR DESCRIPTION
### Description

Allow merging of lists and attrsets in polybar configs.

(I believe I need to set a description or something to fix recursive types in the docs, what do I need to do again?)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
