### PR TITLE
pistol: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -211,6 +211,9 @@
 
 /modules/programs/pidgin.nix                          @rycee
 
+/modules/programs/pistol.nix                          @mtoohey31
+/tests/modules/programs/pistol                        @mtoohey31
+
 /modules/programs/piston-cli.nix                      @ethancedwards8
 
 /modules/programs/powerline-go.nix                    @DamienCassou

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -287,4 +287,10 @@
       fingerprint = "D5D6 FD1F 0D9A 3284 FB9B  C26D 3F98 EC7E C2B8 7ED1";
     }];
   };
+  mtoohey = {
+    name = "Matthew Toohey";
+    email = "contact@mtoohey.com";
+    github = "mtoohey31";
+    githubId = 36740602;
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -568,6 +568,13 @@ in
           A new module is available: 'programs.micro'.
         '';
       }
+
+      {
+        time = "2022-06-24T22:40:27+00:00";
+        message = ''
+          A new module is available: 'programs.pistol'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -132,6 +132,7 @@ let
     ./programs/pazi.nix
     ./programs/pet.nix
     ./programs/pidgin.nix
+    ./programs/pistol.nix
     ./programs/piston-cli.nix
     ./programs/powerline-go.nix
     ./programs/pubs.nix

--- a/modules/programs/pistol.nix
+++ b/modules/programs/pistol.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.pistol;
+
+  configFile =
+    concatStringsSep "\n" (mapAttrsToList (k: v: "${k} ${v}") cfg.config);
+
+in {
+  meta.maintainers = [ hm.maintainers.mtoohey ];
+
+  options.programs.pistol = {
+    enable = mkEnableOption ''
+      Pistol, a general purpose file previewer designed for terminal file
+      managers'';
+
+    config = mkOption {
+      type = with types; attrsOf str;
+      default = { };
+      example = literalExpression ''
+        {
+          "text/*" = "bat --paging=never --color=always %pistol-filename%";
+          "inode/directory" = "ls -l --color %pistol-filename%";
+        }
+      '';
+      description = ''
+        Pistol configuration written to
+        <filename>$XDG_CONFIG_HOME/pistol/pistol.conf</filename>.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    { home.packages = [ pkgs.pistol ]; }
+
+    (mkIf (cfg.config != { } && pkgs.stdenv.hostPlatform.isDarwin) {
+      home.file."Library/Application Support/pistol/pistol.conf".text =
+        configFile;
+    })
+
+    (mkIf (cfg.config != { } && !pkgs.stdenv.hostPlatform.isDarwin) {
+      xdg.configFile."pistol/pistol.conf".text = configFile;
+    })
+  ]);
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -88,6 +88,7 @@ import nmt {
     ./modules/programs/nushell
     ./modules/programs/pandoc
     ./modules/programs/pet
+    ./modules/programs/pistol
     ./modules/programs/powerline-go
     ./modules/programs/pubs
     ./modules/programs/qutebrowser

--- a/tests/modules/programs/pistol/config.nix
+++ b/tests/modules/programs/pistol/config.nix
@@ -1,0 +1,31 @@
+{ pkgs, ... }:
+
+let
+
+  expected = builtins.toFile "settings-expected" ''
+    application/json bat --paging=never --color=always --style=auto --wrap=character --terminal-width=%pistol-extra0% --line-range=1:%pistol-extra1% %pistol-filename%
+    text/* bat --paging=never --color=always --style=auto --wrap=character --terminal-width=%pistol-extra0% --line-range=1:%pistol-extra1% %pistol-filename%'';
+
+in {
+  programs.pistol = {
+    enable = true;
+    config = {
+      "text/*" =
+        "bat --paging=never --color=always --style=auto --wrap=character --terminal-width=%pistol-extra0% --line-range=1:%pistol-extra1% %pistol-filename%";
+      "application/json" =
+        "bat --paging=never --color=always --style=auto --wrap=character --terminal-width=%pistol-extra0% --line-range=1:%pistol-extra1% %pistol-filename%";
+    };
+  };
+
+  test.stubs.pistol = { };
+
+  nmt.script = let
+    path = if pkgs.stdenv.hostPlatform.isDarwin then
+      "home-files/Library/Application Support/pistol/pistol.conf"
+    else
+      "home-files/.config/pistol/pistol.conf";
+  in ''
+    assertFileExists '${path}'
+    assertFileContent '${path}' '${expected}'
+  '';
+}

--- a/tests/modules/programs/pistol/default.nix
+++ b/tests/modules/programs/pistol/default.nix
@@ -1,0 +1,1 @@
+{ pistol-config = ./config.nix; }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds a module for the [pistol file previewer](https://github.com/doronbehar/pistol). Pistol's configuration syntax is very simple and translates well into an attrset from mime type or path to command string.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
