### PR TITLE
gpg-agent: darwin support via launchd service

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -71,6 +71,16 @@
     github = "JustinLovinger";
     githubId = 7183441;
   };
+  montchr = {
+    name = "Chris Montgomery";
+    email = "chris@cdom.io";
+    github = "montchr";
+    githubId = 1757914;
+    keys = [{
+      longkeyid = "rsa4096/0x135EEDD0F71934F3";
+      fingerprint = "6460 4147 C434 F65E C306  A21F 135E EDD0 F719 34F3";
+    }];
+  };
   owm111 = {
     email = "7798336+owm111@users.noreply.github.com";
     name = "Owen McGrath";

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -89,7 +89,7 @@ let
   in hexString: (foldl' go initState (splitChars hexString)).ret;
 
 in {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = with maintainers; [ rycee montchr ];
 
   options = {
     services.gpg-agent = {

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -8,11 +8,10 @@ let
 
   homedir = config.programs.gpg.homedir;
 
-  pinentryBinPath = optionalString (cfg.pinentryFlavor != null)
-    (if cfg.pinentryFlavor == "mac" then
-      "${pkgs.pinentry_mac}/Applications/pinentry-mac.app/Contents/MacOS/pinentry-mac"
-    else
-      "${pkgs.pinentry.${cfg.pinentryFlavor}}/bin/pinentry");
+  pinentryBinPath = (if cfg.pinentryFlavor == "mac" then
+    "${pkgs.pinentry_mac}/Applications/pinentry-mac.app/Contents/MacOS/pinentry-mac"
+  else
+    "${pkgs.pinentry.${cfg.pinentryFlavor}}/bin/pinentry");
 
   gpgSshSupportStr = ''
     ${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye > /dev/null
@@ -27,13 +26,13 @@ let
   # runs as a daemon, so this is already set.
   sshAuthSockStr =
     let sockPathCmd = "$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)";
-    in (if pkgs.stdenv.hostPlatform.isLinux then ''
+    in if pkgs.stdenv.hostPlatform.isLinux then ''
       if [[ -z "$SSH_AUTH_SOCK" ]]; then
         export SSH_AUTH_SOCK="${sockPathCmd}"
       fi
     '' else ''
       export SSH_AUTH_SOCK="${sockPathCmd}"
-    '');
+    '';
 
   gpgFishInitStr = ''
     set -gx GPG_TTY (tty)
@@ -206,6 +205,8 @@ in {
         type = types.nullOr (types.enum (pkgs.pinentry.flavors ++ [ "mac" ]));
         example = "gnome3";
         default = if pkgs.stdenv.hostPlatform.isMacOS then "mac" else "gtk2";
+        defaultText = literalExpression
+          ''if pkgs.stdenv.hostPlatform.isMacOS then "mac" else "gtk2"'';
         description = ''
           Which pinentry interface to use. If not
           <literal>null</literal>, it sets
@@ -278,19 +279,6 @@ in {
       '') cfg.sshKeys;
     })
 
-    {
-      launchd.agents.gpg-agent = {
-        enable = true;
-        config = {
-          ProgramArguments = [ "${gpgPkg}/bin/gpgconf" "--launch" "gpg-agent" ]
-            ++ optionals cfg.verbose [ "--verbose" ];
-          RunAtLoad = true;
-          KeepAlive.SuccessfulExit = false;
-          EnvironmentVariables.GNUPGHOME = homedir;
-        };
-      };
-    }
-
     # The systemd units below are direct translations of the
     # descriptions in the
     #
@@ -330,6 +318,17 @@ in {
         };
 
         Install = { WantedBy = [ "sockets.target" ]; };
+      };
+
+      launchd.agents.gpg-agent = {
+        enable = true;
+        config = {
+          ProgramArguments = [ "${gpgPkg}/bin/gpgconf" "--launch" "gpg-agent" ]
+            ++ optionals cfg.verbose [ "--verbose" ];
+          RunAtLoad = true;
+          KeepAlive.SuccessfulExit = false;
+          EnvironmentVariables.GNUPGHOME = homedir;
+        };
       };
     }
 

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -194,7 +194,7 @@ in {
       pinentryFlavor = mkOption {
         type = types.nullOr (types.enum (pkgs.pinentry.flavors ++ [ "mac" ]));
         example = "gnome3";
-        default = "gtk2";
+        default = if pkgs.stdenv.hostPlatform.isMacOS then "mac" else "gtk2";
         description = ''
           Which pinentry interface to use. If not
           <literal>null</literal>, it sets
@@ -206,8 +206,13 @@ in {
           <programlisting language="nix">
           services.dbus.packages = [ pkgs.gcr ];
           </programlisting>
-          For this reason, the default is <literal>gtk2</literal> for
-          now.
+          For this reason, on Linux systems, the default is
+          <literal>gtk2</literal> for now.
+          On macOS, while <literal>gtk2</literal> will work, the dialog
+          will not receive proper focus.<literal>pinentry-mac</literal>
+          integrates with macOS smoothly, so it will be used as the default
+          on macOS. On Darwin (as opposed to macOS specifically),
+          <literal>gtk2</literal> may still be a preferable default.
         '';
       };
 

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -13,6 +13,12 @@ let
     ${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye > /dev/null
   '';
 
+  pinentryBinPath = optionalString (cfg.pinentryFlavor != null)
+    (if cfg.pinentryFlavor == "mac" then
+      "${pkgs.pinentry_mac}/Applications/pinentry-mac.app/Contents/MacOS/pinentry-mac"
+    else
+      "${pkgs.pinentry.${cfg.pinentryFlavor}}/bin/pinentry");
+
   gpgInitStr = ''
     GPG_TTY="$(tty)"
     export GPG_TTY
@@ -186,7 +192,7 @@ in {
       };
 
       pinentryFlavor = mkOption {
-        type = types.nullOr (types.enum pkgs.pinentry.flavors);
+        type = types.nullOr (types.enum (pkgs.pinentry.flavors ++ [ "mac" ]));
         example = "gnome3";
         default = "gtk2";
         description = ''
@@ -234,8 +240,7 @@ in {
           ++ optional (cfg.maxCacheTtlSsh != null)
           "max-cache-ttl-ssh ${toString cfg.maxCacheTtlSsh}"
           ++ optional (cfg.pinentryFlavor != null)
-          "pinentry-program ${pkgs.pinentry.${cfg.pinentryFlavor}}/bin/pinentry"
-          ++ [ cfg.extraConfig ]);
+          "pinentry-program ${pinentryBinPath}" ++ [ cfg.extraConfig ]);
 
       home.sessionVariablesExtra = optionalString cfg.enableSshSupport ''
         if [[ -z "$SSH_AUTH_SOCK" ]]; then

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -130,6 +130,7 @@ import nmt {
     ./modules/programs/wezterm
     ./modules/programs/zplug
     ./modules/programs/zsh
+    ./modules/services/gpg-agent
     ./modules/xresources
   ] ++ lib.optionals isDarwin [
     ./modules/launchd
@@ -182,7 +183,6 @@ import nmt {
     ./modules/services/fnott
     ./modules/services/fusuma
     ./modules/services/git-sync
-    ./modules/services/gpg-agent
     ./modules/services/gromit-mpx
     ./modules/services/home-manager-auto-upgrade
     ./modules/services/kanshi

--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -2,7 +2,15 @@
 
 with lib;
 
-{
+let
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+  socketPath = if isDarwin then
+    config.launchd.agents.gpg-agent.config.Sockets.ssh.SockPathName
+  else
+    config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
+
+in {
   config = {
     services.gpg-agent.enable = true;
     services.gpg-agent.pinentryFlavor = null; # Don't build pinentry package.
@@ -12,7 +20,7 @@ with lib;
     test.stubs.systemd = { }; # depends on gnupg.override
 
     nmt.script = ''
-      in="${config.systemd.user.sockets.gpg-agent.Socket.ListenStream}"
+      in="${socketPath}"
       if [[ $in != "%t/gnupg/S.gpg-agent" ]]
       then
         echo $in

--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -3,12 +3,10 @@
 with lib;
 
 let
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isLinux;
 
-  socketPath = if isDarwin then
-    config.launchd.agents.gpg-agent.config.Sockets.ssh.SockPathName
-  else
-    config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
+  socketPath =
+    mkIf isLinux config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
 
 in {
   config = {
@@ -19,8 +17,9 @@ in {
     test.stubs.gnupg = { };
     test.stubs.systemd = { }; # depends on gnupg.override
 
-    nmt.script = ''
+    nmt.script = optionalString isLinux ''
       in="${socketPath}"
+    '' + ''
       if [[ $in != "%t/gnupg/S.gpg-agent" ]]
       then
         echo $in

--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -5,9 +5,7 @@ with lib;
 let
   inherit (pkgs.stdenv.hostPlatform) isLinux;
 
-  socketPath =
-    mkIf isLinux config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
-
+  socketPath = config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
 in {
   config = {
     services.gpg-agent.enable = true;

--- a/tests/modules/services/gpg-agent/override-homedir.nix
+++ b/tests/modules/services/gpg-agent/override-homedir.nix
@@ -2,7 +2,15 @@
 
 with lib;
 
-{
+let
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+  socketPath = if isDarwin then
+    config.launchd.agents.gnupg-agent.config.Sockets.ssh.SockPathName
+  else
+    config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
+
+in {
   config = {
     services.gpg-agent.enable = true;
     services.gpg-agent.pinentryFlavor = null; # Don't build pinentry package.
@@ -15,7 +23,7 @@ with lib;
     test.stubs.systemd = { }; # depends on gnupg.override
 
     nmt.script = ''
-      in="${config.systemd.user.sockets.gpg-agent.Socket.ListenStream}"
+      in="${socketPath}"
       if [[ $in != "%t/gnupg/d.wp4h7ks5zxy4dodqadgpbbpz/S.gpg-agent" ]]
       then
         echo $in

--- a/tests/modules/services/gpg-agent/override-homedir.nix
+++ b/tests/modules/services/gpg-agent/override-homedir.nix
@@ -5,9 +5,7 @@ with lib;
 let
   inherit (pkgs.stdenv.hostPlatform) isLinux;
 
-  socketPath =
-    mkIf isLinux config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
-
+  socketPath = config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
 in {
   config = {
     services.gpg-agent.enable = true;

--- a/tests/modules/services/gpg-agent/override-homedir.nix
+++ b/tests/modules/services/gpg-agent/override-homedir.nix
@@ -3,12 +3,10 @@
 with lib;
 
 let
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isLinux;
 
-  socketPath = if isDarwin then
-    config.launchd.agents.gnupg-agent.config.Sockets.ssh.SockPathName
-  else
-    config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
+  socketPath =
+    mkIf isLinux config.systemd.user.sockets.gpg-agent.Socket.ListenStream;
 
 in {
   config = {
@@ -22,8 +20,9 @@ in {
     test.stubs.gnupg = { };
     test.stubs.systemd = { }; # depends on gnupg.override
 
-    nmt.script = ''
+    nmt.script = optionalString isLinux ''
       in="${socketPath}"
+    '' + ''
       if [[ $in != "%t/gnupg/d.wp4h7ks5zxy4dodqadgpbbpz/S.gpg-agent" ]]
       then
         echo $in


### PR DESCRIPTION
### Description

- Add support for running the `gpg-agent` service on Darwin/macOS via `launchd`.
- Add support for `pinentry-mac` as `pinentry_program` and make it the default on macOS.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
