### PR TITLE
modules/services/systembus-notify: init

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -390,6 +390,8 @@
 
 /modules/services/volnoti.nix                         @IvanMalison
 
+/modules/services/systembus-notify.nix                @asymmetric
+
 /modules/targets/darwin                               @midchildan
 /tests/modules/targets-darwin                         @midchildan
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2320,6 +2320,14 @@ in
           A new module is available: 'services.opensnitch-ui'.
         '';
       }
+
+      {
+        time = "2021-12-21T22:17:30+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.systembus-notify'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -220,6 +220,7 @@ let
     ./services/status-notifier-watcher.nix
     ./services/sxhkd.nix
     ./services/syncthing.nix
+    ./services/systembus-notify.nix
     ./services/taffybar.nix
     ./services/tahoe-lafs.nix
     ./services/taskwarrior-sync.nix

--- a/modules/services/systembus-notify.nix
+++ b/modules/services/systembus-notify.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  meta.maintainers = [ maintainers.asymmetric ];
+
+  options = {
+    services.systembus-notify = {
+      enable =
+        mkEnableOption "systembus-notify - system bus notification daemon";
+    };
+  };
+
+  config = mkIf config.services.systembus-notify.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.systembus-notify" pkgs
+        platforms.linux)
+    ];
+
+    systemd.user.services.systembus-notify = {
+      Unit.Description = "systembus-notify daemon";
+      Install.WantedBy = [ "graphical-session.target" ];
+      Service.ExecStart = "${pkgs.systembus-notify}/bin/systembus-notify";
+    };
+  };
+}


### PR DESCRIPTION
### Description

Sets up a user systemd service for [`systembus-notify`](https://github.com/rfjakob/systembus-notify)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
