### PR TITLE
types: fix `dagOf` behaviour with `mkIf`

### DIFF
--- a/tests/lib/types/dag-merge.nix
+++ b/tests/lib/types/dag-merge.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) concatStringsSep hm mkMerge mkOption types;
+  inherit (lib) concatStringsSep hm mkIf mkMerge mkOption types;
 
   dag = lib.hm.dag;
 
@@ -14,10 +14,14 @@ in {
   options.tested.dag = mkOption { type = hm.types.dagOf types.str; };
 
   config = {
-    tested = mkMerge [
-      { dag.after = "after"; }
-      { dag.before = dag.entryBefore [ "after" ] "before"; }
-      { dag.between = dag.entryBetween [ "after" ] [ "before" ] "between"; }
+    tested.dag = mkMerge [
+      { never = mkIf false "never"; }
+      { after = mkMerge [ "after" (mkIf false "neither") ]; }
+      { before = dag.entryBefore [ "after" ] (mkIf true "before"); }
+      {
+        between =
+          mkIf true (dag.entryBetween [ "after" ] [ "before" ] "between");
+      }
     ];
 
     home.file."result.txt".text = result;


### PR DESCRIPTION
This makes definitions like `home.activation.foo = mkIf false "bar"` work, where previously they would complain about `home.activation.foo.data` being used but not defined.

The crucial part is that we don't call `convertAllToDags` in `dagOf.merge`, because we need to process `mkIf`/`mkMerge` properties first. So we let `attrEquivalent.merge` do its job normally, but give it a type `dagEntryOf` that does the conversion.

Ideally this shouldn't require so much boilerplate; I'd like to implement something like `types.changeInto dagContentType elemType dagEntryAnywhere` in nixpkgs.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
