### PR TITLE
mcfly: add fuzzy search factor option

### DIFF
--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -8,6 +8,17 @@ let
 in {
   meta.maintainers = [ maintainers.marsam ];
 
+  imports = [
+    (mkChangedOptionModule # \
+      [ "programs" "mcfly" "enableFuzzySearch" ] # \
+      [ "programs" "mcfly" "fuzzySearchFactor" ] # \
+      (config:
+        let
+          value =
+            getAttrFromPath [ "programs" "mcfly" "enableFuzzySearch" ] config;
+        in if value then 2 else 0))
+  ];
+
   options.programs.mcfly = {
     enable = mkEnableOption "mcfly";
 
@@ -27,11 +38,13 @@ in {
       '';
     };
 
-    enableFuzzySearch = mkOption {
-      default = false;
-      type = types.bool;
+    fuzzySearchFactor = mkOption {
+      default = 0;
+      type = types.ints.unsigned;
       description = ''
         Whether to enable fuzzy searching.
+        0 is off; higher numbers weight toward shorter matches.
+        Values in the 2-5 range get good results so far.
       '';
     };
 
@@ -81,6 +94,8 @@ in {
 
     (mkIf cfg.enableLightTheme { home.sessionVariables.MCFLY_LIGHT = "TRUE"; })
 
-    (mkIf cfg.enableFuzzySearch { home.sessionVariables.MCFLY_FUZZY = "TRUE"; })
+    (mkIf (cfg.fuzzySearchFactor > 0) {
+      home.sessionVariables.MCFLY_FUZZY = cfg.fuzzySearchFactor;
+    })
   ]);
 }


### PR DESCRIPTION
Per the [docs], MCFLY_FUZZY is no longer a boolean, taking now a
positive integer that controls the fuzziness factor.

[docs]: https://github.com/cantino/mcfly#fuzzy-searching

Thanks for writing and maintaining home-manager 🎉 !

<details>
<summary>PR checklist</summary>  

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like [...]
</details>

