### PR TITLE
nix-darwin: sudo --set-home for multiple user activation

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -134,7 +134,7 @@ in
     system.activationScripts.postActivation.text =
       concatStringsSep "\n" (mapAttrsToList (username: usercfg: ''
         echo Activating home-manager configuration for ${username}
-        sudo -u ${username} -s ${pkgs.writeShellScript "activation-${username}" ''
+        sudo -u ${username} -s --set-home ${pkgs.writeShellScript "activation-${username}" ''
           ${lib.optionalString (cfg.backupFileExtension != null)
             "export HOME_MANAGER_BACKUP_EXT=${lib.escapeShellArg cfg.backupFileExtension}"}
           ${lib.optionalString cfg.verbose "export VERBOSE=1"}


### PR DESCRIPTION
Changing from `sudo -i` to `sudo -s` messes up activation when multiple
users are managed. `--set-home` should have similar behavior to `-i` in
that the activation script is run from the user's home directory.

Fixes #2856

### Description

<!--

Please provide a brief description of your change.

-->

My previous fix broke use cases. Hopefully this fixes it again.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible. (This and the previous are breaking but together they're backwards compatible? 😬 )

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
