### PR TITLE
gpg-agent: rewrite hash algo in Nix to avoid IFD

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -21,18 +21,39 @@ let
   # state, but we need the values at build time. original:
   # https://github.com/gpg/gnupg/blob/c6702d77d936b3e9d91b34d8fdee9599ab94ee1b/common/homedir.c#L672-L681
   gpgconf = dir:
-    if homedir == options.programs.gpg.homedir.default then
+    let
+      hash = substring 0 24 (hexStringToBase32 (builtins.hashString "sha1" homedir));
+    in if homedir == options.programs.gpg.homedir.default then
       "%t/gnupg/${dir}"
     else
-      builtins.readFile (pkgs.runCommand dir {} ''
-        PATH=${pkgs.xxd}/bin:$PATH
+      "%t/gnupg/d.${hash}/${dir}";
 
-        hash=$(echo -n ${homedir} | sha1sum -b | xxd -r -p | base32 | \
-               cut -c -24 | tr '[:upper:]' '[:lower:]' | \
-               tr abcdefghijklmnopqrstuvwxyz234567 \
-                  ybndrfg8ejkmcpqxot1uwisza345h769)
-        echo -n "%t/gnupg/d.$hash/${dir}" > "$out"
-      '');
+  # Act like `xxd -r -p | base32` but with z-base-32 alphabet and no trailing padding.
+  # Written in Nix for purity.
+  hexStringToBase32 = let
+    mod = a: b: a - a / b * b;
+    pow2 = elemAt [ 1 2 4 8 16 32 64 128 256 ];
+    splitChars = s: init (tail (splitString "" s));
+
+    base32Alphabet = splitChars "ybndrfg8ejkmcpqxot1uwisza345h769";
+    hexToIntTable = listToAttrs (genList (x: { name = toLower (toHexString x); value = x; }) 16);
+
+    initState = { ret = ""; buf = 0; bufBits = 0; };
+    go = { ret, buf, bufBits }: hex:
+      let
+        buf' = buf * pow2 4 + hexToIntTable.${hex};
+        bufBits' = bufBits + 4;
+        extraBits = bufBits' - 5;
+      in if bufBits >= 5 then {
+        ret = ret + elemAt base32Alphabet (buf' / pow2 extraBits);
+        buf = mod buf' (pow2 extraBits);
+        bufBits = bufBits' - 5;
+      } else {
+        ret = ret;
+        buf = buf';
+        bufBits = bufBits';
+      };
+  in hexString: (foldl' go initState (splitChars hexString)).ret;
 
 in
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -131,6 +131,7 @@ import nmt {
     ./modules/services/fluidsynth
     ./modules/services/fnott
     ./modules/services/git-sync
+    ./modules/services/gpg-agent
     ./modules/services/kanshi
     ./modules/services/lieer
     ./modules/services/pantalaimon

--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -5,6 +5,7 @@ with lib;
 {
   config = {
     services.gpg-agent.enable = true;
+    services.gpg-agent.pinentryFlavor = null; # Don't build pinentry package.
     programs.gpg.enable = true;
 
     test.stubs.gnupg = { };

--- a/tests/modules/services/gpg-agent/override-homedir.nix
+++ b/tests/modules/services/gpg-agent/override-homedir.nix
@@ -5,16 +5,17 @@ with lib;
 {
   config = {
     services.gpg-agent.enable = true;
+    services.gpg-agent.pinentryFlavor = null; # Don't build pinentry package.
     programs.gpg = {
       enable = true;
-      homedir = "${config.home.homeDirectory}/foo/bar";
+      homedir = "/path/to/hash";
     };
 
     test.stubs.gnupg = { };
 
     nmt.script = ''
       in="${config.systemd.user.sockets.gpg-agent.Socket.ListenStream}"
-      if [[ $in != "%t/gnupg/d."????????????????????????"/S.gpg-agent" ]]
+      if [[ $in != "%t/gnupg/d.wp4h7ks5zxy4dodqadgpbbpz/S.gpg-agent" ]]
       then
         echo $in
         fail "gpg-agent socket directory is malformed"


### PR DESCRIPTION
### Description

Rewrite the hash algorithm used for mimic `gpgconf` output in Nix to avoid IFD (import from derivation). IFD is not allowed in restricted mode, which is the default mode for Hydra. `nixos-install` seems also restrict it according to https://github.com/nix-community/home-manager/issues/1262#issuecomment-748672342

Also tests of `gpg-agent` seem not enabled. They're enabled now.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
