### PR TITLE
direnv.nix-direnv: remove enableFlakes

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -15,6 +15,8 @@ in {
       "direnv"
       "enableNixDirenvIntegration"
     ] [ "programs" "direnv" "nix-direnv" "enable" ])
+    (mkRemovedOptionModule [ "programs" "direnv" "nix-direnv" "enableFlakes" ]
+      "Flake support is now always enabled.")
   ];
 
   meta.maintainers = [ maintainers.rycee ];
@@ -79,7 +81,6 @@ in {
         <link
             xlink:href="https://github.com/nix-community/nix-direnv">nix-direnv</link>,
             a fast, persistent use_nix implementation for direnv'';
-      enableFlakes = mkEnableOption "Flake support in nix-direnv";
     };
 
   };
@@ -92,11 +93,9 @@ in {
     };
 
     xdg.configFile."direnv/direnvrc" = let
-      package =
-        pkgs.nix-direnv.override { inherit (cfg.nix-direnv) enableFlakes; };
       text = concatStringsSep "\n" (optional (cfg.stdlib != "") cfg.stdlib
         ++ optional cfg.nix-direnv.enable
-        "source ${package}/share/nix-direnv/direnvrc");
+        "source ${pkgs.nix-direnv}/share/nix-direnv/direnvrc");
     in mkIf (text != "") { inherit text; };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (


### PR DESCRIPTION

### Description

Since https://github.com/NixOS/nixpkgs/pull/144197 flake support is
always available. The upstream `enableFlakes` option is scheduled to be
removed altogether in https://github.com/NixOS/nixpkgs/pull/145236

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
