### PR TITLE
nixos: replace types.anything with submodule type

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -70,8 +70,11 @@ in
 
       sharedModules = mkOption {
         type = with types;
-          listOf (anything // {
+          # TODO: use types.raw once this PR is merged: https://github.com/NixOS/nixpkgs/pull/132448
+          listOf (mkOptionType {
+            name = "submodule";
             inherit (submodule { }) check;
+            merge = lib.options.mergeOneOption;
             description = "Home Manager modules";
           });
         default = [ ];

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -81,8 +81,11 @@ in {
 
       sharedModules = mkOption {
         type = with types;
-          listOf (anything // {
+        # TODO: use types.raw once this PR is merged: https://github.com/NixOS/nixpkgs/pull/132448
+          listOf (mkOptionType {
+            name = "submodule";
             inherit (submodule { }) check;
+            merge = lib.options.mergeOneOption;
             description = "Home Manager modules";
           });
         default = [ ];


### PR DESCRIPTION
### Description

As discussed in this issue:
https://github.com/NixOS/nixpkgs/issues/140879
`types.anything` was never meant to be used for arbitrary modules.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
