### PR TITLE
kakoune: clean up tests

### DIFF
--- a/tests/modules/programs/kakoune/default.nix
+++ b/tests/modules/programs/kakoune/default.nix
@@ -1,8 +1,6 @@
 {
   kakoune-no-plugins = ./no-plugins.nix;
-  # Temporarily disabled until https://github.com/NixOS/nixpkgs/pull/110196
-  # reaches the unstable channel.
-  # kakoune-use-plugins = ./use-plugins.nix;
+  kakoune-use-plugins = ./use-plugins.nix;
   kakoune-whitespace-highlighter = ./whitespace-highlighter.nix;
   kakoune-whitespace-highlighter-corner-cases =
     ./whitespace-highlighter-corner-cases.nix;

--- a/tests/modules/programs/kakoune/no-plugins.nix
+++ b/tests/modules/programs/kakoune/no-plugins.nix
@@ -3,11 +3,11 @@
 with lib;
 
 {
-  config = {
-    programs.kakoune = { enable = true; };
+  imports = [ ./stubs.nix ];
 
-    nmt.script = ''
-      assertPathNotExists home-path/share/kak/autoload/plugins
-    '';
-  };
+  programs.kakoune = { enable = true; };
+
+  nmt.script = ''
+    assertPathNotExists home-path/share/kak/autoload/plugins
+  '';
 }

--- a/tests/modules/programs/kakoune/stubs.nix
+++ b/tests/modules/programs/kakoune/stubs.nix
@@ -1,0 +1,12 @@
+{
+  test.stubs.kakoune-unwrapped = {
+    name = "dummy-kakoune";
+    version = "1";
+    outPath = null;
+    buildScript = ''
+      mkdir -p $out/bin $out/share/kak/doc
+      touch $out/bin/kak
+      chmod +x $out/bin/kak
+    '';
+  };
+}

--- a/tests/modules/programs/kakoune/use-plugins.nix
+++ b/tests/modules/programs/kakoune/use-plugins.nix
@@ -3,14 +3,14 @@
 with lib;
 
 {
-  config = {
-    programs.kakoune = {
-      enable = true;
-      plugins = [ pkgs.kakounePlugins.kak-prelude ];
-    };
+  imports = [ ./stubs.nix ];
 
-    nmt.script = ''
-      assertDirectoryNotEmpty home-path/share/kak/autoload/plugins
-    '';
+  programs.kakoune = {
+    enable = true;
+    plugins = [ pkgs.kakounePlugins.prelude-kak ];
   };
+
+  nmt.script = ''
+    assertDirectoryNotEmpty home-path/share/kak/autoload/plugins
+  '';
 }

--- a/tests/modules/programs/kakoune/whitespace-highlighter-corner-cases.nix
+++ b/tests/modules/programs/kakoune/whitespace-highlighter-corner-cases.nix
@@ -3,23 +3,23 @@
 with lib;
 
 {
-  config = {
-    programs.kakoune = {
-      enable = true;
-      config.showWhitespace = {
-        enable = true;
-        lineFeed = ''"'';
-        space = " ";
-        nonBreakingSpace = "' '"; # backwards compat
-        tab = "'";
-        # tabStop = <default>
-      };
-    };
+  imports = [ ./stubs.nix ];
 
-    nmt.script = ''
-      assertFileExists home-files/.config/kak/kakrc
-      assertFileContains home-files/.config/kak/kakrc \
-        "add-highlighter global/ show-whitespaces -tab \"'\" -spc ' ' -nbsp ' ' -lf '\"'"
-    '';
+  programs.kakoune = {
+    enable = true;
+    config.showWhitespace = {
+      enable = true;
+      lineFeed = ''"'';
+      space = " ";
+      nonBreakingSpace = "' '"; # backwards compat
+      tab = "'";
+      # tabStop = <default>
+    };
   };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/kak/kakrc
+    assertFileContains home-files/.config/kak/kakrc \
+      "add-highlighter global/ show-whitespaces -tab \"'\" -spc ' ' -nbsp ' ' -lf '\"'"
+  '';
 }

--- a/tests/modules/programs/kakoune/whitespace-highlighter.nix
+++ b/tests/modules/programs/kakoune/whitespace-highlighter.nix
@@ -3,23 +3,23 @@
 with lib;
 
 {
-  config = {
-    programs.kakoune = {
-      enable = true;
-      config.showWhitespace = {
-        enable = true;
-        lineFeed = "1";
-        space = "2";
-        nonBreakingSpace = "3";
-        tab = "4";
-        tabStop = "5";
-      };
-    };
+  imports = [ ./stubs.nix ];
 
-    nmt.script = ''
-      assertFileExists home-files/.config/kak/kakrc
-      assertFileContains home-files/.config/kak/kakrc \
-        "add-highlighter global/ show-whitespaces -tab '4' -tabpad '5' -spc '2' -nbsp '3' -lf '1'"
-    '';
+  programs.kakoune = {
+    enable = true;
+    config.showWhitespace = {
+      enable = true;
+      lineFeed = "1";
+      space = "2";
+      nonBreakingSpace = "3";
+      tab = "4";
+      tabStop = "5";
+    };
   };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/kak/kakrc
+    assertFileContains home-files/.config/kak/kakrc \
+      "add-highlighter global/ show-whitespaces -tab '4' -tabpad '5' -spc '2' -nbsp '3' -lf '1'"
+  '';
 }


### PR DESCRIPTION
### Description

- Enable use-plugins test.

- Stub out `kakoune-unwrapped` to avoid unnecessary downloads.

- Unwrap unnecessary `config` attributes.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
