### PR TITLE
xdg-user-dirs: allow paths and define sessionVariables

### DIFF
--- a/modules/misc/xdg-user-dirs.nix
+++ b/modules/misc/xdg-user-dirs.nix
@@ -33,57 +33,62 @@ in {
     # https://gitlab.freedesktop.org/xdg/xdg-user-dirs/blob/master/man/user-dirs.dirs.xml
 
     desktop = mkOption {
-      type = types.str;
+      type = with types; coercedTo path toString str;
       default = "$HOME/Desktop";
       description = "The Desktop directory.";
     };
 
     documents = mkOption {
-      type = types.str;
+      type = with types; coercedTo path toString str;
       default = "$HOME/Documents";
       description = "The Documents directory.";
     };
 
     download = mkOption {
-      type = types.str;
+      type = with types; coercedTo path toString str;
       default = "$HOME/Downloads";
       description = "The Downloads directory.";
     };
 
     music = mkOption {
-      type = types.str;
+      type = with types; coercedTo path toString str;
       default = "$HOME/Music";
       description = "The Music directory.";
     };
 
     pictures = mkOption {
-      type = types.str;
+      type = with types; coercedTo path toString str;
       default = "$HOME/Pictures";
       description = "The Pictures directory.";
     };
 
     publicShare = mkOption {
-      type = types.str;
+      type = with types; coercedTo path toString str;
       default = "$HOME/Public";
       description = "The Public share directory.";
     };
 
     templates = mkOption {
-      type = types.str;
+      type = with types; coercedTo path toString str;
       default = "$HOME/Templates";
       description = "The Templates directory.";
     };
 
     videos = mkOption {
-      type = types.str;
+      type = with types; coercedTo path toString str;
       default = "$HOME/Videos";
       description = "The Videos directory.";
     };
 
     extraConfig = mkOption {
-      type = with types; attrsOf str;
+      type = with types; attrsOf (coercedTo path toString str);
       default = { };
-      example = { XDG_MISC_DIR = "$HOME/Misc"; };
+      defaultText = literalExpression "{ }";
+      example = literalExpression ''
+        {
+          XDG_MISC_DIR = "$HOME/Misc";
+        }
+      '';
       description = "Other user directories.";
     };
 
@@ -112,6 +117,8 @@ in {
     in generators.toKeyValue { } wrapped;
 
     xdg.configFile."user-dirs.conf".text = "enabled=False";
+
+    home.sessionVariables = directories;
 
     home.activation = mkIf cfg.createDirectories {
       createXdgUserDirectories = let


### PR DESCRIPTION
Changed the type of the user directory options from `str` to ~`either str path`~(`coercedTo path toString str`) to allow using path values.

The related session variable is defined for the default and the extra user directories now.

Closes #2694
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
