### PR TITLE
nixos: add timeout to hm-activate service

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -141,6 +141,7 @@ in {
           User = usercfg.home.username;
           Type = "oneshot";
           RemainAfterExit = "yes";
+          TimeoutStartSec = 90;
           SyslogIdentifier = "hm-activate-${username}";
 
           # The activation script is run by a login shell to make sure


### PR DESCRIPTION
### Description

oneshot services do not have a timeout by default, so a misbehaving activation script can stall and prevent a system from ever booting.

90sec was taken from the systemd defaults, but could be lowered if something lower would be more tolerable.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
