### PR TITLE
xscreensaver: have xscreensaver-command in PATH

### DIFF
--- a/modules/services/xscreensaver.nix
+++ b/modules/services/xscreensaver.nix
@@ -53,6 +53,7 @@ in {
 
       Service = {
         ExecStart = "${pkgs.xscreensaver}/bin/xscreensaver -no-splash";
+        Environment = "PATH=${makeBinPath [ pkgs.xscreensaver ]}";
       };
 
       Install = { WantedBy = [ "graphical-session.target" ]; };


### PR DESCRIPTION
### Description
Added to systemd-service:
```
        Environment = "PATH=${makeBinPath [pkgs.xscreensaver]}";
```
Otherwise journal will spam:
```
xscreensaver[468297]: sh: line 1: xscreensaver-command: command not found
xscreensaver-systemd: 12:29:22: exec: "xscreensaver-command -quiet -deactivate" exited with status 127
```
Which might be trying to deactivate it when watching video's, which I
have had issues with.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] (no tests for xscreensaver)! Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
