### PR TITLE
bash: Allow unsetting shell options

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -75,7 +75,14 @@ in
           # Warn if closing shell with running jobs.
           "checkjobs"
         ];
-        description = "Shell options to set.";
+        example = [
+          "extglob"
+          "-cdspell"
+        ];
+        description = ''
+          Shell options to set. Prefix an option with
+          <quote><literal>-</literal></quote> to unset.
+        '';
       };
 
       sessionVariables = mkOption {
@@ -146,8 +153,10 @@ in
         mapAttrsToList (k: v: "alias ${k}=${escapeShellArg v}") cfg.shellAliases
       );
 
-      shoptsStr = concatStringsSep "\n" (
-        map (v: "shopt -s ${v}") cfg.shellOptions
+      shoptsStr = let
+        switch = v: if hasPrefix "-" v then "-u" else "-s";
+      in concatStringsSep "\n" (
+          map (v: "shopt ${switch v} ${removePrefix "-" v}") cfg.shellOptions
       );
 
       sessionVarsStr = config.lib.shell.exportAll cfg.sessionVariables;


### PR DESCRIPTION
I wished to unset a shell option, and, since this already allows setting shell options, I thought it might be appropriate to extend it to allow unsetting a shell option by prefixing it with `-`. (I chose `-` as a prefix rather than `no` because Bash has options which begin with `no`.)

I know that I could unset an option by adding a line to `initExtra`, but this way makes for a cleaner-looking configuration.