### PR TITLE
xsession.pointerCursor: escape special characters in the cursor path

### DIFF
--- a/modules/xcursor.nix
+++ b/modules/xcursor.nix
@@ -36,6 +36,10 @@ let
     };
   };
 
+  cursorPath = "${cfg.package}/share/icons/${escapeShellArg cfg.name}/cursors/${
+      escapeShellArg cfg.defaultCursor
+    }";
+
 in {
   meta.maintainers = [ maintainers.league ];
 
@@ -68,9 +72,7 @@ in {
     home.packages = [ cfg.package ];
 
     xsession.initExtra = ''
-      ${pkgs.xorg.xsetroot}/bin/xsetroot -xcf ${cfg.package}/share/icons/${cfg.name}/cursors/${cfg.defaultCursor} ${
-        toString cfg.size
-      }
+      ${pkgs.xorg.xsetroot}/bin/xsetroot -xcf ${cursorPath} ${toString cfg.size}
     '';
 
     xresources.properties = {


### PR DESCRIPTION
- Escape special character in the cursor name and default cursor file name
  in the cursor path for the xsetroot command.

### Description

small change to address https://github.com/nix-community/home-manager/issues/2081#issuecomment-859580927
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
