### PR TITLE
pandoc: Add new module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -176,6 +176,9 @@
 
 /modules/programs/openssh.nix                         @rycee
 
+/modules/programs/pandoc.nix                          @kirelagin
+/tests/modules/programs/pandoc                        @kirelagin
+
 /modules/programs/password-store.nix                  @pacien
 
 /modules/programs/pazi.nix                            @marsam

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2380,6 +2380,13 @@ in
           A new module is available: 'programs.tint2'.
         '';
       }
+
+      {
+        time = "2022-01-22T17:39:20+00:00";
+        message = ''
+          A new module is available: 'programs.pandoc'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -117,6 +117,7 @@ let
     ./programs/octant.nix
     ./programs/offlineimap.nix
     ./programs/opam.nix
+    ./programs/pandoc.nix
     ./programs/password-store.nix
     ./programs/pazi.nix
     ./programs/pet.nix

--- a/modules/programs/pandoc.nix
+++ b/modules/programs/pandoc.nix
@@ -1,0 +1,104 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  cfg = config.programs.pandoc;
+
+  inherit (lib) literalExpression mkEnableOption mkIf mkOption types;
+
+  jsonFormat = pkgs.formats.json { };
+
+  makeTemplateFile = name: file:
+    lib.nameValuePair "pandoc/templates/${name}" { source = file; };
+
+  getFileName = file:
+    # This is actually safe here, since it is just a file name
+    builtins.unsafeDiscardStringContext (baseNameOf file);
+
+  makeCslFile = file:
+    lib.nameValuePair "pandoc/csl/${getFileName file}" { source = file; };
+
+in {
+  meta.maintainers = [ lib.maintainers.kirelagin ];
+
+  options.programs.pandoc = {
+    enable = mkEnableOption "pandoc";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.pandoc;
+      defaultText = literalExpression "pkgs.pandoc";
+      description = "The pandoc package to use.";
+    };
+
+    # We wrap the executable to pass some arguments
+    finalPackage = mkOption {
+      type = types.package;
+      readOnly = true;
+      description = "Resulting package.";
+    };
+
+    defaults = mkOption {
+      type = jsonFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          metadata = {
+            author = "John Doe";
+          };
+          pdf-engine = "xelatex";
+          citeproc = true;
+        }
+      '';
+      description = ''
+        Options to set by default.
+        These will be converted to JSON and written to a defaults
+        file (see Default files in pandoc documentation).
+      '';
+    };
+
+    defaultsFile = mkOption {
+      type = types.path;
+      readOnly = true;
+      description = "Resulting defaults file.";
+    };
+
+    templates = mkOption {
+      type = types.attrsOf types.path;
+      default = { };
+      example = literalExpression ''
+        {
+          "default.latex" = path/to/your/template;
+        }
+      '';
+      description = "Custom templates.";
+    };
+
+    citationStyles = mkOption {
+      type = types.listOf types.path;
+      default = [ ];
+      example = literalExpression "[ path/to/file.csl ]";
+      description = "List of .csl files to install.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.pandoc = {
+      defaultsFile = jsonFormat.generate "hm.json" cfg.defaults;
+
+      finalPackage = pkgs.symlinkJoin {
+        name = "pandoc-with-defaults";
+        paths = [ cfg.package ];
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+        postBuild = ''
+          wrapProgram "$out/bin/pandoc" \
+            --add-flags '--defaults "${cfg.defaultsFile}"'
+        '';
+      };
+    };
+
+    home.packages = [ cfg.finalPackage ];
+    xdg.dataFile = lib.mapAttrs' makeTemplateFile cfg.templates
+      // lib.listToAttrs (map makeCslFile cfg.citationStyles);
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -86,6 +86,7 @@ import nmt {
     ./modules/programs/nix-index
     ./modules/programs/nnn
     ./modules/programs/nushell
+    ./modules/programs/pandoc
     ./modules/programs/pet
     ./modules/programs/powerline-go
     ./modules/programs/qutebrowser

--- a/tests/modules/programs/pandoc/csl.nix
+++ b/tests/modules/programs/pandoc/csl.nix
@@ -1,0 +1,18 @@
+{ config, ... }:
+
+{
+  programs.pandoc = {
+    enable = true;
+
+    citationStyles = [ ./example.csl ];
+  };
+
+  test.stubs.pandoc = import ./stub.nix;
+
+  nmt.script = ''
+    assertFileExists  home-files/.local/share/pandoc/csl/example.csl
+    assertFileContent home-files/.local/share/pandoc/csl/example.csl \
+      ${./example.csl}
+  '';
+}
+

--- a/tests/modules/programs/pandoc/default.nix
+++ b/tests/modules/programs/pandoc/default.nix
@@ -1,0 +1,5 @@
+{
+  pandoc-citation-styles = ./csl.nix;
+  pandoc-defaults = ./defaults.nix;
+  pandoc-templates = ./templates.nix;
+}

--- a/tests/modules/programs/pandoc/defaults-expected.json
+++ b/tests/modules/programs/pandoc/defaults-expected.json
@@ -1,0 +1,7 @@
+{
+  "citeproc": true,
+  "metadata": {
+    "author": "John Doe"
+  },
+  "pdf-engine": "xelatex"
+}

--- a/tests/modules/programs/pandoc/defaults.nix
+++ b/tests/modules/programs/pandoc/defaults.nix
@@ -1,0 +1,30 @@
+{ config, lib, ... }:
+
+let cfg = config.programs.pandoc;
+
+in {
+  config = lib.mkIf config.test.enableBig {
+    programs.pandoc = {
+      enable = true;
+
+      defaults = {
+        metadata = { author = "John Doe"; };
+        pdf-engine = "xelatex";
+        citeproc = true;
+      };
+    };
+
+    nmt.script = ''
+      assertFileContent ${cfg.defaultsFile} ${./defaults-expected.json}
+
+      # Test that defaults are set by looking at the metadata for an empty file
+      # (it should contain the author that we set in defaults).
+      output=$(mktemp)
+      ${cfg.finalPackage}/bin/pandoc --standalone \
+        -f markdown /dev/null \
+        -t native -o "$output"
+      assertFileContent "$output" ${./output-expected}
+    '';
+  };
+}
+

--- a/tests/modules/programs/pandoc/example.csl
+++ b/tests/modules/programs/pandoc/example.csl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-US">
+  <info>
+    <title>A trivial CSL style for tests</title>
+    <id>https://github.com/nix-community/home-manager/tree/master/tests/modules/tools/pandoc/example.csl</id>
+    <link href="https://github.com/nix-community/home-manager/tree/master/tests/modules/tools/pandoc/example.csl" rel="self"/>
+    <link href=""https://www.zotero.org/styles/association-for-computing-machinery rel="independent-parent"/>
+    <link href="http://aem.asm.org/" rel="documentation"/>
+    <category citation-format="numeric"/>
+    <category field="engineering"/>
+  </info>
+</style>

--- a/tests/modules/programs/pandoc/output-expected
+++ b/tests/modules/programs/pandoc/output-expected
@@ -1,0 +1,2 @@
+Pandoc (Meta {unMeta = fromList [("author",MetaString "John Doe")]})
+[]

--- a/tests/modules/programs/pandoc/stub.nix
+++ b/tests/modules/programs/pandoc/stub.nix
@@ -1,0 +1,10 @@
+{
+  name = "pandoc-stub";
+  outPath = null;
+  buildScript = ''
+    mkdir -p "$out"/bin
+    pandoc="$out"/bin/pandoc
+    echo 'Stub to make the wrapper happy' > "$pandoc"
+    chmod a+x "$pandoc"
+  '';
+}

--- a/tests/modules/programs/pandoc/template.latex
+++ b/tests/modules/programs/pandoc/template.latex
@@ -1,0 +1,9 @@
+\documentclass[a4paper]{scrartcl}
+
+$if(title)$\title{$title$}$endif$
+$if(author)$\author{$for(author)$$author$$sep$ \and $endfor$}$endif$
+
+\begin{document}
+\maketitle
+$body$
+\end{document}

--- a/tests/modules/programs/pandoc/templates.nix
+++ b/tests/modules/programs/pandoc/templates.nix
@@ -1,0 +1,18 @@
+{ config, ... }:
+
+{
+  programs.pandoc = {
+    enable = true;
+
+    templates = { "default.latex" = ./template.latex; };
+  };
+
+  test.stubs.pandoc = import ./stub.nix;
+
+  nmt.script = ''
+    assertFileExists  home-files/.local/share/pandoc/templates/default.latex
+    assertFileContent home-files/.local/share/pandoc/templates/default.latex \
+      ${./template.latex}
+  '';
+}
+


### PR DESCRIPTION
### Description

Add a module for pandoc that provides the following:

1. Setting default configuration options.
2. Installing teampltes.
3. Installing citation styles.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
