### PR TITLE
services/emacs: Add option to make service start with the session

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -81,6 +81,17 @@ in {
       enable = mkEnableOption "systemd socket activation for the Emacs service";
     };
 
+    startWithUserSession = lib.mkOption {
+      type = lib.types.bool;
+      default = !cfg.socketActivation.enable;
+      defaultText =
+        literalExpression "!config.services.emacs.socketActivation.enable";
+      example = true;
+      description = ''
+        Whether to launch Emacs service with the systemd user session.
+      '';
+    };
+
     defaultEditor = mkOption rec {
       type = types.bool;
       default = false;
@@ -145,7 +156,7 @@ in {
           ExecStopPost =
             "${pkgs.coreutils}/bin/chmod --changes +w ${socketDir}";
         };
-      } // optionalAttrs (!cfg.socketActivation.enable) {
+      } // optionalAttrs (cfg.startWithUserSession) {
         Install = { WantedBy = [ "default.target" ]; };
       };
 

--- a/tests/modules/services/emacs/default.nix
+++ b/tests/modules/services/emacs/default.nix
@@ -4,4 +4,6 @@
   emacs-socket-27 = ./emacs-socket-27.nix;
   emacs-socket-28 = ./emacs-socket-28.nix;
   emacs-default-editor = ./emacs-default-editor.nix;
+  emacs-socket-and-startWithUserSession =
+    ./emacs-socket-and-startWithUserSession.nix;
 }

--- a/tests/modules/services/emacs/emacs-socket-and-startWithUserSession.nix
+++ b/tests/modules/services/emacs/emacs-socket-and-startWithUserSession.nix
@@ -1,0 +1,27 @@
+{ lib, pkgs, ... }:
+
+with lib;
+
+{
+  services.emacs = {
+    enable = true;
+    socketActivation.enable = true;
+    startWithUserSession = true;
+  };
+
+  nixpkgs.overlays = [
+    (self: super: rec {
+      emacs = pkgs.writeShellScriptBin "dummy-emacs-28.0.5" "" // {
+        outPath = "@emacs@";
+      };
+      emacsPackagesFor = _:
+        makeScope super.newScope (_: { emacsWithPackages = _: emacs; });
+    })
+  ];
+
+  nmt.script = ''
+    assertFileContains \
+      home-files/.config/systemd/user/emacs.service \
+      "WantedBy=default.target"
+  '';
+}


### PR DESCRIPTION
### Description

Add services.emacs.startWithUserSession boolean to indicate that Emacs
must be started with the systemd user session. This is true by default
unless socket activation is also true.

In the past, the user had to choose between socket activation (to get
the Emacs service started when the user uses emacsclient) and
immediate start with the user session. When choosing immediate start
over socket activation and if the Emacs service is stopped at some
point, using emacsclient would start a new Emacs daemon but the
service would still be turned off. This situation would prevent
`home-manager switch` from completing successfully because it wouldn't
be able to start the Emacs service as Emacs is already running.

This new setting makes it possible to have both socket activation and
immediate start at the same time. In this scenario, Emacs is started
with the user session and, after the Emacs service is stopped, using
emacsclient starts the service again.

This new settings also makes it possible to have neither socket
activation nor immediate start.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
