### PR TITLE
gtk: add final newline to bookmarks to avoid conflicts

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -167,7 +167,7 @@ in {
       ++ optionalPackage cfg.iconTheme;
 
     home.file.${cfg2.configLocation}.text =
-      concatStringsSep "\n" (mapAttrsToList formatGtk2Option ini) + "\n"
+      concatMapStrings (l: l + "\n") (mapAttrsToList formatGtk2Option ini)
       + cfg2.extraConfig;
 
     home.sessionVariables.GTK2_RC_FILES = cfg2.configLocation;
@@ -178,7 +178,7 @@ in {
     xdg.configFile."gtk-3.0/gtk.css".text = cfg3.extraCss;
 
     xdg.configFile."gtk-3.0/bookmarks" = mkIf (cfg3.bookmarks != [ ]) {
-      text = concatStringsSep "\n" cfg3.bookmarks;
+      text = concatMapStrings (l: l + "\n") cfg3.bookmarks;
     };
 
     dconf.settings."org/gnome/desktop/interface" = dconfIni;

--- a/tests/modules/misc/gtk/gtk-basic-config-expected.conf
+++ b/tests/modules/misc/gtk/gtk-basic-config-expected.conf
@@ -1,2 +1,1 @@
-
 gtk-can-change-accels = 1


### PR DESCRIPTION
### Description

Thunar seems to force a newline at the end of the GTK bookmarks file.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
