### PR TITLE
home-environment: Stop exporting __HM_SESS_VARS_SOURCED

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,8 @@
 
 /modules/misc/news.nix                                @rycee
 
+/modules/misc/nixpkgs-disabled.nix                    @thiagokokada
+
 /modules/misc/numlock.nix                             @evanjs
 /tests/modules/misc/numlock                           @evanjs
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -70,16 +70,16 @@ Currently the easiest way to install Home Manager is as follows:
 2.  Add the appropriate Home Manager channel. If you are following
     Nixpkgs master or an unstable channel you can run
 
-    ```console
-    $ nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
-    $ nix-channel --update
+    ```shell
+    nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
+    nix-channel --update
     ```
 
     and if you follow a Nixpkgs version 21.05 channel you can run
 
-    ```console
-    $ nix-channel --add https://github.com/nix-community/home-manager/archive/release-21.05.tar.gz home-manager
-    $ nix-channel --update
+    ```shell
+    nix-channel --add https://github.com/nix-community/home-manager/archive/release-21.05.tar.gz home-manager
+    nix-channel --update
     ```
 
     On NixOS you may need to log out and back in for the channel to
@@ -93,8 +93,8 @@ Currently the easiest way to install Home Manager is as follows:
 
 3.  Install Home Manager and create the first Home Manager generation:
 
-    ```console
-    $ nix-shell '<home-manager>' -A install
+    ```shell
+    nix-shell '<home-manager>' -A install
     ```
 
     Once finished, Home Manager should be active and available in your
@@ -103,7 +103,7 @@ Currently the easiest way to install Home Manager is as follows:
 3.  If you do not plan on having Home Manager manage your shell
     configuration then you must source the
 
-    ```
+    ```shell
     $HOME/.nix-profile/etc/profile.d/hm-session-vars.sh
     ```
 
@@ -191,14 +191,14 @@ To satisfy the above setup we should elaborate the
 
 To activate this configuration you can then run
 
-```console
-$ home-manager switch
+```shell
+home-manager switch
 ```
 
 or if you are not feeling so lucky,
 
-```console
-$ home-manager build
+```shell
+home-manager build
 ```
 
 which will create a `result` link to a directory containing an
@@ -208,8 +208,8 @@ Documentation of available configuration options, including
 descriptions and usage examples, is available in the [Home Manager
 manual][configuration options] or offline by running
 
