### PR TITLE
htop: add package option

### DIFF
--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -136,6 +136,13 @@ in {
         <filename>~/.config/htop/htoprc</filename>.
       '';
     };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.htop;
+      defaultText = literalExpression "pkgs.htop";
+      description = "Package containing the <command>htop</command> program.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -143,7 +150,7 @@ in {
       inherit fields modes leftMeters rightMeters bar text graph led blank;
     };
 
-    home.packages = [ pkgs.htop ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."htop/htoprc" = let
       defaults = {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add `package` option to htop.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
