### PR TITLE
docs: disable `_module.check` for nixos/nix-darwin modules

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -18,6 +18,8 @@ let
     }];
   };
 
+  dontCheckDefinitions = { _module.check = false; };
+
   buildModulesDocs = args:
     nmd.buildModulesDocs ({
       moduleRootPaths = [ ./.. ];
@@ -35,21 +37,7 @@ let
   };
 
   nixosModuleDocs = buildModulesDocs {
-    modules = let
-      nixosModule = module: pkgs.path + "/nixos/modules" + module;
-      mockedNixos = with lib; {
-        options = {
-          environment.pathsToLink = mkSinkUndeclaredOptions { };
-          systemd.services = mkSinkUndeclaredOptions { };
-          users.users = mkSinkUndeclaredOptions { };
-        };
-      };
-    in [
-      ../nixos/default.nix
-      mockedNixos
-      (nixosModule "/misc/assertions.nix")
-      scrubbedPkgsModule
-    ];
+    modules = [ ../nixos scrubbedPkgsModule dontCheckDefinitions ];
     docBook = {
       id = "nixos-options";
       optionIdPrefix = "nixos-opt";
@@ -57,22 +45,7 @@ let
   };
 
   nixDarwinModuleDocs = buildModulesDocs {
-    modules = let
-      nixosModule = module: pkgs.path + "/nixos/modules" + module;
-      mockedNixDarwin = with lib; {
-        options = {
-          environment.pathsToLink = mkSinkUndeclaredOptions { };
-          system.activationScripts.postActivation.text =
-            mkSinkUndeclaredOptions { };
-          users.users = mkSinkUndeclaredOptions { };
-        };
-      };
-    in [
-      ../nix-darwin/default.nix
-      mockedNixDarwin
-      (nixosModule "/misc/assertions.nix")
-      scrubbedPkgsModule
-    ];
+    modules = [ ../nix-darwin scrubbedPkgsModule dontCheckDefinitions ];
     docBook = {
       id = "nix-darwin-options";
       optionIdPrefix = "nix-darwin-opt";


### PR DESCRIPTION
Currently we're maintaining a "mock" module made of sink options, which requires updating whenever the definitions in the nixos/nix-darwin modules change.

Instead, set `_module.check` to false so that definitions in those modules are simply ignored.

This is [what we do](https://github.com/NixOS/nixos-search/blob/75e8457105ee6a9d3f60c71add59661bb809f236/flake-info/src/commands/flake_info.nix#L53) in nixos-search.

This could probably also be done in nmd by default.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
