### PR TITLE
Add Atuin Fish integration

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -40,6 +40,16 @@ in {
       '';
     };
 
+    enableFishIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Atuin's Fish integration.
+        </para><para>
+        If enabled, this will bind the up-arrow key to open the Atuin history.
+      '';
+    };
+
     settings = mkOption {
       type = with types;
         let
@@ -85,6 +95,10 @@ in {
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
       eval "$(${cfg.package}/bin/atuin init zsh)"
+    '';
+
+    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
+      ${cfg.package}/bin/atuin init fish | source
     '';
   };
 }

--- a/tests/modules/programs/atuin/default.nix
+++ b/tests/modules/programs/atuin/default.nix
@@ -2,6 +2,7 @@
   atuin-bash = ./bash.nix;
   atuin-empty-settings = ./empty-settings.nix;
   atuin-example-settings = ./example-settings.nix;
+  atuin-fish = ./fish.nix;
   atuin-no-shell = ./no-shell.nix;
   atuin-zsh = ./zsh.nix;
 }

--- a/tests/modules/programs/atuin/fish.nix
+++ b/tests/modules/programs/atuin/fish.nix
@@ -1,0 +1,25 @@
+{ lib, ... }:
+
+{
+  programs = {
+    atuin.enable = true;
+    fish.enable = true;
+  };
+
+  # Needed to avoid error with dummy fish package.
+  xdg.dataFile."fish/home-manager_generated_completions".source =
+    lib.mkForce (builtins.toFile "empty" "");
+
+  test.stubs = {
+    atuin = { };
+    bash-preexec = { };
+    fish = { };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      'atuin init fish | source'
+  '';
+}

--- a/tests/modules/programs/atuin/no-shell.nix
+++ b/tests/modules/programs/atuin/no-shell.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ lib, ... }:
 
 {
   programs = {
@@ -6,18 +6,26 @@
       enable = true;
       enableBashIntegration = false;
       enableZshIntegration = false;
+      enableFishIntegration = false;
     };
     bash.enable = true;
     zsh.enable = true;
+    fish.enable = true;
   };
+
+  # Needed to avoid error with dummy fish package.
+  xdg.dataFile."fish/home-manager_generated_completions".source =
+    lib.mkForce (builtins.toFile "empty" "");
 
   test.stubs = {
     atuin = { };
     bash-preexec = { };
+    fish = { };
   };
 
   nmt.script = ''
-    assertFileNotRegex home-files/.zshrc '@atuin@ init zsh'
-    assertFileNotRegex home-files/.bashrc '@atuin@ init bash'
+    assertFileNotRegex home-files/.zshrc 'atuin init zsh'
+    assertFileNotRegex home-files/.bashrc 'atuin init bash'
+    assertFileNotRegex home-files/.config/fish/config.fish 'atuin init fish'
   '';
 }


### PR DESCRIPTION
### Description
This adds an enableFishIntegation config key to atuin, which allows atuin to be used in the fish shell without needing to manually add it to fish's config.
Don't use this yet, I need to ~~re-commit for proper formatting~~ done, ~~now I need to make the tests not fail.~~
I think that this is done! LMK if I need to make any changes!
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
