### PR TITLE
gh: remove git overlay in tests

### DIFF
--- a/tests/modules/programs/gh/credential-helper.nix
+++ b/tests/modules/programs/gh/credential-helper.nix
@@ -8,10 +8,7 @@
 
   programs.git.enable = true;
 
-  test.stubs = {
-    gh = { };
-    git = { };
-  };
+  test.stubs.gh = { };
 
   nmt.script = ''
     assertFileExists home-files/.config/git/config


### PR DESCRIPTION
### Description

See https://github.com/nix-community/home-manager/pull/2628#issuecomment-1009558143

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
