### PR TITLE
files: factor the dry run logic out of onChange hooks

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -298,8 +298,13 @@ in
 
     home.activation.onFilesChange = hm.dag.entryAfter ["linkGeneration"] (
       concatMapStrings (v: ''
-        if [[ ''${changedFiles[${escapeShellArg v.target}]} -eq 1 ]]; then
-          ${v.onChange}
+        if (( ''${changedFiles[${escapeShellArg v.target}]} == 1 )); then
+          if [[ -v DRY_RUN || -v VERBOSE ]]; then
+            echo "Running onChange hook for" ${escapeShellArg v.target}
+          fi
+          if [[ ! -v DRY_RUN ]]; then
+            ${v.onChange}
+          fi
         fi
       '') (filter (v: v.onChange != "") (attrValues cfg))
     );

--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -6,14 +6,6 @@ let
 
   cfg = config.programs.i3status-rust;
 
-  restartI3 = ''
-    i3Socket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/i3/ipc-socket.*
-    if [ -S $i3Socket ]; then
-      echo "Reloading i3"
-      $DRY_RUN_CMD ${config.xsession.windowManager.i3.package}/bin/i3-msg -s $i3Socket restart 1>/dev/null
-    fi
-  '';
-
   settingsFormat = pkgs.formats.toml { };
 
 in {
@@ -258,7 +250,12 @@ in {
 
     xdg.configFile = mapAttrs' (cfgFileSuffix: cfg:
       nameValuePair ("i3status-rust/config-${cfgFileSuffix}.toml") ({
-        onChange = mkIf config.xsession.windowManager.i3.enable restartI3;
+        onChange = mkIf config.xsession.windowManager.i3.enable ''
+          i3Socket="''${XDG_RUNTIME_DIR:-/run/user/$UID}/i3/ipc-socket.*"
+          if [[ -S $i3Socket ]]; then
+            ${config.xsession.windowManager.i3.package}/bin/i3-msg -s $i3Socket restart >/dev/null
+          fi
+        '';
 
         source = settingsFormat.generate ("config-${cfgFileSuffix}.toml") ({
           theme = cfg.theme;

--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -309,10 +309,9 @@ in {
       mkIf pkgs.stdenv.hostPlatform.isLinux {
         text = qutebrowserConfig;
         onChange = ''
-          hash="$(echo -n $USER | md5sum | cut -d' ' -f1)"
+          hash="$(echo -n "$USER" | md5sum | cut -d' ' -f1)"
           socket="''${XDG_RUNTIME_DIR:-/run/user/$UID}/qutebrowser/ipc-$hash"
-          if [ -S $socket ]; then
-            echo "Reloading qutebrowser"
+          if [[ -S $socket ]]; then
             command=${
               escapeShellArg (builtins.toJSON {
                 args = [ ":config-source" ];
@@ -320,7 +319,7 @@ in {
                 protocol_version = 1;
               })
             }
-            $DRY_RUN_CMD echo $command | ${pkgs.socat}/bin/socat -lf /dev/null - UNIX-CONNECT:$socket
+            echo "$command" | ${pkgs.socat}/bin/socat -lf /dev/null - UNIX-CONNECT:"$socket"
           fi
           unset hash socket command
         '';

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -192,12 +192,7 @@ in {
       xdg.configFile."dunst/dunstrc" = {
         text = toDunstIni cfg.settings;
         onChange = ''
-          pkillVerbose=""
-          if [[ -v VERBOSE ]]; then
-            pkillVerbose="-e"
-          fi
-          $DRY_RUN_CMD ${pkgs.procps}/bin/pkill -u $USER $pkillVerbose dunst || true
-          unset pkillVerbose
+          ${pkgs.procps}/bin/pkill -u "$USER" ''${VERBOSE+-e} dunst || true
         '';
       };
     })

--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -255,8 +255,7 @@ in {
         onChange = ''
           i3Socket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/i3/ipc-socket.*
           if [ -S $i3Socket ]; then
-            echo "Reloading i3"
-            $DRY_RUN_CMD ${cfg.package}/bin/i3-msg -s $i3Socket reload 1>/dev/null
+            ${cfg.package}/bin/i3-msg -s $i3Socket reload >/dev/null
           fi
         '';
       };

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -438,10 +438,9 @@ in {
       xdg.configFile."sway/config" = {
         source = configFile;
         onChange = ''
-          swaySocket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.$(${pkgs.procps}/bin/pgrep -x sway || ${pkgs.coreutils}/bin/true).sock
+          swaySocket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.$(${pkgs.procps}/bin/pgrep -x sway || true).sock
           if [ -S $swaySocket ]; then
-            echo "Reloading sway"
-            $DRY_RUN_CMD ${pkgs.sway}/bin/swaymsg -s $swaySocket reload
+            ${pkgs.sway}/bin/swaymsg -s $swaySocket reload
           fi
         '';
       };

--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -161,9 +161,8 @@ in {
         source = xmonadBin;
         onChange = ''
           # Attempt to restart xmonad if X is running.
-          if [[ -v DISPLAY ]] ; then
-            echo "Restarting xmonad"
-            $DRY_RUN_CMD ${config.xsession.windowManager.command} --restart
+          if [[ -v DISPLAY ]]; then
+            ${config.xsession.windowManager.command} --restart
           fi
         '';
       };

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -93,8 +93,8 @@ in {
           ++ optionals (cfg.properties != null)
           (mapAttrsToList formatLine cfg.properties)) + "\n";
         onChange = ''
-          if [[ -v DISPLAY ]] ; then
-            $DRY_RUN_CMD ${xrdbMerge}
+          if [[ -v DISPLAY ]]; then
+            ${xrdbMerge}
           fi
         '';
       };


### PR DESCRIPTION
### Description

Fixes #751, see there for background.

I cleaned up the existing `onChange` hooks according to the following guidelines:

- don't use `DRY_RUN`(`_CMD`)
- don't output generic "Reloading foo" messages, but do make use of `VERBOSE`(`_ECHO`) where applicable

and general good Bash practice.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

