### PR TITLE
Only support linux + darwin, not bsd, cygwin, sunos or redox

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   outputs = { self, nixpkgs }:
     let
       # List of systems supported by home-manager binary
-      supportedSystems = nixpkgs.lib.platforms.unix;
+      supportedSystems = with nixpkgs.lib.platforms; linux ++ darwin;
 
       # Function to generate a set based on supported systems
       forAllSystems = f:


### PR DESCRIPTION
This is to prevent errors with `flake check` because for example cygwin can't even build bash

Closes #2829

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
