### PR TITLE
flameshot: add settings option

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -124,6 +124,7 @@ import nmt {
     ./modules/services/devilspie2
     ./modules/services/dropbox
     ./modules/services/emacs
+    ./modules/services/flameshot
     ./modules/services/fluidsynth
     ./modules/services/fnott
     ./modules/services/git-sync

--- a/tests/modules/services/flameshot/default.nix
+++ b/tests/modules/services/flameshot/default.nix
@@ -1,0 +1,4 @@
+{
+  flameshot-empty-settings = ./empty-settings.nix;
+  flameshot-example-settings = ./example-settings.nix;
+}

--- a/tests/modules/services/flameshot/empty-settings.nix
+++ b/tests/modules/services/flameshot/empty-settings.nix
@@ -1,0 +1,13 @@
+{ ... }:
+
+{
+  config = {
+    services.flameshot = { enable = true; };
+
+    test.stubs.flameshot = { };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/flameshot/flameshot.ini
+    '';
+  };
+}

--- a/tests/modules/services/flameshot/example-settings.nix
+++ b/tests/modules/services/flameshot/example-settings.nix
@@ -1,0 +1,30 @@
+{ ... }:
+
+{
+  config = {
+    services.flameshot = {
+      enable = true;
+
+      settings = {
+        General = {
+          disabledTrayIcon = true;
+          showStartupLaunchMessage = false;
+        };
+      };
+    };
+
+    test.stubs.flameshot = { };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/flameshot/flameshot.ini \
+        ${
+          builtins.toFile "expected.ini" ''
+            [General]
+            disabledTrayIcon=true
+            showStartupLaunchMessage=false
+          ''
+        }
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Adds settings option. If empty then no `flameshot.ini` is generated.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```