### PR TITLE
bash: remove unnecessary shebang and executable bit for dotfiles

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -6,6 +6,13 @@ let
 
   cfg = config.programs.bash;
 
+  writeBashScript = name: text: pkgs.writeTextFile {
+    inherit name text;
+    checkPhase = ''
+      ${pkgs.stdenv.shell} -n $out
+    '';
+  };
+
 in
 
 {
@@ -178,7 +185,7 @@ in
           }
         ));
     in mkIf cfg.enable {
-      home.file.".bash_profile".source = pkgs.writeShellScript "bash_profile" ''
+      home.file.".bash_profile".source = writeBashScript "bash_profile" ''
         # include .profile if it exists
         [[ -f ~/.profile ]] && . ~/.profile
 
@@ -186,7 +193,7 @@ in
         [[ -f ~/.bashrc ]] && . ~/.bashrc
       '';
 
-      home.file.".profile".source = pkgs.writeShellScript "profile" ''
+      home.file.".profile".source = writeBashScript "profile" ''
         . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
         ${sessionVarsStr}
@@ -194,7 +201,7 @@ in
         ${cfg.profileExtra}
       '';
 
-      home.file.".bashrc".source = pkgs.writeShellScript "bashrc" ''
+      home.file.".bashrc".source = writeBashScript "bashrc" ''
         ${cfg.bashrcExtra}
 
         # Commands that should be applied only for interactive shells.
@@ -210,7 +217,7 @@ in
       '';
 
       home.file.".bash_logout" = mkIf (cfg.logoutExtra != "") {
-        source = pkgs.writeShellScript "bash_logout" cfg.logoutExtra;
+        source = writeBashScript "bash_logout" cfg.logoutExtra;
       };
     }
   );

--- a/tests/modules/programs/bash/logout.nix
+++ b/tests/modules/programs/bash/logout.nix
@@ -17,7 +17,7 @@ with lib;
       assertFileContent \
         home-files/.bash_logout \
         ${
-          pkgs.writeShellScript "logout-expected" ''
+          builtins.toFile "logout-expected" ''
             clear-console
           ''
         }

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -18,7 +18,7 @@ with lib;
       assertFileContent \
         home-files/.profile \
         ${
-          pkgs.writeShellScript "session-variables-expected" ''
+          builtins.toFile "session-variables-expected" ''
             . "/home/hm-user/.nix-profile/etc/profile.d/hm-session-vars.sh"
 
             export V1="v1"


### PR DESCRIPTION
### Description

Remove unnecessary shebang and executable bit for bash dotfiles while keeping the syntax checks.

I was not able to run the tests in my setup (without any channels).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
