### PR TITLE
sbt: trim output of password command

### DIFF
--- a/modules/programs/sbt.nix
+++ b/modules/programs/sbt.nix
@@ -9,7 +9,7 @@ let
   '';
 
   renderCredential = cred: ''
-    credentials += Credentials("${cred.realm}", "${cred.host}", "${cred.user}", "${cred.passwordCommand}".lazyLines.mkString("\n"))
+    credentials += Credentials("${cred.realm}", "${cred.host}", "${cred.user}", "${cred.passwordCommand}".!!.trim)
   '';
 
   renderCredentials = creds: ''

--- a/tests/modules/programs/sbt/credentials.nix
+++ b/tests/modules/programs/sbt/credentials.nix
@@ -19,8 +19,8 @@ let
   ];
   expectedCredentialsSbt = pkgs.writeText "credentials.sbt" ''
     import scala.sys.process._
-    credentials += Credentials("Sonatype Nexus Repository Manager", "example.com", "user", "echo password".lazyLines.mkString("\n"))
-    credentials += Credentials("Sonatype Nexus Repository Manager X", "v2.example.com", "user1", "echo password1".lazyLines.mkString("\n"))
+    credentials += Credentials("Sonatype Nexus Repository Manager", "example.com", "user", "echo password".!!.trim)
+    credentials += Credentials("Sonatype Nexus Repository Manager X", "v2.example.com", "user1", "echo password1".!!.trim)
   '';
   credentialsSbtPath = ".sbt/1.0/credentials.sbt";
 in {


### PR DESCRIPTION
### Description

Follows from #2337 - the code didn't actually work in sbt 1.0 because `lazyLines` isn't a thing in Scala 2.12.

This kind of reverts the above change, but adds trimming the password command's output under the assumption that passwords don't have surrounding whitespace.

I've checked the credentials sbt receives and they match the file's contents (`.last` char isn't whitespace)

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
