### PR TITLE
treewide: generalize dot directories to xdg base directories

### DIFF
--- a/docs/man-home-manager.xml
+++ b/docs/man-home-manager.xml
@@ -414,7 +414,7 @@
     <listitem>
      <para>
       Indicates the path to the Home Manager configuration file. If not given,
-      <filename>~/.config/nixpkgs/home.nix</filename> is used.
+      <filename>$XDG_CONFIG_HOME/nixpkgs/home.nix</filename> is used.
      </para>
     </listitem>
    </varlistentry>
@@ -589,7 +589,7 @@
   <variablelist>
    <varlistentry>
     <term>
-     <filename>~/.local/share/home-manager/news-read-ids</filename>
+     <filename>$XDG_DATA_HOME/home-manager/news-read-ids</filename>
     </term>
     <listitem>
      <para>

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -123,7 +123,7 @@ in {
           };
           description = ''
             Extra configuration options to add to
-            <filename>~/.config/gtk-3.0/settings.ini</filename>.
+            <filename>$XDG_CONFIG_HOME/gtk-3.0/settings.ini</filename>.
           '';
         };
 
@@ -132,7 +132,7 @@ in {
           default = "";
           description = ''
             Extra configuration lines to add verbatim to
-            <filename>~/.config/gtk-3.0/gtk.css</filename>.
+            <filename>$XDG_CONFIG_HOME/gtk-3.0/gtk.css</filename>.
           '';
         };
       };

--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -37,7 +37,7 @@ in {
         '';
         description = ''
           Configuration written to
-          <filename>~/.config/alacritty/alacritty.yml</filename>. See
+          <filename>$XDG_CONFIG_HOME/alacritty/alacritty.yml</filename>. See
           <link xlink:href="https://github.com/jwilm/alacritty/blob/master/alacritty.yml"/>
           for the default configuration.
         '';

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -60,7 +60,7 @@ in {
       '';
       description = ''
         Configuration written to
-        <filename>~/.config/atuin/config.toml</filename>.
+        <filename>$XDG_CONFIG_HOME/atuin/config.toml</filename>.
         </para><para>
         See <link xlink:href="https://github.com/ellie/atuin/blob/main/docs/config.md" /> for the full list
         of options.

--- a/modules/programs/beets.nix
+++ b/modules/programs/beets.nix
@@ -45,7 +45,7 @@ in {
         default = { };
         description = ''
           Configuration written to
-          <filename>~/.config/beets/config.yaml</filename>
+          <filename>$XDG_CONFIG_HOME/beets/config.yaml</filename>
         '';
       };
     };

--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -29,7 +29,7 @@ in {
       default = { };
       description = ''
         Configuration written to
-        <filename>~/.config/direnv/config.toml</filename>.
+        <filename>$XDG_CONFIG_HOME/direnv/config.toml</filename>.
         </para><para>
         See
         <citerefentry>
@@ -45,7 +45,7 @@ in {
       default = "";
       description = ''
         Custom stdlib written to
-        <filename>~/.config/direnv/direnvrc</filename>.
+        <filename>$XDG_CONFIG_HOME/direnv/direnvrc</filename>.
       '';
     };
 

--- a/modules/programs/hexchat.nix
+++ b/modules/programs/hexchat.nix
@@ -270,7 +270,7 @@ in {
           };
         }'';
       description = ''
-        Configures <filename>~/.config/hexchat/servlist.conf</filename>.
+        Configures <filename>$XDG_CONFIG_HOME/hexchat/servlist.conf</filename>.
       '';
     };
 
@@ -286,7 +286,7 @@ in {
         };
       '';
       description = ''
-        Configuration for <filename>~/.config/hexchat/hexchat.conf</filename>, see
+        Configuration for <filename>$XDG_CONFIG_HOME/hexchat/hexchat.conf</filename>, see
         <link xlink:href="https://hexchat.readthedocs.io/en/latest/settings.html#list-of-settings"/>
         for supported values.
       '';

--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -133,7 +133,7 @@ in {
       '';
       description = ''
         Configuration options to add to
-        <filename>~/.config/htop/htoprc</filename>.
+        <filename>$XDG_CONFIG_HOME/htop/htoprc</filename>.
       '';
     };
 

