### PR TITLE
coc.nvim fixes

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -16,6 +16,8 @@ let
     merge = mergeOneOption;
   };
 
+  plugins = cfg.plugins ++ optional cfg.coc.enable pkgs.vimPlugins.coc-nvim;
+
   pluginWithConfigType = types.submodule {
     options = {
       config = mkOption {
@@ -48,10 +50,10 @@ let
     packages.home-manager = {
       start = filter (f: f != null) (map
         (x: if x ? plugin && x.optional == true then null else (x.plugin or x))
-        cfg.plugins);
+        plugins);
       opt = filter (f: f != null)
         (map (x: if x ? plugin && x.optional == true then x.plugin else null)
-          cfg.plugins);
+          plugins);
     };
     beforePlugins = "";
   };
@@ -274,8 +276,7 @@ in {
       inherit (cfg)
         extraPython3Packages withPython3 withNodeJs withRuby viAlias vimAlias;
       configure = cfg.configure // moduleConfigure;
-      plugins = cfg.plugins
-        ++ optionals cfg.coc.enable [ pkgs.vimPlugins.coc-nvim ];
+      inherit plugins;
       customRC = cfg.extraConfig;
     };
 


### PR DESCRIPTION
### Description

Currently, there are two issues:
1. `programs.neovim.coc.enable` is supposed to install coc.nvim without requiring the user to explicitly add it to the plugin list, but it doesn't work.
2. After manually fixing the above issue, coc.nvim works but it cannot find additional plugins because it only searches `runtimepath` directories directly. home-manager sets up a `packpath` instead, so we need to tell coc.nvim where they are

This code adds the plugin paths through the `packpath`, but an alternative implementation might just use the paths to the plugins directly. It does so by adding a new config option to differentiate them: `programs.neovim.coc.plugins`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
