### PR TITLE
dbus: improve recommended NixOS configuration

### DIFF
--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -100,7 +100,7 @@ error: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name ca.desrt.
 The solution on NixOS is to add
 
 [source,nix]
-services.dbus.packages = with pkgs; [ gnome.dconf ];
+programs.dconf.enable = true;
 
 to your system configuration.
 

--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -16,10 +16,9 @@ in {
       Easyeffects daemon.
       Note, it is necessary to add
       <programlisting language="nix">
-      services.dbus.packages = with pkgs; [ gnome.dconf ];
+      programs.dconf.enable = true;
       </programlisting>
-      to your system configuration for the daemon to work correctly
-    '';
+      to your system configuration for the daemon to work correctly'';
 
     preset = mkOption {
       type = types.str;

--- a/modules/services/pulseeffects.nix
+++ b/modules/services/pulseeffects.nix
@@ -12,7 +12,13 @@ in {
   meta.maintainers = [ maintainers.jonringer ];
 
   options.services.pulseeffects = {
-    enable = mkEnableOption "Pulseeffects daemon";
+    enable = mkEnableOption ''
+      Pulseeffects daemon
+      Note, it is necessary to add
+      <programlisting language="nix">
+      programs.dconf.enable = true;
+      </programlisting>
+      to your system configuration for the daemon to work correctly'';
 
     package = mkOption {
       type = types.package;
@@ -41,9 +47,6 @@ in {
     # at-spi2-core is to minimize journalctl noise of:
     # "AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files"
     home.packages = [ cfg.package pkgs.at-spi2-core ];
-
-    # Will need to add `services.dbus.packages = with pkgs; [ gnome.dconf ];`
-    # to /etc/nixos/configuration.nix for daemon to work correctly
 
     systemd.user.services.pulseeffects = {
       Unit = {


### PR DESCRIPTION
### Description

Specifically, instead of

    services.dbus.packages = with pkgs; [ gnome.dconf ];

we now recommend

    programs.dconf.enable = true;

which does the same and more.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```