### PR TITLE
kanshi: allow multiple exec statements per profile

### DIFF
--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -104,23 +104,26 @@ let
       };
 
       exec = mkOption {
-        type = types.nullOr types.str;
-        default = null;
+        type = with types; coercedTo str singleton (listOf str);
+        default = [ ];
         example =
-          "\${pkg.sway}/bin/swaymsg workspace 1, move workspace to eDP-1";
+          "[ \${pkg.sway}/bin/swaymsg workspace 1, move workspace to eDP-1 ]";
         description = ''
-          Command executed after the profile is succesfully applied.
+          Commands executed after the profile is succesfully applied.
+          Note that if you provide multiple commands, they will be
+          executed asynchronously with no guaranteed ordering.
         '';
       };
     };
   };
 
   profileStr = name:
-    { outputs, exec, ... }:
-    ''
+    { outputs, exec, ... }: ''
       profile ${name} {
-        ${concatStringsSep "\n  " (map outputStr outputs)}
-    '' + optionalString (exec != null) "  exec ${exec}\n" + ''
+        ${
+          concatStringsSep "\n  "
+          (map outputStr outputs ++ map (cmd: "exec ${cmd}") exec)
+        }
       }
     '';
 in {

--- a/tests/modules/services/kanshi/basic-configuration.conf
+++ b/tests/modules/services/kanshi/basic-configuration.conf
@@ -1,8 +1,14 @@
+profile backwardsCompat {
+  output "LVDS-1" enable
+  exec echo "7 eight 9"
+}
+
 profile desktop {
   output "eDP-1" disable
   output "Iiyama North America PLE2483H-DP" enable position 0,0
   output "Iiyama North America PLE2483H-DP 1158765348486" enable mode 1920x1080 position 1920,0 scale 2.100000 transform flipped-270
   exec echo "1 two 3"
+  exec echo "4 five 6"
 }
 
 profile nomad {

--- a/tests/modules/services/kanshi/basic-configuration.nix
+++ b/tests/modules/services/kanshi/basic-configuration.nix
@@ -11,7 +11,7 @@
           }];
         };
         desktop = {
-          exec = ''echo "1 two 3"'';
+          exec = [ ''echo "1 two 3"'' ''echo "4 five 6"'' ];
           outputs = [
             {
               criteria = "eDP-1";
@@ -31,6 +31,13 @@
               transform = "flipped-270";
             }
           ];
+        };
+        backwardsCompat = {
+          outputs = [{
+            criteria = "LVDS-1";
+            status = "enable";
+          }];
+          exec = ''echo "7 eight 9"'';
         };
       };
       extraConfig = ''


### PR DESCRIPTION
### Description

kanshi configurations can have more than one exec statement in a profile. This change allows `services.kanshi.profiles.<name>.exec` to be a list of strings rather than a single string. Bare strings are coerced to single-element lists for backwards compatibility.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
