### PR TITLE
starship: initialize using command in profile

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -8,6 +8,8 @@ let
 
   tomlFormat = pkgs.formats.toml { };
 
+  starshipCmd = "${config.home.profileDirectory}/bin/starship";
+
 in {
   meta.maintainers = [ maintainers.marsam ];
 
@@ -90,19 +92,19 @@ in {
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then
-        eval "$(${cfg.package}/bin/starship init bash)"
+        eval "$(${starshipCmd} init bash)"
       fi
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
       if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then
-        eval "$(${cfg.package}/bin/starship init zsh)"
+        eval "$(${starshipCmd} init zsh)"
       fi
     '';
 
     programs.fish.promptInit = mkIf cfg.enableFishIntegration ''
       if test "$TERM" != "dumb"  -a \( -z "$INSIDE_EMACS"  -o "$INSIDE_EMACS" = "vterm" \)
-        eval (${cfg.package}/bin/starship init fish)
+        eval (${starshipCmd} init fish)
       end
     '';
   };


### PR DESCRIPTION


### Description

Fixes #2316

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```