### PR TITLE
shell agnostic aliases

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -227,6 +227,26 @@ in
       '';
     };
 
+    home.shellAliases = mkOption {
+      type = with types; attrsOf str;
+      default = { };
+      example = literalExample ''
+        {
+          g = "git";
+          "..." = "cd ../..";
+        }
+      '';
+      description = ''
+        An attribute set that maps aliases (the top level attribute names
+        in this option) to command strings or directly to build outputs.
+        </para><para>
+        This option should only be used to manage simple aliases that are
+        compatible across all shells. If you need to use a shell specific
+        feature then make sure to use a shell specific option, for example
+        <xref linkend="opt-programs.bash.shellAliases"/> for Bash.
+      '';
+    };
+
     home.sessionVariables = mkOption {
       default = {};
       type = types.attrs;
@@ -466,6 +486,10 @@ in
         && config.submoduleSupport.externalPackageInstall
       then "/etc/profiles/per-user/${cfg.username}"
       else cfg.homeDirectory + "/.nix-profile";
+      
+    programs.bash.shellAliases = cfg.shellAliases;
+    programs.zsh.shellAliases = cfg.shellAliases;
+    programs.fish.shellAliases = cfg.shellAliases;
 
     home.sessionVariables =
       let


### PR DESCRIPTION
### Description

Implements #1809. I'm not sure that this is the best way to do it. Maybe it is better to do something like `default = config.home.shellAliases`?

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```