### PR TITLE
helix: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,6 +92,9 @@
 
 /modules/programs/go.nix                              @rvolosatovs
 
+/modules/programs/helix.nix                           @Philipp-M
+/tests/modules/programs/helix                         @Philipp-M
+
 /modules/programs/hexchat.nix                         @thiagokokada
 /tests/modules/programs/hexchat                       @thiagokokada
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -169,4 +169,10 @@
     github = "pltanton";
     githubId = 4561823;
   };
+  Philipp-M = {
+    email = "philipp@mildenberger.me";
+    github = "Philipp-M";
+    githubId = 9267430;
+    name = "Philipp Mildenberger";
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2351,6 +2351,13 @@ in
           A new module is available: 'programs.sagemath'.
         '';
       }
+
+      {
+        time = "2022-01-22T14:36:25+00:00";
+        message = ''
+          A new module is available: 'programs.helix'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -72,6 +72,7 @@ let
     ./programs/gnome-terminal.nix
     ./programs/go.nix
     ./programs/gpg.nix
+    ./programs/helix.nix
     ./programs/hexchat.nix
     ./programs/himalaya.nix
     ./programs/home-manager.nix

--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -1,0 +1,151 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.helix;
+  tomlFormat = pkgs.formats.toml { };
+in {
+  meta.maintainers = [ hm.maintainers.Philipp-M ];
+
+  options.programs.helix = {
+    enable = mkEnableOption "helix text editor";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.helix;
+      defaultText = literalExpression "pkgs.helix";
+      description = "The package to use for helix.";
+    };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          theme = "base16";
+          lsp.display-messages = true;
+          keys.normal = {
+            space.space = "file_picker";
+            space.w = ":w";
+            space.q = ":q";
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>$XDG_CONFIG_HOME/helix/config.toml</filename>.
+        </para><para>
+        See <link xlink:href="https://docs.helix-editor.com/configuration.html" />
+        for the full list of options.
+      '';
+    };
+
+    languages = mkOption {
+      type = types.listOf tomlFormat.type;
+      default = [ ];
+      example = [{
+        name = "rust";
+        auto-format = false;
+      }];
+      description = ''
+        Language specific configuration at
+        <filename>$XDG_CONFIG_HOME/helix/languages.toml</filename>.
+        </para><para>
+        See <link xlink:href="https://docs.helix-editor.com/languages.html" />
+        for more information.
+      '';
+    };
+
+    themes = mkOption {
+      type = types.attrsOf tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          base16 = let
+            transparent = "none";
+            gray = "#665c54";
+            dark-gray = "#3c3836";
+            white = "#fbf1c7";
+            black = "#282828";
+            red = "#fb4934";
+            green = "#b8bb26";
+            yellow = "#fabd2f";
+            orange = "#fe8019";
+            blue = "#83a598";
+            magenta = "#d3869b";
+            cyan = "#8ec07c";
+          in {
+            "ui.menu" = transparent;
+            "ui.menu.selected" = { modifiers = [ "reversed" ]; };
+            "ui.linenr" = { fg = gray; bg = dark-gray; };
+            "ui.popup" = { modifiers = [ "reversed" ]; };
+            "ui.linenr.selected" = { fg = white; bg = black; modifiers = [ "bold" ]; };
+            "ui.selection" = { fg = black; bg = blue; };
+            "ui.selection.primary" = { modifiers = [ "reversed" ]; };
+            "comment" = { fg = gray; };
+            "ui.statusline" = { fg = white; bg = dark-gray; };
+            "ui.statusline.inactive" = { fg = dark-gray; bg = white; };
+            "ui.help" = { fg = dark-gray; bg = white; };
+            "ui.cursor" = { modifiers = [ "reversed" ]; };
+            "variable" = red;
+            "variable.builtin" = orange;
+            "constant.numeric" = orange;
+            "constant" = orange;
+            "attributes" = yellow;
+            "type" = yellow;
+            "ui.cursor.match" = { fg = yellow; modifiers = [ "underlined" ]; };
+            "string" = green;
+            "variable.other.member" = red;
+            "constant.character.escape" = cyan;
+            "function" = blue;
+            "constructor" = blue;
+            "special" = blue;
+            "keyword" = magenta;
+            "label" = magenta;
+            "namespace" = blue;
+            "diff.plus" = green;
+            "diff.delta" = yellow;
+            "diff.minus" = red;
+            "diagnostic" = { modifiers = [ "underlined" ]; };
+            "ui.gutter" = { bg = black; };
+            "info" = blue;
+            "hint" = dark-gray;
+            "debug" = dark-gray;
+            "warning" = yellow;
+            "error" = red;
+          };
+        }
+      '';
+      description = ''
+        Each theme is written to
+        <filename>$XDG_CONFIG_HOME/helix/themes/theme-name.toml</filename>.
+        Where the name of each attribute is the theme-name (in the example "base16").
+        </para><para>
+        See <link xlink:href="https://docs.helix-editor.com/themes.html" />
+        for the full list of options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = let
+      settings = {
+        "helix/config.toml" = mkIf (cfg.settings != { }) {
+          source = tomlFormat.generate "helix-config" cfg.settings;
+        };
+        "helix/languages.toml" = mkIf (cfg.languages != [ ]) {
+          source =
+            tomlFormat.generate "helix-config" { language = cfg.languages; };
+        };
+      };
+
+      themes = (mapAttrs' (n: v:
+        nameValuePair "helix/themes/${n}.toml" {
+          source = tomlFormat.generate "helix-theme-${n}" v;
+        }) cfg.themes);
+    in settings // themes;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -64,6 +64,7 @@ import nmt {
     ./modules/programs/gh
     ./modules/programs/git
     ./modules/programs/gpg
+    ./modules/programs/helix
     ./modules/programs/himalaya
     ./modules/programs/htop
     ./modules/programs/i3status

--- a/tests/modules/programs/helix/default.nix
+++ b/tests/modules/programs/helix/default.nix
@@ -1,0 +1,1 @@
+{ helix-example-settings = ./example-settings.nix; }

--- a/tests/modules/programs/helix/example-settings.nix
+++ b/tests/modules/programs/helix/example-settings.nix
@@ -1,0 +1,118 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.helix = {
+      enable = true;
+
+      settings = {
+        theme = "base16";
+        lsp.display-messages = true;
+        keys.normal = {
+          space.space = "file_picker";
+          space.w = ":w";
+          space.q = ":q";
+        };
+      };
+
+      languages = [{
+        name = "rust";
+        auto-format = false;
+      }];
+
+      themes = {
+        base16 = let
+          transparent = "none";
+          gray = "#665c54";
+          dark-gray = "#3c3836";
+          white = "#fbf1c7";
+          black = "#282828";
+          red = "#fb4934";
+          green = "#b8bb26";
+          yellow = "#fabd2f";
+          orange = "#fe8019";
+          blue = "#83a598";
+          magenta = "#d3869b";
+          cyan = "#8ec07c";
+        in {
+          "ui.menu" = transparent;
+          "ui.menu.selected" = { modifiers = [ "reversed" ]; };
+          "ui.linenr" = {
+            fg = gray;
+            bg = dark-gray;
+          };
+          "ui.popup" = { modifiers = [ "reversed" ]; };
+          "ui.linenr.selected" = {
+            fg = white;
+            bg = black;
+            modifiers = [ "bold" ];
+          };
+          "ui.selection" = {
+            fg = black;
+            bg = blue;
+          };
+          "ui.selection.primary" = { modifiers = [ "reversed" ]; };
+          "comment" = { fg = gray; };
+          "ui.statusline" = {
+            fg = white;
+            bg = dark-gray;
+          };
+          "ui.statusline.inactive" = {
+            fg = dark-gray;
+            bg = white;
+          };
+          "ui.help" = {
+            fg = dark-gray;
+            bg = white;
+          };
+          "ui.cursor" = { modifiers = [ "reversed" ]; };
+          "variable" = red;
+          "variable.builtin" = orange;
+          "constant.numeric" = orange;
+          "constant" = orange;
+          "attributes" = yellow;
+          "type" = yellow;
+          "ui.cursor.match" = {
+            fg = yellow;
+            modifiers = [ "underlined" ];
+          };
+          "string" = green;
+          "variable.other.member" = red;
+          "constant.character.escape" = cyan;
+          "function" = blue;
+          "constructor" = blue;
+          "special" = blue;
+          "keyword" = magenta;
+          "label" = magenta;
+          "namespace" = blue;
+          "diff.plus" = green;
+          "diff.delta" = yellow;
+          "diff.minus" = red;
+          "diagnostic" = { modifiers = [ "underlined" ]; };
+          "ui.gutter" = { bg = black; };
+          "info" = blue;
+          "hint" = dark-gray;
+          "debug" = dark-gray;
+          "warning" = yellow;
+          "error" = red;
+        };
+      };
+    };
+
+    test.stubs.helix = { };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/helix/config.toml \
+        ${./settings-expected.toml}
+      assertFileContent \
+        home-files/.config/helix/languages.toml \
+        ${./languages-expected.toml}
+      assertFileContent \
+        home-files/.config/helix/themes/base16.toml \
+        ${./theme-base16-expected.toml}
+    '';
+  };
+}

