### PR TITLE
tests: make `enableBig` an option

### DIFF
--- a/tests/big-test.nix
+++ b/tests/big-test.nix
@@ -1,0 +1,13 @@
+{ lib, ... }:
+
+{
+  options.test.enableBig = lib.mkOption {
+    type = lib.types.bool;
+    default = true;
+    description = ''
+      Whether to enable <quote>big</quote> tests. These are tests that require
+      more resources than typical tests. For example, tests that depend on large
+      packages or tests that take long to run.
+    '';
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -26,7 +26,9 @@ let
       # unnecessary rebuilds of the tests.
       manual.manpages.enable = false;
 
-      imports = [ ./asserts.nix ./stubs.nix ];
+      imports = [ ./asserts.nix ./big-test.nix ./stubs.nix ];
+
+      test.enableBig = enableBig;
     }
   ];
 
@@ -55,6 +57,7 @@ import nmt {
     ./modules/programs/browserpass
     ./modules/programs/dircolors
     ./modules/programs/direnv
+    ./modules/programs/emacs
     ./modules/programs/feh
     ./modules/programs/fish
     ./modules/programs/gh
@@ -101,6 +104,7 @@ import nmt {
   ] ++ lib.optionals isLinux [
     ./modules/config/i18n
     ./modules/i18n/input-method
+    ./modules/misc/debug
     ./modules/misc/gtk
     ./modules/misc/numlock
     ./modules/misc/pam
@@ -109,6 +113,7 @@ import nmt {
     ./modules/misc/xsession
     ./modules/programs/abook
     ./modules/programs/autorandr
+    ./modules/programs/firefox
     ./modules/programs/foot
     ./modules/programs/getmail
     ./modules/programs/gnome-terminal
@@ -152,10 +157,5 @@ import nmt {
     ./modules/services/xsettingsd
     ./modules/systemd
     ./modules/targets-linux
-  ] ++ lib.optionals enableBig [
-    ./modules/programs/emacs
-  ] ++ lib.optionals (enableBig && isLinux) [
-    ./modules/misc/debug
-    ./modules/programs/firefox
   ]);
 }

--- a/tests/modules/misc/debug/default.nix
+++ b/tests/modules/misc/debug/default.nix
@@ -1,25 +1,26 @@
 {
-  debug = { pkgs, config, lib, ... }: {
-    home.enableDebugInfo = true;
-    home.packages = with pkgs; [ curl gdb ];
+  debug = { pkgs, config, lib, ... }:
+    lib.mkIf config.test.enableBig {
+      home.enableDebugInfo = true;
+      home.packages = with pkgs; [ curl gdb ];
 
-    nmt.script = ''
-      [ -L $TESTED/home-path/lib/debug/curl ] \
-        || fail "Debug-symbols for pkgs.curl should exist in \`/home-path/lib/debug'!"
+      nmt.script = ''
+        [ -L $TESTED/home-path/lib/debug/curl ] \
+          || fail "Debug-symbols for pkgs.curl should exist in \`/home-path/lib/debug'!"
 
-      #source $TESTED/home-path/etc/profile.d/hm-session-vars.sh
-      #[[ "$NIX_DEBUG_INFO_DIRS" =~ /lib/debug$ ]] \
-        #|| fail "Invalid NIX_DEBUG_INFO_DIRS!"
-      assertFileExists home-path/etc/profile.d/hm-session-vars.sh
-      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
-          'NIX_DEBUG_INFO_DIRS=.*/lib/debug'
+        #source $TESTED/home-path/etc/profile.d/hm-session-vars.sh
+        #[[ "$NIX_DEBUG_INFO_DIRS" =~ /lib/debug$ ]] \
+          #|| fail "Invalid NIX_DEBUG_INFO_DIRS!"
+        assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+        assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+            'NIX_DEBUG_INFO_DIRS=.*/lib/debug'
 
-      # We need to override NIX_DEBUG_INFO_DIRS here as $HOME evalutes to the home
-      # of the user who executes this testcase :/
-      { echo quit | PATH="$TESTED/home-path/bin''${PATH:+:}$PATH" NIX_DEBUG_INFO_DIRS=$TESTED/home-path/lib/debug \
-        gdb curl 2>&1 | \
-        grep 'Reading symbols from ${builtins.storeDir}/'; \
-      } || fail "Failed to read debug symbols from curl in gdb"
-    '';
-  };
+        # We need to override NIX_DEBUG_INFO_DIRS here as $HOME evalutes to the home
+        # of the user who executes this testcase :/
+        { echo quit | PATH="$TESTED/home-path/bin''${PATH:+:}$PATH" NIX_DEBUG_INFO_DIRS=$TESTED/home-path/lib/debug \
+          gdb curl 2>&1 | \
+          grep 'Reading symbols from ${builtins.storeDir}/'; \
+        } || fail "Failed to read debug symbols from curl in gdb"
+      '';
+    };
 }

--- a/tests/modules/programs/emacs/extra-config.nix
+++ b/tests/modules/programs/emacs/extra-config.nix
@@ -10,7 +10,7 @@ let
 
   emacsBin = "${config.programs.emacs.finalPackage}/bin/emacs";
 
-in {
+in lib.mkIf config.test.enableBig {
   programs.emacs = {
     enable = true;
     package = pkgs.emacs-nox;

--- a/tests/modules/programs/firefox/deprecated-native-messenger.nix
+++ b/tests/modules/programs/firefox/deprecated-native-messenger.nix
@@ -2,37 +2,35 @@
 
 with lib;
 
-{
-  config = {
-    programs.firefox = {
-      enable = true;
-      enableGnomeExtensions = true;
-    };
-
-    nixpkgs.overlays = [
-      (self: super: {
-        firefox-unwrapped = pkgs.runCommandLocal "firefox-0" {
-          meta.description = "I pretend to be Firefox";
-          passthru.gtk3 = null;
-        } ''
-          mkdir -p "$out"/{bin,lib}
-          touch "$out/bin/firefox"
-          chmod 755 "$out/bin/firefox"
-        '';
-
-        chrome-gnome-shell =
-          pkgs.runCommandLocal "dummy-chrome-gnome-shell" { } ''
-            mkdir -p $out/lib/mozilla/native-messaging-hosts
-            touch $out/lib/mozilla/native-messaging-hosts/dummy
-          '';
-      })
-    ];
-
-    test.asserts.warnings.expected = [''
-      Using 'programs.firefox.enableGnomeExtensions' has been deprecated and
-      will be removed in the future. Please change to overriding the package
-      configuration using 'programs.firefox.package' instead. You can refer to
-      its example for how to do this.
-    ''];
+lib.mkIf config.test.enableBig {
+  programs.firefox = {
+    enable = true;
+    enableGnomeExtensions = true;
   };
+
+  nixpkgs.overlays = [
+    (self: super: {
+      firefox-unwrapped = pkgs.runCommandLocal "firefox-0" {
+        meta.description = "I pretend to be Firefox";
+        passthru.gtk3 = null;
+      } ''
+        mkdir -p "$out"/{bin,lib}
+        touch "$out/bin/firefox"
+        chmod 755 "$out/bin/firefox"
+      '';
+
+      chrome-gnome-shell =
+        pkgs.runCommandLocal "dummy-chrome-gnome-shell" { } ''
+          mkdir -p $out/lib/mozilla/native-messaging-hosts
+          touch $out/lib/mozilla/native-messaging-hosts/dummy
+        '';
+    })
+  ];
+
+  test.asserts.warnings.expected = [''
+    Using 'programs.firefox.enableGnomeExtensions' has been deprecated and
+    will be removed in the future. Please change to overriding the package
+    configuration using 'programs.firefox.package' instead. You can refer to
+    its example for how to do this.
+  ''];
 }

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -2,70 +2,67 @@
 
 with lib;
 
-{
-  config = {
-    programs.firefox = {
-      enable = true;
-      profiles.basic.isDefault = true;
+lib.mkIf config.test.enableBig {
+  programs.firefox = {
+    enable = true;
+    profiles.basic.isDefault = true;
 
-      profiles.test = {
-        id = 1;
-        settings = { "general.smoothScroll" = false; };
-      };
-
-      profiles.bookmarks = {
-        id = 2;
-        settings = { "general.smoothScroll" = false; };
-        bookmarks = {
-          wikipedia = {
-            keyword = "wiki";
-            url =
-              "https://en.wikipedia.org/wiki/Special:Search?search=%s&go=Go";
-          };
-          "kernel.org" = { url = "https://www.kernel.org"; };
-        };
-      };
+    profiles.test = {
+      id = 1;
+      settings = { "general.smoothScroll" = false; };
     };
 
-    nixpkgs.overlays = [
-      (self: super: {
-        firefox-unwrapped = pkgs.runCommand "firefox-0" {
-          meta.description = "I pretend to be Firefox";
-          preferLocalBuild = true;
-          passthru.gtk3 = null;
-        } ''
-          mkdir -p "$out"/{bin,lib}
-          touch "$out/bin/firefox"
-          chmod 755 "$out/bin/firefox"
-        '';
-      })
-    ];
-
-    nmt.script = ''
-      assertFileRegex \
-        home-path/bin/firefox \
-        MOZ_APP_LAUNCHER
-
-      assertDirectoryExists home-files/.mozilla/firefox/basic
-
-      assertFileContent \
-        home-files/.mozilla/firefox/test/user.js \
-        ${./profile-settings-expected-user.js}
-
-      bookmarksUserJs=$(normalizeStorePaths \
-        home-files/.mozilla/firefox/bookmarks/user.js)
-
-      assertFileContent \
-        $bookmarksUserJs \
-        ${./profile-settings-expected-bookmarks-user.js}
-
-      bookmarksFile="$(sed -n \
-        '/browser.bookmarks.file/ {s|^.*\(/nix/store[^"]*\).*|\1|;p}' \
-        $TESTED/home-files/.mozilla/firefox/bookmarks/user.js)"
-
-      assertFileContent \
-        $bookmarksFile \
-        ${./profile-settings-expected-bookmarks.html}
-    '';
+    profiles.bookmarks = {
+      id = 2;
+      settings = { "general.smoothScroll" = false; };
+      bookmarks = {
+        wikipedia = {
+          keyword = "wiki";
+          url = "https://en.wikipedia.org/wiki/Special:Search?search=%s&go=Go";
+        };
+        "kernel.org" = { url = "https://www.kernel.org"; };
+      };
+    };
   };
+
+  nixpkgs.overlays = [
+    (self: super: {
+      firefox-unwrapped = pkgs.runCommand "firefox-0" {
+        meta.description = "I pretend to be Firefox";
+        preferLocalBuild = true;
+        passthru.gtk3 = null;
+      } ''
+        mkdir -p "$out"/{bin,lib}
+        touch "$out/bin/firefox"
+        chmod 755 "$out/bin/firefox"
+      '';
+    })
+  ];
+
+  nmt.script = ''
+    assertFileRegex \
+      home-path/bin/firefox \
+      MOZ_APP_LAUNCHER
+
+    assertDirectoryExists home-files/.mozilla/firefox/basic
+
+    assertFileContent \
+      home-files/.mozilla/firefox/test/user.js \
+      ${./profile-settings-expected-user.js}
+
+    bookmarksUserJs=$(normalizeStorePaths \
+      home-files/.mozilla/firefox/bookmarks/user.js)
+
+    assertFileContent \
+      $bookmarksUserJs \
+      ${./profile-settings-expected-bookmarks-user.js}
+
+    bookmarksFile="$(sed -n \
+      '/browser.bookmarks.file/ {s|^.*\(/nix/store[^"]*\).*|\1|;p}' \
+      $TESTED/home-files/.mozilla/firefox/bookmarks/user.js)"
+
+    assertFileContent \
+      $bookmarksFile \
+      ${./profile-settings-expected-bookmarks.html}
+  '';
 }

--- a/tests/modules/programs/firefox/state-version-19_09.nix
+++ b/tests/modules/programs/firefox/state-version-19_09.nix
@@ -2,30 +2,28 @@
 
 with lib;
 
-{
-  config = {
-    home.stateVersion = "19.09";
+lib.mkIf config.test.enableBig {
+  home.stateVersion = "19.09";
 
-    programs.firefox.enable = true;
+  programs.firefox.enable = true;
 
-    nixpkgs.overlays = [
-      (self: super: {
-        firefox-unwrapped = pkgs.runCommand "firefox-0" {
-          meta.description = "I pretend to be Firefox";
-          preferLocalBuild = true;
-          passthru.gtk3 = null;
-        } ''
-          mkdir -p "$out"/{bin,lib}
-          touch "$out/bin/firefox"
-          chmod 755 "$out/bin/firefox"
-        '';
-      })
-    ];
+  nixpkgs.overlays = [
+    (self: super: {
+      firefox-unwrapped = pkgs.runCommand "firefox-0" {
+        meta.description = "I pretend to be Firefox";
+        preferLocalBuild = true;
+        passthru.gtk3 = null;
+      } ''
+        mkdir -p "$out"/{bin,lib}
+        touch "$out/bin/firefox"
+        chmod 755 "$out/bin/firefox"
+      '';
+    })
+  ];
 
-    nmt.script = ''
-      assertFileRegex \
-        home-path/bin/firefox \
-        MOZ_APP_LAUNCHER
-    '';
-  };
+  nmt.script = ''
+    assertFileRegex \
+      home-path/bin/firefox \
+      MOZ_APP_LAUNCHER
+  '';
 }


### PR DESCRIPTION
### Description

This makes it possible to identify the test as big in the test file itself. It also seems like a more natural way to control the test running.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```