### PR TITLE
modules/misc/news.nix: fix instructions

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -898,7 +898,7 @@ in
 
           Note, on NixOS you may need to add
 
-              services.dbus.packages = with pkgs; [ gnome3.dconf ];
+              services.dbus.packages = with pkgs; [ dconf ];
 
           to the system configuration for this module to work as
           expected. In particular if you get the error message


### PR DESCRIPTION
The gnome3.dconf alias doesn't exist anymore, it's now in pkgs.dconf
directly.