### PR TITLE
gnome-terminal: extended doc + option validation

### DIFF
--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -33,34 +33,57 @@ let
       foregroundColor = mkOption {
         type = types.str;
         description = "The foreground color.";
+        example = "rgba(0.9,0.9.0.8,1.0)";
       };
 
       backgroundColor = mkOption {
         type = types.str;
         description = "The background color.";
+        example = "rgb(37,45,37)";
       };
 
       boldColor = mkOption {
         default = null;
         type = types.nullOr types.str;
         description = "The bold color, null to use same as foreground.";
+        example = "#fff";
       };
 
       palette = mkOption {
         type = types.listOf types.str;
         description = "The terminal palette: a list of 16 strings.";
+        example = [
+          "#000000"
+          "#AA0000"
+          "#00AA00"
+          "#AA5500"
+          "#0000AA"
+          "#AA00AA"
+          "#00AAAA"
+          "#AAAAAA"
+          "#555555"
+          "#FF5555"
+          "#55FF55"
+          "#FFFF55"
+          "#5555FF"
+          "#FF55FF"
+          "#55FFFF"
+          "#FFFFFF"
+        ];
       };
 
       cursor = mkOption {
         default = null;
         type = types.nullOr backForeSubModule;
         description = "The color for the terminal cursor.";
+        example = "#abcf";
       };
 
       highlight = mkOption {
         default = null;
         type = types.nullOr backForeSubModule;
         description = "The colors for the terminal’s highlighted area.";
+        example = "rgb(0.75,0.,0.)";
       };
     };
   });
@@ -374,7 +397,11 @@ in {
       profile = mkOption {
         default = { };
         type = types.attrsOf profileSubModule;
-        description = "A set of Gnome Terminal profiles.";
+        description = ''
+          A set of Gnome Terminal profiles. The attribute name of each profile must be an 
+          <link xlink:href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUID</link> 
+        '';
+        example = { "e0b782ed-6aca-44eb-8c75-62b3706b6220" = { }; };
       };
     };
   };

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -118,44 +118,8 @@ let
 
           </para><para>
 
