### PR TITLE
Remove test dependency on zsh

### DIFF
--- a/tests/modules/programs/scmpuff/no-shell.nix
+++ b/tests/modules/programs/scmpuff/no-shell.nix
@@ -10,6 +10,9 @@
       zsh.enable = true;
     };
 
+    nixpkgs.overlays =
+      [ (self: super: { zsh = pkgs.writeScriptBin "dummy" ""; }) ];
+
     nmt.script = ''
       assertFileNotRegex home-files/.zshrc '${pkgs.scmpuff} init -s'
       assertFileNotRegex home-files/.bashrc '${pkgs.scmpuff} init -s'

--- a/tests/modules/programs/scmpuff/no-zsh.nix
+++ b/tests/modules/programs/scmpuff/no-zsh.nix
@@ -8,6 +8,9 @@
       zsh.enable = true;
     };
 
+    nixpkgs.overlays =
+      [ (self: super: { zsh = pkgs.writeScriptBin "dummy" ""; }) ];
+
     nmt.script = ''
       assertFileNotRegex home-files/.zshrc '${pkgs.scmpuff} init -s'
     '';

--- a/tests/modules/programs/scmpuff/zsh.nix
+++ b/tests/modules/programs/scmpuff/zsh.nix
@@ -5,6 +5,9 @@
       zsh.enable = true;
     };
 
+    nixpkgs.overlays =
+      [ (self: super: { zsh = pkgs.writeScriptBin "dummy" ""; }) ];
+
     nmt.script = ''
       assertFileExists home-files/.zshrc
       assertFileContains \


### PR DESCRIPTION
### Description

Avoid pulling down zsh in tests.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```