### PR TITLE
gpg-agent: make shell integrations optional (#2927)

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -170,6 +170,18 @@ in
           now.
         '';
       };
+
+      enableBashIntegration = mkEnableOption "Bash integration" // {
+        default = true;
+      };
+
+      enableZshIntegration = mkEnableOption "Zsh integration" // {
+        default = true;
+      };
+
+      enableFishIntegration = mkEnableOption "Fish integration" // {
+        default = true;
+      };
     };
   };
 
@@ -206,9 +218,9 @@ in
         fi
       '';
 
-      programs.bash.initExtra = gpgInitStr;
-      programs.zsh.initExtra = gpgInitStr;
-      programs.fish.interactiveShellInit = ''
+      programs.bash.initExtra = mkIf cfg.enableBashIntegration gpgInitStr;
+      programs.zsh.initExtra = mkIf cfg.enableZshIntegration gpgInitStr;
+      programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
         set -gx GPG_TTY (tty)
       '';
     }


### PR DESCRIPTION
In esoteric setups, automatically setting GPG_TTY to current tty is not
desired on every shell startup. This change adds configuration options
to allow user to disable that if desired.

(cherry picked from commit df6010551daa826217939641ab805053f0890239)

### Description

<!--

Please provide a brief description of your change.

-->

Backports #2927

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

N/A

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
N/A
