### PR TITLE
overlay: rename parameters to flake specification

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,3 +1,3 @@
-self: super: {
-  home-manager = super.callPackage ./home-manager { path = toString ./.; };
+final: prev: {
+  home-manager = prev.callPackage ./home-manager { path = toString ./.; };
 }


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

### Description

Renaming of the overlay parameters to pass the `nix flake check` test that for some reason requires that [standarize](https://nixos.wiki/wiki/Flakes) the name of the parameters.

I already [did the same alteration](https://github.com/lucasew/borderless-browser.nix/commits/master/flake.nix) in other repo.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
