### PR TITLE
pass-secret-service: Add Tests, Remove Dependency on password-store Module

### DIFF
--- a/modules/programs/password-store.nix
+++ b/modules/programs/password-store.nix
@@ -59,6 +59,9 @@ in {
     home.packages = [ cfg.package ];
     home.sessionVariables = cfg.settings;
 
+    services.pass-secret-service.storePath =
+      mkDefault cfg.settings.PASSWORD_STORE_DIR;
+
     xsession.importedVariables = mkIf config.xsession.enable
       (mapAttrsToList (name: value: name) cfg.settings);
   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -189,6 +189,7 @@ import nmt {
     ./modules/services/mpdris2
     ./modules/services/pantalaimon
     ./modules/services/parcellite
+    ./modules/services/pass-secret-service
     ./modules/services/pbgopy
     ./modules/services/picom
     ./modules/services/playerctld

--- a/tests/modules/services/pass-secret-service/basic-configuration.nix
+++ b/tests/modules/services/pass-secret-service/basic-configuration.nix
@@ -1,0 +1,17 @@
+{ config, pkgs, ... }:
+
+{
+  services.pass-secret-service = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    storePath = "/mnt/password-store";
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/pass-secret-service.service
+
+    assertFileExists $serviceFile
+    assertFileRegex $serviceFile 'ExecStart=.*/bin/pass_secret_service'
+    assertFileRegex $serviceFile '/mnt/password-store'
+  '';
+}

--- a/tests/modules/services/pass-secret-service/default-configuration.nix
+++ b/tests/modules/services/pass-secret-service/default-configuration.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, ... }:
+
+{
+  services.pass-secret-service = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/pass-secret-service.service
+
+    assertFileExists $serviceFile
+    assertFileRegex $serviceFile 'ExecStart=.*/bin/pass_secret_service'
+  '';
+}

--- a/tests/modules/services/pass-secret-service/default.nix
+++ b/tests/modules/services/pass-secret-service/default.nix
@@ -1,0 +1,4 @@
+{
+  pass-secret-service-default-configuration = ./default-configuration.nix;
+  pass-secret-service-basic-configuration = ./basic-configuration.nix;
+}


### PR DESCRIPTION
### Description

Allow setting the application package and storePath used by the config.
Since the programs.password-store home-manager module sets config values
via global environment variables, the default behavior of the module
should continue to behave as before for the user.

Additionally, performs some cleanup and adds a few tests that helped me
catch some bugs.

Closes #2962 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
