### PR TITLE
waybar: allow using attrs for settings

### DIFF
--- a/tests/modules/programs/waybar/default.nix
+++ b/tests/modules/programs/waybar/default.nix
@@ -3,5 +3,6 @@
     ./systemd-with-graphical-session-target.nix;
   waybar-styling = ./styling.nix;
   waybar-settings-complex = ./settings-complex.nix;
+  waybar-settings-with-attrs = ./settings-with-attrs.nix;
   waybar-deprecated-modules-option = ./deprecated-modules-option.nix;
 }

--- a/tests/modules/programs/waybar/settings-complex-expected.json
+++ b/tests/modules/programs/waybar/settings-complex-expected.json
@@ -43,5 +43,21 @@
       "all-outputs": true,
       "disable-scroll": true
     }
+  },
+  {
+    "modules-center": [
+      "clock"
+    ],
+    "modules-left": [
+      "sway/mode"
+    ],
+    "modules-right": [],
+    "output": [
+      "!DP-1"
+    ],
+    "position": "bottom",
+    "sway/mode": {
+      "tooltip": true
+    }
   }
 ]

--- a/tests/modules/programs/waybar/settings-complex.nix
+++ b/tests/modules/programs/waybar/settings-complex.nix
@@ -9,43 +9,52 @@ with lib;
     programs.waybar = {
       package = config.lib.test.mkStubPackage { outPath = "@waybar@"; };
       enable = true;
-      settings = [{
-        layer = "top";
-        position = "top";
-        height = 30;
-        output = [ "DP-1" ];
-        modules-left = [ "sway/workspaces" "sway/mode" "custom/my-module" ];
-        modules-center = [ "sway/window" ];
-        modules-right = [
-          "idle_inhibitor"
-          "pulseaudio"
-          "network"
-          "cpu"
-          "memory"
-          "backlight"
-          "tray"
-          "battery#bat1"
-          "battery#bat2"
-          "clock"
-        ];
+      settings = [
+        {
+          layer = "top";
+          position = "top";
+          height = 30;
+          output = [ "DP-1" ];
+          modules-left = [ "sway/workspaces" "sway/mode" "custom/my-module" ];
+          modules-center = [ "sway/window" ];
+          modules-right = [
+            "idle_inhibitor"
+            "pulseaudio"
+            "network"
+            "cpu"
+            "memory"
+            "backlight"
+            "tray"
+            "battery#bat1"
+            "battery#bat2"
+            "clock"
+          ];
 
-        modules = {
-          "sway/workspaces" = {
-            disable-scroll = true;
-            all-outputs = true;
+          modules = {
+            "sway/workspaces" = {
+              disable-scroll = true;
+              all-outputs = true;
+            };
+            "sway/mode" = { tooltip = false; };
+            "sway/window" = { max-length = 120; };
+            "idle_inhibitor" = { format = "{icon}"; };
+            "custom/my-module" = {
+              format = "hello from {}";
+              exec = let
+                dummyScript =
+                  config.lib.test.mkStubPackage { outPath = "@dummy@"; };
+              in "${dummyScript}/bin/dummy";
+            };
           };
-          "sway/mode" = { tooltip = false; };
-          "sway/window" = { max-length = 120; };
-          "idle_inhibitor" = { format = "{icon}"; };
-          "custom/my-module" = {
-            format = "hello from {}";
-            exec = let
-              dummyScript =
-                config.lib.test.mkStubPackage { outPath = "@dummy@"; };
-            in "${dummyScript}/bin/dummy";
-          };
-        };
-      }];
+        }
+        {
+          position = "bottom";
+          output = [ "!DP-1" ];
+          modules-left = [ "sway/mode" ];
+          modules-center = [ "clock" ];
+          modules = { "sway/mode" = { tooltip = true; }; };
+        }
+      ];
     };
 
     nmt.script = ''

--- a/tests/modules/programs/waybar/settings-with-attrs.nix
+++ b/tests/modules/programs/waybar/settings-with-attrs.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.stateVersion = "21.11";
+
+    programs.waybar = {
+      package = config.lib.test.mkStubPackage { outPath = "@waybar@"; };
+      enable = true;
+      settings = let
+        settingsComplex = (import ./settings-complex.nix {
+          inherit config lib pkgs;
+        }).config.programs.waybar.settings;
+      in {
+        mainBar = builtins.head settingsComplex;
+        secondaryBar = builtins.elemAt settingsComplex 1;
+      };
+    };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/waybar/style.css
+      assertFileContent \
+        home-files/.config/waybar/config \
+        ${./settings-complex-expected.json}
+    '';
+  };
+}


### PR DESCRIPTION
### Description
This change allows using attrs for waybar settings while still keeping backward compatibility and allowing lists.

Motivation: having a name for each bar makes it possible to override specific values easily.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```