### PR TITLE
broot: expose modal option

### DIFF
--- a/modules/programs/broot.nix
+++ b/modules/programs/broot.nix
@@ -44,13 +44,7 @@ in {
       '';
     };
 
-    modal = mkOption {
-      default = false;
-      type = types.bool;
-      description = ''
-        Whether to enable modal (vim) mode.
-      '';
-    };
+    modal = mkEnableOption "modal (vim) mode";
 
     verbs = mkOption {
       type = with types; listOf (attrsOf (either bool str));

--- a/modules/programs/broot.nix
+++ b/modules/programs/broot.nix
@@ -11,6 +11,7 @@ let
   brootConf = {
     verbs = cfg.verbs;
     skin = cfg.skin;
+    modal = cfg.modal;
   };
 
 in {
@@ -40,6 +41,14 @@ in {
       type = types.bool;
       description = ''
         Whether to enable Fish integration.
+      '';
+    };
+
+    modal = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Whether to enable modal (vim) mode.
       '';
     };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -46,6 +46,7 @@ import nmt {
     ./modules/programs/autojump
     ./modules/programs/bash
     ./modules/programs/bat
+    ./modules/programs/broot
     ./modules/programs/browserpass
     ./modules/programs/dircolors
     ./modules/programs/direnv

--- a/tests/modules/programs/broot/broot.nix
+++ b/tests/modules/programs/broot/broot.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.broot = {
+      enable = true;
+      modal = true;
+    };
+
+    nixpkgs.overlays =
+      [ (self: super: { broot = pkgs.writeScriptBin "dummy" ""; }) ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/broot/conf.toml
+      assertFileContent home-files/.config/broot/conf.toml ${
+        pkgs.writeText "broot.expected" ''
+          modal = true
+
+          [[verbs]]
+          execution = ":parent"
+          invocation = "p"
+
+          [[verbs]]
+          execution = "$EDITOR {file}"
+          invocation = "edit"
+          shortcut = "e"
+
+          [[verbs]]
+          execution = "$EDITOR {directory}/{subpath}"
+          invocation = "create {subpath}"
+
+          [[verbs]]
+          execution = "less {file}"
+          invocation = "view"
+
+          [skin]
+        ''
+      }
+    '';
+  };
+}

--- a/tests/modules/programs/broot/default.nix
+++ b/tests/modules/programs/broot/default.nix
@@ -1,0 +1,1 @@
+{ broot = ./broot.nix; }


### PR DESCRIPTION
### Description

Expose the `modal` option in the broot program configuration.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
