### PR TITLE
sway: Make onChange script use cfg.package if set

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -431,12 +431,14 @@ in {
       home.packages = optional (cfg.package != null) cfg.package
         ++ optional cfg.xwayland pkgs.xwayland;
 
-      xdg.configFile."sway/config" = {
+      xdg.configFile."sway/config" = let
+        swayPackage = if cfg.package == null then pkgs.sway else cfg.package;
+      in {
         source = configFile;
         onChange = ''
           swaySocket="''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.$(${pkgs.procps}/bin/pgrep --uid $UID -x sway || true).sock"
           if [ -S "$swaySocket" ]; then
-            ${pkgs.sway}/bin/swaymsg -s $swaySocket reload
+            ${swayPackage}/bin/swaymsg -s $swaySocket reload
           fi
         '';
       };


### PR DESCRIPTION
### Description

On some machines, `pkgs.sway` is not usable and the `wayland.windowManager.sway.package` config can be used to substitute a working version. However `pkgs.sway` is still used for the `onChange` script, so the user may end up with two copies of sway installed or a broken build if `pkgs.sway` doesn't work.

Now if the `package` option is overriden, the `onChange` script will call `swaymsg` without pulling in `pkgs.sway`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.
*I attempted this and was given an error "attribute 'shellDryRun' missing" in modules/programs/bash.nix*

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```