### PR TITLE
offlineimap: Fix for OfflineIMAP 8

### DIFF
--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -65,7 +65,7 @@ let
       remotePassEval =
         let arglist = concatMapStringsSep "," (x: "'${x}'") passwordCommand;
         in optionalAttrs (passwordCommand != null) {
-          remotepasseval = ''get_pass("${name}", [${arglist}]).strip("\n")'';
+          remotepasseval = ''get_pass("${name}", [${arglist}]).strip(b"\n")'';
         };
     in toIni {
       "Account ${name}" = {


### PR DESCRIPTION


### Description

Nixpkgs switched to OfflineIMAP version 8 which means that Python 3 is
now used instead of Python 2. As a result, get_pass() now returns a
byte array instead of a string and the argument to get_pass() must be
a byte array too. See
https://github.com/OfflineIMAP/offlineimap3/issues/103.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
