### PR TITLE
swaynag: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -353,6 +353,8 @@
 /modules/services/window-managers/i3-sway/sway.nix    @alexarice @sumnerevans
 /tests/modules/services/window-managers/sway          @sumnerevans
 
+/modules/services/window-managers/i3-sway/swaynag.nix @polykernel
+
 /modules/services/wlsunset.nix                        @matrss
 /tests/modules/services/wlsunset                      @matrss
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2233,6 +2233,14 @@ in
           A new module is available: 'programs.hexchat'.
         '';
       }
+
+      {
+        time = "2021-11-21T17:21:04+00:00";
+        condition = config.wayland.windowManager.sway.enable;
+        message = ''
+          A new module is available: 'wayland.windowManager.sway.swaynag'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -227,6 +227,7 @@ let
     ./services/window-managers/bspwm/default.nix
     ./services/window-managers/i3-sway/i3.nix
     ./services/window-managers/i3-sway/sway.nix
+    ./services/window-managers/i3-sway/swaynag.nix
     ./services/window-managers/xmonad.nix
     ./services/wlsunset.nix
     ./services/xcape.nix

--- a/modules/services/window-managers/i3-sway/swaynag.nix
+++ b/modules/services/window-managers/i3-sway/swaynag.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.wayland.windowManager.sway.swaynag;
+
+  iniFormat = pkgs.formats.ini { };
+
+  confFormat = with types;
+    let
+      confAtom = nullOr (oneOf [ bool int float str ]) // {
+        description = "Swaynag config atom (null, bool, int, float, str)";
+      };
+    in attrsOf confAtom;
+in {
+  meta.maintainers = with maintainers; [ polykernel ];
+
+  options = {
+    wayland.windowManager.sway.swaynag = {
+      enable = mkEnableOption
+        "configuration of swaynag, a lightweight error bar for sway";
+
+      settings = mkOption {
+        type = types.attrsOf confFormat;
+        default = { };
+        description = ''
+          Configuration written to
+          <filename>$XDG_CONFIG_HOME/swaynag/config</filename>.
+          </para><para>
+          See
+          <citerefentry>
+            <refentrytitle>swaynag</refentrytitle>
+            <manvolnum>5</manvolnum>
+          </citerefentry>
+          for a list of avaliable options and an example configuration.
+          Note, configurations declared under <literal>&lt;config&gt;</literal>
+          will override the default type values of swaynag.
+        '';
+        example = literalExpression ''
+          {
+            "<config>" = {
+              edge = "bottom";
+              font = "Dina 12";
+            };
+
+            green = {
+              edge = "top";
+              background = "00AA00";
+              text = "FFFFFF";
+              button-background = "00CC00";
+              message-padding = 10;
+            };
+          }
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "wayland.windowManager.sway.swaynag" pkgs
+        platforms.linux)
+    ];
+
+    xdg.configFile."swaynag/config" = mkIf (cfg.settings != { }) {
+      source = iniFormat.generate "swaynag.conf" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -10,4 +10,6 @@
   sway-post-2003 = ./sway-post-2003.nix;
   sway-workspace-default = ./sway-workspace-default.nix;
   sway-workspace-output = ./sway-workspace-output.nix;
+  swaynag-example-settings = ./swaynag-example-settings.nix;
+  swaynag-empty-settings = ./swaynag-empty-settings.nix;
 }

--- a/tests/modules/services/window-managers/sway/swaynag-empty-settings.nix
+++ b/tests/modules/services/window-managers/sway/swaynag-empty-settings.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    wayland.windowManager.sway.swaynag = {
+      enable = true;
+
+      settings = { };
+    };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/swaynag
+    '';
+  };
+}

--- a/tests/modules/services/window-managers/sway/swaynag-example-settings-expected.conf
+++ b/tests/modules/services/window-managers/sway/swaynag-example-settings-expected.conf
@@ -1,0 +1,10 @@
+[<config>]
+edge=bottom
+font=Dina 12
+
+[green]
+background=00AA00
+button-background=00CC00
+edge=top
+message-padding=10
+text=FFFFFF

--- a/tests/modules/services/window-managers/sway/swaynag-example-settings.nix
+++ b/tests/modules/services/window-managers/sway/swaynag-example-settings.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    wayland.windowManager.sway.swaynag = {
+      enable = true;
+
+      settings = {
+        "<config>" = {
+          edge = "bottom";
+          font = "Dina 12";
+        };
+
+        green = {
+          edge = "top";
+          background = "00AA00";
+          text = "FFFFFF";
+          button-background = "00CC00";
+          message-padding = 10;
+        };
+      };
+    };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/swaynag/config \
+        ${./swaynag-example-settings-expected.conf}
+    '';
+  };
+}


### PR DESCRIPTION
Swaynag is a replacement of i3-nag for sway. Swaynag is embedded in Sway's build
process albeit it is not an integral part of Sway, therefore it has been added
under `wayland.windowManager.sway` instead of `programs`. It can be moved at a later
time if necessary.

Two unit tests were added validate the module behavior for an empty
configuration and the example configuration.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
