### PR TITLE
mopidy: add support for extraConfigFiles

### DIFF
--- a/modules/services/mopidy.nix
+++ b/modules/services/mopidy.nix
@@ -45,6 +45,9 @@ let
 
   settingsFormat = mopidyConfFormat { };
 
+  configFilePaths = concatStringsSep ":"
+    ([ "${config.xdg.configHome}/mopidy/mopidy.conf" ] ++ cfg.extraConfigFiles);
+
 in {
   meta.maintainers = [ hm.maintainers.foo-dogsquared ];
 
@@ -97,6 +100,16 @@ in {
         more details.
       '';
     };
+
+    extraConfigFiles = mkOption {
+      default = [ ];
+      type = types.listOf types.path;
+      description = ''
+        Extra configuration files read by Mopidy when the service starts.
+        Later files in the list override earlier configuration files and
+        structured settings.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -113,7 +126,9 @@ in {
         After = [ "network.target" "sound.target" ];
       };
 
-      Service = { ExecStart = "${mopidyEnv}/bin/mopidy"; };
+      Service = {
+        ExecStart = "${mopidyEnv}/bin/mopidy --config ${configFilePaths}";
+      };
 
       Install.WantedBy = [ "default.target" ];
     };
@@ -126,7 +141,8 @@ in {
       };
 
       Service = {
-        ExecStart = "${mopidyEnv}/bin/mopidy local scan";
+        ExecStart =
+          "${mopidyEnv}/bin/mopidy --config ${configFilePaths} local scan";
         Type = "oneshot";
       };
 


### PR DESCRIPTION
### Description

Follow-up to #2656:

I use `extraConfigFiles` to avoid storing secrets in the Nix store with sops-nix, and this config option (or a functionally similar one that allows importing files at runtime) is required for that to work. See code at https://github.com/lilyinstarlight/foosteros/blob/08fb35ccff35af18d6436149002665ca703858ba/hosts/bina/configuration.nix#L551-L553 in which I've been using `extraConfigFiles` for an example

cc: @foo-dogsquared

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
