### PR TITLE
home-manager: document the `--version` command option

### DIFF
--- a/docs/man-home-manager.xml
+++ b/docs/man-home-manager.xml
@@ -103,6 +103,10 @@
    </arg>
 
    <arg>
+    --version
+   </arg>
+
+   <arg>
     <group choice="req">
     <arg choice="plain">
      -n
@@ -428,6 +432,16 @@
     <listitem>
      <para>
       Prints usage information for the <command>home-manager</command> tool.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--version</option>
+    </term>
+    <listitem>
+     <para>
+      Prints the version number of the <command>home-manager</command> tool.
      </para>
     </listitem>
    </varlistentry>

--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -293,7 +293,7 @@ _home-manager_completions ()
     Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" \
               "--verbose" "--cores" "--debug" "--impure" "--keep-failed" \
               "--keep-going" "-j" "--max-jobs" "--no-substitute" "--no-out-link" \
-              "--show-trace" "--substitute" "--builders")
+              "--show-trace" "--substitute" "--builders" "--version")
 
     # ^ « home-manager »'s options.
 

--- a/home-manager/completion.fish
+++ b/home-manager/completion.fish
@@ -43,11 +43,12 @@ complete -c home-manager -n "__fish_use_subcommand" -x -a "expire-generations" -
 complete -c home-manager -F -s f -l "file" -d "The home configuration file"
 complete -c home-manager -x -s A -d "Select an expression in the configuration file"
 complete -c home-manager -F -s I -d "Add a path to the Nix expression search path"
-complete -c home-manager -F -l "flake" -d "Use home-manager configuration at specified flake-uri"
+complete -c home-manager -F -l "flake" -d "Use Home Manager configuration at specified flake-uri"
 complete -c home-manager -F -s b -d "Move existing files to new path rather than fail"
 complete -c home-manager -f -s v -l "verbose" -d "Verbose output"
 complete -c home-manager -f -s n -l "dry-run" -d "Do a dry run, only prints what actions would be taken"
 complete -c home-manager -f -s h -l "help" -d "Print this help"
+complete -c home-manager -f -s h -l "version" -d "Print the Home Manager version"
 
 complete -c home-manager -x -l "arg" -d "Override inputs passed to home-manager.nix"
 complete -c home-manager -x -l "argstr" -d "Like --arg but the value is a string"

--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -11,6 +11,7 @@ _arguments \
   '--impure[impure]' \
   '--keep-failed[keep failed]' \
   '--keep-going[keep going]' \
+  '--version[version]' \
   '(-h --help)'{--help,-h}'[help]' \
   '(-v --verbose)'{--verbose,-v}'[verbose]' \
   '(-n --dry-run)'{--dry-run,-n}'[dry run]' \

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -505,11 +505,12 @@ function doHelp() {
     echo "  -A ATTRIBUTE      Optional attribute that selects a configuration"
     echo "                    expression in the configuration file."
     echo "  -I PATH           Add a path to the Nix expression search path."
-    echo "  --flake flake-uri Use home-manager configuration at flake-uri"
+    echo "  --flake flake-uri Use Home Manager configuration at flake-uri"
     echo "  -b EXT            Move existing files to new path rather than fail."
     echo "  -v                Verbose output"
     echo "  -n                Do a dry run, only prints what actions would be taken"
     echo "  -h                Print this help"
+    echo "  --version         Print the Home Manager version"
     echo
     echo "Options passed on to nix-build(1)"
     echo


### PR DESCRIPTION
### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```