### PR TITLE
firefox: create user.js when only bookmarks are specified in config (issue #2492)

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -370,8 +370,8 @@ in {
       "${profilesPath}/${profile.path}/chrome/userContent.css" =
         mkIf (profile.userContent != "") { text = profile.userContent; };
 
-      "${profilesPath}/${profile.path}/user.js" =
-        mkIf (profile.settings != { } || profile.extraConfig != "" || profile.bookmarks != {}) {
+      "${profilesPath}/${profile.path}/user.js" = mkIf (profile.settings != { }
+        || profile.extraConfig != "" || profile.bookmarks != { }) {
           text =
             mkUserJs profile.settings profile.extraConfig profile.bookmarks;
         };

--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -371,7 +371,7 @@ in {
         mkIf (profile.userContent != "") { text = profile.userContent; };
 
       "${profilesPath}/${profile.path}/user.js" =
-        mkIf (profile.settings != { } || profile.extraConfig != "") {
+        mkIf (profile.settings != { } || profile.extraConfig != "" || profile.bookmarks != {}) {
           text =
             mkUserJs profile.settings profile.extraConfig profile.bookmarks;
         };


### PR DESCRIPTION
fix issue #2492 

### Description

Previously, home-manager would not create a user.js for a certain
profile if profile.bookmarks was not empty but
profile.settings was empty and profile.extraConfig was an
empty string.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
