### PR TITLE
modules: Export `pkgs` to match NixOS

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -61,4 +61,6 @@ in
     sort (a: b: a.time > b.time) (
       filter (a: a.condition) rawModule.config.news.entries
     );
+
+  inherit (module._module.args) pkgs;
 }


### PR DESCRIPTION
### Description

This makes it a lot easier to access the `pkgs` that would be used to
build the home configuration, e.g.

    nix build ./dotfiles#homeConfigurations."user@host".pkgs.vim

This is useful as it allows access to a Nixpkgs that has been
instiantiated with config and overlays.

Currently you would need to do:

    nix build ./dotfiles#homeConfigurations."user@host".options._module.args.value.pkgs.vim

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
