### PR TITLE
github: copyedit stale bot's messages

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -36,11 +36,11 @@ issues:
     <details>
     <summary><b>Memorandum on closing issues</b></summary>
     <p>
-      If you have nothing of substance to add, please refrain from commenting and allow the bot close the issue.
+      If you have nothing of substance to add, please refrain from commenting and allow the bot to close the issue.
       Also, don't be afraid to manually close an issue, even if it holds valuable information.
     </p>
     <p>
-      Closed issues stay in the system for people to search, read, cross-reference, or even reopen--nothing is lost!
+      Closed issues stay in the system for people to search, read, cross-reference, or even reopen – nothing is lost!
       Closing obsolete issues is an important way to help maintainers focus their time and effort.
     </p>
     </details>
@@ -57,7 +57,7 @@ pulls:
     <summary><b>If you are the original author of the PR</b></summary>
     <p>
 
-    * GitHub sometimes doesn't notify people who commented / reviewed a PR previously, when you (force) push commits. *If you have addressed the reviews* you can [officially ask for a review](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review) from those who commented to you or anyone else.
+    * GitHub sometimes doesn't notify people who commented / reviewed a PR previously when you (force) push commits. *If you have addressed the reviews* you can [officially ask for a review](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review) from those who commented to you or anyone else.
     * If it is unfinished but you plan to finish it, please mark it as a draft.
     * If you don't expect to work on it any time soon, please consider closing it with a short comment encouraging someone else to pick up your work.
     * To get things rolling again, rebase the PR against the target branch and address valid comments.
@@ -66,7 +66,7 @@ pulls:
     </details>
 
     <details>
-    <summary><b>If you are <i>not</i> the original author of the issue</b></summary>
+    <summary><b>If you are <i>not</i> the original author of the PR</b></summary>
     <p>
 
     * If you want to pick up the work on this PR, please create a new PR and indicate that it supercedes and closes this PR.


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

fixed a couple of typos in the messages emitted by the stale bot

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
