### PR TITLE
gtk: Update example strings for gtk.theme.package

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -51,7 +51,7 @@ let
       package = mkOption {
         type = types.nullOr types.package;
         default = null;
-        example = literalExpression "pkgs.adwaita-icon-theme";
+        example = literalExpression "pkgs.gnome.adwaita-icon-theme";
         description = ''
           Package providing the icon theme. This package will be installed
           to your profile. If <literal>null</literal> then the theme

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -30,7 +30,7 @@ let
       package = mkOption {
         type = types.nullOr types.package;
         default = null;
-        example = literalExpression "pkgs.gnome.gnome_themes_standard";
+        example = literalExpression "pkgs.gnome.gnome-themes-extra";
         description = ''
           Package providing the theme. This package will be installed
           to your profile. If <literal>null</literal> then the theme


### PR DESCRIPTION
### Description
Change the example value of `gtk.theme.package` from `pkgs.gnome.gnome_themes_standard`, which was an alias that was removed on 2022-01-13, to `pkgs.gnome-themes-extra`, which references the actual package.

Change the example value of `gtk.icon.package` from `pkgs.adwaita-icon-theme` to
`pkgs.gnome.adwaita-icon-theme`, as this package is in the `gnome` package set.

### Checklist
- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- [ ] If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
