### PR TITLE
home-manager: fix home-manager build error

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -263,9 +263,9 @@ function doBuild() {
     setFlakeAttribute
     if [[ -v FLAKE_CONFIG_URI ]]; then
         doBuildFlake \
-            "${DRY_RUN+--dry-run} \
-            "${NO_OUT_LINK+--no-link} \
             "$FLAKE_CONFIG_URI.activationPackage" \
+            ${DRY_RUN+--dry-run} \
+            ${NO_OUT_LINK+--no-link} \
             || return
     else
         doBuildAttr \
@@ -294,8 +294,8 @@ function doSwitch() {
     setFlakeAttribute
     if [[ -v FLAKE_CONFIG_URI ]]; then
         doBuildFlake \
-            --out-link "$generation" \
             "$FLAKE_CONFIG_URI.activationPackage" \
+            --out-link "$generation" \
             && "$generation/activate" || return
     else
         doBuildAttr \


### PR DESCRIPTION
Two misplaced quotations were introduced in `doBuild` by https://github.com/nix-community/home-manager/pull/2501, which
caused the parameter expansion of DRY_RUN to include an extraneous tab. Since the flake uri is passed
later into the command, Nix assumes the whitespace sequence as the flake uri and returns that it is not
a valid flake reference.

This PR removes the misplaced quotations in `doBuild` and also places the flake uri as the first argument for
calls to `doBuildFlake` for consistency with `doBuildAttr`. Placing the uri first in the command line also guards
against possible security issues if arbitrary uris are expanded prior to the user given uri.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
