### PR TITLE
docs: change stable from 21.05 to 21.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ will write to your dconf store and cannot tell whether a configuration
 that it is about to be overwritten was from a previous Home Manager
 generation or from manual configuration.
 
-Home Manager targets [NixOS][] unstable and NixOS version 21.05 (the
+Home Manager targets [NixOS][] unstable and NixOS version 21.11 (the
 current stable version), it may or may not work on other Linux
 distributions and NixOS versions.
 
@@ -152,7 +152,7 @@ Home Manager is developed against `nixpkgs-unstable` branch, which
 often causes it to contain tweaks for changes/packages not yet
 released in stable NixOS. To avoid breaking users' configurations,
 Home Manager is released in branches corresponding to NixOS releases
-(e.g. `release-21.05`). These branches get fixes, but usually not new
+(e.g. `release-21.11`). These branches get fixes, but usually not new
 modules. If you need a module to be backported, then feel free to open
 an issue.
 

--- a/docs/release-notes/rl-2111.adoc
+++ b/docs/release-notes/rl-2111.adoc
@@ -1,8 +1,7 @@
 [[sec-release-21.11]]
 == Release 21.11
 
-This is the current unstable branch and the information in this
-section is therefore not final.
+The 21.11 release branch became the stable branch in November, 2021.
 
 [[sec-release-21.11-highlights]]
 === Highlights


### PR DESCRIPTION
### Description

NixOS 21.11 was released November 30rd.

edit: Do I need to backport this to release-21.11?

### Checklist

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
