### PR TITLE
Add initExtra option to neovim

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -79,6 +79,14 @@ in {
         '';
       };
 
+      initExtra = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Configuration to insert on the top of init.vim
+        '';
+      };
+
       vimAlias = mkOption {
         type = types.bool;
         default = false;
@@ -129,15 +137,6 @@ in {
         description = ''
           A function in python.withPackages format, which returns a
           list of Python 3 packages required for your plugins to work.
-        '';
-      };
-
-      generatedConfigViml = mkOption {
-        type = types.lines;
-        visible = true;
-        readOnly = true;
-        description = ''
-          Generated vimscript config.
         '';
       };
 
@@ -277,6 +276,7 @@ in {
       plugins = cfg.plugins
         ++ optionals cfg.coc.enable [ pkgs.vimPlugins.coc-nvim ];
       customRC = cfg.extraConfig;
+      initExtra = cfg.initExtra;
     };
 
   in mkIf cfg.enable {
@@ -289,13 +289,15 @@ in {
         configure.customRC -> programs.neovim.extraConfig
     '';
 
-    programs.neovim.generatedConfigViml = neovimConfig.neovimRcContent;
-
     home.packages = [ cfg.finalPackage ];
 
     xdg.configFile."nvim/init.vim" = mkIf (neovimConfig.neovimRcContent != "") {
-      text = neovimConfig.neovimRcContent;
+      text = ''
+        ${neovimConfig.initExtra}
+        ${neovimConfig.neovimRcContent}
+      '';
     };
+
     xdg.configFile."nvim/coc-settings.json" = mkIf cfg.coc.enable {
       source = jsonFormat.generate "coc-settings.json" cfg.coc.settings;
     };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
This PR adds an `initExtra` option to neovim, allowing users to add vimscript configuration to the top of the generated `init.vim`,
without using workarounds such as #2213. The generated init.vim will have the following shape:

```
{initExtra}
{pluginsConfiguration}
{extraConfig}
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
