### PR TITLE
astroid: fix maildir paths

### DIFF
--- a/modules/programs/astroid.nix
+++ b/modules/programs/astroid.nix
@@ -22,9 +22,9 @@ let
       sendmail = astroid.sendMailCommand;
       additional_sent_tags = "";
       default = boolOpt primary;
-      save_drafts_to = "${maildir.absPath}/${folders.drafts}";
+      save_drafts_to = "${maildir.absPath}/${folders.drafts}/cur/";
       save_sent = "true";
-      save_sent_to = "${maildir.absPath}/${folders.sent}";
+      save_sent_to = "${maildir.absPath}/${folders.sent}/cur/";
       select_query = "";
     } // optionalAttrs (signature.showSignature != "none") {
       signature_attach = boolOpt (signature.showSignature == "attach");


### PR DESCRIPTION


### Description

By maildir spec, emails should be under mailbox/folder/[cur,tmp,new].
Even the [default astroid config](https://github.com/astroidmail/astroid/wiki/Configuration-Reference#accountsaccountnamesave_sent_to) specifies `Default : /home/root/Mail/drafts/`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
