### PR TITLE
systemd: do not install systemd files when user is root

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -258,7 +258,8 @@ in {
 
     # If we run under a Linux system we assume that systemd is
     # available, in particular we assume that systemctl is in PATH.
-    (mkIf pkgs.stdenv.isLinux {
+    # Do not install any user services if username is root.
+    (mkIf (pkgs.stdenv.isLinux && config.home.username != "root") {
       xdg.configFile = mkMerge [
         (lib.listToAttrs ((buildServices "service" cfg.services)
           ++ (buildServices "slices" cfg.slices)

--- a/tests/modules/systemd/default.nix
+++ b/tests/modules/systemd/default.nix
@@ -1,5 +1,6 @@
 {
   systemd-services = ./services.nix;
+  systemd-services-disabled-for-root = ./services-disabled-for-root.nix;
   systemd-session-variables = ./session-variables.nix;
   systemd-timers = ./timers.nix;
 }

--- a/tests/modules/systemd/services-disabled-for-root.nix
+++ b/tests/modules/systemd/services-disabled-for-root.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.username = mkForce "root";
+
+    systemd.user.services."test-service@" = {
+      Unit = { Description = "A basic test service"; };
+
+      Service = {
+        Environment = [ "VAR1=1" "VAR2=2" ];
+        ExecStart = ''/some/exec/start/command --with-arguments "%i"'';
+      };
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/test-service@.service
+      assertPathNotExists $serviceFile
+    '';
+  };
+}


### PR DESCRIPTION
### Description

For the user root, there are no user services provided by systemd.
Therefore, these files will never be used.

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
