### PR TITLE
gpg: fix handling of multiple public keys

### DIFF
--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -109,14 +109,15 @@ let
     }
 
     function importTrust() {
-      local keyId trust
-      keyId="$(gpgKeyId "$1")"
+      local keyIds trust
+      IFS='\n' read -ra keyIds <<< "$(gpgKeyId "$1")"
       trust="$2"
-      if [[ -n $keyId ]] ; then
+      for id in "''${keyIds[@]}" ; do
         { echo trust; echo "$trust"; (( trust == 5 )) && echo y; echo quit; } \
-          | ${gpg} --no-tty --command-fd 0 --edit-key "$keyId"
-      fi
+          | ${gpg} --no-tty --command-fd 0 --edit-key "$id"
+      done
     }
+
   '';
 
   keyringFiles = let


### PR DESCRIPTION


### Description

When processing `publicKeys` entries, handle entries that contain multiple public keys (i.e. gpg --show-key returns multiple `pub` lines) properly, setting the trust level for each key.

Previously, multiple `pub` entries caused an error, since the keyids separated by newlines were passed straight to `gpg --edit-key`.

### Checklist

- [X] Change is backwards compatible. Single keys still work fine.

- [X] Code formatted with `./format`. Manually formatted with `nixfmt`

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
