### PR TITLE
Issues with DesktopEntries after #2496

### DIFF
--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -4,8 +4,12 @@ with lib;
 
 let
   desktopEntry = {
+    imports = [
+      (mkRemovedOptionModule [ "extraConfig" ]
+        "The `extraConfig` option of `xdg.desktopEntries` has been removed following a change in Nixpkgs.")
+    ];
     options = {
-      # Since this module uses the nixpkgs/pkgs/build-support/make-desktopitem function, 
+      # Since this module uses the nixpkgs/pkgs/build-support/make-desktopitem function,
       # our options and defaults follow its parameters, with the following exceptions:
 
       # `desktopName` on makeDesktopItem is controlled by `name`.
@@ -13,14 +17,10 @@ let
       # `name` on makeDesktopItem is controlled by this module's key in the attrset.
       # This is the file's filename excluding ".desktop".
 
-      # `extraEntries` on makeDesktopItem is controlled by `extraConfig`,
-      # and `extraDesktopEntries` by `settings`,
+      # `extraConfig` on makeDesktopItem is controlled by `settings`,
       # to match what's commonly used by other home manager modules.
 
-      # `mimeType` and `categories` on makeDesktopItem ask for a string in the format "one;two;three;",
-      # for usability's sake we ask for a list of strings.
-
-      # Descriptions are taken from the desktop entry spec: 
+      # Descriptions are taken from the desktop entry spec:
       # https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys
 
       type = mkOption {
@@ -31,7 +31,7 @@ let
 
       exec = mkOption {
         description = "Program to execute, possibly with arguments.";
-        type = types.str;
+        type = types.nullOr types.str;
       };
 
       icon = mkOption {
@@ -78,9 +78,9 @@ let
 
       startupNotify = mkOption {
         description = ''
-          If true, it is KNOWN that the application will send a "remove" 
-          message when started with the <literal>DESKTOP_STARTUP_ID</literal> 
-          environment variable set. If false, it is KNOWN that the application 
+          If true, it is KNOWN that the application will send a "remove"
+          message when started with the <literal>DESKTOP_STARTUP_ID</literal>
+          environment variable set. If false, it is KNOWN that the application
           does not work with startup notification at all.'';
         type = types.nullOr types.bool;
         default = null;
@@ -103,19 +103,10 @@ let
         default = null;
       };
 
-      extraConfig = mkOption {
-        description = ''
-          Extra configuration. Will be appended to the end of the file and 
-          may thus contain extra sections.
-        '';
-        type = types.lines;
-        default = "";
-      };
-
       settings = mkOption {
         type = types.attrsOf types.string;
         description = ''
-          Extra key-value pairs to add to the <literal>[Desktop Entry]</literal> section. 
+          Extra key-value pairs to add to the <literal>[Desktop Entry]</literal> section.
           This may override other values.
         '';
         default = { };
@@ -132,11 +123,19 @@ let
         description = "Whether to validate the generated desktop file.";
         default = true;
       };
+
+      # Required for the assertions
+      # TODO: Remove me once `mkRemovedOptionModule` works correctly with submodules
+      assertions = mkOption {
+        type = types.listOf types.unspecified;
+        default = [ ];
+        visible = false;
+        internal = true;
+      };
     };
   };
 
   #formatting helpers
-  ifNotNull = a: a': if a == null then null else a';
   semicolonList = list:
     (concatStringsSep ";" list) + ";"; # requires trailing semicolon
 
@@ -148,11 +147,9 @@ let
         type exec icon comment terminal genericName startupNotify noDisplay
         prefersNonDefaultGPU;
       desktopName = config.name;
-      mimeType = ifNotNull config.mimeType (semicolonList config.mimeType);
-      categories =
-        ifNotNull config.categories (semicolonList config.categories);
-      extraEntries = config.extraConfig;
-      extraDesktopEntries = config.settings;
+      mimeTypes = optionals (config.mimeType != null) config.mimeType;
+      categories = optionals (config.categories != null) config.categories;
+      extraConfig = config.settings;
     };
 in {
   meta.maintainers = [ hm.maintainers.cwyc ];
@@ -182,7 +179,7 @@ in {
   config = mkIf (config.xdg.desktopEntries != { }) {
     assertions = [
       (hm.assertions.assertPlatform "xdg.desktopEntries" pkgs platforms.linux)
-    ];
+    ] ++ flatten (catAttrs "assertions" (attrValues config.xdg.desktopEntries));
 
     home.packages = (map hiPrio # we need hiPrio to override existing entries
       (attrsets.mapAttrsToList makeFile config.xdg.desktopEntries));

--- a/tests/modules/misc/xdg/desktop-entries.nix
+++ b/tests/modules/misc/xdg/desktop-entries.nix
@@ -48,6 +48,13 @@ with lib;
       })
     ];
 
+    test.asserts.assertions.expected =
+      let currentFile = toString ./desktop-entries.nix;
+      in [''
+        The option definition `extraConfig' in `${currentFile}' no longer has any effect; please remove it.
+        The `extraConfig` option of `xdg.desktopEntries` has been removed following a change in Nixpkgs.
+      ''];
+
     nmt.script = ''
       assertFileExists home-path/share/applications/full.desktop
       assertFileExists home-path/share/applications/min.desktop

--- a/tests/modules/misc/xdg/desktop-full-expected.desktop
+++ b/tests/modules/misc/xdg/desktop-full-expected.desktop
@@ -1,18 +1,16 @@
 [Desktop Entry]
-Categories=Network;WebBrowser;
+Categories=Network;WebBrowser
 Comment=My Application
 DBusActivatable=false
 Exec=test --option
 GenericName=Web Browser
 Icon=test
 Keywords=calc;math
-MimeType=text/html;text/xml;
+MimeType=text/html;text/xml
 Name=Test
 NoDisplay=false
 PrefersNonDefaultGPU=false
 StartupNotify=false
 Terminal=true
 Type=Application
-[X-ExtraSection]
-Exec=foo -o
-
+Version=1.4

--- a/tests/modules/misc/xdg/desktop-min-expected.desktop
+++ b/tests/modules/misc/xdg/desktop-min-expected.desktop
@@ -3,3 +3,4 @@ Exec=test --option
 Name=Test
 Terminal=false
 Type=Application
+Version=1.4


### PR DESCRIPTION
### Description

My system wouldn't build due to different errors after #2496 (nixpkgs unstable, hm master - both local checkouts contains what I've seen the relevant commits made for this), I adjusted the module from what I found as "wrong". (with [help](https://github.com/NixOS/nixpkgs/commit/066a581a80c0939423ff8b2d4b451a07ea8e5865) of and the current code)

I'm unsure if there is a replacement for "extraEntries = config.extraConfig;" as changelog says it got removed (but I left it in for feedback). Currently not even the example from the HM-Docs was working for me, which brought me on point - maybe we should add a test against it.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
