### PR TITLE
vscode: add mutable user settings option.

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -135,6 +135,16 @@ in {
           or by Visual Studio Code.
         '';
       };
+
+      mutableUserSettings = mkOption {
+        type = types.bool;
+        default = false;
+        example = false;
+        description = ''
+          Whether user settings can be changed manually or by Visual
+          Studio Code.
+        '';
+      };
     };
   };
 
@@ -142,7 +152,7 @@ in {
     home.packages = [ cfg.package ];
 
     home.file = mkMerge [
-      (mkIf (cfg.userSettings != { }) {
+      (mkIf (!cfg.mutableUserSettings && cfg.userSettings != { }) {
         "${configFilePath}".source =
           jsonFormat.generate "vscode-user-settings" cfg.userSettings;
       })
@@ -172,5 +182,23 @@ in {
         "${extensionPath}".source = extensionsFolder;
       }))
     ];
+
+    home.activation =
+      mkIf (cfg.mutableUserSettings && cfg.userSettings != { }) {
+        injectVscodeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          tmp="$(mktemp)"
+          if [[ -v DRY_RUN ]]; then
+            echo tmp="\$(mktemp)"
+            echo ${pkgs.jq}/bin/jq -s "'reduce .[] as \$x ({}; . * \$x)'" "${
+              jsonFormat.generate "vscode-user-settings" cfg.userSettings
+            }" "${configFilePath}" ">" "$tmp"
+          else
+            ${pkgs.jq}/bin/jq -s 'reduce .[] as $x ({}; . * $x)' "${
+              jsonFormat.generate "vscode-user-settings" cfg.userSettings
+            }" "${configFilePath}" > "$tmp"
+          fi
+          $DRY_RUN_CMD mv "$tmp" "${configFilePath}"
+        '';
+      };
   };
 }


### PR DESCRIPTION
### Description

User settings could not be modified once home-manager took over managing
settings. This setting allows user settings to diverge from what is
configured in the user's home-manager config. New settings from the home-manager config are still
applied but anything removed from the home-manager config will not be removed from the mutable settings. Similarly, any changes the user makes to the mutable settings will take precedence over the home-manager config settings.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
