### PR TITLE
gpg: create homedir with 700 permissions

### DIFF
--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -282,7 +282,12 @@ in {
         source = "${keyringFiles}/pubring.kbx";
       };
 
-    home.activation = mkIf (cfg.publicKeys != [ ]) {
+    home.activation = {
+      createGpgHomedir =
+        hm.dag.entryBetween [ "linkGeneration" ] [ "writeBoundary" ] ''
+          $DRY_RUN_CMD mkdir -m700 -p $VERBOSE_ARG ${escapeShellArg cfg.homedir}
+        '';
+
       importGpgKeys = let
         gpg = "${cfg.package}/bin/gpg";
 
@@ -313,7 +318,8 @@ in {
           unset GNUPGHOME QUIET_ARG keyId importTrust
         '' ++ optional (!cfg.mutableTrust && anyTrust) ''
           install -m 0700 ${keyringFiles}/trustdb.gpg "${cfg.homedir}/trustdb.gpg"'');
-      in lib.hm.dag.entryAfter [ "linkGeneration" ] block;
+      in mkIf (cfg.publicKeys != [ ])
+      (lib.hm.dag.entryAfter [ "linkGeneration" ] block);
     };
   };
 }


### PR DESCRIPTION
It can happen in some cases that home-manager first runs before gpg creates its homedir, and it creates it with 755 permissions which the user then needs to change by hand.

Do this in the module instead: before linking files, make sure the homedir exists, and if it doesn't, create it with the right permissions.

We might drop the `mkMerge` if https://github.com/nix-community/home-manager/pull/2822 gets merged first. (EDIT: done)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
