### PR TITLE
neovim: add `extraLuaPackages` to neovim, fixes #1964.

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -16,6 +16,17 @@ let
     merge = mergeOneOption;
   };
 
+  # Currently, upstream Neovim is pinned on Lua 5.1 for LuaJIT support.
+  # This will need to be updated if Neovim ever migrates to a newer
+  # version of Lua.
+  extraLua51PackageType = mkOptionType {
+    name = "extra-lua51-packages";
+    description = "lua5.1 packages in lua5_1.withPackages format";
+    check = with types;
+      (x: if isFunction x then isList (x pkgs.lua51Packages) else false);
+    merge = mergeOneOption;
+  };
+
   pluginWithConfigType = types.submodule {
     options = {
       config = mkOption {
@@ -58,6 +69,16 @@ let
 
   extraMakeWrapperArgs = lib.optionalString (cfg.extraPackages != [ ])
     ''--suffix PATH : "${lib.makeBinPath cfg.extraPackages}"'';
+  extraMakeWrapperLuaCArgs = lib.optionalString (cfg.extraLuaPackages != [ ]) ''
+    --suffix LUA_CPATH ";" "${
+      lib.concatMapStringsSep ";" pkgs.lua51Packages.getLuaCPath
+      cfg.extraLuaPackages
+    }"'';
+  extraMakeWrapperLuaArgs = lib.optionalString (cfg.extraLuaPackages != [ ]) ''
+    --suffix LUA_PATH ";" "${
+      lib.concatMapStringsSep ";" pkgs.lua51Packages.getLuaPath
+      cfg.extraLuaPackages
+    }"'';
 
 in {
   imports = [
@@ -129,6 +150,17 @@ in {
         description = ''
           A function in python.withPackages format, which returns a
           list of Python 3 packages required for your plugins to work.
+        '';
+      };
+
+      extraLuaPackages = mkOption {
+        type = with types; either extraLua51PackageType (listOf package);
+        default = [ ];
+        defaultText = "[]";
+        example = literalExpression "(ps: with ps; [ luautf8 ])";
+        description = ''
+          A function in lua5_1.withPackages format, which returns a
+          list of Lua packages required for your plugins to work.
         '';
       };
 
@@ -303,7 +335,8 @@ in {
     programs.neovim.finalPackage = pkgs.wrapNeovimUnstable cfg.package
       (neovimConfig // {
         wrapperArgs = (lib.escapeShellArgs neovimConfig.wrapperArgs) + " "
-          + extraMakeWrapperArgs;
+          + extraMakeWrapperArgs + " " + extraMakeWrapperLuaCArgs + " "
+          + extraMakeWrapperLuaArgs;
         wrapRc = false;
       });
 

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -20,6 +20,7 @@ with lib;
           '';
         }
       ];
+      extraLuaPackages = [ pkgs.lua51Packages.luautf8 ];
     };
 
     nmt.script = ''


### PR DESCRIPTION
### Description

Extend neovim program to allow specifying additional lua libraries that will become available to neovim at runtime.  See #1964 for further details.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/doc/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

This is a rebased version of the #1970 which got closed by some reason, without being merged.  Can we please merge this? @teto ?

