### PR TITLE
less: store 'lesskey' under XDG_CONFIG_HOME

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2280,6 +2280,16 @@ in
           modules.
         '';
       }
+
+      {
+        time = "2021-12-08T10:23:42+00:00";
+        condition = config.programs.less.enable;
+        message = ''
+          The 'lesskey' configuration file is now stored under
+          '$XDG_CONFIG_HOME/lesskey' since it is fully supported upstream
+          starting from v596.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/less.nix
+++ b/modules/programs/less.nix
@@ -19,7 +19,7 @@ in {
         '';
         description = ''
           Extra configuration for <command>less</command> written to
-          <filename>$HOME/.lesskey</filename>.
+          <filename>$XDG_CONFIG_HOME/lesskey</filename>.
         '';
       };
     };
@@ -27,6 +27,6 @@ in {
 
   config = mkIf cfg.enable {
     home.packages = [ pkgs.less ];
-    home.file.".lesskey".text = cfg.keys;
+    xdg.configFile."lesskey".text = cfg.keys;
   };
 }

--- a/tests/modules/programs/less/less-with-custom-keys.nix
+++ b/tests/modules/programs/less/less-with-custom-keys.nix
@@ -15,8 +15,8 @@ with lib;
   test.stubs.less = { };
 
   nmt.script = ''
-    assertFileExists home-files/.lesskey
-    assertFileContent home-files/.lesskey ${
+    assertFileExists home-files/.config/lesskey
+    assertFileContent home-files/.config/lesskey ${
       builtins.toFile "less.expected" ''
         s        back-line
         t        forw-line


### PR DESCRIPTION
### Description

Follow-up to https://github.com/nix-community/home-manager/pull/2463#issuecomment-968335345.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
