### PR TITLE
vscode: avoid unnecessary IFD

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -127,11 +127,13 @@ in {
     # Adapted from https://discourse.nixos.org/t/vscode-extensions-setup/1801/2
     home.file = let
       subDir = "share/vscode/extensions";
-      toPaths = path:
-        # Links every dir in path to the extension path.
-        mapAttrsToList
-        (k: _: { "${extensionPath}/${k}".source = "${path}/${subDir}/${k}"; })
-        (builtins.readDir (path + "/${subDir}"));
+      toPaths = ext:
+        # Links every dir in ext to the extension path.
+        map (k: { "${extensionPath}/${k}".source = "${ext}/${subDir}/${k}"; })
+        (if ext ? vscodeExtUniqueId then
+          [ ext.vscodeExtUniqueId ]
+        else
+          builtins.attrNames (builtins.readDir (ext + "/${subDir}")));
       toSymlink = concatMap toPaths cfg.extensions;
       dropNullFields = filterAttrs (_: v: v != null);
     in foldr (a: b: a // b) {


### PR DESCRIPTION
### Description

We can avoid doing an import from derivation for extensions that have a `vscodeExtUniqueId` attribute (i.e. the extensions generated by [`buildVscodeExtension`](https://github.com/NixOS/nixpkgs/blob/e75245614ee24b1e8bfafa836982013abca33642/pkgs/misc/vscode-extensions/vscode-utils.nix#L3)), which should be the excruciating majority of extensions people use.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
