### PR TITLE
xmonad: add support for v0.17.0

### DIFF
--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -132,7 +132,13 @@ in {
 
           # The resulting binary name depends on the arch and os
           # https://github.com/xmonad/xmonad/blob/56b0f850bc35200ec23f05c079eca8b0a1f90305/src/XMonad/Core.hs#L565-L572
-          mv "$XMONAD_DATA_DIR/xmonad-${pkgs.stdenv.hostPlatform.system}" $out/bin/
+          if [ -f "$XMONAD_DATA_DIR/xmonad-${pkgs.stdenv.hostPlatform.system}" ]; then
+            # xmonad 0.15.0
+            mv "$XMONAD_DATA_DIR/xmonad-${pkgs.stdenv.hostPlatform.system}" $out/bin/
+          else
+            # xmonad 0.17.0 (https://github.com/xmonad/xmonad/commit/9813e218b034009b0b6d09a70650178980e05d54)
+            mv "$XMONAD_CACHE_DIR/xmonad-${pkgs.stdenv.hostPlatform.system}" $out/bin/
+          fi
         ''
       }/bin/xmonad-${pkgs.stdenv.hostPlatform.system}";
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Starting from
[~v0.17.0](https://github.com/xmonad/xmonad/commit/9813e218b034009b0b6d09a70650178980e05d54),
xmonad moved the location of its recompile output binary. This change
accommodates that. We might want to drop support for v0.15.0 at some point,
when it hits stackage LTS making `haskellPackages.xmonad` resolve to v0.17.0
(currently, it does not, although there is a separate
`haskellPackages.xmonad_0_17_0`).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
