### PR TITLE
nix: add structural settings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,9 @@
 
 /modules/misc/news.nix                                @rycee
 
+/modules/misc/nix.nix                                 @polykernel
+/tests/modules/misc/nix                               @polykernel
+
 /modules/misc/nixpkgs-disabled.nix                    @thiagokokada
 
 /modules/misc/numlock.nix                             @evanjs

--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -6,8 +6,98 @@ let
 
   cfg = config.nix;
 
+  nixPackage = cfg.package;
+
+  isNixAtLeast = versionAtLeast (getVersion nixPackage);
+
+  nixConf = assert isNixAtLeast "2.2";
+    let
+
+      mkValueString = v:
+        if v == null then
+          ""
+        else if isInt v then
+          toString v
+        else if isBool v then
+          boolToString v
+        else if isFloat v then
+          floatToString v
+        else if isList v then
+          toString v
+        else if isDerivation v then
+          toString v
+        else if builtins.isPath v then
+          toString v
+        else if isString v then
+          v
+        else if isCoercibleToString v then
+          toString v
+        else
+          abort "The nix conf value: ${toPretty { } v} can not be encoded";
+
+      mkKeyValue = k: v: "${escape [ "=" ] k} = ${mkValueString v}";
+
+      mkKeyValuePairs = attrs:
+        concatStringsSep "\n" (mapAttrsToList mkKeyValue attrs);
+
+    in pkgs.writeTextFile {
+      name = "nix.conf";
+      text = ''
+        # WARNING: this file is generated from the nix.settings option in
+        # your Home Manager configuration at $XDG_CONFIG_HOME/nix/nix.conf.
+        # Do not edit it!
+        ${mkKeyValuePairs cfg.settings}
+        ${cfg.extraOptions}
+      '';
+      checkPhase =
+        if pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform then ''
+          echo "Ignoring validation for cross-compilation"
+        '' else ''
+          echo "Validating generated nix.conf"
+          ln -s $out ./nix.conf
+          set -e
+          set +o pipefail
+          NIX_CONF_DIR=$PWD \
+            ${cfg.package}/bin/nix show-config ${
+              optionalString (isNixAtLeast "2.3pre")
+              "--no-net --option experimental-features nix-command"
+            } \
+            |& sed -e 's/^warning:/error:/' \
+            | (! grep '${
+              if cfg.checkConfig then "^error:" else "^error: unknown setting"
+            }')
+          set -o pipefail
+        '';
+    };
+
+  semanticConfType = with types;
+    let
+      confAtom = nullOr (oneOf [ bool int float str path package ]) // {
+        description =
+          "Nix config atom (null, bool, int, float, str, path or package)";
+      };
+    in attrsOf (either confAtom (listOf confAtom));
+
+  jsonFormat = pkgs.formats.json { };
+
 in {
   options.nix = {
+    enable = mkEnableOption ''
+      the Nix configuration module
+    '' // {
+      default = true;
+      visible = false;
+    };
+
+    package = mkOption {
+      type = types.nullOr types.package;
+      default = null;
+      example = literalExpression "pkgs.nix";
+      description = ''
+        The Nix package that the configuration should be generated for.
+      '';
+    };
+
     registry = mkOption {
       type = types.attrsOf (types.submodule (let
         inputAttrs = types.attrsOf
@@ -68,19 +158,81 @@ in {
         User level flake registry.
       '';
     };
+
     registryVersion = mkOption {
       type = types.int;
       default = 2;
       internal = true;
       description = "The flake registry format version.";
     };
-  };
 
-  config = mkIf (cfg.registry != { }) {
-    xdg.configFile."nix/registry.json".text = builtins.toJSON {
-      version = cfg.registryVersion;
-      flakes =
-        mapAttrsToList (n: v: { inherit (v) from to exact; }) cfg.registry;
+    checkConfig = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        If enabled (the default), checks for data type mismatches and that Nix
+        can parse the generated nix.conf.
+      '';
+    };
+
+    extraOptions = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        keep-outputs = true
+        keep-derivations = true
+      '';
+      description =
+        "Additional text appended to <filename>nix.conf</filename>.";
+    };
+
+    settings = mkOption {
+      type = types.submodule { freeformType = semanticConfType; };
+      default = { };
+      example = literalExpression ''
+        {
+          use-sandbox = true;
+          show-trace = true;
+          system-features = [ "big-parallel" "kvm" "recursive-nix" ];
+        }
+      '';
+      description = ''
+        Configuration for Nix, see
+        <link xlink:href="https://nixos.org/manual/nix/stable/#sec-conf-file"/> or
+        <citerefentry>
+          <refentrytitle>nix.conf</refentrytitle>
+          <manvolnum>5</manvolnum>
+        </citerefentry> for avalaible options.
+        The value declared here will be translated directly to the key-value pairs Nix expects.
+        </para>
+        <para>
+        Configuration specified in <option>nix.extraOptions</option> which will be appended
+        verbatim to the resulting config file.
+      '';
     };
   };
+
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = cfg.settings == { } || cfg.package != null;
+      message = ''
+        A corresponding Nix package must be specified via `nix.package` for generating
+        nix.conf.
+      '';
+    }];
+
+    xdg.configFile = {
+      "nix/registry.json" = mkIf (cfg.registry != { }) {
+        source = jsonFormat.generate "registry.json" {
+          version = cfg.registryVersion;
+          flakes =
+            mapAttrsToList (n: v: { inherit (v) from to exact; }) cfg.registry;
+        };
+      };
+
+      "nix/nix.conf" = mkIf (cfg.settings != { }) { source = nixConf; };
+    };
+  };
+
+  meta.maintainers = [ maintainers.polykernel ];
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -45,6 +45,7 @@ import nmt {
     ./modules/files
     ./modules/home-environment
     ./modules/misc/fontconfig
+    ./modules/misc/nix
     ./modules/programs/alacritty
     ./modules/programs/alot
     ./modules/programs/aria2

--- a/tests/modules/misc/nix/default.nix
+++ b/tests/modules/misc/nix/default.nix
@@ -1,0 +1,5 @@
+{
+  nix-empty-settings = ./empty-settings.nix;
+  nix-example-settings = ./example-settings.nix;
+  nix-example-registry = ./example-registry.nix;
+}

--- a/tests/modules/misc/nix/empty-settings.nix
+++ b/tests/modules/misc/nix/empty-settings.nix
@@ -1,0 +1,13 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    nix = { package = config.lib.test.mkStubPackage { }; };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/nix
+    '';
+  };
+}

