### PR TITLE
just: add module for the just command runner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,6 +119,8 @@
 
 /modules/programs/java.nix                            @ShamrockLee
 
+/modules/programs/just.nix                            @maximsmol
+
 /modules/programs/keychain.nix                        @marsam
 
 /modules/programs/kodi.nix                            @dwagenk

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -111,6 +111,12 @@
     githubId = 46252070;
     name = "Sara Johnsson";
   };
+  maximsmol = {
+    email = "maximsmol@gmail.com";
+    github = "maximsmol";
+    githubId = 1472826;
+    name = "Max Smolin";
+  };
   msfjarvis = {
     email = "me@msfjarvis.dev";
     github = "msfjarvis";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2442,6 +2442,13 @@ in
           Use this to enable services based on macOS LaunchAgents.
         '';
       }
+
+      {
+        time = "2022-03-06T08:50:32+00:00";
+        message = ''
+          A new module is available: 'programs.just'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -87,6 +87,7 @@ let
     ./programs/irssi.nix
     ./programs/java.nix
     ./programs/jq.nix
+    ./programs/just.nix
     ./programs/kakoune.nix
     ./programs/keychain.nix
     ./programs/kitty.nix

--- a/modules/programs/just.nix
+++ b/modules/programs/just.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.just;
+
+in {
+  meta.maintainers = [ hm.maintainers.maximsmol ];
+
+  options.programs.just = {
+    enable = mkEnableOption
+      "just, a handy way to save and run project-specific commands";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.just;
+      defaultText = literalExpression "pkgs.just";
+      description = "Package providing the <command>just</command> tool.";
+    };
+
+    enableBashIntegration = mkEnableOption "Bash integration" // {
+      default = true;
+    };
+
+    enableZshIntegration = mkEnableOption "Zsh integration" // {
+      default = true;
+    };
+
+    enableFishIntegration = mkEnableOption "Fish integration" // {
+      default = true;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
+      source ${cfg.package}/share/bash-completion/completions/just.bash
+    '';
+
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      source ${cfg.package}/share/zsh/site-functions/_just
+    '';
+
+    programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
+      source ${cfg.package}/share/fish/vendor_completions.d/just.fish
+    '';
+
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds a module for [just](https://github.com/casey/just) and its shell completions.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
