### PR TITLE
syncthing: add option `extraOptions`

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -2,7 +2,11 @@
 
 with lib;
 
-{
+let
+
+  cfg = config.services.syncthing;
+
+in {
   meta.maintainers = [ maintainers.rycee ];
 
   options = {
@@ -52,7 +56,7 @@ with lib;
   };
 
   config = mkMerge [
-    (mkIf config.services.syncthing.enable {
+    (mkIf cfg.enable {
       home.packages = [ (getOutput "man" pkgs.syncthing) ];
 
       systemd.user.services = {
@@ -67,8 +71,8 @@ with lib;
           Service = {
             ExecStart =
               "${pkgs.syncthing}/bin/syncthing -no-browser -no-restart -logflags=0"
-              + optionalString (config.services.syncthing.extraOptions != [ ])
-              (" " + escapeShellArgs config.services.syncthing.extraOptions);
+              + optionalString (cfg.extraOptions != [ ])
+              (" " + escapeShellArgs cfg.extraOptions);
             Restart = "on-failure";
             SuccessExitStatus = [ 3 4 ];
             RestartForceExitStatus = [ 3 4 ];
@@ -88,49 +92,46 @@ with lib;
       };
     })
 
-    (mkIf (isAttrs config.services.syncthing.tray
-      && config.services.syncthing.tray.enable) {
-        systemd.user.services = {
-          ${config.services.syncthing.tray.package.pname} = {
-            Unit = {
-              Description = config.services.syncthing.tray.package.pname;
-              Requires = [ "tray.target" ];
-              After = [ "graphical-session-pre.target" "tray.target" ];
-              PartOf = [ "graphical-session.target" ];
-            };
-
-            Service = {
-              ExecStart =
-                "${config.services.syncthing.tray.package}/bin/${config.services.syncthing.tray.command}";
-            };
-
-            Install = { WantedBy = [ "graphical-session.target" ]; };
+    (mkIf (isAttrs cfg.tray && cfg.tray.enable) {
+      systemd.user.services = {
+        ${cfg.tray.package.pname} = {
+          Unit = {
+            Description = cfg.tray.package.pname;
+            Requires = [ "tray.target" ];
+            After = [ "graphical-session-pre.target" "tray.target" ];
+            PartOf = [ "graphical-session.target" ];
           };
+
+          Service = {
+            ExecStart = "${cfg.tray.package}/bin/${cfg.tray.command}";
+          };
+
+          Install = { WantedBy = [ "graphical-session.target" ]; };
         };
-      })
+      };
+    })
 
     # deprecated
-    (mkIf (isBool config.services.syncthing.tray
-      && config.services.syncthing.tray) {
-        systemd.user.services = {
-          "syncthingtray" = {
-            Unit = {
-              Description = "syncthingtray";
-              Requires = [ "tray.target" ];
-              After = [ "graphical-session-pre.target" "tray.target" ];
-              PartOf = [ "graphical-session.target" ];
-            };
-
-            Service = {
-              ExecStart = "${pkgs.syncthingtray-minimal}/bin/syncthingtray";
-            };
-
-            Install = { WantedBy = [ "graphical-session.target" ]; };
+    (mkIf (isBool cfg.tray && cfg.tray) {
+      systemd.user.services = {
+        "syncthingtray" = {
+          Unit = {
+            Description = "syncthingtray";
+            Requires = [ "tray.target" ];
+            After = [ "graphical-session-pre.target" "tray.target" ];
+            PartOf = [ "graphical-session.target" ];
           };
+
+          Service = {
+            ExecStart = "${pkgs.syncthingtray-minimal}/bin/syncthingtray";
+          };
+
+          Install = { WantedBy = [ "graphical-session.target" ]; };
         };
-        warnings = [
-          "Specifying 'services.syncthing.tray' as a boolean is deprecated, set 'services.syncthing.tray.enable' instead. See https://github.com/nix-community/home-manager/pull/1257."
-        ];
-      })
+      };
+      warnings = [
+        "Specifying 'services.syncthing.tray' as a boolean is deprecated, set 'services.syncthing.tray.enable' instead. See https://github.com/nix-community/home-manager/pull/1257."
+      ];
+    })
   ];
 }

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -9,6 +9,15 @@ with lib;
     services.syncthing = {
       enable = mkEnableOption "Syncthing continuous file synchronization";
 
+      extraOptions = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "--gui-apikey=apiKey" ];
+        description = ''
+          Extra command-line arguments to pass to <command>syncthing</command>.
+        '';
+      };
+
       tray = mkOption {
         type = with types;
           either bool (submodule {
@@ -57,7 +66,9 @@ with lib;
 
           Service = {
             ExecStart =
-              "${pkgs.syncthing}/bin/syncthing -no-browser -no-restart -logflags=0";
+              "${pkgs.syncthing}/bin/syncthing -no-browser -no-restart -logflags=0"
+              + optionalString (config.services.syncthing.extraOptions != [ ])
+              (" " + escapeShellArgs config.services.syncthing.extraOptions);
             Restart = "on-failure";
             SuccessExitStatus = [ 3 4 ];
             RestartForceExitStatus = [ 3 4 ];

--- a/tests/modules/services/syncthing/default.nix
+++ b/tests/modules/services/syncthing/default.nix
@@ -1,4 +1,5 @@
 {
+  syncthing-extra-options = ./extra-options.nix;
   syncthing-tray = ./tray.nix;
   syncthing-tray-as-bool-triggers-warning = ./tray-as-bool-triggers-warning.nix;
 }

--- a/tests/modules/services/syncthing/extra-options.nix
+++ b/tests/modules/services/syncthing/extra-options.nix
@@ -1,0 +1,16 @@
+{ config, ... }:
+
+{
+  services.syncthing = {
+    enable = true;
+    extraOptions = [ "-foo" ''-bar "baz"'' ];
+  };
+
+  test.stubs.syncthing = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/systemd/user/syncthing.service
+    assertFileContains home-files/.config/systemd/user/syncthing.service \
+      "ExecStart=@syncthing@/bin/syncthing -no-browser -no-restart -logflags=0 '-foo' '-bar \"baz\"'"
+  '';
+}


### PR DESCRIPTION
### Description

Add escape hatch for adding additional command line options.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```