### PR TITLE
treewide: make a few more strings translatable

### DIFF
--- a/home-manager/po/home-manager.pot
+++ b/home-manager/po/home-manager.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2021-12-14 18:53+0100\n"
+"POT-Creation-Date: 2022-01-02 11:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -117,19 +117,19 @@ msgstr ""
 msgid "Home Manager is uninstalled but your home.nix is left untouched."
 msgstr ""
 
-#: home-manager/home-manager:645
+#: home-manager/home-manager:646
 msgid "%s: unknown option '%s'"
 msgstr ""
 
-#: home-manager/home-manager:646
+#: home-manager/home-manager:647
 msgid "Run '%s --help' for usage help"
 msgstr ""
 
-#: home-manager/home-manager:680
+#: home-manager/home-manager:681
 msgid "expire-generations expects one argument, got %d."
 msgstr ""
 
-#: home-manager/home-manager:702
+#: home-manager/home-manager:703
 msgid "Unknown command: %s"
 msgstr ""
 

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -585,21 +585,8 @@ in
       else
         ''
           if ! $DRY_RUN_CMD nix-env -i ${cfg.path} ; then
-            cat <<EOF
-
-          Oops, nix-env failed to install your new Home Manager profile!
-
-          Perhaps there is a conflict with a package that was installed using
-          'nix-env -i'? Try running
-
-              nix-env -q
-
-          and if there is a conflicting package you can remove it with
-
-              nix-env -e {package name}
-
-          Then try activating your Home Manager configuration again.
-          EOF
+            echo
+            _iError $'Oops, nix-env failed to install your new Home Manager profile!\n\nPerhaps there is a conflict with a package that was installed using\n"nix-env -i"? Try running\n\n    nix-env -q\n\nand if there is a conflicting package you can remove it with\n\n    nix-env -e {package name}\n\nThen try activating your Home Manager configuration again.'
             exit 1
           fi
         ''

--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -27,17 +27,12 @@ function setupVars() {
         declare -gr oldGenPath
     fi
 
-    $VERBOSE_ECHO "Sanity checking oldGenNum and oldGenPath"
+    $VERBOSE_RUN _i "Sanity checking oldGenNum and oldGenPath"
     if [[ -v oldGenNum && ! -v oldGenPath
             || ! -v oldGenNum && -v oldGenPath ]]; then
-        errorEcho "Invalid profile number and current profile values! These"
-        errorEcho "must be either both empty or both set but are now set to"
-        errorEcho "    '${oldGenNum:-}' and '${oldGenPath:-}'"
-        errorEcho "If you don't mind losing previous profile generations then"
-        errorEcho "the easiest solution is probably to run"
-        errorEcho "   rm $profilesPath/home-manager*"
-        errorEcho "   rm $gcPath/current-home"
-        errorEcho "and trying home-manager switch again. Good luck!"
+        _i $'The previous generation number and path are in conflict! These\nmust be either both empty or both set but are now set to\n\n    \'%s\' and \'%s\'\n\nIf you don\'t mind losing previous profile generations then\nthe easiest solution is probably to run\n\n   rm %s/home-manager*\n   rm %s/current-home\n\nand trying home-manager switch again. Good luck!' \
+           "${oldGenNum:-}" "${oldGenPath:-}" \
+           "$profilesPath" "$gcPath"
         exit 1
     fi
 }
@@ -45,34 +40,35 @@ function setupVars() {
 if [[ -v VERBOSE ]]; then
     export VERBOSE_ECHO=echo
     export VERBOSE_ARG="--verbose"
+    export VERBOSE_RUN=""
 else
     export VERBOSE_ECHO=true
     export VERBOSE_ARG=""
+    export VERBOSE_RUN=true
 fi
 
 _i "Starting Home Manager activation"
 
 # Verify that we can connect to the Nix store and/or daemon. This will
 # also create the necessary directories in profiles and gcroots.
-$VERBOSE_ECHO "Sanity checking Nix"
+$VERBOSE_RUN _i "Sanity checking Nix"
 nix-build --expr '{}' --no-out-link
 
 setupVars
 
 if [[ -v DRY_RUN ]] ; then
-    echo "This is a dry run"
+    _i "This is a dry run"
     export DRY_RUN_CMD=echo
 else
-    $VERBOSE_ECHO "This is a live run"
+    $VERBOSE_RUN _i "This is a live run"
     export DRY_RUN_CMD=""
 fi
 
 if [[ -v VERBOSE ]]; then
-    echo -n "Using Nix version: "
-    nix-env --version
+    _i 'Using Nix version: %s' "$(nix-env --version)"
 fi
 
-$VERBOSE_ECHO "Activation variables:"
+$VERBOSE_RUN _i "Activation variables:"
 if [[ -v oldGenNum ]] ; then
     $VERBOSE_ECHO "  oldGenNum=$oldGenNum"
     $VERBOSE_ECHO "  oldGenPath=$oldGenPath"

--- a/modules/po/hm-modules.pot
+++ b/modules/po/hm-modules.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager Modules\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2021-12-13 00:45+0100\n"
+"POT-Creation-Date: 2022-01-02 11:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,10 +33,66 @@ msgstr ""
 msgid "No change so reusing latest profile generation %s"
 msgstr ""
 
-#: modules/home-environment.nix:633
+#: modules/home-environment.nix:589
+msgid ""
+"Oops, nix-env failed to install your new Home Manager profile!\n"
+"\n"
+"Perhaps there is a conflict with a package that was installed using\n"
+"\"nix-env -i\"? Try running\n"
+"\n"
+"    nix-env -q\n"
+"\n"
+"and if there is a conflicting package you can remove it with\n"
+"\n"
+"    nix-env -e {package name}\n"
+"\n"
+"Then try activating your Home Manager configuration again."
+msgstr ""
+
+#: modules/home-environment.nix:620
 msgid "Activating %s"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:53
+#: modules/lib-bash/activation-init.sh:30
+msgid "Sanity checking oldGenNum and oldGenPath"
+msgstr ""
+
+#: modules/lib-bash/activation-init.sh:33
+msgid ""
+"The previous generation number and path are in conflict! These\n"
+"must be either both empty or both set but are now set to\n"
+"\n"
+"    '%s' and '%s'\n"
+"\n"
+"If you don't mind losing previous profile generations then\n"
+"the easiest solution is probably to run\n"
+"\n"
+"   rm %s/home-manager*\n"
+"   rm %s/current-home\n"
+"\n"
+"and trying home-manager switch again. Good luck!"
+msgstr ""
+
+#: modules/lib-bash/activation-init.sh:50
 msgid "Starting Home Manager activation"
+msgstr ""
+
+#: modules/lib-bash/activation-init.sh:54
+msgid "Sanity checking Nix"
+msgstr ""
+
+#: modules/lib-bash/activation-init.sh:60
+msgid "This is a dry run"
+msgstr ""
+
+#: modules/lib-bash/activation-init.sh:63
+msgid "This is a live run"
+msgstr ""
+
+#: modules/lib-bash/activation-init.sh:68
+msgid "Using Nix version: %s"
+msgstr ""
+
+#: modules/lib-bash/activation-init.sh:71
+msgid "Activation variables:"
 msgstr ""


### PR DESCRIPTION
### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```