### PR TITLE
Litex

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,11 @@ jobs:
       with:
         name: nix-community
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - run: |
+        if grep -R --exclude stdlib-extended.nix literalExample modules ; then
+          echo "Error: literalExample should be replaced by literalExpression" > /dev/stderr
+          exit 1
+        fi
     - run: ./format -c
     - run: nix-shell . -A install
     - run: nix-shell --arg enableBig false --pure tests -A run.all

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -236,7 +236,7 @@ in
     home.shellAliases = mkOption {
       type = with types; attrsOf str;
       default = { };
-      example = literalExample ''
+      example = literalExpression ''
         {
           g = "git";
           "..." = "cd ../..";


### PR DESCRIPTION
### Description

Use `literalExpression`. Also update CI to fail if code contains `literalExample`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```