### PR TITLE
getmail: Use newer getmail6 over getmail package

### DIFF
--- a/modules/services/getmail.nix
+++ b/modules/services/getmail.nix
@@ -44,7 +44,7 @@ in {
 
     systemd.user.services.getmail = {
       Unit = { Description = "getmail email fetcher"; };
-      Service = { ExecStart = "${pkgs.getmail}/bin/getmail ${configFiles}"; };
+      Service = { ExecStart = "${pkgs.getmail6}/bin/getmail ${configFiles}"; };
     };
 
     systemd.user.timers.getmail = {


### PR DESCRIPTION
The `getmail` package will soon be removed from nixpkgs. The
`nixos-unstable` channel already has it removed and using the service
will result in:

    error: getmail has been removed from nixpkgs, migrate to getmail6

Upgrade to the getmail6 package which is already available and backwards
compatible.