### PR TITLE
 espanso: add module 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -278,6 +278,8 @@
 
 /modules/services/etesync-dav.nix                     @Valodim
 
+/modules/services/espanso.nix                         @lucasew
+
 /modules/services/flameshot.nix                       @moredhel
 
 /modules/services/fluidsynth.nix                      @Valodim

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2417,6 +2417,14 @@ in
           A new module is available: 'programs.eww'.
         '';
       }
+
+      {
+        time = "2022-02-17T23:11:13+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.espanso'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -178,6 +178,7 @@ let
     ./services/easyeffects.nix
     ./services/emacs.nix
     ./services/etesync-dav.nix
+    ./services/espanso.nix
     ./services/flameshot.nix
     ./services/fluidsynth.nix
     ./services/fnott.nix

--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -1,0 +1,86 @@
+{ pkgs, config, lib, ... }:
+
+let
+
+  inherit (lib)
+    mkOption mkEnableOption mkIf maintainers literalExpression types platforms;
+
+  inherit (lib.hm.assertions) assertPlatform;
+
+  cfg = config.services.espanso;
+
+  yaml = pkgs.formats.yaml { };
+
+in {
+  meta.maintainers = with maintainers; [ lucasew ];
+
+  options = {
+    services.espanso = {
+      enable = mkEnableOption "Espanso: cross platform text expander in Rust";
+
+      package = mkOption {
+        type = types.package;
+        description = "Which espanso package to use";
+        default = pkgs.espanso;
+        defaultText = literalExpression "pkgs.espanso";
+      };
+
+      settings = mkOption {
+        type = yaml.type;
+        default = { matches = [ ]; };
+        example = literalExpression ''
+          {
+            matches = [
+              { # Simple text replacement
+                trigger = ":espanso";
+                replace = "Hi there!";
+              }
+              { # Dates
+                trigger = ":date";
+                replace = "{{mydate}}";
+                vars = [{
+                  name = "mydate";
+                  type = "date";
+                  params = { format = "%m/%d/%Y"; };
+                }];
+              }
+              { # Shell commands
+                trigger = ":shell";
+                replace = "{{output}}";
+                vars = [{
+                  name = "output";
+                  type = "shell";
+                  params = { cmd = "echo Hello from your shell"; };
+                }];
+              }
+            ];
+          }
+        '';
+        description = ''
+          The Espanso configuration to use. See
+          <link xlink:href="https://espanso.org/docs/configuration/"/>
+          for a description of available options.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [ (assertPlatform "services.espanso" pkgs platforms.linux) ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."espanso/default.yml".source =
+      yaml.generate "espanso-default.yml" cfg.settings;
+
+    systemd.user.services.espanso = {
+      Unit = { Description = "Espanso: cross platform text expander in Rust"; };
+      Service = {
+        Type = "exec";
+        ExecStart = "${cfg.package}/bin/espanso daemon";
+        Restart = "on-failure";
+      };
+      Install = { WantedBy = [ "default.target" ]; };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -137,6 +137,7 @@ import nmt {
     ./modules/services/devilspie2
     ./modules/services/dropbox
     ./modules/services/emacs
+    ./modules/services/espanso
     ./modules/services/flameshot
     ./modules/services/fluidsynth
     ./modules/services/fnott

--- a/tests/modules/services/espanso/basic-configuration.nix
+++ b/tests/modules/services/espanso/basic-configuration.nix
@@ -1,0 +1,45 @@
+{ ... }:
+
+{
+  services.espanso = {
+    enable = true;
+    settings = {
+      matches = [
+        { # Simple text replacement
+          trigger = ":espanso";
+          replace = "Hi there!";
+        }
+        { # Dates
+          trigger = ":date";
+          replace = "{{mydate}}";
+          vars = [{
+            name = "mydate";
+            type = "date";
+            params = { format = "%m/%d/%Y"; };
+          }];
+        }
+        { # Shell commands
+          trigger = ":shell";
+          replace = "{{output}}";
+          vars = [{
+            name = "output";
+            type = "shell";
+            params = { cmd = "echo Hello from your shell"; };
+          }];
+        }
+      ];
+    };
+  };
+
+  test.stubs.espanso = { };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/espanso.service
+    assertFileExists "$serviceFile"
+    assertFileContent "$serviceFile" ${./basic-configuration.service}
+
+    configFile=home-files/.config/espanso/default.yml
+    assertFileExists "$configFile"
+    assertFileContent "$configFile" ${./basic-configuration.yaml}
+  '';
+}

--- a/tests/modules/services/espanso/basic-configuration.service
+++ b/tests/modules/services/espanso/basic-configuration.service
@@ -1,0 +1,10 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=@espanso@/bin/espanso daemon
+Restart=on-failure
+Type=exec
+
+[Unit]
+Description=Espanso: cross platform text expander in Rust

--- a/tests/modules/services/espanso/basic-configuration.yaml
+++ b/tests/modules/services/espanso/basic-configuration.yaml
@@ -1,0 +1,17 @@
+matches:
+- replace: Hi there!
+  trigger: :espanso
+- replace: '{{mydate}}'
+  trigger: :date
+  vars:
+  - name: mydate
+    params:
+      format: '%m/%d/%Y'
+    type: date
+- replace: '{{output}}'
+  trigger: :shell
+  vars:
+  - name: output
+    params:
+      cmd: echo Hello from your shell
+    type: shell

--- a/tests/modules/services/espanso/default.nix
+++ b/tests/modules/services/espanso/default.nix
@@ -1,0 +1,1 @@
+{ espanso-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION

### Description
Espanso is a text expanding application, this PR adds a module to declaratively configure it.

With Nix it's possible to make very interesting abstractions, that are more integrable than the default yaml format.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
