### PR TITLE
Fix exit codes

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -248,14 +248,12 @@ function doBuild() {
 
     setFlakeAttribute
     if [[ -v FLAKE_CONFIG_URI ]]; then
-        local exitCode=0
         nix build \
             "${PASSTHROUGH_OPTS[@]}" \
              ${DRY_RUN+--dry-run} \
              ${NO_OUT_LINK+--no-link} \
             "$FLAKE_CONFIG_URI.activationPackage" \
-            || exitCode=1
-        return $exitCode
+            || return
     fi
 
     setWorkDir
@@ -263,26 +261,21 @@ function doBuild() {
     local newsInfo
     newsInfo=$(buildNews)
 
-    local exitCode
     doBuildAttr \
                 ${NO_OUT_LINK+--no-out-link} \
                 --attr activationPackage \
-        && exitCode=0 || exitCode=1
+        || return
 
     presentNews "$newsInfo"
-
-    return $exitCode
 }
 
 function doSwitch() {
     setFlakeAttribute
     if [[ -v FLAKE_CONFIG_URI ]]; then
-        local exitCode=0
         nix run \
             "${PASSTHROUGH_OPTS[@]}" \
             "$FLAKE_CONFIG_URI.activationPackage" \
-            || exitCode=1
-        return $exitCode
+            || return
     fi
 
     setWorkDir
@@ -291,7 +284,6 @@ function doSwitch() {
     newsInfo=$(buildNews)
 
     local generation
-    local exitCode=0
 
     # Build the generation and run the activate script. Note, we
     # specify an output link so that it is treated as a GC root. This
@@ -302,11 +294,9 @@ function doSwitch() {
     doBuildAttr \
                 --out-link "$generation" \
                 --attr activationPackage \
-        && "$generation/activate" || exitCode=1
+        && "$generation/activate" || return
 
     presentNews "$newsInfo"
-
-    return $exitCode
 }
 
 function doListGens() {


### PR DESCRIPTION
### Description

home-manager will now exit early if any nix builds fail and will ext with the right exit code.

Before the change if the nix builds failed home-manager would proceed presenting the news and would exit with 0 which breaks multiple script automation and aliases I use.

### Checklist

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
