### PR TITLE
kitty: Allow package to be configurable

### DIFF
--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -32,6 +32,15 @@ in {
   options.programs.kitty = {
     enable = mkEnableOption "Kitty terminal emulator";
 
+    package = mkOption {
+      type = types.package;
+      default = pkgs.kitty;
+      defaultText = literalExample "pkgs.kitty";
+      description = ''
+        Kitty package to install.
+      '';
+    };
+
     darwinLaunchOptions = mkOption {
       type = types.nullOr (types.listOf types.str);
       default = null;
@@ -108,7 +117,7 @@ in {
       '';
     }];
 
-    home.packages = [ pkgs.kitty ] ++ optionalPackage cfg.font;
+    home.packages = [ cfg.package ] ++ optionalPackage cfg.font;
 
     xdg.configFile."kitty/kitty.conf" = {
       text = ''

--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -35,7 +35,7 @@ in {
     package = mkOption {
       type = types.package;
       default = pkgs.kitty;
-      defaultText = literalExample "pkgs.kitty";
+      defaultText = literalExpression "pkgs.kitty";
       description = ''
         Kitty package to install.
       '';


### PR DESCRIPTION
### Description

Add an option to specify which kitty package should be installed.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
