### PR TITLE
autorandr: add filter option

### DIFF
--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -176,6 +176,13 @@ let
           }
         '';
       };
+
+      filter = mkOption {
+        type = types.nullOr (types.enum [ "bilinear" "nearest" ]);
+        description = "Interpolation method to be used for scaling the output.";
+        default = null;
+        example = "nearest";
+      };
     };
   };
 
@@ -261,6 +268,7 @@ let
         ++ optional (config.mode != "") "mode ${config.mode}"
         ++ optional (config.rate != "") "rate ${config.rate}"
         ++ optional (config.rotate != null) "rotate ${config.rotate}"
+        ++ optional (config.filter != null) "filter ${config.filter}"
         ++ optional (config.transform != null) ("transform "
           + concatMapStringsSep "," toString (flatten config.transform))
         ++ optional (config.scale != null)

--- a/tests/modules/programs/autorandr/basic-configuration.nix
+++ b/tests/modules/programs/autorandr/basic-configuration.nix
@@ -17,6 +17,7 @@
               primary = true;
               position = "0x0";
               mode = "1920x1080";
+              filter = "nearest";
               transform = [
                 [ 0.6 0.0 0.0 ] # a b c
                 [ 0.0 0.6 0.0 ] # d e f
@@ -50,6 +51,7 @@
               crtc 0
               primary
               mode 1920x1080
+              filter nearest
               transform 0.600000,0.000000,0.000000,0.000000,0.600000,0.000000,0.000000,0.000000,1.000000''
           }
     '';


### PR DESCRIPTION
### Description

xrandr's `--filter` option is useful for enabling integer scaling on displays that don't have support for it at a graphics card level; autorandr doesn't add this option itself to generated profiles, but happily accepts it if the user adds it to the config.

As an alternative to this change, perhaps an `extraConfig` attribute would be suitable; I didn't take that approach because I only needed this one option added.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.
FIXME(?): seems that `modules/misc/xdg-desktop-entries.nix` made them fail on my machine...?

- [x] Test cases updated/added.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```