### PR TITLE
direnv: Add fish shell hook

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -112,5 +112,12 @@ in {
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
       eval "$(${pkgs.direnv}/bin/direnv hook zsh)"
     '';
+
+    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration (
+      # Using mkAfter to make it more likely to appear after other
+      # manipulations of the prompt.
+      mkAfter ''
+        ${pkgs.direnv}/bin/direnv hook fish | source
+      '');
   };
 }


### PR DESCRIPTION
### Description

Add direnv hook to fish shell. 

The end result is that the auto-generated `~/.config/fish/config.fish` will have `/nix/store/<hash>-direnv-<ver>/bin/direnv hook fish | source` to initiate direnv's fish hook (see: https://direnv.net/docs/hook.html#fish)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
