### PR TITLE
programs.zsh: set ZPLUG_HOME before loading zplug

### DIFF
--- a/modules/programs/zplug.nix
+++ b/modules/programs/zplug.nix
@@ -45,9 +45,9 @@ in {
     home.packages = [ pkgs.zplug ];
 
     programs.zsh.initExtraBeforeCompInit = ''
-      source ${pkgs.zplug}/init.zsh
-
       export ZPLUG_HOME=${cfg.zplugHome}
+
+      source ${pkgs.zplug}/init.zsh
 
       ${optionalString (cfg.plugins != [ ]) ''
         ${concatStrings (map (plugin: ''


### PR DESCRIPTION
### Description

This is a minor bugfix. The option `zplugHome` of the `zplug` module allows to set the directory to which `zplug` downloads plugins. The option sets the shell variable `ZPLUG_HOME` accordingly. However, currently this is set **after** initializing `zplug` via `source ${pkgs.zplug}/init.zsh`. To be taken into account, the variable must be set before the initialization. To fix this, I simply swapped the two lines. This order is also used in `zplug`'s own tests, see [misc/zshrc in zplug](https://github.com/zplug/zplug/blob/c4dea766566b168a32dbfa8d10335e525ce39fcc/misc/zshrc#L6-L11).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] ~~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~~

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~~If this PR adds a new module~~

  - [ ] ~~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~~

  - [ ] ~~Added myself and the module files to `.github/CODEOWNERS`.~~
