### PR TITLE
bspwm: set _JAVA_AWT_WM_NONREPARENTING in xsession.profileExtra

### DIFF
--- a/modules/services/window-managers/bspwm/default.nix
+++ b/modules/services/window-managers/bspwm/default.nix
@@ -65,6 +65,12 @@ in {
       ${concatMapStringsSep "\n" formatStartupProgram cfg.startupPrograms}
     '';
 
+    # for applications not started by bspwm, e.g. sxhkd
+    xsession.profileExtra = ''
+      # java gui fixes
+      export _JAVA_AWT_WM_NONREPARENTING=1
+    '';
+
     xsession.windowManager.command =
       "${cfg.package}/bin/bspwm -c ${config.xdg.configHome}/bspwm/bspwmrc";
   };


### PR DESCRIPTION
Otherwise the fix doesn't affect applications launched via sxhkd.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
