### PR TITLE
neomutt/signature: unset if disabled

### DIFF
--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -223,9 +223,11 @@ let
 
       # Extra configuration
       ${account.neomutt.extraConfig}
-    '' + optionalString (account.signature.showSignature != "none") ''
+    '' + (if (account.signature.showSignature == "none") then ''
+      unset signature
+    '' else ''
       set signature = ${pkgs.writeText "signature.txt" account.signature.text}
-    '' + optionalString account.notmuch.enable (notmuchSection account);
+    '') + optionalString account.notmuch.enable (notmuchSection account);
 
 in {
   options = {

--- a/tests/modules/programs/neomutt/hm-example.com-expected
+++ b/tests/modules/programs/neomutt/hm-example.com-expected
@@ -31,6 +31,7 @@ set trash='+Trash'
 # Extra configuration
 color status cyan default
 
+unset signature
 # notmuch section
 set nm_default_uri = "notmuch:///home/hm-user/Mail"
 virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"

--- a/tests/modules/programs/neomutt/hm-example.com-gpg-expected.conf
+++ b/tests/modules/programs/neomutt/hm-example.com-gpg-expected.conf
@@ -30,3 +30,4 @@ set trash='+Trash'
 
 # Extra configuration
 
+unset signature

--- a/tests/modules/programs/neomutt/hm-example.com-msmtp-expected.conf
+++ b/tests/modules/programs/neomutt/hm-example.com-msmtp-expected.conf
@@ -30,3 +30,4 @@ set trash='+Trash'
 # Extra configuration
 color status cyan default
 
+unset signature

--- a/tests/modules/programs/neomutt/hm-example.com-no-folder-change-expected.conf
+++ b/tests/modules/programs/neomutt/hm-example.com-no-folder-change-expected.conf
@@ -28,3 +28,4 @@ set trash='+Trash'
 
 # Extra configuration
 
+unset signature


### PR DESCRIPTION
### Description

Closes #2876
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
