### PR TITLE
docs: fix link to rollback instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ distributions and NixOS versions.
 
 Also, the `home-manager` tool does not explicitly support rollbacks at
 the moment so if your home directory gets messed up you'll have to fix
-it yourself. See the [rollbacks](#rollbacks) section for instructions
-on how to manually perform a rollback.
+it yourself. See the [rollbacks][] section for instructions on how to
+manually perform a rollback.
 
 Now when your expectations have been built up and you are eager to try
 all this out you can go ahead and read the rest of this text.
@@ -126,3 +126,4 @@ This project is licensed under the terms of the [MIT license](LICENSE).
 [manual nixos install]: https://nix-community.github.io/home-manager/index.html#sec-install-nixos-module
 [manual nix-darwin install]: https://nix-community.github.io/home-manager/index.html#sec-install-nix-darwin-module
 [manual nix flakes]: https://nix-community.github.io/home-manager/index.html#ch-nix-flakes
+[rollbacks]: https://nix-community.github.io/home-manager/index.html#sec-usage-rollbacks


### PR DESCRIPTION
### Description

Fixes #2872

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```