### PR TITLE
treewide: use `remove` when possible

### DIFF
--- a/modules/programs/hexchat.nix
+++ b/modules/programs/hexchat.nix
@@ -212,7 +212,7 @@ let
   # Note: Missing option `D=`.
   transformChannel = channelName:
     let channel = cfg.channels.${channelName};
-    in concatStringsSep "\n" (filter (v: v != null) [
+    in concatStringsSep "\n" (remove null [
       "" # leave a space between one server and another
       (transformField "N" channelName)
       (loginMethod channel)

--- a/modules/programs/lf.nix
+++ b/modules/programs/lf.nix
@@ -180,9 +180,8 @@ in {
             "${k} ${if isInt v then toString v else ''"${v}"''}"
         }";
 
-      settingsStr = concatStringsSep "\n" (filter (x: x != "")
-        (mapAttrsToList fmtSetting
-          (builtins.intersectAttrs knownSettings cfg.settings)));
+      settingsStr = concatStringsSep "\n" (remove "" (mapAttrsToList fmtSetting
+        (builtins.intersectAttrs knownSettings cfg.settings)));
 
       fmtCmdMap = before: k: v:
         "${before} ${k}${optionalString (v != null && v != "") " ${v}"}";

--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -158,8 +158,8 @@ let
       genGroupsChannels = group:
         concatStringsSep "\n" (genChannelStrings group.name group.channels);
       # Generate all channel configurations for all groups for this account.
-    in concatStringsSep "\n" (filter (s: s != "")
-      (mapAttrsToList (name: group: genGroupsChannels group) groups));
+    in concatStringsSep "\n"
+    (remove "" (mapAttrsToList (name: group: genGroupsChannels group) groups));
 
   # Given the attr set of groups, return a string which maps channels to groups
   genAccountGroups = groups:
@@ -177,9 +177,9 @@ let
       # of the groups and its consituent channels.
       genGroupsStrings = mapAttrsToList (name: info:
         concatStringsSep "\n" (genGroupChannelString groups.${name})) groups;
-    in concatStringsSep "\n\n" (filter (s: s != "")
-      genGroupsStrings) # filter for the cases of empty groups
-    + "\n"; # Put all strings together.
+      # Join all non-empty groups.
+      combined = concatStringsSep "\n\n" (remove "" genGroupsStrings) + "\n";
+    in combined;
 
   genGroupConfig = name: channels:
     let

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -46,10 +46,10 @@ let
 
   moduleConfigure = {
     packages.home-manager = {
-      start = filter (f: f != null) (map
+      start = remove null (map
         (x: if x ? plugin && x.optional == true then null else (x.plugin or x))
         cfg.plugins);
-      opt = filter (f: f != null)
+      opt = remove null
         (map (x: if x ? plugin && x.optional == true then x.plugin else null)
           cfg.plugins);
     };

--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -136,7 +136,7 @@ in {
 
   config = (let
     customRC = ''
-      ${concatStringsSep "\n" (filter (v: v != "") (mapAttrsToList setExpr
+      ${concatStringsSep "\n" (remove "" (mapAttrsToList setExpr
         (builtins.intersectAttrs knownSettings cfg.settings)))}
 
       ${cfg.extraConfig}

--- a/modules/services/fnott.nix
+++ b/modules/services/fnott.nix
@@ -5,8 +5,7 @@ with lib;
 let
   cfg = config.services.fnott;
 
-  concatStringsSep' = sep: list:
-    concatStringsSep sep (filter (x: x != "") list);
+  concatStringsSep' = sep: list: concatStringsSep sep (remove "" list);
 
   iniFormat = pkgs.formats.ini { };
 in {

--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -56,12 +56,8 @@ rec {
 
   fontConfigStr = let
     toFontStr = { names, style ? "", size ? "" }:
-      optionalString (names != [ ]) concatStringsSep " " (filter (x: x != "") [
-        "font"
-        "pango:${concatStringsSep ", " names}"
-        style
-        size
-      ]);
+      optionalString (names != [ ]) concatStringsSep " "
+      (remove "" [ "font" "pango:${concatStringsSep ", " names}" style size ]);
   in fontCfg:
   if isList fontCfg then
     toFontStr { names = fontCfg; }


### PR DESCRIPTION
### Description

See https://github.com/nix-community/home-manager/pull/2566.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```