### PR TITLE
direnv: make fish enable flag read-only

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -66,8 +66,11 @@ in {
     enableFishIntegration = mkOption {
       default = true;
       type = types.bool;
+      readOnly = true;
       description = ''
-        Whether to enable Fish integration.
+        Whether to enable Fish integration. Note, enabling the direnv module
+        will always active its functionality for Fish since the direnv package
+        automatically gets loaded in Fish.
       '';
     };
 
@@ -105,10 +108,6 @@ in {
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
       eval "$(${pkgs.direnv}/bin/direnv hook zsh)"
-    '';
-
-    programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
-      ${pkgs.direnv}/bin/direnv hook fish | source
     '';
   };
 }


### PR DESCRIPTION
### Description

We cannot disable direnv for Fish since the functionality is automatically loaded when the package is installed.

Fixes #2357

### Checklist

- [ ] Change is backwards compatible: Not quite since it will cause an error for users who've disabled the module for fish but I think it is OK to interrupt them since the setting is ineffective for them and its probably good that they are informed about this.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```