### PR TITLE
emacs: allow cfg.extraConfig to require packages in cfg.extraPackages

### DIFF
--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -13,11 +13,15 @@ let
 
   emacsWithPackages = emacsPackages.emacsWithPackages;
 
-  createConfPackage = epkgs:
-    epkgs.trivialBuild {
-      pname = "default";
-      src = pkgs.writeText "default.el" cfg.extraConfig;
-    };
+  extraPackages = epkgs:
+    let
+      packages = cfg.extraPackages epkgs;
+      userConfig = epkgs.trivialBuild {
+        pname = "default";
+        src = pkgs.writeText "default.el" cfg.extraConfig;
+        packageRequires = packages;
+      };
+    in packages ++ optional (cfg.extraConfig != "") userConfig;
 
 in {
   meta.maintainers = [ maintainers.rycee ];
@@ -91,10 +95,6 @@ in {
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.finalPackage ];
-    programs.emacs = {
-      finalPackage = emacsWithPackages cfg.extraPackages;
-      extraPackages = epkgs:
-        optional (cfg.extraConfig != "") (createConfPackage epkgs);
-    };
+    programs.emacs.finalPackage = emacsWithPackages extraPackages;
   };
 }

--- a/tests/modules/programs/emacs/extra-config.nix
+++ b/tests/modules/programs/emacs/extra-config.nix
@@ -5,16 +5,32 @@ let
   testScript = pkgs.writeText "test.el" ''
     ;; Emacs won't automatically load default.el when --script is specified
     (load "default")
-    (kill-emacs (if (eq hm 'home-manager) 0 1))
+    (let* ((test-load-config (eq hm 'home-manager))
+           (test-load-package (eq (hm-test-fn) 'success))
+           (is-ok (and test-load-config test-load-package)))
+      (kill-emacs (if is-ok 0 1)))
   '';
 
   emacsBin = "${config.programs.emacs.finalPackage}/bin/emacs";
+
+  mkTestPackage = epkgs:
+    epkgs.trivialBuild {
+      pname = "hm-test";
+      src = pkgs.writeText "hm-test.el" ''
+        (defun hm-test-fn () 'success)
+        (provide 'hm-test)
+      '';
+    };
 
 in lib.mkIf config.test.enableBig {
   programs.emacs = {
     enable = true;
     package = pkgs.emacs-nox;
-    extraConfig = "(setq hm 'home-manager)";
+    extraConfig = ''
+      (require 'hm-test)
+      (setq hm 'home-manager)
+    '';
+    extraPackages = epkgs: [ (mkTestPackage epkgs) ];
   };
 
   # running emacs with --script would enable headless mode


### PR DESCRIPTION
### Description

Fixes https://github.com/nix-community/home-manager/pull/1758#issuecomment-1113706592.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
