### PR TITLE
xdg-desktop-entries: add 'actions' option, deprecate fileValidation

### DIFF
--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -7,6 +7,8 @@ let
     imports = [
       (mkRemovedOptionModule [ "extraConfig" ]
         "The `extraConfig` option of `xdg.desktopEntries` has been removed following a change in Nixpkgs.")
+      (mkRemovedOptionModule [ "fileValidation" ]
+        "Validation of the desktop file is always enabled.")
     ];
     options = {
       # Since this module uses the nixpkgs/pkgs/build-support/make-desktopitem function,
@@ -118,10 +120,35 @@ let
         '';
       };
 
-      fileValidation = mkOption {
-        type = types.bool;
-        description = "Whether to validate the generated desktop file.";
-        default = true;
+      actions = mkOption {
+        type = types.attrsOf (types.submodule ({ name, ... }: {
+          options.name = mkOption {
+            type = types.str;
+            default = name;
+            defaultText = literalExpression "<name>";
+            description = "Name of the action.";
+          };
+          options.exec = mkOption {
+            type = types.nullOr types.str;
+            description = "Program to execute, possibly with arguments.";
+          };
+          options.icon = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = "Icon to display in file manager, menus, etc.";
+          };
+        }));
+        default = { };
+        defaultText = literalExpression "{ }";
+        example = literalExpression ''
+          {
+            "New Window" = {
+              exec = "''${pkgs.firefox}/bin/firefox --new-window %u";
+            };
+          }
+        '';
+        description =
+          "The set of actions made available to application launchers.";
       };
 
       # Required for the assertions
@@ -145,7 +172,7 @@ let
       inherit name;
       inherit (config)
         type exec icon comment terminal genericName startupNotify noDisplay
-        prefersNonDefaultGPU;
+        prefersNonDefaultGPU actions;
       desktopName = config.name;
       mimeTypes = optionals (config.mimeType != null) config.mimeType;
       categories = optionals (config.categories != null) config.categories;

--- a/tests/modules/misc/xdg/desktop-entries.nix
+++ b/tests/modules/misc/xdg/desktop-entries.nix
@@ -18,19 +18,32 @@ with lib;
         startupNotify = false;
         noDisplay = false;
         prefersNonDefaultGPU = false;
-        extraConfig = ''
-          [X-ExtraSection]
-          Exec=foo -o
-        '';
         settings = {
           Keywords = "calc;math";
           DBusActivatable = "false";
         };
-        fileValidation = true;
+        actions = {
+          "New-Window" = {
+            name = "New Window";
+            exec = "test --new-window";
+            icon = "test";
+          };
+          "Default" = { exec = "test --default"; };
+        };
       };
       min = { # minimal definition
         exec = "test --option";
         name = "Test";
+      };
+      deprecated = {
+        exec = "test --option";
+        name = "Test";
+        # Deprecated options
+        fileValidation = true;
+        extraConfig = ''
+          [X-ExtraSection]
+          Exec=foo -o
+        '';
       };
     };
 
@@ -50,10 +63,16 @@ with lib;
 
     test.asserts.assertions.expected =
       let currentFile = toString ./desktop-entries.nix;
-      in [''
-        The option definition `extraConfig' in `${currentFile}' no longer has any effect; please remove it.
-        The `extraConfig` option of `xdg.desktopEntries` has been removed following a change in Nixpkgs.
-      ''];
+      in [
+        ''
+          The option definition `fileValidation' in `${currentFile}' no longer has any effect; please remove it.
+          Validation of the desktop file is always enabled.
+        ''
+        ''
+          The option definition `extraConfig' in `${currentFile}' no longer has any effect; please remove it.
+          The `extraConfig` option of `xdg.desktopEntries` has been removed following a change in Nixpkgs.
+        ''
+      ];
 
     nmt.script = ''
       assertFileExists home-path/share/applications/full.desktop

--- a/tests/modules/misc/xdg/desktop-full-expected.desktop
+++ b/tests/modules/misc/xdg/desktop-full-expected.desktop
@@ -1,4 +1,5 @@
 [Desktop Entry]
+Actions=Default;New-Window
 Categories=Network;WebBrowser
 Comment=My Application
 DBusActivatable=false
@@ -14,3 +15,12 @@ StartupNotify=false
 Terminal=true
 Type=Application
 Version=1.4
+
+[Desktop Action Default]
+Exec=test --default
+Name=Default
+
+[Desktop Action New-Window]
+Exec=test --new-window
+Icon=test
+Name=New Window


### PR DESCRIPTION
### Description

Adds the `actions` option to fix #2777.

The option `fileValidation` is removed because validation cannot be disabled anymore.


### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
