### PR TITLE
powerline-go: add support for -modules-right

### DIFF
--- a/tests/modules/programs/powerline-go/bash.nix
+++ b/tests/modules/programs/powerline-go/bash.nix
@@ -24,7 +24,10 @@ with lib;
       assertFileExists home-files/.bashrc
       assertFileContains \
         home-files/.bashrc \
-        '/bin/powerline-go -error $old_exit_status -modules nix-shell -newline -path-aliases \~/project/foo=prj-foo -ignore-repos /home/me/project1,/home/me/project2'
+        'PS1='
+      assertFileContains \
+        home-files/.bashrc \
+        '/bin/powerline-go -error $old_exit_status -shell bash -modules nix-shell -newline -path-aliases \~/project/foo=prj-foo -ignore-repos /home/me/project1,/home/me/project2'
     '';
   };
 }

--- a/tests/modules/programs/powerline-go/bashmodulesright.nix
+++ b/tests/modules/programs/powerline-go/bashmodulesright.nix
@@ -5,12 +5,13 @@ with lib;
 {
   config = {
     programs = {
-      zsh.enable = true;
+      bash.enable = true;
 
       powerline-go = {
         enable = true;
         newline = true;
         modules = [ "nix-shell" ];
+        modulesRight = [ "git" ];
         pathAliases = { "\\~/project/foo" = "prj-foo"; };
         settings = {
           ignore-repos = [ "/home/me/project1" "/home/me/project2" ];
@@ -18,19 +19,16 @@ with lib;
       };
     };
 
-    test.stubs = {
-      powerline-go = { };
-      zsh = { };
-    };
+    test.stubs.powerline-go = { };
 
     nmt.script = ''
-      assertFileExists home-files/.zshrc
+      assertFileExists home-files/.bashrc
       assertFileContains \
-        home-files/.zshrc \
-        'PS1='
+        home-files/.bashrc \
+        'eval'
       assertFileContains \
-        home-files/.zshrc \
-        '/bin/powerline-go -error $? -shell zsh -modules nix-shell -newline -path-aliases \~/project/foo=prj-foo -ignore-repos /home/me/project1,/home/me/project2'
+        home-files/.bashrc \
+        '/bin/powerline-go -error $old_exit_status -shell bash -eval -modules nix-shell -modules-right git -newline -path-aliases \~/project/foo=prj-foo -ignore-repos /home/me/project1,/home/me/project2'
     '';
   };
 }

--- a/tests/modules/programs/powerline-go/default.nix
+++ b/tests/modules/programs/powerline-go/default.nix
@@ -2,4 +2,6 @@
   powerline-go-bash = ./bash.nix;
   powerline-go-zsh = ./zsh.nix;
   powerline-go-fish = ./fish.nix;
+  powerline-go-bashmodulesright = ./bashmodulesright.nix;
+  powerline-go-zshmodulesright = ./zshmodulesright.nix;
 }

--- a/tests/modules/programs/powerline-go/zshmodulesright.nix
+++ b/tests/modules/programs/powerline-go/zshmodulesright.nix
@@ -11,6 +11,7 @@ with lib;
         enable = true;
         newline = true;
         modules = [ "nix-shell" ];
+        modulesRight = [ "git" ];
         pathAliases = { "\\~/project/foo" = "prj-foo"; };
         settings = {
           ignore-repos = [ "/home/me/project1" "/home/me/project2" ];
@@ -27,10 +28,10 @@ with lib;
       assertFileExists home-files/.zshrc
       assertFileContains \
         home-files/.zshrc \
-        'PS1='
+        'eval'
       assertFileContains \
         home-files/.zshrc \
-        '/bin/powerline-go -error $? -shell zsh -modules nix-shell -newline -path-aliases \~/project/foo=prj-foo -ignore-repos /home/me/project1,/home/me/project2'
+        '/bin/powerline-go -error $? -shell zsh -eval -modules nix-shell -modules-right git -newline -path-aliases \~/project/foo=prj-foo -ignore-repos /home/me/project1,/home/me/project2'
     '';
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

- Add `modulesRight` setting to instruct powerline-go to configure the right-hand side prompt.
- Use eval mode when `modulesRight` setting is set.
- Cleanup how the argument string is built to avoid double whitespace characters.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
