### PR TITLE
darwin: add support for 'defaults -currentHost' options

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -605,6 +605,17 @@ in
           A new module is available: 'programs.librewolf'.
         '';
       }
+
+      {
+        time = "2022-07-24T13:17:01+00:00";
+        condition = hostPlatform.isDarwin;
+        message = ''
+          A new option is available: 'targets.darwin.currentHostDefaults'.
+
+          This exposes macOS preferences that are available through the
+          'defaults -currentHost' command.
+        '';
+      }
     ];
   };
 }

--- a/modules/targets/darwin/default.nix
+++ b/modules/targets/darwin/default.nix
@@ -1,76 +1,13 @@
-{ config, lib, pkgs, ... }:
+{ lib, ... }:
 
-with lib;
+{
+  meta.maintainers = with lib.maintainers; [ midchildan ];
 
-let
-  cfg = config.targets.darwin;
-
-  toDefaultsFile = domain: attrs:
-    pkgs.writeText "${domain}.plist" (lib.generators.toPlist { } attrs);
-
-  toActivationCmd = domain: attrs:
-    "$DRY_RUN_CMD defaults import ${escapeShellArg domain} ${
-      toDefaultsFile domain attrs
-    }";
-
-  nonNullDefaults =
-    mapAttrs (domain: attrs: (filterAttrs (n: v: v != null) attrs))
-    cfg.defaults;
-  writableDefaults = filterAttrs (domain: attrs: attrs != { }) nonNullDefaults;
-  activationCmds = mapAttrsToList toActivationCmd writableDefaults;
-in {
-  meta.maintainers = [ maintainers.midchildan ];
-
-  imports = [ ./fonts.nix ./keybindings.nix ./linkapps.nix ./search.nix ];
-
-  options.targets.darwin.defaults = mkOption {
-    type = types.submodule ./options.nix;
-    default = { };
-    example = {
-      "com.apple.desktopservices" = {
-        DSDontWriteNetworkStores = true;
-        DSDontWriteUSBStores = true;
-      };
-    };
-    description = ''
-      Set macOS user defaults. Values set to <literal>null</literal> are
-      ignored.
-
-      <warning>
-        <para>
-          Some settings might require a re-login to take effect.
-        </para>
-      </warning>
-    '';
-  };
-
-  config = mkIf (activationCmds != [ ]) {
-    assertions = [
-      (hm.assertions.assertPlatform "targets.darwin.defaults" pkgs
-        platforms.darwin)
-    ];
-
-    warnings = let
-      batteryPercentage =
-        attrByPath [ "com.apple.menuextra.battery" "ShowPercent" ] null
-        cfg.defaults;
-      webkitDevExtras = attrByPath [
-        "com.apple.Safari"
-        "com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled"
-      ] null cfg.defaults;
-    in optional (batteryPercentage != null) ''
-      The option 'com.apple.menuextra.battery.ShowPercent' no longer works on
-      macOS 11 and later. Instead, open System Preferences, go to "Dock &amp;
-      Menu Bar", select "Battery", and toggle the checkbox labeled "Show
-      Percentage."
-    '' ++ optional (webkitDevExtras != null) ''
-      The option 'com.apple.Safari.com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled'
-      is no longer present in recent versions of Safari.
-    '';
-
-    home.activation.setDarwinDefaults = hm.dag.entryAfter [ "writeBoundary" ] ''
-      $VERBOSE_ECHO "Configuring macOS user defaults"
-      ${concatStringsSep "\n" activationCmds}
-    '';
-  };
+  imports = [
+    ./user-defaults
+    ./fonts.nix
+    ./keybindings.nix
+    ./linkapps.nix
+    ./search.nix
+  ];
 }

