### PR TITLE
nixos: add modulesPath to specialArgs

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -12,6 +12,7 @@ let
     specialArgs = {
       lib = extendedLib;
       nixosConfig = config;
+      modulesPath = ../modules;
     } // cfg.extraSpecialArgs;
     modules = [
       ({ name, ... }: {
@@ -72,7 +73,6 @@ in {
       extraSpecialArgs = mkOption {
         type = types.attrs;
         default = { };
-        example = literalExample "{ modulesPath = ../modules; }";
         description = ''
           Extra <literal>specialArgs</literal> passed to Home Manager.
         '';


### PR DESCRIPTION
### Description

Fixes #1792

cc @berbiche @lilyball

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
