### PR TITLE
programs.java: init

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,6 +95,8 @@
 
 /modules/programs/i3status-rust.nix                   @workflow
 
+/modules/programs/java.nix                            @ShamrockLee
+
 /modules/programs/keychain.nix                        @marsam
 
 /modules/programs/lazygit.nix                         @kalhauge

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2157,6 +2157,13 @@ in
           A new module is available: 'services.notify-osd'.
         '';
       }
+
+      {
+        time = "2021-08-10T21:28:40+00:00";
+        message = ''
+          A new module is available: 'programs.java'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -77,6 +77,7 @@ let
     ./programs/i3status.nix
     ./programs/info.nix
     ./programs/irssi.nix
+    ./programs/java.nix
     ./programs/jq.nix
     ./programs/kakoune.nix
     ./programs/keychain.nix

--- a/modules/programs/java.nix
+++ b/modules/programs/java.nix
@@ -1,0 +1,46 @@
+# This module provides JAVA_HOME, with a different way to install java locally.
+# This module is modified from the NixOS module `programs.java`
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.java;
+
+in {
+  meta.maintainers = with maintainers; [ ShamrockLee ];
+
+  options = {
+    programs.java = {
+      enable = mkEnableOption "" // {
+        description = ''
+          Install the Java development kit and set the <envar>JAVA_HOME</envar>
+          variable.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.jdk;
+        defaultText = "pkgs.jdk";
+        description = ''
+          Java package to install. Typical values are
+          <literal>pkgs.jdk</literal> or <literal>pkgs.jre</literal>.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.sessionVariables = {
+      JAVA_HOME = fileContents (pkgs.runCommandLocal "java-home" { } ''
+        source "${cfg.package}/nix-support/setup-hook"
+        echo "$JAVA_HOME" > $out
+      '');
+    };
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Create a module `programs.java` that install the java package specified by the `package` attribute and set the corresponding `JAVA_HOME` using `home.sessionVariables`.

Solve issue #845 

Note: Due to `sessionVariables` issue #1011, this may not work out of the box on graphical sessions.

As a workaround, if you use `xsession.windowManager.command`, add the line
```sh
. "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
```
before starting the session.

If you do not use Home Manager to manage the graphical session, put the above line in the init scripts or source it when needed.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`. (Failure prior to this commit, probably due to version mismatch)

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
