### PR TITLE
systemd: fix creation of user service unit files

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -41,7 +41,7 @@ let
       source = pkgs.writeTextFile {
         name = pathSafeName;
         text = toSystemdIni serviceCfg;
-        destination = lib.escapeShellArg "/${filename}";
+        destination = "/${filename}";
       } + "/${filename}";
 
       wantedBy = target: {

--- a/tests/modules/programs/helix/settings-expected.toml
+++ b/tests/modules/programs/helix/settings-expected.toml
@@ -1,7 +1,4 @@
 theme = "base16"
-
-[keys]
-[keys.normal]
 [keys.normal.space]
 q = ":q"
 space = "file_picker"


### PR DESCRIPTION
### Description

Fix #2846, diff provided by @yu-re-ka.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
