### PR TITLE
starship: skip one program invocation on each shell init

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -100,7 +100,7 @@ in {
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then
-        eval "$(${starshipCmd} init bash)"
+        eval "$(${starshipCmd} init bash --print-full-init)"
       fi
     '';
 


### PR DESCRIPTION
### Description

The code that is being evaled without the `--print-full-init` flag is this:

```sh
__main() {
    local major="${BASH_VERSINFO[0]}"
    local minor="${BASH_VERSINFO[1]}"

    if ((major > 4)) || { ((major == 4)) && ((minor >= 1)); }; then
        source <(/nix/store/...-starship-1.3.0/bin/starship init bash --print-full-init)
    else
        source /dev/stdin <<<"$(/nix/store/...-starship-1.3.0/bin/starship init bash --print-full-init)"
    fi
}
__main
unset -f __main
```

This code checks for bash version >= 4.1 , which has been released in 2009. Since this version  is widely unavailable in nixpkgs, we can skip one program invocation and directly call  `starship init bash --print-full-init`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
