### PR TITLE
i3/sway: allow empty criterias using a value of 'true'

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -4,9 +4,10 @@ with lib;
 
 rec {
   criteriaStr = criteria:
-    "[${
-      concatStringsSep " " (mapAttrsToList (k: v: ''${k}="${v}"'') criteria)
-    }]";
+    let
+      toCriteria = k: v:
+        if builtins.isBool v && v then "${k}" else ''${k}="${v}"'';
+    in "[${concatStringsSep " " (mapAttrsToList toCriteria criteria)}]";
 
   keybindingDefaultWorkspace = filterAttrs (n: v:
     cfg.config.defaultWorkspace != null && v == cfg.config.defaultWorkspace)

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -6,7 +6,10 @@ rec {
   criteriaStr = criteria:
     let
       toCriteria = k: v:
-        if builtins.isBool v && v then "${k}" else ''${k}="${v}"'';
+        if builtins.isBool v then
+          (if v then "${k}" else "")
+        else
+          ''${k}="${v}"'';
     in "[${concatStringsSep " " (mapAttrsToList toCriteria criteria)}]";
 
   keybindingDefaultWorkspace = filterAttrs (n: v:

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -353,14 +353,23 @@ let
 
       criteria = mkOption {
         type = criteriaModule;
-        description =
-          "Criteria of the windows on which command should be executed.";
-        example = { title = "x200: ~/work"; };
+        description = ''
+          Criteria of the windows on which command should be executed.
+          </para><para>
+          A value of <literal>true</literal> is equivalent to using an empty
+          criteria (which is different from an empty string criteria).
+        '';
+        example = literalExample ''
+          {
+            title = "x200: ~/work";
+            floating = true;
+          };
+        '';
       };
     };
   };
 
-  criteriaModule = types.attrsOf types.str;
+  criteriaModule = types.attrsOf (types.either types.str types.bool);
 in {
   fonts = mkOption {
     type = with types; either (listOf str) fontOptions;


### PR DESCRIPTION
### Description

Allows criteria used by Sway and i3 to be empty (different from the empty string)
using a boolean value of `true`.

Fixes #2274

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
