### PR TITLE
taskwarrior: make .taskrc writable (attempt nr. 2)

### DIFF
--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -112,9 +112,9 @@ in {
         else
           echo "include ${homeConf}" > "${userConf}"
         fi
-      elif ! ${pkgs.gnugrep}/bin/grep -qF "include ${homeConf}" ${userConf}; then
+      elif ! ${pkgs.gnugrep}/bin/grep -qF "include ${homeConf}" ${escapeShellArg userConf}; then
         # Add include statement for home-manager generated config
-        $DRY_RUN_CMD ${pkgs.gnused}/bin/sed -i '1i include ${homeConf}' ${userConf}
+        $DRY_RUN_CMD ${pkgs.gnused}/bin/sed -i '1i include ${homeConf}' ${escapeShellArg userConf}
       fi
     '';
   };

--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -112,9 +112,13 @@ in {
         else
           echo "include ${homeConf}" > "${userConf}"
         fi
-      elif ! ${pkgs.gnugrep}/bin/grep -qF "include ${homeConf}" ${escapeShellArg userConf}; then
+      elif ! ${pkgs.gnugrep}/bin/grep -qF "include ${homeConf}" ${
+        escapeShellArg userConf
+      }; then
         # Add include statement for home-manager generated config
-        $DRY_RUN_CMD ${pkgs.gnused}/bin/sed -i '1i include ${homeConf}' ${escapeShellArg userConf}
+        $DRY_RUN_CMD ${pkgs.gnused}/bin/sed -i '1i include ${homeConf}' ${
+          escapeShellArg userConf
+        }
       fi
     '';
   };

--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -24,6 +24,8 @@ let
   formatPair = key: value:
     if isAttrs value then formatSet key value else formatLine key value;
 
+  homeConf = "${config.xdg.configHome}/task/home-manager-taskrc";
+  userConf = "${config.xdg.configHome}/task/taskrc";
 in {
   options = {
     programs.taskwarrior = {
@@ -88,7 +90,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ pkgs.taskwarrior ];
 
-    xdg.configFile."task/taskrc".text = ''
+    home.file."${homeConf}".text = ''
       data.location=${cfg.dataLocation}
       ${optionalString (cfg.colorTheme != null) (if isString cfg.colorTheme then
         "include ${cfg.colorTheme}.theme"
@@ -98,6 +100,22 @@ in {
       ${concatStringsSep "\n" (mapAttrsToList formatPair cfg.config)}
 
       ${cfg.extraConfig}
+    '';
+
+    home.activation.regenDotTaskRc = hm.dag.entryAfter [ "writeBoundary" ] ''
+      $VERBOSE_ECHO "Ensuring generated taskwarrior config included in taskrc"
+
+      if [[ ! -s "${userConf}" ]]; then
+        # Ensure file's existence
+        if [[ -v DRY_RUN ]]; then
+          $DRY_RUN_CMD echo "include ${homeConf}" ">" "${userConf}"
+        else
+          echo "include ${homeConf}" > "${userConf}"
+        fi
+      elif ! ${pkgs.gnugrep}/bin/grep -qF "include ${homeConf}" ${userConf}; then
+        # Add include statement for home-manager generated config
+        $DRY_RUN_CMD ${pkgs.gnused}/bin/sed -i '1i include ${homeConf}' ${userConf}
+      fi
     '';
   };
 }

--- a/tests/modules/programs/taskwarrior/taskwarrior.nix
+++ b/tests/modules/programs/taskwarrior/taskwarrior.nix
@@ -21,9 +21,9 @@ with lib;
     test.stubs.taskwarrior = { };
 
     nmt.script = ''
-      assertFileExists home-files/.config/task/taskrc
-      assertFileContent home-files/.config/task/taskrc ${
-        pkgs.writeText "taskwarrior.expected" ''
+      assertFileExists home-files/.config/task/home-manager-taskrc
+      assertFileContent home-files/.config/task/home-manager-taskrc ${
+        pkgs.writeText "taskwarrior.home-conf.expected" ''
           data.location=/some/data/location
           include dark-violets-256.theme
 


### PR DESCRIPTION
This is an updated duplicate of #2697, where I attempted to fix/add tests too.

### Description
1. Make the default `$HOME/.config/taskrc`writeable for users, so as to e.g. allow `task context` commands.
2. Update tests to check for this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
