### PR TITLE
{lib,home-manager}: remove top-level with

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-.PHONY: all all-tests test format
+.PHONY: all all-tests test test-install format
 NIXPKGS_REV := nixpkgs-unstable
 NIX_PATH := nixpkgs=https://github.com/NixOS/nixpkgs/archive/${NIXPKGS_REV}.tar.gz
 
-all: all-tests
+all: all-tests test-install
 
 all-tests:
 	$(MAKE) test TEST=all
@@ -12,6 +12,9 @@ ifndef TEST
 	$(error Use 'make test TEST=<test_name>' to run desired test)
 endif
 	nix-shell --pure tests -I ${NIX_PATH} -A run.${TEST}
+
+test-install:
+	HOME=$(shell mktemp -d) NIX_PATH=${NIX_PATH} nix-shell . -A install
 
 format:
 	./format

--- a/home-manager/home-manager.nix
+++ b/home-manager/home-manager.nix
@@ -5,9 +5,10 @@
 , newsReadIdsFile ? null
 }:
 
-with pkgs.lib;
-
 let
+  inherit (pkgs.lib)
+    concatMapStringsSep fileContents filter length optionalString removeSuffix
+    replaceStrings splitString;
 
   env = import ../modules {
     configuration =

--- a/modules/lib/dag.nix
+++ b/modules/lib/dag.nix
@@ -9,9 +9,8 @@
 
 { lib }:
 
-with lib;
-
-rec {
+let inherit (lib) all any filterAttrs mapAttrs mapAttrsToList toposort;
+in rec {
 
   emptyDag = { };
 

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -1,7 +1,8 @@
 { homeDirectory, lib, pkgs }:
 
-with lib;
-
+let
+  inherit (lib) hasPrefix hm literalExpression mkDefault mkIf mkOption removePrefix types;
+in
 {
   # Constructs a type suitable for a `home.file` like option. The
   # target path may be either absolute or relative, in which case it

--- a/modules/lib/gvariant.nix
+++ b/modules/lib/gvariant.nix
@@ -5,9 +5,9 @@
 
 { lib }:
 
-with lib;
-
 let
+  inherit (lib)
+    concatMapStringsSep concatStrings escape hasPrefix head replaceStrings;
 
   mkPrimitive = t: v: {
     _type = "gvariant";

--- a/modules/lib/strings.nix
+++ b/modules/lib/strings.nix
@@ -1,8 +1,9 @@
 { lib }:
 
-with lib;
-
-{
+let
+  inherit (lib)
+    genList length lowerChars replaceStrings stringToCharacters upperChars;
+in {
   # Figures out a valid Nix store name for the given path.
   storeFileName = path:
     let

--- a/modules/lib/types-dag.nix
+++ b/modules/lib/types-dag.nix
@@ -1,8 +1,10 @@
 { dag, lib }:
 
-with lib;
-
 let
+  inherit (lib)
+    concatStringsSep defaultFunctor fixedWidthNumber imap1 isAttrs isList length
+    listToAttrs mapAttrs mkIf mkOption mkOptionType nameValuePair stringLength
+    types warn;
 
   isDagEntry = e: isAttrs e && (e ? data) && (e ? after) && (e ? before);
 

--- a/modules/lib/types.nix
+++ b/modules/lib/types.nix
@@ -1,9 +1,11 @@
 { lib, dag ? import ./dag.nix { inherit lib; }
 , gvariant ? import ./gvariant.nix { inherit lib; } }:
 
-with lib;
-
 let
+  inherit (lib)
+    all concatMap foldl' getFiles getValues head isFunction literalExpression
+    mergeAttrs mergeDefaultOption mergeOneOption mergeOptions mkOption
+    mkOptionType showFiles showOption types;
 
   typesDag = import ./types-dag.nix { inherit dag lib; };
 

--- a/tests/lib/types/dag-merge.nix
+++ b/tests/lib/types/dag-merge.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) concatStringsSep hm mkMerge mkOption types;
 
   dag = lib.hm.dag;
 

--- a/tests/lib/types/dag-submodule.nix
+++ b/tests/lib/types/dag-submodule.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) concatStringsSep hm mkOption types;
 
   dag = lib.hm.dag;
 

--- a/tests/lib/types/gvariant-merge.nix
+++ b/tests/lib/types/gvariant-merge.nix
@@ -1,9 +1,6 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
-let
-
+let inherit (lib) concatStringsSep hm mapAttrsToList mkMerge mkOption types;
 in {
   options.examples = mkOption { type = types.attrsOf hm.types.gvariant; };
 

--- a/tests/lib/types/list-or-dag-merge.nix
+++ b/tests/lib/types/list-or-dag-merge.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) concatStringsSep hm mkMerge mkOption types;
 
   dag = lib.hm.dag;
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Probably [this PR from nixpkgs](https://github.com/NixOS/nixpkgs/pull/101139) summarizes the reason better than I can.

This PR only tackles `lib` and `home-manager` for now, that should brings the most benefits and performance improvements (if any). Most modules also uses this pattern, but I don't think we should enforce this tree-wide unless there is a better way to migrate this (maybe with a tool).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
