### PR TITLE
Dconf: add note - dconf must be enabled in system config.

### DIFF
--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -91,12 +91,20 @@ while the `common.nix` file contains configuration shared across the two logins.
 
 You can get some inspiration from the {post-your-homenix}[Post your home-manager home.nix file!] Reddit thread.
 
-=== Why do I get an error message about `ca.desrt.dconf`?
+=== Why do I get an error message about `ca.desrt.dconf` or `dconf.service`?
 
-You are most likely trying to configure the GTK or Gnome Terminal but the DBus session is not aware of the dconf service. The full error you might get is
+You are most likely trying to configure something that uses dconf
+but the DBus session is not aware of the dconf service.
+The full error you might get is
 
 ----
 error: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name ca.desrt.dconf was not provided by any .service files
+----
+
+or
+
+----
+error: GDBus.Error:org.freedesktop.systemd1.NoSuchUnit: Unit dconf.service not found.
 ----
 
 The solution on NixOS is to add

--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -21,6 +21,11 @@ in {
         visible = false;
         description = ''
           Whether to enable dconf settings.
+          </para><para>
+          Note, if you use NixOS then you must add
+          <code>programs.dconf.enable = true</code>
+          to your system configuration. Otherwise you will see a systemd error
+          message when your configuration is activated.
         '';
       };
 


### PR DESCRIPTION

### Description
Before enabling dconf in home manager, dconf must be enabled in system config.

Otherwise it will fail like this:
```
↪ home-manager switch                                                                                                                                                                    13:04
Starting Home Manager activation
Activating checkFilesChanged
Activating checkLinkTargets
Activating writeBoundary
Activating installPackages
replacing old 'home-manager-path'
installing 'home-manager-path'
Activating dconfSettings
error: GDBus.Error:org.freedesktop.systemd1.NoSuchUnit: Unit dconf.service not found.
```

I hit this issue and I couldn't find this piece of information anywhere else. So thought I'd add here.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
