### PR TITLE
WIP tests: bump nmt

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,8 +7,8 @@ let
   nmt = pkgs.fetchFromGitLab {
     owner = "rycee";
     repo = "nmt";
-    rev = "89924d8e6e0fcf866a11324d32c6bcaa89cda506";
-    sha256 = "02wzrbmpdpgig58a1rhz8sb0p2rvbapnlcmhi4d4bi8w9md6pmdl";
+    rev = "caa146ff522d7411c3715bd5eaf347bc0f04c68e";
+    sha256 = "1h01pady4m888dcx4d54q807mh1zh01fxry74dak6699vxfyi433";
   };
 
   modules = import ../modules/modules.nix {


### PR DESCRIPTION
### Description

Bump nmt. The new version allows binary substitution of test buids.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```