### PR TITLE
home-manager: ignore broken symlinks

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -119,6 +119,9 @@ in
                 else
                   warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
                 fi
+              # The target file has somehow become an empty symlink, not known what causes this
+              elif link=$(readlink $targetPath) && [[ "$link" == "" ]]; then
+                warnEcho "Existing file '$targetPath' is a broken symlink, will be overwritten"
               else
                 # Fail if nothing else works
                 errorEcho "Existing file '$targetPath' is in the way of '$sourcePath'"


### PR DESCRIPTION
### Description
Occasionally after rebooting all of the files managed by home-manager become broken symlinks to an empty path and stay broken after the activation script runs. I have no clue what causes this but when it happens the only way to fix it is to manually rm all of the symlinks and run the activation script again.
 

![image](https://user-images.githubusercontent.com/12820770/145758758-e7f26f74-858a-4b6b-8c07-4714eb8798be.png)

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
