### PR TITLE
htop: add missing fields

### DIFF
--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -42,6 +42,8 @@ let
     TIME = 49;
     NLWP = 50;
     TGID = 51;
+    PERCENT_NORM_CPU = 52;
+    ELAPSED = 53;
     CMINFLT = 10;
     CMAJFLT = 12;
     UTIME = 13;


### PR DESCRIPTION
### Description

These new fields were added in htop 3.0.3 (PERCENT_NORM_CPU) and 3.1.0 (ELAPSED).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
