### PR TITLE
hexchat: simplify theme example

### DIFF
--- a/modules/programs/hexchat.nix
+++ b/modules/programs/hexchat.nix
@@ -321,21 +321,16 @@ in {
       type = nullOr package;
       default = null;
       example = literalExpression ''
-        stdenv.mkDerivation rec {
-          name = "hexchat-theme-MatriY";
-          buildInputs = [ pkgs.unzip ];
-          src = fetchurl {
-              url = "https://dl.hexchat.net/themes/MatriY.hct";
-              sha256 = "sha256-ffkFJvySfl0Hwja3y7XCiNJceUrGvlEoEm97eYNMTZc=";
-          };
-          unpackPhase = "unzip ''${src}";
-          installPhase = "cp -r . $out";
+        source = pkgs.fetchzip {
+          url = "https://dl.hexchat.net/themes/Monokai.hct#Monokai.zip";
+          sha256 = "sha256-WCdgEr8PwKSZvBMs0fN7E2gOjNM0c2DscZGSKSmdID0=";
+          stripRoot = false;
         };
       '';
       description = ''
         Theme package for HexChat. Expects a derivation containing decompressed
-        theme files. <literal>.hct</literal> file format requires unzip
-        decompression, as seen in example.
+        theme files. Note, <literal>.hct</literal> files are actually ZIP files,
+        as seen in example.
       '';
     };
   };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

The original example was very complex, involving `mkDerivation` with `pkgs.unzip` as `buildInputs`. However, this can be heavily simplified by using `pkgs.fetchzip` instead.

The only non-obvious issues are:

- Since the extension ends with `.hct`, `pkgs.fetchzip` doesn't know what to do with it. However there is a workaround here: https://github.com/NixOS/nixpkgs/issues/60157#issuecomment-524965720
- The `.hct` file doesn't have any directories (`pkgs.fetchzip` expects either a file or a directory). Passing `stripRoot = false;` solves this issue

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
