### PR TITLE
doc: user.users.eve -> users.users.eve for nix-darwin

### DIFF
--- a/doc/installation.adoc
+++ b/doc/installation.adoc
@@ -224,7 +224,7 @@ For example, a nix-darwin configuration may include the lines
 
 [source,nix]
 ----
-user.users.eve = {
+users.users.eve = {
   name = "eve";
   home = "/Users/eve";
 }


### PR DESCRIPTION
### Description

`user.users` doesn't exist on `nix-darwin`. It's `users.users` instead. I ran into this when trying to set up my Mac with Home Manager this morning. This PR makes a minor change to fix that.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [ ] ~Change is backwards compatible.~

- [ ] ~Code formatted with `./format`.~

- [ ] ~Code tested through `nix-shell --pure tests -A run.all`.~

- [ ] ~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~If this PR adds a new module~

  - [ ] ~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~

  - [ ] ~Added myself and the module files to `.github/CODEOWNERS`.~
