### PR TITLE
nix-index: use dummy fish package in tests

### DIFF
--- a/tests/modules/programs/fish/functions.nix
+++ b/tests/modules/programs/fish/functions.nix
@@ -30,6 +30,13 @@ in {
       };
     };
 
+    # Needed to avoid error with dummy fish package.
+    xdg.dataFile."fish/home-manager_generated_completions".source =
+      lib.mkForce (builtins.toFile "empty" "");
+
+    nixpkgs.overlays =
+      [ (self: super: { fish = pkgs.writeScriptBin "dummy" ""; }) ];
+
     nmt = {
       description =
         "if fish.function is set, check file exists and contents match";

--- a/tests/modules/programs/fish/no-functions.nix
+++ b/tests/modules/programs/fish/no-functions.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
@@ -9,6 +9,13 @@ with lib;
 
       functions = { };
     };
+
+    # Needed to avoid error with dummy fish package.
+    xdg.dataFile."fish/home-manager_generated_completions".source =
+      lib.mkForce (builtins.toFile "empty" "");
+
+    nixpkgs.overlays =
+      [ (self: super: { fish = pkgs.writeScriptBin "dummy" ""; }) ];
 
     nmt = {
       description =

--- a/tests/modules/programs/fish/plugins.nix
+++ b/tests/modules/programs/fish/plugins.nix
@@ -46,6 +46,13 @@ in {
       }];
     };
 
+    # Needed to avoid error with dummy fish package.
+    xdg.dataFile."fish/home-manager_generated_completions".source =
+      lib.mkForce (builtins.toFile "empty" "");
+
+    nixpkgs.overlays =
+      [ (self: super: { fish = pkgs.writeScriptBin "dummy" ""; }) ];
+
     nmt = {
       description =
         "if fish.plugins set, check conf.d file exists and contents match";

--- a/tests/modules/programs/nix-index/assert-on-command-not-found.nix
+++ b/tests/modules/programs/nix-index/assert-on-command-not-found.nix
@@ -1,4 +1,6 @@
-{ pkgs, ... }: {
+{ lib, pkgs, ... }:
+
+{
   config = {
     programs.bash.enable = true;
     programs.fish.enable = true;
@@ -6,8 +8,18 @@
 
     programs.command-not-found.enable = true;
 
-    nixpkgs.overlays =
-      [ (self: super: { zsh = pkgs.writeScriptBin "dummy-zsh" ""; }) ];
+    # Needed to avoid error with dummy fish package.
+    xdg.dataFile."fish/home-manager_generated_completions".source =
+      lib.mkForce (builtins.toFile "empty" "");
+
+    nixpkgs.overlays = [
+      (self: super:
+        let dummy = pkgs.writeScriptBin "dummy" "";
+        in {
+          zsh = dummy;
+          fish = dummy;
+        })
+    ];
 
     programs.nix-index.enable = true;
 

--- a/tests/modules/programs/nix-index/integrations.nix
+++ b/tests/modules/programs/nix-index/integrations.nix
@@ -1,4 +1,5 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
+
 let
   fishRegex = ''
     function __fish_command_not_found_handler --on-event fish_command_not_found
@@ -11,8 +12,18 @@ in {
     programs.fish.enable = true;
     programs.zsh.enable = true;
 
-    nixpkgs.overlays =
-      [ (self: super: { zsh = pkgs.writeScriptBin "dummy-zsh" ""; }) ];
+    # Needed to avoid error with dummy fish package.
+    xdg.dataFile."fish/home-manager_generated_completions".source =
+      lib.mkForce (builtins.toFile "empty" "");
+
+    nixpkgs.overlays = [
+      (self: super:
+        let dummy = pkgs.writeScriptBin "dummy" "";
+        in {
+          zsh = dummy;
+          fish = dummy;
+        })
+    ];
 
     programs.nix-index.enable = true;
 


### PR DESCRIPTION
### Description

Avoid pulling in fish in test suite.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
