### PR TITLE
bash: fall back to flag string if `shellDryRun` is unavailable

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -6,10 +6,15 @@ let
 
   cfg = config.programs.bash;
 
+  dryRunCmd =
+    if (pkgs.stdenv ? shellDryRun)
+    then ''${pkgs.stdenv.shellDryRun} "$target"''
+    else "${pkgs.stdenv.shell} -n -O extglob $out";
+
   writeBashScript = name: text: pkgs.writeTextFile {
     inherit name text;
     checkPhase = ''
-      ${pkgs.stdenv.shellDryRun} "$target"
+      ${dryRunCmd}
     '';
   };
 


### PR DESCRIPTION
### Description

Fixes #2722 

`pkgs.stdenv.shellDryRun` is only available in the unstable channel at
the moment. While normally it would be feasible to make a package change
available to stable channels by way of an overlay, overriding `stdenv`
will cause a cascade of rebuilds since every derivation that depends on
it will no longer be able to pull a cached binary.

Despite the fallback, this change retains support for `extglob` by
copying the bash flags from `shellDryRun`.

https://github.com/NixOS/nixpkgs/blob/b20f90e94001f58571067ac1c49b71d1eb73bd52/pkgs/stdenv/generic/default.nix#L175

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
