### PR TITLE
irssi: fix syntax error when no channels are specified

### DIFF
--- a/modules/programs/irssi.nix
+++ b/modules/programs/irssi.nix
@@ -44,14 +44,15 @@ let
       }
     ''));
 
-  channelString = concatStringsSep cnl (flip mapAttrsToList cfg.networks (k: v:
-    concatStringsSep cnl (flip mapAttrsToList v.channels (c: cv: ''
-      {
-        chatnet = "${k}";
-        name = "${c}";
-        autojoin = "${boolStr cv.autoJoin}";
-      }
-    ''))));
+  channelString = concatStringsSep cnl (concatLists
+    (flip mapAttrsToList cfg.networks (k: v:
+      (flip mapAttrsToList v.channels (c: cv: ''
+        {
+          chatnet = "${k}";
+          name = "${c}";
+          autojoin = "${boolStr cv.autoJoin}";
+        }
+      '')))));
 
   channelType = types.submodule {
     options = {


### PR DESCRIPTION
### Description

TL;DR: Don't nest concatStringsSep

`concatStringsSep` will return an empty string when called with empty array. The `concatStringsSep` called with `v.channels` would generate an empty string for each channel:

```
programs.irssi = {
  networks = {
    network1 = {
      ...
    };
    network2 = {
      ...
    };
  };
};
```
generates `[ "" "" ]`, which the `concatStringsSep` called with `v.networks` will use to generate
```
,

```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.