### PR TITLE
neovim: changed neovim rc location

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -54,6 +54,7 @@ let
           cfg.plugins);
     };
     beforePlugins = "";
+
   };
 
   extraMakeWrapperArgs = lib.optionalString (cfg.extraPackages != [ ])
@@ -276,7 +277,10 @@ in {
       configure = cfg.configure // moduleConfigure;
       plugins = cfg.plugins
         ++ optionals cfg.coc.enable [ pkgs.vimPlugins.coc-nvim ];
-      customRC = cfg.extraConfig;
+      customRC = ''
+        filetype off
+        filetype on
+      '' + cfg.extraConfig;
     };
 
   in mkIf cfg.enable {
@@ -293,9 +297,10 @@ in {
 
     home.packages = [ cfg.finalPackage ];
 
-    xdg.configFile."nvim/init.vim" = mkIf (neovimConfig.neovimRcContent != "") {
-      text = neovimConfig.neovimRcContent;
-    };
+    xdg.configFile."nvim/plugin/home-manager.vim" =
+      mkIf (neovimConfig.neovimRcContent != "") {
+        text = neovimConfig.neovimRcContent;
+      };
     xdg.configFile."nvim/coc-settings.json" = mkIf cfg.coc.enable {
       source = jsonFormat.generate "coc-settings.json" cfg.coc.settings;
     };

--- a/tests/modules/programs/neovim/no-init.nix
+++ b/tests/modules/programs/neovim/no-init.nix
@@ -15,7 +15,7 @@ with lib;
       extraPython3Packages = (ps: with ps; [ jedi pynvim ]);
     };
     nmt.script = ''
-      vimrc="home-files/.config/nvim/init.vim"
+      vimrc="home-files/.config/nvim/plugin/home-manager.vim"
       assertPathNotExists "$vimrc"
     '';
   };

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -23,7 +23,7 @@ with lib;
     };
 
     nmt.script = ''
-      vimrc="$TESTED/home-files/.config/nvim/init.vim"
+      vimrc="$TESTED/home-files/.config/nvim/plugin/home-manager.vim"
       vimrcNormalized="$(normalizeStorePaths "$vimrc")"
 
       assertFileExists "$vimrc"

--- a/tests/modules/programs/neovim/plugin-config.vim
+++ b/tests/modules/programs/neovim/plugin-config.vim
@@ -7,4 +7,6 @@ autocmd FileType c setlocal commentstring=//\ %s
 autocmd FileType c setlocal comments=://
 
 " }}}
+filetype off
+filetype on
 " This should be present in vimrc


### PR DESCRIPTION
### Description



Change the neovim rc location to be compatible on systems with init.lua already there



### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.


