### PR TITLE
barrier: change `enableCrypto` behaviour

### DIFF
--- a/modules/services/barrier.nix
+++ b/modules/services/barrier.nix
@@ -70,7 +70,7 @@ in {
       Service.ExecStart = with cfg.client;
         toString ([ "${pkgs.barrier}/bin/barrierc" ]
           ++ optional (name != null) "--name ${name}"
-          ++ optional enableCrypto "--enable-crypto"
+          ++ optional (!enableCrypto) "--disable-crypto"
           ++ optional enableDragDrop "--enable-drag-drop" ++ extraFlags
           ++ [ server ]);
     };

--- a/tests/modules/services/barrier/basic-configuration.nix
+++ b/tests/modules/services/barrier/basic-configuration.nix
@@ -13,7 +13,7 @@
       clientServiceFile=home-files/.config/systemd/user/barrierc.service
 
       assertFileExists $clientServiceFile
-      assertFileRegex $clientServiceFile 'ExecStart=.*/bin/barrierc --enable-crypto -f testServer'
+      assertFileRegex $clientServiceFile 'ExecStart=.*/bin/barrierc -f testServer'
     '';
   };
 }


### PR DESCRIPTION
### Description

`--enable-crypto` is deprecated because crypto is now enabled by default.
`--disable-crypto` should be used instead.

Fixes https://github.com/nix-community/home-manager/issues/3001

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
