### PR TITLE
darwin: add Nix package to activation $PATH

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -29,6 +29,10 @@ let
 
           home.username = config.users.users.${name}.name;
           home.homeDirectory = config.users.users.${name}.home;
+
+          # Make activation script use same version of Nix as system as a whole.
+          # This avoids problems with Nix not being in PATH.
+          home.extraActivationPath = [ config.nix.package ];
         };
       })
     ] ++ cfg.sharedModules;


### PR DESCRIPTION
### Description

The fix for https://github.com/nix-community/home-manager/issues/2178
did not apply the patch to nix-darwin too.

See: https://github.com/nix-community/home-manager/issues/2178#issuecomment-1029015498

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
