### PR TITLE
modules/default.nix: Add useNixpkgsModule parameter

### DIFF
--- a/docs/nix-flakes.adoc
+++ b/docs/nix-flakes.adoc
@@ -69,6 +69,11 @@ writing a Home Manager configuration.
 
         # Optionally use extraSpecialArgs
         # to pass through arguments to home.nix
+
+        # Optionally set
+        # disableNixpkgsModule = false;
+        # to allow using nixpkgs.config/overlays inside the home configuration
+        # instead of directly using the passed pkgs
       };
     };
 }

--- a/docs/release-notes/rl-2211.adoc
+++ b/docs/release-notes/rl-2211.adoc
@@ -34,8 +34,8 @@ have been removed. Instead use the new `modules` argument, which
 accepts a list of NixOS modules.
 +
 Further, the `pkgs` argument is now mandatory and should be set to
-`nixpkgs.legacyPackages.${system}` where `nixpkgs` is the Nixpkgs
-input of your choice.
+an imported `nixpkgs`, for example `nixpkgs.legacyPackages.${system}`
+where `nixpkgs` is the Nixpkgs input of your choice.
 +
 For example, if your Flake currently contains
 +
@@ -74,6 +74,12 @@ homeManagerConfiguration {
 Of course, you can move the assignment of <<opt-home.username>>,
 <<opt-home.homeDirectory>>, and <<opt-home.stateVersion>> to some
 other file or simply place them in your `home.nix`.
+
+* The Flake function `homeManagerConfiguration` now has
+ a new argument `disableNixpkgsModule`, defaulting to true.
+ When set, the `nixpkgs.config/overlays` settings are not available,
+ and the passed `pkgs` instance is used directly, instead of being
+ imported again.
 
 * The `services.picom` module has been refactored to use structural
 settings.

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
       lib = {
         hm = (import ./modules/lib/stdlib-extended.nix nixpkgs.lib).hm;
         homeManagerConfiguration = { modules ? [ ], pkgs, lib ? pkgs.lib
-          , extraSpecialArgs ? { }, check ? true
+          , extraSpecialArgs ? { }, check ? true, disableNixpkgsModule ? true
             # Deprecated:
           , configuration ? null, extraModules ? null, stateVersion ? null
           , username ? null, homeDirectory ? null, system ? null }@args:
@@ -50,11 +50,15 @@
               throwForRemovedArg extraModules # \
               throwForRemovedArg system;
           in throwForRemovedArgs (import ./modules {
-            inherit pkgs lib check extraSpecialArgs;
-            configuration = { ... }: {
-              imports = modules;
-              nixpkgs = { inherit (pkgs) config overlays; };
-            };
+            inherit pkgs lib check extraSpecialArgs disableNixpkgsModule;
+            configuration = { ... }:
+              ({
+                imports = modules;
+              } // (if disableNixpkgsModule then
+                { }
+              else {
+                nixpkgs = { inherit (pkgs) config overlays; };
+              }));
           });
       };
     } // utils.lib.eachDefaultSystem (system:

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -6,6 +6,8 @@
 , check ? true
   # Extra arguments passed to specialArgs.
 , extraSpecialArgs ? { }
+  # If disabled, the pkgs attribute passed to this function is used instead.
+, useNixpkgsModule ? true
 }:
 
 with lib;
@@ -25,7 +27,7 @@ let
 
   hmModules =
     import ./modules.nix {
-      inherit check pkgs;
+      inherit check pkgs useNixpkgsModule;
       lib = extendedLib;
     };
 


### PR DESCRIPTION
### Description

Fixes #2701 by making it possible to disable the nixpkgs module with the unprivileged flake setup.

Sets `disableNixpkgsModule` to `true` by default when using `lib.homeManagerConfiguration`, to avoid reimporting `nixpkgs` and then copying the same exact config and overlays.

<details>
<summary> Click for some obsolete changes before #3037 went in </summary>
I also made this the default for `lib.homeManagerConfiguration` as I think it makes more sense for performance to use the `pkgs` input directly rather than reimporting it and copying config/overlays. I could change that back to being optional if desired, not sure.

The current requirement that `homeManagerConfiguration` take a `stateVersion`, `homeDirectory` and `username` arg feels weird to me as it prevents setting these in that user's configuration nix files (unless you mkForce). This is more often done this way and makes it easier to share the same configuration between use in nixos modules and use for the unprivileged flake setup.

I think it would be best if `homeManagerConfiguration` worked like this:

```
      homeManagerConfiguration = { configuration, system
          , extraModules ? [ ], extraSpecialArgs ? { }
          , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
          , check ? true }@args:
          import ./modules {
            inherit pkgs check extraSpecialArgs useNixpkgsModule;
            configuration = { ... }: {
              imports = [ configuration ] ++ extraModules;
              // removed the home.* settings here and removed the args for them
              // they should be set in extraModules or configuration like all other hm config is
            };
          };
      };
```

But that wouldn't be backwards compatible.

</details>

Update for 2022-08: Most of that was done in https://github.com/nix-community/home-manager/pull/3037, this PR now only has the `useNixpkgsModule` changes.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
