### PR TITLE
gpg: allow specifying trust levels by name

### DIFF
--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -40,30 +40,40 @@ let
       };
 
       trust = mkOption {
-        type = types.nullOr (types.enum [ 1 2 3 4 5 ]);
+        type = types.nullOr (types.enum ["unknown" 1 "never" 2 "marginal" 3 "full" 4 "ultimate" 5]);
         default = null;
+        apply = v:
+          if isString v then
+            {
+              unknown = 1;
+              never = 2;
+              marginal = 3;
+              full = 4;
+              ultimate = 5;
+            }.${v}
+          else v;
         description = ''
           The amount of trust you have in the key ownership and the care the
           owner puts into signing other keys. The available levels are
           <variablelist>
             <varlistentry>
-              <term><literal>1</literal></term>
+              <term><literal>unknown</literal> or <literal>1</literal></term>
               <listitem><para>I don't know or won't say.</para></listitem>
             </varlistentry>
             <varlistentry>
-              <term><literal>2</literal></term>
+              <term><literal>never</literal> or <literal>2</literal></term>
               <listitem><para>I do NOT trust.</para></listitem>
             </varlistentry>
             <varlistentry>
-              <term><literal>3</literal></term>
+              <term><literal>marginal</literal> or <literal>3</literal></term>
               <listitem><para>I trust marginally.</para></listitem>
             </varlistentry>
             <varlistentry>
-              <term><literal>4</literal></term>
+              <term><literal>full</literal> or <literal>4</literal></term>
               <listitem><para>I trust fully.</para></listitem>
             </varlistentry>
             <varlistentry>
-              <term><literal>5</literal></term>
+              <term><literal>ultimate</literal> or <literal>5</literal></term>
               <listitem><para>I trust ultimately.</para></listitem>
             </varlistentry>
           </variablelist>
@@ -94,7 +104,7 @@ let
         keyId="$(gpgKeyId "$1")"
         trust="$2"
         if [[ -n $keyId ]] ; then
-          echo -e "trust\n$trust\ny\nquit" \
+          { echo trust; echo "$trust"; (( trust == 5 )) && echo y; echo quit; } \
             | ${gpg} --no-tty --command-fd 0 --edit-key "$keyId"
         fi
       }

--- a/tests/modules/programs/gpg/immutable-keyfiles.nix
+++ b/tests/modules/programs/gpg/immutable-keyfiles.nix
@@ -14,14 +14,14 @@
             "https://keybase.io/rycee/pgp_keys.asc?fingerprint=36cacf52d098cc0e78fb0cb13573356c25c424d4";
           sha256 = "082mjy6llvrdry6i9r5gx97nw9d89blnam7bghza4ynsjk1mmx6c";
         };
-        trust = 1;
+        trust = 1; # "unknown"
       }
       {
         source = pkgs.fetchurl {
           url = "https://www.rsync.net/resources/pubkey.txt";
           sha256 = "16nzqfb1kvsxjkq919hxsawx6ydvip3md3qyhdmw54qx6drnxckl";
         };
-        trust = 2;
+        trust = "never";
       }
     ];
   };


### PR DESCRIPTION
### Description

Allow setting `trust` by name (unknown, never, marginal, full, ultimate) instead of magic value (1-5).

Also make `importTrust` output `y` only when [required](https://github.com/gpg/gnupg/blob/283ccbc824d8062b86e27818a84ab5a29facd7a5/g10/pkclist.c#L332-L335).

cc @MilesBreslin 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
