### PR TITLE
betterlockscreen: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -214,6 +214,8 @@
 /modules/services/barrier.nix                         @Kritnich
 /tests/modules/services/barrier                       @Kritnich
 
+/modules/services/betterlockscreen.nix                @SebTM
+
 /modules/services/caffeine.nix                        @uvNikita
 
 /modules/services/cbatticon.nix                       @pmiddend

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2188,6 +2188,14 @@ in
           A new module is available: 'services.fnott'.
         '';
       }
+
+      {
+        time = "2021-08-31T18:44:26+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.betterlockscreen'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -148,6 +148,7 @@ let
     ./programs/zsh.nix
     ./programs/zsh/prezto.nix
     ./services/barrier.nix
+    ./services/betterlockscreen.nix
     ./services/blueman-applet.nix
     ./services/caffeine.nix
     ./services/cbatticon.nix

--- a/modules/services/betterlockscreen.nix
+++ b/modules/services/betterlockscreen.nix
@@ -1,0 +1,50 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.betterlockscreen;
+
+in {
+  meta.maintainers = with maintainers; [ sebtm ];
+
+  options = {
+    services.betterlockscreen = {
+      enable = mkEnableOption "betterlockscreen, a screen-locker module";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.betterlockscreen;
+        defaultText = literalExample "pkgs.betterlockscreen";
+        description = "Package providing <command>betterlockscreen</command>.";
+      };
+
+      arguments = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description =
+          "List of arguments appended to <literal>./betterlockscreen --lock [args]</literal>";
+      };
+
+      inactiveInterval = mkOption {
+        type = types.int;
+        default = 10;
+        description = ''
+          Value used for <option>services.screen-locker.inactiveInterval</option>.
+        '';
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    services.screen-locker = {
+      enable = true;
+      inactiveInterval = cfg.inactiveInterval;
+      lockCmd = "${cfg.package}/bin/betterlockscreen --lock ${
+          concatStringsSep " " cfg.arguments
+        }";
+    };
+  };
+}


### PR DESCRIPTION
### Description
As Maintainer and user of Betterlockscreen I wished an easier way to use it as screen-locker under NixOS/with HM.
I would like to extend the module in the future - making arguments configurable and adding tests then.

### Checklist
- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
