### PR TITLE
neovim: fixes #2754

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -79,15 +79,15 @@ let
   extraMakeWrapperArgs = lib.optionalString (cfg.extraPackages != [ ])
     ''--suffix PATH : "${lib.makeBinPath cfg.extraPackages}"'';
   extraMakeWrapperLuaCArgs = lib.optionalString (cfg.extraLuaPackages != [ ]) ''
-    --suffix LUA_CPATH ";" "${
+    --run 'export LUA_CPATH="${
       lib.concatMapStringsSep ";" pkgs.lua51Packages.getLuaCPath
       cfg.extraLuaPackages
-    }"'';
+    };$LUA_CPATH"' '';
   extraMakeWrapperLuaArgs = lib.optionalString (cfg.extraLuaPackages != [ ]) ''
-    --suffix LUA_PATH ";" "${
+    --run 'export LUA_PATH="${
       lib.concatMapStringsSep ";" pkgs.lua51Packages.getLuaPath
       cfg.extraLuaPackages
-    }"'';
+    };$LUA_PATH"' '';
 
 in {
   imports = [

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -26,9 +26,13 @@ with lib;
     nmt.script = ''
       vimrc="$TESTED/home-files/.config/nvim/init.vim"
       vimrcNormalized="$(normalizeStorePaths "$vimrc")"
+      nvim="$TESTED/home-path/bin/nvim"
+
 
       assertFileExists "$vimrc"
       assertFileContent "$vimrcNormalized" "${./plugin-config.vim}"
+      assertFileRegex $nvim LUA_PATH
+      assertFileRegex $nvim LUA_CPATH
     '';
   };
 }


### PR DESCRIPTION
### Description

This is a workaround for the problem described in #2754.  While `--suffix` of the `makeWrapper` is broken, `--run` option works fine.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

