### PR TITLE
fish: enable manpage completion

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -285,6 +285,9 @@ in {
     {
       home.packages = [ cfg.package ];
 
+      # Support completion for `man` by building a cache for `apropos`.
+      programs.man.generateCaches = mkDefault true;
+
       xdg.dataFile."fish/home-manager_generated_completions".source = let
         # paths later in the list will overwrite those already linked
         destructiveSymlinkJoin = args_@{ name, paths, preferLocalBuild ? true


### PR DESCRIPTION
### Description

This patch follows a similar patch[1] in nixpkgs. With this patch,
fish can complete manpages for programs installed through
home-manager, e.g. using home.packages.

[1]: https://github.com/NixOS/nixpkgs/pull/91794


### Checklist


- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
