### PR TITLE
skim: use cfg.package in shell integrations

### DIFF
--- a/modules/programs/skim.nix
+++ b/modules/programs/skim.nix
@@ -124,20 +124,20 @@ in {
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
-        . ${pkgs.skim}/share/skim/completion.bash
-        . ${pkgs.skim}/share/skim/key-bindings.bash
+        . ${cfg.package}/share/skim/completion.bash
+        . ${cfg.package}/share/skim/key-bindings.bash
       fi
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
       if [[ $options[zle] = on ]]; then
-        . ${pkgs.skim}/share/skim/completion.zsh
-        . ${pkgs.skim}/share/skim/key-bindings.zsh
+        . ${cfg.package}/share/skim/completion.zsh
+        . ${cfg.package}/share/skim/key-bindings.zsh
       fi
     '';
 
     programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
-      source ${pkgs.skim}/share/skim/key-bindings.fish && skim_key_bindings
+      source ${cfg.package}/share/skim/key-bindings.fish && skim_key_bindings
     '';
   };
 }


### PR DESCRIPTION
### Description

Closes https://github.com/nix-community/home-manager/issues/2627

I hastily merged the previous Skim PR without looking at the entire file.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
