### PR TITLE
fusuma: introduce a service module for fusuma.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,6 +87,9 @@
 /modules/programs/foot.nix                            @plabadens
 /tests/modules/programs/foot                          @plabadens
 
+/modules/services/fusuma.nix                          @iosmanthus
+/tests/modules/services/fusuma                        @iosmanthus
+
 /modules/programs/gh.nix                              @Gerschtli @berbiche
 /tests/modules/programs/gh                            @Gerschtli @berbiche
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -61,6 +61,12 @@
     github = "olmokramer";
     githubId = 3612514;
   };
+  iosmanthus = {
+    name = "iosmanthus";
+    email = "myosmanthustree@gmail.com";
+    github = "iosmanthus";
+    githubId = 16307070;
+  };
   kalhauge = {
     name = "Christian Gram Kalhauge";
     email = "kalhauge@users.noreply.github.com";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2456,6 +2456,14 @@ in
           A new module is available: 'programs.pubs'.
         '';
       }
+
+      {
+        time = "2022-03-13T20:59:38+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.fusuma'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -187,6 +187,7 @@ let
     ./services/flameshot.nix
     ./services/fluidsynth.nix
     ./services/fnott.nix
+    ./services/fusuma.nix
     ./services/getmail.nix
     ./services/git-sync.nix
     ./services/gnome-keyring.nix

--- a/modules/services/fusuma.nix
+++ b/modules/services/fusuma.nix
@@ -1,0 +1,138 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.fusuma;
+
+  yamlFormat = pkgs.formats.yaml { };
+
+  configJson = pkgs.writeText "config.json" (builtins.toJSON cfg.settings);
+
+  configYamlRaw = pkgs.runCommand "config.yaml.raw" { } ''
+    ${pkgs.remarshal}/bin/json2yaml -i ${configJson} -o $out;
+  '';
+
+  # convert keys into literal numbers where necessary,
+  # fusuma does not support string type finger count.
+  strToInt = pkgs.writers.writePython3 "str2int" {
+    libraries = [ pkgs.python3Packages.pyyaml ];
+  } ''
+    import yaml
+    from yaml import FullLoader
+
+
+    def str2int(config):
+        if type(config) is not dict:
+            return
+
+        for key in list(config):
+            if type(config[key]) is dict and key.isdigit():
+                t = config[key]
+                del config[key]
+                config[int(key)] = t
+            else:
+                str2int(config[key])
+
+
+    if __name__ == '__main__':
+        path = "${configYamlRaw}"
+        with open(path) as f:
+            config = yaml.load(f, Loader=FullLoader)
+            str2int(config)
+            print(yaml.dump(config))
+  '';
+
+  configYaml = pkgs.stdenv.mkDerivation {
+    name = "config.yaml";
+    buildCommand = ''
+      ${strToInt} > $out
+    '';
+  };
+
+  makeBinPath = packages:
+    foldl (a: b: if a == "" then b else "${a}:${b}") ""
+    (map (pkg: "${pkg}/bin") packages);
+
+in {
+  meta.maintainers = [ hm.maintainers.iosmanthus ];
+
+  options.services.fusuma = {
+    enable = mkEnableOption
+      "the fusuma systemd service to automatically enable touchpad gesture";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.fusuma;
+      defaultText = literalExpression "pkgs.fusuma";
+      description = "Package providing <command>fusuma</command>.";
+    };
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      example = literalExpression ''
+        {
+          enable = true;
+          extraPackages = with pkgs;[ xdotool ];
+          config = {
+            threshold = {
+              swipe = 0.1;
+            };
+            interval = {
+              swipe = 0.7;
+            };
+            swipe = {
+              "3" = {
+                left = {
+                  # GNOME: Switch to left workspace
+                  command = "xdotool key ctrl+alt+Right";
+                };
+              };
+            };
+          };
+        };
+      '';
+      description = ''
+        YAML config that will override the default fusuma configuration.
+      '';
+    };
+
+    extraPackages = mkOption {
+      type = types.listOf types.package;
+      default = with pkgs; [ coreutils ];
+      defaultText = literalExpression "pkgs.coreutils";
+      example = literalExpression ''
+        with pkgs; [ coreutils xdotool ];
+      '';
+      description = ''
+        Extra packages needs to bring to the scope of fusuma service.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.fusuma" pkgs
+        lib.platforms.linux)
+    ];
+
+    xdg.configFile."fusuma/config.yaml".source = configYaml;
+
+    systemd.user.services.fusuma = {
+      Unit = {
+        Description = "Fusuma services";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        Environment = with pkgs; "PATH=${makeBinPath cfg.extraPackages}";
+        ExecStart =
+          "${cfg.package}/bin/fusuma -c ${config.xdg.configHome}/fusuma/config.yaml";
+      };
+
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -144,6 +144,7 @@ import nmt {
     ./modules/services/flameshot
     ./modules/services/fluidsynth
     ./modules/services/fnott
+    ./modules/services/fusuma
     ./modules/services/git-sync
     ./modules/services/gpg-agent
     ./modules/services/gromit-mpx

--- a/tests/modules/services/fusuma/default.nix
+++ b/tests/modules/services/fusuma/default.nix
@@ -1,0 +1,4 @@
+{
+  fusuma-example-settings = ./settings.nix;
+  fusuma-systemd-user-service = ./service.nix;
+}

--- a/tests/modules/services/fusuma/expected-service.service
+++ b/tests/modules/services/fusuma/expected-service.service
@@ -1,0 +1,11 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+Environment=PATH=@coreutils@/bin:@xdotool@/bin
+ExecStart=@fusuma@/bin/fusuma -c /home/hm-user/.config/fusuma/config.yaml
+
+[Unit]
+After=graphical-session-pre.target
+Description=Fusuma services
+PartOf=graphical-session.target

--- a/tests/modules/services/fusuma/expected-settings.yaml
+++ b/tests/modules/services/fusuma/expected-settings.yaml
@@ -1,0 +1,12 @@
+interval:
+  swipe: 7
+swipe:
+  3:
+    left:
+      command: xdotool key ctrl+alt+Right
+  4:
+    left:
+      command: xdotool key ctrl+shift+alt+Right
+threshold:
+  swipe: 1
+

--- a/tests/modules/services/fusuma/service.nix
+++ b/tests/modules/services/fusuma/service.nix
@@ -1,0 +1,19 @@
+{ config, ... }:
+
+{
+  services.fusuma = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@fusuma@"; };
+    extraPackages = [
+      (config.lib.test.mkStubPackage { outPath = "@coreutils@"; })
+      (config.lib.test.mkStubPackage { outPath = "@xdotool@"; })
+    ];
+    settings = { };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/systemd/user/fusuma.service \
+        ${./expected-service.service}
+  '';
+}

--- a/tests/modules/services/fusuma/settings.nix
+++ b/tests/modules/services/fusuma/settings.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+
+{
+  services.fusuma = {
+    enable = true;
+    extraPackages = [ (config.lib.test.mkStubPackage { }) ];
+
+    settings = {
+      threshold = { swipe = 1; };
+      interval = { swipe = 7; };
+      swipe = {
+        "3" = { left = { command = "xdotool key ctrl+alt+Right"; }; };
+        "4" = { left = { command = "xdotool key ctrl+shift+alt+Right"; }; };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/fusuma/config.yaml \
+      ${./expected-settings.yaml}
+  '';
+}


### PR DESCRIPTION
Fusuma is a tool that supports multitouch gestures with libinput driver on Linux. This commit introduces a nix module for home-manager.

Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