-```console
-$ man home-configuration.nix
+```shell
+man home-configuration.nix
 ```
 
 Rollbacks

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -504,7 +504,7 @@ in
           text = ''
             # Only source this once.
             if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
-            export __HM_SESS_VARS_SOURCED=1
+            __HM_SESS_VARS_SOURCED=1
 
             ${config.lib.shell.exportAll cfg.sessionVariables}
           '' + lib.optionalString (cfg.sessionPath != [ ]) ''

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -75,12 +75,6 @@
       fingerprint = "F0E0 0311 126A CD72 4392  25E6 68BF 2EAE 6D91 CAFF";
     }];
   };
-  thiagokokada = {
-    email = "thiagokokada@gmail.com";
-    name = "Thiago Kenji Okada";
-    github = "thiagokokada";
-    githubId = 844343;
-  };
   fendse = {
     email = "46252070+Fendse@users.noreply.github.com";
     github = "Fendse";

--- a/modules/misc/nixpkgs-disabled.nix
+++ b/modules/misc/nixpkgs-disabled.nix
@@ -1,0 +1,73 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.nixpkgs;
+
+  # Copied from nixpkgs.nix.
+  isConfig = x: builtins.isAttrs x || builtins.isFunction x;
+
+  # Copied from nixpkgs.nix.
+  optCall = f: x: if builtins.isFunction f then f x else f;
+
+  # Copied from nixpkgs.nix.
+  mergeConfig = lhs_: rhs_:
+    let
+      lhs = optCall lhs_ { inherit pkgs; };
+      rhs = optCall rhs_ { inherit pkgs; };
+    in lhs // rhs // optionalAttrs (lhs ? packageOverrides) {
+      packageOverrides = pkgs:
+        optCall lhs.packageOverrides pkgs
+        // optCall (attrByPath [ "packageOverrides" ] ({ }) rhs) pkgs;
+    } // optionalAttrs (lhs ? perlPackageOverrides) {
+      perlPackageOverrides = pkgs:
+        optCall lhs.perlPackageOverrides pkgs
+        // optCall (attrByPath [ "perlPackageOverrides" ] ({ }) rhs) pkgs;
+    };
+
+  # Copied from nixpkgs.nix.
+  configType = mkOptionType {
+    name = "nixpkgs-config";
+    description = "nixpkgs config";
+    check = x:
+      let traceXIfNot = c: if c x then true else lib.traceSeqN 1 x false;
+      in traceXIfNot isConfig;
+    merge = args: fold (def: mergeConfig def.value) { };
+  };
+
+  # Copied from nixpkgs.nix.
+  overlayType = mkOptionType {
+    name = "nixpkgs-overlay";
+    description = "nixpkgs overlay";
+    check = builtins.isFunction;
+    merge = lib.mergeOneOption;
+  };
+
+in {
+  meta.maintainers = with maintainers; [ thiagokokada ];
+
+  options.nixpkgs = {
+    config = mkOption {
+      default = null;
+      type = types.nullOr configType;
+      visible = false;
+    };
+
+    overlays = mkOption {
+      default = null;
+      type = types.nullOr (types.listOf overlayType);
+      visible = false;
+    };
+  };
+
+  config = {
+    assertions = [{
+      assertion = cfg.config == null || cfg.overlays == null;
+      message = ''
+        `nixpkgs` options are disabled when `home-manager.useGlobalPkgs` is enabled.
+      '';
+    }];
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -242,7 +242,8 @@ let
     ./xsession.nix
     (pkgs.path + "/nixos/modules/misc/assertions.nix")
     (pkgs.path + "/nixos/modules/misc/meta.nix")
-  ] ++ optional useNixpkgsModule ./misc/nixpkgs.nix;
+  ] ++ optional useNixpkgsModule ./misc/nixpkgs.nix
+    ++ optional (!useNixpkgsModule) ./misc/nixpkgs-disabled.nix;
 
   pkgsModule = { config, ... }: {
     config = {

--- a/tests/modules/home-environment/session-variables-expected.txt
+++ b/tests/modules/home-environment/session-variables-expected.txt
@@ -1,6 +1,6 @@
 # Only source this once.
 if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
-export __HM_SESS_VARS_SOURCED=1
+__HM_SESS_VARS_SOURCED=1
 @exportLocaleVar@
 export V1="v1"
 export V2="v2-v1"

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -7,7 +7,7 @@ let
   linuxExpected = ''
     # Only source this once.
     if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
-    export __HM_SESS_VARS_SOURCED=1
+    __HM_SESS_VARS_SOURCED=1
 
     export LOCALE_ARCHIVE_2_27="${pkgs.glibcLocales}/lib/locale/locale-archive"
     export V1="v1"
@@ -20,7 +20,7 @@ let
   darwinExpected = ''
     # Only source this once.
     if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
-    export __HM_SESS_VARS_SOURCED=1
+    __HM_SESS_VARS_SOURCED=1
 
     export V1="v1"
     export V2="v2-v1"

--- a/tests/modules/programs/rofi/config-with-deprecated-options.nix
+++ b/tests/modules/programs/rofi/config-with-deprecated-options.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs.rofi = {
+    enable = true;
+    colors = { };
+  };
+
+  test.stubs.rofi = { };
+  test.asserts.assertions.expected = [
+    (let offendingFile = toString ./config-with-deprecated-options.nix;
+    in ''
+      The option definition `programs.rofi.colors' in `${offendingFile}' no longer has any effect; please remove it.
+      Please use a Rofi theme instead.
+    '')
+  ];
+}

--- a/tests/modules/programs/rofi/default.nix
+++ b/tests/modules/programs/rofi/default.nix
@@ -1,4 +1,5 @@
 {
   rofi-valid-config = ./valid-config.nix;
   rofi-custom-theme = ./custom-theme.nix;
+  rofi-config-with-deprecated-options = ./config-with-deprecated-options.nix;
 }


### PR DESCRIPTION
### Description

If the __HM_SESS_VARS_SOURCED is set in environment of parent process,
then the spawned child shell will inherit it, and won't set the
session variables one expects to be set in their home environment

And, I don't see any need for exporting environment variable, just
setting it is enough for it to be a guard.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
