### PR TITLE
xdg: fix typo and add test

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -108,7 +108,7 @@ in {
       xdg.cacheHome = mkDefault defaultCacheHome;
       xdg.configHome = mkDefault defaultConfigHome;
       xdg.dataHome = mkDefault defaultDataHome;
-      xdg.stateHome = mkDefault stateHome;
+      xdg.stateHome = mkDefault defaultStateHome;
     })
 
     {

--- a/tests/modules/misc/xdg/default-locations.nix
+++ b/tests/modules/misc/xdg/default-locations.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    # Test fallback behavior for stateVersion >= 20.09, which is pure.
+    xdg.enable = lib.mkForce false;
+    home.stateVersion = "20.09";
+
+    xdg.configFile.test.text = "config";
+    xdg.dataFile.test.text = "data";
+    home.file."${config.xdg.cacheHome}/test".text = "cache";
+    home.file."${config.xdg.stateHome}/test".text = "state";
+
+    nmt.script = ''
+      assertFileExists home-files/.config/test
+      assertFileExists home-files/.local/share/test
+      assertFileExists home-files/.cache/test
+      assertFileExists home-files/.local/state/test
+      assertFileContent \
+        home-files/.config/test \
+        ${builtins.toFile "test" "config"}
+      assertFileContent \
+        home-files/.local/share/test \
+        ${builtins.toFile "test" "data"}
+      assertFileContent \
+        home-files/.cache/test \
+        ${builtins.toFile "test" "cache"}
+      assertFileContent \
+        home-files/.local/state/test \
+        ${builtins.toFile "test" "state"}
+    '';
+  };
+}

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -3,4 +3,5 @@
   xdg-system-dirs = ./system-dirs.nix;
   xdg-desktop-entries = ./desktop-entries.nix;
   xdg-file-gen = ./file-gen.nix;
+  xdg-default-locations = ./default-locations.nix;
 }


### PR DESCRIPTION
### Description

Fix typo which cause evaluation failure when `xdg.enable = false` and `home.stateVersion` >= 20.09.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
