### PR TITLE
Use `types.lines` for `irssi.extraConfig`  and `picom.extraOptions`

### DIFF
--- a/modules/programs/irssi.nix
+++ b/modules/programs/irssi.nix
@@ -155,7 +155,7 @@ in {
       extraConfig = mkOption {
         default = "";
         description = "These lines are appended to the Irssi configuration.";
-        type = types.str;
+        type = types.lines;
       };
 
       aliases = mkOption {

--- a/modules/services/picom.nix
+++ b/modules/services/picom.nix
@@ -270,7 +270,7 @@ in {
     };
 
     extraOptions = mkOption {
-      type = types.str;
+      type = types.lines;
       default = "";
       example = ''
         unredir-if-possible = true;


### PR DESCRIPTION
These options should permit multiple definitions.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
