### PR TITLE
powerline-go: fix regression introduced by #2231

### DIFF
--- a/modules/programs/powerline-go.nix
+++ b/modules/programs/powerline-go.nix
@@ -142,7 +142,7 @@ in {
     '';
 
     # https://github.com/justjanne/powerline-go#fish
-    programs.fish.promptInit =
+    programs.fish.interactiveShellInit =
       mkIf (cfg.enable && config.programs.fish.enable) ''
         function fish_prompt
             eval ${pkgs.powerline-go}/bin/powerline-go -error $status -jobs (count (jobs -p)) ${commandLineArguments}


### PR DESCRIPTION
### Description

#2231 introduced a regression when removing `programs.fish.promptInit`.
the mentioned PR rightfully removed a redundant option and replaced its usage in all places but `powerline-go`. fudge happens :)

cc @kidonng @sumnerevans 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
