### PR TITLE
taskwarrior: make .taskrc writable

### DIFF
--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -88,7 +88,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ pkgs.taskwarrior ];
 
-    xdg.configFile."task/taskrc".text = ''
+    xdg.configFile."task/taskrc_".text = ''
       data.location=${cfg.dataLocation}
       ${optionalString (cfg.colorTheme != null) (if isString cfg.colorTheme then
         "include ${cfg.colorTheme}.theme"
@@ -98,6 +98,10 @@ in {
       ${concatStringsSep "\n" (mapAttrsToList formatPair cfg.config)}
 
       ${cfg.extraConfig}
+    '';
+    home.activation.regenDotTaskRc = hm.dag.entryAfter [ "writeBoundary" ] ''
+      $VERBOSE_ECHO "Copying taskwarrior taskrc"
+      $DRY_RUN_CMD echo "include ${xdg.configHome}/task/taskrc_" > ~/.taskrc
     '';
   };
 }


### PR DESCRIPTION
This is achieved by generating the Home Manager configuration
file as `taskrc_` and including that file into ~/.taskrc.

Fixes #2360

### Description

<!--

Please provide a brief description of your change.

-->

Note that the current activation script doesn't work. I get an error and I do not know why:
```
error: undefined variable 'xdg'

       at /nix/store/if0lgmi7k63mn72z8x3drbd3d2x0qlmr-source/modules/programs/taskwarrior.nix:104:36:

          103|       $VERBOSE_ECHO "Copying taskwarrior taskrc"
          104|       $DRY_RUN_CMD echo "include ${xdg.configHome}/task/taskrc_" > ~/.taskrc
             |                                    ^
          105|     '';
(use '--show-trace' to show detailed location information)
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
