### PR TITLE
pubs: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -201,6 +201,9 @@
 
 /modules/programs/powerline-go.nix                    @DamienCassou
 
+/modules/programs/pubs.nix                            @loicreynier
+/tests/modules/programs/pubs                          @loicreynier
+
 /modules/programs/rbw.nix                             @ambroisie
 /tests/modules/programs/rbw                           @ambroisie
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -83,6 +83,12 @@
     github = "kubukoz";
     githubId = 894884;
   };
+  loicreynier = {
+    name = "Loïc Reynier";
+    email = "loic@loireynier.fr";
+    github = "loicreynier";
+    githubId = 88983487;
+  };
   matrss = {
     name = "Matthias Riße";
     email = "matrss@users.noreply.github.com";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2449,6 +2449,13 @@ in
           A new module is available: 'programs.just'.
         '';
       }
+
+      {
+        time = "2022-03-06T09:40:17+00:00";
+        message = ''
+          A new module is available: 'programs.pubs'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -130,6 +130,7 @@ let
     ./programs/pidgin.nix
     ./programs/piston-cli.nix
     ./programs/powerline-go.nix
+    ./programs/pubs.nix
     ./programs/qutebrowser.nix
     ./programs/rbw.nix
     ./programs/readline.nix

--- a/modules/programs/pubs.nix
+++ b/modules/programs/pubs.nix
@@ -1,0 +1,60 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.pubs;
+
+in {
+  meta.maintainers = [ hm.maintainers.loicreynier ];
+
+  options.programs.pubs = {
+    enable = mkEnableOption "pubs";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.pubs;
+      defaultText = literalExpression "pkgs.pubs";
+      description = "The package to use for the pubs script.";
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = literalExpression ''
+        '''
+        [main]
+        pubsdir = ''${config.home.homeDirectory}/.pubs
+        docsdir = ''${config.home.homeDirectory}/.pubs/doc
+        doc_add = link
+        open_cmd = xdg-open
+
+        [plugins]
+        active = git,alias
+
+        [[alias]]
+
+        [[[la]]]
+        command = list -a
+        description = lists papers in lexicographic order
+
+        [[git]]
+        quiet = True
+        manual = False
+        force_color = False
+        ''''';
+      description = ''
+        Configuration using syntax written to
+        <filename>$HOME/.pubsrc</filename>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.file.".pubsrc" =
+      mkIf (cfg.extraConfig != "") { text = cfg.extraConfig; };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -86,6 +86,7 @@ import nmt {
     ./modules/programs/pandoc
     ./modules/programs/pet
     ./modules/programs/powerline-go
+    ./modules/programs/pubs
     ./modules/programs/qutebrowser
     ./modules/programs/readline
     ./modules/programs/sagemath

--- a/tests/modules/programs/pubs/default.nix
+++ b/tests/modules/programs/pubs/default.nix
@@ -1,0 +1,1 @@
+{ pubs-example-settings = ./pubs-example-settings.nix; }

--- a/tests/modules/programs/pubs/pubs-example-settings-expected-pubsrc
+++ b/tests/modules/programs/pubs/pubs-example-settings-expected-pubsrc
@@ -1,0 +1,19 @@
+[main]
+pubsdir = ~/.pubs
+docsdir = ~/.pubs/doc
+doc_add = link
+open_cmd = xdg-open
+
+[plugins]
+active = git,alias
+
+[[alias]]
+
+[[[la]]]
+command = list -a
+description = lists papers in lexicographic order
+
+[[git]]
+quiet = True
+manual = False
+force_color = False

--- a/tests/modules/programs/pubs/pubs-example-settings.nix
+++ b/tests/modules/programs/pubs/pubs-example-settings.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+{
+  programs.pubs = {
+    enable = true;
+
+    extraConfig = ''
+      [main]
+      pubsdir = ~/.pubs
+      docsdir = ~/.pubs/doc
+      doc_add = link
+      open_cmd = xdg-open
+
+      [plugins]
+      active = git,alias
+
+      [[alias]]
+
+      [[[la]]]
+      command = list -a
+      description = lists papers in lexicographic order
+
+      [[git]]
+      quiet = True
+      manual = False
+      force_color = False
+    '';
+  };
+
+  test.stubs.pubs = { };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.pubsrc ${./pubs-example-settings-expected-pubsrc}
+  '';
+}


### PR DESCRIPTION
### Description

Add [pubs](github.com/pubs/pubs) program module bringing basic configuration via `programs.pubs.config`. 

pubs configuration file uses ConfigObj syntax, which is similar to the INI files syntax but with extra functionnalities like nested sections. These functionnalities are used within pubs configuration file and prevent from using Nix's INI format parser. Here is an example of pubs configuration that cannot be parsed using Nix's INI format parser:

```ini
[plugins]

[[git]]
manual=False
```

For this reason, I opted for a stringly-typed configuration since the use of a structured `settings` option would require a custom parser.

### Checklist

- [x] Change is backwards compatible.


- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`.


- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