--- a/modules/targets/darwin/user-defaults/default.nix
+++ b/modules/targets/darwin/user-defaults/default.nix
@@ -1,0 +1,112 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.targets.darwin;
+
+  mkActivationCmds = isLocal: settings:
+    let
+      toDefaultsFile = domain: attrs:
+        pkgs.writeText "${domain}.plist" (lib.generators.toPlist { } attrs);
+
+      cliFlags = lib.optionalString isLocal "-currentHost";
+
+      toActivationCmd = domain: attrs:
+        "$DRY_RUN_CMD defaults ${cliFlags} import ${escapeShellArg domain} ${
+          toDefaultsFile domain attrs
+        }";
+
+      nonNullDefaults =
+        mapAttrs (domain: attrs: (filterAttrs (n: v: v != null) attrs))
+        settings;
+
+      writableDefaults =
+        filterAttrs (domain: attrs: attrs != { }) nonNullDefaults;
+    in mapAttrsToList toActivationCmd writableDefaults;
+
+  defaultsCmds = mkActivationCmds false cfg.defaults;
+  currentHostDefaultsCmds = mkActivationCmds true cfg.currentHostDefaults;
+
+  activationCmds = defaultsCmds ++ currentHostDefaultsCmds;
+in {
+  meta.maintainers = [ maintainers.midchildan ];
+
+  options.targets.darwin.defaults = mkOption {
+    type = types.submodule ./opts-allhosts.nix;
+    default = { };
+    example = {
+      "com.apple.desktopservices" = {
+        DSDontWriteNetworkStores = true;
+        DSDontWriteUSBStores = true;
+      };
+    };
+    description = ''
+      Set macOS user defaults. Values set to <literal>null</literal> are
+      ignored.
+
+      <warning>
+        <para>
+          Some settings might require a re-login to take effect.
+        </para>
+      </warning>
+      <warning>
+        <para>
+          Some settings are only read from
+          <option>targets.darwin.currentHostDefaults</option>.
+        </para>
+      </warning>
+    '';
+  };
+
+  options.targets.darwin.currentHostDefaults = mkOption {
+    type = types.submodule ./opts-currenthost.nix;
+    default = { };
+    example = {
+      "com.apple.controlcenter" = { BatteryShowPercentage = true; };
+    };
+    description = ''
+      Set macOS user defaults. Unlike <option>targets.darwin.defaults</option>,
+      the preferences will only be applied to the currently logged-in host. This
+      distinction is important for networked accounts.
+
+      Values set to <literal>null</literal> are ignored.
+
+      <warning>
+        <para>
+          Some settings might require a re-login to take effect.
+        </para>
+      </warning>
+    '';
+  };
+
+  config = mkIf (activationCmds != [ ]) {
+    assertions = [
+      (hm.assertions.assertPlatform "targets.darwin.defaults" pkgs
+        platforms.darwin)
+    ];
+
+    warnings = let
+      batteryOptionName = ''
+        targets.darwin.currentHostDefaults."com.apple.controlcenter".BatteryShowPercentage'';
+      batteryPercentage =
+        attrByPath [ "com.apple.menuextra.battery" "ShowPercent" ] null
+        cfg.defaults;
+      webkitDevExtras = attrByPath [
+        "com.apple.Safari"
+        "com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled"
+      ] null cfg.defaults;
+    in optional (batteryPercentage != null) ''
+      The option 'com.apple.menuextra.battery.ShowPercent' no longer works on
+      macOS 11 and later. Instead, use '${batteryOptionName}'.
+    '' ++ optional (webkitDevExtras != null) ''
+      The option 'com.apple.Safari.com.apple.Safari.ContentPageGroupIdentifier.WebKit2DeveloperExtrasEnabled'
+      is no longer present in recent versions of Safari.
+    '';
+
+    home.activation.setDarwinDefaults = hm.dag.entryAfter [ "writeBoundary" ] ''
+      $VERBOSE_ECHO "Configuring macOS user defaults"
+      ${concatStringsSep "\n" activationCmds}
+    '';
+  };
+}

--- a/modules/targets/darwin/user-defaults/opts-allhosts.nix
+++ b/modules/targets/darwin/user-defaults/opts-allhosts.nix
@@ -99,9 +99,8 @@ in {
       type = types.enum [ "YES" "NO" ];
       example = "NO";
       description = ''
-        This option no longer works on macOS 11 and later. Instead, open System
-        Preferences, go to "Dock &amp; Menu Bar", select "Battery", and toggle
-        the checkbox labeled "Show Percentage."
+        This option no longer works on macOS 11 and later. Instead, use
+        <option>targets.darwin.currentHostDefaults.\"com.apple.controlcenter\".BatteryShowPercentage</option>.
 
         Whether to show battery percentage in the menu bar.
       '';

--- a/modules/targets/darwin/user-defaults/opts-currenthost.nix
+++ b/modules/targets/darwin/user-defaults/opts-currenthost.nix
@@ -1,0 +1,29 @@
+{ config, lib, ... }:
+
+let
+  mkNullableOption = args:
+    lib.mkOption (args // {
+      type = lib.types.nullOr args.type;
+      default = null;
+    });
+
+  mkNullableEnableOption = name:
+    lib.mkOption {
+      type = with lib.types; nullOr bool;
+      default = null;
+      example = true;
+      description = "Whether to enable ${name}.";
+    };
+in {
+  freeformType = with lib.types; attrsOf (attrsOf anything);
+
+  options = {
+    "com.apple.controlcenter".BatteryShowPercentage = mkNullableOption {
+      type = lib.types.bool;
+      example = true;
+      description = ''
+        Whether to show battery percentage in the menu bar.
+      '';
+    };
+  };
+}

--- a/tests/modules/targets-darwin/default.nix
+++ b/tests/modules/targets-darwin/default.nix
@@ -2,4 +2,5 @@
   # Disabled for now due to conflicting behavior with nix-darwin. See
   # https://github.com/nix-community/home-manager/issues/1341#issuecomment-687286866
   #targets-darwin = ./darwin.nix;
+  user-defaults = ./user-defaults.nix;
 }

--- a/tests/modules/targets-darwin/user-defaults.nix
+++ b/tests/modules/targets-darwin/user-defaults.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+
+{
+  config = {
+    targets.darwin = {
+      defaults."com.apple.desktopservices".DSDontWriteNetworkStores = true;
+      currentHostDefaults."com.apple.controlcenter".BatteryShowPercentage =
+        true;
+    };
+
+    nmt.script = ''
+      assertFileRegex activate \
+        "defaults  import 'com.apple.desktopservices' /nix/store/[a-z0-9]\\{32\\}-com\\.apple\\.desktopservices\\.plist"
+      assertFileRegex activate \
+        "defaults -currentHost import 'com.apple.controlcenter' /nix/store/[a-z0-9]\\{32\\}-com\\.apple\\.controlcenter\\.plist"
+    '';
+  };
+}


### PR DESCRIPTION
### Description
This adds a new option, `targets.darwin.currentHostDefaults`, which exposes additional macOS preferences. It is similar to `targets.darwin.defaults`, but it contains options that are only applicable for the current host instead of all hosts the logged in user has accounts on.

Closes #2615.


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
