### PR TITLE
emacs: allow adding command-line arguments to the emacs daemon.

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -54,6 +54,15 @@ in {
       description = "The Emacs package to use.";
     };
 
+    extraOptions = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      example = [ "-f" "exwm-enable" ];
+      description = ''
+        Extra command-line arguments to pass to <command>emacs</command>.
+      '';
+    };
+
     client = {
       enable = mkEnableOption "generation of Emacs client desktop file";
       arguments = mkOption {
@@ -111,7 +120,7 @@ in {
             # when using socket activation.
               optionalString cfg.socketActivation.enable
               "=${escapeShellArg socketPath}"
-            }"'';
+            } ${escapeShellArgs cfg.extraOptions}"'';
 
           # Emacs will exit with status 15 after having received SIGTERM, which
           # is the default "KillSignal" value systemd uses to stop services.

--- a/tests/modules/services/emacs/emacs-service-27.nix
+++ b/tests/modules/services/emacs/emacs-service-27.nix
@@ -17,6 +17,7 @@ with lib;
     programs.emacs.enable = true;
     services.emacs.enable = true;
     services.emacs.client.enable = true;
+    services.emacs.extraOptions = [ "-f" "exwm-enable" ];
 
     nmt.script = ''
       assertPathNotExists home-files/.config/systemd/user/emacs.socket

--- a/tests/modules/services/emacs/emacs-service-28.nix
+++ b/tests/modules/services/emacs/emacs-service-28.nix
@@ -17,6 +17,7 @@ with lib;
     programs.emacs.enable = true;
     services.emacs.enable = true;
     services.emacs.client.enable = true;
+    services.emacs.extraOptions = [ "-f" "exwm-enable" ];
 
     nmt.script = ''
       assertPathNotExists home-files/.config/systemd/user/emacs.socket

--- a/tests/modules/services/emacs/emacs-service-emacs.service
+++ b/tests/modules/services/emacs/emacs-service-emacs.service
@@ -2,7 +2,7 @@
 WantedBy=default.target
 
 [Service]
-ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon"
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon '-f' 'exwm-enable'"
 Restart=on-failure
 SuccessExitStatus=15
 Type=notify

--- a/tests/modules/services/emacs/emacs-socket-27.nix
+++ b/tests/modules/services/emacs/emacs-socket-27.nix
@@ -19,6 +19,7 @@ in {
     programs.emacs.enable = true;
     services.emacs.enable = true;
     services.emacs.client.enable = true;
+    services.emacs.extraOptions = [ "-f" "exwm-enable" ];
     services.emacs.socketActivation.enable = true;
 
     nmt.script = ''

--- a/tests/modules/services/emacs/emacs-socket-28.nix
+++ b/tests/modules/services/emacs/emacs-socket-28.nix
@@ -19,6 +19,7 @@ in {
     programs.emacs.enable = true;
     services.emacs.enable = true;
     services.emacs.client.enable = true;
+    services.emacs.extraOptions = [ "-f" "exwm-enable" ];
     services.emacs.socketActivation.enable = true;
 
     nmt.script = ''

--- a/tests/modules/services/emacs/emacs-socket-emacs.service
+++ b/tests/modules/services/emacs/emacs-socket-emacs.service
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon='%t/emacs/server'"
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon='%t/emacs/server' '-f' 'exwm-enable'"
 ExecStartPost=@coreutils@/bin/chmod --changes -w %t/emacs
 ExecStopPost=@coreutils@/bin/chmod --changes +w %t/emacs
 Restart=on-failure


### PR DESCRIPTION
### Description

<!--

The module services.emacs currently only allows providing command-line arguments
to emacsclient. This pull request adds the ability to add arguments to the
the start command for the daemon, too. This is accomplished by adding the arguments in
the list provided to services.emacs.arguments after the '--fg-daemon' flag in the start command for the daemon.
One example of where this is useful is starting the daemon with '-f exwm-enable' in order
to use any emacsclient with the exwm package.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
