### PR TITLE
picom: remove deprecated option, add tests

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -155,6 +155,7 @@ import nmt {
     ./modules/services/mpd
     ./modules/services/pantalaimon
     ./modules/services/pbgopy
+    ./modules/services/picom
     ./modules/services/playerctld
     ./modules/services/polybar
     ./modules/services/redshift-gammastep

--- a/tests/modules/services/picom/default.nix
+++ b/tests/modules/services/picom/default.nix
@@ -1,0 +1,1 @@
+{ picom-basic-configuration = ./picom-basic-configuration.nix; }

--- a/tests/modules/services/picom/picom-basic-configuration-expected.conf
+++ b/tests/modules/services/picom/picom-basic-configuration-expected.conf
@@ -1,0 +1,33 @@
+# fading
+fading = true;
+fade-delta    = 5;
+fade-in-step  = 0.04;
+fade-out-step = 0.04;
+fade-exclude  = ["window_type *= 'menu'","name ~= 'Firefox$'","focused = 1"];
+
+# shadows
+shadow = true;
+shadow-offset-x = -10;
+shadow-offset-y = -15;
+shadow-opacity  = 0.8;
+shadow-exclude  = ["window_type *= 'menu'","name ~= 'Firefox$'","focused = 1"];
+
+# opacity
+active-opacity   = 1.0;
+inactive-opacity = 1.0;
+inactive-dim     = 0.0;
+opacity-rule     = [];
+
+wintypes:
+{
+  dock          = { shadow = false; };
+  dnd           = { shadow = false; };
+  popup_menu    = { opacity = 1.0; };
+  dropdown_menu = { opacity = 1.0; };
+};
+
+# other options
+backend = "xrender";
+vsync = true;
+unredir-if-possible = true;
+dbe = true;

--- a/tests/modules/services/picom/picom-basic-configuration-expected.service
+++ b/tests/modules/services/picom/picom-basic-configuration-expected.service
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@picom@/bin/picom --config /nix/store/00000000000000000000000000000000-hm_picompicom.conf --experimental-backends
+Restart=always
+RestartSec=3
+
+[Unit]
+After=graphical-session-pre.target
+Description=Picom X11 compositor
+PartOf=graphical-session.target

--- a/tests/modules/services/picom/picom-basic-configuration.nix
+++ b/tests/modules/services/picom/picom-basic-configuration.nix
@@ -1,0 +1,37 @@
+{ config, pkgs, ... }:
+
+{
+  services.picom = {
+    enable = true;
+    fade = true;
+    fadeDelta = 5;
+    fadeSteps = [ "0.04" "0.04" ];
+    fadeExclude =
+      [ "window_type *= 'menu'" "name ~= 'Firefox$'" "focused = 1" ];
+    shadow = true;
+    shadowOffsets = [ (-10) (-15) ];
+    shadowOpacity = "0.8";
+    shadowExclude =
+      [ "window_type *= 'menu'" "name ~= 'Firefox$'" "focused = 1" ];
+    backend = "xrender";
+    vSync = true;
+    extraOptions = ''
+      unredir-if-possible = true;
+      dbe = true;
+    '';
+    experimentalBackends = true;
+  };
+
+  test.stubs.picom = { };
+
+  nmt.script = ''
+    assertFileContent \
+        home-files/.config/picom/picom.conf \
+        ${./picom-basic-configuration-expected.conf}
+
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/picom.service)
+    assertFileContent \
+        "$serviceFile" \
+        ${./picom-basic-configuration-expected.service}
+  '';
+}


### PR DESCRIPTION
### Description

Remove `services.picom.refreshRate`. This option was deprecated since release [v9](https://github.com/yshui/picom/releases/tag/v9), and it is generating the following warn in the log:

```
[ DD/MM/YYYY HH:MM:SS.mmm parse_config_libconfig WARN ] The refresh-rate option has been deprecated. Please remove it from your configuration file. If you encounter any problems without this feature, please feel free to open a bug report
```

To ensure that I didn't break anything, I decided to add a test to the module (since it didn't had before). To make testing easier, I did a small refactoring in the module, that includes adding the file to the `~/.config/picom/picom.conf` path that is the expected one for the application. This change should also make it easier to debug errors in the config (no more getting the current generated file from the service file).

Also removed an old workaround for MESA 18. Not tested, but I don't think it is needed anymore.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.
  + Mostly. If you use `services.picom.refreshRate` your config will break, but this should show the proper error thanks to the usage of `mkRemovedOptionModule`.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
