### PR TITLE
neovim/coc: fix loading CoC plugin

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -64,14 +64,21 @@ let
     '' else
       "";
 
+  allPlugins = cfg.plugins ++ optional cfg.coc.enable {
+    type = "viml";
+    plugin = pkgs.vimPlugins.coc-nvim;
+    config = cfg.coc.pluginConfig;
+    optional = false;
+  };
+
   moduleConfigure = {
     packages.home-manager = {
       start = remove null (map
         (x: if x ? plugin && x.optional == true then null else (x.plugin or x))
-        cfg.plugins);
+        allPlugins);
       opt = remove null
         (map (x: if x ? plugin && x.optional == true then x.plugin else null)
-          cfg.plugins);
+          allPlugins);
     };
     beforePlugins = "";
   };
@@ -328,6 +335,12 @@ in {
             for options.
           '';
         };
+
+        pluginConfig = mkOption {
+          type = types.lines;
+          default = "";
+          description = "Script to configure CoC. Must be viml.";
+        };
       };
     };
   };
@@ -342,16 +355,15 @@ in {
         plugin = x;
         config = "";
         optional = false;
-      }) cfg.plugins;
+      }) allPlugins;
     suppressNotVimlConfig = p:
       if p.type != "viml" then p // { config = ""; } else p;
 
     neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
-      inherit (cfg)
-        extraPython3Packages withPython3 withNodeJs withRuby viAlias vimAlias;
+      inherit (cfg) extraPython3Packages withPython3 withRuby viAlias vimAlias;
+      withNodeJs = cfg.withNodeJs or cfg.coc.enable;
       configure = cfg.configure // moduleConfigure;
-      plugins = (map suppressNotVimlConfig pluginsNormalized)
-        ++ optionals cfg.coc.enable [{ plugin = pkgs.vimPlugins.coc-nvim; }];
+      plugins = map suppressNotVimlConfig pluginsNormalized;
       customRC = cfg.extraConfig;
     };
 


### PR DESCRIPTION
### Description

Specifically, refactored all places that use cfg.plugins to use a new combined list that includes CoC if it's enabled.

Closes #2386



### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.