### PR TITLE
plex-mpv-shim: init service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -426,3 +426,5 @@ Makefile                                              @thiagokokada
 /tests/modules/services/swayidle                      @c0deaddict
 
 /modules/programs/ion.nix                             @jo1gi
+
+/modules/services/plex-mpv-shim.nix                   @starcraft66

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -216,6 +216,7 @@ let
     ./services/picom.nix
     ./services/plan9port.nix
     ./services/playerctld.nix
+    ./services/plex-mpv-shim.nix
     ./services/polybar.nix
     ./services/poweralertd.nix
     ./services/pulseeffects.nix

--- a/modules/services/plex-mpv-shim.nix
+++ b/modules/services/plex-mpv-shim.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  jsonFormat = pkgs.formats.json { };
+  cfg = config.services.plex-mpv-shim;
+
+in {
+  meta.maintainers = [ maintainers.starcraft66 ];
+
+  options = {
+    services.plex-mpv-shim = {
+      enable = mkEnableOption "Plex mpv shim";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.plex-mpv-shim;
+        defaultText = literalExpression "pkgs.plex-mpv-shim";
+        description = "The package to use for the Plex mpv shim.";
+      };
+
+      settings = mkOption {
+        type = jsonFormat.type;
+        default = { };
+        example = literalExpression ''
+          {
+            adaptive_transcode = false;
+            allow_http = false;
+            always_transcode = false;
+            audio_ac3passthrough = false;
+            audio_dtspassthrough = false;
+            auto_play = true;
+            auto_transcode = true;
+          }
+        '';
+        description = ''
+          Configuration written to
+          <filename>$XDG_CONFIG_HOME/plex-mpv-shim/config.json</filename>. See
+          <link xlink:href="https://github.com/iwalton3/plex-mpv-shim/blob/master/README.md"/>
+          for the configuration documentation.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.plex-mpv-shim" pkgs
+        lib.platforms.linux)
+    ];
+
+    xdg.configFile."plex-mpv-shim/conf.json" = mkIf (cfg.settings != { }) {
+      source = jsonFormat.generate "conf.json" cfg.settings;
+    };
+
+    systemd.user.services.plex-mpv-shim = {
+      Unit = {
+        Description = "Plex mpv shim";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = { ExecStart = "${cfg.package}/bin/plex-mpv-shim"; };
+
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+    };
+  };
+}


### PR DESCRIPTION
### Description

Adds a home-manager module to create a config file and run a systemd user service for [plex-mpv-shim](https://github.com/iwalton3/plex-mpv-shim)
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
