### PR TITLE
docs: fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,18 +110,18 @@ License
 
 This project is licensed under the terms of the [MIT license](LICENSE).
 
-[Nix]: https://nixos.org/nix/
+[Nix]: https://nixos.org/explore.html
 [NixOS]: https://nixos.org/
-[Nixpkgs]: https://nixos.org/nixpkgs/
-[manual]: https://nix-community.github.io/home-manager/
+[Nixpkgs]: https://github.com/NixOS/nixpkgs
+[manual]: https://nix-community.github.io/home-manager/index.html
 [contributing]: https://nix-community.github.io/home-manager/#ch-contributing
 [manual usage]: https://nix-community.github.io/home-manager/#ch-usage
 [configuration options]: https://nix-community.github.io/home-manager/options.html
 [#home-manager]: https://webchat.oftc.net/?channels=home-manager
 [OFTC]: https://oftc.net/
-[Nix Pills]: https://nixos.org/nixos/nix-pills/
+[Nix Pills]: https://nixos.org/guides/nix-pills/
 [Nix Flakes]: https://nixos.wiki/wiki/Flakes
-[nix-darwin]: https://github.com/LnL7/nix-darwin/
+[nix-darwin]: https://github.com/LnL7/nix-darwin
 [manual standalone install]: https://nix-community.github.io/home-manager/index.html#sec-install-standalone
 [manual nixos install]: https://nix-community.github.io/home-manager/index.html#sec-install-nixos-module
 [manual nix-darwin install]: https://nix-community.github.io/home-manager/index.html#sec-install-nix-darwin-module


### PR DESCRIPTION
### Description

Fix some links in README which are either broken or redirected.

If anyone has better place to link to, suggestions welcome.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
