### PR TITLE
lib.gvariant: fix rendering of empty non-string arrays

### DIFF
--- a/modules/lib/gvariant.nix
+++ b/modules/lib/gvariant.nix
@@ -71,6 +71,8 @@ in rec {
 
   inherit type typeOf;
 
+  isGVariant = v: v._type or "" == "gvariant";
+
   isArray = hasPrefix "a";
   isMaybe = hasPrefix "m";
   isTuple = hasPrefix "(";

--- a/modules/lib/types.nix
+++ b/modules/lib/types.nix
@@ -70,7 +70,11 @@ in rec {
     check = v: gvar.mkValue v != null;
     merge = loc: defs:
       let
-        vdefs = map (d: d // { value = gvar.mkValue d.value; }) defs;
+        vdefs = map (d:
+          d // {
+            value =
+              if gvar.isGVariant d.value then d.value else gvar.mkValue d.value;
+          }) defs;
         vals = map (d: d.value) vdefs;
         defTypes = map (x: x.type) vals;
         sameOrNull = x: y: if x == y then y else null;
@@ -82,8 +86,10 @@ in rec {
           + " mismatched GVariant types given in"
           + " ${showFiles (getFiles defs)}.")
       else if gvar.isArray sharedDefType && allChecked then
-        (types.listOf gvariant).merge loc
-        (map (d: d // { value = d.value.value; }) vdefs)
+        gvar.mkValue ((types.listOf gvariant).merge loc
+          (map (d: d // { value = d.value.value; }) vdefs)) // {
+            type = sharedDefType;
+          }
       else if gvar.isTuple sharedDefType && allChecked then
         mergeOneOption loc defs
       else if gvar.isMaybe sharedDefType && allChecked then

--- a/tests/lib/types/gvariant-merge.nix
+++ b/tests/lib/types/gvariant-merge.nix
@@ -33,8 +33,10 @@ in {
         { uint64 = mkUint64 42; }
         { uint64 = mkUint64 42; }
 
-        { list = [ "one" ]; }
-        { list = mkArray type.string [ "two" ]; }
+        { array1 = [ "one" ]; }
+        { array1 = mkArray type.string [ "two" ]; }
+        { array2 = mkArray type.uint32 [ 1 ]; }
+        { array2 = mkArray type.uint32 [ 2 ]; }
 
         { emptyArray1 = [ ]; }
         { emptyArray2 = mkEmptyArray type.uint32; }
@@ -63,15 +65,16 @@ in {
         home-files/result.txt \
         ${
           pkgs.writeText "expected.txt" ''
+            array1 = @as ['one','two']
+            array2 = @au [1,2]
             bool = true
             emptyArray1 = @as []
-            emptyArray2 = @as []
+            emptyArray2 = @au []
             escapedString = '\'\\\n'
             float = 3.140000
             int = -42
             int16 = @n -42
             int64 = @x -42
-            list = @as ['one','two']
             maybe1 = @ms nothing
             maybe2 = just @u 4
             string = 'foo'


### PR DESCRIPTION
### Description

Before, empty arrays would always be rendered as an empty string array.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```