### PR TITLE
neovim/coc: add package option

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -66,7 +66,7 @@ let
 
   allPlugins = cfg.plugins ++ optional cfg.coc.enable {
     type = "viml";
-    plugin = pkgs.vimPlugins.coc-nvim;
+    plugin = cfg.coc.package;
     config = cfg.coc.pluginConfig;
     optional = false;
   };
@@ -301,6 +301,13 @@ in {
 
       coc = {
         enable = mkEnableOption "Coc";
+
+        package = mkOption {
+          type = types.package;
+          default = pkgs.vimPlugins.coc-nvim;
+          defaultText = literalExpression "pkgs.vimPlugins.coc-nvim";
+          description = "The package to use for the CoC plugin.";
+        };
 
         settings = mkOption {
           type = jsonFormat.type;


### PR DESCRIPTION
### Description

Adds a `package` option for the CoC.

Allows users to override the coc package so that things like #2966 can be fixed.

CC: @t4ccer 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
