### PR TITLE
specialization: basic configuration specialization

### DIFF
--- a/modules/misc/specialization.nix
+++ b/modules/misc/specialization.nix
@@ -1,0 +1,71 @@
+{ config, extendModules, lib, ... }:
+
+with lib;
+
+{
+  options.specialization = mkOption {
+    type = types.attrsOf (types.submodule {
+      options = {
+        configuration = mkOption {
+          type = let
+            stopRecursion = { specialization = mkOverride 0 { }; };
+            extended = extendModules { modules = [ stopRecursion ]; };
+          in extended.type;
+          default = { };
+          visible = "shallow";
+          description = ''
+            Arbitrary Home Manager configuration settings.
+          '';
+        };
+      };
+    });
+    default = { };
+    description = ''
+      A set of named specialized configurations. These can be used to extend
+      your base configuration with additional settings. For example, you can
+      have specializations named <quote>light</quote> and <quote>dark</quote>
+      that applies light and dark color theme configurations.
+
+      </para><para>
+
+      Note, this is an experimental option for now and you therefore have to
+      activate the specialization by looking up and running the activation
+      script yourself. Note, running the activation script will create a new
+      Home Manager generation.
+
+      </para><para>
+
+      For example, to activate the <quote>dark</quote> specialization. You can
+      first look up your current Home Manager generation by running
+
+      <programlisting language="console">
+        $ home-manager generations | head -1
+        2022-05-02 22:49 : id 1758 -> /nix/store/jy…ac-home-manager-generation
+      </programlisting>
+
+      then run
+
+      <programlisting language="console">
+        $ /nix/store/jy…ac-home-manager-generation/specialization/dark/activate
+        Starting Home Manager activation
+        …
+      </programlisting>
+
+      </para><para>
+
+      WARNING! Since this option is experimental, the activation process may
+      change in backwards incompatible ways.
+    '';
+  };
+
+  config = mkIf (config.specialization != { }) {
+    home.extraBuilderCommands = let
+      link = n: v:
+        let pkg = v.configuration.home.activationPackage;
+        in "ln -s ${pkg} $out/specialization/${n}";
+    in ''
+      mkdir $out/specialization
+      ${concatStringsSep "\n" (mapAttrsToList link config.specialization)}
+    '';
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -30,6 +30,7 @@ let
     ./misc/numlock.nix
     ./misc/pam.nix
     ./misc/qt.nix
+    ./misc/specialization.nix
     ./misc/submodule-support.nix
     ./misc/tmpfiles.nix
     ./misc/version.nix

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -46,6 +46,7 @@ import nmt {
     ./modules/home-environment
     ./modules/misc/fontconfig
     ./modules/misc/nix
+    ./modules/misc/specialization
     ./modules/programs/alacritty
     ./modules/programs/alot
     ./modules/programs/aria2

--- a/tests/modules/misc/specialization/default.nix
+++ b/tests/modules/misc/specialization/default.nix
@@ -1,0 +1,1 @@
+{ specialization = ./specialization.nix; }

--- a/tests/modules/misc/specialization/specialization.nix
+++ b/tests/modules/misc/specialization/specialization.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  home.file.testfile.text = "not special";
+  specialization.test.configuration = {
+    home.file.testfile.text = "very special";
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/testfile
+    assertFileContains home-files/testfile "not special"
+
+    assertFileExists specialization/test/home-files/testfile
+    assertFileContains specialization/test/home-files/testfile "not special"
+  '';
+}


### PR DESCRIPTION
### Description

Adds support for configuration specialization similar to the same feature in NixOS.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```