### PR TITLE
nixos: Fix race condition with user units

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -129,6 +129,7 @@ in {
         wantedBy = [ "multi-user.target" ];
         wants = [ "nix-daemon.socket" ];
         after = [ "nix-daemon.socket" ];
+        before = [ "systemd-user-sessions.service" ];
 
         environment = serviceEnvironment;
 


### PR DESCRIPTION
### Description

One of the things managed by the `home-manager-<username>` unit is the systemd user directory `.config/systemd/user`.  However, this directory needs to be in place completely before systemd user sessions start up or the user sessions will come up with an incomplete listing of enabled units, etc.

There was a race condition where nothing prevented `systemd-user-sessions.service` from starting ahead of the systemd user
directory's initialization completing.  This commit makes `home-manager-<username>` finishes _before_ we start `systemd-user-sessions.service` to avoid such race condition.

This issue was probably not all that noticeable in most cases, but when using a non-persistent root config (i.e. tmp on / or https://grahamc.com/blog/erase-your-darlings) the race condition triggering causes all kinds of issues on each reboot.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
