### PR TITLE
tests/nnn: fix tests 

### DIFF
--- a/tests/modules/programs/nnn/nnn.nix
+++ b/tests/modules/programs/nnn/nnn.nix
@@ -24,6 +24,8 @@
 
     test.stubs = {
       nnnDummy.buildScript = ''
+        runHook preInstall
+
         mkdir -p "$out/bin"
         touch "$out/bin/nnn"
         chmod +x "$out/bin/nnn"
@@ -40,17 +42,13 @@
       script = ''
         assertDirectoryExists home-files/.config/nnn/plugins
 
-        assertFileRegex \
-          home-path/bin/nnn \
-          "^export NNN_BMS='D:~/Downloads;d:~/Documents;p:~/Pictures;v:~/Videos'\''${NNN_BMS:+':'}\$NNN_BMS$"
+        for bookmark in 'export NNN_BMS' '~/Downloads' '~/Documents' '~/Pictures' '~/Videos'; do
+          assertFileRegex home-path/bin/nnn "$bookmark"
+        done
 
-        assertFileRegex \
-          home-path/bin/nnn \
-          "^export NNN_PLUG='c:fzcd;f:finder;v:imgview'\''${NNN_PLUG:+':'}\$NNN_PLUG$"
-
-        assertFileRegex \
-          home-path/bin/nnn \
-          "/nix/store/.*-"{foo,bar}"/bin"
+        for plugin in 'export NNN_PLUG' 'fzcd' 'finder' 'imgview'; do
+          assertFileRegex home-path/bin/nnn "$plugin"
+        done
       '';
     };
   };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
There seems to be some changes on how wrapped binaries are implemented on nixpkgs. This broke the nnn tests since the tests were coupled with the old implementation.

This commit fix the tests, and also make it less coupled by just testing if the bookmarks/plugins/environment variables are available.

Fix #2745.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
