### PR TITLE
pylint: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -194,6 +194,8 @@
 
 /modules/programs/powerline-go.nix                    @DamienCassou
 
+/modules/programs/pylint.nix                          @florpe
+
 /modules/programs/rbw.nix                             @ambroisie
 /tests/modules/programs/rbw                           @ambroisie
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -105,6 +105,12 @@
     githubId = 46252070;
     name = "Sara Johnsson";
   };
+  florpe = {
+    email = "jens.krewald@gmail.com";
+    github = "florpe";
+    githubId = 53856373;
+    name = "Jens Krewald";
+  };
   msfjarvis = {
     email = "me@msfjarvis.dev";
     github = "msfjarvis";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -127,6 +127,7 @@ let
     ./programs/pidgin.nix
     ./programs/piston-cli.nix
     ./programs/powerline-go.nix
+    ./programs/pylint.nix
     ./programs/qutebrowser.nix
     ./programs/rbw.nix
     ./programs/readline.nix

--- a/modules/programs/pylint.nix
+++ b/modules/programs/pylint.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.pylint;
+
+  # generators.toINI fails when it encounters a list, so we have to set up
+  # some infrastructure.
+  mkVal = generators.mkValueStringDefault { };
+  mkINIVal = v:
+    if isList v then
+      builtins.concatStringsSep ", " (builtins.map mkVal v)
+    else
+      mkVal v;
+  mkINIKeyVal = generators.mkKeyValueDefault { mkValueString = mkINIVal; } "=";
+  mkINI = attrOfAttrs:
+    generators.toINI { mkKeyValue = mkINIKeyVal; } attrOfAttrs;
+  writeINI = name: attrsOfAttrs: pkgs.writeText name (mkINI attrsOfAttrs);
+
+in {
+  meta.maintainers = [ hm.maintainers.florpe ];
+  options.programs.pylint = {
+    enable = mkEnableOption "the pylint Python linter";
+    package = mkOption {
+      type = types.package;
+      default = pkgs.python3Packages.pylint;
+      defaultText = literalExpression "pkgs.python3Packages.pylint";
+      description = "pylint package to use.";
+    };
+    settings = mkOption {
+      type = types.attrs;
+      default = { };
+      defaultText = literalExpression "{}";
+      description = "The pylint [BASIC] configuration to use.";
+    };
+    advanced = mkOption {
+      type = types.attrsOf types.attrs;
+      default = { };
+      defaultText = literalExpression "{}";
+      description =
+        "The pylint configuration other than the [BASIC] section to use.";
+    };
+  };
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    home.sessionVariables =
+      let pylintcfg = cfg.advanced // { BASIC = cfg.settings; };
+      in { PYLINTRC = writeINI ".pylintrc" pylintcfg; };
+  };
+}

--- a/modules/programs/pylint.nix
+++ b/modules/programs/pylint.nix
@@ -17,8 +17,6 @@ let
   mkINIKeyVal = generators.mkKeyValueDefault { mkValueString = mkINIVal; } "=";
   mkINI = attrOfAttrs:
     generators.toINI { mkKeyValue = mkINIKeyVal; } attrOfAttrs;
-  writeINI = name: attrsOfAttrs: pkgs.writeText name (mkINI attrsOfAttrs);
-
 in {
   meta.maintainers = [ hm.maintainers.florpe ];
   options.programs.pylint = {
@@ -45,8 +43,7 @@ in {
   };
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
-    home.sessionVariables =
-      let pylintcfg = cfg.advanced // { BASIC = cfg.settings; };
-      in { PYLINTRC = writeINI ".pylintrc" pylintcfg; };
+    home.file.".pylintrc".text =
+      mkINI (cfg.advanced // { BASIC = cfg.settings; });
   };
 }

--- a/modules/programs/pylint.nix
+++ b/modules/programs/pylint.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   cfg = config.programs.pylint;
-  listToValue = concatMapStringsSep ",\n    " (generators.mkValueStringDefault { });
+  listToValue = concatMapStringsSep ", " (generators.mkValueStringDefault { });
   iniFormat = pkgs.formats.ini { inherit listToValue; };
 in {
   meta.maintainers = [ hm.maintainers.florpe ];

--- a/modules/programs/pylint.nix
+++ b/modules/programs/pylint.nix
@@ -10,7 +10,7 @@ let
 in {
   meta.maintainers = [ hm.maintainers.florpe ];
   options.programs.pylint = {
-    enable = mkEnableOption "The pylint Python linter.";
+    enable = mkEnableOption "the pylint Python linter";
     package = mkOption {
       type = types.package;
       default = pkgs.python3Packages.pylint;


### PR DESCRIPTION
### Description

Adds a module for the Python linter pylint.

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
