### PR TITLE
home-manager: add basic i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ Home Manager can be used in three primary ways:
    installation][manual nix-darwin install] in the manual for a
    description of this setup.
 
+Translations
+------------
+
+Home Manager has basic support for internationalization through
+[gettext](https://www.gnu.org/software/gettext/). The translations are
+hosted by [Weblate](https://weblate.org/). If you would like to
+contribute to the translation effort then start by going to the
+[Home Manager Weblate project](https://hosted.weblate.org/engage/home-manager/).
+
+<a href="https://hosted.weblate.org/engage/home-manager/">
+<img src="https://hosted.weblate.org/widgets/home-manager/-/multi-auto.svg" alt="Translation status" />
+</a>
+
 Nix Flakes
 ----------
 

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -1,14 +1,15 @@
 #!@bash@/bin/bash
 
 # Prepare to use tools from Nixpkgs.
-PATH=@coreutils@/bin:@findutils@/bin:@gnused@/bin:@less@/bin:@nixos-option@/bin${PATH:+:}$PATH
+PATH=@DEP_PATH@${PATH:+:}$PATH
 
 set -euo pipefail
 
-function errorEcho() {
-    # shellcheck disable=2048,2086
-    echo $* >&2
-}
+export TEXTDOMAIN=home-manager
+export TEXTDOMAINDIR=@OUT@/share/locale
+
+# shellcheck disable=1091
+source @HOME_MANAGER_LIB@
 
 function setVerboseAndDryRun() {
     if [[ -v VERBOSE ]]; then
@@ -39,7 +40,8 @@ function setWorkDir() {
 function setConfigFile() {
     if [[ -v HOME_MANAGER_CONFIG ]] ; then
         if [[ ! -e "$HOME_MANAGER_CONFIG" ]] ; then
-            errorEcho "No configuration file found at $HOME_MANAGER_CONFIG"
+            _i "No configuration file found at %s" \
+               "$HOME_MANAGER_CONFIG" >&2
             exit 1
         fi
 
@@ -57,8 +59,8 @@ function setConfigFile() {
         fi
     done
 
-    errorEcho "No configuration file found." \
-         "Please create one at $defaultConfFile"
+    _i "No configuration file found. Please create one at %s" \
+       "$defaultConfFile" >&2
     exit 1
 }
 
@@ -100,7 +102,7 @@ function setFlakeAttribute() {
 function doInspectOption() {
     setFlakeAttribute
     if [[ -v FLAKE_CONFIG_URI ]]; then
-        errorEcho "Can't inspect options of a flake configuration"
+        _iError "Can't inspect options of a flake configuration"
         exit 1
     fi
     setConfigFile
@@ -140,7 +142,7 @@ function doInspectOption() {
 function doInstantiate() {
     setFlakeAttribute
     if [[ -v FLAKE_CONFIG_URI ]]; then
-        errorEcho "Can't instantiate a flake configuration"
+        _i "Can't instantiate a flake configuration" >&2
         exit 1
     fi
     setConfigFile
@@ -212,20 +214,16 @@ function presentNews() {
     elif [[ "$newsDisplay" == "silent" ]]; then
         return
     elif [[ "$newsDisplay" == "notify" ]]; then
-        local msg
-        if [[ $newsNumUnread -eq 1 ]]; then
-            msg="There is an unread and relevant news item.\n"
-            msg+="Read it by running the command '$(basename "$0") news'."
-        else
-            msg="There are $newsNumUnread unread and relevant news items.\n"
-            msg+="Read them by running the command '$(basename "$0") news'."
-        fi
+        local cmd msg
+        cmd="$(basename "$0")"
+        msg="$(_ip \
+                $'There is %d unread and relevant news item.\nRead it by running the command "%s news".' \
+                $'There are %d unread and relevant news items.\nRead them by running the command "%s news".' \
+                "$newsNumUnread" "$newsNumUnread" "$cmd")"
 
         # Not actually an error but here stdout is reserved for
         # nix-build output.
-        errorEcho
-        errorEcho -e "$msg"
-        errorEcho
+        echo $'\n'"$msg"$'\n' >&2
 
         if [[ -v DISPLAY ]] && type -P notify-send > /dev/null; then
             notify-send "Home Manager" "$msg"
@@ -233,13 +231,14 @@ function presentNews() {
     elif [[ "$newsDisplay" == "show" ]]; then
         doShowNews --unread
     else
-        errorEcho "Unknown 'news.display' setting '$newsDisplay'."
+        _i 'Unknown "news.display" setting "%s".' "$newsDisplay" >&2
     fi
 }
 
 function doEdit() {
     if [[ ! -v EDITOR || -z $EDITOR ]]; then
-        errorEcho "Please set the \$EDITOR environment variable"
+        # shellcheck disable=2016
+        _i 'Please set the $EDITOR environment variable' >&2
         return 1
     fi
 
@@ -254,7 +253,7 @@ function doEdit() {
 
 function doBuild() {
     if [[ ! -w . ]]; then
-        errorEcho "Cannot run build in read-only directory";
+        _i 'Cannot run build in read-only directory' >&2
         return 1
     fi
 
@@ -336,11 +335,11 @@ function doRmGenerations() {
         local linkName="home-manager-$generationId-link"
 
         if [[ ! -e $linkName ]]; then
-            errorEcho "No generation with ID $generationId"
+            _i 'No generation with ID %s' "$generationId" >&2
         elif [[ $linkName == $(readlink home-manager) ]]; then
-            errorEcho "Cannot remove the current generation $generationId"
+            _i 'Cannot remove the current generation %s' "$generationId" >&2
         else
-            echo Removing generation $generationId
+            _i 'Removing generation %s' "$generationId"
             $DRY_RUN_CMD rm $VERBOSE_ARG $linkName
         fi
     done
@@ -366,7 +365,7 @@ function doExpireGenerations() {
         # shellcheck disable=2086
         doRmGenerations $generations
     elif [[ -v VERBOSE ]]; then
-        echo "No generations to expire"
+        _i "No generations to expire"
     fi
 }
 
@@ -376,7 +375,7 @@ function doListPackages() {
     if [[ -n "$outPath" ]] ; then
         nix-store -q --references "$outPath" | sed 's/[^-]*-//'
     else
-        errorEcho "No home-manager packages seem to be installed."
+        _i 'No home-manager packages seem to be installed.' >&2
     fi
 }
 
@@ -433,7 +432,7 @@ function doShowNews() {
             ${PAGER:-less} "$newsFileUnread"
             ;;
         *)
-            errorEcho "Unknown argument $1"
+            _i 'Unknown argument %s' "$1"
             return 1
     esac
 
@@ -448,19 +447,19 @@ function doShowNews() {
 function doUninstall() {
     setVerboseAndDryRun
 
-    echo "This will remove Home Manager from your system."
+    _i 'This will remove Home Manager from your system.'
 
     if [[ -v DRY_RUN ]]; then
-        echo "This is a dry run, nothing will actually be uninstalled."
+        _i 'This is a dry run, nothing will actually be uninstalled.'
     fi
 
     local confirmation
-    read -r -n 1 -p "Really uninstall Home Manager? [y/n] " confirmation
+    read -r -n 1 -p "$(_i 'Really uninstall Home Manager?') [y/n] " confirmation
     echo
 
     case $confirmation in
         y|Y)
-            echo "Switching to empty Home Manager configuration..."
+            _i "Switching to empty Home Manager configuration..."
             HOME_MANAGER_CONFIG="$(mktemp --tmpdir home-manager.XXXXXXXXXX)"
             echo "{ lib, ... }: { home.file = lib.mkForce {}; }" > "$HOME_MANAGER_CONFIG"
             doSwitch
@@ -472,28 +471,28 @@ function doUninstall() {
                 "$NIX_STATE_DIR/gcroots/per-user/$USER/current-home"
             ;;
         *)
-            echo "Yay!"
+            _i "Yay!"
             exit 0
             ;;
     esac
 
     local deleteProfiles
     read -r -n 1 \
-         -p 'Remove all Home Manager generations? [y/n] ' \
+         -p "$(_i 'Remove all Home Manager generations?') [y/n] " \
          deleteProfiles
     echo
 
     case $deleteProfiles in
         y|Y)
             doRmAllGenerations
-            echo "All generations are now eligible for garbage collection."
+            _i 'All generations are now eligible for garbage collection.'
             ;;
         *)
-            echo "Leaving generations but they may still be garbage collected."
+            _i 'Leaving generations but they may still be garbage collected.'
             ;;
     esac
 
-    echo "Home Manager is uninstalled but your home.nix is left untouched."
+    _i "Home Manager is uninstalled but your home.nix is left untouched."
 }
 
 function doHelp() {
@@ -643,8 +642,8 @@ while [[ $# -gt 0 ]]; do
                     COMMAND_ARGS+=("$opt")
                     ;;
                 *)
-                    errorEcho "$0: unknown option '$opt'"
-                    errorEcho "Run '$0 --help' for usage help"
+                    _iError "%s: unknown option '%s'" "$0" "$opt" >&2
+                    _i "Run '%s --help' for usage help" "$0" >&2
                     exit 1
                     ;;
             esac
@@ -678,7 +677,7 @@ case $COMMAND in
         ;;
     expire-generations)
         if [[ ${#COMMAND_ARGS[@]} != 1 ]]; then
-            errorEcho "expire-generations expects one argument, got ${#COMMAND_ARGS[@]}."
+            _i 'expire-generations expects one argument, got %d.' "${#COMMAND_ARGS[@]}" >&2
             exit 1
         else
             doExpireGenerations "${COMMAND_ARGS[@]}"
@@ -700,7 +699,7 @@ case $COMMAND in
         doHelp
         ;;
     *)
-        errorEcho "Unknown command: $COMMAND"
+        _iError 'Unknown command: %s' "$COMMAND" >&2
         doHelp >&2
         exit 1
         ;;

--- a/home-manager/po/home-manager.pot
+++ b/home-manager/po/home-manager.pot
@@ -1,0 +1,134 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Home Manager contributors
+# This file is distributed under the same license as the Home Manager package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Home Manager\n"
+"Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
+"POT-Creation-Date: 2021-12-13 00:45+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: home-manager/home-manager:43
+msgid "No configuration file found at %s"
+msgstr ""
+
+#: home-manager/home-manager:62
+msgid "No configuration file found. Please create one at %s"
+msgstr ""
+
+#: home-manager/home-manager:105
+msgid "Can't inspect options of a flake configuration"
+msgstr ""
+
+#: home-manager/home-manager:145
+msgid "Can't instantiate a flake configuration"
+msgstr ""
+
+#: home-manager/home-manager:220
+msgid ""
+"There is %d unread and relevant news item.\n"
+"Read it by running the command \"%s news\"."
+msgid_plural ""
+"There are %d unread and relevant news items.\n"
+"Read them by running the command \"%s news\"."
+msgstr[0] ""
+msgstr[1] ""
+
+#: home-manager/home-manager:234
+msgid "Unknown \"news.display\" setting \"%s\"."
+msgstr ""
+
+#: home-manager/home-manager:241
+#, sh-format
+msgid "Please set the $EDITOR environment variable"
+msgstr ""
+
+#: home-manager/home-manager:256
+msgid "Cannot run build in read-only directory"
+msgstr ""
+
+#: home-manager/home-manager:338
+msgid "No generation with ID %s"
+msgstr ""
+
+#: home-manager/home-manager:340
+msgid "Cannot remove the current generation %s"
+msgstr ""
+
+#: home-manager/home-manager:342
+msgid "Removing generation %s"
+msgstr ""
+
+#: home-manager/home-manager:368
+msgid "No generations to expire"
+msgstr ""
+
+#: home-manager/home-manager:378
+msgid "No home-manager packages seem to be installed."
+msgstr ""
+
+#: home-manager/home-manager:435
+msgid "Unknown argument %s"
+msgstr ""
+
+#: home-manager/home-manager:450
+msgid "This will remove Home Manager from your system."
+msgstr ""
+
+#: home-manager/home-manager:453
+msgid "This is a dry run, nothing will actually be uninstalled."
+msgstr ""
+
+#: home-manager/home-manager:457
+msgid "Really uninstall Home Manager?"
+msgstr ""
+
+#: home-manager/home-manager:462
+msgid "Switching to empty Home Manager configuration..."
+msgstr ""
+
+#: home-manager/home-manager:474
+msgid "Yay!"
+msgstr ""
+
+#: home-manager/home-manager:481
+msgid "Remove all Home Manager generations?"
+msgstr ""
+
+#: home-manager/home-manager:488
+msgid "All generations are now eligible for garbage collection."
+msgstr ""
+
+#: home-manager/home-manager:491
+msgid "Leaving generations but they may still be garbage collected."
+msgstr ""
+
+#: home-manager/home-manager:495
+msgid "Home Manager is uninstalled but your home.nix is left untouched."
+msgstr ""
+
+#: home-manager/home-manager:645
+msgid "%s: unknown option '%s'"
+msgstr ""
+
+#: home-manager/home-manager:646
+msgid "Run '%s --help' for usage help"
+msgstr ""
+
+#: home-manager/home-manager:680
+msgid "expire-generations expects one argument, got %d."
+msgstr ""
+
+#: home-manager/home-manager:702
+msgid "Unknown command: %s"
+msgstr ""

--- a/home-manager/po/sv.po
+++ b/home-manager/po/sv.po
@@ -1,0 +1,139 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Home Manager\n"
+"Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/"
+"issues\n"
+"POT-Creation-Date: 2021-12-12 23:05+0100\n"
+"PO-Revision-Date: 2021-12-12 23:19+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.4.3\n"
+
+#: home-manager/home-manager:43
+msgid "No configuration file found at %s"
+msgstr "Det finns ingen konfigurationsfil i %s"
+
+#: home-manager/home-manager:62
+msgid "No configuration file found. Please create one at %s"
+msgstr "Hittade ingen konfigurationsfil. Skapa en i %s"
+
+#: home-manager/home-manager:105
+msgid "Can't inspect options of a flake configuration"
+msgstr "Kan inte granska alternativ i en flake-konfiguration"
+
+#: home-manager/home-manager:145
+msgid "Can't instantiate a flake configuration"
+msgstr "Kan inte instansera en flake-konfiguration"
+
+#: home-manager/home-manager:220
+msgid ""
+"There is %d unread and relevant news item.\n"
+"Read it by running the command \"%s news\"."
+msgid_plural ""
+"There are %d unread and relevant news items.\n"
+"Read them by running the command \"%s news\"."
+msgstr[0] ""
+"Det finns %d oläst och relevant nyhet.\n"
+"Läs den genom att köra kommandot \"%s news\"."
+msgstr[1] ""
+"Det finns %d olästa och relevanta nyheter.\\nLäs dem genom att köra "
+"kommandot \"%s news\"."
+
+#: home-manager/home-manager:234
+msgid "Unknown \"news.display\" setting \"%s\"."
+msgstr "Okänt \"news.display\"-värde \"%s\"."
+
+#: home-manager/home-manager:241
+#, sh-format
+msgid "Please set the $EDITOR environment variable"
+msgstr "Vänligen tilldela miljövariablen $EDITOR"
+
+#: home-manager/home-manager:256
+msgid "Cannot run build in read-only directory"
+msgstr "Kan inte bygga i katalog med bara läsrättigheter"
+
+#: home-manager/home-manager:338
+msgid "No generation with ID %s"
+msgstr "Ingen generation med ID %s"
+
+#: home-manager/home-manager:340
+msgid "Cannot remove the current generation %s"
+msgstr "Kan inte ta bort nuvarande generation %s"
+
+#: home-manager/home-manager:342
+msgid "Removing generation %s"
+msgstr "Tar bort generation %s"
+
+#: home-manager/home-manager:368
+msgid "No generations to expire"
+msgstr "Ingen generation att förfalla"
+
+#: home-manager/home-manager:378
+msgid "No home-manager packages seem to be installed."
+msgstr "Paketet home-manager verkar inte vara installerat."
+
+#: home-manager/home-manager:435
+msgid "Unknown argument %s"
+msgstr "Okänt argument %s"
+
+#: home-manager/home-manager:450
+msgid "This will remove Home Manager from your system."
+msgstr "Detta kommer att ta bort Home Manager från ditt system."
+
+#: home-manager/home-manager:453
+msgid "This is a dry run, nothing will actually be uninstalled."
+msgstr "Detta är en testkörning, inget kommer att bli avinstallerat."
+
+#: home-manager/home-manager:457
+msgid "Really uninstall Home Manager?"
+msgstr "Verkligen avinstallera Home Manager?"
+
+#: home-manager/home-manager:462
+msgid "Switching to empty Home Manager configuration..."
+msgstr "Byter till tom Home Manager-konfiguration..."
+
+#: home-manager/home-manager:474
+msgid "Yay!"
+msgstr "Hurra!"
+
+#: home-manager/home-manager:481
+msgid "Remove all Home Manager generations?"
+msgstr "Ta bort alla Home Manager-generationer?"
+
+#: home-manager/home-manager:488
+msgid "All generations are now eligible for garbage collection."
+msgstr "Alla generationer kan nu skräpsamlas."
+
+#: home-manager/home-manager:491
+msgid "Leaving generations but they may still be garbage collected."
+msgstr "Låter generationer vara kvar men de kan fortfarande skräpsamlas."
+
+#: home-manager/home-manager:495
+msgid "Home Manager is uninstalled but your home.nix is left untouched."
+msgstr "Home Manager är avinstallerad men din home.nix är orörd."
+
+#: home-manager/home-manager:645
+msgid "%s: unknown option '%s'"
+msgstr "%s: okänt val '%s'"
+
+#: home-manager/home-manager:646 home-manager/home-manager:659
+msgid "Run '%s --help' for usage help"
+msgstr "Kör '%s --help' för användarhjälp"
+
+#: home-manager/home-manager:682
+msgid "expire-generations expects one argument, got %d."
+msgstr "expect-generations förväntar sig ett argument, fick %d."
+
+#: home-manager/home-manager:704
+msgid "Unknown command: %s"
+msgstr "Okänd kommando: %s"

--- a/lib/bash/color-echo
+++ b/lib/bash/color-echo
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# The check for terminal output and color support is heavily inspired
+# by https://unix.stackexchange.com/a/10065.
+#
+# Allow opt out by respecting the `NO_COLOR` environment variable.
+
+function setupColors() {
+    normalColor=""
+    errorColor=""
+    warnColor=""
+    noteColor=""
+
+    # Enable colors for terminals, and allow opting out.
+    if [[ ! -v NO_COLOR && -t 1 ]]; then
+        # See if it supports colors.
+        local ncolors
+        ncolors=$(tput colors)
+
+        if [[ -n "$ncolors" && "$ncolors" -ge 8 ]]; then
+            normalColor="$(tput sgr0)"
+            errorColor="$(tput bold)$(tput setaf 1)"
+            warnColor="$(tput setaf 3)"
+            noteColor="$(tput bold)$(tput setaf 6)"
+        fi
+    fi
+}
+
+setupColors
+
+function errorEcho() {
+    echo "${errorColor}$*${normalColor}"
+}
+
+function warnEcho() {
+    echo "${warnColor}$*${normalColor}"
+}
+
+function noteEcho() {
+    echo "${noteColor}$*${normalColor}"
+}

--- a/lib/bash/home-manager.sh
+++ b/lib/bash/home-manager.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+#
+# This file contains a number of utilities for use by the home-manager tool and
+# the generated Home Manager activation scripts. No guarantee is made about
+# backwards or forward compatibility.
+#
+
+# Sets up colors suitable for the `errorEcho`, `warnEcho`, and `noteEcho`
+# functions.
+#
+# The check for terminal output and color support is heavily inspired by
+# https://unix.stackexchange.com/a/10065.
+#
+# The setup respects the `NO_COLOR` environment variable.
+function setupColors() {
+    normalColor=""
+    errorColor=""
+    warnColor=""
+    noteColor=""
+
+    # Enable colors for terminals, and allow opting out.
+    if [[ ! -v NO_COLOR && -t 1 ]]; then
+        # See if it supports colors.
+        local ncolors
+        ncolors=$(tput colors)
+
+        if [[ -n "$ncolors" && "$ncolors" -ge 8 ]]; then
+            normalColor="$(tput sgr0)"
+            errorColor="$(tput bold)$(tput setaf 1)"
+            warnColor="$(tput setaf 3)"
+            noteColor="$(tput bold)$(tput setaf 6)"
+        fi
+    fi
+}
+
+setupColors
+
+function errorEcho() {
+    echo "${errorColor}$*${normalColor}"
+}
+
+function warnEcho() {
+    echo "${warnColor}$*${normalColor}"
+}
+
+function noteEcho() {
+    echo "${noteColor}$*${normalColor}"
+}
+
+function _i() {
+    local msgid="$1"
+    shift
+
+    # shellcheck disable=2059
+    printf "$(gettext "$msgid")\n" "$@"
+}
+
+function _ip() {
+    local msgid="$1"
+    local msgidPlural="$2"
+    local count="$3"
+    shift 3
+
+    # shellcheck disable=2059
+    printf "$(ngettext "$msgid" "$msgidPlural" "$count")\n" "$@"
+}
+
+function _iError() {
+    echo -n "${errorColor}"
+    _i "$@"
+    echo -n "${normalColor}"
+}
+
+function _iWarn() {
+    echo -n "${warnColor}"
+    _i "$@"
+    echo -n "${normalColor}"
+}
+
+function _iNote() {
+    echo -n "${noteColor}"
+    _i "$@"
+    echo -n "${normalColor}"
+}

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -80,7 +80,7 @@ in
             (filterAttrs (n: v: v.force) cfg));
 
         check = pkgs.writeText "check" ''
-          . ${./lib-bash/color-echo.sh}
+          ${config.lib.bash.initHomeManagerLib}
 
           # A symbolic link whose target path matches this pattern will be
           # considered part of a Home Manager generation.
@@ -192,7 +192,7 @@ in
         '';
 
         cleanup = pkgs.writeShellScript "cleanup" ''
-          . ${./lib-bash/color-echo.sh}
+          ${config.lib.bash.initHomeManagerLib}
 
           # A symbolic link whose target path matches this pattern will be
           # considered part of a Home Manager generation.
@@ -230,7 +230,7 @@ in
       in
         ''
           function linkNewGen() {
-            echo "Creating home file links in $HOME"
+            _i "Creating home file links in %s" "$HOME"
 
             local newGenFiles
             newGenFiles="$(readlink -e "$newGenPath/home-files")"
@@ -243,7 +243,7 @@ in
               return
             fi
 
-            echo "Cleaning up orphan links from $HOME"
+            _i "Cleaning up orphan links from %s" "$HOME"
 
             local newGenFiles oldGenFiles
             newGenFiles="$(readlink -e "$newGenPath/home-files")"
@@ -259,11 +259,11 @@ in
           cleanOldGen
 
           if [[ ! -v oldGenPath || "$oldGenPath" != "$newGenPath" ]] ; then
-            echo "Creating profile generation $newGenNum"
+            _i "Creating profile generation %s" "$newGenNum"
             $DRY_RUN_CMD nix-env $VERBOSE_ARG --profile "$genProfilePath" --set "$newGenPath"
             $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG "$newGenPath" "$newGenGcPath"
           else
-            echo "No change so reusing latest profile generation $oldGenNum"
+            _i "No change so reusing latest profile generation %s" "$oldGenNum"
           fi
 
           linkNewGen

--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -50,7 +50,7 @@ else
     export VERBOSE_ARG=""
 fi
 
-echo "Starting home manager activation"
+_i "Starting Home Manager activation"
 
 # Verify that we can connect to the Nix store and/or daemon. This will
 # also create the necessary directories in profiles and gcroots.

--- a/modules/po/hm-modules.pot
+++ b/modules/po/hm-modules.pot
@@ -1,0 +1,42 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Home Manager contributors
+# This file is distributed under the same license as the Home Manager Modules package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Home Manager Modules\n"
+"Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
+"POT-Creation-Date: 2021-12-13 00:45+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: modules/files.nix:233
+msgid "Creating home file links in %s"
+msgstr ""
+
+#: modules/files.nix:246
+msgid "Cleaning up orphan links from %s"
+msgstr ""
+
+#: modules/files.nix:262
+msgid "Creating profile generation %s"
+msgstr ""
+
+#: modules/files.nix:266
+msgid "No change so reusing latest profile generation %s"
+msgstr ""
+
+#: modules/home-environment.nix:633
+msgid "Activating %s"
+msgstr ""
+
+#: modules/lib-bash/activation-init.sh:53
+msgid "Starting Home Manager activation"
+msgstr ""

--- a/modules/po/sv.po
+++ b/modules/po/sv.po
@@ -1,0 +1,43 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Home Manager contributors
+# This file is distributed under the same license as the Home Manager Modules package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Home Manager Modules\n"
+"Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
+"POT-Creation-Date: 2021-12-13 00:45+0100\n"
+"PO-Revision-Date: 2021-12-13 00:49+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.4.3\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: modules/files.nix:233
+msgid "Creating home file links in %s"
+msgstr "Skapar hemfil-länkar i %s"
+
+#: modules/files.nix:246
+msgid "Cleaning up orphan links from %s"
+msgstr "Rensar bort överflödiga länkar från %s"
+
+#: modules/files.nix:262
+msgid "Creating profile generation %s"
+msgstr "Skapar profil för generation %s"
+
+#: modules/files.nix:266
+msgid "No change so reusing latest profile generation %s"
+msgstr "Ingen förändring, återanvänder därför profil-generation %s"
+
+#: modules/home-environment.nix:633
+msgid "Activating %s"
+msgstr "Aktiverar %s"
+
+#: modules/lib-bash/activation-init.sh:53
+msgid "Starting Home Manager activation"
+msgstr "Startar Home Manager-aktivering"

--- a/xgettext
+++ b/xgettext
@@ -1,0 +1,36 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -I https://github.com/NixOS/nixpkgs/archive/05f0934825c2a0750d4888c4735f9420c906b388.tar.gz -i bash -p gettext
+
+set -euo pipefail
+shopt -s globstar
+
+function run() {
+  packageName="$1"
+  output="$2"
+  domain="$3"
+  shift 3
+
+  xgettext -v --package-name="$packageName" \
+           --copyright-holder='Home Manager contributors' \
+           --msgid-bugs-address=https://github.com/nix-community/home-manager/issues \
+           -L Shell -k \
+           -k_i:1 --flag=_i:1:c-format \
+           -k_iError:1 --flag=_i:1:c-format \
+           -k_iWarn:1 --flag=_i:1:c-format \
+           -k_iNote:1 --flag=_i:1:c-format \
+           -k_ip:1,2 --flag=_ip:1:c-format --flag=_ip:2:c-format \
+           -k_ipError:1,2 --flag=_ip:1:c-format --flag=_ip:2:c-format \
+           -k_ipWarn:1,2 --flag=_ip:1:c-format --flag=_ip:2:c-format \
+           -k_ipNote:1,2 --flag=_ip:1:c-format --flag=_ip:2:c-format \
+           -o "$output" -d "$domain" "$@"
+}
+
+run 'Home Manager' \
+    home-manager/po/home-manager.pot \
+    home-manager \
+    home-manager/home-manager
+
+run 'Home Manager Modules' \
+    modules/po/hm-modules.pot \
+    hm-modules \
+    modules/**/*.{nix,sh}


### PR DESCRIPTION

### Description

The support for translated strings is, for now, limited to strings generated in Bash code.

Resurrection of #1972 with more polished implementation and support for i18n in (bundled) activation scripts.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.