### PR TITLE
offlineimap: remove dependency on python2 (#2909)

### DIFF
--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -158,13 +158,13 @@ in {
     xdg.configFile."offlineimap/get_settings.py".text = cfg.pythonFile;
     xdg.configFile."offlineimap/get_settings.pyc".source = "${
         pkgs.runCommandLocal "get_settings-compile" {
-          nativeBuildInputs = [ pkgs.python2 ];
+          nativeBuildInputs = [ pkgs.offlineimap ];
           pythonFile = cfg.pythonFile;
           passAsFile = [ "pythonFile" ];
         } ''
           mkdir -p $out/bin
           cp $pythonFilePath $out/bin/get_settings.py
-          python2 -m py_compile $out/bin/get_settings.py
+          python -m py_compile $out/bin/get_settings.py
         ''
       }/bin/get_settings.pyc";
 


### PR DESCRIPTION
### Description

Remove the dependency on `python2` and instead use the `python` version packaged with `oflineimap`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.