### PR TITLE
zellij: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -245,6 +245,8 @@
 
 /modules/programs/zathura.nix                         @rprospero
 
+/modules/programs/zellij.nix                          @mainrs
+
 /modules/programs/zoxide.nix                          @marsam
 
 /modules/programs/zsh/prezto.nix                      @NickHu

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -205,4 +205,10 @@
     github = "pinage404";
     githubId = 6325757;
   };
+  mainrs = {
+    name = "mainrs";
+    email = "5113257+mainrs@users.noreply.github.com";
+    github = "mainrs";
+    githubId = 5113257;
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2403,6 +2403,13 @@ in
           A new module is available: 'services.twmn'.
         '';
       }
+
+      {
+        time = "2022-02-16T23:50:35+00:00";
+        message = ''
+          A new module is available: 'programs.zellij'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -158,6 +158,7 @@ let
     ./programs/xmobar.nix
     ./programs/z-lua.nix
     ./programs/zathura.nix
+    ./programs/zellij.nix
     ./programs/zoxide.nix
     ./programs/zplug.nix
     ./programs/zsh.nix

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.zellij;
+  yamlFormat = pkgs.formats.yaml { };
+
+in {
+  meta.maintainers = [ hm.maintainers.mainrs ];
+
+  options.programs.zellij = {
+    enable = mkEnableOption "zellij";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.zellij;
+      defaultText = literalExpression "pkgs.zellij";
+      description = ''
+        The zellij package to install.
+      '';
+    };
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          theme = "custom";
+          themes.custom.fg = 5;
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>$XDG_CONFIG_HOME/zellij/config.yaml</filename>.
+        </para><para>
+        See <link xlink:href="https://zellij.dev/documentation" /> for the full
+        list of options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."zellij/config.yaml" = mkIf (cfg.settings != { }) {
+      source = yamlFormat.generate "zellij.yaml" cfg.settings;
+    };
+  };
+}


### PR DESCRIPTION
Closes #2666

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`. **Edit:** This fails on my machine with `error: attribute 'shellDryRun' missing` at `home-manager/modules/programs/bash.nix:12:9`. I didn't touch that module.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
