### PR TITLE
darwin: keep the options for the "defaults" system up-to-date

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -381,4 +381,7 @@
 
 /modules/services/volnoti.nix                         @IvanMalison
 
+/modules/targets/darwin                               @midchildan
+/tests/modules/targets-darwin                         @midchildan
+
 Makefile                                              @thiagokokada

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2259,6 +2259,16 @@ in
           A new module is available: 'programs.less'.
         '';
       }
+
+      {
+        time = "2021-11-29T15:15:59+00:00";
+        condition = hostPlatform.isDarwin;
+        message = ''
+          The option 'targets.darwin.defaults."com.apple.menuextra.battery".ShowPercent'
+          has been deprecated since it no longer works on the latest version of
+          macOS.
+        '';
+      }
     ];
   };
 }

--- a/modules/targets/darwin/default.nix
+++ b/modules/targets/darwin/default.nix
@@ -19,6 +19,8 @@ let
   writableDefaults = filterAttrs (domain: attrs: attrs != { }) nonNullDefaults;
   activationCmds = mapAttrsToList toActivationCmd writableDefaults;
 in {
+  meta.maintainers = [ maintainers.midchildan ];
+
   imports = [ ./fonts.nix ./keybindings.nix ./linkapps.nix ./search.nix ];
 
   options.targets.darwin.defaults = mkOption {

--- a/modules/targets/darwin/default.nix
+++ b/modules/targets/darwin/default.nix
@@ -48,6 +48,24 @@ in {
         platforms.darwin)
     ];
 
+    warnings = let
+      batteryPercentage =
+        attrByPath [ "com.apple.menuextra.battery" "ShowPercent" ] null
+        cfg.defaults;
+      webkitDevExtras = attrByPath [
+        "com.apple.Safari"
+        "com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled"
+      ] null cfg.defaults;
+    in optional (batteryPercentage != null) ''
+      The option 'com.apple.menuextra.battery.ShowPercent' no longer works on
+      macOS 11 and later. Instead, open System Preferences, go to "Dock &amp;
+      Menu Bar", select "Battery", and toggle the checkbox labeled "Show
+      Percentage."
+    '' ++ optional (webkitDevExtras != null) ''
+      The option 'com.apple.Safari.com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled'
+      is no longer present in recent versions of Safari.
+    '';
+
     home.activation.setDarwinDefaults = hm.dag.entryAfter [ "writeBoundary" ] ''
       $VERBOSE_ECHO "Configuring macOS user defaults"
       ${concatStringsSep "\n" activationCmds}

--- a/modules/targets/darwin/options.nix
+++ b/modules/targets/darwin/options.nix
@@ -98,7 +98,13 @@ in {
     "com.apple.menuextra.battery".ShowPercent = mkNullableOption {
       type = types.enum [ "YES" "NO" ];
       example = "NO";
-      description = "Whether to show battery percentage in the menu bar.";
+      description = ''
+        This option no longer works on macOS 11 and later. Instead, open System
+        Preferences, go to "Dock &amp; Menu Bar", select "Battery", and toggle
+        the checkbox labeled "Show Percentage."
+
+        Whether to show battery percentage in the menu bar.
+      '';
     };
 
     "com.apple.Safari" = {
@@ -125,20 +131,35 @@ in {
           </warning>
         '';
       };
-      "com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled" =
-        mkNullableOption {
-          type = types.bool;
-          description = ''
-            Configures the web inspector.
+      "WebKitPreferences.developerExtrasEnabled" = mkNullableOption {
+        type = types.bool;
+        description = ''
+          Configures the web inspector.
 
-            <warning>
-              <para>
-                Instead of setting this option directly, set
-                <option>IncludeDevelopMenu</option> instead.
-              </para>
-            </warning>
-          '';
-        };
+          <warning>
+            <para>
+              Instead of setting this option directly, set
+              <option>IncludeDevelopMenu</option> instead.
+            </para>
+          </warning>
+        '';
+      };
+    };
+
+    "com.apple.Safari.SandboxBroker" = {
+      ShowDevelopMenu = mkNullableOption {
+        type = types.bool;
+        description = ''
+          Show the "Develop" menu in Safari's menubar.
+
+          <warning>
+            <para>
+              Instead of setting this option directly, set
+              <option>"com.apple.Safari".IncludeDevelopMenu</option> instead.
+            </para>
+          </warning>
+        '';
+      };
     };
 
     "com.googlecode.iterm2" = {
@@ -182,8 +203,11 @@ in {
   config = {
     "com.apple.Safari" = mkIf (safari.IncludeDevelopMenu != null) {
       WebKitDeveloperExtrasEnabledPreferenceKey = safari.IncludeDevelopMenu;
-      "com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled" =
-        safari.IncludeDevelopMenu;
+      "WebKitPreferences.developerExtrasEnabled" = safari.IncludeDevelopMenu;
     };
+    "com.apple.Safari.SandboxBroker" =
+      mkIf (safari.IncludeDevelopMenu != null) {
+        ShowDevelopMenu = safari.IncludeDevelopMenu;
+      };
   };
 }


### PR DESCRIPTION
### Description

This includes the following changes to keep up to date with the latest version of macOS.

- darwin: keep the options for the "defaults" system up-to-date
- darwin: add midchildan to maintainers

It also adds myself to maintainers of the darwin module.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
