### PR TITLE
tests: bump nmt

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,8 +7,8 @@ let
   nmt = pkgs.fetchFromGitLab {
     owner = "rycee";
     repo = "nmt";
-    rev = "89924d8e6e0fcf866a11324d32c6bcaa89cda506";
-    sha256 = "02wzrbmpdpgig58a1rhz8sb0p2rvbapnlcmhi4d4bi8w9md6pmdl";
+    rev = "d83601002c99b78c89ea80e5e6ba21addcfe12ae";
+    sha256 = "1xzwwxygzs1cmysg97hzd285r7n1g1lwx5y1ar68gwq07a1rczmv";
   };
 
   modules = import ../modules/modules.nix {

--- a/tests/modules/misc/gtk/gtk3-basic-settings.nix
+++ b/tests/modules/misc/gtk/gtk3-basic-settings.nix
@@ -15,7 +15,7 @@ with lib;
     test.stubs.dconf = { };
 
     nmt.script = ''
-      assertPathExists home-files/.config/gtk-3.0
+      assertFileExists home-files/.config/gtk-3.0/settings.ini
 
       assertFileContent home-files/.config/gtk-3.0/settings.ini \
         ${./gtk3-basic-settings-expected.ini}

--- a/tests/modules/services/mpd/basic-configuration.service
+++ b/tests/modules/services/mpd/basic-configuration.service
@@ -4,7 +4,7 @@ WantedBy=default.target
 [Service]
 Environment=PATH=/home/hm-user/.nix-profile/bin
 ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf
-ExecStartPre=/nix/store/00000000000000000000000000000000-bash-5.1-p16/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils-9.0/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
+ExecStartPre=/nix/store/00000000000000000000000000000000-bash/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
 Type=notify
 
 [Unit]

--- a/tests/modules/services/window-managers/herbstluftwm/autostart
+++ b/tests/modules/services/window-managers/herbstluftwm/autostart
@@ -1,4 +1,4 @@
-#!/nix/store/00000000000000000000000000000000-bash-5.1-p16/bin/bash
+#!/nix/store/00000000000000000000000000000000-bash/bin/bash
 shopt -s expand_aliases
 
 # shellcheck disable=SC2142
@@ -19,7 +19,7 @@ herbstclient set frame_bg_active_color '#000000'
 herbstclient set frame_gap '12'
 herbstclient set frame_padding '-12'
 
-if @herbstluftwm@/bin/herbstclient object_tree tags.by-name | /nix/store/00000000000000000000000000000000-gnugrep-3.7/bin/grep default; then
+if @herbstluftwm@/bin/herbstclient object_tree tags.by-name | /nix/store/00000000000000000000000000000000-gnugrep/bin/grep default; then
   herbstclient rename default '1'
 fi
 


### PR DESCRIPTION
### Description

Also updated golden files to match new store path normalization
output.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```