### PR TITLE
pam: add yubico option

### DIFF
--- a/modules/misc/pam.nix
+++ b/modules/misc/pam.nix
@@ -4,10 +4,10 @@ with lib;
 
 let
 
-  vars = config.pam.sessionVariables;
+  cfg = config.pam;
 
 in {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = with maintainers; [ rycee veehaitch ];
 
   options = {
     pam.sessionVariables = mkOption {
@@ -26,10 +26,44 @@ in {
         therefore discouraged.
       '';
     };
+
+    pam.yubico.authorizedYubiKeys = {
+      ids = mkOption {
+        type = with types;
+          let
+            yubiKeyId = addCheck str (s: stringLength s == 12) // {
+              name = "yubiKeyId";
+              description = "string of length 12";
+            };
+          in listOf yubiKeyId;
+        default = [ ];
+        description = ''
+          List of authorized YubiKey token IDs. Refer to
+          <link xlink:href="https://developers.yubico.com/yubico-pam"/>
+          for details on how to obtain the token ID of a YubiKey.
+        '';
+      };
+      path = mkOption {
+        type = types.str;
+        default = ".yubico/authorized_yubikeys";
+        description = ''
+          File path to write the authorized YubiKeys,
+          relative to <envar>HOME</envar>.
+        '';
+      };
+    };
   };
 
-  config = mkIf (vars != { }) {
-    home.file.".pam_environment".text = concatStringsSep "\n"
-      (mapAttrsToList (n: v: ''${n} OVERRIDE="${toString v}"'') vars) + "\n";
-  };
+  config = mkMerge [
+    (mkIf (cfg.sessionVariables != { }) {
+      home.file.".pam_environment".text = concatStringsSep "\n"
+        (mapAttrsToList (n: v: ''${n} OVERRIDE="${toString v}"'')
+          cfg.sessionVariables) + "\n";
+    })
+    (mkIf (cfg.yubico.authorizedYubiKeys.ids != [ ]) {
+      home.file.${cfg.yubico.authorizedYubiKeys.path}.text =
+        concatStringsSep ":"
+        ([ config.home.username ] ++ cfg.yubico.authorizedYubiKeys.ids);
+    })
+  ];
 }

--- a/tests/modules/misc/pam/default.nix
+++ b/tests/modules/misc/pam/default.nix
@@ -1,1 +1,5 @@
-{ pam-session-variables = ./session-variables.nix; }
+{
+  pam-session-variables = ./session-variables.nix;
+  yubico-with-ids = ./yubico-with-ids.nix;
+  yubico-no-ids = ./yubico-with-ids.nix;
+}

--- a/tests/modules/misc/pam/yubico-no-ids.nix
+++ b/tests/modules/misc/pam/yubico-no-ids.nix
@@ -1,0 +1,7 @@
+{
+  config = {
+    nmt.script = ''
+      assertPathNotExists home-files/.yubico/authorized_yubikeys
+    '';
+  };
+}

--- a/tests/modules/misc/pam/yubico-with-ids-expected.txt
+++ b/tests/modules/misc/pam/yubico-with-ids-expected.txt
@@ -1,0 +1,1 @@
+hm-user:abcdefghijkl:012345678912

--- a/tests/modules/misc/pam/yubico-with-ids.nix
+++ b/tests/modules/misc/pam/yubico-with-ids.nix
@@ -1,0 +1,12 @@
+{
+  config = {
+    pam.yubico.authorizedYubiKeys.ids = [ "abcdefghijkl" "012345678912" ];
+
+    nmt.script = ''
+      assertFileExists home-files/.yubico/authorized_yubikeys
+      assertFileContent \
+        home-files/.yubico/authorized_yubikeys \
+        ${./yubico-with-ids-expected.txt}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Write YubiKey token IDs in the format yubico_pam expects. See
https://developers.yubico.com/yubico-pam/ for details. Also refer to the
NixOS option [`security.pam.services.<name>.yubicoAuth`](https://search.nixos.org/options?channel=21.05&show=security.pam.services.%3Cname%3E.yubicoAuth&from=0&size=100&sort=relevance&type=packages&query=security.pam.services+yubicoAuth).
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
