### PR TITLE
vim: add option to specify pkgs.vim_configurable

### DIFF
--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -124,6 +124,13 @@ in {
         description = "Resulting customized vim package";
         readOnly = true;
       };
+
+      packageConfigurable = mkOption {
+        type = types.package;
+        description = "Configurable vim package";
+        default = pkgs.vim_configurable;
+        defaultText = "pkgs.vim_configurable";
+      };
     };
   };
 
@@ -135,7 +142,7 @@ in {
       ${cfg.extraConfig}
     '';
 
-    vim = pkgs.vim_configurable.customize {
+    vim = cfg.packageConfigurable.customize {
       name = "vim";
       vimrcConfig = {
         inherit customRC;


### PR DESCRIPTION
### Description

Feel free to suggest a better option name.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