-          A color can be a string containing one of the following:
-
-          <itemizedlist>
-            <listitem>
-              <para>
-                A standard name as specified in the 
-                <link xlink:href="http://dev.w3.org/csswg/css-color/#named-colors">
-                  CSS standard
-                </link>
-              </para>
-            </listitem>
-            <listitem>
-              <para>
-                A hexadecimal value 
-                (#rgb, #rrggbb, #rrrgggbbb, #rrrrggggbbbb)
-              </para>
-            </listitem>
-            <listitem>
-              <para>
-                A hexadecimal value with the alpha component 
-                (#rgba, #rrggbbaa, #rrrrggggbbbbaaaa)
-              </para>
-            </listitem>
-            <listitem>
-              <para>
-                A RGB color prefixed with "rgb" (rgb(r,g,b))
-              </para>
-            </listitem>
-            <listitem>
-              <para>
-                A RGBA color prefixed with "rgba" (rgba(r,g,b,a))
-              </para>
-            </listitem>
-          </itemizedlist>
-
-          In the case of rgb(r,g,b) and rgb(r,g,b,a), the value for r,g,b and a
-          (respectively red, green, blue, and alpha) are either integers between 
-          0 and 255, or floating point numbers between 0. and 1.
+          The valid string format for colors is described in the
+          <link xlink:href="https://docs.gtk.org/gtk3/css-overview.html#colors">GTK documentation</link>.
 
           </para><para>
 

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -388,18 +388,15 @@ in {
   config = mkIf cfg.enable {
 
     assertions = [
-      {
-        assertion = all (x: x == 16) (mapAttrsToList
-          (n: v: if v ? colors.palette then length v.colors.palette else 16)
-          cfg.profile);
-        message = "A palette needs to contain exactly 16 colors.";
-      }
-      {
-        assertion = length (filter (x: x)
-          (mapAttrsToList (n: v: if v ? default then v.default else false)
-            cfg.profile)) == 1;
-        message = "One and only one profile must be set as default.";
-      }
+      (let
+        defaults = catAttrs "visibleName"
+          (filter (a: a.default) (attrValues cfg.profile));
+      in {
+        assertion = length defaults == 1;
+        message = "One and only one profile must be set as default but found "
+          + toString (length defaults) + optionalString (length defaults > 1)
+          (", namely " + concatStringsSep ", " defaults);
+      })
     ];
 
     home.packages = [ pkgs.gnome.gnome-terminal ];

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -50,7 +50,11 @@ let
       };
 
       palette = mkOption {
-        type = types.listOf types.str;
+        type = let baseType = types.listOf types.str;
+        in baseType // {
+          check = x: baseType.check x && length x == 16;
+          description = "list of 16 color values";
+        };
         description = "The terminal palette: a list of 16 strings.";
         example = literalExample ''
           [
@@ -100,15 +104,17 @@ let
 
       visibleName = mkOption {
         type = types.str;
-        description =
-          "The profile name. This is what will show up as a name in the Gnome Terminal preferences window.";
+        description = ''
+          The profile name. This is what will show up as a name in the
+          Gnome Terminal preferences window.
+        '';
       };
 
       colors = mkOption {
         default = null;
         type = types.nullOr profileColorsSubModule;
         description = ''
-          The terminal colors, null to use system default.
+          The terminal colors, <literal>null</literal> to use system default.
 
           </para><para>
 

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -52,24 +52,26 @@ let
       palette = mkOption {
         type = types.listOf types.str;
         description = "The terminal palette: a list of 16 strings.";
-        example = [
-          "#000000"
-          "#AA0000"
-          "#00AA00"
-          "#AA5500"
-          "#0000AA"
-          "#AA00AA"
-          "#00AAAA"
-          "#AAAAAA"
-          "#555555"
-          "#FF5555"
-          "#55FF55"
-          "#FFFF55"
-          "#5555FF"
-          "#FF55FF"
-          "#55FFFF"
-          "#FFFFFF"
-        ];
+        example = literalExample ''
+          [
+            "#000000"
+            "#AA0000"
+            "#00AA00"
+            "#AA5500"
+            "#0000AA"
+            "#AA00AA"
+            "#00AAAA"
+            "#AAAAAA"
+            "#555555"
+            "#FF5555"
+            "#55FF55"
+            "#FFFF55"
+            "#5555FF"
+            "#FF55FF"
+            "#55FFFF"
+            "#FFFFFF"
+          ]
+        '';
       };
 
       cursor = mkOption {
@@ -99,7 +101,7 @@ let
       visibleName = mkOption {
         type = types.str;
         description =
-          "The profile name. If null, the profile name will be the same as the nix attribute.";
+          "The profile name. This is what will show up as a name in the Gnome Terminal preferences window.";
       };
 
       colors = mkOption {
@@ -107,6 +109,8 @@ let
         type = types.nullOr profileColorsSubModule;
         description = ''
           The terminal colors, null to use system default.
+
+          </para><para>
 
           A color can be a string containing one of the following:
 
@@ -146,6 +150,8 @@ let
           In the case of rgb(r,g,b) and rgb(r,g,b,a), the value for r,g,b and a
           (respectively red, green, blue, and alpha) are either integers between 
           0 and 255, or floating point numbers between 0. and 1.
+
+          </para><para>
 
           The alpha can be set, but will be ignored 
           (colors have always full opacity).
@@ -320,8 +326,7 @@ let
   buildProfileSet = pcfg:
     {
       audible-bell = pcfg.audibleBell;
-      visible-name =
-        if (pcfg.visibleName != null) then pcfg.visibleName else attrNames pcfg;
+      visible-name = pcfg.visibleName;
       scroll-on-output = pcfg.scrollOnOutput;
       scrollbar-policy = if pcfg.showScrollbar then "always" else "never";
       scrollback-lines = pcfg.scrollbackLines;
@@ -399,9 +404,13 @@ in {
         type = types.attrsOf profileSubModule;
         description = ''
           A set of Gnome Terminal profiles. The attribute name of each profile must be an 
-          <link xlink:href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUID</link> 
+          <link xlink:href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUID</link>.
         '';
-        example = { "e0b782ed-6aca-44eb-8c75-62b3706b6220" = { }; };
+        example = literalExample ''
+          { 
+            "e0b782ed-6aca-44eb-8c75-62b3706b6220" = { }; 
+          }
+        '';
       };
     };
   };
@@ -413,13 +422,13 @@ in {
         assertion = all (x: x == 16) (mapAttrsToList
           (n: v: if v ? colors.palette then length v.colors.palette else 16)
           cfg.profile);
-        message = "A palette needs to contain exactly 16 colors";
+        message = "A palette needs to contain exactly 16 colors.";
       }
       {
-        assertion = any (x: x)
+        assertion = length (filter (x: x)
           (mapAttrsToList (n: v: if v ? default then v.default else false)
-            cfg.profile);
-        message = "At least one profile needs to be set as default";
+            cfg.profile)) == 1;
+        message = "One and only one profile must be set as default.";
       }
     ];
 


### PR DESCRIPTION
### Description

New documentation to describe the color format expected by
gnome-terminal. The doc for the colors option is a rewrite
of a comment from the GTK library that gnome-terminal
uses to parse the colors. (See https://gitlab.gnome.org/GNOME/gtk/-/blob/master/gdk/gdkrgba.c#L159-184 for the original)

Two assertion added:
- one to check that palette contains exactly 16 colors
- one to check that at least one profile is set as the default one

Should resolve #2299 


### Checklist

- [ ] Change is backwards compatible
  I'm not sure about that one: The added assertion checking for the number of colors in the palette could break some config (but those would probably not work anyway with gnome-terminal)

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef)
  Do I need to add test cases for the assertions?

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
