### PR TITLE
vscode: add user tasks

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -28,6 +28,7 @@ let
     "${config.xdg.configHome}/${configDir}/User";
 
   configFilePath = "${userDir}/settings.json";
+  tasksFilePath = "${userDir}/tasks.json";
   keybindingsFilePath = "${userDir}/keybindings.json";
 
   # TODO: On Darwin where are the extensions?
@@ -67,6 +68,27 @@ in {
         description = ''
           Configuration written to Visual Studio Code's
           <filename>settings.json</filename>.
+        '';
+      };
+
+      userTasks = mkOption {
+        type = jsonFormat.type;
+        default = { };
+        example = literalExpression ''
+          {
+            "version": "2.0.0",
+            "tasks": [
+              {
+                "type": "shell",
+                "label": "Hello task",
+                "command": "hello",
+              }
+            ]
+          }
+        '';
+        description = ''
+          Configuration written to Visual Studio Code's
+          <filename>tasks.json</filename>.
         '';
       };
 
@@ -145,6 +167,10 @@ in {
       (mkIf (cfg.userSettings != { }) {
         "${configFilePath}".source =
           jsonFormat.generate "vscode-user-settings" cfg.userSettings;
+      })
+      (mkIf (cfg.userTasks != { }) {
+        "${tasksFilePath}".source =
+          jsonFormat.generate "vscode-user-tasks" cfg.userTasks;
       })
       (mkIf (cfg.keybindings != [ ])
         (let dropNullFields = filterAttrs (_: v: v != null);


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Currently home manager does not provide a way to define VSCode [user level tasks](https://code.visualstudio.com/docs/editor/tasks#_user-level-tasks)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
