### PR TITLE
doc: Add an example for a git includes section

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -108,8 +108,26 @@ let
       contents = mkOption {
         type = types.attrsOf types.anything;
         default = { };
+        example = literalExample ''
+          {
+            user = {
+              email = "bob@work.example.com";
+              name = "Bob Work";
+              signingKey = "1A2B3C4D5E6F7G8H";
+            };
+            commit = {
+              gpgSign = true;
+            };
+          };
+        '';
         description = ''
           Configuration to include. If empty then a path must be given.
+
+          This follows the configuration structure as described in
+          <citerefentry>
+            <refentrytitle>git-config</refentrytitle>
+            <manvolnum>1</manvolnum>
+          </citerefentry>.
         '';
       };
     };


### PR DESCRIPTION
This adds an example for the `programs.git.includes.*.contents` section
since it was a bit ambiguous as to what kind of format it expects.

### Description

<!--

I had a bit of troubles with the format this option expected. At first I thought that the keys should be the same that home-manager git configuration uses, but then I figured out that they should be as git-config expects them. I think that an example as to what kind of format it expects solves this issue.

First time contributor, so let me know if there are any issues. 

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
