### PR TITLE
home-manager: Fix cross-compiles, fixes #2675

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -617,7 +617,7 @@ in
     lib.bash.initHomeManagerLib =
       let
         domainDir = pkgs.runCommand "hm-modules-messages" {
-          nativeBuildInputs = [ pkgs.gettext ];
+          nativeBuildInputs = [ pkgs.buildPackages.gettext ];
         } ''
           for path in ${./po}/*.po; do
             lang="''${path##*/}"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

The fix is exactly as suggested in #2675, otherwise during cross compiles the incorrect architecture is used.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
