### PR TITLE
Makefile: init

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -361,3 +361,5 @@
 /modules/xsession.nix                                 @rycee
 
 /modules/services/volnoti.nix                         @IvanMalison
+
+Makefile                                              @thiagokokada

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all all-tests test
+NIX_PATH := nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz
+
+all: all-tests
+
+all-tests:
+	$(MAKE) test TEST=all
+
+test:
+ifndef TEST
+	$(error Use 'make test TEST=<test_name>' to run desired test)
+endif
+	nix-shell --pure tests -I ${NIX_PATH} -A run.${TEST}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
The idea of this file is to make it easier to run tests. It will ensure that the tests are running with the correct `NIX_PATH` (pointing it to e.g.: unstable), and also allowing it to run either one or all tests.

The reason I am creating this is that I always forget the correct incantation to run `home-manager` tests (yeah, it is on the manual, however I use stable generally so I also need to remember to point it to unstable).

This is just an idea to make it easier for newcomers or people that rarely commit to this repo (like me).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
