### PR TITLE
himalaya: Add support for `account.folders`

### DIFF
--- a/modules/programs/himalaya.nix
+++ b/modules/programs/himalaya.nix
@@ -14,6 +14,11 @@ let
         name = account.realName;
         default = account.primary;
 
+        inbox-folder = account.folders.inbox;
+        sent-folder = account.folders.sent;
+        draft-folder = account.folders.drafts;
+        # NOTE: himalaya does not support configuring the name of the trash folder
+
         # FIXME: does not support disabling TLS altogether
         # NOTE: does not accept sequence of strings for password commands
         imap-login = account.userName;

--- a/tests/modules/programs/himalaya/himalaya-expected.toml
+++ b/tests/modules/programs/himalaya/himalaya-expected.toml
@@ -4,13 +4,16 @@ name = ""
 ["hm@example.com"]
 default = true
 default-page-size = 50
+draft-folder = "Drafts"
 email = "hm@example.com"
 imap-host = "imap.example.com"
 imap-login = "home.manager"
 imap-passwd-cmd = "'password-command'"
 imap-port = 995
 imap-starttls = false
+inbox-folder = "In"
 name = "H. M. Test"
+sent-folder = "Out"
 smtp-host = "smtp.example.com"
 smtp-login = "home.manager"
 smtp-passwd-cmd = "'password-command'"

--- a/tests/modules/programs/himalaya/himalaya.nix
+++ b/tests/modules/programs/himalaya/himalaya.nix
@@ -13,6 +13,12 @@ with lib;
         settings = { default-page-size = 50; };
       };
 
+      folders = {
+        inbox = "In";
+        sent = "Out";
+        drafts = "Drafts";
+      };
+
       imap.port = 995;
       smtp.port = 465;
     };


### PR DESCRIPTION
### Description

Add support for `account.folders.(inbox|sent|draft)` in the himalaya
account configuration.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
