### PR TITLE
docs: clarify stand-alone installation instructions

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -62,14 +62,15 @@ $ nix-channel --add https://github.com/nix-community/home-manager/archive/releas
 $ nix-channel --update
 ----
 +
-On NixOS you may need to log out and back in for the channel to become
-available. On non-NixOS you may have to add
+On non-NixOS, you may have to add
 +
 [source,bash]
-export NIX_PATH=$HOME/.nix-defexpr/channels${NIX_PATH:+:}$NIX_PATH
+export NIX_PATH=$HOME/.nix-defexpr/channels:/nix/var/nix/profiles/per-user/root/channels${NIX_PATH:+:$NIX_PATH}
 +
-to your shell (see
-https://github.com/NixOS/nix/issues/2033[nix#2033]).
+to your shell (see https://github.com/NixOS/nix/issues/2033[nix#2033]
+and
+https://discourse.nixos.org/t/where-is-nix-path-supposed-to-be-set/16434/8[this
+reply on the Nix Discourse]).
 
 3. Run the Home Manager installation command and create the first Home
 Manager generation:


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This includes the root Nix channels in `NIX_PATH` in the instructions for setting up Home Manager on non-NixOS (at the end of the second step under [Standalone installation](https://nix-community.github.io/home-manager/index.html#sec-install-standalone)). On system-wide Nix installations, the `nixpkgs` channel is located in `/nix/var/nix/profiles/per-user/root/channels` (instead of `~/.nix-defexpr/channels`), which is now by default not included in `NIX_PATH` on non-NixOS. Mentioning that it must be added manually should help users running into #2564.

This also links to a reply on the NixOS Discourse that explains the `NIX_PATH`-related changes made to Nix and removes the note on logging out and back in on NixOS as that does not seem necessary (please correct me if I'm wrong).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.


- [ ] Code formatted with `./format`.
- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
