### PR TITLE
eww: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,6 +76,8 @@
 
 /modules/programs/emacs.nix                           @rycee
 
+/modules/programs/eww.nix                             @mainrs
+
 /modules/programs/exa.nix                             @kalhauge
 
 /modules/programs/firefox.nix                         @rycee

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2410,6 +2410,13 @@ in
           A new module is available: 'programs.zellij'.
         '';
       }
+
+      {
+        time = "2022-02-17T17:12:46+00:00";
+        message = ''
+          A new module is available: 'programs.eww'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -60,6 +60,7 @@ let
     ./programs/direnv.nix
     ./programs/eclipse.nix
     ./programs/emacs.nix
+    ./programs/eww.nix
     ./programs/exa.nix
     ./programs/feh.nix
     ./programs/firefox.nix

--- a/modules/programs/eww.nix
+++ b/modules/programs/eww.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.eww;
+
+in {
+  meta.maintainers = [ maintainers.mainrs ];
+
+  options.programs.eww = {
+    enable = mkEnableOption "eww";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.eww;
+      defaultText = literalExpression "pkgs.eww";
+      example = literalExpression "pkgs.eww";
+      description = ''
+        The eww package to install.
+      '';
+    };
+
+    configDir = mkOption {
+      type = types.path;
+      example = literalExpression "./eww-config-dir";
+      description = ''
+        The directory that gets symlinked to
+        <filename>$XDG_CONFIG_HOME/eww</filename>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    xdg.configFile."eww".source = cfg.configDir;
+  };
+}


### PR DESCRIPTION
Closes #2682.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`. **Edit:** This fails on my machine with `error: attribute 'shellDryRun' missing` at `home-manager/modules/programs/bash.nix:12:9`. I didn't touch that module.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
