### PR TITLE
xsession: add xplugd service to accompany setxkbmap

### DIFF
--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -126,6 +126,29 @@ in {
               in "${pkgs.xorg.setxkbmap}/bin/setxkbmap ${toString args}";
           };
         };
+
+        xplugd = {
+          Unit = {
+            Description = "Rerun setxkbmap.service when I/O is changed";
+            After = [ "graphical-session-pre.target" ];
+            PartOf = [ "graphical-session.target" ];
+          };
+
+          Install = { WantedBy = [ "graphical-session.target" ]; };
+
+          Service = {
+            Type = "forking";
+            ExecStart = let
+              script = pkgs.writeShellScript "xplugrc" ''
+                case "$1,$3" in
+                  keyboard,connected)
+                  systemctl --user restart setxkbmap.service
+                  ;;
+                esac
+              '';
+            in "${pkgs.xplugd}/bin/xplugd ${script}";
+          };
+        };
       };
 
       targets = {


### PR DESCRIPTION

### Description

This fixes #1638; xplugd will restart setxkbmap if a new keyboard is
plugged in to ensure it is also configured correctly.

### Checklist


- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
