### PR TITLE
Remove gnidorah from maintainers/CODEOWNERS due to being removed from nixpkgs maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 /modules/i18n/input-method                            @Kranzes
 /tests/modules/i18n/input-method                      @Kranzes
 
-/modules/misc/dconf.nix                               @gnidorah @rycee
+/modules/misc/dconf.nix                               @rycee
 
 /modules/misc/fontconfig.nix                          @rycee
 /tests/modules/misc/fontconfig                        @rycee

--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -11,7 +11,7 @@ let
   mkIniKeyValue = key: value: "${key}=${toString (hm.gvariant.mkValue value)}";
 
 in {
-  meta.maintainers = [ maintainers.gnidorah maintainers.rycee ];
+  meta.maintainers = [ maintainers.rycee ];
 
   options = {
     dconf = {


### PR DESCRIPTION
### Description

I removed gnidorah from the maintainers list of dconf and the codeowners file, matching https://github.com/NixOS/nixpkgs/pull/121119.

```
$ nix eval .#homeConfigurations.lun
error: attribute 'gnidorah' missing

       at /nix/store/x594sxkl8gd42rxbispbq924qzk89nj1-source/modules/misc/dconf.nix:14:24:

           13| in {
           14|   meta.maintainers = [ maintainers.gnidorah maintainers.rycee ];
             |                        ^
           15|
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.