### PR TITLE
fish: generate completions using python 3

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -307,7 +307,7 @@ in {
         generateCompletions = package:
           pkgs.runCommand "${package.name}-fish-completions" {
             src = package;
-            nativeBuildInputs = [ pkgs.python2 ];
+            nativeBuildInputs = [ pkgs.python3 ];
             buildInputs = [ cfg.package ];
             preferLocalBuild = true;
           } ''


### PR DESCRIPTION
### Description

Was browsing issues and noticed fixing #2910 looked straightforward.

I checked that Python 3 is now used in the script that generates completions, and sampled what was generated to see if there were any differences and didn't find any.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
