### PR TITLE
rofi: add finalPackage option

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -1,8 +1,10 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib)
+    attrNames filterAttrs generators getAttr hm isAttrs isBool isInt isList
+    isString literalExpression maintainers mapAttrsToList mkEnableOption mkIf
+    mkOption mkRemovedOptionModule platforms removeSuffix strings types;
 
   cfg = config.programs.rofi;
 
@@ -40,7 +42,8 @@ let
         end = "";
       } name value;
 
-  toRasi = attrs: concatStringsSep "\n" (mapAttrsToList mkRasiSection attrs);
+  toRasi = attrs:
+    strings.concatStringsSep "\n" (mapAttrsToList mkRasiSection attrs);
 
   locationsMap = {
     center = 0;
@@ -283,5 +286,5 @@ in {
     });
   };
 
-  meta.maintainers = with maintainers; [ thiagokokada ];
+  meta.maintainers = [ maintainers.thiagokokada ];
 }

--- a/tests/modules/programs/rofi/custom-theme.nix
+++ b/tests/modules/programs/rofi/custom-theme.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 {
   config = {
     programs.rofi = {

--- a/tests/modules/programs/rofi/default.nix
+++ b/tests/modules/programs/rofi/default.nix
@@ -2,4 +2,5 @@
   rofi-valid-config = ./valid-config.nix;
   rofi-custom-theme = ./custom-theme.nix;
   rofi-config-with-deprecated-options = ./config-with-deprecated-options.nix;
+  rofi-with-plugins = ./with-plugins.nix;
 }

--- a/tests/modules/programs/rofi/valid-config.nix
+++ b/tests/modules/programs/rofi/valid-config.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 {
   config = {
     programs.rofi = {

--- a/tests/modules/programs/rofi/with-plugins.nix
+++ b/tests/modules/programs/rofi/with-plugins.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    programs.rofi = {
+      enable = true;
+      plugins = [ pkgs.rofi-calc ];
+    };
+
+    test.stubs = {
+      rofi = { };
+      rofi-calc = { };
+    };
+  };
+}

--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -34,8 +34,8 @@ let
 
   dummyPackage = pkgs.runCommandLocal "dummy" { } defaultBuildScript;
 
-  mkStubPackage = { name ? "dummy", outPath ? null, version ? null
-    , buildScript ? defaultBuildScript }:
+  mkStubPackage' = { name ? "dummy", outPath ? null, version ? null
+    , buildScript ? defaultBuildScript, ... }:
     let
       pkg = if name == "dummy" && buildScript == defaultBuildScript then
         dummyPackage
@@ -43,6 +43,8 @@ let
         pkgs.runCommandLocal name { } buildScript;
     in pkg // optionalAttrs (outPath != null) { inherit outPath; }
     // optionalAttrs (version != null) { inherit version; };
+
+  mkStubPackage = lib.makeOverridable mkStubPackage';
 
 in {
   options.test.stubs = mkOption {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add `programs.rofi.finalPackage` option, to be set with the result package (since it maybe modified by the module thanks `programs.rofi.plugins` option).

Also some refactorings.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
