### PR TITLE
Makefile: improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-.PHONY: all all-tests test
-NIX_PATH := nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz
+.PHONY: all all-tests test format
+NIXPKGS_REV := nixpkgs-unstable
+NIX_PATH := nixpkgs=https://github.com/NixOS/nixpkgs/archive/${NIXPKGS_REV}.tar.gz
 
 all: all-tests
 
@@ -11,3 +12,6 @@ ifndef TEST
 	$(error Use 'make test TEST=<test_name>' to run desired test)
 endif
 	nix-shell --pure tests -I ${NIX_PATH} -A run.${TEST}
+
+format:
+	./format


### PR DESCRIPTION
### Description

- Add `NIXPKGS_REV`, so we can pass arbitrary revisions for testing (for example, `release-21.05` so we can test backports).
- Add `format` target, that calls the format script.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
