### PR TITLE
screen-locker: Add option to configure x screensaver cycle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -378,8 +378,8 @@
 /modules/services/redshift-gammastep                  @rycee @petabyteboy @thiagokokada
 /tests/modules/redshift-gammastep                     @thiagokokada
 
-/modules/services/screen-locker.nix                   @jrobsonchase
-/tests/modules/services/screen-locker                 @jrobsonchase
+/modules/services/screen-locker.nix                   @jrobsonchase @rszamszur
+/tests/modules/services/screen-locker                 @jrobsonchase @rszamszur
 
 /modules/services/status-notifier-watcher.nix         @pltanton
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -247,4 +247,10 @@
     github = "sebtm";
     githubId = 17243347;
   };
+  rszamszur = {
+    name = "Radosław Szamszur";
+    email = "radoslawszamszur@gmail.com";
+    github = "rszamszur";
+    githubId = 10353018;
+  };
 }

--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -94,6 +94,16 @@ in {
           Extra command-line arguments to pass to <command>xss-lock</command>.
         '';
       };
+
+      screensaverCycle = mkOption {
+        type = types.int;
+        default = 600;
+        description = ''
+          X server's screensaver cycle value expresed as seconds.
+          This will be used with <command>xset</command> to configure
+          the cycle along with timeout.
+        '';
+      };
     };
   };
 
@@ -122,7 +132,9 @@ in {
     }
     (mkIf (!cfg.xautolock.enable) {
       systemd.user.services.xss-lock.Service.ExecStartPre =
-        "${pkgs.xorg.xset}/bin/xset s ${toString (cfg.inactiveInterval * 60)}";
+        "${pkgs.xorg.xset}/bin/xset s ${toString (cfg.inactiveInterval * 60)} ${
+          toString cfg.xss-lock.screensaverCycle
+        }";
     })
     (mkIf cfg.xautolock.enable {
       systemd.user.services.xautolock-session = {

--- a/tests/modules/services/screen-locker/no-xautolock.nix
+++ b/tests/modules/services/screen-locker/no-xautolock.nix
@@ -6,7 +6,10 @@
       enable = true;
       inactiveInterval = 5;
       lockCmd = "${pkgs.i3lock}/bin/i3lock -n -c AA0000";
-      xss-lock = { extraOptions = [ "-test" ]; };
+      xss-lock = {
+        extraOptions = [ "-test" ];
+        screensaverCycle = 5;
+      };
       xautolock = { enable = false; };
     };
 
@@ -18,7 +21,7 @@
 
       assertFileExists $xssService
       assertFileRegex $xssService 'ExecStart=.*/bin/xss-lock.*-test.*i3lock -n -c AA0000'
-      assertFileRegex $xssService 'ExecStartPre=.*/xset s 300'
+      assertFileRegex $xssService 'ExecStartPre=.*/xset s 300 5'
     '';
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Some screen lockers which will be used with `xss-lock` might require
to set x screensaver timeout with cycle.

Resolves: #2852

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
