### PR TITLE
Add lib argument to homeManagerConfiguration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,11 +45,11 @@
         homeManagerConfiguration = { configuration, system, homeDirectory
           , username, extraModules ? [ ], extraSpecialArgs ? { }
           , pkgs ? builtins.getAttr system nixpkgs.outputs.legacyPackages
-          , check ? true, stateVersion ? "20.09" }@args:
+          , lib ? pkgs.lib, check ? true, stateVersion ? "20.09" }@args:
           assert nixpkgs.lib.versionAtLeast stateVersion "20.09";
 
           import ./modules {
-            inherit pkgs check extraSpecialArgs;
+            inherit pkgs lib check extraSpecialArgs;
             configuration = { ... }: {
               imports = [ configuration ] ++ extraModules;
               home = { inherit homeDirectory stateVersion username; };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -21,7 +21,7 @@ let
     in
       fold f res res.config.warnings;
 
-  extendedLib = import ./lib/stdlib-extended.nix pkgs.lib;
+  extendedLib = import ./lib/stdlib-extended.nix lib;
 
   hmModules =
     import ./modules.nix {


### PR DESCRIPTION
### Description

Add a `lib` argument to `homeManagerConfiguration` to specify the lib to use instead of the one from `pkgs`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.
