### PR TITLE
Revert "direnv.nix-direnv: remove enableFlakes (#2458)"

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -15,8 +15,6 @@ in {
       "direnv"
       "enableNixDirenvIntegration"
     ] [ "programs" "direnv" "nix-direnv" "enable" ])
-    (mkRemovedOptionModule [ "programs" "direnv" "nix-direnv" "enableFlakes" ]
-      "Flake support is now always enabled.")
   ];
 
   meta.maintainers = [ maintainers.rycee ];
@@ -81,6 +79,7 @@ in {
         <link
             xlink:href="https://github.com/nix-community/nix-direnv">nix-direnv</link>,
             a fast, persistent use_nix implementation for direnv'';
+      enableFlakes = mkEnableOption "Flake support in nix-direnv";
     };
 
   };
@@ -93,9 +92,11 @@ in {
     };
 
     xdg.configFile."direnv/direnvrc" = let
+      package =
+        pkgs.nix-direnv.override { inherit (cfg.nix-direnv) enableFlakes; };
       text = concatStringsSep "\n" (optional (cfg.stdlib != "") cfg.stdlib
         ++ optional cfg.nix-direnv.enable
-        "source ${pkgs.nix-direnv}/share/nix-direnv/direnvrc");
+        "source ${package}/share/nix-direnv/direnvrc");
     in mkIf (text != "") { inherit text; };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (


### PR DESCRIPTION
### Description

This reverts commit 1e5c8e9bff00d0844bc3d25d1a98eab5633e600b. I'm not sure if its the `enableFlakes` option removal in the `nix-direnv` package not being in `nixpkgs-unstable` yet, or something else just not being included. But currently home-manager https://github.com/nix-community/home-manager/commit/1e5c8e9bff00d0844bc3d25d1a98eab5633e600b and Nixpkgs https://github.com/NixOS/nixpkgs/commit/f096b7122ab08e93c8b052c92461ca71b80c0cc8 breaks `nix-direnv` and flakes, since it's trying to call Nix 2.3.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
