### PR TITLE
redshift-gammastep: add 'hooks' option

### DIFF
--- a/modules/services/redshift-gammastep/gammastep.nix
+++ b/modules/services/redshift-gammastep/gammastep.nix
@@ -15,6 +15,7 @@ let
     mainExecutable = "gammastep";
     appletExecutable = "gammastep-indicator";
     xdgConfigFilePath = "gammastep/config.ini";
+    xdgConfigDir = "gammastep";
     serviceDocumentation = "https://gitlab.com/chinstrap/gammastep/";
   };
 

--- a/modules/services/redshift-gammastep/redshift.nix
+++ b/modules/services/redshift-gammastep/redshift.nix
@@ -14,6 +14,7 @@ let
     mainExecutable = "redshift";
     appletExecutable = "redshift-gtk";
     xdgConfigFilePath = "redshift/redshift.conf";
+    xdgConfigDir = "redshift";
     serviceDocumentation = "http://jonls.dk/redshift/";
   };
 


### PR DESCRIPTION
### Description

This is a draft until I have time to add a test case.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
