### PR TITLE
home-environment: document how home.sessionPath paths are escaped

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -274,11 +274,21 @@ in
       type = with types; listOf str;
       default = [ ];
       example = [
-        ".git/safe/../../bin"
+        "$HOME/.local/bin"
         "\${xdg.configHome}/emacs/bin"
-        "~/.local/bin"
+        ".git/safe/../../bin"
       ];
-      description = "Extra directories to add to <envar>PATH</envar>.";
+      description = ''
+        Extra directories to add to <envar>PATH</envar>.
+
+        </para><para>
+
+        These directories are added to the <envar>PATH</envar> variable in a
+        double-quoted context, so expressions like <code>$HOME</code> are
+        expanded by the shell. However, since expressions like <code>~</code> or
+        <code>*</code> are escaped, they will end up in the <envar>PATH</envar>
+        verbatim.
+      '';
     };
 
     home.sessionVariablesExtra = mkOption {


### PR DESCRIPTION
### Description

The example for `home.sessionPath` included a tilde in one of the paths. The tilde would end up in the `PATH` verbatim and not get expanded by the shell. This PR changes the example and documents how the paths are quoted before they end up in the `PATH`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
