### PR TITLE
bspwm: add missing rule setting `rectangle`

### DIFF
--- a/modules/services/window-managers/bspwm/options.nix
+++ b/modules/services/window-managers/bspwm/options.nix
@@ -4,7 +4,11 @@ with lib;
 
 let
 
+  primitive = with types; oneOf [ bool int float str ];
+
   rule = types.submodule {
+    freeformType = with types; attrsOf primitive;
+
     options = {
       monitor = mkOption {
         type = types.nullOr types.str;
@@ -139,6 +143,14 @@ let
         description = "Whether the node should have border.";
         example = true;
       };
+
+      rectangle = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description =
+          "The node's geometry, in the format <literal>WxH+X+Y</literal>.";
+        example = "800x600+32+32";
+      };
     };
   };
 
@@ -155,9 +167,7 @@ in {
     };
 
     settings = mkOption {
-      type = with types;
-        let primitive = either bool (either int (either float str));
-        in attrsOf (either primitive (listOf primitive));
+      type = with types; attrsOf (either primitive (listOf primitive));
       default = { };
       description = "General settings given to <literal>bspc config</literal>.";
       example = {

--- a/tests/modules/services/window-managers/bspwm/bspwmrc
+++ b/tests/modules/services/window-managers/bspwm/bspwmrc
@@ -9,7 +9,7 @@ bspc config 'ignore_ewmh_fullscreen' 'enter,exit'
 bspc config 'split_ratio' '0.520000'
 
 bspc rule -r '*'
-bspc rule -a '*' 'center=off' 'desktop=d'\''esk top#next' 'split_dir=north' 'sticky=on'
+bspc rule -a '*' 'center=off' 'desktop=d'\''esk top#next' 'split_dir=north' 'sticky=on' 'unknown_rule=42'
 
 # java gui fixes
 export _JAVA_AWT_WM_NONREPARENTING=1

--- a/tests/modules/services/window-managers/bspwm/configuration.nix
+++ b/tests/modules/services/window-managers/bspwm/configuration.nix
@@ -22,6 +22,7 @@ with lib;
         desktop = "d'esk top#next";
         splitDir = "north";
         border = null;
+        unknownRule = 42;
       };
       extraConfig = ''
         extra config


### PR DESCRIPTION
Also add a `freeformType` so that we don't have to do this in the future.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
