### PR TITLE
update i3status-rust default to new format

### DIFF
--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -144,8 +144,8 @@ in {
             {
               block = "memory";
               display_type = "memory";
-              format_mem = "{Mup}%";
-              format_swap = "{SUp}%";
+              format_mem = "{mem_used_percents}";
+              format_swap = "{swap_used_percents}";
             }
             {
               block = "cpu";

--- a/tests/modules/programs/i3status-rust/with-default.nix
+++ b/tests/modules/programs/i3status-rust/with-default.nix
@@ -28,8 +28,8 @@ with lib;
             [[block]]
             block = "memory"
             display_type = "memory"
-            format_mem = "{Mup}%"
-            format_swap = "{SUp}%"
+            format_mem = "{mem_used_percents}"
+            format_swap = "{swap_used_percents}"
 
             [[block]]
             block = "cpu"


### PR DESCRIPTION
### Description

The i3status-rust format has changed. The default in home-manager is not valid format anymore. Without defining a bar, it generates a cryptic error about format and {Mup} .
This PR just updates to the latest format.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
