### PR TITLE
timidity: Add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -221,6 +221,8 @@
 
 /modules/programs/texlive.nix                         @rycee
 
+/modules/programs/timidity.nix                        @amesgen
+
 /modules/programs/topgrade.nix                        @msfjarvis
 /tests/modules/programs/topgrade                      @msfjarvis
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -7,6 +7,12 @@
 # [1] https://github.com/NixOS/nixpkgs/blob/fca0d6e093c82b31103dc0dacc48da2a9b06e24b/maintainers/maintainer-list.nix#LC1
 
 {
+  amesgen = {
+    name = "amesgen";
+    email = "amesgen@amesgen.de";
+    github = "amesgen";
+    githubId = 15369874;
+  };
   justinlovinger = {
     name = "Justin Lovinger";
     email = "git@justinlovinger.com";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2365,6 +2365,13 @@ in
           A new module is available: 'programs.watson'.
         '';
       }
+
+      {
+        time = "2022-01-22T15:33:42+00:00";
+        message = ''
+          A new module is available: 'programs.timidity'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -142,6 +142,7 @@ let
     ./programs/terminator.nix
     ./programs/termite.nix
     ./programs/texlive.nix
+    ./programs/timidity.nix
     ./programs/tmux.nix
     ./programs/topgrade.nix
     ./programs/urxvt.nix

--- a/modules/programs/timidity.nix
+++ b/modules/programs/timidity.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  cfg = config.programs.timidity;
+
+in {
+  meta.maintainers = [ lib.hm.maintainers.amesgen ];
+
+  options.programs.timidity = {
+    enable = lib.mkEnableOption "timidity, a software MIDI renderer";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.timidity;
+      defaultText = lib.literalExpression "pkgs.timidity";
+      description = "The timidity package to use.";
+    };
+
+    finalPackage = lib.mkOption {
+      readOnly = true;
+      type = lib.types.package;
+      description = "Resulting package.";
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      example = lib.literalExpression ''
+        '''
+          soundfont ''${pkgs.soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2
+        '''
+      '';
+      description = "Extra configuration.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.finalPackage ];
+
+    programs.timidity.finalPackage = pkgs.symlinkJoin {
+      name = "timidity-with-config";
+      paths = [ cfg.package ];
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      postBuild = ''
+        wrapProgram $out/bin/timidity \
+          --add-flags '-c ${pkgs.writeText "timidity.cfg" cfg.extraConfig}'
+      '';
+    };
+  };
+}


### PR DESCRIPTION
### Description

Add a module for timidity, originally inspired by https://discourse.nixos.org/t/adding-soundfont-for-timidity-requires-rebuilding/16784

By default, timidity does not consider any configuration files in `~`, so I did not add an intermediate config file via `home.file` in this case, but I have no strong opinion here.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
