### PR TITLE
targets.genericLinux: include additional directories in XCURSOR_PATH

### DIFF
--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -43,6 +43,17 @@ in {
       "/var/lib/snapd/desktop"
     ];
 
+    # We need to append system-wide FHS directories due to the default prefix
+    # resolving to the Nix store.
+    # https://github.com/nix-community/home-manager/pull/2891#issuecomment-1101064521
+    home.sessionVariables = {
+      XCURSOR_PATH = "$XCURSOR_PATH\${XCURSOR_PATH:+:}" + concatStringsSep ":" [
+        "${config.home.profileDirectory}/share/icons"
+        "/usr/share/icons"
+        "/usr/share/pixmaps"
+      ];
+    };
+
     home.sessionVariablesExtra = ''
       . "${pkgs.nix}/etc/profile.d/nix.sh"
 


### PR DESCRIPTION
This commit appends system-wide icon and pixmap directory and the icon
directory in the home-manager profile to the XCURSOR_PATH session variable
for the generic linux target. This is necessary because the default prefix
for libXcursor resolves to the Nix store which excludes the aforementioned
directories from being searched for cursor themes. [1]

[1] - https://github.com/nix-community/home-manager/pull/2891#issuecomment-1101064521.

### Description

<!--



Please provide a brief description of your change.

-->

cc: @EHfive

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
