### PR TITLE
docs: update session-vars info about fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ Currently the easiest way to install Home Manager is as follows:
     $HOME/.nix-profile/etc/profile.d/hm-session-vars.sh
     ```
 
-    file in your shell configuration. Unfortunately, in this specific
-    case we currently only support POSIX.2-like shells such as
-    [Bash][] or [Z shell][].
+    file in your shell configuration. This file can be sourced
+    directly by POSIX.2-like shells such as [Bash][] or [Z shell][].
 
     For example, if you use Bash then add
 
@@ -124,7 +123,9 @@ Currently the easiest way to install Home Manager is as follows:
     . "/etc/profiles/per-user/$USER/etc/profile.d/hm-session-vars.sh"
     ```
 
-    to your `~/.profile` file.
+    to your `~/.profile` file. For fish shell, it is possible to use
+    [foreign-env](https://github.com/oh-my-fish/plugin-foreign-env) to
+    source the file.
 
 If instead of using channels you want to run Home Manager from a Git
 checkout of the repository then you can use the

--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -43,15 +43,21 @@ The solution is typically to uninstall the package from the environment using `n
 You could also opt to unistall _all_ of the packages from your profile with `nix-env --uninstall '*'`.
 
 === Why are the session variables not set?
+:foreign-env: https://github.com/oh-my-fish/plugin-foreign-env
 
-Home Manager is only able to set session variables automatically if it manages your Bash or Z shell configuration. If you don't want to let Home Manager manage your shell then you will have to manually source the `~/.nix-profile/etc/profile.d/hm-session-vars.sh` file in an appropriate way. In Bash and Z shell this can be done by adding
+Home Manager is only able to set session variables automatically if it manages your Bash, Z shell, or fish shell configuration. If you don't want to let Home Manager manage your shell then you will have to manually source the `~/.nix-profile/etc/profile.d/hm-session-vars.sh` file in an appropriate way. In Bash and Z shell this can be done by adding
 
 [source,bash]
 ----
 . "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
 ----
 
-to your `.profile` and `.zshrc` files, respectively. The `hm-session-vars.sh` file should work in most Bourne-like shells.
+to your `.profile` and `.zshrc` files, respectively. The `hm-session-vars.sh` file should work in most Bourne-like shells. For fish shell, it is possible to source it using {foreign-env}[the foreign-env plugin]
+
+[source,bash]
+----
+fenv source "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh" > /dev/null
+----
 
 === How to set up a configuration for multiple users/machines?
 :post-your-homenix: https://www.reddit.com/r/NixOS/comments/9bb9h9/post_your_homemanager_homenix_file/

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -86,7 +86,7 @@ file in your shell configuration. Alternatively source
 +
 when managing home configuration together with system configuration.
 +
-Unfortunately, we currently only support POSIX.2-like shells such as
+This file can be sourced directly by POSIX.2-like shells such as
 https://www.gnu.org/software/bash/[Bash] or
 http://zsh.sourceforge.net/[Z shell].
 +
@@ -97,7 +97,9 @@ For example, if you use Bash then add
 . "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
 ----
 +
-to your `~/.profile` file.
+to your `~/.profile` file. For fish shell, it is possible to use
+https://github.com/oh-my-fish/plugin-foreign-env[foreign-env] to
+source the file.
 
 If instead of using channels you want to run Home Manager from a Git
 checkout of the repository then you can use the


### PR DESCRIPTION
The docs seemed to me to imply that fish was not really supported, but
if fish is managed by home-manager, the generated config does use fenv
to source the session-vars file. Update the faq to mention that fish
does work, and mention fenv in the README.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
