### PR TITLE
zsh: move sessionVariables from .zshrc to .zshenv

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -443,6 +443,19 @@ in
     })
 
     {
+      home.file."${relToDotDir ".zshenv"}".text = ''
+        # Environment variables
+        . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
+
+        # Only source this once
+        if [[ -z "$__HM_ZSH_SESS_VARS_SOURCED" ]]; then
+          export __HM_ZSH_SESS_VARS_SOURCED=1
+          ${envVarsStr}
+        fi
+      '';
+    }
+
+    {
       home.packages = with pkgs; [ zsh ]
         ++ optional cfg.enableCompletion nix-zsh-completions
         ++ optional cfg.oh-my-zsh.enable oh-my-zsh;
@@ -490,10 +503,6 @@ in
         ${optionalString cfg.enableSyntaxHighlighting
           "source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
         }
-
-        # Environment variables
-        . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
-        ${envVarsStr}
 
         ${optionalString cfg.oh-my-zsh.enable ''
             # oh-my-zsh extra settings for plugins

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -16,9 +16,9 @@ with lib;
     test.stubs.zsh = { };
 
     nmt.script = ''
-      assertFileExists home-files/.zshrc
-      assertFileRegex home-files/.zshrc 'export V1="v1"'
-      assertFileRegex home-files/.zshrc 'export V2="v2-v1"'
+      assertFileExists home-files/.zshenv
+      assertFileRegex home-files/.zshenv 'export V1="v1"'
+      assertFileRegex home-files/.zshenv 'export V2="v2-v1"'
     '';
   };
 }


### PR DESCRIPTION
### Description

This patch moves both home.sessionVariables and
programs.zsh.sessionVariables from .zshrc to .zshenv. Additionally,
these two kinds of session variables will not be sourced more than
once to allow user-customized ones to take effect.

Before, session variables are in .zshrc, which causes non-interactive
shells to not be able to get those variables. For example, running a
command through SSH is in a non-interactive and non-login shell, which
suffers from this. With this patch, all kinds of shells can get
session variables.

The reason why these session variables are not moved to .zprofile is
that programs started by systemd user instances are not able to get
variables defined in that file. For example, GNOME
Terminal (gnome-terminal-server.service) is one of these programs and
doesn't get variables defined in .zprofile. As a result, the shells it
starts, which are interactive and non-login, do not get those
variables.

Fixes #2445

Related https://github.com/NixOS/nixpkgs/issues/33219
Related https://github.com/NixOS/nixpkgs/pull/45784

This file is not formatted before and is excluded by ./format, so I don't format it.

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
