### PR TITLE
foot: set OOMPolicy=continue for foot server

### DIFF
--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -71,6 +71,7 @@ in {
         Service = {
           ExecStart = "${cfg.package}/bin/foot --server";
           Restart = "on-failure";
+          OOMPolicy = "continue";
         };
 
         Install = { WantedBy = [ "graphical-session.target" ]; };

--- a/tests/modules/programs/foot/systemd-user-service-expected.service
+++ b/tests/modules/programs/foot/systemd-user-service-expected.service
@@ -3,6 +3,7 @@ WantedBy=graphical-session.target
 
 [Service]
 ExecStart=@foot@/bin/foot --server
+OOMPolicy=continue
 Restart=on-failure
 
 [Unit]


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Previously, if a process inside a foot client triggered the OOM killer,
systemd would also kill the parent unit, namely the foot server.
This is not ideal if a user has a lot of clients attached, and it's
usually not the terminal emulator's fault that a process inside it has
ended up using all the available memory.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
