### PR TITLE
notmuch: add a `package` option

### DIFF
--- a/modules/programs/alot-accounts.nix
+++ b/modules/programs/alot-accounts.nix
@@ -19,7 +19,7 @@ with lib;
       default = {
         type = "shellcommand";
         command =
-          "'${pkgs.notmuch}/bin/notmuch address --format=json --output=recipients  date:6M..'";
+          "'${config.programs.notmuch.package}/bin/notmuch address --format=json --output=recipients  date:6M..'";
         regexp = "'\\[?{" + ''
           "name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"''
           + "}[,\\]]?'";

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -3,6 +3,7 @@
 with lib;
 
 let
+
   cfg = config.programs.notmuch;
 
   mkIniKeyValue = key: value:
@@ -188,7 +189,7 @@ in {
       hook = name: cmds: {
         "${notmuchIni.database.path}/.notmuch/hooks/${name}".source =
           pkgs.writeShellScript name ''
-            export PATH="${pkgs.notmuch}/bin''${PATH:+:}$PATH"
+            export PATH="${cfg.package}/bin''${PATH:+:}$PATH"
             export NOTMUCH_CONFIG="${config.xdg.configHome}/notmuch/notmuchrc"
             export NMBGIT="${config.xdg.dataHome}/notmuch/nmbug"
 

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -3,7 +3,6 @@
 with lib;
 
 let
-
   cfg = config.programs.notmuch;
 
   mkIniKeyValue = key: value:
@@ -48,6 +47,13 @@ in {
   options = {
     programs.notmuch = {
       enable = mkEnableOption "Notmuch mail indexer";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.notmuch;
+        defaultText = literalExample "pkgs.notmuch";
+        description = "The notmuch package to install.";
+      };
 
       new = mkOption {
         type = types.submodule {
@@ -164,7 +170,7 @@ in {
       }
     ];
 
-    home.packages = [ pkgs.notmuch ];
+    home.packages = [ cfg.package ];
 
     home.sessionVariables = {
       NOTMUCH_CONFIG = "${config.xdg.configHome}/notmuch/notmuchrc";

--- a/modules/services/imapnotify-accounts.nix
+++ b/modules/services/imapnotify-accounts.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, config, ... }:
 
 with lib;
 
@@ -18,7 +18,7 @@ with lib;
       default = "";
       example = {
         mail =
-          "\${pkgs.notmuch}/bin/notmuch new && \${pkgs.libnotify}/bin/notify-send 'New mail arrived'";
+          "\${config.programs.notmuch.package}/bin/notmuch new && \${pkgs.libnotify}/bin/notify-send 'New mail arrived'";
       };
       description = "Shell commands to run after onNotify event.";
     };

--- a/modules/services/muchsync.nix
+++ b/modules/services/muchsync.nix
@@ -173,7 +173,7 @@ in {
         CPUSchedulingPolicy = "idle";
         IOSchedulingClass = "idle";
         Environment = [
-          ''"PATH=${pkgs.notmuch}/bin"''
+          ''"PATH=${config.programs.notmuch.package}/bin"''
           ''"NOTMUCH_CONFIG=${config.home.sessionVariables.NOTMUCH_CONFIG}"''
           ''"NMBGIT=${config.home.sessionVariables.NMBGIT}"''
         ];


### PR DESCRIPTION
### Description

This PR adds the possibility for the user to select a specific package for notmuch.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.