### PR TITLE
doc: options.html: Update old ZSH properties

### DIFF
--- a/options.html
+++ b/options.html
@@ -8891,7 +8891,7 @@ for the full list of options.
         true
       </code></p><p><span class="emphasis"><em>Declared by:</em></span></p><table border="0" summary="Simple list" class="simplelist"><tr><td><code class="filename"><a class="filename" href="https://github.com/nix-community/home-manager/blob/master/modules/programs/zsh.nix#blob-path" target="_top">
                     &lt;home-manager/modules/programs/zsh.nix&gt;
-                </a></code></td></tr></table></dd><dt><span class="term"><a id="opt-programs.zsh.enableAutosuggestions"></a><a class="term" href="options.html#opt-programs.zsh.enableAutosuggestions"><code class="option">programs.zsh.enableAutosuggestions</code></a></span></dt><dd><p>Enable zsh autosuggestions</p><p><span class="emphasis"><em>Type:</em></span> unspecified</p><p><span class="emphasis"><em>Default:</em></span> <code class="literal">
+                </a></code></td></tr></table></dd><dt><span class="term"><a id="opt-programs.zsh.autosuggestions.enable"></a><a class="term" href="options.html#opt-programs.zsh.autosuggestions.enable"><code class="option">programs.zsh.autosuggestions.enable</code></a></span></dt><dd><p>Enable zsh autosuggestions</p><p><span class="emphasis"><em>Type:</em></span> boolean</p><p><span class="emphasis"><em>Default:</em></span> <code class="literal">
         false
       </code></p><p><span class="emphasis"><em>Declared by:</em></span></p><table border="0" summary="Simple list" class="simplelist"><tr><td><code class="filename"><a class="filename" href="https://github.com/nix-community/home-manager/blob/master/modules/programs/zsh.nix#blob-path" target="_top">
                     &lt;home-manager/modules/programs/zsh.nix&gt;
@@ -8904,7 +8904,7 @@ to your system configuration to get completion for system packages (e.g. systemd
         true
       </code></p><p><span class="emphasis"><em>Declared by:</em></span></p><table border="0" summary="Simple list" class="simplelist"><tr><td><code class="filename"><a class="filename" href="https://github.com/nix-community/home-manager/blob/master/modules/programs/zsh.nix#blob-path" target="_top">
                     &lt;home-manager/modules/programs/zsh.nix&gt;
-                </a></code></td></tr></table></dd><dt><span class="term"><a id="opt-programs.zsh.enableSyntaxHighlighting"></a><a class="term" href="options.html#opt-programs.zsh.enableSyntaxHighlighting"><code class="option">programs.zsh.enableSyntaxHighlighting</code></a></span></dt><dd><p>Enable zsh syntax highlighting</p><p><span class="emphasis"><em>Type:</em></span> unspecified</p><p><span class="emphasis"><em>Default:</em></span> <code class="literal">
+                </a></code></td></tr></table></dd><dt><span class="term"><a id="opt-programs.zsh.syntaxHighlighting.enable"></a><a class="term" href="options.html#opt-programs.zsh.syntaxHighlighting.enable"><code class="option">programs.zsh.syntaxHighlighting.enable</code></a></span></dt><dd><p>Enable zsh syntax highlighting</p><p><span class="emphasis"><em>Type:</em></span> boolean</p><p><span class="emphasis"><em>Default:</em></span> <code class="literal">
         false
       </code></p><p><span class="emphasis"><em>Declared by:</em></span></p><table border="0" summary="Simple list" class="simplelist"><tr><td><code class="filename"><a class="filename" href="https://github.com/nix-community/home-manager/blob/master/modules/programs/zsh.nix#blob-path" target="_top">
                     &lt;home-manager/modules/programs/zsh.nix&gt;


### PR DESCRIPTION
### Description

Update old ZSH properties (enableAutosuggestions and enableSyntaxHishlighting). 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
