### PR TITLE
modules/files: Bash-quote the cmp args

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -107,7 +107,7 @@ in
             elif [[ -e "$targetPath" \
                 && ! "$(readlink "$targetPath")" == $homeFilePattern ]] ; then
               # The target file already exists and it isn't a symlink owned by Home Manager.
-              if cmp -s $sourcePath $targetPath; then
+              if cmp -s "$sourcePath" "$targetPath"; then
                 # First compare the files' content. If they're equal, we're fine.
                 warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be skipped since they are the same"
               elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
@@ -180,7 +180,7 @@ in
               $DRY_RUN_CMD mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
             fi
 
-            if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s $sourcePath $targetPath ; then
+            if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath" ; then
               # The target exists but is identical – don't do anything.
               $VERBOSE_ECHO "Skipping '$targetPath' as it is identical to '$sourcePath'"
             else


### PR DESCRIPTION
### Description

Quote args to `cmp`. Without this change, nixpkgs's VSCodium on Darwin is liable to print out the following because it cares about `~/Library/Application Support/VSCodium/...`.

```
Activating checkLinkTargets
cmp: invalid --ignore-initial value '/Users/Patrick/Library/Application'
cmp: Try 'cmp --help' for more information.
```

I didn't know how to test this; personally I'd be happy not to test it, but do let me know if there's a way.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
