### PR TITLE
lxqt-policykit-agent: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -275,6 +275,8 @@
 
 /modules/services/lorri.nix                           @Gerschtli
 
+/modules/services/lxqt-policykit-agent.nix            @bobvanderlinden
+
 /modules/services/mako.nix                            @onny
 
 /modules/services/mbsync.nix                          @pjones

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -139,4 +139,10 @@
     github = "hawkw";
     githubId = 2796466;
   };
+  bobvanderlinden = {
+    name = "Bob van der Linden";
+    email = "bobvanderlinden@gmail.com";
+    github = "bobvanderlinden";
+    githubId = 6375609;
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -182,6 +182,7 @@ let
     ./services/keynav.nix
     ./services/lieer.nix
     ./services/lorri.nix
+    ./services/lxqt-policykit-agent.nix
     ./services/mako.nix
     ./services/mbsync.nix
     ./services/mpd.nix

--- a/modules/services/lxqt-policykit-agent.nix
+++ b/modules/services/lxqt-policykit-agent.nix
@@ -15,6 +15,11 @@ with lib; {
   };
 
   config = mkIf config.services.lxqt-policykit-agent.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.lxqt-policykit-agent" pkgs
+        lib.platforms.linux)
+    ];
+
     systemd.user.services.lxqt-policykit-agent = {
       Unit = {
         Description = "LXQT PolicyKit Agent";

--- a/modules/services/lxqt-policykit-agent.nix
+++ b/modules/services/lxqt-policykit-agent.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+with lib; {
+  meta.maintainers = [ maintainers.bobvanderlinden ];
+
+  options.services.lxqt-policykit-agent = {
+    enable = mkEnableOption "LXQT Policykit Agent";
+    package = mkOption {
+      type = types.package;
+      default = pkgs.lxqt.lxqt-policykit;
+      defaultText = literalExample "pkgs.lxqt.lxqt-policykit";
+      description = ''
+        LXQT Policykit package to use
+      '';
+    };
+  };
+
+  config = mkIf config.services.lxqt-policykit-agent.enable {
+    systemd.user.services.lxqt-policykit-agent = {
+      Unit = {
+        Description = "LXQT PolicyKit Agent";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+
+      Service = {
+        ExecStart =
+          "${config.services.lxqt-policykit-agent.package}/bin/lxqt-policykit-agent";
+      };
+    };
+  };
+}

--- a/modules/services/lxqt-policykit-agent.nix
+++ b/modules/services/lxqt-policykit-agent.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 with lib; {
-  meta.maintainers = [ maintainers.bobvanderlinden ];
+  meta.maintainers = [ hm.maintainers.bobvanderlinden ];
 
   options.services.lxqt-policykit-agent = {
     enable = mkEnableOption "LXQT Policykit Agent";


### PR DESCRIPTION
### Description

I was missing a polkit agent and found the one from LXQT to be a nice candidate. I've been running this module for a number of months and thought to contribute it upstream.

It shows a GUI password prompt whenever an application requires more privileges. For instance when running `systemctl start docker`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
