### PR TITLE
pet: Fix settings format issue

### DIFF
--- a/docs/release-notes/rl-2111.adoc
+++ b/docs/release-notes/rl-2111.adoc
@@ -45,3 +45,14 @@ changes are only active if the `home.stateVersion` option is set to
 "21.11" or later.
 
 * The <<opt-home.keyboard>> option now defaults to `null`, meaning that Home Manager won't do any keyboard layout management. For example, `setxkbmap` won't be run in X sessions.
+
+* The <<opt-programs.pet.settings>> option no longer place its value inside a `General` attribute.
+For example, is you before had
++
+[source,nix]
+programs.pet.settings.editor = "nvim";
++
+then you now need
++
+[source,nix]
+programs.pet.settings.General.editor = "nvim";

--- a/modules/programs/pet.nix
+++ b/modules/programs/pet.nix
@@ -80,16 +80,25 @@ in {
   };
 
   config = mkIf cfg.enable {
-    programs.pet.settings = {
-      selectcmd = mkDefault "fzf";
-      snippetfile = config.xdg.configHome + "/pet/snippet.toml";
-    };
+    programs.pet.settings = let
+      defaultGeneral = {
+        selectcmd = mkDefault "fzf";
+        snippetfile = config.xdg.configHome + "/pet/snippet.toml";
+      };
+    in if versionAtLeast config.home.stateVersion "21.11" then {
+      General = defaultGeneral;
+    } else
+      defaultGeneral;
 
     home.packages = [ pkgs.pet cfg.selectcmdPackage ];
 
     xdg.configFile = {
-      "pet/config.toml".source =
-        format.generate "config.toml" { General = cfg.settings; };
+      "pet/config.toml".source = format.generate "config.toml"
+        (if versionAtLeast config.home.stateVersion "21.11" then
+          cfg.settings
+        else {
+          General = cfg.settings;
+        });
       "pet/snippet.toml".source =
         format.generate "snippet.toml" { snippets = cfg.snippets; };
     };

--- a/tests/modules/programs/pet/default.nix
+++ b/tests/modules/programs/pet/default.nix
@@ -1,1 +1,5 @@
-{ pet-snippets = ./snippets.nix; }
+{
+  pet-snippets = ./snippets.nix;
+  pet-settings_21_05 = ./settings_21_05.nix;
+  pet-settings_21_11 = ./settings_21_11.nix;
+}

--- a/tests/modules/programs/pet/settings_21_05.nix
+++ b/tests/modules/programs/pet/settings_21_05.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  home.stateVersion = "21.05";
+  programs.pet = {
+    enable = true;
+    selectcmdPackage = config.lib.test.mkStubPackage { };
+    settings.editor = "nvim";
+  };
+
+  test.stubs.pet = { };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/pet/config.toml \
+      ${
+        builtins.toFile "pet-settings.toml" ''
+          [General]
+          editor = "nvim"
+          selectcmd = "fzf"
+          snippetfile = "/home/hm-user/.config/pet/snippet.toml"
+        ''
+      }
+  '';
+}

--- a/tests/modules/programs/pet/settings_21_11.nix
+++ b/tests/modules/programs/pet/settings_21_11.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  home.stateVersion = "21.11";
+  programs.pet = {
+    enable = true;
+    selectcmdPackage = config.lib.test.mkStubPackage { };
+    settings = {
+      General = {
+        backend = "Gitlab";
+        editor = "nvim";
+      };
+      Gitlab = {
+        access_token = "1234";
+        file_name = "pet-snippets.toml";
+        visibility = "public";
+      };
+    };
+  };
+
+  test.stubs.pet = { };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/pet/config.toml \
+      ${
+        builtins.toFile "pet-settings.toml" ''
+          [General]
+          backend = "Gitlab"
+          editor = "nvim"
+          selectcmd = "fzf"
+          snippetfile = "/home/hm-user/.config/pet/snippet.toml"
+
+          [Gitlab]
+          access_token = "1234"
+          file_name = "pet-snippets.toml"
+          visibility = "public"
+        ''
+      }
+  '';
+}


### PR DESCRIPTION
### Description

related gh issue: https://github.com/nix-community/home-manager/issues/2413

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.