### PR TITLE
Remove platform check from the systemd module

### DIFF
--- a/modules/services/blueman-applet.nix
+++ b/modules/services/blueman-applet.nix
@@ -21,6 +21,11 @@ with lib;
   };
 
   config = mkIf config.services.blueman-applet.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.blueman-applet" pkgs
+        platforms.linux)
+    ];
+
     systemd.user.services.blueman-applet = {
       Unit = {
         Description = "Blueman applet";

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -130,6 +130,10 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
+      assertions = [
+        (hm.assertions.assertPlatform "services.dunst" pkgs platforms.linux)
+      ];
+
       home.packages = [ cfg.package ];
 
       xdg.dataFile."dbus-1/services/org.knopwob.dunst.service".source =

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -263,6 +263,10 @@ in {
     #
     # directory.
     {
+      assertions = [
+        (hm.assertions.assertPlatform "services.gpg-agent" pkgs platforms.linux)
+      ];
+
       systemd.user.services.gpg-agent = {
         Unit = {
           Description = "GnuPG cryptographic agent and passphrase cache";

--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -27,6 +27,11 @@ in {
     (mkIf cfg.enable {
       home.packages = [ package ];
 
+      assertions = [
+        (hm.assertions.assertPlatform "services.kdeconnect" pkgs
+          platforms.linux)
+      ];
+
       systemd.user.services.kdeconnect = {
         Unit = {
           Description =
@@ -46,6 +51,11 @@ in {
     })
 
     (mkIf cfg.indicator {
+      assertions = [
+        (hm.assertions.assertPlatform "services.kdeconnect" pkgs
+          platforms.linux)
+      ];
+
       systemd.user.services.kdeconnect-indicator = {
         Unit = {
           Description = "kdeconnect-indicator";

--- a/modules/services/keepassx.nix
+++ b/modules/services/keepassx.nix
@@ -12,6 +12,10 @@ with lib;
   };
 
   config = mkIf config.services.keepassx.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.keepassx" pkgs platforms.linux)
+    ];
+
     systemd.user.services.keepassx = {
       Unit = {
         Description = "KeePassX password manager";

--- a/modules/services/mpd-discord-rpc.nix
+++ b/modules/services/mpd-discord-rpc.nix
@@ -39,6 +39,11 @@ in {
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.mpd-discord-rpc" pkgs
+        platforms.linux)
+    ];
+
     xdg.configFile."discord-rpc/config.toml".source = configFile;
 
     systemd.user.services.mpd-discord-rpc = {

--- a/modules/services/owncloud-client.nix
+++ b/modules/services/owncloud-client.nix
@@ -8,6 +8,11 @@ with lib;
   };
 
   config = mkIf config.services.owncloud-client.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.owncloud-client" pkgs
+        platforms.linux)
+    ];
+
     systemd.user.services.owncloud-client = {
       Unit = {
         Description = "Owncloud Client";

--- a/modules/services/pasystray.nix
+++ b/modules/services/pasystray.nix
@@ -10,6 +10,10 @@ with lib;
   };
 
   config = mkIf config.services.pasystray.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.pasystray" pkgs platforms.linux)
+    ];
+
     systemd.user.services.pasystray = {
       Unit = {
         Description = "PulseAudio system tray";

--- a/modules/services/picom.nix
+++ b/modules/services/picom.nix
@@ -270,6 +270,11 @@ in {
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.picom" pkgs
+        lib.platforms.linux)
+    ];
+
     services.picom.settings = mkDefaultAttrs {
       # fading
       fading = cfg.fade;

--- a/modules/services/random-background.nix
+++ b/modules/services/random-background.nix
@@ -68,6 +68,11 @@ in {
 
   config = mkIf cfg.enable (mkMerge ([
     {
+      assertions = [
+        (hm.assertions.assertPlatform "services.random-background" pkgs
+          platforms.linux)
+      ];
+
       systemd.user.services.random-background = {
         Unit = {
           Description = "Set random desktop background using feh";

--- a/modules/services/stalonetray.nix
+++ b/modules/services/stalonetray.nix
@@ -51,6 +51,11 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
+      assertions = [
+        (hm.assertions.assertPlatform "services.stalonetray" pkgs
+          platforms.linux)
+      ];
+
       home.packages = [ cfg.package ];
 
       systemd.user.services.stalonetray = {

--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -108,6 +108,10 @@ in {
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.swayidle" pkgs platforms.linux)
+    ];
+
     systemd.user.services.swayidle = {
       Unit = {
         Description = "Idle manager for Wayland";

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -98,6 +98,11 @@ in {
     })
 
     (mkIf (isAttrs cfg.tray && cfg.tray.enable) {
+      assertions = [
+        (hm.assertions.assertPlatform "services.syncthing.tray" pkgs
+          platforms.linux)
+      ];
+
       systemd.user.services = {
         ${cfg.tray.package.pname} = {
           Unit = {
@@ -118,6 +123,11 @@ in {
 
     # deprecated
     (mkIf (isBool cfg.tray && cfg.tray) {
+      assertions = [
+        (hm.assertions.assertPlatform "services.syncthing.tray" pkgs
+          platforms.linux)
+      ];
+
       systemd.user.services = {
         "syncthingtray" = {
           Unit = {

--- a/modules/services/taffybar.nix
+++ b/modules/services/taffybar.nix
@@ -24,6 +24,10 @@ in {
   };
 
   config = mkIf config.services.taffybar.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.taffybar" pkgs platforms.linux)
+    ];
+
     systemd.user.services.taffybar = {
       Unit = {
         Description = "Taffybar desktop bar";

--- a/modules/services/tahoe-lafs.nix
+++ b/modules/services/tahoe-lafs.nix
@@ -10,6 +10,10 @@ with lib;
   };
 
   config = mkIf config.services.tahoe-lafs.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.tahoe-lafs" pkgs platforms.linux)
+    ];
+
     systemd.user.services.tahoe-lafs = {
       Unit = { Description = "Tahoe-LAFS"; };
 

--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -98,6 +98,10 @@ in {
   };
 
   config = mkIf config.services.udiskie.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.udiskie" pkgs platforms.linux)
+    ];
+
     xdg.configFile."udiskie/config.yml".source =
       yaml.generate "udiskie-config.yml" (mergeSets [
         {


### PR DESCRIPTION
### Description
This is related to https://github.com/nix-community/home-manager/pull/2497#discussion_r754814040.

The systemd module currently contains checks to make sure user services aren't defined on Darwin hosts. But with launchd support now in HM, this can result in feature gating boilerplate when trying to create modules that supports both systemd and launchd.

After this change, modules would be able to define both systemd services and launchd agents without the boilerplate. The systemd module would just ignore them on macOS and vice versa for launchd. I'm hoping this wouldn't be a big issue because most consumers of the systemd module already checks if it supports the target OS. I've also added checks for those that didn't.

For a more concrete example, here's how a module supporting both systemd and launchd might look before this change:

```nix
{ lib, pkgs, ... }:

let
  cfg = config.services.example;
  inherit (lib) mkIf mkMerge;
  inherit (pkgs.stdenv.hostPlatforms) isLinux isDarwin;
in {
  options.services.example.enable = mkEnableOption "example service";

  config = mkIf cfg.enable (mkMerge [
    (lib.mkIf isLinux {
      systemd.user.services.example = {
        Unit.Description = "example service";
        Service.ExecStart = "${pkgs.example}/bin/example";
        Install.WantedBy = [ "default.target" ];
      };
    })

    (lib.mkIf isDarwin {
      launchd.agents.example = {
        enable = true;
        config = {
          ProgramArguments = [ "${pkgs.example}/bin/example" ];
          ProcessType = "Background";
        };
      };
    })
  ]);
}
```

And here's how it'd look after this change:

```nix
{ lib, pkgs, ... }:

let
  cfg = config.services.example;
  inherit (lib) mkIf mkMerge;
in {
  options.services.example.enable = mkEnableOption "example service";

  config = mkIf cfg.enable {
    systemd.user.services.example = {
      Unit.Description = "example service";
      Service.ExecStart = "${pkgs.example}/bin/example";
      Install.WantedBy = [ "default.target" ];
    };

    launchd.agents.example = {
      enable = true;
      config = {
        ProgramArguments = [ "${pkgs.example}/bin/example" ];
        ProcessType = "Background";
      };
    };
  };
}
```
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
