### PR TITLE
Remove remaining `allowSubstitutes = false`

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -16,7 +16,6 @@ let
 
 in runCommand "home-manager" {
   preferLocalBuild = true;
-  allowSubstitutes = false;
   meta = with lib; {
     description = "A user environment configurator";
     maintainers = [ maintainers.rycee ];

--- a/home-manager/install.nix
+++ b/home-manager/install.nix
@@ -3,7 +3,6 @@
 runCommand "home-manager-install" {
   propagatedBuildInputs = [ home-manager ];
   preferLocalBuild = true;
-  allowSubstitutes = false;
   shellHookOnly = true;
   shellHook = ''
     confFile="''${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home.nix"

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -652,7 +652,6 @@ in
           "home-manager-generation"
           {
             preferLocalBuild = true;
-            allowSubstitutes = false;
           }
           ''
             mkdir -p $out

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -310,7 +310,6 @@ in {
             nativeBuildInputs = [ pkgs.python2 ];
             buildInputs = [ cfg.package ];
             preferLocalBuild = true;
-            allowSubstitutes = false;
           } ''
             mkdir -p $out
             if [ -d $src/share/man ]; then

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -32,7 +32,6 @@ with lib;
         firefox-unwrapped = pkgs.runCommand "firefox-0" {
           meta.description = "I pretend to be Firefox";
           preferLocalBuild = true;
-          allowSubstitutes = false;
           passthru.gtk3 = null;
         } ''
           mkdir -p "$out/bin"

--- a/tests/modules/programs/firefox/state-version-19_09.nix
+++ b/tests/modules/programs/firefox/state-version-19_09.nix
@@ -13,7 +13,6 @@ with lib;
         firefox-unwrapped = pkgs.runCommand "firefox-0" {
           meta.description = "I pretend to be Firefox";
           preferLocalBuild = true;
-          allowSubstitutes = false;
           passthru.gtk3 = null;
         } ''
           mkdir -p "$out/bin"


### PR DESCRIPTION
### Description

See, e.g., https://github.com/NixOS/nix/issues/4442 for wider discussions.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```