### PR TITLE
picom: add tooltip opacity config

### DIFF
--- a/modules/services/picom.nix
+++ b/modules/services/picom.nix
@@ -41,6 +41,7 @@ let
       dnd           = { shadow = ${toJSON (!cfg.noDNDShadow)}; };
       popup_menu    = { opacity = ${cfg.menuOpacity}; };
       dropdown_menu = { opacity = ${cfg.menuOpacity}; };
+      tooltip       = { opacity = ${cfg.tooltipOpacity}; };
     };
 
     # other options
@@ -216,6 +217,15 @@ in {
       example = "0.8";
       description = ''
         Opacity of dropdown and popup menu.
+      '';
+    };
+
+    tooltipOpacity = mkOption {
+      type = types.str;
+      default = "1.0";
+      example = "0.8";
+      description = ''
+        Opacity of tooltips.
       '';
     };
 


### PR DESCRIPTION
### Description

Currently there is no way to specify tooltips opacity in picom config. It accepts only one `wintypes` setting. So add as parameter.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
