### PR TITLE
home-manager: pass through `--experimental-features` and `--extra-experimental-features`

### DIFF
--- a/docs/nix-flakes.adoc
+++ b/docs/nix-flakes.adoc
@@ -99,6 +99,7 @@ $ nix build --no-link <flake-uri>#homeConfigurations.jdoe.activationPackage
 $ "$(nix path-info <flake-uri>#homeConfigurations.jdoe.activationPackage)"/bin/activate
 ----
 +
+Substitute `<flake-uri>` with the flake URI of the configuration flake.
 If `flake.nix` resides in `~/.config/nixpkgs`,
 `<flake-uri>` may be `~/.config/nixpkgs`
 as a Git tree or `path:~/.config/nixpkgs` if not.
@@ -107,7 +108,7 @@ as a Git tree or `path:~/.config/nixpkgs` if not.
 building a flake-based configuration is as simple as
 +
 [source,console]
-$ home-manager switch --flake 'flake-uri#jdoe'
+$ home-manager switch --flake '<flake-uri>#jdoe'
 +
 once home-manager is installed.
 +

--- a/docs/nix-flakes.adoc
+++ b/docs/nix-flakes.adoc
@@ -18,10 +18,13 @@ Either set in `nix.conf`
 [source,bash]
 experimental-features = nix-command flakes
 +
-or pass them to `nix` by
+or pass them to `nix` and `home-manager` by
 +
 [source,console]
-nix --experimental-features "nix-command flakes" your command
+----
+$ nix --extra-experimental-features "nix-command flakes" <sub-commands>
+$ home-manager --extra-experimental-features "nix-command flakes" <sub-commands>
+----
 
 * Prepare your Home Manager configuration (`home.nix`).
 +

--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -293,7 +293,9 @@ _home-manager_completions ()
     Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" \
               "--verbose" "--cores" "--debug" "--impure" "--keep-failed" \
               "--keep-going" "-j" "--max-jobs" "--no-substitute" "--no-out-link" \
-              "--show-trace" "--substitute" "--builders" "--version")
+              "--show-trace" "--substitute" "--builders" "--version" \
+              "--update-input" "--override-input" "--experimental-features" \
+              "--extra-experimental-features" )
 
     # ^ « home-manager »'s options.
 

--- a/home-manager/completion.fish
+++ b/home-manager/completion.fish
@@ -64,3 +64,7 @@ complete -c home-manager -f -l "show-trace" -d "Print stack trace of evaluation 
 complete -c home-manager -f -l "substitute"
 complete -c home-manager -f -l "no-substitute"
 complete -c home-manager -f -l "no-out-link"
+complete -c home-manager -f -l "update-input"
+complete -c home-manager -f -l "override-input"
+complete -c home-manager -f -l "experimental-features"
+complete -c home-manager -f -l "extra-experimental-features"

--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -20,6 +20,10 @@ _arguments \
   '--option[option]:NAME VALUE:()' \
   '--builders[builders]:SPEC:()' \
   '--show-trace[show trace]' \
+  '--override-input[override flake input]:NAME VALUE:()' \
+  '--update-input[update flake input]:NAME:()' \
+  '--experimental-features[set experimental Nix features]:VALUE:()' \
+  '--extra-experimental-features:[append to experimental Nix features]:VALUE:()' \
   '1: :->cmds' \
   '*:: :->args' && ret=0
 
@@ -57,7 +61,11 @@ case "$state" in
           '--option[option]:NAME VALUE:()' \
           '--show-trace[show trace]' \
           '--substitute[substitute]' \
-          '--builders[builders]:SPEC:()'
+          '--builders[builders]:SPEC:()' \
+          '--override-input[override flake input]:NAME VALUE:()' \
+          '--update-input[update flake input]:NAME:()' \
+          '--experimental-features[set experimental Nix features]:VALUE:()' \
+          '--extra-experimental-features:[append to experimental Nix features]:VALUE:()'
         ;;
     esac
 esac

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -608,6 +608,14 @@ while [[ $# -gt 0 ]]; do
             PASSTHROUGH_OPTS+=("$opt" "$1" "$2")
             shift 2
             ;;
+        --experimental-features)
+            PASSTHROUGH_OPTS+=("$opt" "$1")
+            shift
+            ;;
+        --extra-experimental-features)
+            PASSTHROUGH_OPTS+=("$opt" "$1")
+            shift
+            ;;
         --no-out-link)
             NO_OUT_LINK=1
             ;;


### PR DESCRIPTION
### Description

This change enable the `home-manager` command-line utility to pass through `--experimental-features` and `--extra-experimental-features` to override or extend the Nix configuration in the environment and enable unprivileged users to use `home-manager --flake` when `nix-command` and `flakes` is not included in the system `experimental-featuers`. 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
