### PR TITLE
xcursor: remove warning and use mkDefault for GTK options

### DIFF
--- a/modules/xcursor.nix
+++ b/modules/xcursor.nix
@@ -60,11 +60,6 @@ in {
         platforms.linux)
     ];
 
-    warnings = [''
-      GTK cursor settings will no longer be handled in the xsession.pointerCursor module in future.
-      Please use gtk.cursorTheme for GTK cursor settings instead.
-    ''];
-
     home.packages = [ cfg.package ];
 
     xsession.initExtra = ''
@@ -78,8 +73,7 @@ in {
       "Xcursor.size" = cfg.size;
     };
 
-    # TODO: deprecate after next version release.
-    gtk.cursorTheme = { inherit (cfg) package name size; };
+    gtk.cursorTheme = mkDefault { inherit (cfg) package name size; };
 
     # Set name in icons theme, for compatibility with AwesomeWM etc. See:
     # https://github.com/nix-community/home-manager/issues/2081


### PR DESCRIPTION
### Description

See discussion at https://github.com/nix-community/home-manager/pull/2481#issuecomment-1072973278.

I'd like this to be merged quickly as I think the warning will only create confusion and cause users to stop using the xcursor module. Then we can decide how to structure cursor options at peace.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
