### PR TITLE
fish: consider extra outputs to install completions

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -332,7 +332,7 @@ in {
             mkdir -p $out
             for src in $srcs; do
               if [ -d $src/share/man ]; then
-                find $src/share/man -type f \
+                find -L $src/share/man -type f \
                   | xargs python ${cfg.package}/share/fish/tools/create_manpage_completions.py --directory $out \
                   > /dev/null
               fi


### PR DESCRIPTION
### Description
After switching to fish, I noticed that some man pages are not considered when generating completions.
This is because

- Some packages provide man pages in extraOutputs, e.g. tmux and tmux.man and
- Some packages link man pages, e.g. if a package is wrapped with `buildEnv`.

To fix this I added `extraOutputsToInstall` an source for man pages, similar to nixpkgs `buildEnv`

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
