### PR TITLE
mpd: add basic test case

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -148,6 +148,7 @@ import nmt {
     ./modules/services/home-manager-auto-upgrade
     ./modules/services/kanshi
     ./modules/services/lieer
+    ./modules/services/mpd
     ./modules/services/pantalaimon
     ./modules/services/pbgopy
     ./modules/services/playerctld

--- a/tests/modules/services/mpd/basic-configuration.conf
+++ b/tests/modules/services/mpd/basic-configuration.conf
@@ -1,0 +1,11 @@
+music_directory     "/home/hm-user/music"
+playlist_directory  "/home/hm-user/.local/share/mpd/playlists"
+db_file             "/home/hm-user/.local/share/mpd/tag_cache"
+
+state_file          "/home/hm-user/.local/share/mpd/state"
+sticker_file        "/home/hm-user/.local/share/mpd/sticker.sql"
+
+bind_to_address "127.0.0.1"
+
+
+

--- a/tests/modules/services/mpd/basic-configuration.nix
+++ b/tests/modules/services/mpd/basic-configuration.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  services.mpd.enable = true;
+
+  test.stubs.mpd = { };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/mpd.service)
+    assertFileContent "$serviceFile" ${./basic-configuration.service}
+
+    confFile=$(grep -o \
+        '/nix/store/.*-mpd.conf' \
+        $TESTED/home-files/.config/systemd/user/mpd.service)
+    assertFileContent "$confFile" ${./basic-configuration.conf}
+  '';
+}

--- a/tests/modules/services/mpd/basic-configuration.service
+++ b/tests/modules/services/mpd/basic-configuration.service
@@ -1,0 +1,13 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+Environment=PATH=/home/hm-user/.nix-profile/bin
+ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf
+ExecStartPre=/nix/store/00000000000000000000000000000000-bash-5.1-p12/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils-9.0/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
+Type=notify
+
+[Unit]
+After=network.target
+After=sound.target
+Description=Music Player Daemon

--- a/tests/modules/services/mpd/default.nix
+++ b/tests/modules/services/mpd/default.nix
@@ -1,0 +1,1 @@
+{ mpd-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

Just a simple test case.

### Checklist

- [x] Change is backwards compatible.

- [x]  Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```