### PR TITLE
misc: fix nix.conf generation

### DIFF
--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -230,7 +230,9 @@ in {
         };
       };
 
-      "nix/nix.conf" = mkIf (cfg.settings != { }) { source = nixConf; };
+      "nix/nix.conf" = mkIf (cfg.settings != { } || cfg.extraOptions != "") {
+        source = nixConf;
+      };
     };
   };
 


### PR DESCRIPTION
nix/nix.conf should generate if cfg.extraOptions is not empty.

### Description

<!--

Please provide a brief description of your change.

-->

I've encountered `nix/nix.conf` not generated with the following config:

```
nix.extraOptions = ''
  experimental-features = nix-command flakes
'';
```

By checking the config files, this file is only generated when `cfg.settings != {}`. It missed one case that `extraOptions` is outside `settings`.

This PR fixes the logic and generates `nix/nix.conf` correctly.

It doesn't involve any package change so I guess most of the checklists are not applicable?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
