### PR TITLE
bash: use shellDryRun to check scripts

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -9,7 +9,7 @@ let
   writeBashScript = name: text: pkgs.writeTextFile {
     inherit name text;
     checkPhase = ''
-      ${pkgs.stdenv.shell} -n $out
+      ${pkgs.stdenv.shellDryRun} "$target"
     '';
   };
 


### PR DESCRIPTION
Allows using extglob in initialisation files. See https://github.com/NixOS/nixpkgs/pull/151371

That change got into `master` 2 days ago and into `nixos-unstable` an hour ago, so we might want to wait a bit before merging.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
