### PR TITLE
taskwarrior: change config file location and use relative theme path

### DIFF
--- a/docs/release-notes/rl-2111.adoc
+++ b/docs/release-notes/rl-2111.adoc
@@ -37,6 +37,10 @@ https://github.com/nix-community/home-manager/issues/1906[issue #1906].
 +
 You can replicate your old configuration by moving those options to <<opt-programs.rofi.theme>>. Keep in mind that the syntax is different so you may need to do some changes.
 
+* Taskwarrior version 2.6.0 respects XDG Specification for the config file now.
+Option <<opt-programs.taskwarrior.config>> and friends now generate the config file at
+`$XDG_CONFIG_HOME/task/taskrc` instead of `~/.taskrc`.
+
 [[sec-release-21.11-state-version-changes]]
 === State Version Changes
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2241,6 +2241,15 @@ in
           A new module is available: 'wayland.windowManager.sway.swaynag'.
         '';
       }
+
+      {
+        time = "2021-11-23T20:26:37+00:00";
+        message = ''
+          Taskwarrior version 2.6.0 respects XDG Specification for the config file now.
+          Option 'opt-programs.taskwarrior.config' and friends now generate the config file at
+          '$XDG_CONFIG_HOME/task/taskrc' instead of '~/.taskrc'.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -6,16 +6,6 @@ let
 
   cfg = config.programs.taskwarrior;
 
-  themePath = theme: "${pkgs.taskwarrior}/share/doc/task/rc/${theme}.theme";
-
-  includeTheme = location:
-    if location == null then
-      ""
-    else if isString location then
-      "include ${themePath location}"
-    else
-      "include ${location}";
-
   formatValue = value:
     if isBool value then
       if value then "true" else "false"
@@ -59,7 +49,7 @@ in {
         '';
         description = ''
           Key-value configuration written to
-          <filename>~/.taskrc</filename>.
+          <filename>$XDG_CONFIG_HOME/task/taskrc</filename>.
         '';
       };
 
@@ -89,7 +79,7 @@ in {
         default = "";
         description = ''
           Additional content written at the end of
-          <filename>~/.taskrc</filename>.
+          <filename>$XDG_CONFIG_HOME/task/taskrc</filename>.
         '';
       };
     };
@@ -98,9 +88,12 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ pkgs.taskwarrior ];
 
-    home.file.".taskrc".text = ''
+    xdg.configFile."task/taskrc".text = ''
       data.location=${cfg.dataLocation}
-      ${includeTheme cfg.colorTheme}
+      ${optionalString (cfg.colorTheme != null) (if isString cfg.colorTheme then
+        "include ${cfg.colorTheme}.theme"
+      else
+        "include ${cfg.colorTheme}")}
 
       ${concatStringsSep "\n" (mapAttrsToList formatPair cfg.config)}
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -87,6 +87,7 @@ import nmt {
     ./modules/programs/sm64ex
     ./modules/programs/ssh
     ./modules/programs/starship
+    ./modules/programs/taskwarrior
     ./modules/programs/texlive
     ./modules/programs/tmux
     ./modules/programs/topgrade

--- a/tests/modules/programs/taskwarrior/default.nix
+++ b/tests/modules/programs/taskwarrior/default.nix
@@ -1,0 +1,1 @@
+{ taskwarrior = ./taskwarrior.nix; }

--- a/tests/modules/programs/taskwarrior/taskwarrior.nix
+++ b/tests/modules/programs/taskwarrior/taskwarrior.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.taskwarrior = {
+      enable = true;
+      colorTheme = "dark-violets-256";
+      dataLocation = "/some/data/location";
+      config = {
+        urgency.user.tag.next.coefficient = 42.42;
+        urgency.blocked.coefficient = -42;
+      };
+      extraConfig = ''
+        include /my/stuff
+        urgency.user.tag.test.coefficient=-42.42
+      '';
+    };
+
+    test.stubs.taskwarrior = { };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/task/taskrc
+      assertFileContent home-files/.config/task/taskrc ${
+        pkgs.writeText "taskwarrior.expected" ''
+          data.location=/some/data/location
+          include dark-violets-256.theme
+
+          urgency.blocked.coefficient=-42
+          urgency.user.tag.next.coefficient=42.420000
+
+          include /my/stuff
+          urgency.user.tag.test.coefficient=-42.42
+
+        ''
+      }
+    '';
+  };
+}


### PR DESCRIPTION


### Description

After taskwarrior 2.6.0, its default config file now locates in `$XDG_CONFIG_HOME/task/taskrc`, and builtin themes can be included via relative path.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.
  This change relies on taskwarrior >= 2.6.0, which is already in `nixos-unstable`. Our `master` is also targeting unstable.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
