### PR TITLE
i3-sway: only return current user's socket

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -434,8 +434,8 @@ in {
       xdg.configFile."sway/config" = {
         source = configFile;
         onChange = ''
-          swaySocket=''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.$(${pkgs.procps}/bin/pgrep -x sway || true).sock
-          if [ -S $swaySocket ]; then
+          swaySocket="''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.$(${pkgs.procps}/bin/pgrep --uid $UID -x sway || true).sock"
+          if [ -S "$swaySocket" ]; then
             ${pkgs.sway}/bin/swaymsg -s $swaySocket reload
           fi
         '';


### PR DESCRIPTION
Constrain the pgrep command to only return results for the current user.
Additionally, quote the socket variables to prevent splitting.

Previously, if multiple users on a system were running `sway`, the
`pgrep` used in finding `swaySocket` would return multiple results. As a
result, reloads of sway would fail.

Fixes #2912.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.
  - I was only able to run the Sway tests because my local build is blocked by #2693 as I don't currently use `unstable`:
    ```sway-bar-focused-colors: OK
    sway-bindkeys-to-code: OK
    sway-default: OK
    sway-followmouse: OK
    sway-followmouse-legacy: OK
    sway-modules: OK
    sway-no-xwayland: OK
    sway-null-config: OK
    sway-null-package: OK
    sway-post-2003: OK
    sway-workspace-default: OK
    sway-workspace-output: OK
    swaynag-empty-settings: OK
    swaynag-example-settings: OK
    ```

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  - Not sure how to test this as it requires multiple users and `home-manager` normally only manages one user at a time. Happy to try to make a test case if someone can give me pointers.


- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
