### PR TITLE
modules: pkgs.hostPlatform -> pkgs.stdenv.hostPlatform

### DIFF
--- a/modules/config/i18n.nix
+++ b/modules/config/i18n.nix
@@ -36,7 +36,7 @@ let
 in {
   meta.maintainers = with maintainers; [ midchildan ];
 
-  config = mkIf pkgs.hostPlatform.isLinux {
+  config = mkIf pkgs.stdenv.hostPlatform.isLinux {
     # For shell sessions.
     home.sessionVariables = localeVars;
 

--- a/modules/misc/xdg-mime.nix
+++ b/modules/misc/xdg-mime.nix
@@ -10,7 +10,7 @@ in {
   options = {
     xdg.mime.enable = mkOption {
       type = types.bool;
-      default = pkgs.hostPlatform.isLinux;
+      default = pkgs.stdenv.hostPlatform.isLinux;
       defaultText =
         literalExpression "true if host platform is Linux, false otherwise";
       description = ''

--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -132,9 +132,9 @@ in {
 
           # The resulting binary name depends on the arch and os
           # https://github.com/xmonad/xmonad/blob/56b0f850bc35200ec23f05c079eca8b0a1f90305/src/XMonad/Core.hs#L565-L572
-          mv "$XMONAD_DATA_DIR/xmonad-${pkgs.hostPlatform.system}" $out/bin/
+          mv "$XMONAD_DATA_DIR/xmonad-${pkgs.stdenv.hostPlatform.system}" $out/bin/
         ''
-      }/bin/xmonad-${pkgs.hostPlatform.system}";
+      }/bin/xmonad-${pkgs.stdenv.hostPlatform.system}";
 
   in mkIf cfg.enable (mkMerge [
     {
@@ -157,7 +157,7 @@ in {
     (mkIf (cfg.config != null) {
       xsession.windowManager.command = xmonadBin;
       home.file.".xmonad/xmonad.hs".source = cfg.config;
-      home.file.".xmonad/xmonad-${pkgs.hostPlatform.system}" = {
+      home.file.".xmonad/xmonad-${pkgs.stdenv.hostPlatform.system}" = {
         source = xmonadBin;
         onChange = ''
           # Attempt to restart xmonad if X is running.

--- a/modules/targets/darwin/fonts.nix
+++ b/modules/targets/darwin/fonts.nix
@@ -12,7 +12,7 @@ let
   fonts = "${fontsEnv}/share/fonts";
 in {
   # macOS won't recognize symlinked fonts
-  config = mkIf pkgs.hostPlatform.isDarwin {
+  config = mkIf pkgs.stdenv.hostPlatform.isDarwin {
     home.activation.copyFonts = hm.dag.entryAfter [ "writeBoundary" ] ''
       copyFonts() {
         rm -rf ${homeDir}/Library/Fonts/HomeManager || :


### PR DESCRIPTION
We are attempting to deprecate these top-level attrs in upstream nixpkgs.

See also bc0acdad8c001843d4e22cfa20a6ce84b462ab19

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
