### PR TITLE
man: add package option

### DIFF
--- a/modules/programs/man.nix
+++ b/modules/programs/man.nix
@@ -2,7 +2,8 @@
 
 with lib;
 
-{
+let cfg = config.programs.man;
+in {
   options = {
     programs.man = {
       enable = mkOption {
@@ -13,6 +14,13 @@ with lib;
           command. This also includes "man" outputs of all
           <literal>home.packages</literal>.
         '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.man;
+        defaultText = literalExpression "pkgs.man";
+        description = "The man package to use.";
       };
 
       generateCaches = mkOption {
@@ -39,7 +47,7 @@ with lib;
   };
 
   config = mkIf config.programs.man.enable {
-    home.packages = [ pkgs.man ];
+    home.packages = [ cfg.package ];
     home.extraOutputsToInstall = [ "man" ];
 
     # This is mostly copy/pasted/adapted from NixOS' documentation.nix.


### PR DESCRIPTION
Closes #2634

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`. **Edit:** This fails on my machine with `error: attribute 'shellDryRun' missing` at `home-manager/modules/programs/bash.nix:12:9`. I didn't touch that module.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
