### PR TITLE
Fix more missing / removed maintainer entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,7 +92,7 @@
 
 /modules/programs/go.nix                              @rvolosatovs
 
-/modules/programs/hexchat.nix                         @superherointj @thiagokokada
+/modules/programs/hexchat.nix                         @thiagokokada
 /tests/modules/programs/hexchat                       @thiagokokada
 
 /modules/programs/himalaya.nix                        @ambroisie

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           echo "Error: literalExample should be replaced by literalExpression" > /dev/stderr
           exit 1
         fi
+    - run: nix-build -A docs.jsonModuleMaintainers
     - run: ./format -c
     - run: nix-shell . -A install
     - run: nix-shell --arg enableBig false --pure tests -A run.all

--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@ rec {
     html = manual.html;
     manPages = manPages;
     json = options.json;
+    jsonModuleMaintainers = jsonModuleMaintainers; # Unstable, mainly for CI.
   };
 
   home-manager = pkgs.callPackage ./home-manager { path = toString ./.; };

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -117,4 +117,14 @@ in {
   manPages = docs.manPages;
 
   manual = { inherit (docs) html htmlOpenTool; };
+
+  # Unstable, mainly for CI.
+  jsonModuleMaintainers = pkgs.writeText "hm-module-maintainers.json" (let
+    result = lib.evalModules {
+      modules = import ../modules/modules.nix {
+        inherit lib pkgs;
+        check = false;
+      } ++ [ scrubbedPkgsModule ];
+    };
+  in builtins.toJSON result.config.meta.maintainers);
 }

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -163,4 +163,10 @@
     github = "nurelin";
     githubId = 5276274;
   };
+  pltanton = {
+    name = "pltanton";
+    email = "plotnikovanton@gmail.com";
+    github = "pltanton";
+    githubId = 4561823;
+  };
 }

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -157,4 +157,10 @@
     github = "t4ccer";
     githubId = 64430288;
   };
+  nurelin = {
+    name = "nurelin";
+    email = "nurelin@users.noreply.github.com";
+    github = "nurelin";
+    githubId = 5276274;
+  };
 }

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -151,4 +151,10 @@
     github = "aheaume";
     githubId = 13830042;
   };
+  t4ccer = {
+    name = "t4ccer";
+    email = "t4ccer@users.noreply.github.com";
+    github = "t4ccer";
+    githubId = 64430288;
+  };
 }

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -145,4 +145,10 @@
     github = "onny";
     githubId = 757752;
   };
+  aheaume = {
+    name = "aheaume";
+    email = "aheaume@users.noreply.github.com";
+    github = "aheaume";
+    githubId = 13830042;
+  };
 }

