### PR TITLE
rofi: add finalPackage option

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -110,6 +110,14 @@ in {
       '';
     };
 
+    finalPackage = mkOption {
+      type = types.package;
+      readOnly = true;
+      description = ''
+        Resulting customized rofi package.
+      '';
+    };
+
     plugins = mkOption {
       default = [ ];
       type = types.listOf types.package;
@@ -249,14 +257,15 @@ in {
       inherit value;
     };
 
-    home.packages = let
+    programs.rofi.finalPackage = let
       rofiWithPlugins = cfg.package.override
         (old: rec { plugins = (old.plugins or [ ]) ++ cfg.plugins; });
-      rofiPackage = if builtins.hasAttr "override" cfg.package then
-        rofiWithPlugins
-      else
-        cfg.package;
-    in [ rofiPackage ];
+    in if builtins.hasAttr "override" cfg.package then
+      rofiWithPlugins
+    else
+      cfg.package;
+
+    home.packages = [ cfg.finalPackage ];
 
     home.file."${cfg.configPath}".text = toRasi {
       configuration = ({


### PR DESCRIPTION
### Description

Extract only the `finalPackage` change from #2432.

cc: @thiagokokada

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
