### PR TITLE
fontconfig: use a prettier "real directory" hack

### DIFF
--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -36,22 +36,11 @@ in {
   };
 
   config = mkIf cfg.enable {
-    # Create two dummy files in /lib/fontconfig to make sure that
-    # buildEnv creates a real directory path. These files are removed
-    # in home.extraProfileCommands below so the packages will not
-    # become "runtime" dependencies.
     home.packages = [
-      (pkgs.writeTextFile {
-        name = "hm-dummy1";
-        destination = "/lib/fontconfig/hm-dummy1";
-        text = "dummy";
-      })
-
-      (pkgs.writeTextFile {
-        name = "hm-dummy2";
-        destination = "/lib/fontconfig/hm-dummy2";
-        text = "dummy";
-      })
+      # Make sure that buildEnv creates a real directory path so that we avoid
+      # trying to write to a read-only location.
+      (pkgs.runCommandLocal "dummy-fc-dir1" { } "mkdir -p $out/lib/fontconfig")
+      (pkgs.runCommandLocal "dummy-fc-dir2" { } "mkdir -p $out/lib/fontconfig")
     ];
 
     home.extraProfileCommands = ''
@@ -76,8 +65,7 @@ in {
         unset FONTCONFIG_FILE
       fi
 
-      # Remove hacky dummy files.
-      rm $out/lib/fontconfig/hm-dummy?
+      # Remove the fontconfig directory if no files were available.
       rmdir --ignore-fail-on-non-empty -p $out/lib/fontconfig
     '';
 


### PR DESCRIPTION
### Description

Creating actual files is a bit silly here, it suffices to create two directories.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```