### PR TITLE
xdg: add `XDG_*_HOME` variables to `systemd.user.sessionVariables`

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -80,18 +80,22 @@ in {
   };
 
   config = mkMerge [
-    (mkIf cfg.enable {
-      xdg.cacheHome = mkDefault defaultCacheHome;
-      xdg.configHome = mkDefault defaultConfigHome;
-      xdg.dataHome = mkDefault defaultDataHome;
-      xdg.stateHome = mkDefault defaultStateHome;
-
-      home.sessionVariables = {
+    (let
+      variables = {
         XDG_CACHE_HOME = cfg.cacheHome;
         XDG_CONFIG_HOME = cfg.configHome;
         XDG_DATA_HOME = cfg.dataHome;
         XDG_STATE_HOME = cfg.stateHome;
       };
+    in mkIf cfg.enable {
+      xdg.cacheHome = mkDefault defaultCacheHome;
+      xdg.configHome = mkDefault defaultConfigHome;
+      xdg.dataHome = mkDefault defaultDataHome;
+      xdg.stateHome = mkDefault defaultStateHome;
+
+      home.sessionVariables = variables;
+      systemd.user.sessionVariables =
+        mkIf pkgs.stdenv.hostPlatform.isLinux variables;
     })
 
     # Legacy non-deterministic setup.

--- a/tests/modules/misc/xdg/system-dirs.nix
+++ b/tests/modules/misc/xdg/system-dirs.nix
@@ -11,8 +11,12 @@
       assertFileContent $envFile ${
         pkgs.writeText "expected" ''
           LOCALE_ARCHIVE_2_27=${pkgs.glibcLocales}/lib/locale/locale-archive
+          XDG_CACHE_HOME=/home/hm-user/.cache
           XDG_CONFIG_DIRS=/etc/xdg:/foo/bar''${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}
+          XDG_CONFIG_HOME=/home/hm-user/.config
           XDG_DATA_DIRS=/usr/local/share:/usr/share:/baz/quux''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}
+          XDG_DATA_HOME=/home/hm-user/.local/share
+          XDG_STATE_HOME=/home/hm-user/.local/state
         ''
       }
 

--- a/tests/modules/systemd/session-variables-expected.conf
+++ b/tests/modules/systemd/session-variables-expected.conf
@@ -1,3 +1,0 @@
-LOCALE_ARCHIVE_2_27=@glibcLocales@/lib/locale/locale-archive
-V_int=1
-V_str=2

--- a/tests/modules/systemd/session-variables.nix
+++ b/tests/modules/systemd/session-variables.nix
@@ -15,6 +15,10 @@
           LOCALE_ARCHIVE_2_27=${pkgs.glibcLocales}/lib/locale/locale-archive
           V_int=1
           V_str=2
+          XDG_CACHE_HOME=/home/hm-user/.cache
+          XDG_CONFIG_HOME=/home/hm-user/.config
+          XDG_DATA_HOME=/home/hm-user/.local/share
+          XDG_STATE_HOME=/home/hm-user/.local/state
         ''
       }
     '';


### PR DESCRIPTION
Make sure those variables are set in systemd user services. This mirrors the situation for `XDG_*_DIRS` variables.

cc @tadfisher https://github.com/nix-community/home-manager/pull/1797

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
