### PR TITLE
Prepare inclusion in nixos-search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-/flake.lock
 /result*

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,16 @@
 { pkgs ? import <nixpkgs> { } }:
 
-rec {
+let
+
+  flake = (import
+    (let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in fetchTarball {
+      url =
+        "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }) { src = ./.; }).defaultNix;
+
+in rec {
   docs = with import ./docs { inherit pkgs; }; {
     html = manual.html;
     manPages = manPages;
@@ -16,4 +26,6 @@ rec {
   nixos = import ./nixos;
 
   path = ./.;
+
+  inherit (flake) inputs;
 }

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,17 +1,9 @@
-{ pkgs
+{ pkgs, nmdSrc ? (import ./.. { }).inputs.nmd
 
-# Note, this should be "the standard library" + HM extensions.
+  # Note, this should be "the standard library" + HM extensions.
 , lib ? import ../modules/lib/stdlib-extended.nix pkgs.lib }:
 
 let
-
-  nmdSrc = pkgs.fetchFromGitLab {
-    name = "nmd";
-    owner = "rycee";
-    repo = "nmd";
-    rev = "9e7a20e6ee3f6751f699f79c0b299390f81f7bcd";
-    sha256 = "1s49gjn1wapcjn0q4gabi8jwp8k5f18354a9c1vji0hfqsaknxzj";
-  };
 
   nmd = import nmdSrc { inherit lib pkgs; };
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1654230545,
+        "narHash": "sha256-8Vlwf0x8ow6pPOK2a04bT+pxIeRnM1+O0Xv9/CuDzRs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "236cc2971ac72acd90f0ae3a797f9f83098b17ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1654230545,
@@ -16,9 +32,44 @@
         "type": "github"
       }
     },
+    "nmd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1653339422,
+        "narHash": "sha256-8nc7lcYOgih3YEmRMlBwZaLLJYpLPYKBlewqHqx8ieg=",
+        "owner": "rycee",
+        "repo": "nmd",
+        "rev": "9e7a20e6ee3f6751f699f79c0b299390f81f7bcd",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmd",
+        "type": "gitlab"
+      }
+    },
+    "nmt": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648075362,
+        "narHash": "sha256-u36WgzoA84dMVsGXzml4wZ5ckGgfnvS0ryzo/3zn/Pc=",
+        "owner": "rycee",
+        "repo": "nmt",
+        "rev": "d83601002c99b78c89ea80e5e6ba21addcfe12ae",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "rycee",
+        "repo": "nmt",
+        "type": "gitlab"
+      }
+    },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
+        "nmd": "nmd",
+        "nmt": "nmt",
         "utils": "utils"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,16 @@
   description = "Home Manager for Nix";
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-  inputs.utils.url = "github:numtide/flake-utils";
+  inputs.nmd.url = "gitlab:rycee/nmd";
+  inputs.nmd.flake = false;
+  inputs.nmt.url = "gitlab:rycee/nmt";
+  inputs.nmt.flake = false;
 
-  outputs = { self, nixpkgs, utils }:
+  inputs.utils.url = "github:numtide/flake-utils";
+  inputs.flake-compat.url = "github:edolstra/flake-compat";
+  inputs.flake-compat.flake = false;
+
+  outputs = { self, nixpkgs, nmd, utils, ... }:
     {
       nixosModules = rec {
         home-manager = import ./nixos;
@@ -40,7 +47,10 @@
     } // utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
-        docs = import ./docs { inherit pkgs; };
+        docs = import ./docs {
+          inherit pkgs;
+          nmdSrc = nmd;
+        };
       in {
         packages = rec {
           home-manager = pkgs.callPackage ./home-manager { };

--- a/flake.nix
+++ b/flake.nix
@@ -1,43 +1,24 @@
 {
   description = "Home Manager for Nix";
 
-  outputs = { self, nixpkgs }:
-    let
-      # List of systems supported by home-manager binary
-      supportedSystems = with nixpkgs.lib.platforms; linux ++ darwin;
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.utils.url = "github:numtide/flake-utils";
 
-      # Function to generate a set based on supported systems
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+  outputs = { self, nixpkgs, utils }:
+    {
+      nixosModules = rec {
+        home-manager = import ./nixos;
+        default = home-manager;
+      };
+      # deprecated in Nix 2.8
+      nixosModule = self.nixosModules.default;
 
-      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
-    in rec {
-      nixosModules.home-manager = import ./nixos;
-      nixosModule = self.nixosModules.home-manager;
-
-      darwinModules.home-manager = import ./nix-darwin;
-      darwinModule = self.darwinModules.home-manager;
-
-      packages = forAllSystems (system:
-        let docs = import ./docs { pkgs = nixpkgsFor.${system}; };
-        in {
-          home-manager = nixpkgsFor.${system}.callPackage ./home-manager { };
-          docs-html = docs.manual.html;
-          docs-manpages = docs.manPages;
-          docs-json = docs.options.json;
-          default = self.packages.${system}.home-manager;
-        });
-
-      # defaultPackage is deprecated as of Nix 2.7.0
-      defaultPackage = forAllSystems (system: self.packages.${system}.default);
-
-      apps = forAllSystems (system: {
-        home-manager = {
-          type = "app";
-          program = "${defaultPackage.${system}}/bin/home-manager";
-        };
-      });
-
-      defaultApp = forAllSystems (system: apps.${system}.home-manager);
+      darwinModules = rec {
+        home-manager = import ./nix-darwin;
+        default = home-manager;
+      };
+      # unofficial; deprecated in Nix 2.8
+      darwinModule = self.darwinModules.default;
 
       lib = {
         hm = import ./modules/lib { lib = nixpkgs.lib; };
@@ -56,5 +37,19 @@
             };
           };
       };
-    };
+    } // utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        docs = import ./docs { inherit pkgs; };
+      in {
+        packages = rec {
+          home-manager = pkgs.callPackage ./home-manager { };
+          docs-html = docs.manual.html;
+          docs-manpages = docs.manPages;
+          docs-json = docs.options.json;
+          default = home-manager;
+        };
+        # deprecated in Nix 2.7
+        defaultPackage = self.packages.${system}.default;
+      });
 }

--- a/format
+++ b/format
@@ -27,6 +27,5 @@ find . -name '*.nix' \
   ! -path ./modules/programs/bash.nix \
   ! -path ./modules/programs/ssh.nix \
   ! -path ./modules/programs/zsh.nix \
-  ! -path ./nix-darwin/default.nix \
   ! -path ./tests/default.nix \
   -exec nixfmt $CHECK_ARG {} +

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -19,6 +19,7 @@ in runCommand "home-manager" {
   preferLocalBuild = true;
   nativeBuildInputs = [ gettext ];
   meta = with lib; {
+    mainProgram = "home-manager";
     description = "A user environment configurator";
     maintainers = [ maintainers.rycee ];
     platforms = platforms.unix;

--- a/integration-common.nix
+++ b/integration-common.nix
@@ -1,0 +1,122 @@
+# This module is the common base for the NixOS and nix-darwin modules.
+# For OS-specific configuration, please edit nixos/default.nix or nix-darwin/default.nix instead.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.home-manager;
+
+  extendedLib = import ./modules/lib/stdlib-extended.nix pkgs.lib;
+
+  hmModule = types.submoduleWith {
+    specialArgs = {
+      lib = extendedLib;
+      osConfig = config;
+      modulesPath = builtins.toString ./modules;
+    } // cfg.extraSpecialArgs;
+    modules = [
+      ({ name, ... }: {
+        imports = import ./modules/modules.nix {
+          inherit pkgs;
+          lib = extendedLib;
+          useNixpkgsModule = !cfg.useGlobalPkgs;
+        };
+
+        config = {
+          submoduleSupport.enable = true;
+          submoduleSupport.externalPackageInstall = cfg.useUserPackages;
+
+          home.username = config.users.users.${name}.name;
+          home.homeDirectory = config.users.users.${name}.home;
+
+          # Make activation script use same version of Nix as system as a whole.
+          # This avoids problems with Nix not being in PATH.
+          home.extraActivationPath = [ config.nix.package ];
+        };
+      })
+    ] ++ cfg.sharedModules;
+  };
+
+in {
+  options.home-manager = {
+    useUserPackages = mkEnableOption ''
+      installation of user packages through the
+      <option>users.users.&lt;name&gt;.packages</option> option
+    '';
+
+    useGlobalPkgs = mkEnableOption ''
+      using the system configuration's <literal>pkgs</literal>
+      argument in Home Manager. This disables the Home Manager
+      options <option>nixpkgs.*</option>
+    '';
+
+    backupFileExtension = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "backup";
+      description = ''
+        On activation move existing files by appending the given
+        file extension rather than exiting with an error.
+      '';
+    };
+
+    extraSpecialArgs = mkOption {
+      type = types.attrs;
+      default = { };
+      example = literalExpression "{ inherit emacs-overlay; }";
+      description = ''
+        Extra <literal>specialArgs</literal> passed to Home Manager. This
+        option can be used to pass additional arguments to all modules.
+      '';
+    };
+
+    sharedModules = mkOption {
+      type = with types;
+      # TODO: use types.raw once this PR is merged: https://github.com/NixOS/nixpkgs/pull/132448
+        listOf (mkOptionType {
+          name = "submodule";
+          inherit (submodule { }) check;
+          merge = lib.options.mergeOneOption;
+          description = "Home Manager modules";
+        });
+      default = [ ];
+      example = literalExpression "[ { home.packages = [ nixpkgs-fmt ]; } ]";
+      description = ''
+        Extra modules added to all users.
+      '';
+    };
+
+    verbose = mkEnableOption "verbose output on activation";
+
+    users = mkOption {
+      type = types.attrsOf hmModule;
+      default = { };
+      # Set as not visible to prevent the entire submodule being included in
+      # the documentation.
+      visible = false;
+      description = ''
+        Per-user Home Manager configuration.
+      '';
+    };
+  };
+
+  config = mkIf (cfg.users != { }) {
+    warnings = flatten (flip mapAttrsToList cfg.users (user: config:
+      flip map config.warnings (warning: "${user} profile: ${warning}")));
+
+    assertions = flatten (flip mapAttrsToList cfg.users (user: config:
+      flip map config.assertions (assertion: {
+        inherit (assertion) assertion;
+        message = "${user} profile: ${assertion.message}";
+      })));
+
+    users.users = mkIf cfg.useUserPackages
+      (mapAttrs (username: usercfg: { packages = [ usercfg.home.path ]; })
+        cfg.users);
+
+    environment.pathsToLink = mkIf cfg.useUserPackages [ "/etc/profile.d" ];
+  };
+}

--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -152,7 +152,7 @@ let
       };
 
       # Required for the assertions
-      # TODO: Remove me once `mkRemovedOptionModule` works correctly with submodules
+      # TODO: Remove me once https://github.com/NixOS/nixpkgs/issues/96006 is fixed
       assertions = mkOption {
         type = types.listOf types.unspecified;
         default = [ ];

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -6,140 +6,26 @@ let
 
   cfg = config.home-manager;
 
-  extendedLib = import ../modules/lib/stdlib-extended.nix pkgs.lib;
+in {
+  imports = [ ../integration-common.nix ];
 
-  hmModule = types.submoduleWith {
-    specialArgs = {
-      lib = extendedLib;
-      darwinConfig = config;
-      osConfig = config;
-      modulesPath = builtins.toString ../modules;
-    } // cfg.extraSpecialArgs;
-    modules = [
-      ({ name, ... }: {
-        imports = import ../modules/modules.nix {
-          inherit pkgs;
-          lib = extendedLib;
-          useNixpkgsModule = !cfg.useGlobalPkgs;
-        };
-
-        config = {
-          submoduleSupport.enable = true;
-          submoduleSupport.externalPackageInstall = cfg.useUserPackages;
-
-          home.username = config.users.users.${name}.name;
-          home.homeDirectory = config.users.users.${name}.home;
-
-          # Make activation script use same version of Nix as system as a whole.
-          # This avoids problems with Nix not being in PATH.
-          home.extraActivationPath = [ config.nix.package ];
-        };
-      })
-    ] ++ cfg.sharedModules;
-  };
-
-in
-
-{
-  options = {
-    home-manager = {
-      useUserPackages = mkEnableOption ''
-        installation of user packages through the
-        <option>users.users.&lt;name?&gt;.packages</option> option.
-      '';
-
-      useGlobalPkgs = mkEnableOption ''
-        using the system configuration's <literal>pkgs</literal>
-        argument in Home Manager. This disables the Home Manager
-        options <option>nixpkgs.*</option>
-      '';
-
-      backupFileExtension = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = "backup";
-        description = ''
-          On activation move existing files by appending the given
-          file extension rather than exiting with an error.
-        '';
-      };
-
-      extraSpecialArgs = mkOption {
-        type = types.attrs;
-        default = { };
-        example = literalExpression "{ inherit emacs-overlay; }";
-        description = ''
-          Extra <literal>specialArgs</literal> passed to Home Manager. This
-          option can be used to pass additional arguments to all modules.
-        '';
-      };
-
-      sharedModules = mkOption {
-        type = with types;
-          # TODO: use types.raw once this PR is merged: https://github.com/NixOS/nixpkgs/pull/132448
-          listOf (mkOptionType {
-            name = "submodule";
-            inherit (submodule { }) check;
-            merge = lib.options.mergeOneOption;
-            description = "Home Manager modules";
-          });
-        default = [ ];
-        example = literalExpression "[ { home.packages = [ nixpkgs-fmt ]; } ]";
-        description = ''
-          Extra modules added to all users.
-        '';
-      };
-
-      verbose = mkEnableOption "verbose output on activation";
-
-      users = mkOption {
-        type = types.attrsOf hmModule;
-        default = {};
-        # Set as not visible to prevent the entire submodule being included in
-        # the documentation.
-        visible = false;
-        description = ''
-          Per-user Home Manager configuration.
-        '';
-      };
-    };
-  };
-
-  config = mkIf (cfg.users != {}) {
-    warnings =
-      flatten (flip mapAttrsToList cfg.users (user: config:
-        flip map config.warnings (warning:
-          "${user} profile: ${warning}"
-        )
-      ));
-
-    assertions =
-      flatten (flip mapAttrsToList cfg.users (user: config:
-        flip map config.assertions (assertion:
-          {
-            inherit (assertion) assertion;
-            message = "${user} profile: ${assertion.message}";
+  config = mkMerge [
+    { home-manager.extraSpecialArgs.darwinConfig = config; }
+    (mkIf (cfg.users != { }) {
+      system.activationScripts.postActivation.text = concatStringsSep "\n"
+        (mapAttrsToList (username: usercfg: ''
+          echo Activating home-manager configuration for ${username}
+          sudo -u ${username} -s --set-home ${
+            pkgs.writeShellScript "activation-${username}" ''
+              ${lib.optionalString (cfg.backupFileExtension != null)
+              "export HOME_MANAGER_BACKUP_EXT=${
+                lib.escapeShellArg cfg.backupFileExtension
+              }"}
+              ${lib.optionalString cfg.verbose "export VERBOSE=1"}
+              exec ${usercfg.home.activationPackage}/activate
+            ''
           }
-        )
-      ));
-
-    users.users = mkIf cfg.useUserPackages (
-      mapAttrs (username: usercfg: {
-        packages = [ usercfg.home.path ];
-      }) cfg.users
-    );
-
-    environment.pathsToLink = mkIf cfg.useUserPackages [ "/etc/profile.d" ];
-
-    system.activationScripts.postActivation.text =
-      concatStringsSep "\n" (mapAttrsToList (username: usercfg: ''
-        echo Activating home-manager configuration for ${username}
-        sudo -u ${username} -s --set-home ${pkgs.writeShellScript "activation-${username}" ''
-          ${lib.optionalString (cfg.backupFileExtension != null)
-            "export HOME_MANAGER_BACKUP_EXT=${lib.escapeShellArg cfg.backupFileExtension}"}
-          ${lib.optionalString cfg.verbose "export VERBOSE=1"}
-          exec ${usercfg.home.activationPackage}/activate
-        ''}
-      '') cfg.users);
-  };
+        '') cfg.users);
+    })
+  ];
 }

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -6,180 +6,80 @@ let
 
   cfg = config.home-manager;
 
-  extendedLib = import ../modules/lib/stdlib-extended.nix pkgs.lib;
-
-  hmModule = types.submoduleWith {
-    specialArgs = {
-      lib = extendedLib;
-      nixosConfig = config;
-      osConfig = config;
-      modulesPath = builtins.toString ../modules;
-    } // cfg.extraSpecialArgs;
-    modules = [
-      ({ name, ... }: {
-        imports = import ../modules/modules.nix {
-          inherit pkgs;
-          lib = extendedLib;
-          useNixpkgsModule = !cfg.useGlobalPkgs;
-        };
-
-        config = {
-          submoduleSupport.enable = true;
-          submoduleSupport.externalPackageInstall = cfg.useUserPackages;
-
-          # The per-user directory inside /etc/profiles is not known by
-          # fontconfig by default.
-          fonts.fontconfig.enable = cfg.useUserPackages
-            && config.fonts.fontconfig.enable;
-
-          home.username = config.users.users.${name}.name;
-          home.homeDirectory = config.users.users.${name}.home;
-
-          # Make activation script use same version of Nix as system as a whole.
-          # This avoids problems with Nix not being in PATH.
-          home.extraActivationPath = [ config.nix.package ];
-        };
-      })
-    ] ++ cfg.sharedModules;
-  };
-
   serviceEnvironment = optionalAttrs (cfg.backupFileExtension != null) {
     HOME_MANAGER_BACKUP_EXT = cfg.backupFileExtension;
   } // optionalAttrs cfg.verbose { VERBOSE = "1"; };
 
 in {
-  options = {
-    home-manager = {
-      useUserPackages = mkEnableOption ''
-        installation of user packages through the
-        <option>users.users.&lt;name&gt;.packages</option> option
-      '';
+  imports = [ ../integration-common.nix ];
 
-      useGlobalPkgs = mkEnableOption ''
-        using the system configuration's <literal>pkgs</literal>
-        argument in Home Manager. This disables the Home Manager
-        options <option>nixpkgs.*</option>
-      '';
+  config = mkMerge [
+    {
+      home-manager = {
+        extraSpecialArgs.nixosConfig = config;
 
-      backupFileExtension = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = "backup";
-        description = ''
-          On activation move existing files by appending the given
-          file extension rather than exiting with an error.
-        '';
+        sharedModules = [{
+          # The per-user directory inside /etc/profiles is not known by
+          # fontconfig by default.
+          fonts.fontconfig.enable = cfg.useUserPackages
+            && config.fonts.fontconfig.enable;
+        }];
       };
+    }
+    (mkIf (cfg.users != { }) {
+      systemd.services = mapAttrs' (_: usercfg:
+        let username = usercfg.home.username;
+        in nameValuePair ("home-manager-${utils.escapeSystemdPath username}") {
+          description = "Home Manager environment for ${username}";
+          wantedBy = [ "multi-user.target" ];
+          wants = [ "nix-daemon.socket" ];
+          after = [ "nix-daemon.socket" ];
+          before = [ "systemd-user-sessions.service" ];
 
-      extraSpecialArgs = mkOption {
-        type = types.attrs;
-        default = { };
-        example = literalExpression "{ inherit emacs-overlay; }";
-        description = ''
-          Extra <literal>specialArgs</literal> passed to Home Manager. This
-          option can be used to pass additional arguments to all modules.
-        '';
-      };
+          environment = serviceEnvironment;
 
-      sharedModules = mkOption {
-        type = with types;
-        # TODO: use types.raw once this PR is merged: https://github.com/NixOS/nixpkgs/pull/132448
-          listOf (mkOptionType {
-            name = "submodule";
-            inherit (submodule { }) check;
-            merge = lib.options.mergeOneOption;
-            description = "Home Manager modules";
-          });
-        default = [ ];
-        example = literalExpression "[ { home.packages = [ nixpkgs-fmt ]; } ]";
-        description = ''
-          Extra modules added to all users.
-        '';
-      };
+          unitConfig = { RequiresMountsFor = usercfg.home.homeDirectory; };
 
-      verbose = mkEnableOption "verbose output on activation";
+          stopIfChanged = false;
 
-      users = mkOption {
-        type = types.attrsOf hmModule;
-        default = { };
-        # Set as not visible to prevent the entire submodule being included in
-        # the documentation.
-        visible = false;
-        description = ''
-          Per-user Home Manager configuration.
-        '';
-      };
-    };
-  };
+          serviceConfig = {
+            User = usercfg.home.username;
+            Type = "oneshot";
+            RemainAfterExit = "yes";
+            TimeoutStartSec = 90;
+            SyslogIdentifier = "hm-activate-${username}";
 
-  config = mkIf (cfg.users != { }) {
-    warnings = flatten (flip mapAttrsToList cfg.users (user: config:
-      flip map config.warnings (warning: "${user} profile: ${warning}")));
+            ExecStart = let
+              systemctl =
+                "XDG_RUNTIME_DIR=\${XDG_RUNTIME_DIR:-/run/user/$UID} systemctl";
 
-    assertions = flatten (flip mapAttrsToList cfg.users (user: config:
-      flip map config.assertions (assertion: {
-        inherit (assertion) assertion;
-        message = "${user} profile: ${assertion.message}";
-      })));
+              sed = "${pkgs.gnused}/bin/sed";
 
-    users.users = mkIf cfg.useUserPackages
-      (mapAttrs (username: usercfg: { packages = [ usercfg.home.path ]; })
-        cfg.users);
+              exportedSystemdVariables = concatStringsSep "|" [
+                "DBUS_SESSION_BUS_ADDRESS"
+                "DISPLAY"
+                "WAYLAND_DISPLAY"
+                "XAUTHORITY"
+                "XDG_RUNTIME_DIR"
+              ];
 
-    environment.pathsToLink = mkIf cfg.useUserPackages [ "/etc/profile.d" ];
+              setupEnv = pkgs.writeScript "hm-setup-env" ''
+                #! ${pkgs.runtimeShell} -el
 
-    systemd.services = mapAttrs' (_: usercfg:
-      let username = usercfg.home.username;
-      in nameValuePair ("home-manager-${utils.escapeSystemdPath username}") {
-        description = "Home Manager environment for ${username}";
-        wantedBy = [ "multi-user.target" ];
-        wants = [ "nix-daemon.socket" ];
-        after = [ "nix-daemon.socket" ];
-        before = [ "systemd-user-sessions.service" ];
+                # The activation script is run by a login shell to make sure
+                # that the user is given a sane environment.
+                # If the user is logged in, import variables from their current
+                # session environment.
+                eval "$(
+                  ${systemctl} --user show-environment 2> /dev/null \
+                  | ${sed} -En '/^(${exportedSystemdVariables})=/s/^/export /p'
+                )"
 
-        environment = serviceEnvironment;
-
-        unitConfig = { RequiresMountsFor = usercfg.home.homeDirectory; };
-
-        stopIfChanged = false;
-
-        serviceConfig = {
-          User = usercfg.home.username;
-          Type = "oneshot";
-          RemainAfterExit = "yes";
-          TimeoutStartSec = 90;
-          SyslogIdentifier = "hm-activate-${username}";
-
-          ExecStart = let
-            systemctl =
-              "XDG_RUNTIME_DIR=\${XDG_RUNTIME_DIR:-/run/user/$UID} systemctl";
-
-            sed = "${pkgs.gnused}/bin/sed";
-
-            exportedSystemdVariables = concatStringsSep "|" [
-              "DBUS_SESSION_BUS_ADDRESS"
-              "DISPLAY"
-              "WAYLAND_DISPLAY"
-              "XAUTHORITY"
-              "XDG_RUNTIME_DIR"
-            ];
-
-            setupEnv = pkgs.writeScript "hm-setup-env" ''
-              #! ${pkgs.runtimeShell} -el
-
-              # The activation script is run by a login shell to make sure
-              # that the user is given a sane environment.
-              # If the user is logged in, import variables from their current
-              # session environment.
-              eval "$(
-                ${systemctl} --user show-environment 2> /dev/null \
-                | ${sed} -En '/^(${exportedSystemdVariables})=/s/^/export /p'
-              )"
-
-              exec "$1/activate"
-            '';
-          in "${setupEnv} ${usercfg.home.activationPackage}";
-        };
-      }) cfg.users;
-  };
+                exec "$1/activate"
+              '';
+            in "${setupEnv} ${usercfg.home.activationPackage}";
+          };
+        }) cfg.users;
+    })
+  ];
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4,12 +4,7 @@ let
 
   lib = import ../modules/lib/stdlib-extended.nix pkgs.lib;
 
-  nmt = pkgs.fetchFromGitLab {
-    owner = "rycee";
-    repo = "nmt";
-    rev = "d83601002c99b78c89ea80e5e6ba21addcfe12ae";
-    sha256 = "1xzwwxygzs1cmysg97hzd285r7n1g1lwx5y1ar68gwq07a1rczmv";
-  };
+  inherit ((import ./.. { }).inputs) nmt;
 
   modules = import ../modules/modules.nix {
     inherit lib pkgs;


### PR DESCRIPTION
### Description

Lays the groundwork for https://github.com/NixOS/nixos-search/issues/323 by making
```
nix run nixos-search#flake-info -- flake github:nix-community/home-manager
```
succeed. Note that this PR does **NOT** solve the [problem](https://github.com/nix-community/home-manager/issues/2297#issuecomment-1079698898) of how to expose Home Manager modules/options in the flake, it only ensures that we can index packages and NixOS options.

Best reviewed one commit at a time.

This PR partly supersedes https://github.com/nix-community/home-manager/pull/1934, although it does not add an auto-update workflow.

Tested the NixOS module and the manual. nix-darwin testers welcome.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
