### PR TITLE
lib.gvariant: escape newlines in strings

### DIFF
--- a/modules/lib/gvariant.nix
+++ b/modules/lib/gvariant.nix
@@ -122,8 +122,9 @@ in rec {
     };
 
   mkString = v:
-    mkPrimitive type.string v // {
-      __toString = self: "'${escape [ "'" "\\" ] self.value}'";
+    let sanitize = s: replaceStrings [ "\n" ] [ "\\n" ] (escape [ "'" "\\" ] s);
+    in mkPrimitive type.string v // {
+      __toString = self: "'${sanitize self.value}'";
     };
 
   mkObjectpath = v:

--- a/tests/lib/types/gvariant-merge.nix
+++ b/tests/lib/types/gvariant-merge.nix
@@ -26,7 +26,11 @@ in {
 
         { string = "foo"; }
         { string = "foo"; }
-        { escapedString = "' \\"; }
+        {
+          escapedString = ''
+            '\
+          '';
+        }
 
         { tuple = mkTuple [ 1 [ "foo" ] ]; }
 
@@ -47,7 +51,7 @@ in {
             bool = true
             emptyArray1 = @as []
             emptyArray2 = @as []
-            escapedString = '\' \\'
+            escapedString = '\'\\\n'
             float = 3.140000
             int = 42
             list = @as ['one','two']


### PR DESCRIPTION
### Description

Handle Nix strings that contain newline characters. See #2096

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```