### PR TITLE
programs.zsh.zplug: add zplugHome option

### DIFF
--- a/modules/programs/zplug.nix
+++ b/modules/programs/zplug.nix
@@ -31,6 +31,14 @@ in {
       type = types.listOf pluginModule;
       description = "List of zplug plugins.";
     };
+
+    zplugHome = mkOption {
+      type = types.path;
+      default = "${config.home.homeDirectory}/.zplug";
+      defaultText = "~/.zplug";
+      apply = toString;
+      description = "Path to zplug home directory.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -38,6 +46,8 @@ in {
 
     programs.zsh.initExtraBeforeCompInit = ''
       source ${pkgs.zplug}/init.zsh
+
+      export ZPLUG_HOME=${cfg.zplugHome}
 
       ${optionalString (cfg.plugins != [ ]) ''
         ${concatStrings (map (plugin: ''

--- a/tests/modules/programs/zplug/modules.nix
+++ b/tests/modules/programs/zplug/modules.nix
@@ -8,6 +8,7 @@ with lib;
       enable = true;
       zplug = {
         enable = true;
+        zplugHome = ~/.customZplugHome;
         plugins = [
           {
             name = "plugins/git";
@@ -43,6 +44,9 @@ with lib;
 
       assertFileRegex home-files/.zshrc \
         '^zplug load$'
+
+      assertFileContains home-files/.zshrc \
+        'export ZPLUG_HOME=${config.programs.zsh.zplug.zplugHome}'
     '';
   };
 }


### PR DESCRIPTION
### Description

Add an option to set custom $ZPLUG_HOME. Changing it with home.sessionVariables doesnt work, since it has to be exported before Zplug is initialised

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```