### PR TITLE
tmux: add notes to existing keybindings (#2540)

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -49,8 +49,8 @@ let
     ${optionalString cfg.newSession "new-session"}
 
     ${optionalString cfg.reverseSplit ''
-      bind v split-window -h
-      bind s split-window -v
+      bind -N "Split the pane into two, left and right" v split-window -h
+      bind -N "Split the pane into two, top and bottom" s split-window -v
     ''}
 
     set -g status-keys ${cfg.keyMode}
@@ -58,34 +58,40 @@ let
 
     ${optionalString
     (cfg.keyMode == "vi" && cfg.customPaneNavigationAndResize) ''
-      bind h select-pane -L
-      bind j select-pane -D
-      bind k select-pane -U
-      bind l select-pane -R
+      bind h -N "Select pane to the left of the active pane" select-pane -L
+      bind j -N "Select pane below the active pane" select-pane -D
+      bind k -N "Select pane above the active pane" select-pane -U
+      bind l -N "Select pane to the right of the active pane" select-pane -R
 
-      bind -r H resize-pane -L ${toString cfg.resizeAmount}
-      bind -r J resize-pane -D ${toString cfg.resizeAmount}
-      bind -r K resize-pane -U ${toString cfg.resizeAmount}
-      bind -r L resize-pane -R ${toString cfg.resizeAmount}
+      bind -r -N "Resize the pane left by ${toString cfg.resizeAmount}" \
+        H resize-pane -L ${toString cfg.resizeAmount}
+      bind -r -N "Resize the pane down by ${toString cfg.resizeAmount}" \
+        J resize-pane -D ${toString cfg.resizeAmount}
+      bind -r -N "Resize the pane up by ${toString cfg.resizeAmount}" \
+        K resize-pane -U ${toString cfg.resizeAmount}
+      bind -r -N "Resize the pane right by ${toString cfg.resizeAmount}" \
+        L resize-pane -R ${toString cfg.resizeAmount}
     ''}
 
     ${if cfg.prefix != null then ''
       # rebind main key: ${cfg.prefix}
       unbind C-${defaultShortcut}
       set -g prefix ${cfg.prefix}
-      bind ${cfg.prefix} send-prefix
+      bind -N "Send the prefix key through to the application" \
+        ${cfg.prefix} send-prefix
     '' else
       optionalString (cfg.shortcut != defaultShortcut) ''
         # rebind main key: C-${cfg.shortcut}
         unbind C-${defaultShortcut}
         set -g prefix C-${cfg.shortcut}
-        bind ${cfg.shortcut} send-prefix
+        bind -N "Send the prefix key through to the application" \
+          ${cfg.shortcut} send-prefix
         bind C-${cfg.shortcut} last-window
       ''}
 
     ${optionalString cfg.disableConfirmationPrompt ''
-      bind-key & kill-window
-      bind-key x kill-pane
+      bind-key -N "Kill the current window" & kill-window
+      bind-key -N "Kill the current pane" x kill-pane
     ''}
 
     setw -g aggressive-resize ${boolToStr cfg.aggressiveResize}

--- a/tests/modules/programs/tmux/disable-confirmation-prompt.conf
+++ b/tests/modules/programs/tmux/disable-confirmation-prompt.conf
@@ -19,8 +19,8 @@ set -g mode-keys   emacs
 
 
 
-bind-key & kill-window
-bind-key x kill-pane
+bind-key -N "Kill the current window" & kill-window
+bind-key -N "Kill the current pane" x kill-pane
 
 
 setw -g aggressive-resize off

--- a/tests/modules/programs/tmux/emacs-with-plugins.conf
+++ b/tests/modules/programs/tmux/emacs-with-plugins.conf
@@ -10,8 +10,8 @@ setw -g pane-base-index 0
 
 new-session
 
-bind v split-window -h
-bind s split-window -v
+bind -N "Split the pane into two, left and right" v split-window -h
+bind -N "Split the pane into two, top and bottom" s split-window -v
 
 
 set -g status-keys emacs

--- a/tests/modules/programs/tmux/prefix.conf
+++ b/tests/modules/programs/tmux/prefix.conf
@@ -20,7 +20,8 @@ set -g mode-keys   emacs
 # rebind main key: C-a
 unbind C-b
 set -g prefix C-a
-bind C-a send-prefix
+bind -N "Send the prefix key through to the application" \
+  C-a send-prefix
 
 
 

--- a/tests/modules/programs/tmux/shortcut-without-prefix.conf
+++ b/tests/modules/programs/tmux/shortcut-without-prefix.conf
@@ -20,7 +20,8 @@ set -g mode-keys   emacs
 # rebind main key: C-a
 unbind C-b
 set -g prefix C-a
-bind a send-prefix
+bind -N "Send the prefix key through to the application" \
+  a send-prefix
 bind C-a last-window
 
 

--- a/tests/modules/programs/tmux/vi-all-true.conf
+++ b/tests/modules/programs/tmux/vi-all-true.conf
@@ -10,8 +10,8 @@ setw -g pane-base-index 0
 
 new-session
 
-bind v split-window -h
-bind s split-window -v
+bind -N "Split the pane into two, left and right" v split-window -h
+bind -N "Split the pane into two, top and bottom" s split-window -v
 
 
 set -g status-keys vi


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds notes to the keybindings created in the tmux config, making them show up when checking `C-b ?` or `tmux list-keys -N`, fixing #2540. I also adjusted the reference configs in the test cases to expect the notes.

Keys without notes are not displayed when checking `C-b ?` (since tmux 3.1), making them hard to discover for users.

The explanations are mostly taken from/based on the tmux man-page (which is licensed under Zero-Clause BSD).

I ran all tests which don't complain about the `shellDryRun` attribute missing (see #2722) and all tests that pass without the commit also pass with it (only `herbstluftwm-simple-config` fails, both with and without my commit).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`. (Mostly of done, see above)

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
