### PR TITLE
gtk: Add support for GTK4 configuration

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -7,6 +7,7 @@ let
   cfg = config.gtk;
   cfg2 = config.gtk.gtk2;
   cfg3 = config.gtk.gtk3;
+  cfg4 = config.gtk.gtk4;
 
   toGtk3Ini = generators.toINI {
     mkKeyValue = key: value:
@@ -136,6 +137,21 @@ in {
           '';
         };
       };
+
+      gtk4 = {
+        extraConfig = mkOption {
+          type = with types; attrsOf (either bool (either int str));
+          default = { };
+          example = {
+            gtk-cursor-blink = false;
+            gtk-recent-files-limit = 20;
+          };
+          description = ''
+            Extra configuration options to add to
+            <filename>$XDG_CONFIG_HOME/gtk-4.0/settings.ini</filename>.
+          '';
+        };
+      };
     };
   };
 
@@ -180,6 +196,9 @@ in {
     xdg.configFile."gtk-3.0/bookmarks" = mkIf (cfg3.bookmarks != [ ]) {
       text = concatMapStrings (l: l + "\n") cfg3.bookmarks;
     };
+
+    xdg.configFile."gtk-4.0/settings.ini".text =
+      toGtk3Ini { Settings = ini // cfg4.extraConfig; };
 
     dconf.settings."org/gnome/desktop/interface" = dconfIni;
   });


### PR DESCRIPTION
### Description

Fixes https://github.com/nix-community/home-manager/issues/2572 . Adding support to configure GTK4. I use this to prefer dark theme styling:
```
gtk.gtk4.extraConfig = {
  gtk-application-prefer-dark-theme = true;
};
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
