### PR TITLE
nixpkgs: assert when home-manager.useGlobalPkgs is enabled

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,8 @@
 
 /modules/misc/news.nix                                @rycee
 
+/modules/misc/nixpkgs-disabled.nix                    @thiagokokada
+
 /modules/misc/numlock.nix                             @evanjs
 /tests/modules/misc/numlock                           @evanjs
 

--- a/modules/misc/nixpkgs-disabled.nix
+++ b/modules/misc/nixpkgs-disabled.nix
@@ -1,0 +1,73 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.nixpkgs;
+
+  # Copied from nixpkgs.nix.
+  isConfig = x: builtins.isAttrs x || builtins.isFunction x;
+
+  # Copied from nixpkgs.nix.
+  optCall = f: x: if builtins.isFunction f then f x else f;
+
+  # Copied from nixpkgs.nix.
+  mergeConfig = lhs_: rhs_:
+    let
+      lhs = optCall lhs_ { inherit pkgs; };
+      rhs = optCall rhs_ { inherit pkgs; };
+    in lhs // rhs // optionalAttrs (lhs ? packageOverrides) {
+      packageOverrides = pkgs:
+        optCall lhs.packageOverrides pkgs
+        // optCall (attrByPath [ "packageOverrides" ] ({ }) rhs) pkgs;
+    } // optionalAttrs (lhs ? perlPackageOverrides) {
+      perlPackageOverrides = pkgs:
+        optCall lhs.perlPackageOverrides pkgs
+        // optCall (attrByPath [ "perlPackageOverrides" ] ({ }) rhs) pkgs;
+    };
+
+  # Copied from nixpkgs.nix.
+  configType = mkOptionType {
+    name = "nixpkgs-config";
+    description = "nixpkgs config";
+    check = x:
+      let traceXIfNot = c: if c x then true else lib.traceSeqN 1 x false;
+      in traceXIfNot isConfig;
+    merge = args: fold (def: mergeConfig def.value) { };
+  };
+
+  # Copied from nixpkgs.nix.
+  overlayType = mkOptionType {
+    name = "nixpkgs-overlay";
+    description = "nixpkgs overlay";
+    check = builtins.isFunction;
+    merge = lib.mergeOneOption;
+  };
+
+in {
+  meta.maintainers = with maintainers; [ thiagokokada ];
+
+  options.nixpkgs = {
+    config = mkOption {
+      default = null;
+      type = types.nullOr configType;
+      visible = false;
+    };
+
+    overlays = mkOption {
+      default = null;
+      type = types.nullOr (types.listOf overlayType);
+      visible = false;
+    };
+  };
+
+  config = {
+    assertions = [{
+      assertion = cfg.config == null || cfg.overlays == null;
+      message = ''
+        `nixpkgs` options are disabled when `home-manager.useGlobalPkgs` is enabled.
+      '';
+    }];
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -242,7 +242,8 @@ let
     ./xsession.nix
     (pkgs.path + "/nixos/modules/misc/assertions.nix")
     (pkgs.path + "/nixos/modules/misc/meta.nix")
-  ] ++ optional useNixpkgsModule ./misc/nixpkgs.nix;
+  ] ++ optional useNixpkgsModule ./misc/nixpkgs.nix
+    ++ optional (!useNixpkgsModule) ./misc/nixpkgs-disabled.nix;
 
   pkgsModule = { config, ... }: {
     config = {


### PR DESCRIPTION
### Description

This commit introduces the `nixpkgs-disabled` module, that is basically a mock of `nixpkgs` module where any value different from `null` will cause an assertion error.

This is to help debugging cases where `home-manager.useGlobalPkgs` is set to `true` and `nixpkgs.*` options are being used.

Nowadays this returns the following error:

```
error: The option `home-manager.users.<user>.nixpkgs` does not exist.
```

This will change too:

```
error: `nixpkgs` options are disabled when `home-manager.useGlobalPkgs` is enabled.
```

That will direct the user to the correct solution (either removing `nixpkgs` or disable `home-manager.useGlobalPkgs`).

Related issues: #2243 #1683

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
