### PR TITLE
zellij: fix configuration for darwin

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -7,6 +7,11 @@ let
   cfg = config.programs.zellij;
   yamlFormat = pkgs.formats.yaml { };
 
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Application Support/org.Zellij-Contributors.Zellij"
+  else
+    "${config.xdg.configHome}/zellij";
+
 in {
   meta.maintainers = [ hm.maintainers.mainrs ];
 
@@ -44,7 +49,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."zellij/config.yaml" = mkIf (cfg.settings != { }) {
+    home.file."${configDir}/config.yaml" = mkIf (cfg.settings != { }) {
       source = yamlFormat.generate "zellij.yaml" cfg.settings;
     };
   };


### PR DESCRIPTION
### Description

Zellij uses a different path to hold its configuration on Darwin.
See: https://zellij.dev/documentation/configuration.html


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.