### PR TITLE
treewide: apply nixfmt to a few more files

### DIFF
--- a/format
+++ b/format
@@ -25,13 +25,8 @@ find . -name '*.nix' \
   ! -path ./modules/manual.nix \
   ! -path ./modules/misc/news.nix \
   ! -path ./modules/programs/bash.nix \
-  ! -path ./modules/programs/gpg.nix \
   ! -path ./modules/programs/ssh.nix \
   ! -path ./modules/programs/zsh.nix \
-  ! -path ./modules/services/gpg-agent.nix \
-  ! -path ./modules/services/mpd.nix \
   ! -path ./nix-darwin/default.nix \
   ! -path ./tests/default.nix \
-  ! -path ./tests/modules/home-environment/session-variables.nix \
-  ! -path ./tests/modules/programs/gpg/override-defaults.nix \
   -exec nixfmt $CHECK_ARG {} +

--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -6,9 +6,7 @@ let
   cfg = config.programs.gpg;
 
   mkKeyValue = key: value:
-    if isString value
-    then "${key} ${value}"
-    else optionalString value key;
+    if isString value then "${key} ${value}" else optionalString value key;
 
   cfgText = generators.toKeyValue {
     inherit mkKeyValue;
@@ -22,7 +20,7 @@ let
 
   primitiveType = types.oneOf [ types.str types.bool ];
 
-  publicKeyOpts = { config, ...}: {
+  publicKeyOpts = { config, ... }: {
     options = {
       text = mkOption {
         type = types.nullOr types.str;
@@ -40,7 +38,18 @@ let
       };
 
       trust = mkOption {
-        type = types.nullOr (types.enum ["unknown" 1 "never" 2 "marginal" 3 "full" 4 "ultimate" 5]);
+        type = types.nullOr (types.enum [
+          "unknown"
+          1
+          "never"
+          2
+          "marginal"
+          3
+          "full"
+          4
+          "ultimate"
+          5
+        ]);
         default = null;
         apply = v:
           if isString v then
@@ -51,7 +60,8 @@ let
               full = 4;
               ultimate = 5;
             }.${v}
-          else v;
+          else
+            v;
         description = ''
           The amount of trust you have in the key ownership and the care the
           owner puts into signing other keys. The available levels are
@@ -85,58 +95,55 @@ let
     };
 
     config = {
-      source = mkIf (config.text != null)
-        (pkgs.writeText "gpg-pubkey" config.text);
+      source =
+        mkIf (config.text != null) (pkgs.writeText "gpg-pubkey" config.text);
     };
   };
 
-  importTrustBashFunctions =
-    let gpg = "${cfg.package}/bin/gpg";
-    in ''
-      function gpgKeyId() {
-        ${gpg} --show-key --with-colons "$1" \
-          | grep ^pub: \
-          | cut -d: -f5
-      }
+  importTrustBashFunctions = let gpg = "${cfg.package}/bin/gpg";
+  in ''
+    function gpgKeyId() {
+      ${gpg} --show-key --with-colons "$1" \
+        | grep ^pub: \
+        | cut -d: -f5
+    }
 
-      function importTrust() {
-        local keyId trust
-        keyId="$(gpgKeyId "$1")"
-        trust="$2"
-        if [[ -n $keyId ]] ; then
-          { echo trust; echo "$trust"; (( trust == 5 )) && echo y; echo quit; } \
-            | ${gpg} --no-tty --command-fd 0 --edit-key "$keyId"
-        fi
-      }
+    function importTrust() {
+      local keyId trust
+      keyId="$(gpgKeyId "$1")"
+      trust="$2"
+      if [[ -n $keyId ]] ; then
+        { echo trust; echo "$trust"; (( trust == 5 )) && echo y; echo quit; } \
+          | ${gpg} --no-tty --command-fd 0 --edit-key "$keyId"
+      fi
+    }
   '';
 
-  keyringFiles =
-    let
-      gpg = "${cfg.package}/bin/gpg";
+  keyringFiles = let
+    gpg = "${cfg.package}/bin/gpg";
 
-      importKey = { source, trust, ... }: ''
-        ${gpg} --import ${source}
-        ${optionalString (trust != null) ''
-          importTrust "${source}" ${toString trust}''}
-      '';
-
-      importKeys = concatMapStringsSep "\n" importKey cfg.publicKeys;
-    in pkgs.runCommand "gpg-pubring" { buildInputs = [ cfg.package ]; } ''
-      export GNUPGHOME
-      GNUPGHOME=$(mktemp -d)
-
-      ${importTrustBashFunctions}
-      ${importKeys}
-
-      mkdir $out
-      cp $GNUPGHOME/pubring.kbx $out/pubring.kbx
-      if [[ -e $GNUPGHOME/trustdb.gpg ]] ; then
-        cp $GNUPGHOME/trustdb.gpg $out/trustdb.gpg
-      fi
+    importKey = { source, trust, ... }: ''
+      ${gpg} --import ${source}
+      ${optionalString (trust != null)
+      ''importTrust "${source}" ${toString trust}''}
     '';
 
-in
-{
+    importKeys = concatMapStringsSep "\n" importKey cfg.publicKeys;
+  in pkgs.runCommand "gpg-pubring" { buildInputs = [ cfg.package ]; } ''
+    export GNUPGHOME
+    GNUPGHOME=$(mktemp -d)
+
+    ${importTrustBashFunctions}
+    ${importKeys}
+
+    mkdir $out
+    cp $GNUPGHOME/pubring.kbx $out/pubring.kbx
+    if [[ -e $GNUPGHOME/trustdb.gpg ]] ; then
+      cp $GNUPGHOME/trustdb.gpg $out/trustdb.gpg
+    fi
+  '';
+
+in {
   options.programs.gpg = {
     enable = mkEnableOption "GnuPG";
 
@@ -145,11 +152,13 @@ in
       default = pkgs.gnupg;
       defaultText = literalExpression "pkgs.gnupg";
       example = literalExpression "pkgs.gnupg23";
-      description = "The Gnupg package to use (also used the gpg-agent service).";
+      description =
+        "The Gnupg package to use (also used the gpg-agent service).";
     };
 
     settings = mkOption {
-      type = types.attrsOf (types.either primitiveType (types.listOf types.str));
+      type =
+        types.attrsOf (types.either primitiveType (types.listOf types.str));
       example = literalExpression ''
         {
           no-comments = false;
@@ -167,7 +176,8 @@ in
     };
 
     scdaemonSettings = mkOption {
-      type = types.attrsOf (types.either primitiveType (types.listOf types.str));
+      type =
+        types.attrsOf (types.either primitiveType (types.listOf types.str));
       example = literalExpression ''
         {
           disable-ccid = true;
@@ -182,9 +192,10 @@ in
 
     homedir = mkOption {
       type = types.path;
-      example = literalExpression "\"\${config.xdg.dataHome}/gnupg\"";
+      example = literalExpression ''"''${config.xdg.dataHome}/gnupg"'';
       default = "${config.home.homeDirectory}/.gnupg";
-      defaultText = literalExpression "\"\${config.home.homeDirectory}/.gnupg\"";
+      defaultText =
+        literalExpression ''"''${config.home.homeDirectory}/.gnupg"'';
       description = "Directory to store keychains and configuration.";
     };
 
@@ -236,7 +247,8 @@ in
       personal-cipher-preferences = mkDefault "AES256 AES192 AES";
       personal-digest-preferences = mkDefault "SHA512 SHA384 SHA256";
       personal-compress-preferences = mkDefault "ZLIB BZIP2 ZIP Uncompressed";
-      default-preference-list = mkDefault "SHA512 SHA384 SHA256 AES256 AES192 AES ZLIB BZIP2 ZIP Uncompressed";
+      default-preference-list = mkDefault
+        "SHA512 SHA384 SHA256 AES256 AES192 AES ZLIB BZIP2 ZIP Uncompressed";
       cert-digest-algo = mkDefault "SHA512";
       s2k-digest-algo = mkDefault "SHA512";
       s2k-cipher-algo = mkDefault "AES256";
@@ -258,9 +270,7 @@ in
     };
 
     home.packages = [ cfg.package ];
-    home.sessionVariables = {
-      GNUPGHOME = cfg.homedir;
-    };
+    home.sessionVariables = { GNUPGHOME = cfg.homedir; };
 
     home.file."${cfg.homedir}/gpg.conf".text = cfgText;
 
@@ -268,45 +278,42 @@ in
 
     # Link keyring if keys are not mutable
     home.file."${cfg.homedir}/pubring.kbx" =
-      mkIf (!cfg.mutableKeys && cfg.publicKeys != []) {
+      mkIf (!cfg.mutableKeys && cfg.publicKeys != [ ]) {
         source = "${keyringFiles}/pubring.kbx";
       };
 
-    home.activation = mkIf (cfg.publicKeys != []) {
-      importGpgKeys =
-        let
-          gpg = "${cfg.package}/bin/gpg";
+    home.activation = mkIf (cfg.publicKeys != [ ]) {
+      importGpgKeys = let
+        gpg = "${cfg.package}/bin/gpg";
 
-          importKey = { source, trust, ... }:
-            # Import mutable keys
-            optional cfg.mutableKeys ''
-              $DRY_RUN_CMD ${gpg} $QUIET_ARG --import ${source}''
+        importKey = { source, trust, ... }:
+          # Import mutable keys
+          optional cfg.mutableKeys
+          "$DRY_RUN_CMD ${gpg} $QUIET_ARG --import ${source}"
 
-            # Import mutable trust
-            ++ optional (trust != null && cfg.mutableTrust) ''
-              $DRY_RUN_CMD importTrust "${source}" ${toString trust}'';
+          # Import mutable trust
+          ++ optional (trust != null && cfg.mutableTrust)
+          ''$DRY_RUN_CMD importTrust "${source}" ${toString trust}'';
 
-          anyTrust = any (k: k.trust != null) cfg.publicKeys;
+        anyTrust = any (k: k.trust != null) cfg.publicKeys;
 
-          importKeys = concatStringsSep "\n" (concatMap importKey cfg.publicKeys);
+        importKeys = concatStringsSep "\n" (concatMap importKey cfg.publicKeys);
 
-          # If any key/trust should be imported then create the block. Otherwise
-          # leave it empty.
-          block = concatStringsSep "\n" (
-            optional (importKeys != "") ''
-              export GNUPGHOME=${escapeShellArg cfg.homedir}
-              if [[ ! -v VERBOSE ]]; then
-                QUIET_ARG="--quiet"
-              else
-                QUIET_ARG=""
-              fi
-              ${importTrustBashFunctions}
-              ${importKeys}
-              unset GNUPGHOME QUIET_ARG keyId importTrust
-            '' ++ optional (!cfg.mutableTrust && anyTrust) ''
-              install -m 0700 ${keyringFiles}/trustdb.gpg "${cfg.homedir}/trustdb.gpg"''
-          );
-        in lib.hm.dag.entryAfter ["linkGeneration"] block;
+        # If any key/trust should be imported then create the block. Otherwise
+        # leave it empty.
+        block = concatStringsSep "\n" (optional (importKeys != "") ''
+          export GNUPGHOME=${escapeShellArg cfg.homedir}
+          if [[ ! -v VERBOSE ]]; then
+            QUIET_ARG="--quiet"
+          else
+            QUIET_ARG=""
+          fi
+          ${importTrustBashFunctions}
+          ${importKeys}
+          unset GNUPGHOME QUIET_ARG keyId importTrust
+        '' ++ optional (!cfg.mutableTrust && anyTrust) ''
+          install -m 0700 ${keyringFiles}/trustdb.gpg "${cfg.homedir}/trustdb.gpg"'');
+      in lib.hm.dag.entryAfter [ "linkGeneration" ] block;
     };
   };
 }

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -31,7 +31,8 @@ let
     export XDG_STATE_HOME="/home/hm-user/.local/state"
   '';
 
-  expected = pkgs.writeText "expected" (if isDarwin then darwinExpected else linuxExpected);
+  expected = pkgs.writeText "expected"
+    (if isDarwin then darwinExpected else linuxExpected);
 
 in {
   config = {

--- a/tests/modules/programs/gpg/override-defaults.nix
+++ b/tests/modules/programs/gpg/override-defaults.nix
@@ -11,10 +11,7 @@ with lib;
         no-comments = false;
         s2k-cipher-algo = "AES128";
         throw-keyids = true;
-        trusted-key = [
-          "0xXXXXXXXXXXXXX"
-          "0xYYYYYYYYYYYYY"
-        ];
+        trusted-key = [ "0xXXXXXXXXXXXXX" "0xYYYYYYYYYYYYY" ];
       };
 
       homedir = "${config.home.homeDirectory}/bar/foopg";
@@ -22,7 +19,9 @@ with lib;
 
     nmt.script = ''
       assertFileExists home-files/bar/foopg/gpg.conf
-      assertFileContent home-files/bar/foopg/gpg.conf ${./override-defaults-expected.conf}
+      assertFileContent home-files/bar/foopg/gpg.conf ${
+        ./override-defaults-expected.conf
+      }
 
       assertFileNotRegex activate "^unset GNUPGHOME keyId importTrust$"
     '';


### PR DESCRIPTION
### Description

Removes a few of the remaining exceptions.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```