### PR TITLE
waybar: Add `spacing` option

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -52,6 +52,13 @@ let
           description = "Bar position relative to the output.";
         };
 
+        spacing = mkOption {
+          type = nullOr ints.unsigned;
+          default = null;
+          example = 4;
+          description = "Size of gaps in between of the different modules.";
+        };
+
         height = mkOption {
           type = nullOr ints.unsigned;
           default = null;
@@ -170,6 +177,7 @@ in {
             layer = "top";
             position = "top";
             height = 30;
+            spacing = 4;
             output = [
               "eDP-1"
               "HDMI-A-1"

--- a/tests/modules/programs/waybar/settings-complex-expected.json
+++ b/tests/modules/programs/waybar/settings-complex-expected.json
@@ -33,6 +33,7 @@
       "DP-1"
     ],
     "position": "top",
+    "spacing": 3,
     "sway/mode": {
       "tooltip": false
     },

--- a/tests/modules/programs/waybar/settings-complex.nix
+++ b/tests/modules/programs/waybar/settings-complex.nix
@@ -13,6 +13,7 @@ with lib;
         {
           layer = "top";
           position = "top";
+          spacing = 3;
           height = 30;
           output = [ "DP-1" ];
           modules-left = [ "sway/workspaces" "sway/mode" "custom/my-module" ];


### PR DESCRIPTION
### Description

Trying to use/replicate the sample config from https://github.com/Alexays/Waybar/blob/master/resources/config
resulted in an error since the `spacing` option does not exist:

```nix
waybar = {
  enable = true;

  settings = [{
    "layer" = "top";
    "spacing" = 4; # Gaps between modules (4px)
  }];
  ...
};
```

```
error: The option `home-manager.users.claudio.programs.waybar.settings.[definition 1-entry 1].spacing' does not exist. Definition values:
       - In `/nix/store/hm20phh5wa2sgdaz633vzzzpma610p02-source/outputs/nixos-conf.nix': 4
```

The guidelines says to only add valuable options, I would be tempted to say this is one of them.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
