### PR TITLE
pywal: fixed i3 config

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -164,6 +164,7 @@ let
     ./programs/vim.nix
     ./programs/vscode.nix
     ./programs/vscode/haskell.nix
+    ./programs/pywal.nix
     ./programs/watson.nix
     ./programs/waybar.nix
     ./programs/xmobar.nix

--- a/modules/programs/pywal.nix
+++ b/modules/programs/pywal.nix
@@ -25,6 +25,11 @@ in {
     programs.rofi.theme."@import" =
       "${config.xdg.cacheHome}/wal/colors-rofi-dark.rasi";
 
+    programs.neovim.plugins = [{
+      plugin = pkgs.vimPlugins.pywal-nvim;
+      type = "lua";
+    }];
+
     # wal generates and that's the one we should load from /home/teto/.cache/wal/colors.Xresources ~/.Xresources
     xsession.windowManager.i3 = {
       extraConfig = ''


### PR DESCRIPTION
module was never imported and thus useless. This adds a neovim plugin too.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
