### PR TITLE
kakoune: fix ui options

### DIFF
--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -530,20 +530,20 @@ let
 
     uiOptions = with cfg.config.ui;
       concatStringsSep " " [
-        "ncurses_set_title=${if setTitle then "true" else "false"}"
-        "ncurses_status_on_top=${
+        "terminal_set_title=${if setTitle then "true" else "false"}"
+        "terminal_status_on_top=${
           if (statusLine == "top") then "true" else "false"
         }"
-        "ncurses_assistant=${assistant}"
-        "ncurses_enable_mouse=${if enableMouse then "true" else "false"}"
-        "ncurses_change_colors=${if changeColors then "true" else "false"}"
+        "terminal_assistant=${assistant}"
+        "terminal_enable_mouse=${if enableMouse then "true" else "false"}"
+        "terminal_change_colors=${if changeColors then "true" else "false"}"
         "${optionalString (wheelDownButton != null)
-        "ncurses_wheel_down_button=${wheelDownButton}"}"
+        "terminal_wheel_down_button=${wheelDownButton}"}"
         "${optionalString (wheelUpButton != null)
-        "ncurses_wheel_up_button=${wheelUpButton}"}"
+        "terminal_wheel_up_button=${wheelUpButton}"}"
         "${optionalString (shiftFunctionKeys != null)
-        "ncurses_shift_function_key=${toString shiftFunctionKeys}"}"
-        "ncurses_builtin_key_parser=${
+        "terminal_shift_function_key=${toString shiftFunctionKeys}"}"
+        "terminal_builtin_key_parser=${
           if useBuiltinKeyParser then "true" else "false"
         }"
       ];


### PR DESCRIPTION
### Description

These were renamed in v2021.08.28, commit [7e66846172165eb1f860f26f51f7a20790b0af29](https://github.com/mawww/kakoune/commit/7e66846172165eb1f860f26f51f7a20790b0af29#diff-7b9337fcff3141736997afd31f7a2764b3538153922282c8407af5f43d543cab).

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.kakoune-{no-plugins,use-plugins,whitespace-highlighter,whitespace-highlighter-corner-cases}`.
    `xdg-desktop-entries` fails but that is unrelated (fails on `master` as well).
- [x] Commit messages are formatted like
    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.