### PR TITLE
doc: make documentation links more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,16 @@ using the [Nix][] package manager together with the Nix libraries
 found in [Nixpkgs][]. It allows declarative configuration of user
 specific (non global) packages and dotfiles.
 
+Usage
+-----
+
 Before attempting to use Home Manager please read the warning below.
 
-For a more systematic overview of Home Manager and its available
-options, please see the Home Manager [manual][manual] and
-[options][configuration options].
+For a systematic overview of Home Manager and its available options,
+please see
+
+- the [Home Manager manual][manual] and
+- the [Home Manager configuration options][configuration options].
 
 If you would like to contribute to Home Manager
 then please have a look at the [contributing][] chapter of the manual.


### PR DESCRIPTION
### Description

Making the documentation links stand out more - previously it was easy to miss them, because they were only single words. Also adding a Usage section to highlight them even more - I can't begin to tell you how many times I've googled "home-manager configuration" or ended up on the URL https://rycee.gitlab.io/home-manager/options.html instead of https://nix-community.github.io/home-manager/options.html .

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
