### PR TITLE
less: allow customization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,6 +113,8 @@
 
 /modules/programs/lazygit.nix                         @kalhauge
 
+/modules/programs/less.nix                            @pamplemousse
+
 /modules/programs/lesspipe.nix                        @rycee
 
 /modules/programs/lf.nix                              @owm111

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -133,4 +133,11 @@
     github = "hawkw";
     githubId = 2796466;
   };
+
+  pamplemousse = {
+    name = "Xavier Maso";
+    email = "xav.maso@gmail.com";
+    github = "pamplemousse";
+    githubId = 2647236;
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -86,6 +86,7 @@ let
     ./programs/keychain.nix
     ./programs/kitty.nix
     ./programs/lazygit.nix
+    ./programs/less.nix
     ./programs/lesspipe.nix
     ./programs/lf.nix
     ./programs/lieer.nix

--- a/modules/programs/less.nix
+++ b/modules/programs/less.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.programs.less;
+in {
+  meta.maintainers = [ maintainers.pamplemousse ];
+
+  options = {
+    programs.less = {
+      enable = mkEnableOption "less, opposite of more";
+
+      keys = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          s        back-line
+          t        forw-line
+        '';
+        description = ''
+          Extra configuration for <command>less</command> written to <filename>$HOME/.lesskey</filename>.
+        '';
+      };
+    };
+  };
+
+  config = mkIf (cfg.enable) {
+    home.packages = [ pkgs.less ];
+    home.file.".lesskey".text = cfg.keys;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -66,6 +66,7 @@ import nmt {
     ./modules/programs/irssi
     ./modules/programs/kakoune
     ./modules/programs/kitty
+    ./modules/programs/less
     ./modules/programs/lf
     ./modules/programs/lieer
     ./modules/programs/man

--- a/tests/modules/programs/less/default.nix
+++ b/tests/modules/programs/less/default.nix
@@ -1,0 +1,3 @@
+{
+  less-with-custom-keys = ./less-with-custom-keys.nix;
+}

--- a/tests/modules/programs/less/less-with-custom-keys.nix
+++ b/tests/modules/programs/less/less-with-custom-keys.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.less = {
+      enable = true;
+
+      keys = ''
+        s        back-line
+        t        forw-line
+      '';
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.lesskey
+      assertFileContent home-files/.lesskey ${
+        pkgs.writeText "less.expected" ''
+          s        back-line
+          t        forw-line
+        ''
+      }
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Allow to specify the content of a less configuration file via `home-manager`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
