### PR TITLE
imapnotify: Do not shell-escape password cmd

### DIFF
--- a/modules/services/imapnotify.nix
+++ b/modules/services/imapnotify.nix
@@ -49,8 +49,7 @@ let
       inherit port;
       tls = account.imap.tls.enable;
       username = account.userName;
-      passwordCmd =
-        lib.concatMapStringsSep " " lib.escapeShellArg account.passwordCommand;
+      passwordCmd = lib.concatStringsSep " " account.passwordCommand;
       inherit (account.imapnotify) boxes;
     } // optionalAttrs (account.imapnotify.onNotify != "") {
       onNewMail = account.imapnotify.onNotify;


### PR DESCRIPTION
### Description

Fix a regression introduced in #1675. (cc @duairc @teto)

tldr: `escapeShellArg` breaks the pipe in `pass some-account | head -n1`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible. (**ACTUALLY NOT**)

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
