### PR TITLE
htop: fix darwin defaults

### DIFF
--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -3,6 +3,7 @@
 with lib;
 
 let
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
   cfg = config.programs.htop;
 
@@ -72,6 +73,21 @@ let
     M_SWAP = 119;
     M_PSSWP = 120;
   };
+
+  defaultFields = with fields; [
+    PID
+    USER
+    PRIORITY
+    NICE
+    M_SIZE
+    M_RESIDENT
+    M_SHARE
+    STATE
+    PERCENT_CPU
+    PERCENT_MEM
+    TIME
+    COMM
+  ];
 
   modes = {
     Bar = 1;
@@ -154,20 +170,10 @@ in {
 
     xdg.configFile."htop/htoprc" = let
       defaults = {
-        fields = with fields; [
-          PID
-          USER
-          PRIORITY
-          NICE
-          M_SIZE
-          M_RESIDENT
-          M_SHARE
-          STATE
-          PERCENT_CPU
-          PERCENT_MEM
-          TIME
-          COMM
-        ];
+        fields = if isDarwin then
+          remove fields.M_SHARE defaultFields
+        else
+          defaultFields;
       };
 
       before = optionalAttrs (cfg.settings ? header_layout) {

--- a/tests/modules/programs/htop/header_layout.nix
+++ b/tests/modules/programs/htop/header_layout.nix
@@ -17,7 +17,12 @@ with lib;
 
     # Test that the 'fields' key is written in addition to the customized
     # settings or htop won't read the options.
-    nmt.script = ''
+    nmt.script = let
+      fields = if pkgs.stdenv.hostPlatform.isDarwin then
+        "0 48 17 18 38 39 2 46 47 49 1"
+      else
+        "0 48 17 18 38 39 40 2 46 47 49 1";
+    in ''
       htoprc=home-files/.config/htop/htoprc
       assertFileExists $htoprc
       assertFileContent $htoprc \
@@ -28,7 +33,7 @@ with lib;
             column_meters_1=Tasks LoadAverage Uptime Systemd
             column_meters_modes_0=1 1 1 2
             column_meters_modes_1=2 2 2 2
-            fields=0 48 17 18 38 39 40 2 46 47 49 1
+            fields=${fields}
           ''
         }
     '';

--- a/tests/modules/programs/htop/settings-without-fields.nix
+++ b/tests/modules/programs/htop/settings-without-fields.nix
@@ -11,14 +11,19 @@ with lib;
 
     # Test that the 'fields' key is written in addition to the customized
     # settings or htop won't read the options.
-    nmt.script = ''
+    nmt.script = let
+      fields = if pkgs.stdenv.hostPlatform.isDarwin then
+        "0 48 17 18 38 39 2 46 47 49 1"
+      else
+        "0 48 17 18 38 39 40 2 46 47 49 1";
+    in ''
       htoprc=home-files/.config/htop/htoprc
       assertFileExists $htoprc
       assertFileContent $htoprc \
         ${
           builtins.toFile "htoprc-expected" ''
             color_scheme=6
-            fields=0 48 17 18 38 39 40 2 46 47 49 1
+            fields=${fields}
           ''
         }
     '';


### PR DESCRIPTION

### Description

`M_SHARE` is not a valid column on Darwin. It seems that previously htop ignored unknown columns, but the current version does not display all subsequent columns:

<img width="555" alt="image" src="https://user-images.githubusercontent.com/831307/168389237-1d34f7bd-deec-4799-a34c-e1892a7f1127.png">


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
