### PR TITLE
tmux: fix broken vi bindings

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -58,10 +58,10 @@ let
 
     ${optionalString
     (cfg.keyMode == "vi" && cfg.customPaneNavigationAndResize) ''
-      bind h -N "Select pane to the left of the active pane" select-pane -L
-      bind j -N "Select pane below the active pane" select-pane -D
-      bind k -N "Select pane above the active pane" select-pane -U
-      bind l -N "Select pane to the right of the active pane" select-pane -R
+      bind -N "Select pane to the left of the active pane" h select-pane -L
+      bind -N "Select pane below the active pane" j select-pane -D
+      bind -N "Select pane above the active pane" k select-pane -U
+      bind -N "Select pane to the right of the active pane" l select-pane -R
 
       bind -r -N "Resize the pane left by ${toString cfg.resizeAmount}" \
         H resize-pane -L ${toString cfg.resizeAmount}


### PR DESCRIPTION
### Description

Keybindings have wrong order of arguments: the -N flag should go before the binding key. https://www.man7.org/linux/man-pages/man1/tmux.1.html#KEY_BINDINGS

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
