### PR TITLE
gtk: fix missing newline in formatted config

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -250,8 +250,8 @@ in {
     ];
 
     home.file.${cfg2.configLocation}.text =
-      concatStringsSep "\n" (mapAttrsToList formatGtk2Option gtkIni)
-      + cfg2.extraConfig;
+      concatMapStrings (l: l + "\n") (mapAttrsToList formatGtk2Option gtkIni)
+      + cfg2.extraConfig + "\n";
 
     home.sessionVariables.GTK2_RC_FILES = cfg2.configLocation;
 
@@ -262,7 +262,7 @@ in {
       mkIf (cfg3.extraCss != "") { text = cfg3.extraCss; };
 
     xdg.configFile."gtk-3.0/bookmarks" = mkIf (cfg3.bookmarks != [ ]) {
-      text = concatStringsSep "\n" cfg3.bookmarks;
+      text = concatMapStrings (l: l + "\n") cfg3.bookmarks;
     };
 
     xdg.configFile."gtk-4.0/settings.ini".text =

--- a/tests/modules/misc/gtk/gtk2-basic-config-expected.conf
+++ b/tests/modules/misc/gtk/gtk2-basic-config-expected.conf
@@ -1,1 +1,2 @@
+gtk-theme-name = "Adwaita"
 gtk-can-change-accels = 1

--- a/tests/modules/misc/gtk/gtk2-basic-config.nix
+++ b/tests/modules/misc/gtk/gtk2-basic-config.nix
@@ -6,6 +6,7 @@ with lib;
   config = {
     gtk = {
       enable = true;
+      theme.name = "Adwaita";
       gtk2.extraConfig = "gtk-can-change-accels = 1";
     };
 


### PR DESCRIPTION
The conversion from `concatMapStrings` to `concatStringsSep` introduced in https://github.com/nix-community/home-manager/pull/2481
creates an unintended behavior change where the formatted config does not end in a newline.[1]
This is problematic for manipulation at the Nix level. In particular, this cause a regression in
the generation of gtk2 settings due to concatenated of the formatted config and `gtk2.extraConfig`
without a newline in between.

This commit restores `concatMapStrings` to match the previous behavior and adds a newline to
the final string for the generated gtk2 config. The test case for gtk2-basic-config
was also updated to check behavior at concatenation boundaries.

[1] - https://github.com/nix-community/home-manager/pull/2481#discussion_r830648706

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