--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -147,7 +147,7 @@ let
       extraDesktopEntries = config.settings;
     };
 in {
-  meta.maintainers = with maintainers; [ cwyc ];
+  meta.maintainers = [ hm.maintainers.cwyc ];
 
   options.xdg.desktopEntries = mkOption {
     description = ''

--- a/modules/programs/broot.nix
+++ b/modules/programs/broot.nix
@@ -15,7 +15,7 @@ let
   };
 
 in {
-  meta.maintainers = [ maintainers.aheaume ];
+  meta.maintainers = [ hm.maintainers.aheaume ];
 
   options.programs.broot = {
     enable = mkEnableOption "Broot, a better way to navigate directories";

--- a/modules/programs/exa.nix
+++ b/modules/programs/exa.nix
@@ -15,7 +15,7 @@ let
   };
 
 in {
-  meta.maintainers = [ maintainers.kalhauge ];
+  meta.maintainers = [ hm.maintainers.kalhauge ];
 
   options.programs.exa = {
     enable =

--- a/modules/programs/hexchat.nix
+++ b/modules/programs/hexchat.nix
@@ -229,7 +229,7 @@ let
     ]);
 
 in {
-  meta.maintainers = with maintainers; [ superherointj thiagokokada ];
+  meta.maintainers = with maintainers; [ thiagokokada ];
 
   options.programs.hexchat = with types; {
     enable = mkEnableOption "HexChat, a graphical IRC client";

--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -89,7 +89,7 @@ let
   blank = text "Blank";
 
 in {
-  meta.maintainers = [ maintainers.bjpbakker ];
+  meta.maintainers = [ hm.maintainers.bjpbakker ];
 
   options.programs.htop = {
     enable = mkEnableOption "htop";

--- a/modules/programs/lazygit.nix
+++ b/modules/programs/lazygit.nix
@@ -11,7 +11,7 @@ let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
 in {
-  meta.maintainers = [ maintainers.kalhauge ];
+  meta.maintainers = [ hm.maintainers.kalhauge ];
 
   options.programs.lazygit = {
     enable = mkEnableOption "lazygit, a simple terminal UI for git commands";

--- a/modules/programs/ncmpcpp.nix
+++ b/modules/programs/ncmpcpp.nix
@@ -44,7 +44,7 @@ let
   });
 
 in {
-  meta.maintainers = with maintainers; [ olmokramer ];
+  meta.maintainers = [ hm.maintainers.olmokramer ];
 
   options.programs.ncmpcpp = {
     enable =

--- a/modules/programs/xmobar.nix
+++ b/modules/programs/xmobar.nix
@@ -55,5 +55,5 @@ in {
     xdg.configFile."xmobar/.xmobarrc".text = cfg.extraConfig;
   };
 
-  meta.maintainers = with maintainers; [ t4ccer ];
+  meta.maintainers = [ hm.maintainers.t4ccer ];
 }

--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -128,7 +128,7 @@ let
     '';
 in {
 
-  meta.maintainers = [ maintainers.nurelin ];
+  meta.maintainers = [ hm.maintainers.nurelin ];
 
   options.services.kanshi = {
     enable = mkEnableOption

--- a/modules/services/pasystray.nix
+++ b/modules/services/pasystray.nix
@@ -3,7 +3,7 @@
 with lib;
 
 {
-  meta.maintainers = [ maintainers.pltanton ];
+  meta.maintainers = [ hm.maintainers.pltanton ];
 
   options = {
     services.pasystray = { enable = mkEnableOption "PulseAudio system tray"; };

--- a/modules/services/playerctld.nix
+++ b/modules/services/playerctld.nix
@@ -7,7 +7,7 @@ let
   cfg = config.services.playerctld;
 
 in {
-  meta.maintainers = [ maintainers.fendse ];
+  meta.maintainers = [ hm.maintainers.fendse ];
 
   options.services.playerctld = {
     enable = mkEnableOption "playerctld daemon";

--- a/modules/services/status-notifier-watcher.nix
+++ b/modules/services/status-notifier-watcher.nix
@@ -7,7 +7,7 @@ let
   cfg = config.services.status-notifier-watcher;
 
 in {
-  meta.maintainers = [ maintainers.pltanton ];
+  meta.maintainers = [ hm.maintainers.pltanton ];
 
   options = {
     services.status-notifier-watcher = {

--- a/modules/services/trayer.nix
+++ b/modules/services/trayer.nix
@@ -100,7 +100,7 @@ let
   cfg = config.services.trayer;
 
 in {
-  meta.maintainers = [ maintainers.mager ];
+  meta.maintainers = [ hm.maintainers.mager ];
 
   options = {
     services.trayer = {

--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -5,7 +5,7 @@ with lib;
 let cfg = config.services.wlsunset;
 
 in {
-  meta.maintainers = [ maintainers.matrss ];
+  meta.maintainers = [ hm.maintainers.matrss ];
 
   options.services.wlsunset = {
     enable = mkEnableOption "Whether to enable wlsunset.";


### PR DESCRIPTION
### Description

Many entries in maintainers either had no entry in maintainers.nix, or were missing `hm.`.

One more was removed from nixpkgs' maintainers list and should probably be removed here.

Marked this as a draft so it doesn't ping everyone involved asking for review on Christmas day, it can wait!

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.