### PR TITLE
i3: Use default keybindings for changing focus

### DIFF
--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -26,10 +26,10 @@ let
           "${cfg.config.modifier}+Shift+q" = "kill";
           "${cfg.config.modifier}+d" = "exec ${cfg.config.menu}";
 
-          "${cfg.config.modifier}+Left" = "focus left";
-          "${cfg.config.modifier}+Down" = "focus down";
-          "${cfg.config.modifier}+Up" = "focus up";
-          "${cfg.config.modifier}+Right" = "focus right";
+          "${cfg.config.modifier}+j" = "focus left";
+          "${cfg.config.modifier}+k" = "focus down";
+          "${cfg.config.modifier}+l" = "focus up";
+          "${cfg.config.modifier}+;" = "focus right";
 
           "${cfg.config.modifier}+Shift+Left" = "move left";
           "${cfg.config.modifier}+Shift+Down" = "move down";


### PR DESCRIPTION
### Description

The [i3 docs](https://i3wm.org/docs/userguide.html#_opening_terminals_and_moving_around) say that the default keybindings for changing focus are:
```
$mod+j is left, $mod+k is down, $mod+l is up and $mod+; is right.
```

This PR sets those as the default config instead of the arrow keys. I was confused as to why i3 wasn't working out of the box until I checked the soure.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.
(Although it will change keybindings for people who havent' explicitly configured them).
- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
