### PR TITLE
bottom: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,6 +58,9 @@
 
 /modules/programs/beets.nix                           @rycee
 
+/modules/programs/bottom.nix                          @polykernel
+/tests/modules/programs/bottom                        @polykernel
+
 /modules/programs/broot.nix                           @aheaume
 
 /modules/programs/dircolors.nix                       @JustinLovinger

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2196,6 +2196,13 @@ in
           A new module is available: 'services.betterlockscreen'.
         '';
       }
+
+      {
+        time = "2021-09-14T21:31:03+00:00";
+        message = ''
+          A new module is available: 'programs.bottom'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -50,6 +50,7 @@ let
     ./programs/bash.nix
     ./programs/bat.nix
     ./programs/beets.nix
+    ./programs/bottom.nix
     ./programs/broot.nix
     ./programs/browserpass.nix
     ./programs/chromium.nix

--- a/modules/programs/bottom.nix
+++ b/modules/programs/bottom.nix
@@ -1,0 +1,66 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.bottom;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Application Support"
+  else
+    config.xdg.configHome;
+
+in {
+  options = {
+    programs.bottom = {
+      enable = mkEnableOption ''
+        bottom, a cross-platform graphical process/system monitor with a
+        customizable interface'';
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.bottom;
+        defaultText = literalExample "pkgs.bottom";
+        description = "Package providing <command>bottom</command>.";
+      };
+
+      settings = mkOption {
+        type = tomlFormat.type;
+        default = { };
+        description = ''
+          Configuration written to
+          <filename>$XDG_CONFIG_HOME/bottom/bottom.toml</filename> on Linux or
+          <filename>$HOME/Library/Application Support/bottom/bottom.toml</filename> on Darwin.
+          </para><para>
+          See <link xlink:href="https://github.com/ClementTsang/bottom/blob/master/sample_configs/default_config.toml"/>
+          for the default configuration.
+        '';
+        example = literalExample ''
+          {
+            flags = {
+              avg_cpu = true;
+              temperature_type = "c";
+            };
+
+            colors = {
+              low_battery_color = "red";
+            };
+          }
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.file."${configDir}/bottom/bottom.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "bottom.toml" cfg.settings;
+    };
+  };
+
+  meta.maintainers = [ maintainers.polykernel ];
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -46,6 +46,7 @@ import nmt {
     ./modules/programs/autojump
     ./modules/programs/bash
     ./modules/programs/bat
+    ./modules/programs/bottom
     ./modules/programs/broot
     ./modules/programs/browserpass
     ./modules/programs/dircolors

--- a/tests/modules/programs/bottom/default.nix
+++ b/tests/modules/programs/bottom/default.nix
@@ -1,0 +1,4 @@
+{
+  bottom-empty-settings = ./empty-settings.nix;
+  bottom-example-settings = ./example-settings.nix;
+}

--- a/tests/modules/programs/bottom/empty-settings.nix
+++ b/tests/modules/programs/bottom/empty-settings.nix
@@ -1,0 +1,16 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.bottom = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy" "";
+    };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/bottom
+    '';
+  };
+}

--- a/tests/modules/programs/bottom/example-settings.nix
+++ b/tests/modules/programs/bottom/example-settings.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.bottom = {
+      enable = true;
+      package = pkgs.writeShellScriptBin "dummy" "";
+
+      settings = {
+        flags = {
+          avg_cpu = true;
+          temperature_type = "c";
+        };
+
+        colors = { low_battery_color = "red"; };
+      };
+    };
+
+    nmt.script = let
+      configDir = if pkgs.stdenv.isDarwin then
+        "home-files/Library/Application Support"
+      else
+        "home-files/.config";
+    in ''
+      assertFileContent \
+        "${configDir}/bottom/bottom.toml" \
+        ${
+          builtins.toFile "example-settings-expected.toml" ''
+            [colors]
+            low_battery_color = "red"
+
+            [flags]
+            avg_cpu = true
+            temperature_type = "c"
+          ''
+        }
+    '';
+  };
+}


### PR DESCRIPTION
Bottom is a cross-platform graphical process/system monitor with a customizable
interface and a multitude of features.

Two unit tests were added validate the module behavior for an empty
configuration and the example configuration.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