--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -635,7 +635,7 @@ in {
         default = "";
         description = ''
           Extra configuration lines to add to
-          <filename>~/.config/kak/kakrc</filename>.
+          <filename>$XDG_CONFIG_HOME/kak/kakrc</filename>.
         '';
       };
 

--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -57,7 +57,7 @@ in {
       '';
       description = ''
         Configuration written to
-        <filename>~/.config/kitty/kitty.conf</filename>. See
+        <filename>$XDG_CONFIG_HOME/kitty/kitty.conf</filename>. See
         <link xlink:href="https://sw.kovidgoyal.net/kitty/conf.html" />
         for the documentation.
       '';

--- a/modules/programs/lazygit.nix
+++ b/modules/programs/lazygit.nix
@@ -32,7 +32,7 @@ in {
       '';
       description = ''
         Configuration written to
-        <filename>~/.config/lazygit/config.yml</filename> on Linux
+        <filename>$XDG_CONFIG_HOME/lazygit/config.yml</filename> on Linux
         or <filename>~/Library/Application Support/lazygit/config.yml</filename> on Darwin. See
         <link xlink:href="https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md"/>
         for supported values.

--- a/modules/programs/lsd.nix
+++ b/modules/programs/lsd.nix
@@ -39,7 +39,7 @@ in {
       };
       description = ''
         Configuration written to
-        <filename>~/.config/lsd/config.yaml</filename>. See
+        <filename>$XDG_CONFIG_HOME/lsd/config.yaml</filename>. See
         <link xlink:href="https://github.com/Peltoche/lsd#config-file-content"/>
         for supported values.
       '';

--- a/modules/programs/mangohud.nix
+++ b/modules/programs/mangohud.nix
@@ -55,7 +55,7 @@ in {
         '';
         description = ''
           Configuration written to
-          <filename>~/.config/MangoHud/MangoHud.conf</filename>. See
+          <filename>$XDG_CONFIG_HOME/MangoHud/MangoHud.conf</filename>. See
           <link xlink:href="https://github.com/flightlessmango/MangoHud/blob/master/bin/MangoHud.conf"/>
           for the default configuration.
         '';
@@ -74,7 +74,7 @@ in {
         description = ''
           Sets MangoHud settings per application.
           Configuration written to
-          <filename>~/.config/MangoHud/{application_name}.conf</filename>. See
+          <filename>$XDG_CONFIG_HOME/MangoHud/{application_name}.conf</filename>. See
           <link xlink:href="https://github.com/flightlessmango/MangoHud/blob/master/bin/MangoHud.conf"/>
           for the default configuration.
         '';

--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -90,7 +90,7 @@ in {
       config = mkOption {
         description = ''
           Configuration written to
-          <filename>~/.config/mpv/mpv.conf</filename>. See
+          <filename>$XDG_CONFIG_HOME/mpv/mpv.conf</filename>. See
           <citerefentry>
             <refentrytitle>mpv</refentrytitle>
             <manvolnum>1</manvolnum>
@@ -112,7 +112,7 @@ in {
       profiles = mkOption {
         description = ''
           Sub-configuration options for specific profiles written to
-          <filename>~/.config/mpv/mpv.conf</filename>. See
+          <filename>$XDG_CONFIG_HOME/mpv/mpv.conf</filename>. See
           <option>programs.mpv.config</option> for more information.
         '';
         type = mpvProfiles;
@@ -143,7 +143,7 @@ in {
       bindings = mkOption {
         description = ''
           Input configuration written to
-          <filename>~/.config/mpv/input.conf</filename>. See
+          <filename>$XDG_CONFIG_HOME/mpv/input.conf</filename>. See
           <citerefentry>
             <refentrytitle>mpv</refentrytitle>
             <manvolnum>1</manvolnum>

--- a/modules/programs/ncspot.nix
+++ b/modules/programs/ncspot.nix
@@ -32,7 +32,7 @@ in {
       '';
       description = ''
         Configuration written to
-        <filename>~/.config/ncspot/config.toml</filename>.
+        <filename>$XDG_CONFIG_HOME/ncspot/config.toml</filename>.
         </para><para>
         See <link xlink:href="https://github.com/hrkfdn/ncspot#configuration" />
         for the full list of options.

--- a/modules/programs/noti.nix
+++ b/modules/programs/noti.nix
@@ -17,7 +17,7 @@ in {
       default = { };
       description = ''
         Configuration written to
-        <filename>~/.config/noti/noti.yaml</filename>.
+        <filename>$XDG_CONFIG_HOME/noti/noti.yaml</filename>.
         </para><para>
         See
         <citerefentry>

--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -42,7 +42,7 @@ in {
       '';
       description = ''
         Configuration written to
-        <filename>~/.config/nushell/config.toml</filename>.
+        <filename>$XDG_CONFIG_HOME/nushell/config.toml</filename>.
         </para><para>
         See <link xlink:href="https://www.nushell.sh/book/configuration.html" /> for the full list
         of options.

--- a/modules/programs/rtorrent.nix
+++ b/modules/programs/rtorrent.nix
@@ -17,7 +17,7 @@ in {
       default = "";
       description = ''
         Configuration written to
-        <filename>~/.config/rtorrent/rtorrent.rc</filename>. See
+        <filename>$XDG_CONFIG_HOME/rtorrent/rtorrent.rc</filename>. See
         <link xlink:href="https://github.com/rakshasa/rtorrent/wiki/Config-Guide" />
         for explanation about possible values.
       '';

--- a/modules/programs/sm64ex.nix
+++ b/modules/programs/sm64ex.nix
@@ -80,7 +80,7 @@ in {
         nullOr (attrsOf (either str (either int (either bool (listOf str)))));
       default = null;
       description =
-        "Settings for sm64ex's <filename>~/.local/share/sm64pc/sm64config.txt</filename> file.";
+        "Settings for sm64ex's <filename>$XDG_DATA_HOME/sm64pc/sm64config.txt</filename> file.";
       example = literalExpression ''
         {
           fullscreen = false;

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -51,7 +51,7 @@ in {
       '';
       description = ''
         Configuration written to
-        <filename>~/.config/starship.toml</filename>.
+        <filename>$XDG_CONFIG_HOME/starship.toml</filename>.
         </para><para>
         See <link xlink:href="https://starship.rs/config/" /> for the full list
         of options.

--- a/modules/programs/topgrade.nix
+++ b/modules/programs/topgrade.nix
@@ -42,7 +42,7 @@ in {
       '';
       description = ''
         Configuration written to
-        <filename>~/.config/topgrade.toml</filename>.
+        <filename>$XDG_CONFIG_HOME/topgrade.toml</filename>.
         </para><para>
         See <link xlink:href="https://github.com/r-darwish/topgrade/wiki/Step-list" /> for the full list
         of options.

--- a/modules/services/grobi.nix
+++ b/modules/services/grobi.nix
@@ -24,7 +24,7 @@ in {
           Commands to be run after an output configuration was
           changed. The Nix value declared here will be translated to
           JSON and written to the <option>execute_after</option> key
-          in <filename>~/.config/grobi.conf</filename>.
+          in <filename>$XDG_CONFIG_HOME/grobi.conf</filename>.
         '';
       };
 
@@ -64,7 +64,7 @@ in {
           <link xlink:href="https://github.com/fd0/grobi/blob/master/doc/grobi.conf"/>
           for more information. The Nix value declared here will be
           translated to JSON and written to the <option>rules</option>
-          key in <filename>~/.config/grobi.conf</filename>.
+          key in <filename>$XDG_CONFIG_HOME/grobi.conf</filename>.
         '';
       };
     };


### PR DESCRIPTION
Currently, dot directories and xdg base directories are used inconsistently in the home-manager
option declarations. This creates ambiguity for the user as to where the location of the file
should be albeit this is rarely encountered in practice as it is sufficient to read upstream
documentation. The rationale for the generalization is to make declarations consistent and make
a clear distinction between hardcoded and modular specifications.

References to ~/.config in relevant nixpkgs modules were untouched as the location is hardcoded
upstream[1]. Furthermore, modules of programs which do not follow xdg specifications were also untouched.

Generalization of tilde(~) expansions to $HOME were also considered, however there isn't sufficent
rationale despite the use of $HOME being more universal. The expansion is standardized in POSIX[2]
and is essentially portable across all shells, thus there is no pragmatic value to introducing the change.

[1] - https://github.com/nixos/nixpkgs/blob/master/pkgs/top-level/impure.nix
[2] - https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_01

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
