### PR TITLE
swayidle: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -399,3 +399,6 @@
 /tests/modules/targets-darwin                         @midchildan
 
 Makefile                                              @thiagokokada
+
+/modules/services/swayidle.nix                        @c0deaddict
+/tests/modules/services/swayidle                      @c0deaddict

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2336,6 +2336,14 @@ in
           A new module is available: 'xsession.windowManager.herbstluftwm'.
         '';
       }
+
+      {
+        time = "2022-01-03T10:34:45+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.swayidle'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -218,6 +218,7 @@ let
     ./services/spotifyd.nix
     ./services/stalonetray.nix
     ./services/status-notifier-watcher.nix
+    ./services/swayidle.nix
     ./services/sxhkd.nix
     ./services/syncthing.nix
     ./services/systembus-notify.nix

--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -1,0 +1,118 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.swayidle;
+
+  mkTimeout = t:
+    [ "timeout" (toString t.timeout) (escapeShellArg t.command) ]
+    ++ optionals (t.resumeCommand != null) [
+      "resume"
+      (escapeShellArg t.resumeCommand)
+    ];
+
+  mkEvent = e: [ e.event (escapeShellArg e.command) ];
+
+  args = (concatMap mkTimeout cfg.timeouts) ++ (concatMap mkEvent cfg.events)
+    ++ cfg.extraArgs;
+
+in {
+  meta.maintainers = [ maintainers.c0deaddict ];
+
+  options.services.swayidle = let
+
+    timeoutModule = { ... }: {
+      options = {
+        timeout = mkOption {
+          type = types.ints.positive;
+          description = "Timeout in seconds";
+          example = 60;
+        };
+
+        command = mkOption {
+          type = types.str;
+          description = "Command to run after timeout seconds of inactivity";
+        };
+
+        resumeCommand = mkOption {
+          type = with types; nullOr str;
+          default = null;
+          description = "Command to run when there is activity again";
+        };
+      };
+    };
+
+    eventModule = { ... }: {
+      options = {
+        event = mkOption {
+          type = types.enum [ "before-sleep" "after-resume" "lock" "unlock" ];
+          description = "Event name";
+        };
+
+        command = mkOption {
+          type = types.str;
+          description = "Command to run when event occurs";
+        };
+      };
+    };
+
+  in {
+    enable = mkEnableOption "Idle manager for Wayland";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.swayidle;
+      defaultText = literalExpression "pkgs.swayidle";
+      description = "Swayidle package to install.";
+    };
+
+    timeouts = mkOption {
+      type = with types; listOf (submodule timeoutModule);
+      default = [ ];
+      description = "List of commands to run after idle timeout";
+      example = ''
+        [
+          { timeout = 60; command = "swaylock -fF"; }
+        ]
+      '';
+    };
+
+    events = mkOption {
+      type = with types; listOf (submodule eventModule);
+      default = [ ];
+      example = ''
+        [
+          { event = "before-sleep"; command = "swaylock"; }
+          { event = "lock"; command = "lock"; }
+        ]
+      '';
+      description = "Run command on occurence of a event";
+    };
+
+    extraArgs = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      description = "Extra arguments to pass to swayidle";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.swayidle = {
+      Unit = {
+        Description = "Idle manager for Wayland";
+        Documentation = "man:swayidle(1)";
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        Type = "simple";
+        ExecStart =
+          "${cfg.package}/bin/swayidle -w ${concatStringsSep " " args}";
+      };
+
+      Install = { WantedBy = [ "sway-session.target" ]; };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -146,6 +146,7 @@ import nmt {
     ./modules/services/polybar
     ./modules/services/redshift-gammastep
     ./modules/services/screen-locker
+    ./modules/services/swayidle
     ./modules/services/sxhkd
     ./modules/services/syncthing
     ./modules/services/trayer

--- a/tests/modules/services/swayidle/basic-configuration.nix
+++ b/tests/modules/services/swayidle/basic-configuration.nix
@@ -1,0 +1,52 @@
+{ config, pkgs, lib, ... }:
+
+{
+  config = {
+    services.swayidle = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { };
+      timeouts = [
+        {
+          timeout = 50;
+          command = ''notify-send -t 10000 -- "Screen lock in 10 seconds"'';
+        }
+        {
+          timeout = 60;
+          command = "swaylock -fF";
+        }
+        {
+          timeout = 300;
+          command = ''swaymsg "output * dpms off"'';
+          resumeCommand = ''swaymsg "output * dpms on"'';
+        }
+      ];
+      events = [
+        {
+          event = "before-sleep";
+          command = "swaylock -fF";
+        }
+        {
+          event = "lock";
+          command = "swaylock -fF";
+        }
+      ];
+    };
+
+    nmt.script = let
+      escapeForRegex = builtins.replaceStrings [ "'" "*" ] [ "'\\''" "\\*" ];
+      expectedArgs = escapeForRegex (lib.concatStringsSep " " [
+        "-w"
+        "timeout 50 'notify-send -t 10000 -- \"Screen lock in 10 seconds\"'"
+        "timeout 60 'swaylock -fF'"
+        "timeout 300 'swaymsg \"output * dpms off\"' resume 'swaymsg \"output * dpms on\"'"
+        "before-sleep 'swaylock -fF'"
+        "lock 'swaylock -fF'"
+      ]);
+    in ''
+      serviceFile=home-files/.config/systemd/user/swayidle.service
+
+      assertFileExists $serviceFile
+      assertFileRegex $serviceFile 'ExecStart=.*/bin/swayidle ${expectedArgs}'
+    '';
+  };
+}

--- a/tests/modules/services/swayidle/default.nix
+++ b/tests/modules/services/swayidle/default.nix
@@ -1,0 +1,1 @@
+{ swayidle-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

Add module `services.swayidle`. This module has been running stable on my laptop for about a year. I thought it might be nice to contribute it :)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
