### PR TITLE
lib/types: make DAG entries mergeable

### DIFF
--- a/tests/lib/types/dag-merge-result.txt
+++ b/tests/lib/types/dag-merge-result.txt
@@ -1,3 +1,4 @@
 before:before
+merged:left,middle,middle,right
 between:between
 after:after

--- a/tests/lib/types/dag-merge.nix
+++ b/tests/lib/types/dag-merge.nix
@@ -1,7 +1,8 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) concatStringsSep hm mkIf mkMerge mkOption types;
+  inherit (lib)
+    concatStringsSep hm mkIf mkMerge mkBefore mkAfter mkOption types;
 
   dag = lib.hm.dag;
 
@@ -11,17 +12,22 @@ let
   in concatStringsSep "\n" data + "\n";
 
 in {
-  options.tested.dag = mkOption { type = hm.types.dagOf types.str; };
+  options.tested.dag = mkOption { type = hm.types.dagOf types.commas; };
 
   config = {
     tested.dag = mkMerge [
-      { never = mkIf false "never"; }
+      (mkIf false { never = "never"; })
+      { never2 = mkIf false "never2"; }
       { after = mkMerge [ "after" (mkIf false "neither") ]; }
       { before = dag.entryBefore [ "after" ] (mkIf true "before"); }
       {
         between =
           mkIf true (dag.entryBetween [ "after" ] [ "before" ] "between");
       }
+      { merged = dag.entryBefore [ "between" ] "middle"; }
+      { merged = mkBefore "left"; }
+      { merged = dag.entryBetween [ "after" ] [ "before" ] (mkAfter "right"); }
+      { merged = dag.entryBefore [ "between" ] "middle"; }
     ];
 
     home.file."result.txt".text = result;


### PR DESCRIPTION
### Description

Fixes https://github.com/nix-community/home-manager/issues/2944

Removes the `uniq` constraint on `after` and `before` so that we can merge multiple definitions for the same DAG entry:

```nix
{
  dag = mkMerge [
    {
      foo = lib.hm.dag.entryBefore [ "bar" ] {
        # definition 1
      };
    }
    {
      foo = lib.hm.dag.entryBefore [ "qux" ] {
        # definition 2
      };
    }
    {
      foo = {
        # definition 3
      };
    }
  ];
}
```


In this example `foo` will come before `bar` and `qux`.

It might also be worth considering enabling things like

```nix
{
  foo.after = "qux";
}
```

which currently would be treated as a definition of the underlying data (so the change wouldn't be backwards compatible), though that can be done with the current PR as

```nix
{
  foo = lib.hm.dag.entryAfter "qux" (mkMerge []);
}
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
