### PR TITLE
Add gotop

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,6 +86,9 @@
 /modules/programs/glow.nix                            @geowy
 /tests/modules/programs/glow                          @geowy
 
+/modules/programs/gotop.nix                           @geowy
+/tests/modules/programs/gotop                         @geowy
+
 /modules/programs/gnome-terminal.nix                  @kamadorueda @rycee
 
 /modules/programs/go.nix                              @rvolosatovs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,6 +83,9 @@
 
 /modules/programs/git.nix                             @rycee
 
+/modules/programs/glow.nix                            @geowy
+/tests/modules/programs/glow                          @geowy
+
 /modules/programs/gnome-terminal.nix                  @kamadorueda @rycee
 
 /modules/programs/go.nix                              @rvolosatovs

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -127,4 +127,10 @@
     githubId = 605641;
     name = "Bart Bakker";
   };
+  geowy = {
+    email = "github@georgewyatt.fastmail.com";
+    github = "geowy";
+    githubId = 5038349;
+    name = "George Wyatt";
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -68,6 +68,7 @@ let
     ./programs/getmail.nix
     ./programs/gh.nix
     ./programs/git.nix
+    ./programs/glow.nix
     ./programs/gnome-terminal.nix
     ./programs/go.nix
     ./programs/gpg.nix

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -71,6 +71,7 @@ let
     ./programs/glow.nix
     ./programs/gnome-terminal.nix
     ./programs/go.nix
+    ./programs/gotop.nix
     ./programs/gpg.nix
     ./programs/himalaya.nix
     ./programs/home-manager.nix

--- a/modules/programs/glow.nix
+++ b/modules/programs/glow.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.glow;
+  yamlFormat = pkgs.formats.yaml { };
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+in {
+  meta.maintainers = [ maintainers.geowy ];
+
+  options.programs.glow = {
+    enable = mkEnableOption "Glow, a terminal based markdown reader";
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      defaultText = literalExample "{ }";
+      example = literalExample ''
+        {
+          # style name or JSON path (default "auto")
+          style = "light";
+          # show local files only; no network (TUI-mode only)
+          local = true;
+          # mouse support (TUI-mode only)
+          mouse = true;
+          # use pager to display markdown
+          pager = true;
+          # word-wrap at width
+          width = 80;
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>~/.config/glow/glow.yml</filename> on Linux
+        or <filename>~/Library/Preferences/glow/glow.yml</filename> on Darwin. See
+        <link xlink:href="https://github.com/charmbracelet/glow#the-config-file"/>
+        for supported values.
+      '';
+    };
+  };
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+      home.packages = [ pkgs.glow ];
+
+      home.file."Library/Preferences/glow/glow.yml" =
+        mkIf (cfg.settings != { } && isDarwin) {
+          text = builtins.toJSON cfg.settings;
+        };
+
+      xdg.configFile."glow/glow.yml" = mkIf (cfg.settings != { } && !isDarwin) {
+        text = builtins.toJSON cfg.settings;
+      };
+    })
+  ];
+}

--- a/modules/programs/gotop.nix
+++ b/modules/programs/gotop.nix
@@ -1,0 +1,48 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.gotop;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+in {
+  meta.maintainers = [ maintainers.geowy ];
+
+  options.programs.gotop = {
+    enable =
+      mkEnableOption "gotop, a terminal based graphical activity monitor";
+
+    settings = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      defaultText = literalExample "{ }";
+      example = literalExample ''
+        {
+          colorscheme = "solarized";
+          layout = "kitchensink";
+        }
+      '';
+      description = ''
+        gotop configuration options. Available options are described
+        in the gotop documentation:
+        <link xlink:href="https://github.com/xxxserxxx/gotop/blob/master/docs/configuration.md"/>.
+      '';
+    };
+  };
+
+  config = mkMerge [
+    (mkIf cfg.enable {
+      home.packages = [ pkgs.gotop ];
+
+      home.file."Library/Application Support/gotop/gotop.conf" =
+        mkIf (cfg.settings != { } && isDarwin) {
+          text = generators.toKeyValue { } cfg.settings;
+        };
+
+      xdg.configFile."gotop/gotop.conf" =
+        mkIf (cfg.settings != { } && !isDarwin) {
+          text = generators.toKeyValue { } cfg.settings;
+        };
+    })
+  ];
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -56,6 +56,7 @@ import nmt {
     ./modules/programs/gh
     ./modules/programs/git
     ./modules/programs/glow
+    ./modules/programs/gotop
     ./modules/programs/gpg
     ./modules/programs/himalaya
     ./modules/programs/htop

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -55,6 +55,7 @@ import nmt {
     ./modules/programs/fish
     ./modules/programs/gh
     ./modules/programs/git
+    ./modules/programs/glow
     ./modules/programs/gpg
     ./modules/programs/himalaya
     ./modules/programs/htop

--- a/tests/modules/programs/glow/default.nix
+++ b/tests/modules/programs/glow/default.nix
@@ -1,0 +1,1 @@
+{ glow-settings = ./settings.nix; }

--- a/tests/modules/programs/glow/settings.nix
+++ b/tests/modules/programs/glow/settings.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+  configPath = if isDarwin then
+    "home-files/Library/Preferences/glow/glow.yml"
+  else
+    "home-files/.config/glow/glow.yml";
+in {
+  config = {
+    programs.glow = {
+      enable = true;
+
+      settings = {
+        style = "light";
+        local = true;
+        mouse = true;
+        pager = true;
+        width = 80;
+      };
+    };
+
+    nixpkgs.overlays =
+      [ (self: super: { glow = pkgs.writeScriptBin "dummy-glow" ""; }) ];
+
+    nmt.script = ''
+      assertFileContent \
+        ${configPath} \
+          ${
+            pkgs.writeText "glow-expected-config.conf" ''
+              {"local":true,"mouse":true,"pager":true,"style":"light","width":80}''
+          }
+    '';
+  };
+}

--- a/tests/modules/programs/gotop/default.nix
+++ b/tests/modules/programs/gotop/default.nix
@@ -1,0 +1,1 @@
+{ gotop-settings = ./settings.nix; }

--- a/tests/modules/programs/gotop/settings.nix
+++ b/tests/modules/programs/gotop/settings.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+  configPath = if isDarwin then
+    "home-files/Library/Application\\ Support/gotop/gotop.conf"
+  else
+    "home-files/.config/gotop/gotop.conf";
+in {
+  config = {
+    programs.gotop = {
+      enable = true;
+
+      settings = {
+        colorscheme = "solarized";
+        layout = "kitchensink";
+      };
+    };
+
+    nixpkgs.overlays =
+      [ (self: super: { gotop = pkgs.writeScriptBin "dummy-gotop" ""; }) ];
+
+    nmt.script = ''
+      assertFileContent \
+        ${configPath} \
+          ${
+            pkgs.writeText "gotop-expected-config.conf" ''
+              colorscheme=solarized
+              layout=kitchensink
+            ''
+          }
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Add gotop, a terminal based graphical activity monitor.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
