### PR TITLE
WIP: nix-darwin + nix 2.4: change some nix-env calls to nix profile

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -5,6 +5,20 @@ PATH=@coreutils@/bin:@findutils@/bin:@gnused@/bin:@less@/bin:@nixos-option@/bin$
 
 set -euo pipefail
 
+function removeByName() {
+  nix profile list | { grep "$1" || test $? = 1; } \
+      | awk -F ' ' '{ print $4 }' | \
+      xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
+}
+
+if [[ -e ~/.nix-profile/manifest.json ]] ; then
+  LIST_OUTPATH_CMD="nix profile list"
+  REMOVE_CMD="removeByName"
+else
+  LIST_OUTPATH_CMD="nix-env -q --outpath"
+  REMOVE_CMD="nix-env -q"
+fi
+
 function errorEcho() {
     # shellcheck disable=2048,2086
     echo $* >&2
@@ -371,7 +385,7 @@ function doExpireGenerations() {
 
 function doListPackages() {
     local outPath
-    outPath="$(nix-env -q --out-path | grep -o '/.*home-manager-path$')"
+    outPath="$($LIST_OUTPATH_CMD | grep -o '/.*home-manager-path$')"
     if [[ -n "$outPath" ]] ; then
         nix-store -q --references "$outPath" | sed 's/[^-]*-//'
     else
@@ -463,7 +477,7 @@ function doUninstall() {
             HOME_MANAGER_CONFIG="$(mktemp --tmpdir home-manager.XXXXXXXXXX)"
             echo "{ lib, ... }: { home.file = lib.mkForce {}; }" > "$HOME_MANAGER_CONFIG"
             doSwitch
-            $DRY_RUN_CMD nix-env -e home-manager-path || true
+            $DRY_RUN_CMD $REMOVE_CMD home-manager-path || true
             rm "$HOME_MANAGER_CONFIG"
             $DRY_RUN_CMD rm $VERBOSE_ARG -r \
                 "${XDG_DATA_HOME:-$HOME/.local/share}/home-manager"

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -247,7 +247,12 @@ in
 
             local newGenFiles oldGenFiles
             newGenFiles="$(readlink -e "$newGenPath/home-files")"
-            oldGenFiles="$(readlink -e "$oldGenPath/home-files")"
+            oldGenFiles="$(readlink -e "$oldGenPath/home-files" || echo -n "")"
+
+            if [[ -z "$oldGenFiles" ]] ; then
+              echo "Did not find old home-files in $oldGenPath"
+              return
+            fi
 
             # Apply the cleanup script on each leaf in the old
             # generation. The find command below will print the

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -260,7 +260,13 @@ in
 
           if [[ ! -v oldGenPath || "$oldGenPath" != "$newGenPath" ]] ; then
             echo "Creating profile generation $newGenNum"
-            $DRY_RUN_CMD nix-env $VERBOSE_ARG --profile "$genProfilePath" --set "$newGenPath"
+            $DRY_RUN_CMD nix profile remove '.*' $VERBOSE_ARG --profile "$genProfilePath"
+
+            # Remove all packages from "$genProfilePath"
+            # `nix profile remove '.*' --profile "$genProfilePath"` was not working, so here is a workaround:
+            nix profile list --profile "$genProfilePath" | awk -F ' ' '{ print $4 }' | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG --profile "$genProfilePath"
+
+            $DRY_RUN_CMD nix profile install $VERBOSE_ARG --profile "$genProfilePath" "$newGenPath"
             $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG "$newGenPath" "$newGenGcPath"
           else
             echo "No change so reusing latest profile generation $oldGenNum"

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -265,9 +265,13 @@ in
 
           if [[ ! -v oldGenPath || "$oldGenPath" != "$newGenPath" ]] ; then
             echo "Creating profile generation $newGenNum"
-            # Remove all packages from "$genProfilePath"
-            # `nix profile remove '.*' --profile "$genProfilePath"` was not working, so here is a workaround:
-            nix profile list --profile "$genProfilePath" | awk -F ' ' '{ print $4 }' | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG --profile "$genProfilePath"
+            if [[ -e "$genProfilePath"/manifest.json ]] ; then
+              # Remove all packages from "$genProfilePath"
+              # `nix profile remove '.*' --profile "$genProfilePath"` was not working, so here is a workaround:
+              nix profile list --profile "$genProfilePath" | awk -F ' ' '{ print $4 }' | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG --profile "$genProfilePath"
+            else
+              $DRY_RUN_CMD nix-env $VERBOSE_ARG --profile "$genProfilePath" --set "$newGenPath"
+            fi
 
             $DRY_RUN_CMD nix profile install $VERBOSE_ARG --profile "$genProfilePath" "$newGenPath"
             $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG "$newGenPath" "$newGenGcPath"

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -260,8 +260,6 @@ in
 
           if [[ ! -v oldGenPath || "$oldGenPath" != "$newGenPath" ]] ; then
             echo "Creating profile generation $newGenNum"
-            $DRY_RUN_CMD nix profile remove '.*' $VERBOSE_ARG --profile "$genProfilePath"
-
             # Remove all packages from "$genProfilePath"
             # `nix profile remove '.*' --profile "$genProfilePath"` was not working, so here is a workaround:
             nix profile list --profile "$genProfilePath" | awk -F ' ' '{ print $4 }' | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG --profile "$genProfilePath"

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -587,7 +587,7 @@ in
           Oops, nix profile failed to install your new Home Manager profile!
 
           Perhaps there is a conflict with a package that was installed using
-          'nix profile install ? Try running
+          'nix profile install' ? Try running
 
               nix profile list
 

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -577,25 +577,23 @@ in
       if config.submoduleSupport.externalPackageInstall
       then
         ''
-          if nix-env -q | grep '^home-manager-path$'; then
-            $DRY_RUN_CMD nix-env -e home-manager-path
-          fi
+         nix profile list | grep 'home-manager-path$' | awk -F ' ' '{ print $4 }' | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
         ''
       else
         ''
-          if ! $DRY_RUN_CMD nix-env -i ${cfg.path} ; then
+          if ! $DRY_RUN_CMD nix profile install ${cfg.path} ; then
             cat <<EOF
 
-          Oops, nix-env failed to install your new Home Manager profile!
+          Oops, nix profile failed to install your new Home Manager profile!
 
           Perhaps there is a conflict with a package that was installed using
-          'nix-env -i'? Try running
+          'nix profile install ? Try running
 
-              nix-env -q
+              nix profile list
 
           and if there is a conflicting package you can remove it with
 
-              nix-env -e {package name}
+              nix profile remove {number | store path}
 
           Then try activating your Home Manager configuration again.
           EOF

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -577,7 +577,7 @@ in
       if config.submoduleSupport.externalPackageInstall
       then
         ''
-         if [[ -e "$genProfilePath"/manifest.json ]] ; then
+         if [[ -e "$nixProfilePath"/manifest.json ]] ; then
            nix profile list | { grep 'home-manager-path$' || test $? = 1; } | awk -F ' ' '{ print $4 }' | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
          else
            if nix-env -q | grep '^home-manager-path$'; then
@@ -587,7 +587,7 @@ in
         ''
       else
         ''
-          if [[ -e "$genProfilePath"/manifest.json ]] ; then
+          if [[ -e "$nixProfilePath"/manifest.json ]] ; then
             INSTALL_CMD="nix profile install"
             LIST_CMD="nix profile list"
             REMOVE_CMD_SYNTAX='nix profile remove {number | store path}'

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -577,7 +577,7 @@ in
       if config.submoduleSupport.externalPackageInstall
       then
         ''
-         nix profile list | grep 'home-manager-path$' | awk -F ' ' '{ print $4 }' | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
+         nix profile list | { grep 'home-manager-path$' || test $? = 1; } | awk -F ' ' '{ print $4 }' | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
         ''
       else
         ''

--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -5,6 +5,7 @@ function setupVars() {
     local profilesPath="$nixStateDir/profiles/per-user/$USER"
     local gcPath="$nixStateDir/gcroots/per-user/$USER"
 
+    declare -gr nixProfilePath="$profilesPath/profile"
     declare -gr genProfilePath="$profilesPath/home-manager"
     declare -gr newGenPath="@GENERATION_DIR@";
     declare -gr newGenGcPath="$gcPath/current-home"


### PR DESCRIPTION
### Description

Fix use of home-manager with now stable nix 2.4 (nix profile).
Keep backward compatibility with nix-env.

#2438 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
