### PR TITLE
swayidle: Fix ordering of arguments

### DIFF
--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -15,8 +15,8 @@ let
 
   mkEvent = e: [ e.event (escapeShellArg e.command) ];
 
-  args = (concatMap mkTimeout cfg.timeouts) ++ (concatMap mkEvent cfg.events)
-    ++ cfg.extraArgs;
+  args = cfg.extraArgs ++ (concatMap mkTimeout cfg.timeouts)
+    ++ (concatMap mkEvent cfg.events);
 
 in {
   meta.maintainers = [ maintainers.c0deaddict ];


### PR DESCRIPTION
### Description
The `extraArgs` were passed to `swayidle` at the end of the command, while `swayidle` expects them **before** the `events` and `timeouts`, causing it to exit with an error. This PR fixes the order of the arguments.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
