### PR TITLE
powerline-go: add fish integration

### DIFF
--- a/modules/programs/powerline-go.nix
+++ b/modules/programs/powerline-go.nix
@@ -140,5 +140,14 @@ in {
         install_powerline_precmd
       fi
     '';
+
+    # https://github.com/justjanne/powerline-go#fish
+    programs.fish.promptInit =
+      mkIf (cfg.enable && config.programs.fish.enable) ''
+        function fish_prompt
+            eval ${pkgs.powerline-go}/bin/powerline-go -error $status -jobs (count (jobs -p)) ${commandLineArguments}
+            ${cfg.extraUpdatePS1}
+        end
+      '';
   };
 }

--- a/tests/modules/programs/powerline-go/default.nix
+++ b/tests/modules/programs/powerline-go/default.nix
@@ -1,4 +1,5 @@
 {
   powerline-go-bash = ./bash.nix;
   powerline-go-zsh = ./zsh.nix;
+  powerline-go-fish = ./fish.nix;
 }

--- a/tests/modules/programs/powerline-go/fish.nix
+++ b/tests/modules/programs/powerline-go/fish.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs = {
+      fish.enable = true;
+
+      powerline-go = {
+        enable = true;
+        newline = true;
+        modules = [ "nix-shell" ];
+        pathAliases = { "\\~/project/foo" = "prj-foo"; };
+        settings = {
+          ignore-repos = [ "/home/me/project1" "/home/me/project2" ];
+        };
+      };
+    };
+
+    # Needed to avoid error with dummy fish package.
+    xdg.dataFile."fish/home-manager_generated_completions".source =
+      mkForce (builtins.toFile "empty" "");
+
+    nixpkgs.overlays = [
+      (self: super:
+        let dummy = pkgs.writeScriptBin "dummy" "";
+        in {
+          powerline-go = dummy;
+          fish = dummy;
+        })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/fish/config.fish
+      assertFileContains \
+        home-files/.config/fish/config.fish \
+        '/bin/powerline-go -error $status -jobs (count (jobs -p)) -modules nix-shell -newline -path-aliases \~/project/foo=prj-foo -ignore-repos /home/me/project1,/home/me/project2'
+    '';
+  };
+}


### PR DESCRIPTION
### Description
Add fish integration for powerline-go.

### Checklist
- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like
```
{component}: {description}
{long description}
```
See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
