### PR TITLE
swayidle: fix systemd command string parse failure

### DIFF
--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -108,8 +108,9 @@ in {
 
       Service = {
         Type = "simple";
-        ExecStart =
-          "${cfg.package}/bin/swayidle -w ${concatStringsSep " " args}";
+        ExecStart = "${pkgs.writeShellScript "swayidle" ''
+          ${cfg.package}/bin/swayidle -w ${concatStringsSep " " args}
+        ''}";
       };
 
       Install = { WantedBy = [ "sway-session.target" ]; };

--- a/tests/modules/services/swayidle/basic-configuration.nix
+++ b/tests/modules/services/swayidle/basic-configuration.nix
@@ -32,21 +32,11 @@
       ];
     };
 
-    nmt.script = let
-      escapeForRegex = builtins.replaceStrings [ "'" "*" ] [ "'\\''" "\\*" ];
-      expectedArgs = escapeForRegex (lib.concatStringsSep " " [
-        "-w"
-        "timeout 50 'notify-send -t 10000 -- \"Screen lock in 10 seconds\"'"
-        "timeout 60 'swaylock -fF'"
-        "timeout 300 'swaymsg \"output * dpms off\"' resume 'swaymsg \"output * dpms on\"'"
-        "before-sleep 'swaylock -fF'"
-        "lock 'swaylock -fF'"
-      ]);
-    in ''
+    nmt.script = ''
       serviceFile=home-files/.config/systemd/user/swayidle.service
 
       assertFileExists $serviceFile
-      assertFileRegex $serviceFile 'ExecStart=.*/bin/swayidle ${expectedArgs}'
+      assertFileRegex $serviceFile 'ExecStart=.*-swayidle'
     '';
   };
 }


### PR DESCRIPTION
### Description

This should fix #2752 and I guess this should also fix #2811

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
