### PR TITLE
Provide path option for dircolors

### DIFF
--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -18,7 +18,7 @@ in {
         and set <code>LS_COLORS</code>.
       '';
     };
-    
+
     path = mkOption {
       type = types.str;
       default = "${config.home.homeDirectory}/.dir_colors";

--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -24,7 +24,7 @@ in {
       default = "${config.home.homeDirectory}/.dir_colors";
       defaultText = "$HOME/.dir_colors";
       description =
-        "Path where Home Manager should link the <filename>.dir_colors</filename> file.";
+        "The path where Home Manager should link the <filename>.dir_colors</filename> file.";
     };
 
     enableBashIntegration = mkOption {

--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -211,7 +211,7 @@ in {
       ".xspf" = mkDefault "00;36";
     };
 
-    home.file.".dir_colors".text = concatStringsSep "\n" ([ ]
+    home.file.${cfg.path}.text = concatStringsSep "\n" ([ ]
       ++ mapAttrsToList formatLine cfg.settings ++ [ "" ]
       ++ optional (cfg.extraConfig != "") cfg.extraConfig);
 

--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -18,6 +18,14 @@ in {
         and set <code>LS_COLORS</code>.
       '';
     };
+    
+    path = mkOption {
+      type = types.str;
+      default = "${config.home.homeDirectory}/.dir_colors";
+      defaultText = "$HOME/.dir_colors";
+      description =
+        "Path where Home Manager should link the <filename>.dir_colors</filename> file.";
+    };
 
     enableBashIntegration = mkOption {
       type = types.bool;
@@ -208,16 +216,16 @@ in {
       ++ optional (cfg.extraConfig != "") cfg.extraConfig);
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      eval $(${pkgs.coreutils}/bin/dircolors -b ~/.dir_colors)
+      eval $(${pkgs.coreutils}/bin/dircolors -b ${cfg.path})
     '';
 
     programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
-      eval (${pkgs.coreutils}/bin/dircolors -c ~/.dir_colors)
+      eval (${pkgs.coreutils}/bin/dircolors -c ${cfg.path})
     '';
 
     # Set `LS_COLORS` before Oh My Zsh and `initExtra`.
     programs.zsh.initExtraBeforeCompInit = mkIf cfg.enableZshIntegration ''
-      eval $(${pkgs.coreutils}/bin/dircolors -b ~/.dir_colors)
+      eval $(${pkgs.coreutils}/bin/dircolors -b ${cfg.path})
     '';
   };
 }

--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -20,7 +20,7 @@ in {
     };
 
     path = mkOption {
-      type = types.str;
+      type = types.path;
       default = "${config.home.homeDirectory}/.dir_colors";
       defaultText = "$HOME/.dir_colors";
       description =


### PR DESCRIPTION
### Description

Add path option for dircolors, allowing user to change its location for XDG compliance

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
