### PR TITLE
bash: add bash-completion

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,7 +59,7 @@
 
 /modules/programs/autorandr.nix                       @uvNikita
 
-/modules/programs/bash.nix                            @rycee
+/modules/programs/bash.nix                            @rycee @maximsmol
 
 /modules/programs/bat.nix                             @marsam
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -42,10 +42,14 @@ let
       };
     };
 
-    config = { id = mkDefault (builtins.hashString "sha256" config.message); };
+    config = {
+      id = mkDefault (builtins.hashString "sha256" config.message);
+    };
   });
 
-in {
+in
+
+{
   meta.maintainers = [ maintainers.rycee ];
 
   options = {
@@ -99,7 +103,7 @@ in {
       entries = mkOption {
         internal = true;
         type = types.listOf entryModule;
-        default = [ ];
+        default = [];
         description = "News entries.";
       };
     };
@@ -163,8 +167,10 @@ in {
 
       {
         time = "2017-09-12T13:11:48+00:00";
-        condition = (config.programs.zsh.enable
-          && config.programs.zsh.shellAliases != { });
+        condition = (
+          config.programs.zsh.enable &&
+          config.programs.zsh.shellAliases != {}
+        );
         message = ''
           Aliases defined in 'programs.zsh.shellAliases'
           are now have the highest priority. Such aliases will
@@ -306,7 +312,7 @@ in {
       {
         time = "2017-10-20T12:15:27+00:00";
         condition = with config.systemd.user;
-          services != { } || sockets != { } || targets != { } || timers != { };
+          services != {} || sockets != {} || targets != {} || timers != {};
         message = ''
           Home Manager's interaction with systemd is now done using
           'systemctl' from Nixpkgs, not the 'systemctl' in '$PATH'.
@@ -405,8 +411,9 @@ in {
 
       {
         time = "2017-11-14T19:56:49+00:00";
-        condition = with config.xsession.windowManager;
-          (i3.enable && i3.config != null && i3.config.startup != [ ]);
+        condition = with config.xsession.windowManager; (
+          i3.enable && i3.config != null && i3.config.startup != []
+        );
         message = ''
           A new 'notification' option was added to
           xsession.windowManager.i3.startup submodule.
@@ -552,7 +559,7 @@ in {
 
       {
         time = "2018-03-25T06:49:57+00:00";
-        condition = with config.programs.ssh; enable && matchBlocks != { };
+        condition = with config.programs.ssh; enable && matchBlocks != {};
         message = ''
           Options set through the 'programs.ssh' module are now placed
           at the end of the SSH configuration file. This was done to
@@ -862,7 +869,7 @@ in {
 
       {
         time = "2018-12-04T21:54:38+00:00";
-        condition = config.programs.beets.settings != { };
+        condition = config.programs.beets.settings != {};
         message = ''
           A new option 'programs.beets.enable' has been added.
           Starting with state version 19.03 this option defaults to
@@ -1771,7 +1778,7 @@ in {
 
       {
         time = "2021-01-01T08:51:11+00:00";
-        condition = config.pam.sessionVariables != { };
+        condition = config.pam.sessionVariables != {};
         message = ''
           The option 'pam.sessionVariables' will be deprecated in the future.
           This is due to PAM 1.5.0 deprecating reading of the user environment.
@@ -1979,7 +1986,7 @@ in {
 
       {
         time = "2021-05-18T12:22:42+00:00";
-        condition = config.services.syncthing != { };
+        condition = config.services.syncthing != {};
         message = ''
           Setting 'services.syncthing.tray' as a boolean will be deprecated in
           the future.
@@ -2182,8 +2189,7 @@ in {
 
       {
         time = "2021-09-23T17:04:48+00:00";
-        condition = hostPlatform.isLinux
-          && config.services.screen-locker.enable;
+        condition = hostPlatform.isLinux && config.services.screen-locker.enable;
         message = ''
           'xautolock' is now optional in 'services.screen-locker', and the
           'services.screen-locker' options have been reorganized for clarity.

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -42,14 +42,10 @@ let
       };
     };
 
-    config = {
-      id = mkDefault (builtins.hashString "sha256" config.message);
-    };
+    config = { id = mkDefault (builtins.hashString "sha256" config.message); };
   });
 
-in
-
-{
+in {
   meta.maintainers = [ maintainers.rycee ];
 
   options = {
@@ -103,7 +99,7 @@ in
       entries = mkOption {
         internal = true;
         type = types.listOf entryModule;
-        default = [];
+        default = [ ];
         description = "News entries.";
       };
     };
@@ -167,10 +163,8 @@ in
 
       {
         time = "2017-09-12T13:11:48+00:00";
-        condition = (
-          config.programs.zsh.enable &&
-          config.programs.zsh.shellAliases != {}
-        );
+        condition = (config.programs.zsh.enable
+          && config.programs.zsh.shellAliases != { });
         message = ''
           Aliases defined in 'programs.zsh.shellAliases'
           are now have the highest priority. Such aliases will
@@ -312,7 +306,7 @@ in
       {
         time = "2017-10-20T12:15:27+00:00";
         condition = with config.systemd.user;
-          services != {} || sockets != {} || targets != {} || timers != {};
+          services != { } || sockets != { } || targets != { } || timers != { };
         message = ''
           Home Manager's interaction with systemd is now done using
           'systemctl' from Nixpkgs, not the 'systemctl' in '$PATH'.
@@ -411,9 +405,8 @@ in
 
       {
         time = "2017-11-14T19:56:49+00:00";
-        condition = with config.xsession.windowManager; (
-          i3.enable && i3.config != null && i3.config.startup != []
-        );
+        condition = with config.xsession.windowManager;
+          (i3.enable && i3.config != null && i3.config.startup != [ ]);
         message = ''
           A new 'notification' option was added to
           xsession.windowManager.i3.startup submodule.
@@ -559,7 +552,7 @@ in
 
       {
         time = "2018-03-25T06:49:57+00:00";
-        condition = with config.programs.ssh; enable && matchBlocks != {};
+        condition = with config.programs.ssh; enable && matchBlocks != { };
         message = ''
           Options set through the 'programs.ssh' module are now placed
           at the end of the SSH configuration file. This was done to
@@ -869,7 +862,7 @@ in
 
       {
         time = "2018-12-04T21:54:38+00:00";
-        condition = config.programs.beets.settings != {};
+        condition = config.programs.beets.settings != { };
         message = ''
           A new option 'programs.beets.enable' has been added.
           Starting with state version 19.03 this option defaults to
@@ -1778,7 +1771,7 @@ in
 
       {
         time = "2021-01-01T08:51:11+00:00";
-        condition = config.pam.sessionVariables != {};
+        condition = config.pam.sessionVariables != { };
         message = ''
           The option 'pam.sessionVariables' will be deprecated in the future.
           This is due to PAM 1.5.0 deprecating reading of the user environment.
@@ -1986,7 +1979,7 @@ in
 
       {
         time = "2021-05-18T12:22:42+00:00";
-        condition = config.services.syncthing != {};
+        condition = config.services.syncthing != { };
         message = ''
           Setting 'services.syncthing.tray' as a boolean will be deprecated in
           the future.
@@ -2189,7 +2182,8 @@ in
 
       {
         time = "2021-09-23T17:04:48+00:00";
-        condition = hostPlatform.isLinux && config.services.screen-locker.enable;
+        condition = hostPlatform.isLinux
+          && config.services.screen-locker.enable;
         message = ''
           'xautolock' is now optional in 'services.screen-locker', and the
           'services.screen-locker' options have been reorganized for clarity.
@@ -2454,6 +2448,16 @@ in
         time = "2022-03-06T09:40:17+00:00";
         message = ''
           A new module is available: 'programs.pubs'.
+        '';
+      }
+
+      {
+        time = "2022-03-09T22:35:27+00:00";
+        message = ''
+          'programs.bash' now ships with 'bash-completion' by default. Certain
+          3rd-party completions use functions from this module and previously
+          failed. In addition, auto-completion from packages is picked up
+          automatically if linked to any nix profile.
         '';
       }
     ];

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -15,7 +15,7 @@ let
     };
 
 in {
-  meta.maintainers = [ maintainers.rycee maintainers.maximsmol ];
+  meta.maintainers = [ maintainers.rycee hm.maintainers.maximsmol ];
 
   imports = [
     (mkRenamedOptionModule [ "programs" "bash" "enableAutojump" ] [


### PR DESCRIPTION
### Description

Add `bash-completion` support to the bash module, similar to the [NixOS module](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/bash/bash-completion.nix). Solves #1464 + related to #191

Note sure what to do about tests with this one since it does not seem we currently test `.bashrc` (`initExtra`) in any way but will add one if needed

Note: sorry for the awful diff, the file was not formatted correctly on master so `nixfmt` messed it up

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
