### PR TITLE
nix-darwin,nixos: replace {darwin,nixos}Config with osConfig

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -12,6 +12,7 @@ let
     specialArgs = {
       lib = extendedLib;
       darwinConfig = config;
+      osConfig = config;
     } // cfg.extraSpecialArgs;
     modules = [
       ({ name, ... }: {

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -12,6 +12,7 @@ let
     specialArgs = {
       lib = extendedLib;
       nixosConfig = config;
+      osConfig = config;
       modulesPath = ../modules;
     } // cfg.extraSpecialArgs;
     modules = [


### PR DESCRIPTION
### Description

Having either argument defined based on the OS is a problem when
trying to write generic Nix code.

The current workaround is to use accept both and specify a default
value for each argument:

```
{ config, lib, nixosConfig ? {}, darwinConfig ? {}, ... }:

let
  osConfig = nixosConfig // darwinConfig;
in
{
  # Do something with `osConfig`
}
```

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
