### PR TITLE
tests: re-enable commented tests

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -46,8 +46,7 @@ import nmt {
     ./modules/home-environment
     ./modules/misc/fontconfig
     ./modules/programs/alacritty
-    # TODO: Re-enable once https://github.com/NixOS/nixpkgs/pull/154309 is fixed
-    # ./modules/programs/alot
+    ./modules/programs/alot
     ./modules/programs/aria2
     ./modules/programs/atuin
     ./modules/programs/autojump
@@ -73,15 +72,13 @@ import nmt {
     ./modules/programs/kitty
     ./modules/programs/less
     ./modules/programs/lf
-    # TODO: Re-enable once https://github.com/NixOS/nixpkgs/pull/154309 is fixed
-    # ./modules/programs/lieer
+    ./modules/programs/lieer
     ./modules/programs/man
     ./modules/programs/mbsync
     ./modules/programs/mpv
     ./modules/programs/ncmpcpp
     ./modules/programs/ne
-    # TODO: Re-enable once https://github.com/NixOS/nixpkgs/pull/154309 is fixed
-    # ./modules/programs/neomutt
+    ./modules/programs/neomutt
     ./modules/programs/newsboat
     ./modules/programs/nix-index
     ./modules/programs/nnn


### PR DESCRIPTION
### Description

The issue is now fixed in Nixpkgs.


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```