### PR TITLE
mpd-discord-rpc: init service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -318,6 +318,8 @@
 
 /modules/services/mpdris2.nix                         @pjones
 
+/modules/services/mpd-discord-rpc.nix                 @Kranzes
+
 /modules/services/mpris-proxy.nix                     @ThibautMarty
 
 /modules/services/muchsync.nix                        @pacien

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -201,6 +201,7 @@ let
     ./services/mbsync.nix
     ./services/mpd.nix
     ./services/mpdris2.nix
+    ./services/mpd-discord-rpc.nix
     ./services/mpris-proxy.nix
     ./services/muchsync.nix
     ./services/network-manager-applet.nix

--- a/modules/services/mpd-discord-rpc.nix
+++ b/modules/services/mpd-discord-rpc.nix
@@ -1,0 +1,55 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.mpd-discord-rpc;
+  tomlFormat = pkgs.formats.toml { };
+  configFile = tomlFormat.generate "config.toml" cfg.settings;
+in {
+  meta.maintainers = [ maintainers.kranzes ];
+
+  options.services.mpd-discord-rpc = {
+    enable = mkEnableOption "the mpd-discord-rpc service";
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          hosts = [ "localhost:6600" ];
+          format = {
+            details = "$title";
+            state = "On $album by $artist";
+          };
+        }
+      '';
+      description = ''
+        Configuration included in <literal>config.toml</literal>.
+        For available options see <link xlink:href="https://github.com/JakeStanger/mpd-discord-rpc#configuration"/> 
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.mpd-discord-rpc;
+      defaultText = literalExpression "pkgs.mpd-discord-rpc";
+      description = "mpd-discord-rpc package to use.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    xdg.configFile."discord-rpc/config.toml".source = configFile;
+
+    systemd.user.services.mpd-discord-rpc = {
+      Unit = {
+        Description = "Discord Rich Presence for MPD";
+        Documentation = "https://github.com/JakeStanger/mpd-discord-rpc";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.desktop" ];
+      };
+      Service.ExecStart = "${cfg.package}/bin/mpd-discord-rpc";
+      Install.WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}


### PR DESCRIPTION
### Description
This PR adds a configurable service that runs [mpd-discord-rpc](https://github.com/JakeStanger/mpd-discord-rpc).

~~I am waiting for the upstream package to merge this pull request https://github.com/JakeStanger/mpd-discord-rpc/pull/16 so the package can be added to nixpkgs.~~

The module has also been tested to be working fine on my personal system with an overlay for the package mpd-discord-rpc ~~since it is not in nixpkgs yet.~~ ,it is now.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
