### PR TITLE
syncthing: start tray after syncthing.service

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -98,7 +98,11 @@ in {
           Unit = {
             Description = cfg.tray.package.pname;
             Requires = [ "tray.target" ];
-            After = [ "graphical-session-pre.target" "tray.target" ];
+            After = [
+              "graphical-session-pre.target"
+              "tray.target"
+              "syncthing.service"
+            ];
             PartOf = [ "graphical-session.target" ];
           };
 
@@ -118,7 +122,11 @@ in {
           Unit = {
             Description = "syncthingtray";
             Requires = [ "tray.target" ];
-            After = [ "graphical-session-pre.target" "tray.target" ];
+            After = [
+              "graphical-session-pre.target"
+              "tray.target"
+              "syncthing.service"
+            ];
             PartOf = [ "graphical-session.target" ];
           };
 


### PR DESCRIPTION
### Description

Fixes #2963

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
