### PR TITLE
programs.pywal: init

### DIFF
--- a/modules/programs/pywal.nix
+++ b/modules/programs/pywal.nix
@@ -1,0 +1,78 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.programs.pywal;
+
+in {
+  options = { programs.pywal = { enable = mkEnableOption "pywal"; }; };
+
+  config = mkIf cfg.enable {
+
+    home.packages = [ pkgs.pywal ];
+
+    programs.zsh.initExtra = ''
+      # Import colorscheme from 'wal' asynchronously
+      # &   # Run the process in the background.
+      # ( ) # Hide shell job control messages.
+      (cat ~/.cache/wal/sequences &)
+
+      # Alternative (blocks terminal for 0-3ms)
+      cat ~/.cache/wal/sequences
+    '';
+
+    programs.kitty.extraConfig = ''
+      include ${config.xdg.cacheHome}/wal/colors-kitty.conf
+    '';
+
+    programs.rofi.theme."@import" =
+      "${config.xdg.cacheHome}/wal/colors-rofi-dark.rasi";
+
+    # wal generates and that's the one we should load from /home/teto/.cache/wal/colors.Xresources ~/.Xresources
+    xsession.windowManager.i3 = {
+      extraConfig = ''
+        set_from_resource $bg           i3wm.color0 #ff0000
+        set_from_resource $bg-alt       i3wm.color14 #ff0000
+        set_from_resource $fg           i3wm.color15 #ff0000
+        set_from_resource $fg-alt       i3wm.color2 #ff0000
+        set_from_resource $hl           i3wm.color13 #ff0000
+      '';
+
+      config.colors = {
+        focused = {
+          border = "$fg-alt";
+          background = "$bg";
+          text = "$hl";
+          indicator = "$fg-alt";
+          childBorder = "$hl";
+        };
+        focusedInactive = {
+          border = "$fg-alt";
+          background = "$bg";
+          text = "$fg";
+          indicator = "$fg-alt";
+          childBorder = "$fg-alt";
+        };
+
+        unfocused = {
+          border = "$fg-alt";
+          background = "$bg";
+          text = "$fg";
+          indicator = "$fg-alt";
+          childBorder = "$fg-alt";
+        };
+
+        urgent = {
+          border = "$fg-alt";
+          background = "$bg";
+          text = "$fg";
+          indicator = "$fg-alt";
+          childBorder = "$fg-alt";
+        };
+
+        background = "$bg";
+      };
+    };
+  };
+}
+

--- a/modules/programs/pywal.nix
+++ b/modules/programs/pywal.nix
@@ -15,10 +15,7 @@ in {
       # Import colorscheme from 'wal' asynchronously
       # &   # Run the process in the background.
       # ( ) # Hide shell job control messages.
-      (cat ~/.cache/wal/sequences &)
-
-      # Alternative (blocks terminal for 0-3ms)
-      cat ~/.cache/wal/sequences
+      (cat ${config.xdg.cacheHome}/wal/sequences &)
     '';
 
     programs.kitty.extraConfig = ''
@@ -46,6 +43,7 @@ in {
           indicator = "$fg-alt";
           childBorder = "$hl";
         };
+
         focusedInactive = {
           border = "$fg-alt";
           background = "$bg";


### PR DESCRIPTION
pywal allows to change your theme for much software:
https://github.com/dylanaraps/pywal/wiki/Customization#table-of-contents

home-manager is the perfect tool to leverage since a single setting
could enable wal-compatible theming for all this software.

In this PR, I've just enabled zsh, kitty and i3 but I hope follow up PRs will
enable more software.
At some point we may even need a blacklist.

Once enabled, run:
wal --theme random

to change your colorschemes.


edit: for neovim support we would need  https://github.com/dylanaraps/wal.vim/pull/26

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
