### PR TITLE
nix-darwin,nixos: convert `modulesPath` to string

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -13,7 +13,7 @@ let
       lib = extendedLib;
       darwinConfig = config;
       osConfig = config;
-      modulesPath = ../modules;
+      modulesPath = builtins.toString ../modules;
     } // cfg.extraSpecialArgs;
     modules = [
       ({ name, ... }: {

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -13,7 +13,7 @@ let
       lib = extendedLib;
       nixosConfig = config;
       osConfig = config;
-      modulesPath = ../modules;
+      modulesPath = builtins.toString ../modules;
     } // cfg.extraSpecialArgs;
     modules = [
       ({ name, ... }: {


### PR DESCRIPTION
`modulesPath` is usually used with antiquotation (`"${modulesPath}/some-module.nix"`). Antiquoted paths are copied to the Nix store and one must do `"${toString modulesPath}/some-module.nix"` to avoid the copying. Ideally `modulesPath` should be a string to avoid this. Note that `modulesPath` is already defined as a string in `<home-manager>/modules/default.nix` and `<nixpkgs>/nixos/lib/eval-config.nix`.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
