### PR TITLE
xsettingsd: make configurable through module

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -139,6 +139,7 @@ import nmt {
     ./modules/services/window-managers/i3
     ./modules/services/window-managers/sway
     ./modules/services/wlsunset
+    ./modules/services/xsettingsd
     ./modules/systemd
     ./modules/targets-linux
   ] ++ lib.optionals enableBig [

--- a/tests/modules/services/xsettingsd/basic-configuration.conf
+++ b/tests/modules/services/xsettingsd/basic-configuration.conf
@@ -1,0 +1,4 @@
+Net/ThemeName "Numix"
+Xft/Antialias 1
+Xft/Hinting 1
+Xft/RGBA "rgb"

--- a/tests/modules/services/xsettingsd/basic-configuration.nix
+++ b/tests/modules/services/xsettingsd/basic-configuration.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.xsettingsd = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { };
+      settings = {
+        "Net/ThemeName" = "Numix";
+        "Xft/Antialias" = true;
+        "Xft/Hinting" = true;
+        "Xft/RGBA" = "rgb";
+      };
+    };
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/xsettingsd.service
+
+      assertFileExists $serviceFile
+      assertFileRegex $serviceFile 'ExecStart=.*/bin/xsettingsd.*'
+
+      assertFileExists ${config.services.xsettingsd.configFile}
+      assertFileContent ${config.services.xsettingsd.configFile} \
+        ${./basic-configuration.conf}
+    '';
+  };
+}

--- a/tests/modules/services/xsettingsd/default.nix
+++ b/tests/modules/services/xsettingsd/default.nix
@@ -1,0 +1,1 @@
+{ xsettingsd-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

This introduces a `config` option for xsettingsd, making it fully configurable through home-manager. 

I've also added a `configLocation` option, which works by setting xsettingsd's `-c` option on the systemd unit.

The unit now can reload its configuration ([as documented here](https://github.com/derat/xsettingsd/wiki/Installation#configuration)), which it does when the managed config is changed.

I took extra care to include a `mkIf` to avoid writing the configuration if it's not set, to keep backward compatibility with configurations not managed through home-manager.

Please let me know if you have any feedback!

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
