### PR TITLE
gpg-agent: shell integration is configurable

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -198,28 +198,16 @@ in {
         '';
       };
 
-      enableBashIntegration = mkOption {
+      enableBashIntegration = mkEnableOption "Bash integration" // {
         default = true;
-        type = types.bool;
-        description = ''
-          Whether to enable Bash integration.
-        '';
       };
 
-      enableZshIntegration = mkOption {
+      enableZshIntegration = mkEnableOption "Zsh integration" // {
         default = true;
-        type = types.bool;
-        description = ''
-          Whether to enable Zsh integration.
-        '';
       };
 
-      enableFishIntegration = mkOption {
+      enableFishIntegration = mkEnableOption "Fish integration" // {
         default = true;
-        type = types.bool;
-        description = ''
-          Whether to enable Fish integration.
-        '';
       };
     };
   };

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -197,6 +197,30 @@ in {
           now.
         '';
       };
+
+      enableBashIntegration = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Whether to enable Bash integration.
+        '';
+      };
+
+      enableZshIntegration = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Whether to enable Zsh integration.
+        '';
+      };
+
+      enableFishIntegration = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Whether to enable Fish integration.
+        '';
+      };
     };
   };
 
@@ -224,9 +248,9 @@ in {
         fi
       '';
 
-      programs.bash.initExtra = gpgInitStr;
-      programs.zsh.initExtra = gpgInitStr;
-      programs.fish.interactiveShellInit = ''
+      programs.bash.initExtra = mkIf cfg.enableBashIntegration gpgInitStr;
+      programs.zsh.initExtra = mkIf cfg.enableZshIntegration gpgInitStr;
+      programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
         set -gx GPG_TTY (tty)
       '';
     }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

In esoteric setups, automatically setting GPG_TTY to current tty is not
desired on every shell startup. This change adds configuration options
to allow user to disable that if desired.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

Appears an unrelated test case is failing even before my change:
```
❯ nix-shell --pure tests -A run.all
error: attribute 'shellDryRun' missing

       at /home/user/projects/home-manager/modules/programs/bash.nix:12:9:

           11|     checkPhase = ''
           12|       ${pkgs.stdenv.shellDryRun} "$target"
             |         ^
           13|     '';
(use '--show-trace' to show detailed location information)
```

However, all the gpg-agent related tests do pass:
```
❯ for t in gpg-agent-default-homedir gpg-agent-override-homedir; do nix-shell --pure tests -A run.$t; done
❯ for t in gpg-agent-default-homedir gpg-agent-override-homedir; do nix-shell --pure tests -A run.$t; done
gpg-agent-default-homedir: OK
gpg-agent-override-homedir: OK
```

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

Change seems trivial enough it shouldn't need new testcases? Happy to be wrong, so please let me know if you would like me to add some.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

This PR does not.
