### PR TITLE
home-environment: make `home.profileDirectory` public

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -205,12 +205,13 @@ in
 
     home.profileDirectory = mkOption {
       type = types.path;
-      defaultText = "~/.nix-profile";
-      internal = true;
+      defaultText = literalExpression ''
+        "''${home.homeDirectory}/.nix-profile"  or
+        "/etc/profiles/per-user/''${home.username}"
+      '';
       readOnly = true;
       description = ''
-        The profile directory where Home Manager generations are
-        installed.
+        The profile directory where Home Manager generations are installed.
       '';
     };
 
@@ -502,7 +503,7 @@ in
         && config.submoduleSupport.externalPackageInstall
       then "/etc/profiles/per-user/${cfg.username}"
       else cfg.homeDirectory + "/.nix-profile";
-      
+
     programs.bash.shellAliases = cfg.shellAliases;
     programs.zsh.shellAliases = cfg.shellAliases;
     programs.fish.shellAliases = cfg.shellAliases;


### PR DESCRIPTION
### Description

This option has been stable for a long time and may be generally useful.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```