### PR TITLE
ion: Add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -402,3 +402,5 @@ Makefile                                              @thiagokokada
 
 /modules/services/swayidle.nix                        @c0deaddict
 /tests/modules/services/swayidle                      @c0deaddict
+
+/modules/programs/ion.nix                             @jo1gi

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -79,6 +79,7 @@ let
     ./programs/i3status-rust.nix
     ./programs/i3status.nix
     ./programs/info.nix
+    ./programs/ion.nix
     ./programs/irssi.nix
     ./programs/java.nix
     ./programs/jq.nix

--- a/modules/programs/exa.nix
+++ b/modules/programs/exa.nix
@@ -32,5 +32,6 @@ in {
 
     programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
 
+    programs.ion.shellAliases = mkIf cfg.enableAliases aliases;
   };
 }

--- a/modules/programs/ion.nix
+++ b/modules/programs/ion.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.ion;
+
+  aliasesStr = concatStringsSep "\n"
+    (mapAttrsToList (k: v: "alias ${k} = ${escapeShellArg v}")
+      cfg.shellAliases);
+in {
+  meta.maintainers = [ maintainers.jo1gi ];
+
+  options.programs.ion = {
+    enable = mkEnableOption "The Ion Shell. Compatible with Redox and Linux.";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.ion;
+      defaultText = literalExpression "pkgs.ion";
+      description = ''
+        The ion package to install. May be used to change the version.
+      '';
+    };
+
+    initExtra = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Ion script which is called during ion initialization
+      '';
+    };
+
+    shellAliases = mkOption {
+      type = with types; attrsOf str;
+      default = { };
+      example = literalExpression ''
+        {
+          g = "git";
+        }
+      '';
+      description = ''
+        An attribute set that maps aliases (the top level attribute names
+        in this option) to command strings or directly to build outputs.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."ion/initrc".text = ''
+      # Aliases
+      ${aliasesStr}
+
+      ${cfg.initExtra}
+    '';
+  };
+}

--- a/modules/programs/ion.nix
+++ b/modules/programs/ion.nix
@@ -12,7 +12,7 @@ in {
   meta.maintainers = [ maintainers.jo1gi ];
 
   options.programs.ion = {
-    enable = mkEnableOption "The Ion Shell. Compatible with Redox and Linux.";
+    enable = mkEnableOption "the Ion Shell. Compatible with Redox and Linux";
 
     package = mkOption {
       type = types.package;

--- a/modules/programs/ion.nix
+++ b/modules/programs/ion.nix
@@ -27,7 +27,7 @@ in {
       type = types.lines;
       default = "";
       description = ''
-        Ion script which is called during ion initialization
+        Ion script which is called during ion initialization.
       '';
     };
 

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -81,6 +81,14 @@ in {
         Whether to enable Fish integration.
       '';
     };
+
+    enableIonIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Ion integration.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -105,6 +113,12 @@ in {
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
       if test "$TERM" != "dumb"  -a \( -z "$INSIDE_EMACS"  -o "$INSIDE_EMACS" = "vterm" \)
         eval (${starshipCmd} init fish)
+      end
+    '';
+
+    programs.ion.initExtra = mkIf cfg.enableIonIntegration ''
+      if test $TERM != "dumb" && not exists -s INSIDE_EMACS || test $INSIDE_EMACS = "vterm"
+        eval $(${starshipCmd} init ion)
       end
     '';
   };


### PR DESCRIPTION
Add basic configuration options for ion shell with support for exa and starship.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
