### PR TITLE
mpv: allow `package = null`

### DIFF
--- a/tests/modules/programs/mpv/default.nix
+++ b/tests/modules/programs/mpv/default.nix
@@ -2,4 +2,5 @@
   # Temporarily commented until fixed for recent changes in Nixpkgs.
   # mpv-example-settings = ./mpv-example-settings.nix;
   # mpv-invalid-settings = ./mpv-invalid-settings.nix;
+  # mpv-null-package = ./mpv-null-package.nix;
 }

--- a/tests/modules/programs/mpv/mpv-null-package.nix
+++ b/tests/modules/programs/mpv/mpv-null-package.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    programs.mpv = {
+      enable = true;
+      package = null;
+
+      bindings = {
+        WHEEL_UP = "seek 10";
+        WHEEL_DOWN = "seek -10";
+        "Alt+0" = "set window-scale 0.5";
+      };
+
+      config = {
+        force-window = true;
+        ytdl-format = "bestvideo+bestaudio";
+        cache-default = 4000000;
+      };
+
+      profiles = {
+        fast = { vo = "vdpau"; };
+        "protocol.dvd" = {
+          profile-desc = "profile for dvd:// streams";
+          alang = "en";
+        };
+      };
+
+      defaultProfiles = [ "gpu-hq" ];
+    };
+
+    nmt.script = ''
+      assertFileContent \
+         home-files/.config/mpv/mpv.conf \
+         ${./mpv-example-settings-expected-config}
+      assertFileContent \
+         home-files/.config/mpv/input.conf \
+         ${./mpv-example-settings-expected-bindings}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Allow to use `package = null` to generate MPV configuration files with Home Manager while using the system package / NixOS module.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
