### PR TITLE
Add Terraform program module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -377,3 +377,5 @@
 /modules/services/volnoti.nix                         @IvanMalison
 
 Makefile                                              @thiagokokada
+
+/modules/programs/terraform.nix                       @bryanhonof

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -133,4 +133,10 @@
     github = "hawkw";
     githubId = 2796466;
   };
+  bryanhonof = {
+    name = "Bryan Honof";
+    email = "bjth@inuits.eu";
+    github = "bryanhonof";
+    githubId = 5932804;
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2233,6 +2233,13 @@ in
           A new module is available: 'programs.hexchat'.
         '';
       }
+
+      {
+        time = "2021-11-13T20:31:52+00:00";
+        message = ''
+          A new module is available: 'programs.terraform'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -136,6 +136,7 @@ let
     ./programs/taskwarrior.nix
     ./programs/terminator.nix
     ./programs/termite.nix
+    ./programs/terraform.nix
     ./programs/texlive.nix
     ./programs/tmux.nix
     ./programs/topgrade.nix

--- a/modules/programs/terraform.nix
+++ b/modules/programs/terraform.nix
@@ -31,7 +31,7 @@ in {
       default = false;
       description = ''
         Wether or not to install the autocomplete functionality. Normally this
-        is done by running `terraform -install-autocomplete`.
+        is done by running <literal>terraform -install-autocomplete</literal>.
       '';
     };
 
@@ -41,7 +41,7 @@ in {
     home.packages = [ cfg.package ];
 
     programs.bash.bashrcExtra = ''
-      complete -C ${cfg.package}/bin/terraform terraform
+      complete -C ${cfg.package}/bin/${cfg.package.pname} ${cfg.package.pname}
     '';
   };
 }

--- a/modules/programs/terraform.nix
+++ b/modules/programs/terraform.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.terraform;
+
+in {
+  meta.maintainers = [ maintainers.bryanhonof ];
+
+  options.programs.terraform = {
+
+    enable = mkEnableOption ''
+      Terraform is an open-source infrastructure as code software tool that
+      provides a consistent CLI workflow to manage hundreds of cloud services.
+      Terraform codifies cloud APIs into declarative configuration files.
+
+      https://www.terraform.io/
+    '';
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.terraform;
+      defaultText = "pkgs.terraform";
+      description = "The Terraform package to use";
+    };
+
+    installCompletion = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Wether or not to install the autocomplete functionality. Normally this
+        is done by running `terraform -install-autocomplete`.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.bash.bashrcExtra = ''
+      complete -C ${cfg.package}/bin/terraform terraform
+    '';
+  };
+}

--- a/modules/programs/terraform.nix
+++ b/modules/programs/terraform.nix
@@ -40,8 +40,9 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    programs.bash.bashrcExtra = ''
-      complete -C ${cfg.package}/bin/${cfg.package.pname} ${cfg.package.pname}
+    programs.bash.bashrcExtra = let program = "terraform";
+    in ''
+      complete -C ${cfg.package}/bin/${program} ${program}
     '';
   };
 }

--- a/modules/programs/terraform.nix
+++ b/modules/programs/terraform.nix
@@ -45,7 +45,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package.withPlugins (p: with p; cfg.providers) ];
+    home.packages = [ (cfg.package.withPlugins (_: cfg.providers)) ];
 
     programs.bash.bashrcExtra = let program = "terraform";
     in mkIf cfg.installCompletion ''

--- a/modules/programs/terraform.nix
+++ b/modules/programs/terraform.nix
@@ -41,7 +41,7 @@ in {
     home.packages = [ cfg.package ];
 
     programs.bash.bashrcExtra = let program = "terraform";
-    in ''
+    in mkIf cfg.installCompletion ''
       complete -C ${cfg.package}/bin/${program} ${program}
     '';
   };

--- a/modules/programs/terraform.nix
+++ b/modules/programs/terraform.nix
@@ -7,16 +7,15 @@ let
   cfg = config.programs.terraform;
 
 in {
-  meta.maintainers = [ maintainers.bryanhonof ];
+  meta.maintainers = [ hm.maintainers.bryanhonof ];
 
   options.programs.terraform = {
 
     enable = mkEnableOption ''
-      Terraform is an open-source infrastructure as code software tool that
+      <link xlink:href="https://www.terraform.io">Terraform</link>, an open-source infrastructure as code software tool that
       provides a consistent CLI workflow to manage hundreds of cloud services.
+      </para>
       Terraform codifies cloud APIs into declarative configuration files.
-
-      https://www.terraform.io/
     '';
 
     package = mkOption {
@@ -27,19 +26,30 @@ in {
     };
 
     providers = mkOption {
-      type = types.listOf types.package;
-      default = [ ];
-      description = "A list of Terraform providers.";
+      type = hm.types.selectorFunction;
+      default = providers: [ ];
+      defaultText = literalExpression "providers: [ ]";
+      example = literalExpression ''
+        providers: [ providers.consul providers.dyn ];
+      '';
+      description = ''
+        A list of Terraform providers.
+        </para>
+        <para>
+        A list of available providers can be obtained with either of the following commands:
+        <orderedlist numeration="arabic">
+          <listitem>
+            <para><command>nix-env -f '&lt;nixpkgs&gt;' -qaP -A terraform-providers</command></para>
+          </listitem>
+          <listitem>
+            <para><command>nix search 'nixpkgs#terraform-providers'</command></para>
+          </listitem>
+        </orderedlist>
+      '';
     };
 
-    installCompletion = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Wether or not to install the autocomplete functionality. Normally this
-        is done by running <literal>terraform -install-autocomplete</literal>.
-        Currently only installs for bash.
-      '';
+    enableBashIntegration = mkEnableOption "Bash integration" // {
+      default = true;
     };
 
   };
@@ -47,9 +57,8 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ (cfg.package.withPlugins (_: cfg.providers)) ];
 
-    programs.bash.bashrcExtra = let program = "terraform";
-    in mkIf cfg.installCompletion ''
-      complete -C ${cfg.package}/bin/${program} ${program}
+    programs.bash.initExtra = mkIf cfg.installCompletion ''
+      complete -C ${cfg.package}/bin/terraform terraform
     '';
   };
 }

--- a/modules/programs/terraform.nix
+++ b/modules/programs/terraform.nix
@@ -55,9 +55,9 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ (cfg.package.withPlugins (_: cfg.providers)) ];
+    home.packages = [ (cfg.package.withPlugins cfg.providers) ];
 
-    programs.bash.initExtra = mkIf cfg.installCompletion ''
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       complete -C ${cfg.package}/bin/terraform terraform
     '';
   };

--- a/modules/programs/terraform.nix
+++ b/modules/programs/terraform.nix
@@ -26,19 +26,26 @@ in {
       description = "The Terraform package to use";
     };
 
+    providers = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      description = "A list of Terraform providers.";
+    };
+
     installCompletion = mkOption {
       type = types.bool;
       default = false;
       description = ''
         Wether or not to install the autocomplete functionality. Normally this
         is done by running <literal>terraform -install-autocomplete</literal>.
+        Currently only installs for bash.
       '';
     };
 
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = [ cfg.package.withPlugins (p: with p; cfg.providers) ];
 
     programs.bash.bashrcExtra = let program = "terraform";
     in mkIf cfg.installCompletion ''


### PR DESCRIPTION
### Description

These changes introduce a new way of managing Terraform, and its providers. Using home-manager it's also possible to automatically install the autocomplete feature of Terraform.

I'm not sure if tests are necessary for a program of this kind?

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
