### PR TITLE
kime: Fix kime systemd service broken

### DIFF
--- a/modules/i18n/input-method/kime.nix
+++ b/modules/i18n/input-method/kime.nix
@@ -48,11 +48,12 @@ in {
       replaceStrings [ "\\\\" ] [ "\\" ] (builtins.toJSON cfg.config);
 
     systemd.user.services.kime-daemon = {
-      Unit = { Description = "Kime input method editor"; };
-      PartOf = [ "graphical-session.target" ];
+      Unit = {
+        Description = "Kime input method editor";
+        PartOf = [ "graphical-session.target" ];
+      };
       Service.ExecStart = "${pkgs.kime}/bin/kime";
       Install.WantedBy = [ "graphical-session.target" ];
     };
   };
-
 }

--- a/tests/modules/i18n/input-method/default.nix
+++ b/tests/modules/i18n/input-method/default.nix
@@ -1,1 +1,4 @@
-{ input-method-fcitx5-configuration = ./fcitx5-configuration.nix; }
+{
+  input-method-fcitx5-configuration = ./fcitx5-configuration.nix;
+  input-method-kime-configuration = ./kime-configuration.nix;
+}

--- a/tests/modules/i18n/input-method/kime-configuration.nix
+++ b/tests/modules/i18n/input-method/kime-configuration.nix
@@ -6,7 +6,7 @@
     kime.config = { engine = { hangul = { layout = "dubeolsik"; }; }; };
   };
 
-  test.stubs.kime = { };
+  test.stubs.kime = { outPath = null; };
 
   nmt.script = ''
     assertFileExists home-files/.config/systemd/user/kime-daemon.service

--- a/tests/modules/i18n/input-method/kime-configuration.nix
+++ b/tests/modules/i18n/input-method/kime-configuration.nix
@@ -6,6 +6,8 @@
     kime.config = { engine = { hangul = { layout = "dubeolsik"; }; }; };
   };
 
+  test.stubs.kime = { };
+
   nmt.script = ''
     assertFileExists home-files/.config/systemd/user/kime-daemon.service
   '';

--- a/tests/modules/i18n/input-method/kime-configuration.nix
+++ b/tests/modules/i18n/input-method/kime-configuration.nix
@@ -3,13 +3,7 @@
 {
   i18n.inputMethod = {
     enabled = "kime";
-    kime.config = {
-      engine = {
-        hangul = {
-          layout = "dubeolsik";
-        };
-      };
-    };
+    kime.config = { engine = { hangul = { layout = "dubeolsik"; }; }; };
   };
 
   nmt.script = ''

--- a/tests/modules/i18n/input-method/kime-configuration.nix
+++ b/tests/modules/i18n/input-method/kime-configuration.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, ... }:
+
+{
+  i18n.inputMethod = {
+    enabled = "kime";
+    kime.config = {
+      engine = {
+        hangul = {
+          layout = "dubeolsik";
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/systemd/user/kime-daemon.service
+  '';
+}


### PR DESCRIPTION
### Description

Fix `i18n.inputMethod.kime` systemd service. (`PartOf` -> `Unit.PartOf`)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
