### PR TITLE
screen-locker: Make xautolock optional, reorganize options

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -311,6 +311,9 @@
 /modules/services/redshift-gammastep                  @rycee @petabyteboy @thiagokokada
 /tests/modules/redshift-gammastep                     @thiagokokada
 
+/modules/services/screen-locker.nix                   @jrobsonchase
+/tests/modules/services/screen-locker                 @jrobsonchase
+
 /modules/services/status-notifier-watcher.nix         @pltanton
 
 /modules/services/syncthing.nix                       @rycee

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -127,4 +127,10 @@
     githubId = 605641;
     name = "Bart Bakker";
   };
+  jrobsonchase = {
+    email = "josh@robsonchase.com";
+    github = "jrobsonchase";
+    githubId = 1553581;
+    name = "Josh Robson Chase";
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2203,6 +2203,16 @@ in
           A new module is available: 'programs.bottom'.
         '';
       }
+
+      {
+        time = "2021-09-23T17:04:48+00:00";
+        message = ''
+          'xautolock' is now optional in 'services.screen-locker', and the
+          'services.screen-locker' options have been reorganized for clarity.
+          See the 'xautolock' and 'xss-lock' options modules in
+          'services.screen-locker'.
+        '';
+      }
     ];
   };
 }

--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -51,6 +51,14 @@ in {
         description = "Use xautolock for time-based locking.";
       };
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.xautolock;
+        description = ''
+          Package providing the <command>xautolock</command> binary.
+        '';
+      };
+
       detectSleep = mkOption {
         type = types.bool;
         default = true;
@@ -71,6 +79,14 @@ in {
     };
 
     xss-lock = {
+      package = mkOption {
+        type = types.package;
+        default = pkgs.xss-lock;
+        description = ''
+          Package providing the <command>xss-lock</command> binary.
+        '';
+      };
+
       extraOptions = mkOption {
         type = types.listOf types.str;
         default = [ ];
@@ -99,7 +115,7 @@ in {
 
         Service = {
           ExecStart = concatStringsSep " "
-            ([ "${pkgs.xss-lock}/bin/xss-lock" "-s \${XDG_SESSION_ID}" ]
+            ([ "${cfg.xss-lock.package}/bin/xss-lock" "-s \${XDG_SESSION_ID}" ]
               ++ cfg.xss-lock.extraOptions ++ [ "-- ${cfg.lockCmd}" ]);
         };
       };
@@ -120,7 +136,7 @@ in {
 
         Service = {
           ExecStart = concatStringsSep " " ([
-            "${pkgs.xautolock}/bin/xautolock"
+            "${cfg.xautolock.package}/bin/xautolock"
             "-time ${toString cfg.inactiveInterval}"
             "-locker '${pkgs.systemd}/bin/loginctl lock-session \${XDG_SESSION_ID}'"
           ] ++ optional cfg.xautolock.detectSleep "-detectsleep"

--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -7,6 +7,8 @@ let
   cfg = config.services.screen-locker;
 
 in {
+  meta.maintainers = [ lib.hm.maintainers.jrobsonchase ];
+
   imports = let
     origOpt = name: [ "services" "screen-locker" name ];
     xautolockOpt = name: [ "services" "screen-locker" "xautolock" name ];

--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -7,6 +7,18 @@ let
   cfg = config.services.screen-locker;
 
 in {
+  imports = let
+    origOpt = name: [ "services" "screen-locker" name ];
+    xautolockOpt = name: [ "services" "screen-locker" "xautolock" name ];
+    xssLockOpt = name: [ "services" "screen-locker" "xss-lock" name ];
+  in [
+    (mkRenamedOptionModule (origOpt "xssLockExtraOptions")
+      (xssLockOpt "extraOptions"))
+    (mkRenamedOptionModule (origOpt "xautolockExtraOptions")
+      (xautolockOpt "extraOptions"))
+    (mkRenamedOptionModule (origOpt "enableDetectSleep")
+      (xautolockOpt "detectSleep"))
+  ];
 
   options.services.screen-locker = {
     enable = mkEnableOption "screen locker for X session";
@@ -17,81 +29,102 @@ in {
       example = "\${pkgs.i3lock}/bin/i3lock -n -c 000000";
     };
 
-    enableDetectSleep = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to reset timers when awaking from sleep.
-      '';
-    };
-
     inactiveInterval = mkOption {
       type = types.int;
       default = 10;
       description = ''
         Inactive time interval in minutes after which session will be locked.
         The minimum is 1 minute, and the maximum is 1 hour.
+        If <option>xautolock.enable</option> is true, it will use this setting.
         See <link xlink:href="https://linux.die.net/man/1/xautolock"/>.
+        Otherwise, this will be used with <command>xset</command> to configure
+        the X server's screensaver timeout.
       '';
     };
 
-    xautolockExtraOptions = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      description = ''
-        Extra command-line arguments to pass to <command>xautolock</command>.
-      '';
-    };
-
-    xssLockExtraOptions = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      description = ''
-        Extra command-line arguments to pass to <command>xss-lock</command>.
-      '';
-    };
-  };
-
-  config = mkIf cfg.enable {
-    assertions = [
-      (lib.hm.assertions.assertPlatform "services.screen-locker" pkgs
-        lib.platforms.linux)
-    ];
-
-    systemd.user.services.xautolock-session = {
-      Unit = {
-        Description = "xautolock, session locker service";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+    xautolock = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Use xautolock for time-based locking.";
       };
 
-      Install = { WantedBy = [ "graphical-session.target" ]; };
+      detectSleep = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to reset xautolock timers when awaking from sleep.
+          No effect if <option>xautolock.enable</option> is false.
+        '';
+      };
 
-      Service = {
-        ExecStart = concatStringsSep " " ([
-          "${pkgs.xautolock}/bin/xautolock"
-          "-time ${toString cfg.inactiveInterval}"
-          "-locker '${pkgs.systemd}/bin/loginctl lock-session $XDG_SESSION_ID'"
-        ] ++ optional cfg.enableDetectSleep "-detectsleep"
-          ++ cfg.xautolockExtraOptions);
+      extraOptions = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Extra command-line arguments to pass to <command>xautolock</command>.
+          No effect if <option>xautolock.enable</option> is false.
+        '';
       };
     };
 
-    systemd.user.services.xss-lock = {
-      Unit = {
-        Description = "xss-lock, session locker service";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
-      };
-
-      Install = { WantedBy = [ "graphical-session.target" ]; };
-
-      Service = {
-        ExecStart = concatStringsSep " "
-          ([ "${pkgs.xss-lock}/bin/xss-lock" "-s \${XDG_SESSION_ID}" ]
-            ++ cfg.xssLockExtraOptions ++ [ "-- ${cfg.lockCmd}" ]);
+    xss-lock = {
+      extraOptions = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Extra command-line arguments to pass to <command>xss-lock</command>.
+        '';
       };
     };
   };
 
+  config = mkIf cfg.enable (mkMerge [
+    {
+      assertions = [
+        (lib.hm.assertions.assertPlatform "services.screen-locker" pkgs
+          lib.platforms.linux)
+      ];
+
+      systemd.user.services.xss-lock = {
+        Unit = {
+          Description = "xss-lock, session locker service";
+          After = [ "graphical-session-pre.target" ];
+          PartOf = [ "graphical-session.target" ];
+        };
+
+        Install = { WantedBy = [ "graphical-session.target" ]; };
+
+        Service = {
+          ExecStart = concatStringsSep " "
+            ([ "${pkgs.xss-lock}/bin/xss-lock" "-s \${XDG_SESSION_ID}" ]
+              ++ cfg.xss-lock.extraOptions ++ [ "-- ${cfg.lockCmd}" ]);
+        };
+      };
+    }
+    (mkIf (!cfg.xautolock.enable) {
+      systemd.user.services.xss-lock.Service.ExecStartPre =
+        "${pkgs.xorg.xset}/bin/xset s ${toString (cfg.inactiveInterval * 60)}";
+    })
+    (mkIf cfg.xautolock.enable {
+      systemd.user.services.xautolock-session = {
+        Unit = {
+          Description = "xautolock, session locker service";
+          After = [ "graphical-session-pre.target" ];
+          PartOf = [ "graphical-session.target" ];
+        };
+
+        Install = { WantedBy = [ "graphical-session.target" ]; };
+
+        Service = {
+          ExecStart = concatStringsSep " " ([
+            "${pkgs.xautolock}/bin/xautolock"
+            "-time ${toString cfg.inactiveInterval}"
+            "-locker '${pkgs.systemd}/bin/loginctl lock-session \${XDG_SESSION_ID}'"
+          ] ++ optional cfg.xautolock.detectSleep "-detectsleep"
+            ++ cfg.xautolock.extraOptions);
+        };
+      };
+    })
+  ]);
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -132,6 +132,7 @@ import nmt {
     ./modules/services/playerctld
     ./modules/services/polybar
     ./modules/services/redshift-gammastep
+    ./modules/services/screen-locker
     ./modules/services/sxhkd
     ./modules/services/syncthing
     ./modules/services/trayer

--- a/tests/modules/services/screen-locker/basic-configuration.nix
+++ b/tests/modules/services/screen-locker/basic-configuration.nix
@@ -14,6 +14,9 @@
       };
     };
 
+    test.stubs.i3lock = { };
+    test.stubs.xss-lock = { };
+
     nmt.script = ''
       xssService=home-files/.config/systemd/user/xss-lock.service
       xautolockService=home-files/.config/systemd/user/xautolock-session.service

--- a/tests/modules/services/screen-locker/basic-configuration.nix
+++ b/tests/modules/services/screen-locker/basic-configuration.nix
@@ -1,0 +1,27 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.screen-locker = {
+      enable = true;
+      inactiveInterval = 5;
+      lockCmd = "${pkgs.i3lock}/bin/i3lock -n -c AA0000";
+      xss-lock = { extraOptions = [ "-test" ]; };
+      xautolock = {
+        enable = true;
+        detectSleep = true;
+        extraOptions = [ "-test" ];
+      };
+    };
+
+    nmt.script = ''
+      xssService=home-files/.config/systemd/user/xss-lock.service
+      xautolockService=home-files/.config/systemd/user/xautolock-session.service
+
+      assertFileExists $xssService
+      assertFileRegex $xssService 'ExecStart=.*/bin/xss-lock.*-test.*i3lock -n -c AA0000'
+      assertFileExists $xautolockService
+      assertFileRegex $xautolockService 'ExecStart=.*/bin/xautolock.*-time 5.*-detectsleep.*-test.*'
+    '';
+  };
+}

--- a/tests/modules/services/screen-locker/default.nix
+++ b/tests/modules/services/screen-locker/default.nix
@@ -1,0 +1,5 @@
+{
+  screen-locker-basic-configuration = ./basic-configuration.nix;
+  screen-locker-no-xautolock = ./no-xautolock.nix;
+  screen-locker-moved-options = ./moved-options.nix;
+}

--- a/tests/modules/services/screen-locker/moved-options.nix
+++ b/tests/modules/services/screen-locker/moved-options.nix
@@ -11,6 +11,9 @@
       enableDetectSleep = true;
     };
 
+    test.stubs.i3lock = { };
+    test.stubs.xss-lock = { };
+
     # Use the same verification script as the basic configuration. The result
     # with the old options should be identical.
     nmt.script = (import ./basic-configuration.nix {

--- a/tests/modules/services/screen-locker/moved-options.nix
+++ b/tests/modules/services/screen-locker/moved-options.nix
@@ -1,0 +1,33 @@
+{ config, pkgs, options, lib, ... }:
+
+{
+  config = {
+    services.screen-locker = {
+      enable = true;
+      inactiveInterval = 5;
+      lockCmd = "${pkgs.i3lock}/bin/i3lock -n -c AA0000";
+      xssLockExtraOptions = [ "-test" ];
+      xautolockExtraOptions = [ "-test" ];
+      enableDetectSleep = true;
+    };
+
+    # Use the same verification script as the basic configuration. The result
+    # with the old options should be identical.
+    nmt.script = (import ./basic-configuration.nix {
+      inherit config pkgs;
+    }).config.nmt.script;
+
+    test.asserts.warnings.expected = with lib;
+      let
+        renamed = {
+          xssLockExtraOptions = "xss-lock.extraOptions";
+          xautolockExtraOptions = "xautolock.extraOptions";
+          enableDetectSleep = "xautolock.detectSleep";
+        };
+      in mapAttrsToList (old: new:
+        builtins.replaceStrings [ "\n" ] [ " " ] ''
+          The option `services.screen-locker.${old}' defined in
+          ${showFiles options.services.screen-locker.${old}.files}
+          has been renamed to `services.screen-locker.${new}'.'') renamed;
+  };
+}

--- a/tests/modules/services/screen-locker/no-xautolock.nix
+++ b/tests/modules/services/screen-locker/no-xautolock.nix
@@ -10,6 +10,9 @@
       xautolock = { enable = false; };
     };
 
+    test.stubs.i3lock = { };
+    test.stubs.xss-lock = { };
+
     nmt.script = ''
       xssService=home-files/.config/systemd/user/xss-lock.service
 

--- a/tests/modules/services/screen-locker/no-xautolock.nix
+++ b/tests/modules/services/screen-locker/no-xautolock.nix
@@ -1,0 +1,21 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.screen-locker = {
+      enable = true;
+      inactiveInterval = 5;
+      lockCmd = "${pkgs.i3lock}/bin/i3lock -n -c AA0000";
+      xss-lock = { extraOptions = [ "-test" ]; };
+      xautolock = { enable = false; };
+    };
+
+    nmt.script = ''
+      xssService=home-files/.config/systemd/user/xss-lock.service
+
+      assertFileExists $xssService
+      assertFileRegex $xssService 'ExecStart=.*/bin/xss-lock.*-test.*i3lock -n -c AA0000'
+      assertFileRegex $xssService 'ExecStartPre=.*/xset s 300'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

xautolock isn't really needed to trigger xss-lock on the basis of time
since the built-in screensaver functionality of X serves as one of the
event sources for xss-lock. Keeping it around and defaulting to
"enabled" to avoid unexpected breakage.

Also shuffled around the options to submodules for xss-lock and
xautolock to get rid of prefixes in option names and to make detectSleep
a bit clearer.

Resolves #2341 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```