### PR TITLE
home-manager: allow remote builders for nix-build

### DIFF
--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -292,7 +292,8 @@ _home-manager_completions ()
     local Options
     Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" "--verbose" \
               "--cores" "--debug" "--keep-failed" "--keep-going" "-j" "--max-jobs" \
-              "--no-substitute" "--no-out-link" "--show-trace" "--substitute")
+              "--no-substitute" "--no-out-link" "--show-trace" "--substitute" \
+              "--builders")
 
     # ^ « home-manager »'s options.
 

--- a/home-manager/completion.fish
+++ b/home-manager/completion.fish
@@ -57,6 +57,7 @@ complete -c home-manager -f -l "keep-failed" -d "Keep temporary directory used b
 complete -c home-manager -f -l "keep-going" -d "Keep going in case of failed builds"
 complete -c home-manager -x -s j -l "max-jobs" -d "Max number of build jobs in parallel"
 complete -c home-manager -x -l "option" -d "Set Nix configuration option"
+complete -c home-manager -x -l "builders" -d "Remote builders"
 complete -c home-manager -f -l "show-trace" -d "Print stack trace of evaluation errors"
 complete -c home-manager -f -l "substitute"
 complete -c home-manager -f -l "no-substitute"

--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -16,6 +16,7 @@ _arguments \
   '(-f --file)'{--file,-f}'[configuration file]:FILE:_files' \
   '(-j --max-jobs)'{--max-jobs,-j}'[max jobs]:NUM:()' \
   '--option[option]:NAME VALUE:()' \
+  '--builders[builders]:SPEC:()' \
   '--show-trace[show trace]' \
   '1: :->cmds' \
   '*:: :->args' && ret=0
@@ -52,7 +53,8 @@ case "$state" in
           '--no-substitute[no substitute]' \
           '--option[option]:NAME VALUE:()' \
           '--show-trace[show trace]' \
-          '--substitute[substitute]'
+          '--substitute[substitute]' \
+          '--builders[builders]:SPEC:()'
         ;;
     esac
 esac

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -523,6 +523,7 @@ function doHelp() {
     echo "  --show-trace"
     echo "  --(no-)substitute"
     echo "  --no-out-link            Do not create a symlink to the output path"
+    echo "  --builders VALUE"
     echo
     echo "Commands"
     echo
@@ -618,7 +619,7 @@ while [[ $# -gt 0 ]]; do
             PASSTHROUGH_OPTS+=("$opt" "$1" "$2")
             shift 2
             ;;
-        -j|--max-jobs|--cores)
+        -j|--max-jobs|--cores|--builders)
             PASSTHROUGH_OPTS+=("$opt" "$1")
             shift
             ;;


### PR DESCRIPTION
### Description

This allows running home-manager with `--builders` option passed through to `nix-build`, which will then pass build execution to remote builders on other machines.

This may be useful with relatively complex home-manager configurations where building the profile on a local machine is not feasible.

### Checklist

- [x] Change is backwards compatible.
- [x] Commit messages are formatted like the contributing guidelines suggest.
