### PR TITLE
bash,zsh: add config guards

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -170,6 +170,10 @@ in
         ));
     in mkIf cfg.enable {
       home.file.".bash_profile".source = pkgs.writeShellScript "bash_profile" ''
+        # Only execute this file once per shell.
+        if [ -n "$__HM_BASH_PROFILE_SOURCED" ]; then return; fi
+        __HM_BASH_PROFILE_SOURCED=1
+
         # include .profile if it exists
         [[ -f ~/.profile ]] && . ~/.profile
 
@@ -178,6 +182,10 @@ in
       '';
 
       home.file.".profile".source = pkgs.writeShellScript "profile" ''
+        # Only execute this file once per shell.
+        if [ -n "$__HM_PROFILE_SOURCED" ]; then return; fi
+        __HM_PROFILE_SOURCED=1
+
         . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
         ${sessionVarsStr}
@@ -186,6 +194,10 @@ in
       '';
 
       home.file.".bashrc".source = pkgs.writeShellScript "bashrc" ''
+        # Only execute this file once per shell.
+        if [ -n "$__HM_BASHRC_SOURCED" ]; then return; fi
+        __HM_BASHRC_SOURCED=1
+
         ${cfg.bashrcExtra}
 
         # Commands that should be applied only for interactive shells.

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -410,7 +410,13 @@ in
     })
 
     (mkIf (cfg.profileExtra != "") {
-      home.file."${relToDotDir ".zprofile"}".text = cfg.profileExtra;
+      home.file."${relToDotDir ".zprofile"}".text = ''
+        # Only execute this file once per shell.
+        if [ -n "$__HM_ZPROFILE_SOURCED" ]; then return; fi
+        __HM_ZPROFILE_SOURCED=1
+
+        ${cfg.profileExtra}
+      '';
     })
 
     (mkIf (cfg.loginExtra != "") {
@@ -438,6 +444,10 @@ in
       # already set correctly (by e.g. spawning a zsh inside a zsh), all env
       # vars still get exported
       home.file.".zshenv".text = ''
+        # Only execute this file once per shell.
+        if [ -n "$__HM_ZSHENV_SOURCED" ]; then return; fi
+        __HM_ZSHENV_SOURCED=1
+
         source ${zdotdir}/.zshenv
       '';
     })
@@ -448,6 +458,10 @@ in
         ++ optional cfg.oh-my-zsh.enable oh-my-zsh;
 
       home.file."${relToDotDir ".zshrc"}".text = ''
+        # Only execute this file once per shell.
+        if [ -n "$__HM_ZSHRC_SOURCED" ]; then return; fi
+        __HM_ZSHRC_SOURCED=1
+
         ${cfg.initExtraFirst}
 
         typeset -U path cdpath fpath manpath


### PR DESCRIPTION
### Description

Add guards to prevent user from accidentally sourcing the same config file for a second time and wrecking the environment.

See https://github.com/nix-community/home-manager/pull/2230#issuecomment-894872504

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
