### PR TITLE
flake: remove default stateVersion in lib.homeManagerConfiguration

### DIFF
--- a/docs/release-notes/rl-2205.adoc
+++ b/docs/release-notes/rl-2205.adoc
@@ -10,6 +10,9 @@ This is the current unstable branch and the information in this section is there
 
 This release has the following notable changes:
 
+* The <<opt-home.stateVersion>> option no longer has a default value of `18.09`.
+This option must now be set.
+
 * The `programs.waybar.settings.modules` option was removed.
 Waybar modules should now be declared directly under `programs.waybar.settings`.
 

--- a/flake.nix
+++ b/flake.nix
@@ -43,9 +43,9 @@
       lib = {
         hm = import ./modules/lib { lib = nixpkgs.lib; };
         homeManagerConfiguration = { configuration, system, homeDirectory
-          , username, extraModules ? [ ], extraSpecialArgs ? { }
+          , username, stateVersion, extraModules ? [ ], extraSpecialArgs ? { }
           , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
-          , check ? true, stateVersion ? "20.09" }@args:
+          , check ? true }@args:
           assert nixpkgs.lib.versionAtLeast stateVersion "20.09";
 
           import ./modules {

--- a/modules/misc/version.nix
+++ b/modules/misc/version.nix
@@ -16,7 +16,6 @@ with lib;
         "21.11"
         "22.05"
       ];
-      default = "18.09";
       description = ''
         It is occasionally necessary for Home Manager to change
         configuration defaults in a way that is incompatible with

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -21,6 +21,9 @@ let
       xdg.enable = true;
       home.username = "hm-user";
       home.homeDirectory = "/home/hm-user";
+      # The old default value for home.stateVersion
+      # this corresponds to the release it was introduced in
+      home.stateVersion = "18.09";
 
       # Avoid including documentation since this will cause
       # unnecessary rebuilds of the tests.


### PR DESCRIPTION
### Description

Either the default stateVersion is always updated to be the lastest version or it's not defined.

See #2622 and https://github.com/nix-community/home-manager/pull/2510#pullrequestreview-816315847

This is not backwards compatible.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
