### PR TITLE
zsh: add `envExtraFirst` option + consolidate `.zshenv` generated file additions

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -405,10 +405,6 @@ in
   };
 
   config = mkIf cfg.enable (mkMerge [
-    (mkIf (cfg.envExtra != "") {
-      home.file."${relToDotDir ".zshenv"}".text = cfg.envExtra;
-    })
-
     (mkIf (cfg.profileExtra != "") {
       home.file."${relToDotDir ".zprofile"}".text = cfg.profileExtra;
     })
@@ -421,18 +417,8 @@ in
       home.file."${relToDotDir ".zlogout"}".text = cfg.logoutExtra;
     })
 
-    (mkIf cfg.oh-my-zsh.enable {
-      home.file."${relToDotDir ".zshenv"}".text = ''
-        ZSH="${pkgs.oh-my-zsh}/share/oh-my-zsh";
-        ZSH_CACHE_DIR="${config.xdg.cacheHome}/oh-my-zsh";
-      '';
-    })
 
     (mkIf (cfg.dotDir != null) {
-      home.file."${relToDotDir ".zshenv"}".text = ''
-        ZDOTDIR=${zdotdir}
-      '';
-
       # When dotDir is set, only use ~/.zshenv to source ZDOTDIR/.zshenv,
       # This is so that if ZDOTDIR happens to be
       # already set correctly (by e.g. spawning a zsh inside a zsh), all env
@@ -444,6 +430,15 @@ in
 
     {
       home.file."${relToDotDir ".zshenv"}".text = ''
+        ${optionalString (cfg.dotDir != null) ''
+          ZDOTDIR=${zdotdir}
+        ''}
+
+        ${optionalString cfg.oh-my-zsh.enable ''
+          ZSH="${pkgs.oh-my-zsh}/share/oh-my-zsh";
+          ZSH_CACHE_DIR="${config.xdg.cacheHome}/oh-my-zsh";
+        ''}
+
         # Environment variables
         . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
@@ -452,6 +447,8 @@ in
           export __HM_ZSH_SESS_VARS_SOURCED=1
           ${envVarsStr}
         fi
+
+        ${cfg.envExtra}
       '';
     }
 

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -333,6 +333,12 @@ in
         description = "Commands that should be added to top of <filename>.zshrc</filename>.";
       };
 
+      envExtraFirst = mkOption {
+        default = "";
+        type = types.lines;
+        description = "Commands that should be added to top of <filename>.zshenv</filename>.";
+      };
+
       envExtra = mkOption {
         default = "";
         type = types.lines;
@@ -430,6 +436,8 @@ in
 
     {
       home.file."${relToDotDir ".zshenv"}".text = ''
+        ${cfg.envExtraFirst}
+
         ${optionalString (cfg.dotDir != null) ''
           ZDOTDIR=${zdotdir}
         ''}


### PR DESCRIPTION
- Add a new option – `programs.zsh.envExtraFirst`. This option is the equivalent to `programs.zsh.initExtraFirst`, allowing for user-specified lines to be added at the very beginning of the generated `.zshenv` file.
- Combine all additions to `.zshenv` into one multiline block to avoid implicit/unclear ordering of the additions to the file.
- This may address #2751 by ensuring that `envExtra` is predictably appended to the end of `.zshenv`, which, based on my understanding of the issues in that ticket, would retain something similar to the initial order of `.zshenv` prior to #2708.

### Description

Currently, the `.zshenv` file generated by this module relies on an
implicit order of sections via the module's invocation of `lib.mkMerge`.
The current state leaves the resulting `.zshenv` file output unclear at
a glance.

With the changes in this commit, the text of the `.zshenv` file is
written explicitly in a single multiline string, with the conditional
sections handled with `lib.optionalString`. This approach makes the
text contents of the generated `.zshenv` file clear from reading the
source code.

By writing the generated file explicitly, at a glance we can easily
determine the order in which the various config values are loaded:

1. `envExtraFirst` – new option
2. `$ZDOTDIR`
3. oh-my-zsh vars
4. sourced home-manager session vars
5. `envVarsStr`
6. `envExtra`

### Checklist

- [ ] Change is backwards compatible. 

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
