### PR TITLE
home-manager: support i18n of install script

### DIFF
--- a/home-manager/po/home-manager.pot
+++ b/home-manager/po/home-manager.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2021-12-13 00:45+0100\n"
+"POT-Creation-Date: 2021-12-14 18:53+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -131,4 +131,37 @@ msgstr ""
 
 #: home-manager/home-manager:702
 msgid "Unknown command: %s"
+msgstr ""
+
+#: home-manager/install.nix:22
+msgid "Creating initial Home Manager configuration..."
+msgstr ""
+
+#: home-manager/install.nix:66
+msgid "Creating initial Home Manager generation..."
+msgstr ""
+
+#. translators: The "%s" specifier will be replaced by a file path.
+#: home-manager/install.nix:71
+msgid ""
+"All done! The home-manager tool should now be installed and you can edit\n"
+"\n"
+"    %s\n"
+"\n"
+"to configure Home Manager. Run 'man home-configuration.nix' to\n"
+"see all available options."
+msgstr ""
+
+#. translators: The "%s" specifier will be replaced by a URL.
+#: home-manager/install.nix:76
+msgid ""
+"Uh oh, the installation failed! Please create an issue at\n"
+"\n"
+"    %s\n"
+"\n"
+"if the error seems to be the fault of Home Manager."
+msgstr ""
+
+#: home-manager/install.nix:83
+msgid "This derivation is not buildable, please run it using nix-shell."
 msgstr ""

--- a/xgettext
+++ b/xgettext
@@ -22,13 +22,14 @@ function run() {
            -k_ipError:1,2 --flag=_ip:1:c-format --flag=_ip:2:c-format \
            -k_ipWarn:1,2 --flag=_ip:1:c-format --flag=_ip:2:c-format \
            -k_ipNote:1,2 --flag=_ip:1:c-format --flag=_ip:2:c-format \
+           --add-comments=translators: \
            -o "$output" -d "$domain" "$@"
 }
 
 run 'Home Manager' \
     home-manager/po/home-manager.pot \
     home-manager \
-    home-manager/home-manager
+    home-manager/home-manager home-manager/**/*.nix
 
 run 'Home Manager Modules' \
     modules/po/hm-modules.pot \


### PR DESCRIPTION
### Description

Make it possible to translate the installation script output.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```