### PR TITLE
gitui: Add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,6 +90,9 @@
 
 /modules/programs/git.nix                             @rycee
 
+/modules/programs/gitui/gitui.nix                     @mifom
+/modules/programs/gitui/default_key_config.ron        @mifom
+
 /modules/programs/gnome-terminal.nix                  @kamadorueda @rycee
 
 /modules/programs/go.nix                              @rvolosatovs

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -89,6 +89,12 @@
     github = "matrss";
     githubId = 9308656;
   };
+  mifom = {
+    name = "mifom";
+    email = "mifom@users.noreply.github.com";
+    github = "mifom";
+    githubId = 23462908;
+  };
   seylerius = {
     email = "sable@seyleri.us";
     name = "Sable Seyler";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2425,6 +2425,13 @@ in
           A new module is available: 'services.espanso'.
         '';
       }
+
+      {
+        time = "2022-02-24T22:35:22+00:00";
+        message = ''
+          A new module is available: 'programs.gitui'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -70,6 +70,7 @@ let
     ./programs/getmail.nix
     ./programs/gh.nix
     ./programs/git.nix
+    ./programs/gitui.nix
     ./programs/gnome-terminal.nix
     ./programs/go.nix
     ./programs/gpg.nix

--- a/modules/programs/gitui.nix
+++ b/modules/programs/gitui.nix
@@ -1,0 +1,82 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.gitui;
+
+in {
+  meta.maintainers = [ hm.maintainers.mifom ];
+
+  options.programs.gitui = {
+    enable =
+      mkEnableOption "gitui, blazing fast terminal-ui for git written in rust";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.gitui;
+      defaultText = "pkgs.gitui";
+      description = "The package to use.";
+    };
+
+    keyConfig = mkOption {
+      type = types.either types.path types.lines;
+      default = "";
+      example = ''
+        exit: Some(( code: Char('c'), modifiers: ( bits: 2,),)),
+        quit: Some(( code: Char('q'), modifiers: ( bits: 0,),)),
+        exit_popup: Some(( code: Esc, modifiers: ( bits: 0,),)),
+      '';
+      description = ''
+        Key config in Ron file format. This is written to
+        <filename>$XDG_CONFIG_HOME/gitui/key_config.ron</filename>.
+      '';
+    };
+
+    theme = mkOption {
+      type = types.either types.path types.lines;
+      default = ''
+        (
+          selected_tab: Reset,
+          command_fg: White,
+          selection_bg: Blue,
+          cmdbar_extra_lines_bg: Blue,
+          disabled_fg: DarkGray,
+          diff_line_add: Green,
+          diff_line_delete: Red,
+          diff_file_added: LightGreen,
+          diff_file_removed: LightRed,
+          diff_file_moved: LightMagenta,
+          diff_file_modified: Yellow,
+          commit_hash: Magenta,
+          commit_time: LightCyan,
+          commit_author: Green,
+          danger_fg: Red,
+          push_gauge_bg: Blue,
+          push_gauge_fg: Reset,
+        )
+      '';
+      description = ''
+        Theme in Ron file format. This is written to
+        <filename>$XDG_CONFIG_HOME/gitui/theme.ron</filename>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."gitui/theme.ron".source =
+      if builtins.isPath cfg.theme || lib.isStorePath cfg.theme then
+        cfg.theme
+      else
+        pkgs.writeText "gitui-theme.ron" cfg.theme;
+
+    xdg.configFile."gitui/key_bindings.ron".source =
+      if builtins.isPath cfg.keyConfig || lib.isStorePath cfg.keyConfig then
+        cfg.keyConfig
+      else
+        pkgs.writeText "gitui-key-config.ron" cfg.keyConfig;
+  };
+}


### PR DESCRIPTION
### Description

Gitui module added to programs.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
I'm not sure how to test this module.

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
