### PR TITLE
waybar: configurable systemd WantedBy target

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -197,6 +197,20 @@ in {
 
     systemd.enable = mkEnableOption "Waybar systemd integration";
 
+    systemd.target = mkOption {
+      type = str;
+      default = "graphical-session.target";
+      example = "sway-session.target";
+      description = ''
+        The systemd target that will automatically start the Waybar service.
+        </para>
+        <para>
+        When setting this value to <literal>"sway-session.target"</literal>,
+        make sure to also enable <option>wayland.windowManager.sway.systemdIntegration</option>,
+        otherwise the service may never be started.
+      '';
+    };
+
     style = mkOption {
       type = nullOr (either path str);
       default = null;
@@ -302,7 +316,7 @@ in {
           KillMode = "mixed";
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = { WantedBy = [ cfg.systemd.target ]; };
       };
     })
   ]);

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
@@ -10,6 +10,7 @@ with lib;
       package = config.lib.test.mkStubPackage { outPath = "@waybar@"; };
       enable = true;
       systemd.enable = true;
+      systemd.target = "sway-session.target";
     };
 
     nmt.script = ''

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -1,5 +1,5 @@
 [Install]
-WantedBy=graphical-session.target
+WantedBy=sway-session.target
 
 [Service]
 ExecReload=kill -SIGUSR2 $MAINPID


### PR DESCRIPTION
### Description

Before this PR, a user needed to override the systemd target that
would start Waybar with `mkForce`, this is no longer necessary.

I think the option name needs to be changed, but I don't have any better idea.

Linked to: https://github.com/nix-community/home-manager/issues/2505#issuecomment-977442048

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
