### PR TITLE
kitty: add option `theme`

### DIFF
--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -72,6 +72,18 @@ in {
       '';
     };
 
+    theme = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Apply a Kitty color theme. This option takes the friendly name of
+        any theme given by the command <command>kitty +kitten themes</command>.
+        See <link xlink:href="https://github.com/kovidgoyal/kitty-themes"/>
+        for more details.
+      '';
+      example = "Space Gray Eighties";
+    };
+
     font = mkOption {
       type = types.nullOr hm.types.fontType;
       default = null;
@@ -128,6 +140,13 @@ in {
           font_family ${cfg.font.name}
           ${optionalString (cfg.font.size != null)
           "font_size ${toString cfg.font.size}"}
+        ''}
+
+        ${optionalString (cfg.theme != null) ''
+          include ${pkgs.kitty-themes}/${
+            (head (filter (x: x.name == cfg.theme) (builtins.fromJSON
+              (builtins.readFile "${pkgs.kitty-themes}/themes.json")))).file
+          }
         ''}
 
         ${toKittyConfig cfg.settings}

--- a/tests/modules/programs/kitty/example-settings-expected.conf
+++ b/tests/modules/programs/kitty/example-settings-expected.conf
@@ -5,6 +5,8 @@ font_family DejaVu Sans
 font_size 8
 
 
+
+
 enable_audio_bell no
 scrollback_lines 10000
 update_check_interval 0


### PR DESCRIPTION
### Description
Add a new option to use the recently added `kitty-themes` nix package to set the theme. Use the friendly name of the theme seen in `kitty +kitten themes` 

https://github.com/kovidgoyal/kitty-themes

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
The current test for kitty is a simple match against a example file. Because this change adds a path to the nix store, that will no longer work because the path can change. I'm not sure if it's worth re-writing all the kitty tests just to cover themes

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
