### PR TITLE
htop: fix order or header_columns setting

### DIFF
--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -170,9 +170,19 @@ in {
         ];
       };
 
+      before = if (hasAttr "header_layout" cfg.settings) then {
+        header_layout = cfg.settings.header_layout;
+      } else
+        { };
+
+      settings = defaults // (removeAttrs cfg.settings (attrNames before));
+
+      formatOptions = mapAttrsToList formatOption;
+
     in mkIf (cfg.settings != { }) {
-      text = concatStringsSep "\n"
-        (mapAttrsToList formatOption (defaults // cfg.settings)) + "\n";
+      text =
+        concatStringsSep "\n" (formatOptions before ++ formatOptions settings)
+        + "\n";
     };
   };
 }

--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -170,10 +170,9 @@ in {
         ];
       };
 
-      before = if (hasAttr "header_layout" cfg.settings) then {
-        header_layout = cfg.settings.header_layout;
-      } else
-        { };
+      before = optionalAttrs (cfg.settings ? header_layout) {
+        inherit (cfg.settings) header_layout;
+      };
 
       settings = defaults // (removeAttrs cfg.settings (attrNames before));
 

--- a/tests/modules/programs/htop/default.nix
+++ b/tests/modules/programs/htop/default.nix
@@ -1,5 +1,6 @@
 {
   htop-empty-settings = ./empty-settings.nix;
   htop-example-settings = ./example-settings.nix;
-  settings-without-fields = ./settings-without-fields.nix;
+  htop-header_layout = ./header_layout.nix;
+  htop-settings-without-fields = ./settings-without-fields.nix;
 }

--- a/tests/modules/programs/htop/header_layout.nix
+++ b/tests/modules/programs/htop/header_layout.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = with config.lib.htop; {
+    programs.htop.enable = true;
+    programs.htop.settings = {
+      header_layout = "two_50_50";
+      column_meters_0 = [ "AllCPUs2" "Memory" "Swap" "Zram" ];
+      column_meters_modes_0 = [ modes.Bar modes.Bar modes.Bar modes.Text ];
+      column_meters_1 = [ "Tasks" "LoadAverage" "Uptime" "Systemd" ];
+      column_meters_modes_1 = [ modes.Text modes.Text modes.Text modes.Text ];
+    };
+
+    test.stubs.htop = { };
+
+    # Test that the 'fields' key is written in addition to the customized
+    # settings or htop won't read the options.
+    nmt.script = ''
+      htoprc=home-files/.config/htop/htoprc
+      assertFileExists $htoprc
+      assertFileContent $htoprc \
+        ${
+          builtins.toFile "htoprc-expected" ''
+            header_layout=two_50_50
+            column_meters_0=AllCPUs2 Memory Swap Zram
+            column_meters_1=Tasks LoadAverage Uptime Systemd
+            column_meters_modes_0=1 1 1 2
+            column_meters_modes_1=2 2 2 2
+            fields=0 48 17 18 38 39 40 2 46 47 49 1
+          ''
+        }
+    '';
+  };
+
+}


### PR DESCRIPTION
### Description

When `header_columns` is in settings it must appear before any of the
`column_meters_*` options.

Fixes #2426.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
