### PR TITLE
browserpass: add brave support

### DIFF
--- a/tests/modules/programs/browserpass/browserpass.nix
+++ b/tests/modules/programs/browserpass/browserpass.nix
@@ -6,11 +6,11 @@ with lib;
   config = {
     programs.browserpass = {
       enable = true;
-      browsers = [ "chrome" "chromium" "firefox" "vivaldi" ];
+      browsers = [ "brave" "chrome" "chromium" "firefox" "vivaldi" ];
     };
 
     nmt.script = if pkgs.stdenv.hostPlatform.isDarwin then ''
-      for dir in "Google/Chrome" "Chromium" "Mozilla" "Vivaldi"; do
+      for dir in "BraveSoftware/Brave-Browser" "Google/Chrome" "Chromium" "Mozilla" "Vivaldi"; do
         assertFileExists "home-files/Library/Application Support/$dir/NativeMessagingHosts/com.github.browserpass.native.json"
       done
 
@@ -18,8 +18,11 @@ with lib;
         assertFileExists "home-files/Library/Application Support/$dir/policies/managed/com.github.browserpass.native.json"
       done
     '' else ''
-      for dir in "google-chrome" "chromium" "vivaldi"; do
+      for dir in "BraveSoftware/Brave-Browser" "google-chrome" "chromium" "vivaldi"; do
         assertFileExists "home-files/.config/$dir/NativeMessagingHosts/com.github.browserpass.native.json"
+      done
+
+      for dir in "google-chrome" "chromium" "vivaldi"; do
         assertFileExists "home-files/.config/$dir/policies/managed/com.github.browserpass.native.json"
       done
 


### PR DESCRIPTION
### Description

Add support of [Brave browser](https://brave.com/) to browserpass module

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
