### PR TITLE
fzf: do shell initialization a bit earlier

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -146,19 +146,25 @@ in {
         FZF_TMUX_OPTS = cfg.tmux.shellIntegrationOptions;
       });
 
-    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
+    # Note, since fzf unconditionally binds C-r we use `mkOrder` to make the
+    # initialization show up a bit earlier. This is to make initialization of
+    # other history managers, like mcfly or atuin, take precedence.
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkOrder 200 ''
       if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
         . ${cfg.package}/share/fzf/completion.bash
         . ${cfg.package}/share/fzf/key-bindings.bash
       fi
-    '';
+    '');
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    # Note, since fzf unconditionally binds C-r we use `mkOrder` to make the
+    # initialization show up a bit earlier. This is to make initialization of
+    # other history managers, like mcfly or atuin, take precedence.
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration (mkOrder 200 ''
       if [[ $options[zle] = on ]]; then
         . ${cfg.package}/share/fzf/completion.zsh
         . ${cfg.package}/share/fzf/key-bindings.zsh
       fi
-    '';
+    '');
 
     programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
       source ${cfg.package}/share/fzf/key-bindings.fish && fzf_key_bindings


### PR DESCRIPTION
### Description

This is to better integrate with more advanced shell history managers like McFly and Atuin. By initializing fzf first, we allow the history managers to steal the C-r key binding from fzf.

### Checklist

- [x] Change is backwards compatible.

    Could potentially cause problems if somebody relies on the existing order. Should be easy to fix by using `mkBefore`.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```