### PR TITLE
xdg: add option 'xdg.stateHome'

### DIFF
--- a/home-manager/install.nix
+++ b/home-manager/install.nix
@@ -23,6 +23,9 @@ runCommand "home-manager-install" {
       if [[ -v XDG_DATA_HOME && $XDG_DATA_HOME != "$HOME/.local/share" ]]; then
         xdgVars="$xdgVars  xdg.dataHome = \"$XDG_DATA_HOME\";$nl"
       fi
+      if [[ -v XDG_STATE_HOME && $XDG_STATE_HOME != "$HOME/.local/state" ]]; then
+        xdgVars="$xdgVars  xdg.stateHome = \"$XDG_STATE_HOME\";$nl"
+      fi
 
       mkdir -p "$(dirname "$confFile")"
       cat > $confFile <<EOF

--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -14,6 +14,7 @@ let
   defaultCacheHome = "${config.home.homeDirectory}/.cache";
   defaultConfigHome = "${config.home.homeDirectory}/.config";
   defaultDataHome = "${config.home.homeDirectory}/.local/share";
+  defaultStateHome = "${config.home.homeDirectory}/.local/state";
 
   getEnvFallback = name: fallback:
     let value = builtins.getEnv name;
@@ -67,6 +68,15 @@ in {
         Absolute path to directory holding application data.
       '';
     };
+
+    stateHome = mkOption {
+      type = types.path;
+      defaultText = "~/.local/state";
+      apply = toString;
+      description = ''
+        Absolute path to directory holding application states.
+      '';
+    };
   };
 
   config = mkMerge [
@@ -74,11 +84,13 @@ in {
       xdg.cacheHome = mkDefault defaultCacheHome;
       xdg.configHome = mkDefault defaultConfigHome;
       xdg.dataHome = mkDefault defaultDataHome;
+      xdg.stateHome = mkDefault defaultStateHome;
 
       home.sessionVariables = {
         XDG_CACHE_HOME = cfg.cacheHome;
         XDG_CONFIG_HOME = cfg.configHome;
         XDG_DATA_HOME = cfg.dataHome;
+        XDG_STATE_HOME = cfg.stateHome;
       };
     })
 
@@ -96,6 +108,7 @@ in {
       xdg.cacheHome = mkDefault defaultCacheHome;
       xdg.configHome = mkDefault defaultConfigHome;
       xdg.dataHome = mkDefault defaultDataHome;
+      xdg.stateHome = mkDefault stateHome;
     })
 
     {

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -15,6 +15,7 @@ let
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
+    export XDG_STATE_HOME="/home/hm-user/.local/state"
   '';
 
   darwinExpected = ''
@@ -27,6 +28,7 @@ let
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
+    export XDG_STATE_HOME="/home/hm-user/.local/state"
   '';
 
   expected = pkgs.writeText "expected" (if isDarwin then darwinExpected else linuxExpected);

--- a/tests/modules/misc/xdg/file-gen.nix
+++ b/tests/modules/misc/xdg/file-gen.nix
@@ -7,15 +7,18 @@ with lib;
     xdg.configHome = /. + "${config.home.homeDirectory}/.dummy-config";
     xdg.dataHome = /. + "${config.home.homeDirectory}/.dummy-data";
     xdg.cacheHome = /. + "${config.home.homeDirectory}/.dummy-cache";
+    xdg.stateHome = /. + "${config.home.homeDirectory}/.dummy-state";
 
     xdg.configFile.test.text = "config";
     xdg.dataFile.test.text = "data";
     home.file."${config.xdg.cacheHome}/test".text = "cache";
+    home.file."${config.xdg.stateHome}/test".text = "state";
 
     nmt.script = ''
       assertFileExists home-files/.dummy-config/test
       assertFileExists home-files/.dummy-cache/test
       assertFileExists home-files/.dummy-data/test
+      assertFileExists home-files/.dummy-state/test
       assertFileContent \
         home-files/.dummy-config/test \
         ${builtins.toFile "test" "config"}
@@ -25,6 +28,9 @@ with lib;
       assertFileContent \
         home-files/.dummy-cache/test \
         ${builtins.toFile "test" "cache"}
+      assertFileContent \
+        home-files/.dummy-state/test \
+        ${builtins.toFile "test" "state"}
     '';
   };
 }


### PR DESCRIPTION

### Description

It corresponds to the newly introduced `XDG_STATE_HOME`.

See: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
