### PR TITLE
neovim: Support Lua for plugin configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -157,6 +157,9 @@
 /modules/programs/ne.nix                              @cwyc
 /tests/modules/programs/ne                            @cwyc
 
+/modules/programs/neovim.nix                          @cdunster
+/tests/modules/programs/neovim                        @cdunster
+
 /modules/programs/newsboat.nix                        @sumnerevans
 /tests/modules/programs/newsboat                      @sumnerevans
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -205,4 +205,10 @@
     github = "pinage404";
     githubId = 6325757;
   };
+  cdunster = {
+    name = "Callum Dunster";
+    email = "cdunster@users.noreply.github.com";
+    github = "cdunster";
+    githubId = 5011912;
+  };
 }

--- a/tests/modules/programs/neovim/default.nix
+++ b/tests/modules/programs/neovim/default.nix
@@ -1,6 +1,7 @@
 {
   neovim-plugin-config = ./plugin-config.nix;
   neovim-coc-config = ./coc-config.nix;
+  neovim-plugin-config-lua = ./plugin-config-lua.nix;
   # waiting for a nixpkgs patch
   # neovim-no-init = ./no-init.nix;
 }

--- a/tests/modules/programs/neovim/plugin-config-lua.nix
+++ b/tests/modules/programs/neovim/plugin-config-lua.nix
@@ -1,0 +1,34 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.neovim = {
+      enable = true;
+      extraConfig = ''
+        " This should be present in init.vim
+      '';
+      plugins = with pkgs.vimPlugins; [
+        vim-nix
+        {
+          plugin = vim-commentary;
+          type = "lua";
+          config = ''
+            -- This should be present in a lua block.
+            vim.opt.number = true
+          '';
+        }
+      ];
+    };
+
+    nmt.script = ''
+      vimrc="$TESTED/home-files/.config/nvim/init.vim"
+      vimrcNormalized="$(normalizeStorePaths "$vimrc")"
+
+      assertFileExists "$vimrc"
+      assertFileContent "$vimrcNormalized" "${./plugin-config-lua.vim}"
+    '';
+  };
+}
+

--- a/tests/modules/programs/neovim/plugin-config-lua.vim
+++ b/tests/modules/programs/neovim/plugin-config-lua.vim
@@ -1,0 +1,11 @@
+set packpath^=/nix/store/00000000000000000000000000000000-vim-pack-dir
+set runtimepath^=/nix/store/00000000000000000000000000000000-vim-pack-dir
+
+" vim-commentary {{{
+lua << EOF
+-- This should be present in a lua block.
+vim.opt.number = true
+
+EOF
+" }}}
+" This should be present in init.vim


### PR DESCRIPTION
### Description

This is to support the use of Lua as a language for plugin configuration in neovim.
Lua plugins are becoming the norm in neovim so it is useful to be able to configure them with Lua.

This should be expanded on later to add better support for Lua but this is a good first step.

P.S. I am very new to Nix and home-manager so any feedback is welcome, but please be kind :grin: 

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.
    (_bash module tests not passing, I think this is an error on master though_)

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
  (_not new but no current maintainer_)

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
