### PR TITLE
ssh: add includes option

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -414,6 +414,22 @@ in
       '';
     };
 
+    includes = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = ''
+        File globs of ssh config files that should be included via the
+        <literal>Include</literal> directive.
+        </para><para>
+        See
+        <citerefentry>
+          <refentrytitle>ssh_config</refentrytitle>
+          <manvolnum>5</manvolnum>
+        </citerefentry>
+        for more information.
+      '';
+    };
+
     matchBlocks = mkOption {
       type = hm.types.listOrDagOf matchBlockModule;
       default = {};
@@ -474,9 +490,12 @@ in
           else abort "Dependency cycle in SSH match blocks: ${sortedMatchBlocksStr}";
       in ''
       ${concatStringsSep "\n" (
-        mapAttrsToList (n: v: "${n} ${v}") cfg.extraOptionOverrides)}
-
-      ${concatStringsSep "\n\n" (map (block: matchBlockStr block.data) matchBlocks)}
+        (mapAttrsToList (n: v: "${n} ${v}") cfg.extraOptionOverrides)
+        ++ (optional (cfg.includes != [ ]) ''
+          Include ${concatStringsSep " " cfg.includes}
+        '')
+        ++ (map (block: matchBlockStr block.data) matchBlocks)
+      )}
 
       Host *
         ForwardAgent ${yn cfg.forwardAgent}

--- a/tests/modules/programs/ssh/default-config-expected.conf
+++ b/tests/modules/programs/ssh/default-config-expected.conf
@@ -1,7 +1,5 @@
 
 
-
-
 Host *
   ForwardAgent no
   Compression no

--- a/tests/modules/programs/ssh/default.nix
+++ b/tests/modules/programs/ssh/default.nix
@@ -1,5 +1,6 @@
 {
   ssh-defaults = ./default-config.nix;
+  ssh-includes = ./includes.nix;
   ssh-match-blocks = ./match-blocks-attrs.nix;
 
   ssh-forwards-dynamic-valid-bind-no-asserts =

--- a/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts-expected.conf
+++ b/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts-expected.conf
@@ -1,8 +1,5 @@
-
-
 Host dynamicBindAddressWithPort
   DynamicForward [127.0.0.1]:3000
-
 Host dynamicBindPathNoPort
   DynamicForward /run/user/1000/gnupg/S.gpg-agent.extra
 

--- a/tests/modules/programs/ssh/includes.nix
+++ b/tests/modules/programs/ssh/includes.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    programs.ssh = {
+      enable = true;
+      includes = [ "config.d/*" "other/dir" ];
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.ssh/config
+      assertFileContains home-files/.ssh/config "Include config.d/* other/dir"
+    '';
+  };
+}

--- a/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
+++ b/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
@@ -1,13 +1,9 @@
-
-
 Host * !github.com
   Port 516
   IdentityFile file1
   IdentityFile file2
-
 Host abc
   ProxyJump jump-host
-
 Host xyz
   ServerAliveInterval 60
   ServerAliveCountMax 10
@@ -16,7 +12,6 @@ Host xyz
   RemoteForward [localhost]:8081 [10.0.0.2]:80
   RemoteForward /run/user/1000/gnupg/S.gpg-agent.extra /run/user/1000/gnupg/S.gpg-agent
   DynamicForward [localhost]:2839
-
 Host ordered
   Port 1
 


### PR DESCRIPTION
### Description

Add support for `Include` directive in ssh config files.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
