### PR TITLE
swaylock: Add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -248,6 +248,7 @@
 /modules/programs/starship.nix                        @marsam
 
 /modules/programs/swaylock.nix                        @rcerc
+/tests/modules/programs/swaylock                      @rcerc
 
 /modules/programs/tealdeer.nix                        @marsam
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -247,6 +247,8 @@
 
 /modules/programs/starship.nix                        @marsam
 
+/modules/programs/swaylock.nix                        @rcerc
+
 /modules/programs/tealdeer.nix                        @marsam
 
 /modules/programs/terminator.nix                      @chisui

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -271,4 +271,14 @@
     github = "rszamszur";
     githubId = 10353018;
   };
+  rcerc = {
+    name = "rcerc";
+    email = "88944439+rcerc@users.noreply.github.com";
+    github = "rcerc";
+    githubId = 88944439;
+    keys = [{
+      longkeyid = "ed25519/0x3F98EC7EC2B87ED1";
+      fingerprint = "D5D6 FD1F 0D9A 3284 FB9B  C26D 3F98 EC7E C2B8 7ED1";
+    }];
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -150,6 +150,7 @@ let
     ./programs/sqls.nix
     ./programs/ssh.nix
     ./programs/starship.nix
+    ./programs/swaylock.nix
     ./programs/taskwarrior.nix
     ./programs/tealdeer.nix
     ./programs/terminator.nix

--- a/modules/programs/swaylock.nix
+++ b/modules/programs/swaylock.nix
@@ -1,0 +1,32 @@
+{ config, lib, ... }:
+
+let cfg = config.programs.swaylock;
+in {
+  meta.maintainers = [ lib.hm.maintainers.rcerc ];
+
+  options.programs.swaylock.settings = lib.mkOption {
+    type = with lib.types; attrsOf (oneOf [ bool float int str ]);
+    default = { };
+    description = ''
+      Default arguments to <command>swaylock</command>. An empty set
+      disables configuration generation.
+    '';
+    example = {
+      color = "808080";
+      font-size = 24;
+      indicator-idle-visible = false;
+      indicator-radius = 100;
+      line-color = "ffffff";
+      show-failed-attempts = true;
+    };
+  };
+
+  config.xdg.configFile."swaylock/config" = lib.mkIf (cfg.settings != { }) {
+    text = lib.concatStrings (lib.mapAttrsToList (n: v:
+      if v == false then
+        ""
+      else
+        (if v == true then n else n + "=" + builtins.toString v) + "\n")
+      cfg.settings);
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -135,6 +135,7 @@ import nmt {
     ./modules/programs/rbw
     ./modules/programs/rofi
     ./modules/programs/rofi-pass
+    ./modules/programs/swaylock
     ./modules/programs/terminator
     ./modules/programs/waybar
     ./modules/programs/xmobar

--- a/tests/modules/programs/swaylock/config
+++ b/tests/modules/programs/swaylock/config
@@ -1,0 +1,5 @@
+color=808080
+font-size=24
+indicator-radius=100
+line-color=ffffff
+show-failed-attempts

--- a/tests/modules/programs/swaylock/default.nix
+++ b/tests/modules/programs/swaylock/default.nix
@@ -1,0 +1,4 @@
+{
+  swaylock-disabled = import ./disabled.nix;
+  swaylock-settings = import ./settings.nix;
+}

--- a/tests/modules/programs/swaylock/disabled.nix
+++ b/tests/modules/programs/swaylock/disabled.nix
@@ -1,0 +1,7 @@
+{ ... }: {
+  programs.swaylock.settings = { };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/swaylock/config
+  '';
+}

--- a/tests/modules/programs/swaylock/settings.nix
+++ b/tests/modules/programs/swaylock/settings.nix
@@ -1,0 +1,16 @@
+{ ... }: {
+  programs.swaylock.settings = {
+    color = "808080";
+    font-size = 24;
+    indicator-idle-visible = false; # Test that this does nothing
+    indicator-radius = 100;
+    line-color = "ffffff";
+    show-failed-attempts = true;
+  };
+
+  nmt.script = let homeConfig = "home-files/.config/swaylock/config";
+  in ''
+    assertFileExists ${homeConfig}
+    assertFileContent ${homeConfig} ${./config}
+  '';
+}


### PR DESCRIPTION
### Description

This adds a module to configure [swaylock](https://github.com/swaywm/swaylock) (a screen locker for Wayland). All swaylock options must be specified through `programs.swaylock.settings` and the user must give them appropriate types (because there are no Home Manager options for specific swaylock options). This is done for forward compatibility (but could be changed if necessary). Unless `programs.swaylock.settings` is an empty set, the swaylock configuration file is automatically added to the user's home directory (this should be fine because the user can forcefully disable it by setting `programs.swaylock.settings` to `lib.mkForce { }`).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.