### PR TITLE
sbt: Run passwordCommand without trailing newline

### DIFF
--- a/modules/programs/sbt.nix
+++ b/modules/programs/sbt.nix
@@ -9,7 +9,7 @@ let
   '';
 
   renderCredential = cred: ''
-    credentials += Credentials("${cred.realm}", "${cred.host}", "${cred.user}", "${cred.passwordCommand}".!!)
+    credentials += Credentials("${cred.realm}", "${cred.host}", "${cred.user}", "${cred.passwordCommand}".lazyLines.mkString("\n"))
   '';
 
   renderCredentials = creds: ''

--- a/tests/modules/programs/sbt/credentials.nix
+++ b/tests/modules/programs/sbt/credentials.nix
@@ -19,8 +19,8 @@ let
   ];
   expectedCredentialsSbt = pkgs.writeText "credentials.sbt" ''
     import scala.sys.process._
-    credentials += Credentials("Sonatype Nexus Repository Manager", "example.com", "user", "echo password".!!)
-    credentials += Credentials("Sonatype Nexus Repository Manager X", "v2.example.com", "user1", "echo password1".!!)
+    credentials += Credentials("Sonatype Nexus Repository Manager", "example.com", "user", "echo password".lazyLines.mkString("\n"))
+    credentials += Credentials("Sonatype Nexus Repository Manager X", "v2.example.com", "user1", "echo password1".lazyLines.mkString("\n"))
   '';
   credentialsSbtPath = ".sbt/1.0/credentials.sbt";
 in {


### PR DESCRIPTION
### Description

I hadn't realized I actually never used this functionality. When I tried, I noticed the result of any command would include a trailing newline, which is never part of a password so it would virtually never work.

This ensures we only keep the content actually present in the file.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module