--- a/tests/modules/misc/nix/example-registry-expected.json
+++ b/tests/modules/misc/nix/example-registry-expected.json
@@ -1,0 +1,17 @@
+{
+  "flakes": [
+    {
+      "exact": true,
+      "from": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      },
+      "to": {
+        "owner": "my-org",
+        "repo": "my-nixpkgs",
+        "type": "github"
+      }
+    }
+  ],
+  "version": 2
+}

--- a/tests/modules/misc/nix/example-registry.nix
+++ b/tests/modules/misc/nix/example-registry.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    nix = {
+      registry = {
+        nixpkgs = {
+          to = {
+            type = "github";
+            owner = "my-org";
+            repo = "my-nixpkgs";
+          };
+        };
+      };
+    };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/nix/registry.json \
+        ${./example-registry-expected.json}
+    '';
+  };
+}

--- a/tests/modules/misc/nix/example-settings-expected.conf
+++ b/tests/modules/misc/nix/example-settings-expected.conf
@@ -1,0 +1,7 @@
+# WARNING: this file is generated from the nix.settings option in
+# your Home Manager configuration at $XDG_CONFIG_HOME/nix/nix.conf.
+# Do not edit it!
+show-trace = true
+system-features = big-parallel kvm recursive-nix
+use-sandbox = true
+

--- a/tests/modules/misc/nix/example-settings.nix
+++ b/tests/modules/misc/nix/example-settings.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    nix = {
+      package = config.lib.test.mkStubPackage {
+        version = lib.getVersion pkgs.nixStable;
+        buildScript = ''
+          target=$out/bin/nix
+          mkdir -p "$(dirname "$target")"
+
+          echo -n "true" > "$target"
+
+          chmod +x "$target"
+        '';
+      };
+
+      settings = {
+        use-sandbox = true;
+        show-trace = true;
+        system-features = [ "big-parallel" "kvm" "recursive-nix" ];
+      };
+    };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/nix/nix.conf \
+        ${./example-settings-expected.conf}
+    '';
+  };
+}


### PR DESCRIPTION
Nix permits user level configurations through ~/.config/nix/nix.conf that allow
customization of system-wide settings and behavior. This is beneficial in chroot
environments and for per-user configurations. System level Nix configurations in the
form of /etc/nix/nix.conf can be specified declaratively via the NixOS nix module but as
of currently no counter part exists in home-manager.

This PR is a port of the RFC42 implementation for the NixOS nix module[1]
to home-manager. Non-applicable options have been excluded and the config generation
backends have been tweaked to the backends offered by home-manager. A notable change
from the NixOS module is a mandatory option to specify the Nix binary corresponding
to the version "nix.conf" should be generated against. This is necessary because
the validation phase is dependent on the `nix show-config` subcommand on the host platform.
While it is possible to avoid validation entirely, the lack of type checking was deemed too significant.
In NixOs, the version information can be retrieved from the `package` option itself which
declares the Nix binary system-wide. However in home-manager, there is no pure way to
detect the system Nix version and what state version the "nix.conf" should be generated
against. Thus an option is used to overcome this limitation by forcing the user to
specify the Nix package. Note this interaction can still be automated by forwarding
the system-wide Nix package to the home-manager module if needed.

Three unit tests were added to test the module behavior for the empty settings, the example
settings and the example registry configurations respectively.

[1] - https://github.com/NixOS/nixpkgs/pull/139075

### Description
Efforts towards https://github.com/nix-community/home-manager/issues/2324

Todo

- [x] Write unit tests

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
