### PR TITLE
flameshot: extend module with package-option

### DIFF
--- a/modules/services/flameshot.nix
+++ b/modules/services/flameshot.nix
@@ -6,8 +6,6 @@ let
 
   cfg = config.services.flameshot;
 
-  package = pkgs.flameshot;
-
   iniFormat = pkgs.formats.ini { };
 
   iniFile = iniFormat.generate "flameshot.ini" cfg.settings;
@@ -17,6 +15,13 @@ in {
 
   options.services.flameshot = {
     enable = mkEnableOption "Flameshot";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.flameshot;
+      defaultText = literalExpression "pkgs.flameshot";
+      description = "Package providing <command>flameshot</command>.";
+    };
 
     settings = mkOption {
       type = iniFormat.type;
@@ -41,7 +46,7 @@ in {
         lib.platforms.linux)
     ];
 
-    home.packages = [ package ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile = mkIf (cfg.settings != { }) {
       "flameshot/flameshot.ini".source = iniFile;
@@ -60,7 +65,7 @@ in {
 
       Service = {
         Environment = "PATH=${config.home.profileDirectory}/bin";
-        ExecStart = "${package}/bin/flameshot";
+        ExecStart = "${cfg.package}/bin/flameshot";
         Restart = "on-abort";
 
         # Sandboxing.


### PR DESCRIPTION
### Description
Extend module for package-option, tested chages

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
