### PR TITLE
mu: allow aliases to be used by mu configuration file

### DIFF
--- a/modules/programs/mu.nix
+++ b/modules/programs/mu.nix
@@ -12,12 +12,14 @@ let
   # Takes the list of accounts with mu.enable = true, and generates a
   # command-line flag for initializing the mu database.
   myAddresses = let
-    # List of account sets where mu.enable = true.
+    # Set of email account sets where mu.enable = true.
     muAccounts =
       filter (a: a.mu.enable) (attrValues config.accounts.email.accounts);
     addrs = map (a: a.address) muAccounts;
-    # Prefix --my-address= to each account's address with mu.enable.
-    addMyAddress = map (addr: "--my-address=" + addr) addrs;
+    # Construct list of lists containing email aliases, and flatten
+    aliases = flatten (map (a: a.aliases) muAccounts);
+    # Prefix --my-address= to each account's address AND all defined aliases
+    addMyAddress = map (addr: "--my-address=" + addr) (addrs ++ aliases);
   in concatStringsSep " " addMyAddress;
 
 in {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -76,6 +76,7 @@ import nmt {
     ./modules/programs/man
     ./modules/programs/mbsync
     ./modules/programs/mpv
+    ./modules/programs/mu
     ./modules/programs/ncmpcpp
     ./modules/programs/ne
     ./modules/programs/neomutt

--- a/tests/modules/programs/mu/basic-configuration.nix
+++ b/tests/modules/programs/mu/basic-configuration.nix
@@ -1,0 +1,24 @@
+{ ... }:
+
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  accounts.email.accounts = {
+    "hm@example.com" = {
+      mu.enable = true;
+      aliases = [ "foo@example.com" ];
+    };
+  };
+
+  programs.mu.enable = true;
+
+  test.stubs.mu = { };
+
+  nmt.script = ''
+    assertFileContains activate \
+      'if [[ ! -d "/home/hm-user/.cache/mu" ]]; then'
+
+    assertFileContains activate \
+      '$DRY_RUN_CMD mu init --maildir=/home/hm-user/Mail --my-address=hm@example.com --my-address=foo@example.com $VERBOSE_ARG;'
+  '';
+}

--- a/tests/modules/programs/mu/default.nix
+++ b/tests/modules/programs/mu/default.nix
@@ -1,0 +1,1 @@
+{ mu-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
This has no effect if the user does not have any aliases defined for
any accounts.
This will also only add `--my-address=` to only accounts that are
enabled to be tracked by mu.

### Description

home-manager allows for users to define a list of aliases for a main email address.
Previously, this `mu` module did not understand these aliases.
Now `mu` will understand aliases and allow them to be treated "my-address", which makes them special in the eyes of mu.
This allows for filtering based on threads containing your email addresses and/or their aliases.

#2724

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
