### PR TITLE
Add example how to use flakes on none NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,33 @@ as follows:
 }
 ```
 
+If you are not using NixOS you can place the following flake in
+`~/.config/nixpkgs/flake.nix` to load your standard Home Manager
+configuration:
+
+```nix
+{
+  description = "A Home Manager flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs: {
+    homeConfigurations = {
+      jdoe = inputs.home-manager.lib.homeManagerConfiguration {
+        system = "x86_64-linux";
+        homeDirectory = "/home/jdoe";
+        username = "jdoe";
+        configuration.imports = [ ./home.nix ];
+      };
+    };
+  };
+}
+```
+
 Note, the Home Manager library is exported by the flake under
 `lib.hm`.
 


### PR DESCRIPTION
### Description

Make it easier for other people to use flakes with home-manager on none NixOS.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
