### PR TITLE
kitty: add environment and darwinLaunchOptions options

### DIFF
--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -25,6 +25,9 @@ let
     mkKeyValue = key: command: "map ${key} ${command}";
   };
 
+  toKittyEnv =
+    generators.toKeyValue { mkKeyValue = name: value: "env ${name}=${value}"; };
+
 in {
   options.programs.kitty = {
     enable = mkEnableOption "Kitty terminal emulator";
@@ -65,6 +68,17 @@ in {
       '';
     };
 
+    environment = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = "Environment variables to set or override.";
+      example = literalExample ''
+        {
+          "LS_COLORS" = "1";
+        }
+      '';
+    };
+
     extraConfig = mkOption {
       default = "";
       type = types.lines;
@@ -88,6 +102,8 @@ in {
       ${toKittyConfig cfg.settings}
 
       ${toKittyKeybindings cfg.keybindings}
+
+      ${toKittyEnv cfg.environment}
 
       ${cfg.extraConfig}
     '';

--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -32,6 +32,19 @@ in {
   options.programs.kitty = {
     enable = mkEnableOption "Kitty terminal emulator";
 
+    darwinLaunchOptions = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      description = "Command-line options to use when launched by Mac OS GUI";
+      example = literalExample ''
+        [
+          "--single-instance"
+          "--directory=/tmp/my-dir"
+          "--listen-on=unix:/tmp/my-socket"
+        ]
+      '';
+    };
+
     settings = mkOption {
       type = types.attrsOf eitherStrBoolInt;
       default = { };
@@ -107,5 +120,10 @@ in {
 
       ${cfg.extraConfig}
     '';
+
+    xdg.configFile."kitty/macos-launch-services-cmdline" =
+      mkIf (!(isNull cfg.darwinLaunchOptions)) {
+        text = concatStringsSep " " cfg.darwinLaunchOptions;
+      };
   };
 }

--- a/tests/modules/programs/kitty/example-macos-launch-services-cmdline
+++ b/tests/modules/programs/kitty/example-macos-launch-services-cmdline
@@ -1,0 +1,1 @@
+--single-instance --directory=/tmp/my-dir --listen-on=unix:/tmp/my-socket

--- a/tests/modules/programs/kitty/example-settings-expected.conf
+++ b/tests/modules/programs/kitty/example-settings-expected.conf
@@ -14,4 +14,7 @@ map ctrl+c copy_or_interrupt
 map ctrl+f>2 set_font_size 20
 
 
+env LS_COLORS=1
+
+
 

--- a/tests/modules/programs/kitty/example-settings.nix
+++ b/tests/modules/programs/kitty/example-settings.nix
@@ -6,6 +6,13 @@ with lib;
   config = {
     programs.kitty = {
       enable = true;
+
+      darwinLaunchOptions = [
+        "--single-instance"
+        "--directory=/tmp/my-dir"
+        "--listen-on=unix:/tmp/my-socket"
+      ];
+
       settings = {
         scrollback_lines = 10000;
         enable_audio_bell = false;
@@ -31,6 +38,9 @@ with lib;
       assertFileContent \
         home-files/.config/kitty/kitty.conf \
         ${./example-settings-expected.conf}
+      assertFileContent \
+        home-files/.config/kitty/macos-launch-services-cmdline \
+        ${./example-macos-launch-services-cmdline}
     '';
   };
 }

--- a/tests/modules/programs/kitty/example-settings.nix
+++ b/tests/modules/programs/kitty/example-settings.nix
@@ -19,6 +19,8 @@ with lib;
         "ctrl+c" = "copy_or_interrupt";
         "ctrl+f>2" = "set_font_size 20";
       };
+
+      environment = { LS_COLORS = "1"; };
     };
 
     nixpkgs.overlays =


### PR DESCRIPTION
### Description

Add `environment` and `darwinLaunchOptions`.


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.



ASIDE: ./format refuses to run, but I was able to run nixfmt manually:
```
ᐅ ./format
error: anonymous function at /nix/store/lhwxcryxzszrjxbpnwjwcp2y7c6m60h9-source/pkgs/top-level/default.nix:20:1 called with unexpected argument 'inNixShell'

       at /nix/store/lhwxcryxzszrjxbpnwjwcp2y7c6m60h9-source/pkgs/top-level/impure.nix:84:1:

           83|
           84| import ./. (builtins.removeAttrs args [ "system" "platform" ] // {
             | ^
           85|   inherit config overlays crossSystem crossOverlays;
```