### PR TITLE
Fix tests for herbstluftwm and mpd (bash-version)

### DIFF
--- a/tests/modules/services/mpd/basic-configuration.service
+++ b/tests/modules/services/mpd/basic-configuration.service
@@ -4,7 +4,7 @@ WantedBy=default.target
 [Service]
 Environment=PATH=/home/hm-user/.nix-profile/bin
 ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf
-ExecStartPre=/nix/store/00000000000000000000000000000000-bash-5.1-p12/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils-9.0/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
+ExecStartPre=/nix/store/00000000000000000000000000000000-bash-5.1-p16/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils-9.0/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
 Type=notify
 
 [Unit]

--- a/tests/modules/services/window-managers/herbstluftwm/autostart
+++ b/tests/modules/services/window-managers/herbstluftwm/autostart
@@ -1,4 +1,4 @@
-#!/nix/store/00000000000000000000000000000000-bash-5.1-p12/bin/bash
+#!/nix/store/00000000000000000000000000000000-bash-5.1-p16/bin/bash
 shopt -s expand_aliases
 
 # shellcheck disable=SC2142


### PR DESCRIPTION
### Description

Fix current failing tests for herbstluftwm and mpd.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
