### PR TITLE
doc: improve extraSpecialArgs docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ as follows:
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
             home-manager.users.jdoe = import ./home.nix;
+
+            # Optionally, use home-manager.extraSpecialArgs to pass
+            # arguments to home.nix
           }
         ];
       };

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -63,8 +63,10 @@ in
       extraSpecialArgs = mkOption {
         type = types.attrs;
         default = { };
+        example = literalExpression "{ inherit emacs-overlay; }";
         description = ''
-          Extra <literal>specialArgs</literal> passed to Home Manager.
+          Extra <literal>specialArgs</literal> passed to Home Manager. This
+          option can be used to pass additional arguments to all modules.
         '';
       };
 

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -74,8 +74,10 @@ in {
       extraSpecialArgs = mkOption {
         type = types.attrs;
         default = { };
+        example = literalExpression "{ inherit emacs-overlay; }";
         description = ''
-          Extra <literal>specialArgs</literal> passed to Home Manager.
+          Extra <literal>specialArgs</literal> passed to Home Manager. This
+          option can be used to pass additional arguments to all modules.
         '';
       };
 


### PR DESCRIPTION
### Description

Clarifies, with an example, the use of `extraSpecialArgs`.

See #2433, #698 for examples of confused users

cc @berbiche 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
