### PR TITLE
Replace literalExample with literal{Expression,Docbook}

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -115,7 +115,7 @@ let
           if versionAtLeast config.home.stateVersion "19.09"
           then null
           else "us";
-        defaultText = literalExample "null";
+        defaultText = literalExpression "null";
         description = ''
           Keyboard layout. If <literal>null</literal>, then the system
           configuration will be used.
@@ -149,7 +149,7 @@ let
           if versionAtLeast config.home.stateVersion "19.09"
           then null
           else "";
-        defaultText = literalExample "null";
+        defaultText = literalExpression "null";
         example = "colemak";
         description = ''
           X keyboard variant. If <literal>null</literal>, then the
@@ -182,7 +182,7 @@ in
   options = {
     home.username = mkOption {
       type = types.str;
-      defaultText = literalExample ''
+      defaultText = literalDocbook ''
         "$USER"   for state version < 20.09,
         undefined for state version ≥ 20.09
       '';
@@ -192,7 +192,7 @@ in
 
     home.homeDirectory = mkOption {
       type = types.path;
-      defaultText = literalExample ''
+      defaultText = literalDocbook ''
         "$HOME"   for state version < 20.09,
         undefined for state version ≥ 20.09
       '';
@@ -321,7 +321,7 @@ in
     home.activation = mkOption {
       type = hm.types.dagOf types.str;
       default = {};
-      example = literalExample ''
+      example = literalExpression ''
         {
           myActivationAction = lib.hm.dag.entryAfter ["writeBoundary"] '''
             $DRY_RUN_CMD ln -s $VERBOSE_ARG \

--- a/modules/i18n/input-method/fcitx.nix
+++ b/modules/i18n/input-method/fcitx.nix
@@ -17,7 +17,7 @@ in {
       engines = mkOption {
         type = with types; listOf fcitxEngine;
         default = [ ];
-        example = literalExample "with pkgs.fcitx-engines; [ mozc hangul ]";
+        example = literalExpression "with pkgs.fcitx-engines; [ mozc hangul ]";
         description = let
           enginesDrv = filterAttrs (const isDerivation) pkgs.fcitx-engines;
           engines = concatStringsSep ", "

--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -12,7 +12,7 @@ in {
       addons = mkOption {
         type = with types; listOf package;
         default = [ ];
-        example = literalExample "with pkgs; [ fcitx5-rime ]";
+        example = literalExpression "with pkgs; [ fcitx5-rime ]";
         description = ''
           Enabled Fcitx5 addons.
         '';

--- a/modules/i18n/input-method/kime.nix
+++ b/modules/i18n/input-method/kime.nix
@@ -9,7 +9,7 @@ in {
       config = mkOption {
         type = yamlFormat.type;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             daemon = {
               modules = ["Xim" "Indicator"];

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -21,7 +21,7 @@ with lib;
               absPath = if hasPrefix "/" p then p else "${basePath}/${p}";
             in
               removePrefix (homeDirectory + "/") absPath;
-          defaultText = literalExample "<name>";
+          defaultText = literalExpression "<name>";
           description = ''
             Path to target file relative to ${basePathDesc}.
           '';

--- a/modules/lib/types.nix
+++ b/modules/lib/types.nix
@@ -37,7 +37,7 @@ in rec {
       package = mkOption {
         type = types.nullOr types.package;
         default = null;
-        example = literalExample "pkgs.dejavu_fonts";
+        example = literalExpression "pkgs.dejavu_fonts";
         description = ''
           Package providing the font. This package will be installed
           to your profile. If <literal>null</literal> then the font

--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -27,7 +27,7 @@ in {
       settings = mkOption {
         type = with types; attrsOf (attrsOf hm.types.gvariant);
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             "org/gnome/calculator" = {
               button-mode = "programming";

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -33,7 +33,7 @@ let
       package = mkOption {
         type = types.nullOr types.package;
         default = null;
-        example = literalExample "pkgs.gnome.gnome_themes_standard";
+        example = literalExpression "pkgs.gnome.gnome_themes_standard";
         description = ''
           Package providing the theme. This package will be installed
           to your profile. If <literal>null</literal> then the theme
@@ -97,9 +97,9 @@ in {
           type = types.path;
           default = "${config.home.homeDirectory}/.gtkrc-2.0";
           defaultText =
-            literalExample ''"''${config.home.homeDirectory}/.gtkrc-2.0"'';
+            literalExpression ''"''${config.home.homeDirectory}/.gtkrc-2.0"'';
           example =
-            literalExample ''"''${config.xdg.configHome}/gtk-2.0/gtkrc"'';
+            literalExpression ''"''${config.xdg.configHome}/gtk-2.0/gtkrc"'';
           description = ''
             The location to put the GTK configuration file.
           '';

--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -78,7 +78,7 @@ in {
 
     overlays = mkOption {
       default = null;
-      example = literalExample ''
+      example = literalExpression ''
         [ (self: super: {
             openssh = super.openssh.override {
               hpnSupport = true;

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -78,7 +78,7 @@ in {
         package = mkOption {
           type = types.nullOr types.package;
           default = null;
-          example = literalExample "pkgs.adwaita-qt";
+          example = literalExpression "pkgs.adwaita-qt";
           description = "Theme package to be used in Qt5 applications.";
         };
       };

--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -105,7 +105,7 @@ let
           This may override other values.
         '';
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             Keywords = "calc;math";
             DBusActivatable = "false";
@@ -157,7 +157,7 @@ in {
     '';
     default = { };
     type = types.attrsOf (types.submodule desktopEntry);
-    example = literalExample ''
+    example = literalExpression ''
       {
         firefox = {
           name = "Firefox";

--- a/modules/misc/xdg-mime-apps.nix
+++ b/modules/misc/xdg-mime-apps.nix
@@ -30,7 +30,7 @@ in {
     associations.added = mkOption {
       type = types.attrsOf strListOrSingleton;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           "mimetype1" = [ "foo1.desktop" "foo2.desktop" "foo3.desktop" ];
           "mimetype2" = "foo4.desktop";
@@ -57,7 +57,7 @@ in {
     defaultApplications = mkOption {
       type = types.attrsOf strListOrSingleton;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           "mimetype1" = [ "default1.desktop" "default2.desktop" ];
         }

--- a/modules/misc/xdg-mime.nix
+++ b/modules/misc/xdg-mime.nix
@@ -12,7 +12,7 @@ in {
       type = types.bool;
       default = pkgs.hostPlatform.isLinux;
       defaultText =
-        literalExample "true if host platform is Linux, false otherwise";
+        literalExpression "true if host platform is Linux, false otherwise";
       description = ''
         Whether to install programs and files to support the
         XDG Shared MIME-info specification and XDG MIME Applications

--- a/modules/misc/xdg-system-dirs.nix
+++ b/modules/misc/xdg-system-dirs.nix
@@ -17,7 +17,7 @@ in {
     config = mkOption {
       type = types.listOf types.str;
       default = [ ];
-      example = literalExample ''[ "/etc/xdg" ]'';
+      example = literalExpression ''[ "/etc/xdg" ]'';
       description = ''
         Directory names to add to <envar>XDG_CONFIG_DIRS</envar>
         in the user session.
@@ -27,7 +27,7 @@ in {
     data = mkOption {
       type = types.listOf types.str;
       default = [ ];
-      example = literalExample ''[ "/usr/share" "/usr/local/share" ]'';
+      example = literalExpression ''[ "/usr/share" "/usr/local/share" ]'';
       description = ''
         Directory names to add to <envar>XDG_DATA_DIRS</envar>
         in the user session.

--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -13,14 +13,14 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.alacritty;
-        defaultText = literalExample "pkgs.alacritty";
+        defaultText = literalExpression "pkgs.alacritty";
         description = "The Alacritty package to install.";
       };
 
       settings = mkOption {
         type = yamlFormat.type;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             window.dimensions = {
               lines = 3;

--- a/modules/programs/alot-accounts.nix
+++ b/modules/programs/alot-accounts.nix
@@ -25,7 +25,7 @@ with lib;
           + "}[,\\]]?'";
         shellcommand_external_filtering = "False";
       };
-      example = literalExample ''
+      example = literalExpression ''
         {
           type = "shellcommand";
           command = "abook --mutt-query";

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -200,7 +200,7 @@ in {
           handle_mouse = true;
           prefer_plaintext = true;
         };
-        example = literalExample ''
+        example = literalExpression ''
           {
             auto_remove_unread = true;
             ask_subject = false;

--- a/modules/programs/aria2.nix
+++ b/modules/programs/aria2.nix
@@ -31,7 +31,7 @@ in {
         </citerefentry>
         for options.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           listen-port = 60000;
           dht-listen-port = 60000;

--- a/modules/programs/astroid.nix
+++ b/modules/programs/astroid.nix
@@ -93,7 +93,7 @@ in {
       extraConfig = mkOption {
         type = jsonFormat.type;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             poll.interval = 0;
           }

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -17,7 +17,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.atuin;
-      defaultText = literalExample "pkgs.atuin";
+      defaultText = literalExpression "pkgs.atuin";
       description = "The package to use for atuin.";
     };
 
@@ -50,7 +50,7 @@ in {
           entries = entryOrAttrsOf (entryOrAttrsOf entry);
         in attrsOf entries // { description = "Atuin configuration"; };
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           auto_sync = true;
           sync_frequency = "5m";

--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -106,7 +106,7 @@ let
       transform = mkOption {
         type = types.nullOr (matrixOf 3 3 types.float);
         default = null;
-        example = literalExample ''
+        example = literalExpression ''
           [
             [ 0.6 0.0 0.0 ]
             [ 0.0 0.6 0.0 ]
@@ -169,7 +169,7 @@ let
           exclusive.
         '';
         default = null;
-        example = literalExample ''
+        example = literalExpression ''
           {
             x = 1.25;
             y = 1.25;
@@ -280,7 +280,7 @@ in {
         type = globalHooksModule;
         description = "Global hook scripts";
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             postswitch = {
               "notify-i3" = "''${pkgs.i3}/bin/i3-msg restart";
@@ -312,7 +312,7 @@ in {
         type = types.attrsOf profileModule;
         description = "Autorandr profiles specification.";
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             "work" = {
               fingerprint = {

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -97,7 +97,7 @@ in
       shellAliases = mkOption {
         default = {};
         type = types.attrsOf types.str;
-        example = literalExample ''
+        example = literalExpression ''
           {
             ll = "ls -l";
             ".." = "cd ..";

--- a/modules/programs/bat.nix
+++ b/modules/programs/bat.nix
@@ -33,7 +33,7 @@ in {
     themes = mkOption {
       type = types.attrsOf types.lines;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           dracula = builtins.readFile (pkgs.fetchFromGitHub {
             owner = "dracula";

--- a/modules/programs/beets.nix
+++ b/modules/programs/beets.nix
@@ -31,9 +31,9 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.beets;
-        defaultText = literalExample "pkgs.beets";
+        defaultText = literalExpression "pkgs.beets";
         example =
-          literalExample "(pkgs.beets.override { enableCheck = true; })";
+          literalExpression "(pkgs.beets.override { enableCheck = true; })";
         description = ''
           The <literal>beets</literal> package to use.
           Can be used to specify extensions.

--- a/modules/programs/bottom.nix
+++ b/modules/programs/bottom.nix
@@ -23,7 +23,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.bottom;
-        defaultText = literalExample "pkgs.bottom";
+        defaultText = literalExpression "pkgs.bottom";
         description = "Package providing <command>bottom</command>.";
       };
 
@@ -38,7 +38,7 @@ in {
           See <link xlink:href="https://github.com/ClementTsang/bottom/blob/master/sample_configs/default_config.toml"/>
           for the default configuration.
         '';
-        example = literalExample ''
+        example = literalExpression ''
           {
             flags = {
               avg_cpu = true;

--- a/modules/programs/broot.nix
+++ b/modules/programs/broot.nix
@@ -67,7 +67,7 @@ in {
           execution = "less {file}";
         }
       ];
-      example = literalExample ''
+      example = literalExpression ''
         [
           { invocation = "p"; execution = ":parent"; }
           { invocation = "edit"; shortcut = "e"; execution = "$EDITOR {file}" ; }
@@ -124,14 +124,14 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.broot;
-      defaultText = literalExample "pkgs.broot";
+      defaultText = literalExpression "pkgs.broot";
       description = "Package providing broot";
     };
 
     skin = mkOption {
       type = types.attrsOf types.str;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           status_normal_fg = "grayscale(18)";
           status_normal_bg = "grayscale(3)";

--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -21,7 +21,7 @@ let
         inherit visible;
         type = types.package;
         default = defaultPkg;
-        defaultText = literalExample "pkgs.${browser}";
+        defaultText = literalExpression "pkgs.${browser}";
         description = "The ${name} package to use.";
       };
     } // optionalAttrs (!isProprietaryChrome) {
@@ -72,7 +72,7 @@ let
             };
           in listOf (coercedTo str (v: { id = v; }) extensionType);
         default = [ ];
-        example = literalExample ''
+        example = literalExpression ''
           [
             { id = "cjpalhdlnbpafiamejdnhcphjbkeiagm"; } # ublock origin
             {

--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -51,7 +51,7 @@ in {
         See <command>dircolors --print-database</command>
         for options.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           OTHER_WRITABLE = "30;46";
           ".sh" = "01;32";

--- a/modules/programs/eclipse.nix
+++ b/modules/programs/eclipse.nix
@@ -16,8 +16,8 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.eclipses.eclipse-platform;
-        defaultText = literalExample "pkgs.eclipses.eclipse-platform";
-        example = literalExample "pkgs.eclipses.eclipse-java";
+        defaultText = literalExpression "pkgs.eclipses.eclipse-platform";
+        example = literalExpression "pkgs.eclipses.eclipse-java";
         description = ''
           The Eclipse package to install.
         '';

--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -29,8 +29,8 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.emacs;
-        defaultText = literalExample "pkgs.emacs";
-        example = literalExample "pkgs.emacs25-nox";
+        defaultText = literalExpression "pkgs.emacs";
+        example = literalExpression "pkgs.emacs25-nox";
         description = "The Emacs package to use.";
       };
 
@@ -55,7 +55,7 @@ in {
         default = self: [ ];
         type = hm.types.selectorFunction;
         defaultText = "epkgs: []";
-        example = literalExample "epkgs: [ epkgs.emms epkgs.magit ]";
+        example = literalExpression "epkgs: [ epkgs.emms epkgs.magit ]";
         description = ''
           Extra packages available to Emacs. To get a list of
           available packages run:
@@ -67,7 +67,7 @@ in {
         default = self: super: { };
         type = hm.types.overlayFunction;
         defaultText = "self: super: {}";
-        example = literalExample ''
+        example = literalExpression ''
           self: super: rec {
             haskell-mode = self.melpaPackages.haskell-mode;
             # ...

--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -107,8 +107,8 @@ in {
           pkgs.firefox
         else
           pkgs.firefox-unwrapped;
-        defaultText = literalExample "pkgs.firefox";
-        example = literalExample ''
+        defaultText = literalExpression "pkgs.firefox";
+        example = literalExpression ''
           pkgs.firefox.override {
             # See nixpkgs' firefox/wrapper.nix to check which options you can use
             cfg = {
@@ -129,7 +129,7 @@ in {
       extensions = mkOption {
         type = types.listOf types.package;
         default = [ ];
-        example = literalExample ''
+        example = literalExpression ''
           with pkgs.nur.repos.rycee.firefox-addons; [
             https-everywhere
             privacy-badger
@@ -182,7 +182,7 @@ in {
             settings = mkOption {
               type = with types; attrsOf (either bool (either int str));
               default = { };
-              example = literalExample ''
+              example = literalExpression ''
                 {
                   "browser.startup.homepage" = "https://nixos.org";
                   "browser.search.region" = "GB";
@@ -254,7 +254,7 @@ in {
                 };
               }));
               default = { };
-              example = literalExample ''
+              example = literalExpression ''
                 {
                   wikipedia = {
                     keyword = "wiki";

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -153,7 +153,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.fish;
-        defaultText = literalExample "pkgs.fish";
+        defaultText = literalExpression "pkgs.fish";
         description = ''
           The fish package to install. May be used to change the version.
         '';
@@ -162,7 +162,7 @@ in {
       shellAliases = mkOption {
         type = with types; attrsOf str;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             g = "git";
             "..." = "cd ../..";
@@ -227,7 +227,7 @@ in {
     programs.fish.plugins = mkOption {
       type = types.listOf pluginModule;
       default = [ ];
-      example = literalExample ''
+      example = literalExpression ''
         [
           {
             name = "z";
@@ -261,7 +261,7 @@ in {
     programs.fish.functions = mkOption {
       type = with types; attrsOf (either lines functionModule);
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           __fish_command_not_found_handler = {
             body = "__fish_default_command_not_found_handler $argv[1]";

--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -16,7 +16,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.foot;
-      defaultText = literalExample "pkgs.foot";
+      defaultText = literalExpression "pkgs.foot";
       description = "The foot package to install";
     };
 
@@ -31,7 +31,7 @@ in {
         xlink:href="https://codeberg.org/dnkl/foot/src/branch/master/foot.ini"/>
         for a list of available options.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           main = {
             term = "xterm-256color";

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -18,7 +18,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.fzf;
-      defaultText = literalExample "pkgs.fzf";
+      defaultText = literalExpression "pkgs.fzf";
       description = "Package providing the <command>fzf</command> tool.";
     };
 
@@ -96,7 +96,7 @@ in {
       shellIntegrationOptions = mkOption {
         type = types.listOf types.str;
         default = [ ];
-        example = literalExample ''[ "-d 40%" ]'';
+        example = literalExpression ''[ "-d 40%" ]'';
         description = ''
           If <option>programs.fzf.tmux.enableShellIntegration</option> is set to <literal>true</literal>,
           shell integration will use these options for fzf-tmux.

--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -15,7 +15,7 @@ in {
     aliases = mkOption {
       type = with types; attrsOf str;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           co = "pr checkout";
           pv = "pr view";

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -108,7 +108,7 @@ let
       contents = mkOption {
         type = types.attrsOf types.anything;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             user = {
               email = "bob@work.example.com";
@@ -146,7 +146,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.git;
-        defaultText = literalExample "pkgs.git";
+        defaultText = literalExpression "pkgs.git";
         description = ''
           Git package to install. Use <varname>pkgs.gitAndTools.gitFull</varname>
           to gain access to <command>git send-email</command> for instance.
@@ -213,7 +213,7 @@ in {
       includes = mkOption {
         type = types.listOf includeModule;
         default = [ ];
-        example = literalExample ''
+        example = literalExpression ''
           [
             { path = "~/path/to/config.inc"; }
             {

--- a/modules/programs/go.nix
+++ b/modules/programs/go.nix
@@ -16,14 +16,14 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.go;
-        defaultText = literalExample "pkgs.go";
+        defaultText = literalExpression "pkgs.go";
         description = "The Go package to use.";
       };
 
       packages = mkOption {
         type = with types; attrsOf path;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             "golang.org/x/text" = builtins.fetchGit "https://go.googlesource.com/text";
             "golang.org/x/time" = builtins.fetchGit "https://go.googlesource.com/time";

--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -29,14 +29,14 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.gnupg;
-      defaultText = literalExample "pkgs.gnupg";
-      example = literalExample "pkgs.gnupg23";
+      defaultText = literalExpression "pkgs.gnupg";
+      example = literalExpression "pkgs.gnupg23";
       description = "The Gnupg package to use (also used the gpg-agent service).";
     };
 
     settings = mkOption {
       type = types.attrsOf (types.either primitiveType (types.listOf types.str));
-      example = literalExample ''
+      example = literalExpression ''
         {
           no-comments = false;
           s2k-cipher-algo = "AES128";
@@ -54,7 +54,7 @@ in
 
     scdaemonSettings = mkOption {
       type = types.attrsOf (types.either primitiveType (types.listOf types.str));
-      example = literalExample ''
+      example = literalExpression ''
         {
           disable-ccid = true;
         }
@@ -68,9 +68,9 @@ in
 
     homedir = mkOption {
       type = types.path;
-      example = literalExample "\"\${config.xdg.dataHome}/gnupg\"";
+      example = literalExpression "\"\${config.xdg.dataHome}/gnupg\"";
       default = "${config.home.homeDirectory}/.gnupg";
-      defaultText = literalExample "\"\${config.home.homeDirectory}/.gnupg\"";
+      defaultText = literalExpression "\"\${config.home.homeDirectory}/.gnupg\"";
       description = "Directory to store keychains and configuration.";
     };
   };

--- a/modules/programs/himalaya.nix
+++ b/modules/programs/himalaya.nix
@@ -45,7 +45,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.himalaya;
-        defaultText = literalExample "pkgs.himalaya";
+        defaultText = literalExpression "pkgs.himalaya";
         description = ''
           Package providing the <command>himalaya</command> mail client.
         '';
@@ -54,7 +54,7 @@ in {
       settings = mkOption {
         type = tomlFormat.type;
         default = { };
-        example = lib.literalExample ''
+        example = lib.literalExpression ''
           {
             default-page-size = 50;
           }
@@ -76,7 +76,7 @@ in {
             settings = mkOption {
               type = tomlFormat.type;
               default = { };
-              example = lib.literalExample ''
+              example = lib.literalExpression ''
                 {
                   default-page-size = 50;
                 }

--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -97,7 +97,7 @@ in {
     settings = mkOption {
       type = types.attrs;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           color_scheme = 6;
           cpu_count_from_one = 0;

--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -59,7 +59,7 @@ in {
               <link xlink:href="https://github.com/greshake/i3status-rust/blob/master/blocks.md"/>
               for block options.
             '';
-            example = literalExample ''
+            example = literalExpression ''
               [
                 {
                   block = "disk_space";
@@ -91,7 +91,7 @@ in {
               Any extra options to add to i3status-rust
               <filename>config</filename>.
             '';
-            example = literalExample ''
+            example = literalExpression ''
               {
                 theme =  {
                   name = "solarized-dark";
@@ -181,7 +181,7 @@ in {
         </citerefentry>
         for options.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         bottom = {
           blocks = [
             {
@@ -234,7 +234,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.i3status-rust;
-      defaultText = literalExample "pkgs.i3status-rust";
+      defaultText = literalExpression "pkgs.i3status-rust";
       description = "Package providing i3status-rust";
     };
 

--- a/modules/programs/i3status.nix
+++ b/modules/programs/i3status.nix
@@ -60,7 +60,7 @@ in {
         </citerefentry>
         for options.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           colors = true;
           color_good = "#e0e0e0";
@@ -99,7 +99,7 @@ in {
               </citerefentry>
               for options.
             '';
-            example = literalExample ''
+            example = literalExpression ''
               {
                 format = "♪ %volume";
                 format_muted = "♪ muted (%volume)";
@@ -119,7 +119,7 @@ in {
         </citerefentry>
         for options.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           "volume master" = {
             position = 1;

--- a/modules/programs/irssi.nix
+++ b/modules/programs/irssi.nix
@@ -170,7 +170,7 @@ in
 
       networks = mkOption {
         default = {};
-        example = literalExample ''
+        example = literalExpression ''
           {
             freenode = {
               nick = "hmuser";

--- a/modules/programs/jq.nix
+++ b/modules/programs/jq.nix
@@ -33,7 +33,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.jq;
-        defaultText = literalExample "pkgs.jq";
+        defaultText = literalExpression "pkgs.jq";
         description = "jq package to use.";
       };
 
@@ -44,7 +44,7 @@ in {
           <para>See <link xlink:href="https://stedolan.github.io/jq/manual/#Colors"/>.
         '';
 
-        example = literalExample ''
+        example = literalExpression ''
           {
             null    = "1;30";
             false   = "0;31";

--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -642,7 +642,7 @@ in {
       plugins = mkOption {
         type = with types; listOf package;
         default = [ ];
-        example = literalExample "[ pkgs.kakounePlugins.kak-fzf ]";
+        example = literalExpression "[ pkgs.kakounePlugins.kak-fzf ]";
         description = ''
           List of kakoune plugins to install. To get a list of
           supported plugins run:

--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -24,7 +24,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.keychain;
-      defaultText = literalExample "pkgs.keychain";
+      defaultText = literalExpression "pkgs.keychain";
       description = ''
         Keychain package to install.
       '';

--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -36,7 +36,7 @@ in {
       type = types.nullOr (types.listOf types.str);
       default = null;
       description = "Command-line options to use when launched by Mac OS GUI";
-      example = literalExample ''
+      example = literalExpression ''
         [
           "--single-instance"
           "--directory=/tmp/my-dir"
@@ -48,7 +48,7 @@ in {
     settings = mkOption {
       type = types.attrsOf eitherStrBoolInt;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           scrollback_lines = 10000;
           enable_audio_bell = false;
@@ -73,7 +73,7 @@ in {
       type = types.attrsOf types.str;
       default = { };
       description = "Mapping of keybindings to actions.";
-      example = literalExample ''
+      example = literalExpression ''
         {
           "ctrl+c" = "copy_or_interrupt";
           "ctrl+f>2" = "set_font_size 20";
@@ -85,7 +85,7 @@ in {
       type = types.attrsOf types.str;
       default = { };
       description = "Environment variables to set or override.";
-      example = literalExample ''
+      example = literalExpression ''
         {
           "LS_COLORS" = "1";
         }

--- a/modules/programs/lazygit.nix
+++ b/modules/programs/lazygit.nix
@@ -19,8 +19,8 @@ in {
     settings = mkOption {
       type = yamlFormat.type;
       default = { };
-      defaultText = literalExample "{ }";
-      example = literalExample ''
+      defaultText = literalExpression "{ }";
+      example = literalExpression ''
         {
           gui.theme = {
             lightTheme = true;

--- a/modules/programs/lf.nix
+++ b/modules/programs/lf.nix
@@ -117,7 +117,7 @@ in {
       cmdKeybindings = mkOption {
         type = with types; attrsOf (nullOr str);
         default = { };
-        example = literalExample ''{ "<c-g>" = "cmd-escape"; }'';
+        example = literalExpression ''{ "<c-g>" = "cmd-escape"; }'';
         description = ''
           Keys to bind to command line commands which can only be one of the
           builtin commands. Keys set to null or an empty string are deleted.
@@ -127,7 +127,7 @@ in {
       previewer.source = mkOption {
         type = with types; nullOr path;
         default = null;
-        example = literalExample ''
+        example = literalExpression ''
           pkgs.writeShellScript "pv.sh" '''
             #!/bin/sh
 

--- a/modules/programs/mangohud.nix
+++ b/modules/programs/mangohud.nix
@@ -31,7 +31,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.mangohud;
-        defaultText = literalExample "pkgs.mangohud";
+        defaultText = literalExpression "pkgs.mangohud";
         description = "The Mangohud package to install.";
       };
 
@@ -47,7 +47,7 @@ in {
       settings = mkOption {
         type = with types; attrsOf settingsType;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             output_folder = ~/Documents/mangohud/;
             full = true;
@@ -64,7 +64,7 @@ in {
       settingsPerApplication = mkOption {
         type = with types; attrsOf (attrsOf settingsType);
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             mpv = {
               no_display = true;

--- a/modules/programs/matplotlib.nix
+++ b/modules/programs/matplotlib.nix
@@ -28,7 +28,7 @@ in {
         Add terms to the <filename>matplotlibrc</filename> file to
         control the default matplotlib behavior.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           backend = "Qt5Agg";
           axes = {

--- a/modules/programs/mbsync-accounts.nix
+++ b/modules/programs/mbsync-accounts.nix
@@ -192,7 +192,7 @@ in {
     extraConfig.channel = mkOption {
       type = extraConfigType;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           MaxMessages = 10000;
           MaxSize = "1m";
@@ -222,7 +222,7 @@ in {
     extraConfig.account = mkOption {
       type = extraConfigType;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           PipelineDepth = 10;
           Timeout = 60;

--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -197,15 +197,15 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.isync;
-        defaultText = literalExample "pkgs.isync";
-        example = literalExample "pkgs.isync";
+        defaultText = literalExpression "pkgs.isync";
+        example = literalExpression "pkgs.isync";
         description = "The package to use for the mbsync binary.";
       };
 
       groups = mkOption {
         type = types.attrsOf (types.attrsOf (types.listOf types.str));
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             inboxes = {
               account1 = [ "Inbox" ];

--- a/modules/programs/mercurial.nix
+++ b/modules/programs/mercurial.nix
@@ -17,7 +17,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.mercurial;
-        defaultText = literalExample "pkgs.mercurial";
+        defaultText = literalExpression "pkgs.mercurial";
         description = "Mercurial package to install.";
       };
 

--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -62,7 +62,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.mpv;
-        example = literalExample
+        example = literalExpression
           "pkgs.wrapMpv (pkgs.mpv-unwrapped.override { vapoursynthSupport = true; }) { youtubeSupport = true; }";
         description = ''
           Package providing mpv.
@@ -81,7 +81,7 @@ in {
       scripts = mkOption {
         type = with types; listOf (either package str);
         default = [ ];
-        example = literalExample "[ pkgs.mpvScripts.mpris ]";
+        example = literalExpression "[ pkgs.mpvScripts.mpris ]";
         description = ''
           List of scripts to use with mpv.
         '';
@@ -99,7 +99,7 @@ in {
         '';
         type = mpvOptions;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             profile = "gpu-hq";
             force-window = true;
@@ -117,7 +117,7 @@ in {
         '';
         type = mpvProfiles;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             fast = {
               vo = "vdpau";
@@ -152,7 +152,7 @@ in {
         '';
         type = mpvBindings;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             WHEEL_UP = "seek 10";
             WHEEL_DOWN = "seek -10";

--- a/modules/programs/ncmpcpp.nix
+++ b/modules/programs/ncmpcpp.nix
@@ -53,12 +53,12 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.ncmpcpp;
-      defaultText = literalExample "pkgs.ncmpcpp";
+      defaultText = literalExpression "pkgs.ncmpcpp";
       description = ''
         Package providing the <code>ncmpcpp</code> command.
       '';
       example =
-        literalExample "pkgs.ncmpcpp.override { visualizerSupport = true; }";
+        literalExpression "pkgs.ncmpcpp.override { visualizerSupport = true; }";
     };
 
     mpdMusicDir = mkOption {
@@ -68,7 +68,7 @@ in {
         mpdCfg.musicDirectory
       else
         null;
-      defaultText = literalExample ''
+      defaultText = literalExpression ''
         if pkgs.stdenv.hostPlatform.isLinux && config.services.mpd.enable then
           config.services.mpd.musicDirectory
         else
@@ -101,7 +101,7 @@ in {
       type = types.listOf bindingType;
       default = [ ];
       description = "List of keybindings.";
-      example = literalExample ''
+      example = literalExpression ''
         [
           { key = "j"; command = "scroll_down"; }
           { key = "k"; command = "scroll_up"; }

--- a/modules/programs/ncspot.nix
+++ b/modules/programs/ncspot.nix
@@ -17,14 +17,14 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.ncspot;
-      defaultText = literalExample "pkgs.ncspot";
+      defaultText = literalExpression "pkgs.ncspot";
       description = "The package to use for ncspot.";
     };
 
     settings = mkOption {
       type = tomlFormat.type;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           shuffle = true;
           gapless = true;

--- a/modules/programs/ne.nix
+++ b/modules/programs/ne.nix
@@ -49,7 +49,7 @@ in {
     automaticPreferences = mkOption {
       type = types.attrsOf types.lines;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           nix = '''
             TAB 0

--- a/modules/programs/neomutt-accounts.nix
+++ b/modules/programs/neomutt-accounts.nix
@@ -30,7 +30,7 @@ in {
         "msmtpq --read-envelope-from --read-recipients"
       else
         null;
-      defaultText = literalExample ''
+      defaultText = literalExpression ''
         if config.msmtp.enable then
           "msmtpq --read-envelope-from --read-recipients"
         else

--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -234,7 +234,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.neomutt;
-        defaultText = literalExample "pkgs.neomutt";
+        defaultText = literalExpression "pkgs.neomutt";
         description = "The neomutt package to use.";
       };
 

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -125,7 +125,7 @@ in {
         type = with types; either extraPython3PackageType (listOf package);
         default = (_: [ ]);
         defaultText = "ps: []";
-        example = literalExample "(ps: with ps; [ python-language-server ])";
+        example = literalExpression "(ps: with ps; [ python-language-server ])";
         description = ''
           A function in python.withPackages format, which returns a
           list of Python 3 packages required for your plugins to work.
@@ -144,7 +144,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.neovim-unwrapped;
-        defaultText = literalExample "pkgs.neovim-unwrapped";
+        defaultText = literalExpression "pkgs.neovim-unwrapped";
         description = "The package to use for the neovim binary.";
       };
 
@@ -158,7 +158,7 @@ in {
       configure = mkOption {
         type = types.attrsOf types.anything;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           configure = {
               customRC = $''''
               " here your custom configuration goes!
@@ -210,7 +210,7 @@ in {
       plugins = mkOption {
         type = with types; listOf (either package pluginWithConfigType);
         default = [ ];
-        example = literalExample ''
+        example = literalExpression ''
           with pkgs.vimPlugins; [
             yankring
             vim-nix
@@ -235,7 +235,7 @@ in {
         settings = mkOption {
           type = jsonFormat.type;
           default = { };
-          example = literalExample ''
+          example = literalExpression ''
             {
               "suggest.noselect" = true;
               "suggest.enablePreview" = true;

--- a/modules/programs/nix-index.nix
+++ b/modules/programs/nix-index.nix
@@ -9,7 +9,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.nix-index;
-      defaultText = literalExample "pkgs.nix-index";
+      defaultText = literalExpression "pkgs.nix-index";
       description = "Package providing the <command>nix-index</command> tool.";
     };
 

--- a/modules/programs/nnn.nix
+++ b/modules/programs/nnn.nix
@@ -14,7 +14,7 @@ let
     options = {
       src = mkOption {
         type = with types; nullOr path;
-        example = literalExample ''
+        example = literalExpression ''
           (pkgs.fetchFromGitHub {
             owner = "jarun";
             repo = "nnn";
@@ -34,7 +34,7 @@ let
           Key mappings to the plugins.
         '';
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             c = "fzcd";
             f = "finder";
@@ -54,9 +54,9 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.nnn;
-        defaultText = literalExample "pkgs.nnn";
+        defaultText = literalExpression "pkgs.nnn";
         example =
-          literalExample "pkgs.nnn.override ({ withNerdIcons = true; });";
+          literalExpression "pkgs.nnn.override ({ withNerdIcons = true; });";
         description = ''
           Package containing the <command>nnn</command> program.
         '';
@@ -76,7 +76,7 @@ in {
         description = ''
           Directory bookmarks.
         '';
-        example = literalExample ''
+        example = literalExpression ''
           {
             d = "~/Documents";
             D = "~/Downloads";
@@ -90,7 +90,7 @@ in {
       extraPackages = mkOption {
         type = with types; listOf package;
         example =
-          literalExample "with pkgs; [ ffmpegthumbnailer mediainfo sxiv ]";
+          literalExpression "with pkgs; [ ffmpegthumbnailer mediainfo sxiv ]";
         description = ''
           Extra packages available to nnn.
         '';

--- a/modules/programs/noti.nix
+++ b/modules/programs/noti.nix
@@ -26,7 +26,7 @@ in {
         </citerefentry>.
         for the full list of options.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           say = {
             voice = "Alex";

--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -17,7 +17,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.nushell;
-      defaultText = literalExample "pkgs.nushell";
+      defaultText = literalExpression "pkgs.nushell";
       description = "The package to use for nushell.";
     };
 
@@ -31,7 +31,7 @@ in {
           entries = entryOrAttrsOf (entryOrAttrsOf entry);
         in attrsOf entries // { description = "Nushell configuration"; };
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           edit_mode = "vi";
           startup = [ "alias la [] { ls -a }" "alias e [msg] { echo $msg }" ];

--- a/modules/programs/obs-studio.nix
+++ b/modules/programs/obs-studio.nix
@@ -16,7 +16,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.obs-studio;
-        defaultText = literalExample "pkgs.obs-studio";
+        defaultText = literalExpression "pkgs.obs-studio";
         description = ''
           OBS Studio package to install.
         '';
@@ -31,7 +31,7 @@ in {
 
       plugins = mkOption {
         default = [ ];
-        example = literalExample "[ pkgs.obs-studio-plugins.wlrobs ]";
+        example = literalExpression "[ pkgs.obs-studio-plugins.wlrobs ]";
         description = "Optional OBS plugins.";
         type = types.listOf types.package;
       };

--- a/modules/programs/octant.nix
+++ b/modules/programs/octant.nix
@@ -28,14 +28,14 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.octant;
-        defaultText = literalExample "pkgs.octant";
-        example = literalExample "pkgs.octant-other";
+        defaultText = literalExpression "pkgs.octant";
+        example = literalExpression "pkgs.octant-other";
         description = "The Octant package to use.";
       };
 
       plugins = mkOption {
         default = [ ];
-        example = literalExample "[ pkgs.starboard-octant-plugin ]";
+        example = literalExpression "[ pkgs.starboard-octant-plugin ]";
         description = "Optional Octant plugins.";
         type = types.listOf types.package;
       };

--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -132,7 +132,7 @@ in {
       extraConfig.mbnames = mkOption {
         type = extraConfigType;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             filename = "~/.config/mutt/mailboxes";
             header = "'mailboxes '";

--- a/modules/programs/opam.nix
+++ b/modules/programs/opam.nix
@@ -15,7 +15,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.opam;
-      defaultText = literalExample "pkgs.opam";
+      defaultText = literalExpression "pkgs.opam";
       description = "Opam package to install.";
     };
 

--- a/modules/programs/password-store.nix
+++ b/modules/programs/password-store.nix
@@ -15,8 +15,8 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.pass;
-      defaultText = literalExample "pkgs.pass";
-      example = literalExample ''
+      defaultText = literalExpression "pkgs.pass";
+      example = literalExpression ''
         pkgs.pass.withExtensions (exts: [ exts.pass-otp ])
       '';
       description = ''
@@ -31,10 +31,10 @@ in {
       default = {
         PASSWORD_STORE_DIR = "${config.xdg.dataHome}/password-store";
       };
-      defaultText = literalExample ''
+      defaultText = literalExpression ''
         { PASSWORD_STORE_DIR = "$XDG_DATA_HOME/password-store"; }
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           PASSWORD_STORE_DIR = "/some/directory";
           PASSWORD_STORE_KEY = "12345678";

--- a/modules/programs/pet.nix
+++ b/modules/programs/pet.nix
@@ -40,7 +40,7 @@ let
       tag = mkOption {
         type = types.listOf types.str;
         default = [ ];
-        example = literalExample ''["git" "nixpkgs"]'';
+        example = literalExpression ''["git" "nixpkgs"]'';
         description = ''
           List of tags attached to the command.
         '';
@@ -64,7 +64,7 @@ in {
     selectcmdPackage = mkOption {
       type = types.package;
       default = pkgs.fzf;
-      defaultText = literalExample "pkgs.fzf";
+      defaultText = literalExpression "pkgs.fzf";
       description = ''
         The package needed for the <varname>settings.selectcmd</varname>.
       '';

--- a/modules/programs/pidgin.nix
+++ b/modules/programs/pidgin.nix
@@ -16,13 +16,13 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.pidgin;
-        defaultText = literalExample "pkgs.pidgin";
+        defaultText = literalExpression "pkgs.pidgin";
         description = "The Pidgin package to use.";
       };
 
       plugins = mkOption {
         default = [ ];
-        example = literalExample "[ pkgs.pidgin-otr pkgs.pidgin-osd ]";
+        example = literalExpression "[ pkgs.pidgin-otr pkgs.pidgin-osd ]";
         description = "Plugins that should be available to Pidgin.";
       };
     };

--- a/modules/programs/piston-cli.nix
+++ b/modules/programs/piston-cli.nix
@@ -14,14 +14,14 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.piston-cli;
-      defaultText = literalExample "pkgs.piston-cli";
+      defaultText = literalExpression "pkgs.piston-cli";
       description = "The piston-cli package to use.";
     };
 
     settings = mkOption {
       type = yamlFormat.type;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           theme = "emacs";
           box_style = "MINIMAL_DOUBLE_HEAD";

--- a/modules/programs/powerline-go.nix
+++ b/modules/programs/powerline-go.nix
@@ -73,7 +73,7 @@ in {
           may use '~' to represent your home directory but you should
           protect it to avoid shell substitution.
         '';
-        example = literalExample ''
+        example = literalExpression ''
           { "\\~/projects/home-manager" = "prj:home-manager"; }
         '';
       };
@@ -85,7 +85,7 @@ in {
           This can be any key/value pair as described in
           <link xlink:href="https://github.com/justjanne/powerline-go"/>.
         '';
-        example = literalExample ''
+        example = literalExpression ''
           {
             hostname-only-if-ssh = true;
             numeric-exit-codes = true;

--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -41,7 +41,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.qutebrowser;
-      defaultText = literalExample "pkgs.qutebrowser";
+      defaultText = literalExpression "pkgs.qutebrowser";
       description = "Qutebrowser package to install.";
     };
 
@@ -77,7 +77,7 @@ in {
         prepending the search engine name to the search term, for example
         <literal>:open google qutebrowser</literal>.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           w = "https://en.wikipedia.org/wiki/Special:Search?search={}&go=Go&ns0=1";
           aw = "https://wiki.archlinux.org/?search={}";
@@ -95,7 +95,7 @@ in {
         See <link xlink:href="https://qutebrowser.org/doc/help/settings.html"/>
         for options.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           colors = {
             hints = {
@@ -239,7 +239,7 @@ in {
           </varlistentry>
         </variablelist>
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           normal = {
             "<Ctrl-v>" = "spawn mpv {url}";
@@ -260,7 +260,7 @@ in {
         Quickmarks to add to qutebrowser's <filename>quickmarks</filename> file.
         Note that when Home Manager manages your quickmarks, you cannot edit them at runtime.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         {
           nixpkgs = "https://github.com/NixOS/nixpkgs";
           home-manager = "https://github.com/nix-community/home-manager";

--- a/modules/programs/rbw.nix
+++ b/modules/programs/rbw.nix
@@ -73,7 +73,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.rbw;
-      defaultText = literalExample "pkgs.rbw";
+      defaultText = literalExpression "pkgs.rbw";
       description = ''
         Package providing the <command>rbw</command> tool and its
         <command>rbw-agent</command> daemon.
@@ -83,7 +83,7 @@ in {
     settings = mkOption {
       type = types.nullOr settingsModule;
       default = null;
-      example = literalExample ''
+      example = literalExpression ''
         {
           email = "name@example.com";
           lock_timeout = 300;

--- a/modules/programs/readline.nix
+++ b/modules/programs/readline.nix
@@ -30,7 +30,7 @@ in {
     bindings = mkOption {
       default = { };
       type = types.attrsOf types.str;
-      example = literalExample ''
+      example = literalExpression ''
         { "\\C-h" = "backward-kill-word"; }
       '';
       description = "Readline bindings.";

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -202,7 +202,7 @@ in {
       description = ''
         Package providing the <command>rofi</command> binary.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         pkgs.rofi.override { plugins = [ pkgs.rofi-emoji ]; };
       '';
     };
@@ -213,7 +213,7 @@ in {
       description = ''
         List of rofi plugins to be installed.
       '';
-      example = literalExample "[ pkgs.rofi-calc ]";
+      example = literalExpression "[ pkgs.rofi-calc ]";
     };
 
     width = mkOption {
@@ -323,7 +323,7 @@ in {
         therefore the <varname>programs.rofi.theme</varname> option
         should be used whenever possible.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         colors = {
           window = {
             background = "argb:583a4c54";
@@ -349,7 +349,7 @@ in {
     theme = mkOption {
       default = null;
       type = with types; nullOr (oneOf [ str path themeType ]);
-      example = literalExample ''
+      example = literalExpression ''
         let
           inherit (config.lib.formats.rasi) mkLiteral;
         in {
@@ -388,7 +388,7 @@ in {
 
     extraConfig = mkOption {
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           modi = "drun,emoji,ssh";
           kb-primary-paste = "Control+V,Shift+Insert";

--- a/modules/programs/sbt.nix
+++ b/modules/programs/sbt.nix
@@ -76,7 +76,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.sbt;
-      defaultText = literalExample "pkgs.sbt";
+      defaultText = literalExpression "pkgs.sbt";
       description = "The package with sbt to be installed.";
     };
 
@@ -89,7 +89,7 @@ in {
     plugins = mkOption {
       type = types.listOf (sbtTypes.plugin);
       default = [ ];
-      example = literalExample ''
+      example = literalExpression ''
         [
           {
             org = "net.virtual-void";
@@ -111,7 +111,7 @@ in {
     credentials = mkOption {
       type = types.listOf (sbtTypes.credential);
       default = [ ];
-      example = literalExample ''
+      example = literalExpression ''
         [{
           realm = "Sonatype Nexus Repository Manager";
           host = "example.com";

--- a/modules/programs/scmpuff.nix
+++ b/modules/programs/scmpuff.nix
@@ -12,7 +12,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.scmpuff;
-      defaultText = literalExample "pkgs.scmpuff";
+      defaultText = literalExpression "pkgs.scmpuff";
       description = "Package providing the <command>scmpuff</command> tool.";
     };
 

--- a/modules/programs/senpai.nix
+++ b/modules/programs/senpai.nix
@@ -11,7 +11,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.senpai;
-      defaultText = literalExample "pkgs.senpai";
+      defaultText = literalExpression "pkgs.senpai";
       description = "The <literal>senpai</literal> package to use.";
     };
     config = mkOption {
@@ -48,7 +48,7 @@ in {
           };
         };
       };
-      example = literalExample ''
+      example = literalExpression ''
         {
           addr = "libera.chat:6697";
           nick = "nicholas";

--- a/modules/programs/sm64ex.nix
+++ b/modules/programs/sm64ex.nix
@@ -44,11 +44,11 @@ in {
       type = types.nullOr (types.enum [ "us" "eu" "jp" ]);
       default = null;
       defaultText =
-        literalExample "us"; # This is set both in nixpkgs and upstream
+        literalExpression ''"us"''; # This is set both in nixpkgs and upstream
       description = ''
         Your baserom's region. Note that only "us", "eu", and "jp" are supported.
       '';
-      example = literalExample "jp";
+      example = literalExpression ''"jp"'';
     };
 
     baserom = mkOption {
@@ -56,7 +56,7 @@ in {
       default = null;
       description =
         "The path to the Super Mario 64 baserom to extract assets from.";
-      example = literalExample "/home/foo/baserom.us.z64";
+      example = literalExpression ''"/home/foo/baserom.us.z64"'';
     };
 
     extraCompileFlags = mkOption {
@@ -67,7 +67,7 @@ in {
         <link xlink:href="https://github.com/sm64pc/sm64ex/wiki/Build-options"/>
         for more information.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         [
           "BETTERCAMERA=1"
           "NODRAWINGDISTANCE=1"
@@ -81,7 +81,7 @@ in {
       default = null;
       description =
         "Settings for sm64ex's <filename>~/.local/share/sm64pc/sm64config.txt</filename> file.";
-      example = literalExample ''
+      example = literalExpression ''
         {
           fullscreen = false;
           window_x = 0;

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -217,7 +217,7 @@ let
       localForwards = mkOption {
         type = types.listOf forwardModule;
         default = [];
-        example = literalExample ''
+        example = literalExpression ''
           [
             {
               bind.port = 8080;
@@ -238,7 +238,7 @@ let
       remoteForwards = mkOption {
         type = types.listOf forwardModule;
         default = [];
-        example = literalExample ''
+        example = literalExpression ''
           [
             {
               bind.port = 8080;
@@ -259,7 +259,7 @@ let
       dynamicForwards = mkOption {
         type = types.listOf dynamicForwardModule;
         default = [];
-        example = literalExample ''
+        example = literalExpression ''
           [ { port = 8080; } ];
         '';
         description = ''
@@ -417,7 +417,7 @@ in
     matchBlocks = mkOption {
       type = hm.types.listOrDagOf matchBlockModule;
       default = {};
-      example = literalExample ''
+      example = literalExpression ''
         {
           "john.example.com" = {
             hostname = "example.com";

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -19,7 +19,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.starship;
-      defaultText = literalExample "pkgs.starship";
+      defaultText = literalExpression "pkgs.starship";
       description = "The package to use for the starship binary.";
     };
 
@@ -33,7 +33,7 @@ in {
           entries = entryOrAttrsOf (entryOrAttrsOf entry);
         in attrsOf entries // { description = "Starship configuration"; };
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           add_newline = false;
           format = lib.concatStrings [

--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -42,7 +42,7 @@ in {
       config = mkOption {
         type = types.attrsOf types.anything;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             confirmation = false;
             report.minimal.filter = "status:pending";

--- a/modules/programs/terminator.nix
+++ b/modules/programs/terminator.nix
@@ -36,7 +36,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.terminator;
-      example = literalExample "pkgs.terminator";
+      example = literalExpression "pkgs.terminator";
       description = "terminator package to install.";
     };
 
@@ -53,7 +53,7 @@ in {
         man page.
       '';
       type = types.attrsOf types.anything;
-      example = literalExample ''
+      example = literalExpression ''
         {
           global_config.borderless = true;
           profiles.default.background_color = "#002b36";

--- a/modules/programs/texlive.nix
+++ b/modules/programs/texlive.nix
@@ -18,14 +18,14 @@ in {
 
       packageSet = mkOption {
         default = pkgs.texlive;
-        defaultText = literalExample "pkgs.texlive";
+        defaultText = literalExpression "pkgs.texlive";
         description = "TeX Live package set to use.";
       };
 
       extraPackages = mkOption {
         default = tpkgs: { inherit (tpkgs) collection-basic; };
         defaultText = "tpkgs: { inherit (tpkgs) collection-basic; }";
-        example = literalExample ''
+        example = literalExpression ''
           tpkgs: { inherit (tpkgs) collection-fontsrecommended algorithms; }
         '';
         description = "Extra packages available to TeX Live.";

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -218,8 +218,8 @@ in
       package = mkOption {
         type = types.package;
         default = pkgs.tmux;
-        defaultText = literalExample "pkgs.tmux";
-        example = literalExample "pkgs.tmux";
+        defaultText = literalExpression "pkgs.tmux";
+        example = literalExpression "pkgs.tmux";
         description = "The tmux package to install";
       };
 
@@ -302,7 +302,7 @@ in
           run at the top of your configuration.
         '';
         default = [ ];
-        example = literalExample ''
+        example = literalExpression ''
           with pkgs; [
             tmuxPlugins.cpu
             {

--- a/modules/programs/topgrade.nix
+++ b/modules/programs/topgrade.nix
@@ -18,15 +18,15 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.topgrade;
-      defaultText = literalExample "pkgs.topgrade";
+      defaultText = literalExpression "pkgs.topgrade";
       description = "The package to use for the topgrade binary.";
     };
 
     settings = mkOption {
       type = tomlFormat.type;
       default = { };
-      defaultText = literalExample "{ }";
-      example = literalExample ''
+      defaultText = literalExpression "{ }";
+      example = literalExpression ''
         {
           assume_yes = true;
           disable = [

--- a/modules/programs/urxvt.nix
+++ b/modules/programs/urxvt.nix
@@ -13,7 +13,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.rxvt_unicode;
-      defaultText = literalExample "pkgs.rxvt_unicode";
+      defaultText = literalExpression "pkgs.rxvt_unicode";
       description = "rxvt-unicode package to install.";
     };
 
@@ -28,7 +28,7 @@ in {
       type = types.attrsOf types.str;
       default = { };
       description = "Mapping of keybindings to actions";
-      example = literalExample ''
+      example = literalExpression ''
         {
           "Shift-Control-C" = "eval:selection_to_clipboard";
           "Shift-Control-V" = "eval:paste_clipboard";

--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -68,7 +68,7 @@ in {
       plugins = mkOption {
         type = with types; listOf (either str package);
         default = defaultPlugins;
-        example = literalExample "[ pkgs.vimPlugins.YankRing ]";
+        example = literalExpression "[ pkgs.vimPlugins.YankRing ]";
         description = ''
           List of vim plugins to install. To get a list of supported plugins run:
           <command>nix-env -f '&lt;nixpkgs&gt;' -qaP -A vimPlugins</command>.
@@ -82,7 +82,7 @@ in {
       settings = mkOption {
         type = vimSettingsType;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             expandtab = true;
             history = 1000;

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -41,7 +41,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.vscode;
-        example = literalExample "pkgs.vscodium";
+        example = literalExpression "pkgs.vscodium";
         description = ''
           Version of Visual Studio Code to install.
         '';
@@ -50,7 +50,7 @@ in {
       userSettings = mkOption {
         type = jsonFormat.type;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             "update.channel" = "none";
             "[nix]"."editor.tabSize" = 2;
@@ -94,7 +94,7 @@ in {
           };
         });
         default = [ ];
-        example = literalExample ''
+        example = literalExpression ''
           [
             {
               key = "ctrl+c";
@@ -112,7 +112,7 @@ in {
       extensions = mkOption {
         type = types.listOf types.package;
         default = [ ];
-        example = literalExample "[ pkgs.vscode-extensions.bbenoist.Nix ]";
+        example = literalExpression "[ pkgs.vscode-extensions.bbenoist.Nix ]";
         description = ''
           The extensions Visual Studio Code should be started with.
           These will override but not delete manually installed ones.

--- a/modules/programs/vscode/haskell.nix
+++ b/modules/programs/vscode/haskell.nix
@@ -8,7 +8,7 @@ let
 
   defaultHieNixExe = hie-nix.hies + "/bin/hie-wrapper";
   defaultHieNixExeText =
-    literalExample ''"''${pkgs.hie-nix.hies}/bin/hie-wrapper"'';
+    literalExpression ''"''${pkgs.hie-nix.hies}/bin/hie-wrapper"'';
 
   hie-nix = pkgs.hie-nix or (abort ''
     vscode.haskell: pkgs.hie-nix missing. Please add an overlay such as:
@@ -42,7 +42,7 @@ in {
         overlay or set this option. Example overlay configuration:
         <programlisting language="nix">${exampleOverlay}</programlisting>
       '';
-      example = literalExample ''
+      example = literalExpression ''
         (import ~/src/haskell-ide-engine {}).hies + "/bin/hie-wrapper";
       '';
     };

--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -5,7 +5,7 @@ let
     any attrByPath attrNames concatMap concatMapStringsSep elem elemAt filter
     filterAttrs flip foldl' hasPrefix head length mergeAttrs optionalAttrs
     stringLength subtractLists types unique;
-  inherit (lib.options) literalExample mkEnableOption mkOption;
+  inherit (lib.options) literalExpression mkEnableOption mkOption;
   inherit (lib.modules) mkIf mkMerge;
 
   cfg = config.programs.waybar;
@@ -82,7 +82,7 @@ let
         output = mkOption {
           type = nullOr (either str (listOf str));
           default = null;
-          example = literalExample ''
+          example = literalExpression ''
             [ "DP-1" "!DP-2" "!DP-3" ]
           '';
           description = ''
@@ -118,7 +118,7 @@ let
           type = listOf str;
           default = [ ];
           description = "Modules that will be displayed on the left.";
-          example = literalExample ''
+          example = literalExpression ''
             [ "sway/workspaces" "sway/mode" "wlr/taskbar" ]
           '';
         };
@@ -127,7 +127,7 @@ let
           type = listOf str;
           default = [ ];
           description = "Modules that will be displayed in the center.";
-          example = literalExample ''
+          example = literalExpression ''
             [ "sway/window" ]
           '';
         };
@@ -136,7 +136,7 @@ let
           type = listOf str;
           default = [ ];
           description = "Modules that will be displayed on the right.";
-          example = literalExample ''
+          example = literalExpression ''
             [ "mpd" "custom/mymodule#with-css-id" "temperature" ]
           '';
         };
@@ -145,7 +145,7 @@ let
           type = jsonFormat.type;
           default = { };
           description = "Modules configuration.";
-          example = literalExample ''
+          example = literalExpression ''
             {
               "sway/window" = {
                 max-length = 50;
@@ -206,7 +206,7 @@ in {
           xlink:href="https://github.com/Alexays/Waybar/wiki/Configuration"/>
         for supported values.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         [
           {
             layer = "top";

--- a/modules/programs/xmobar.nix
+++ b/modules/programs/xmobar.nix
@@ -9,7 +9,7 @@ in {
 
     package = mkOption {
       default = pkgs.haskellPackages.xmobar;
-      defaultText = literalExample "pkgs.haskellPackages.xmobar";
+      defaultText = literalExpression "pkgs.haskellPackages.xmobar";
       type = types.package;
       description = ''
         Package providing the <command>xmobar</command> binary.
@@ -18,7 +18,7 @@ in {
 
     extraConfig = mkOption {
       default = "";
-      example = literalExample ''
+      example = literalExpression ''
         Config
           { font        = "Fira Code"
           , borderColor = "#d0d0d0"

--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -15,7 +15,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.zoxide;
-      defaultText = literalExample "pkgs.zoxide";
+      defaultText = literalExpression "pkgs.zoxide";
       description = ''
         Zoxide package to install.
       '';

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -56,18 +56,18 @@ let
         default = if versionAtLeast stateVersion "20.03"
           then "$HOME/.zsh_history"
           else relToDotDir ".zsh_history";
-        defaultText = literalExample ''
+        defaultText = literalDocbook ''
           "$HOME/.zsh_history" if state version ≥ 20.03,
           "$ZDOTDIR/.zsh_history" otherwise
         '';
-        example = literalExample ''"''${config.xdg.dataHome}/zsh/zsh_history"'';
+        example = literalExpression ''"''${config.xdg.dataHome}/zsh/zsh_history"'';
         description = "History file location";
       };
 
       ignorePatterns = mkOption {
         type = types.listOf types.str;
         default = [];
-        example = literalExample ''[ "rm *" "pkill *" ]'';
+        example = literalExpression ''[ "rm *" "pkill *" ]'';
         description = ''
           Do not enter command lines into the history list
           if they match any one of the given shell patterns.
@@ -224,7 +224,7 @@ in
 
       shellAliases = mkOption {
         default = {};
-        example = literalExample ''
+        example = literalExpression ''
           {
             ll = "ls -l";
             ".." = "cd ..";
@@ -239,7 +239,7 @@ in
 
       shellGlobalAliases = mkOption {
         default = {};
-        example = literalExample ''
+        example = literalExpression ''
           {
             UUID = "$(uuidgen | tr -d \\n)";
             G = "| grep";
@@ -254,7 +254,7 @@ in
 
       dirHashes = mkOption {
         default = {};
-        example = literalExample ''
+        example = literalExpression ''
           {
             docs  = "$HOME/Documents";
             vids  = "$HOME/Videos";
@@ -360,7 +360,7 @@ in
       plugins = mkOption {
         type = types.listOf pluginModule;
         default = [];
-        example = literalExample ''
+        example = literalExpression ''
           [
             {
               # will source zsh-autosuggestions.plugin.zsh

--- a/modules/services/barrier.nix
+++ b/modules/services/barrier.nix
@@ -44,7 +44,7 @@ in {
       extraFlags = mkOption {
         type = types.listOf types.str;
         default = [ "-f" ];
-        defaultText = literalExample ''[ "-f" ]'';
+        defaultText = literalExpression ''[ "-f" ]'';
         description = ''
           Additional flags to pass to <command>barrierc</command>.
           See <command>barrierc --help</command>.

--- a/modules/services/betterlockscreen.nix
+++ b/modules/services/betterlockscreen.nix
@@ -14,7 +14,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.betterlockscreen;
-        defaultText = literalExample "pkgs.betterlockscreen";
+        defaultText = literalExpression "pkgs.betterlockscreen";
         description = "Package providing <command>betterlockscreen</command>.";
       };
 

--- a/modules/services/dropbox.nix
+++ b/modules/services/dropbox.nix
@@ -20,7 +20,7 @@ in {
         type = types.path;
         default = "${config.home.homeDirectory}/Dropbox";
         defaultText =
-          literalExample ''"''${config.home.homeDirectory}/Dropbox"'';
+          literalExpression ''"''${config.home.homeDirectory}/Dropbox"'';
         apply = toString; # Prevent copies to Nix store.
         description = "Where to put the Dropbox directory.";
       };

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -25,7 +25,7 @@ let
     options = {
       package = mkOption {
         type = types.package;
-        example = literalExample "pkgs.gnome.adwaita-icon-theme";
+        example = literalExpression "pkgs.gnome.adwaita-icon-theme";
         description = "Package providing the theme.";
       };
 
@@ -60,7 +60,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.dunst;
-        defaultText = literalExample "pkgs.dunst";
+        defaultText = literalExpression "pkgs.dunst";
         description = "Package providing <command>dunst</command>.";
       };
 
@@ -105,7 +105,7 @@ in {
         default = { };
         description =
           "Configuration written to <filename>$XDG_CONFIG_HOME/dunst/dunstrc</filename>.";
-        example = literalExample ''
+        example = literalExpression ''
           {
             global = {
               geometry = "300x5-30+50";

--- a/modules/services/dwm-status.nix
+++ b/modules/services/dwm-status.nix
@@ -21,7 +21,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.dwm-status;
-        defaultText = literalExample "pkgs.dwm-status";
+        defaultText = literalExpression "pkgs.dwm-status";
         example = "pkgs.dwm-status.override { enableAlsaUtils = false; }";
         description = "Which dwm-status package to use.";
       };
@@ -34,7 +34,7 @@ in {
       extraConfig = mkOption {
         type = jsonFormat.type;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             separator = "#";
 

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -47,7 +47,7 @@ in {
     package = mkOption {
       type = types.package;
       default = if emacsCfg.enable then emacsCfg.finalPackage else pkgs.emacs;
-      defaultText = literalExample ''
+      defaultText = literalExpression ''
         if config.programs.emacs.enable then config.programs.emacs.finalPackage
         else pkgs.emacs
       '';

--- a/modules/services/etesync-dav.nix
+++ b/modules/services/etesync-dav.nix
@@ -32,7 +32,7 @@ in {
     settings = mkOption {
       type = types.attrsOf (types.oneOf [ types.str types.int ]);
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           ETESYNC_LISTEN_ADDRESS = "localhost";
           ETESYNC_LISTEN_PORT = 37358;

--- a/modules/services/fnott.nix
+++ b/modules/services/fnott.nix
@@ -27,7 +27,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.fnott;
-        defaultText = literalExample "pkgs.fnott";
+        defaultText = literalExpression "pkgs.fnott";
         description = "Package providing <command>fnott</command>.";
       };
 
@@ -72,7 +72,7 @@ in {
           xlink:href="https://codeberg.org/dnkl/fnott/src/branch/master/fnott.ini"/>
           for an example configuration.
         '';
-        example = literalExample ''
+        example = literalExpression ''
           {
             main = {
               notification-margin = 5;

--- a/modules/services/git-sync.nix
+++ b/modules/services/git-sync.nix
@@ -74,7 +74,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.git-sync;
-        defaultText = literalExample "pkgs.git-sync";
+        defaultText = literalExpression "pkgs.git-sync";
         description = ''
           Package containing the <command>git-sync</command> program.
         '';

--- a/modules/services/grobi.nix
+++ b/modules/services/grobi.nix
@@ -31,7 +31,7 @@ in {
       rules = mkOption {
         type = with types; listOf (attrsOf eitherStrBoolIntList);
         default = [ ];
-        example = literalExample ''
+        example = literalExpression ''
           [
             {
               name = "Home";

--- a/modules/services/hound.nix
+++ b/modules/services/hound.nix
@@ -45,7 +45,7 @@ in {
     repositories = mkOption {
       type = types.attrsOf jsonFormat.type;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           SomeGitRepo = {
             url = "https://www.github.com/YourOrganization/RepoOne.git";

--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -137,7 +137,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.kanshi;
-      defaultText = literalExample "pkgs.kanshi";
+      defaultText = literalExpression "pkgs.kanshi";
       description = ''
         kanshi derivation to use.
       '';
@@ -149,7 +149,7 @@ in {
       description = ''
         List of profiles.
       '';
-      example = literalExample ''
+      example = literalExpression ''
         undocked = {
           outputs = [
             {

--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -15,7 +15,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.lorri;
-      defaultText = literalExample "pkgs.lorri";
+      defaultText = literalExpression "pkgs.lorri";
       description = "Which lorri package to install.";
     };
   };

--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -274,7 +274,7 @@ in {
       extraConfig = mkOption {
         default = "";
         type = types.lines;
-        example = literalExample ''
+        example = literalExpression ''
           [urgency=low]
           border-color=#b8bb26
         '';

--- a/modules/services/mbsync.nix
+++ b/modules/services/mbsync.nix
@@ -18,8 +18,8 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.isync;
-      defaultText = literalExample "pkgs.isync";
-      example = literalExample "pkgs.isync";
+      defaultText = literalExpression "pkgs.isync";
+      example = literalExpression "pkgs.isync";
       description = "The package to use for the mbsync binary.";
     };
 

--- a/modules/services/mpdris2.nix
+++ b/modules/services/mpdris2.nix
@@ -40,7 +40,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.mpdris2;
-      defaultText = literalExample "pkgs.mpdris2";
+      defaultText = literalExpression "pkgs.mpdris2";
       description = "The mpDris2 package to use.";
     };
 

--- a/modules/services/muchsync.nix
+++ b/modules/services/muchsync.nix
@@ -135,7 +135,7 @@ in {
     remotes = mkOption {
       type = with types; attrsOf (submodule syncOptions);
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           server = {
             frequency = "*:0/10";

--- a/modules/services/nextcloud-client.nix
+++ b/modules/services/nextcloud-client.nix
@@ -14,7 +14,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.nextcloud-client;
-        defaultText = literalExample "pkgs.nextcloud-client";
+        defaultText = literalExpression "pkgs.nextcloud-client";
         description = "The package to use for the nextcloud client binary.";
       };
 

--- a/modules/services/notify-osd.nix
+++ b/modules/services/notify-osd.nix
@@ -16,7 +16,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.notify-osd;
-        defaultText = literalExample "pkgs.notify-osd";
+        defaultText = literalExpression "pkgs.notify-osd";
         description = ''
           Package containing the <command>notify-osd</command> program.
         '';

--- a/modules/services/pantalaimon.nix
+++ b/modules/services/pantalaimon.nix
@@ -17,7 +17,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.pantalaimon;
-        defaultText = literalExample "pkgs.pantalaimon";
+        defaultText = literalExpression "pkgs.pantalaimon";
         description =
           "Package providing the <command>pantalaimon</command> executable to use.";
       };
@@ -25,8 +25,8 @@ in {
       settings = mkOption {
         type = iniFmt.type;
         default = { };
-        defaultText = literalExample "{ }";
-        example = literalExample ''
+        defaultText = literalExpression "{ }";
+        example = literalExpression ''
           {
             Default = {
               LogLevel = "Debug";

--- a/modules/services/parcellite.nix
+++ b/modules/services/parcellite.nix
@@ -15,8 +15,8 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.parcellite;
-      defaultText = literalExample "pkgs.parcellite";
-      example = literalExample "pkgs.clipit";
+      defaultText = literalExpression "pkgs.parcellite";
+      example = literalExpression "pkgs.clipit";
       description = "Parcellite derivation to use.";
     };
   };

--- a/modules/services/picom.nix
+++ b/modules/services/picom.nix
@@ -262,8 +262,8 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.picom;
-      defaultText = literalExample "pkgs.picom";
-      example = literalExample "pkgs.picom";
+      defaultText = literalExpression "pkgs.picom";
+      example = literalExpression "pkgs.picom";
       description = ''
         picom derivation to use.
       '';

--- a/modules/services/playerctld.nix
+++ b/modules/services/playerctld.nix
@@ -15,7 +15,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.playerctl;
-      defaultText = literalExample "pkgs.playerctl";
+      defaultText = literalExpression "pkgs.playerctl";
       description = "The playerctl package to use.";
     };
   };

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -68,9 +68,9 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.polybar;
-        defaultText = literalExample "pkgs.polybar";
+        defaultText = literalExpression "pkgs.polybar";
         description = "Polybar package to install.";
-        example = literalExample ''
+        example = literalExpression ''
           pkgs.polybar.override {
             i3GapsSupport = true;
             alsaSupport = true;
@@ -90,7 +90,7 @@ in {
           See also <option>services.polybar.settings</option> for a more nix-friendly format.
         '';
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             "bar/top" = {
               monitor = "\''${env:MONITOR:eDP1}";
@@ -147,7 +147,7 @@ in {
           </programlisting>
         '';
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             "module/volume" = {
               type = "internal/pulseaudio";

--- a/modules/services/pulseeffects.nix
+++ b/modules/services/pulseeffects.nix
@@ -23,7 +23,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.pulseeffects-legacy;
-      defaultText = literalExample "pkgs.pulseeffects-legacy";
+      defaultText = literalExpression "pkgs.pulseeffects-legacy";
       description = "Pulseeffects package to use.";
     };
 

--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -106,7 +106,7 @@ in {
     package = mkOption {
       type = types.package;
       default = defaultPackage;
-      defaultText = literalExample examplePackage;
+      defaultText = literalExpression examplePackage;
       description = ''
         ${programName} derivation to use.
       '';
@@ -124,7 +124,7 @@ in {
     settings = mkOption {
       type = types.submodule { freeformType = settingsFormat.type; };
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           ${mainSection} = {
             adjustment-method = "randr";

--- a/modules/services/spotifyd.nix
+++ b/modules/services/spotifyd.nix
@@ -17,9 +17,9 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.spotifyd;
-      defaultText = literalExample "pkgs.spotifyd";
+      defaultText = literalExpression "pkgs.spotifyd";
       example =
-        literalExample "(pkgs.spotifyd.override { withKeyring = true; })";
+        literalExpression "(pkgs.spotifyd.override { withKeyring = true; })";
       description = ''
         The <literal>spotifyd</literal> package to use.
         Can be used to specify extensions.
@@ -30,7 +30,7 @@ in {
       type = tomlFormat.type;
       default = { };
       description = "Configuration for spotifyd";
-      example = literalExample ''
+      example = literalExpression ''
         {
           global = {
             username = "Alex";

--- a/modules/services/stalonetray.nix
+++ b/modules/services/stalonetray.nix
@@ -13,9 +13,9 @@ in {
 
       package = mkOption {
         default = pkgs.stalonetray;
-        defaultText = literalExample "pkgs.stalonetray";
+        defaultText = literalExpression "pkgs.stalonetray";
         type = types.package;
-        example = literalExample "pkgs.stalonetray";
+        example = literalExpression "pkgs.stalonetray";
         description = "The package to use for the Stalonetray binary.";
       };
 

--- a/modules/services/status-notifier-watcher.nix
+++ b/modules/services/status-notifier-watcher.nix
@@ -16,9 +16,9 @@ in {
       package = mkOption {
         default = pkgs.haskellPackages.status-notifier-item;
         defaultText =
-          literalExample "pkgs.haskellPackages.status-notifier-item";
+          literalExpression "pkgs.haskellPackages.status-notifier-item";
         type = types.package;
-        example = literalExample "pkgs.haskellPackages.status-notifier-item";
+        example = literalExpression "pkgs.haskellPackages.status-notifier-item";
         description =
           "The package to use for the status notifier watcher binary.";
       };

--- a/modules/services/sxhkd.nix
+++ b/modules/services/sxhkd.nix
@@ -34,14 +34,14 @@ in {
       default = [ ];
       description =
         "Command line arguments to invoke <command>sxhkd</command> with.";
-      example = literalExample ''[ "-m 1" ]'';
+      example = literalExpression ''[ "-m 1" ]'';
     };
 
     keybindings = mkOption {
       type = types.attrsOf (types.nullOr types.str);
       default = { };
       description = "An attribute set that assigns hotkeys to commands.";
-      example = literalExample ''
+      example = literalExpression ''
         {
           "super + shift + {r,c}" = "i3-msg {restart,reload}";
           "super + {s,w}"         = "i3-msg {stacking,tabbed}";
@@ -53,7 +53,7 @@ in {
       default = "";
       type = types.lines;
       description = "Additional configuration to add.";
-      example = literalExample ''
+      example = literalExpression ''
         super + {_,shift +} {1-9,0}
           i3-msg {workspace,move container to workspace} {1-10}
       '';

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -22,16 +22,16 @@ with lib;
               command = mkOption {
                 type = types.str;
                 default = "syncthingtray";
-                defaultText = literalExample "syncthingtray";
-                example = literalExample "qsyncthingtray";
+                defaultText = literalExpression ''"syncthingtray"'';
+                example = literalExpression ''"qsyncthingtray"'';
                 description = "Syncthing tray command to use.";
               };
 
               package = mkOption {
                 type = types.package;
                 default = pkgs.syncthingtray-minimal;
-                defaultText = literalExample "pkgs.syncthingtray-minimal";
-                example = literalExample "pkgs.qsyncthingtray";
+                defaultText = literalExpression "pkgs.syncthingtray-minimal";
+                example = literalExpression "pkgs.qsyncthingtray";
                 description = "Syncthing tray package to use.";
               };
             };

--- a/modules/services/taffybar.nix
+++ b/modules/services/taffybar.nix
@@ -15,9 +15,9 @@ in {
 
       package = mkOption {
         default = pkgs.taffybar;
-        defaultText = literalExample "pkgs.taffybar";
+        defaultText = literalExpression "pkgs.taffybar";
         type = types.package;
-        example = literalExample "pkgs.taffybar";
+        example = literalExpression "pkgs.taffybar";
         description = "The package to use for the Taffybar binary.";
       };
     };

--- a/modules/services/trayer.nix
+++ b/modules/services/trayer.nix
@@ -109,9 +109,9 @@ in {
 
       package = mkOption {
         default = pkgs.trayer;
-        defaultText = literalExample "pkgs.trayer";
+        defaultText = literalExpression "pkgs.trayer";
         type = types.package;
-        example = literalExample "pkgs.trayer";
+        example = literalExpression "pkgs.trayer";
         description = "The package to use for the trayer binary.";
       };
 
@@ -141,7 +141,7 @@ in {
           </tbody></tgroup></informaltable>
         '';
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             edge = "top";
             padding = 6;

--- a/modules/services/unclutter.nix
+++ b/modules/services/unclutter.nix
@@ -13,7 +13,7 @@ in {
       description = "unclutter derivation to use.";
       type = types.package;
       default = pkgs.unclutter-xfixes;
-      defaultText = literalExample "pkgs.unclutter-xfixes";
+      defaultText = literalExpression "pkgs.unclutter-xfixes";
     };
 
     timeout = mkOption {

--- a/modules/services/unison.nix
+++ b/modules/services/unison.nix
@@ -47,7 +47,7 @@ let
 
       roots = mkOption {
         type = pairOf types.str;
-        example = literalExample ''
+        example = literalExpression ''
           [
             "/home/user/documents"
             "ssh://remote/documents"
@@ -78,7 +78,7 @@ in {
     pairs = mkOption {
       type = with types; attrsOf (submodule pairOptions);
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           roots = [
             "/home/user/documents"

--- a/modules/services/volnoti.nix
+++ b/modules/services/volnoti.nix
@@ -16,7 +16,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.volnoti;
-        defaultText = literalExample "pkgs.volnoti";
+        defaultText = literalExpression "pkgs.volnoti";
         description = ''
           Package containing the <command>volnoti</command> program.
         '';

--- a/modules/services/window-managers/awesome.nix
+++ b/modules/services/window-managers/awesome.nix
@@ -19,7 +19,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.awesome;
-        defaultText = literalExample "pkgs.awesome";
+        defaultText = literalExpression "pkgs.awesome";
         description = "Package to use for running the Awesome WM.";
       };
 
@@ -30,7 +30,7 @@ in {
           List of lua packages available for being
           used in the Awesome configuration.
         '';
-        example = literalExample "[ pkgs.luaPackages.vicious ]";
+        example = literalExpression "[ pkgs.luaPackages.vicious ]";
       };
 
       noArgb = mkOption {

--- a/modules/services/window-managers/bspwm/options.nix
+++ b/modules/services/window-managers/bspwm/options.nix
@@ -149,9 +149,9 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.bspwm;
-      defaultText = literalExample "pkgs.bspwm";
+      defaultText = literalExpression "pkgs.bspwm";
       description = "The bspwm package to use.";
-      example = literalExample "pkgs.bspwm-unstable";
+      example = literalExpression "pkgs.bspwm-unstable";
     };
 
     settings = mkOption {
@@ -190,7 +190,7 @@ in {
       default = { };
       description =
         "Rule configuration. The keys of the attribute set are the targets of the rules.";
-      example = literalExample ''
+      example = literalExpression ''
         {
           "Gimp" = {
             desktop = "^8";

--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -99,7 +99,7 @@ let
           Consider to use <code>lib.mkOptionDefault</code> function to extend or override
           default keybindings instead of specifying all of them from scratch.
         '';
-        example = literalExample ''
+        example = literalExpression ''
           let
             modifier = config.xsession.windowManager.i3.config.modifier;
           in lib.mkOptionDefault {
@@ -216,8 +216,8 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.i3;
-        defaultText = literalExample "pkgs.i3";
-        example = literalExample "pkgs.i3-gaps";
+        defaultText = literalExpression "pkgs.i3";
+        example = literalExpression "pkgs.i3-gaps";
         description = ''
           i3 package to use.
           If 'i3.config.gaps' settings are specified, 'pkgs.i3-gaps' will be set as a default package.

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -12,12 +12,12 @@ let
       names = mkOption {
         type = types.listOf types.str;
         default = [ "monospace" ];
-        defaultText = literalExample ''[ "monospace" ]'';
+        defaultText = literalExpression ''[ "monospace" ]'';
         description = ''
           List of font names list used for window titles. Only FreeType fonts are supported.
           The order here is important (e.g. icons font should go before the one used for text).
         '';
-        example = literalExample ''[ "FontAwesome" "Terminus" ]'';
+        example = literalExpression ''[ "FontAwesome" "Terminus" ]'';
       };
 
       style = mkOption {
@@ -82,7 +82,7 @@ let
         mkOption (args // {
           type = types.nullOr type;
           default = if versionAtLeast2009 then null else default;
-          defaultText = literalExample ''
+          defaultText = literalDocbook ''
             null for state version ≥ 20.09, as example otherwise
           '';
           example = default;
@@ -91,7 +91,7 @@ let
       fonts = mkOption {
         type = with types; either (listOf str) fontOptions;
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             names = [ "DejaVu Sans Mono" "FontAwesome5Free" ];
             style = "Bold Semi-Condensed";
@@ -359,7 +359,7 @@ let
           A value of <literal>true</literal> is equivalent to using an empty
           criteria (which is different from an empty string criteria).
         '';
-        example = literalExample ''
+        example = literalExpression ''
           {
             title = "x200: ~/work";
             floating = true;
@@ -374,7 +374,7 @@ in {
   fonts = mkOption {
     type = with types; either (listOf str) fontOptions;
     default = { };
-    example = literalExample ''
+    example = literalExpression ''
       {
         names = [ "DejaVu Sans Mono" "FontAwesome5Free" ];
         style = "Bold Semi-Condensed";
@@ -531,7 +531,7 @@ in {
       An attribute set that assigns applications to workspaces based
       on criteria.
     '';
-    example = literalExample ''
+    example = literalExpression ''
       {
       "1: web" = [{ class = "^Firefox$"; }];
       "0: extra" = [{ class = "^Firefox$"; window_role = "About"; }];
@@ -714,7 +714,7 @@ in {
       };
     }] else
       [ { } ];
-    defaultText = literalExample "see code";
+    defaultText = literalDocbook "see code";
     description = ''
       ${capitalModuleName} bars settings blocks. Set to empty list to remove bars completely.
     '';
@@ -729,7 +729,7 @@ in {
       See <link xlink:href="https://i3wm.org/docs/userguide.html#_automatically_starting_applications_on_i3_startup"/>.
     '';
     example = if isI3 then
-      literalExample ''
+      literalExpression ''
         [
         { command = "systemctl --user restart polybar"; always = true; notification = false; }
         { command = "dropbox start"; notification = false; }
@@ -737,7 +737,7 @@ in {
         ];
       ''
     else
-      literalExample ''
+      literalExpression ''
         [
         { command = "systemctl --user restart waybar"; always = true; }
         { command = "dropbox start"; }

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -128,7 +128,7 @@ let
           Consider to use <code>lib.mkOptionDefault</code> function to extend or override
           default keybindings instead of specifying all of them from scratch.
         '';
-        example = literalExample ''
+        example = literalExpression ''
           let
             modifier = config.wayland.windowManager.sway.config.modifier;
           in lib.mkOptionDefault {
@@ -332,7 +332,7 @@ in {
     package = mkOption {
       type = with types; nullOr package;
       default = defaultSwayPackage;
-      defaultText = literalExample "${pkgs.sway}";
+      defaultText = literalExpression "${pkgs.sway}";
       description = ''
         Sway package to use. Will override the options
         'wrapperFeatures', 'extraSessionCommands', and 'extraOptions'.

--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -22,8 +22,8 @@ in {
 
       haskellPackages = mkOption {
         default = pkgs.haskellPackages;
-        defaultText = literalExample "pkgs.haskellPackages";
-        example = literalExample "pkgs.haskell.packages.ghc784";
+        defaultText = literalExpression "pkgs.haskellPackages";
+        example = literalExpression "pkgs.haskell.packages.ghc784";
         description = ''
           The <varname>haskellPackages</varname> used to build xmonad
           and other packages. This can be used to change the GHC
@@ -35,7 +35,7 @@ in {
       extraPackages = mkOption {
         default = self: [ ];
         defaultText = "self: []";
-        example = literalExample ''
+        example = literalExpression ''
           haskellPackages: [
             haskellPackages.xmonad-contrib
             haskellPackages.monad-logger
@@ -58,7 +58,7 @@ in {
       config = mkOption {
         type = types.nullOr types.path;
         default = null;
-        example = literalExample ''
+        example = literalExpression ''
           pkgs.writeText "xmonad.hs" '''
             import XMonad
             main = xmonad defaultConfig
@@ -84,7 +84,7 @@ in {
       libFiles = mkOption {
         type = types.attrsOf (types.oneOf [ types.path ]);
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             "Tools.hs" = pkgs.writeText "Tools.hs" '''
                module Tools where

--- a/modules/services/xembed-sni-proxy.nix
+++ b/modules/services/xembed-sni-proxy.nix
@@ -16,7 +16,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.plasma-workspace;
-        defaultText = literalExample "pkgs.plasma-workspace";
+        defaultText = literalExpression "pkgs.plasma-workspace";
         description = ''
           Package containing the <command>xembedsniproxy</command>
           program.

--- a/modules/services/xidlehook.nix
+++ b/modules/services/xidlehook.nix
@@ -44,7 +44,7 @@ in {
     environment = mkOption {
       type = types.attrsOf types.str;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           "primary-display" = "$(xrandr | awk '/ primary/{print $1}')";
         }
@@ -81,7 +81,7 @@ in {
           };
           command = mkOption {
             type = types.nullOr types.str;
-            example = literalExample ''
+            example = literalExpression ''
               ''${pkgs.libnotify}/bin/notify-send "Idle" "Sleeping in 1 minute"
             '';
             description = ''
@@ -93,7 +93,7 @@ in {
           canceller = mkOption {
             type = types.str;
             default = "";
-            example = literalExample ''
+            example = literalExpression ''
               ''${pkgs.libnotify}/bin/notify-send "Idle" "Resuming activity"
             '';
             description = ''
@@ -106,7 +106,7 @@ in {
         };
       });
       default = [ ];
-      example = literalExample ''
+      example = literalExpression ''
         [
           {
             delay = 60;

--- a/modules/services/xsettingsd.nix
+++ b/modules/services/xsettingsd.nix
@@ -30,7 +30,7 @@ in {
       package = mkOption {
         type = types.package;
         default = pkgs.xsettingsd;
-        defaultText = literalExample "pkgs.xsettingsd";
+        defaultText = literalExpression "pkgs.xsettingsd";
         description = ''
           Package containing the <command>xsettingsd</command> program.
         '';
@@ -39,7 +39,7 @@ in {
       settings = mkOption {
         type = with types; attrsOf (oneOf [ bool int str ]);
         default = { };
-        example = literalExample ''
+        example = literalExpression ''
           {
             "Net/ThemeName" = "Numix";
             "Xft/Antialias" = true;

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -4,7 +4,7 @@ let
 
   cfg = config.systemd.user;
 
-  inherit (lib) getAttr hm isBool literalExample mkIf mkMerge mkOption types;
+  inherit (lib) getAttr hm isBool literalExpression mkIf mkMerge mkOption types;
 
   # From <nixpkgs/nixos/modules/system/boot/systemd-lib.nix>
   mkPathSafeName =
@@ -78,7 +78,7 @@ let
   '';
 
   unitExample = type:
-    literalExample ''
+    literalExpression ''
       {
         ${lib.toLower type}-name = {
           Unit = {

--- a/modules/xcursor.nix
+++ b/modules/xcursor.nix
@@ -10,7 +10,7 @@ let
     options = {
       package = mkOption {
         type = types.package;
-        example = literalExample "pkgs.vanilla-dmz";
+        example = literalExpression "pkgs.vanilla-dmz";
         description = "Package providing the cursor theme.";
       };
 

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -36,7 +36,7 @@ in {
           entry = either prim (listOf prim);
         in nullOr (attrsOf entry);
       default = null;
-      example = literalExample ''
+      example = literalExpression ''
         {
           "Emacs*toolBar" = 0;
           "XTerm*faceName" = "dejavu sans mono";
@@ -58,7 +58,7 @@ in {
     xresources.extraConfig = mkOption {
       type = types.lines;
       default = "";
-      example = literalExample ''
+      example = literalExpression ''
         builtins.readFile (
             pkgs.fetchFromGitHub {
                 owner = "solarized";

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -35,7 +35,7 @@ in {
 
       windowManager.command = mkOption {
         type = types.str;
-        example = literalExample ''
+        example = literalExpression ''
           let
             xmonad = pkgs.xmonad-with-packages.override {
               packages = self: [ self.xmonad-contrib self.taffybar ];

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -62,7 +62,7 @@ in
       extraSpecialArgs = mkOption {
         type = types.attrs;
         default = { };
-        example = literalExample "{ modulesPath = ../modules; }";
+        example = literalExpression "{ modulesPath = ../modules; }";
         description = ''
           Extra <literal>specialArgs</literal> passed to Home Manager.
         '';
@@ -75,7 +75,7 @@ in
             description = "Home Manager modules";
           });
         default = [ ];
-        example = literalExample "[ { home.packages = [ nixpkgs-fmt ]; } ]";
+        example = literalExpression "[ { home.packages = [ nixpkgs-fmt ]; } ]";
         description = ''
           Extra modules added to all users.
         '';

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -86,7 +86,7 @@ in {
             description = "Home Manager modules";
           });
         default = [ ];
-        example = literalExample "[ { home.packages = [ nixpkgs-fmt ]; } ]";
+        example = literalExpression "[ { home.packages = [ nixpkgs-fmt ]; } ]";
         description = ''
           Extra modules added to all users.
         '';


### PR DESCRIPTION
### Description

`lib.literalExample` is now deprecated (see https://github.com/NixOS/nixpkgs/pull/136909 / https://github.com/NixOS/nixpkgs/commit/52a2e4136e270f9efd6838adb69304fe6d4d431e) and replaced with `lib.literalExpression` and `lib.literalDocbook`. I went through and replaced instances of `lib.literalExample` with the appropriate replacement.

I'm considering adding a polyfill (wrapper that checks if if `lib.literalExpression` exists, then uses `lib.literalExample` if it doesn't) so we can be backwards-compatible with old nixpkgs, I'd love to hear people's opinion on that.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.
  - No. This requires an up-to-date nixpkgs.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
