### PR TITLE
bottom: fix empty-settings test on darwin

### DIFF
--- a/tests/modules/programs/bottom/empty-settings.nix
+++ b/tests/modules/programs/bottom/empty-settings.nix
@@ -9,8 +9,13 @@ with lib;
       package = config.lib.test.mkStubPackage { };
     };
 
-    nmt.script = ''
-      assertPathNotExists home-files/.config/bottom
+    nmt.script = let
+      configDir = if pkgs.stdenv.isDarwin then
+        "home-files/Library/Application Support"
+      else
+        "home-files/.config";
+    in ''
+      assertPathNotExists ${configDir}/bottom
     '';
   };
 }

--- a/tests/modules/programs/bottom/example-settings-expected.toml
+++ b/tests/modules/programs/bottom/example-settings-expected.toml
@@ -1,0 +1,6 @@
+[colors]
+low_battery_color = "red"
+
+[flags]
+avg_cpu = true
+temperature_type = "c"

--- a/tests/modules/programs/bottom/example-settings.nix
+++ b/tests/modules/programs/bottom/example-settings.nix
@@ -26,16 +26,7 @@ with lib;
     in ''
       assertFileContent \
         "${configDir}/bottom/bottom.toml" \
-        ${
-          builtins.toFile "example-settings-expected.toml" ''
-            [colors]
-            low_battery_color = "red"
-
-            [flags]
-            avg_cpu = true
-            temperature_type = "c"
-          ''
-        }
+        ${./example-settings-expected.toml}
     '';
   };
 }


### PR DESCRIPTION
The empty configuration test for the bottom module introduced as of https://github.com/nix-community/home-manager/pull/2323
is not cross platform. Specifically, it silently fails under a darwin environment due to
the configuration file not being generated at $XDG_CONFIG_HOME. This PR add cross platform support
by specifying the platform-dependent configuration directories to check. The expected unit test data
was also extracted to a separate file to differentiate between test data changes and
changes to the test itself.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
