### PR TITLE
programs.ssh: Make match blocks aware of exec matches

### DIFF
--- a/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
+++ b/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
@@ -15,6 +15,9 @@ Host xyz
 Host ordered
   Port 1
 
+Match host "execHost" exec "nc -G 1 -z %h %p"
+  HostName 1.2.3.4
+
 Host *
   ForwardAgent no
   Compression no

--- a/tests/modules/programs/ssh/match-blocks-attrs.nix
+++ b/tests/modules/programs/ssh/match-blocks-attrs.nix
@@ -41,6 +41,12 @@ with lib;
           identityFile = [ "file1" "file2" ];
           port = 516;
         };
+
+        withExec = {
+          hostname = "1.2.3.4";
+          host = "execHost";
+          exec = "nc -G 1 -z %h %p";
+        };
       };
     };
 


### PR DESCRIPTION
### Description

This commit makes it possible to produce Match blocks that execute a
command for  application of declarations.
Using the `exec` criterion together with the `host` criterion is
possible as well.

In case the `exec` criterion is configured, a `Match` section ("block")
is produced instead of a `Host` block.
There are more criteria supported by ssh (see `ssh_config(5)`), however
this commit only introduces support for the `exec` criterion.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
