### PR TITLE
rofi: allow extending themes

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -40,7 +40,12 @@ let
         end = "";
       } name value) + "\n";
 
-  toRasi = attrs: concatStringsSep "\n" (mapAttrsToList mkRasiSection attrs);
+  toRasi = attrs:
+    concatStringsSep "\n" (concatMap (mapAttrsToList mkRasiSection) [
+      (filterAttrs (n: _: n == "@theme") attrs)
+      (filterAttrs (n: _: n == "@import") attrs)
+      (removeAttrs attrs [ "@theme" "@import" ])
+    ]);
 
   locationsMap = {
     center = 0;

--- a/tests/modules/programs/rofi/custom-theme.rasi
+++ b/tests/modules/programs/rofi/custom-theme.rasi
@@ -1,3 +1,5 @@
+@import "~/.cache/wal/colors-rofi-dark"
+
 #inputbar {
 children: [ prompt,entry ];
 }
@@ -15,5 +17,3 @@ border-color: #FFFFFF;
 foreground-color: rgba ( 250, 251, 252, 100 % );
 width: 512;
 }
-
-@import "~/.cache/wal/colors-rofi-dark"


### PR DESCRIPTION
Move `@import` and `@theme` directives to the top of custom theme definitions so as to allow extending other themes.

Without this, a theme like

```nix
{
  "@import" = "default";
  "*".background = background;
}
```

would have the default background colour because `*` sorts before `@`.

@thiagokokada @lilyinstarlight 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
