### PR TITLE
vscode: add options to disable update checks

### DIFF
--- a/tests/modules/programs/vscode/default.nix
+++ b/tests/modules/programs/vscode/default.nix
@@ -1,1 +1,4 @@
-{ vscode-keybindings = ./keybindings.nix; }
+{
+  vscode-keybindings = ./keybindings.nix;
+  vscode-update-checks = ./update-checks.nix;
+}

--- a/tests/modules/programs/vscode/keybindings.nix
+++ b/tests/modules/programs/vscode/keybindings.nix
@@ -27,12 +27,17 @@ let
     }
   ];
 
-  targetPath = if pkgs.stdenv.hostPlatform.isDarwin then
+  keybindingsPath = if pkgs.stdenv.hostPlatform.isDarwin then
     "Library/Application Support/Code/User/keybindings.json"
   else
     ".config/Code/User/keybindings.json";
 
-  expectedJson = pkgs.writeText "expected.json" ''
+  settingsPath = if pkgs.stdenv.hostPlatform.isDarwin then
+    "Library/Application Support/Code/User/settings.json"
+  else
+    ".config/Code/User/settings.json";
+
+  expectedKeybindings = pkgs.writeText "expected.json" ''
     [
       {
         "command": "editor.action.clipboardCopyAction",
@@ -58,6 +63,7 @@ let
       }
     ]
   '';
+
 in {
   config = {
     programs.vscode = {
@@ -67,8 +73,10 @@ in {
     };
 
     nmt.script = ''
-      assertFileExists "home-files/${targetPath}"
-      assertFileContent "home-files/${targetPath}" "${expectedJson}"
+      assertFileExists "home-files/${keybindingsPath}"
+      assertFileContent "home-files/${keybindingsPath}" "${expectedKeybindings}"
+
+      assertPathNotExists "home-files/${settingsPath}"
     '';
   };
 }

--- a/tests/modules/programs/vscode/update-checks.nix
+++ b/tests/modules/programs/vscode/update-checks.nix
@@ -1,0 +1,29 @@
+{ pkgs, ... }:
+
+let
+
+  settingsPath = if pkgs.stdenv.hostPlatform.isDarwin then
+    "Library/Application Support/Code/User/settings.json"
+  else
+    ".config/Code/User/settings.json";
+
+  expectedSettings = pkgs.writeText "settings-expected.json" ''
+    {
+      "extensions.autoCheckUpdates": false,
+      "update.mode": "none"
+    }
+  '';
+
+in {
+  programs.vscode = {
+    enable = true;
+    package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
+    enableUpdateCheck = false;
+    enableExtensionUpdateCheck = false;
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/${settingsPath}"
+    assertFileContent "home-files/${settingsPath}" "${expectedSettings}"
+  '';
+}


### PR DESCRIPTION
### Description

Update notification popups are annoying when vscode/vscodium is
managed by home-manager. However, as these settings also require
the config to be managed via userSettings, they are disabled by
default.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
