### PR TITLE
emacs: add an option for the shell launching Emacs to fix missing environment variable problem

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -44,6 +44,15 @@ in {
   options.services.emacs = {
     enable = mkEnableOption "the Emacs daemon";
 
+    shell = mkOption {
+      type = types.shellPackage;
+      default = pkgs.bash;
+      defaultText = literalExpression "pkgs.bash";
+      example = literalExpression "pkgs.zsh";
+      description =
+        "The shell that launches an Emacs daemon and should be the same as your shell.";
+    };
+
     package = mkOption {
       type = types.package;
       default = if emacsCfg.enable then emacsCfg.finalPackage else pkgs.emacs;
@@ -123,7 +132,9 @@ in {
           # worth investigating a more targeted approach for user services to
           # import the user environment.
           ExecStart = ''
-            ${pkgs.runtimeShell} -l -c "${emacsBinPath}/emacs --fg-daemon${
+            ${
+              cfg.shell + cfg.shell.shellPath
+            } -l -c "${emacsBinPath}/emacs --fg-daemon${
             # In case the user sets 'server-directory' or 'server-name' in
             # their Emacs config, we want to specify the socket path explicitly
             # so launching 'emacs.service' manually doesn't break emacsclient


### PR DESCRIPTION
### Description

This patch adds an option services.emacs.shell to choose the shell
launching an Emacs daemon.

This option defaults to bash (runtimeShell), which has backword
compatibility, and should be set to the user's shell to get the right
environment for Emacs.

Before, this shell is hardcoded to runtimeShell, i.e. bash. If a
user's shell is not bash and programs.bash.enable is false, the Emacs
daemon will miss some environment variables,
e.g. home.sessionVariables and programs.zsh.sessionVariables (if zsh
is the user's shell).

Fixes #2139 (for zsh, #2708 is also needed)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
