### PR TITLE
kconifg:init

### DIFF
--- a/modules/misc/qt/kconfig.nix
+++ b/modules/misc/qt/kconfig.nix
@@ -1,0 +1,73 @@
+{ config, pkgs, lib, ... }:
+
+let
+
+  cfg = config.qt.kde.settings;
+in {
+  options.qt.kde.settings = lib.mkOption {
+    type = with lib.types;
+      let
+        valueType =
+          nullOr (oneOf [ bool int float str path (attrsOf valueType) ]) // {
+            description = "KDE option value";
+          };
+      in attrsOf valueType;
+    default = { };
+    example = {
+      powermanagementprofilesrc.AC.HandleButtonEvents.lidAction = 32;
+    };
+    description = ''
+      A set of values to be modified by {command}`kwriteconfig5`.
+
+      The example value would cause the following command to run in the
+      activation script:
+
+      ``` shell
+      kwriteconfig5 --file $XDG_CONFIG_HOME/powermanagementprofilesrc \
+                    --group AC \
+                    --group HandleButtonEvents \
+                    --group lidAction \
+                    --key lidAction \
+                    32
+      ```
+
+      Note, `null` values will delete the corresponding entry instead of
+      inserting any value.
+    '';
+  };
+
+  config = lib.mkIf (cfg != { }) {
+    home.activation.kconfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      ${let
+        inherit (config.xdg) configHome;
+        toValue = v:
+          let t = builtins.typeOf v;
+          in if v == null then
+            "--delete"
+          else if t == "bool" then
+            "--type bool ${builtins.toJSON v}"
+          else
+            toString v;
+        toLine = file: path: value:
+          if builtins.isAttrs value then
+            lib.mapAttrsToList
+            (group: value: toLine file (path ++ [ group ]) value) value
+          else
+            "run test -f '${configHome}/${file}' && run ${pkgs.libsForQt5.kconfig}/bin/kwriteconfig5 --file '${configHome}/${file}' ${
+              lib.concatMapStringsSep " " (x: "--group ${x}")
+              (lib.lists.init path)
+            } --key '${lib.lists.last path}' ${toValue value}";
+        lines = lib.flatten
+          (lib.mapAttrsToList (file: attrs: toLine file [ ] attrs) cfg);
+      in builtins.concatStringsSep "\n" lines}
+
+      # TODO: some way to only call the dbus calls needed
+      run ${pkgs.libsForQt5.qttools.bin}/bin/qdbus org.kde.KWin /KWin reconfigure || echo "KWin reconfigure failed"
+      # the actual values are https://github.com/KDE/plasma-workspace/blob/c97dddf20df5702eb429b37a8c10b2c2d8199d4e/kcms/kcms-common_p.h#L13
+      for changeType in {0..10}; do
+        # even if one of those calls fails the others keep running
+        run ${pkgs.dbus}/bin/dbus-send /KGlobalSettings org.kde.KGlobalSettings.notifyChange int32:$changeType int32:0 || echo "KGlobalSettings.notifyChange $changeType failed"
+      done
+    '';
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -34,6 +34,7 @@ let
     ./misc/numlock.nix
     ./misc/pam.nix
     ./misc/qt.nix
+    ./misc/qt/kconfig.nix
     ./misc/specialisation.nix
     ./misc/submodule-support.nix
     ./misc/tmpfiles.nix


### PR DESCRIPTION
### Description
Fixes https://github.com/nix-community/home-manager/issues/607 by providing a way to programattically set kde configuration files. 
However as note that any theme changed with this module requires a logout, as the proper way would be to exec `plasma-apply-*` and those commands seem to require a working DBus and thus https://github.com/nix-community/home-manager/pull/2548 for testing on my setup.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