--- a/tests/modules/programs/helix/languages-expected.toml
+++ b/tests/modules/programs/helix/languages-expected.toml
@@ -1,0 +1,3 @@
+[[language]]
+auto-format = false
+name = "rust"

--- a/tests/modules/programs/helix/settings-expected.toml
+++ b/tests/modules/programs/helix/settings-expected.toml
@@ -1,0 +1,11 @@
+theme = "base16"
+
+[keys]
+[keys.normal]
+[keys.normal.space]
+q = ":q"
+space = "file_picker"
+w = ":w"
+
+[lsp]
+display-messages = true

--- a/tests/modules/programs/helix/theme-base16-expected.toml
+++ b/tests/modules/programs/helix/theme-base16-expected.toml
@@ -1,0 +1,74 @@
+attributes = "#fabd2f"
+constant = "#fe8019"
+"constant.character.escape" = "#8ec07c"
+"constant.numeric" = "#fe8019"
+constructor = "#83a598"
+debug = "#3c3836"
+"diff.delta" = "#fabd2f"
+"diff.minus" = "#fb4934"
+"diff.plus" = "#b8bb26"
+error = "#fb4934"
+function = "#83a598"
+hint = "#3c3836"
+info = "#83a598"
+keyword = "#d3869b"
+label = "#d3869b"
+namespace = "#83a598"
+special = "#83a598"
+string = "#b8bb26"
+type = "#fabd2f"
+"ui.menu" = "none"
+variable = "#fb4934"
+"variable.builtin" = "#fe8019"
+"variable.other.member" = "#fb4934"
+warning = "#fabd2f"
+
+[comment]
+fg = "#665c54"
+
+[diagnostic]
+modifiers = ["underlined"]
+
+["ui.cursor"]
+modifiers = ["reversed"]
+
+["ui.cursor.match"]
+fg = "#fabd2f"
+modifiers = ["underlined"]
+
+["ui.gutter"]
+bg = "#282828"
+
+["ui.help"]
+bg = "#fbf1c7"
+fg = "#3c3836"
+
+["ui.linenr"]
+bg = "#3c3836"
+fg = "#665c54"
+
+["ui.linenr.selected"]
+bg = "#282828"
+fg = "#fbf1c7"
+modifiers = ["bold"]
+
+["ui.menu.selected"]
+modifiers = ["reversed"]
+
+["ui.popup"]
+modifiers = ["reversed"]
+
+["ui.selection"]
+bg = "#83a598"
+fg = "#282828"
+
+["ui.selection.primary"]
+modifiers = ["reversed"]
+
+["ui.statusline"]
+bg = "#3c3836"
+fg = "#fbf1c7"
+
+["ui.statusline.inactive"]
+bg = "#fbf1c7"
+fg = "#3c3836"


### PR DESCRIPTION
### Description

Adds helix-editor as module supporting the options settings, languages and themes and package.

This currently requires (and is tested with) helix-editor from master (using the current https://docs.helix-editor.com/ as reference), which is why I marked this as a draft (I'm not sure what helix-editor 0.5 supports, and it's not officially documented AFAIK)

Apart from this version issue, this PR is ready to merge.
I'm not sure if it makes sense to merge this as is, or to wait for a new release of helix.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
