### PR TITLE
fluidsynth: add sound service option

### DIFF
--- a/modules/services/fluidsynth.nix
+++ b/modules/services/fluidsynth.nix
@@ -22,7 +22,7 @@ in {
       };
 
       soundService = mkOption {
-        type = types.enum [ "jack" "pipewire-pulse" "pulseaudio" ]
+        type = types.enum [ "jack" "pipewire-pulse" "pulseaudio" ];
         default = "pulseaudio";
         example = "pipewire-pulse";
         description = ''

--- a/modules/services/fluidsynth.nix
+++ b/modules/services/fluidsynth.nix
@@ -22,7 +22,7 @@ in {
       };
 
       soundService = mkOption {
-        type = types.str;
+        type = types.enum [ "jack" "pipewire-pulse" "pulseaudio" ]
         default = "pulseaudio";
         example = "pipewire-pulse";
         description = ''

--- a/modules/services/fluidsynth.nix
+++ b/modules/services/fluidsynth.nix
@@ -21,6 +21,15 @@ in {
         '';
       };
 
+      soundService = mkOption {
+        type = types.str;
+        default = "pulseaudio";
+        example = "pipewire-pulse";
+        description = ''
+          The systemd sound service to depend on.
+        '';
+      };
+
       extraOptions = mkOption {
         type = types.listOf types.str;
         default = [ ];
@@ -46,8 +55,8 @@ in {
       Unit = {
         Description = "FluidSynth Daemon";
         Documentation = "man:fluidsynth(1)";
-        BindsTo = [ "pulseaudio.service" ];
-        After = [ "pulseaudio.service" ];
+        BindsTo = [ (cfg.soundService + ".service") ];
+        After = [ (cfg.soundService + ".service") ];
       };
 
       Install = { WantedBy = [ "default.target" ]; };

--- a/tests/modules/services/fluidsynth/service.nix
+++ b/tests/modules/services/fluidsynth/service.nix
@@ -1,6 +1,7 @@
 { config, pkgs, ... }: {
   config = {
     services.fluidsynth.enable = true;
+    services.fluidsynth.soundService = "pipewire-pulse";
     services.fluidsynth.soundFont = "/path/to/soundFont";
     services.fluidsynth.extraOptions = [ "--sample-rate 96000" ];
 
@@ -19,6 +20,12 @@
 
       assertFileContains $serviceFile \
         'ExecStart=@fluidsynth@/bin/fluidsynth -a pulseaudio -si --sample-rate 96000 /path/to/soundFont'
+
+      assertFileContains $serviceFile \
+        'After=pipewire-pulse.service'
+
+      assertFileContains $serviceFile \
+        'BindsTo=pipewire-pulse.service'
     '';
   };
 }


### PR DESCRIPTION
Fluidsynth's systemd unit currently has a hard dependency on the
pulseaudio systemd service. Since fluidsynth can use other sound
services (e.g., pipewire-pulse), this should be configurable. This commit
adds the relevant option.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
