### PR TITLE
bspwm: add alwaysResetDesktops

### DIFF
--- a/modules/services/window-managers/bspwm/default.nix
+++ b/modules/services/window-managers/bspwm/default.nix
@@ -10,7 +10,19 @@ let
     builtins.replaceStrings upperChars (map (c: "_${c}") lowerChars);
 
   formatMonitor = monitor: desktops:
-    "bspc monitor ${escapeShellArg monitor} -d ${escapeShellArgs desktops}";
+    let
+      resetDesktops =
+        "bspc monitor ${escapeShellArg monitor} -d ${escapeShellArgs desktops}";
+      defaultDesktopName =
+        "Desktop"; # https://github.com/baskerville/bspwm/blob/master/src/desktop.h
+    in if cfg.alwaysResetDesktops then
+      resetDesktops
+    else ''
+      if [[ $(bspc query --desktops --names --monitor ${
+        escapeShellArg monitor
+      }) == ${defaultDesktopName} ]]; then
+        ${resetDesktops}
+      fi'';
 
   formatValue = v:
     if isList v then

--- a/modules/services/window-managers/bspwm/options.nix
+++ b/modules/services/window-managers/bspwm/options.nix
@@ -185,6 +185,19 @@ in {
       example = { "HDMI-0" = [ "web" "terminal" "III" "IV" ]; };
     };
 
+    alwaysResetDesktops = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        If set to <literal>true</literal>, desktops configured in <option>monitors</option> will be reset
+        every time the config is run.
+
+        If set to <literal>false</literal>, desktops will only be configured the first time the config is run.
+        This is useful if you want to dynamically add desktops and you don't want them to be destroyed if you
+        re-run <literal>bspwmrc</literal>.
+      '';
+    };
+
     rules = mkOption {
       type = types.attrsOf rule;
       default = { };

--- a/tests/modules/services/window-managers/bspwm/bspwmrc
+++ b/tests/modules/services/window-managers/bspwm/bspwmrc
@@ -1,4 +1,6 @@
-bspc monitor 'focused' -d 'desktop 1' 'd'\''esk top'
+if [[ $(bspc query --desktops --names --monitor 'focused') == Desktop ]]; then
+  bspc monitor 'focused' -d 'desktop 1' 'd'\''esk top'
+fi
 
 bspc config 'border_width' '2'
 bspc config 'external_rules_command' '/path/to/external rules command'

--- a/tests/modules/services/window-managers/bspwm/configuration.nix
+++ b/tests/modules/services/window-managers/bspwm/configuration.nix
@@ -8,6 +8,7 @@ with lib;
       enable = true;
       monitors.focused =
         [ "desktop 1" "d'esk top" ]; # pathological desktop names
+      alwaysResetDesktops = false;
       settings = {
         border_width = 2;
         split_ratio = 0.52;


### PR DESCRIPTION
### Description

If set to true, desktops configured in `monitors` will be reset every time the config is run.

If set to false, desktops will only be configured the first time the config is run.
This is useful if you want to dynamically add desktops and you don't want them to be destroyed if you re-run `bspwmrc`.

Tested.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

