### PR TITLE
local gpg-agent acting as ssh-agent should yield (#667)

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -205,7 +205,7 @@ in
 
       home.sessionVariablesExtra = optionalString cfg.enableSshSupport ''
         if [[ -z "$SSH_AUTH_SOCK" ]]; then
-          export SSH_AUTH_SOCK=$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)
+          export SSH_AUTH_SOCK="$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)"
         fi
       '';
 

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -203,10 +203,11 @@ in
         [ cfg.extraConfig ]
       );
 
-      home.sessionVariables =
-        optionalAttrs cfg.enableSshSupport {
-          SSH_AUTH_SOCK = "$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)";
-        };
+      home.sessionVariablesExtra = optionalString cfg.enableSshSupport ''
+        if [[ -z "$SSH_AUTH_SOCK" ]]; then
+          export SSH_AUTH_SOCK=$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)
+        fi
+      '';
 
       programs.bash.initExtra = gpgInitStr;
       programs.zsh.initExtra = gpgInitStr;


### PR DESCRIPTION
### Description

This happens commonly if someone using home manager with gpg-agent
acting as ssh-agent on both machines.

@rycee brought up how gpg-itself has some support for agents on both
ends, but in that case one is forwarding the gpg-agent socket rather
than forwardning the gpg-agent-as-ssh-agent socket. There is no need to
forward both.

So I think this is a good default:

 - Forward just gpg-agent socket and this doesn't matter.

 - Forward just the ssh-agent socket and this does the right thing.

 - Forward both sockets and now the ssh one takes priority instead, but
   forwarding both was always a silly thing to do.

Fixes #667

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
