### PR TITLE
Replace literalExample with literalExpression

### DIFF
--- a/modules/programs/hexchat.nix
+++ b/modules/programs/hexchat.nix
@@ -66,7 +66,7 @@ let
         commands = mkOption {
           type = listOf str;
           default = [ ];
-          example = literalExample ''[ "ECHO Greetings fellow Nixer! ]'';
+          example = literalExpression ''[ "ECHO Greetings fellow Nixer! ]'';
           description = "Commands to be executed on connecting to server.";
         };
 
@@ -237,7 +237,7 @@ in {
     channels = mkOption {
       type = attrsOf modChannelOption;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           freenode = {
             autojoin = [
@@ -277,7 +277,7 @@ in {
     settings = mkOption {
       default = null;
       type = nullOr (attrsOf str);
-      example = literalExample ''
+      example = literalExpression ''
         {
           irc_nick1 = "mynick";
           irc_username = "bob";
@@ -320,7 +320,7 @@ in {
     theme = mkOption {
       type = nullOr package;
       default = null;
-      example = literalExample ''
+      example = literalExpression ''
         stdenv.mkDerivation rec {
           name = "hexchat-theme-MatriY";
           buildInputs = [ pkgs.unzip ];


### PR DESCRIPTION
### Description

`literalExample` was still present in modules/programs/hexchat.nix

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
