### PR TITLE
services/emacs: add option to set `emacsclient` as the default editor

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -87,7 +87,7 @@ in {
       example = !default;
       description = ''
         Whether to configure <command>emacsclient</command> as the default
-        editor using the <varname>EDITOR</varname> environment variable.
+        editor using the <envar>EDITOR</envar> environment variable.
       '';
     };
   };

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -80,6 +80,16 @@ in {
     socketActivation = {
       enable = mkEnableOption "systemd socket activation for the Emacs service";
     };
+
+    defaultEditor = mkOption rec {
+      type = types.bool;
+      default = false;
+      example = !default;
+      description = ''
+        Whether to configure <command>emacsclient</command> as the default
+        editor using the <varname>EDITOR</varname> environment variable.
+      '';
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
@@ -139,7 +149,16 @@ in {
         Install = { WantedBy = [ "default.target" ]; };
       };
 
-      home.packages = optional cfg.client.enable (hiPrio clientDesktopItem);
+      home = {
+        packages = optional cfg.client.enable (hiPrio clientDesktopItem);
+
+        sessionVariables = mkIf cfg.defaultEditor {
+          EDITOR = getBin (pkgs.writeShellScript "editor" ''
+            exec ${
+              getBin cfg.package
+            }/bin/emacsclient "''${@:---create-frame}"'');
+        };
+      };
     }
 
     (mkIf cfg.socketActivation.enable {

--- a/tests/modules/services/emacs/default.nix
+++ b/tests/modules/services/emacs/default.nix
@@ -3,4 +3,5 @@
   emacs-service-28 = ./emacs-service-28.nix;
   emacs-socket-27 = ./emacs-socket-27.nix;
   emacs-socket-28 = ./emacs-socket-28.nix;
+  emacs-default-editor = ./emacs-default-editor.nix;
 }

--- a/tests/modules/services/emacs/emacs-default-editor.nix
+++ b/tests/modules/services/emacs/emacs-default-editor.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+{
+  nixpkgs.overlays = [
+    (self: super: {
+      # Use `cat` instead of `echo` to prevent arguments from being
+      # interpreted as an option.
+      emacs = pkgs.writeShellScriptBin "emacsclient"
+        ''${pkgs.coreutils}/bin/cat <<< "$*"'';
+    })
+  ];
+
+  services.emacs = {
+    defaultEditor = true;
+    enable = true;
+  };
+
+  nmt.script = "source ${
+      pkgs.substituteAll {
+        inherit (pkgs) coreutils;
+        src = ./emacs-default-editor.sh;
+      }
+    }";
+}

--- a/tests/modules/services/emacs/emacs-default-editor.sh
+++ b/tests/modules/services/emacs/emacs-default-editor.sh
@@ -1,0 +1,18 @@
+set +u
+source $TESTED/home-path/etc/profile.d/hm-session-vars.sh
+set -u
+
+check_arguments () {
+    if [ "$1" != "$2" ]; then
+	@coreutils@/bin/cat <<- EOF
+	Expected arguments:
+	$1
+	but got:
+	$2
+	EOF
+	exit 1
+    fi
+}
+
+check_arguments "--create-frame" "$($EDITOR)"
+check_arguments "foo bar baz" "$($EDITOR foo bar baz)"


### PR DESCRIPTION
### Description

Adds a `defaultEditor` option to `modules/services/emacs.nix` that sets `emacsclient` as the default text editor using the `EDITOR` environment variable. Also passes `--create-frame` to `emacsclient` if no arguments are given, so a new frame is opened instead of a file (otherwise, `emacsclient` fails with `file name or argument required`).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
