### PR TITLE
flake: add templates

### DIFF
--- a/docs/nix-flakes.adoc
+++ b/docs/nix-flakes.adoc
@@ -84,6 +84,10 @@ and `nixpkgs` url to `github:NixOS/nixpkgs/nixos-22.05`.
 
 * The Home Manager library is exported by the flake under
 `lib.hm`.
+
+* You can use the above `flake.nix` as a template in `~/.config/nixpkgs` by
+[source,console]
+$ nix flake new ~/.config/nixpkgs -t github:nix-community/home-manager
 ====
 
 2. Install Home Manager and apply the configuration by
@@ -170,6 +174,11 @@ The Home Manager configuration is then part of the NixOS configuration
 and is automatically rebuilt with the system when using the appropriate command
 for the system, such as `nixos-rebuild switch --flake <flake-uri>`.
 
+You can use the above `flake.nix` as a template in `/etc/nixos` by
+
+[source,console]
+$ nix flake new /etc/nixos -t github:nix-community/home-manager#nixos
+
 [[sec-flakes-nix-darwin-module]]
 === nix-darwin module
 
@@ -213,3 +222,8 @@ is similar to that of NixOS. The `flake.nix` would be:
 
 and it is also rebuilt with the nix-darwin generations.
 The rebuild command here may be `darwin-rebuild switch --flake <flake-uri>`.
+
+You can use the above `flake.nix` as a template in `~/.config/darwin` by
+
+[source,console]
+$ nix flake new ~/.config/darwin -t github:nix-community/home-manager#nix-darwin

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,23 @@
       # unofficial; deprecated in Nix 2.8
       darwinModule = self.darwinModules.default;
 
+      templates = {
+        standalone = {
+          path = ./templates/standalone;
+          description = "Standalone setup";
+        };
+        nixos = {
+          path = ./templates/nixos;
+          description = "Home Manager as a NixOS module,";
+        };
+        nix-darwin = {
+          path = ./templates/nix-darwin;
+          description = "Home Manager as a nix-darwin module,";
+        };
+      };
+
+      defaultTemplate = self.templates.standalone;
+
       lib = {
         hm = import ./modules/lib { lib = nixpkgs.lib; };
         homeManagerConfiguration = { modules ? [ ], pkgs, lib ? pkgs.lib

--- a/templates/nix-darwin/flake.nix
+++ b/templates/nix-darwin/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "NixOS configuration";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    darwin.url = "github:lnl7/nix-darwin";
+    darwin.inputs.nixpkgs.follows = "nixpkgs";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs@{ nixpkgs, home-manager, darwin, ... }: {
+    darwinConfigurations = {
+      hostname = darwin.lib.darwinSystem {
+        system = "x86_64-darwin";
+        modules = [
+          ./configuration.nix
+          home-manager.darwinModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.users.jdoe = import ./home.nix;
+
+            # Optionally, use home-manager.extraSpecialArgs to pass
+            # arguments to home.nix
+          }
+        ];
+      };
+    };
+  };
+}

--- a/templates/nixos/flake.nix
+++ b/templates/nixos/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "NixOS configuration";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs@{ nixpkgs, home-manager, ... }: {
+    nixosConfigurations = {
+      hostname = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ./configuration.nix
+          home-manager.nixosModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.users.jdoe = import ./home.nix;
+
+            # Optionally, use home-manager.extraSpecialArgs to pass
+            # arguments to home.nix
+          }
+        ];
+      };
+    };
+  };
+}

--- a/templates/standalone/flake.nix
+++ b/templates/standalone/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "Home Manager configuration of Jane Doe";
+
+  inputs = {
+    # Specify the source of Home Manager and Nixpkgs.
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, home-manager, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      homeConfigurations.jdoe = home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+
+        # Specify your home configuration modules here, for example,
+        # the path to your home.nix.
+        modules = [ ./home.nix ];
+
+        # Optionally use extraSpecialArgs
+        # to pass through arguments to home.nix
+      };
+    };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Add example flakes from `docs/nix-flakes.adoc` as templates.
Format standalone flake in `docs/nix-flakes.adoc`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.