### PR TITLE
flake: add `packages.<system>.default`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,10 +25,11 @@
           docs-html = docs.manual.html;
           docs-manpages = docs.manPages;
           docs-json = docs.options.json;
+          default = self.packages.${system}.home-manager;
         });
 
-      defaultPackage =
-        forAllSystems (system: self.packages.${system}.home-manager);
+      # defaultPackage is deprecated as of Nix 2.7.0
+      defaultPackage = forAllSystems (system: self.packages.${system}.default);
 
       apps = forAllSystems (system: {
         home-manager = {


### PR DESCRIPTION

### Description

Since Nix 2.7.0, `defaultPackage` is deprecated and instead we should
use `packages.<system>.default`.  This commit adds the new field but
keep the old for backward compatibility.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
