### PR TITLE
nix: add module

### DIFF
--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -1,0 +1,86 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.nix;
+
+in {
+  options.nix = {
+    registry = mkOption {
+      type = types.attrsOf (types.submodule (let
+        inputAttrs = types.attrsOf
+          (types.oneOf [ types.str types.int types.bool types.package ]);
+      in { config, name, ... }: {
+        options = {
+          from = mkOption {
+            type = inputAttrs;
+            example = {
+              type = "indirect";
+              id = "nixpkgs";
+            };
+            description = "The flake reference to be rewritten.";
+          };
+          to = mkOption {
+            type = inputAttrs;
+            example = {
+              type = "github";
+              owner = "my-org";
+              repo = "my-nixpkgs";
+            };
+            description =
+              "The flake reference to which <option>from></option> is to be rewritten.";
+          };
+          flake = mkOption {
+            type = types.nullOr types.attrs;
+            default = null;
+            example = literalExpression "nixpkgs";
+            description = ''
+              The flake input to which <option>from></option> is to be rewritten.
+            '';
+          };
+          exact = mkOption {
+            type = types.bool;
+            default = true;
+            description = ''
+              Whether the <option>from</option> reference needs to match exactly. If set,
+              a <option>from</option> reference like <literal>nixpkgs</literal> does not
+              match with a reference like <literal>nixpkgs/nixos-20.03</literal>.
+            '';
+          };
+        };
+        config = {
+          from = mkDefault {
+            type = "indirect";
+            id = name;
+          };
+          to = mkIf (config.flake != null) ({
+            type = "path";
+            path = config.flake.outPath;
+          } // lib.filterAttrs (n: v:
+            n == "lastModified" || n == "rev" || n == "revCount" || n
+            == "narHash") config.flake);
+        };
+      }));
+      default = { };
+      description = ''
+        User level flake registry.
+      '';
+    };
+    registryVersion = mkOption {
+      type = types.int;
+      default = 2;
+      internal = true;
+      description = "The flake registry format version.";
+    };
+  };
+
+  config = mkIf (cfg.registry != { }) {
+    xdg.configFile."nix/registry.json".text = builtins.toJSON {
+      version = cfg.registryVersion;
+      flakes =
+        mapAttrsToList (n: v: { inherit (v) from to exact; }) cfg.registry;
+    };
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -250,6 +250,7 @@ let
     ./xcursor.nix
     ./xresources.nix
     ./xsession.nix
+    ./misc/nix.nix
     (pkgs.path + "/nixos/modules/misc/assertions.nix")
     (pkgs.path + "/nixos/modules/misc/meta.nix")
   ] ++ optional useNixpkgsModule ./misc/nixpkgs.nix


### PR DESCRIPTION
### Description

Adds `nix.registry` option to allow users to generate the user registry `~/.config/nix/registry.json` (the precedence of this file can be found at: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-registry.html#description)

This should be useful for non-NixOS users as it will make it easier for them to generate this file and set flake registry overrides, and for NixOS users they will be able to set user level overrides.

This was lifted with love from https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/misc/nix-daemon.nix#L503-L553

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
