### PR TITLE
modules/programs/neomutt: configurable package

### DIFF
--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -231,6 +231,13 @@ in {
     programs.neomutt = {
       enable = mkEnableOption "the NeoMutt mail client";
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.neomutt;
+        defaultText = literalExample "pkgs.neomutt";
+        description = "The neomutt package to use.";
+      };
+
       sidebar = mkOption {
         type = sidebarModule;
         default = { };
@@ -300,7 +307,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.neomutt ];
+    home.packages = [ cfg.package ];
     home.file = let
       rcFile = account: {
         "${accountFilename account}".text = accountStr account;


### PR DESCRIPTION
This makes it possible to easily use a different (e.g. more recent or patched) neomutt package.

### Description

Many modules already expose an API to specify a different package, so this is nothing fundamentally new.

Background/off-topic: I'm using home-manager in a Flakes context (/etc/nixos). I only found two ways to inject a different neomutt package into home-manager's module: either by forking nixpkgs (`inputs.nixpkgs.follows = "nixpkgs"`) and patching neomutt there, or by exposing the `package` option in home-manager. Then I can use my nixpkgs **with overlays** (since I'm in the `outputs` context) and simply say `package = pkgs.neomutt`. If anyone knows a way to use nixpkgs with overlays in the `inputs` section of Nix flakes, I'd be happy to know.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`. (does not work locally (`pkgs/top-level/default.nix:20:1 called with unexpected argument 'inNixShell'`), but formatting should be fine)

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
