### PR TITLE
waybar: fix command not found when reloading

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -318,7 +318,7 @@ in {
 
         Service = {
           ExecStart = "${cfg.package}/bin/waybar";
-          ExecReload = "kill -SIGUSR2 $MAINPID";
+          ExecReload = "${pkgs.coreutils}/bin/kill -SIGUSR2 $MAINPID";
           Restart = "on-failure";
           KillMode = "mixed";
         };

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
@@ -17,9 +17,10 @@ with lib;
       assertPathNotExists home-files/.config/waybar/config
       assertPathNotExists home-files/.config/waybar/style.css
 
-      assertFileContent \
-        home-files/.config/systemd/user/waybar.service \
-        ${./systemd-with-graphical-session-target.service}
+      serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/waybar.service)
+      assertFileContent "$serviceFile" ${
+        ./systemd-with-graphical-session-target.service
+      }
     '';
   };
 }

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -2,7 +2,7 @@
 WantedBy=sway-session.target
 
 [Service]
-ExecReload=kill -SIGUSR2 $MAINPID
+ExecReload=/nix/store/00000000000000000000000000000000-coreutils/bin/kill -SIGUSR2 $MAINPID
 ExecStart=@waybar@/bin/waybar
 KillMode=mixed
 Restart=on-failure


### PR DESCRIPTION
### Description

Currently, trying to run `systemctl --user reload waybar.service` fails with:

```
Apr 05 19:31:39 StarBook-MkV systemd[2313]: Reloading Highly customizable Wayland bar for Sway and Wlroots based compositors....
Apr 05 19:31:39 StarBook-MkV systemd[46289]: waybar.service: Failed to locate executable kill: No such file or directory
Apr 05 19:31:39 StarBook-MkV systemd[46289]: waybar.service: Failed at step EXEC spawning kill: No such file or directory
Apr 05 19:31:39 StarBook-MkV systemd[2313]: waybar.service: Control process exited, code=exited, status=203/EXEC
Apr 05 19:31:39 StarBook-MkV systemd[2313]: Reload failed for Highly customizable Wayland bar for Sway and Wlroots based compositors..
```

Fixed this by inserting the full path to the `kill` command from the `busybox` package.

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- [x] (Extra:) Code tested on a live system.