### PR TITLE
emacs: extend startWithUserSession to start after graphical session

### DIFF
--- a/tests/modules/services/emacs/default.nix
+++ b/tests/modules/services/emacs/default.nix
@@ -1,6 +1,8 @@
 {
   emacs-service-27 = ./emacs-service-27.nix;
   emacs-service-28 = ./emacs-service-28.nix;
+  emacs-service-28-after-graphical-session-target =
+    ./emacs-service-28-after-graphical-session-target.nix;
   emacs-socket-27 = ./emacs-socket-27.nix;
   emacs-socket-28 = ./emacs-socket-28.nix;
   emacs-default-editor = ./emacs-default-editor.nix;

--- a/tests/modules/services/emacs/emacs-service-28-after-graphical-session-target.nix
+++ b/tests/modules/services/emacs/emacs-service-28-after-graphical-session-target.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    nixpkgs.overlays = [
+      (self: super: rec {
+        emacs = pkgs.writeShellScriptBin "dummy-emacs-28.2" "" // {
+          outPath = "@emacs@";
+        };
+        emacsPackagesFor = _:
+          makeScope super.newScope (_: { emacsWithPackages = _: emacs; });
+      })
+    ];
+
+    programs.emacs.enable = true;
+    services.emacs.enable = true;
+    services.emacs.client.enable = true;
+    services.emacs.extraOptions = [ "-f" "exwm-enable" ];
+    services.emacs.startWithUserSession = "graphical";
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/systemd/user/emacs.socket
+      assertFileExists home-files/.config/systemd/user/emacs.service
+      assertFileExists home-path/share/applications/emacsclient.desktop
+
+      assertFileContent home-files/.config/systemd/user/emacs.service \
+                        ${
+                          pkgs.substituteAll {
+                            inherit (pkgs) runtimeShell;
+                            src =
+                              ./emacs-service-emacs-after-graphical-session-target.service;
+                          }
+                        }
+      assertFileContent home-path/share/applications/emacsclient.desktop \
+                        ${./emacs-28-emacsclient.desktop}
+    '';
+  };
+}

--- a/tests/modules/services/emacs/emacs-service-emacs-after-graphical-session-target.service
+++ b/tests/modules/services/emacs/emacs-service-emacs-after-graphical-session-target.service
@@ -1,0 +1,15 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon '-f' 'exwm-enable'"
+Restart=on-failure
+SuccessExitStatus=15
+Type=notify
+
+[Unit]
+After=graphical-session.target
+Description=Emacs text editor
+Documentation=info:emacs man:emacs(1) https://gnu.org/software/emacs/
+PartOf=graphical-session.target
+X-RestartIfChanged=false


### PR DESCRIPTION
### Description

It's useful if you want emacs daemon to get some environment variables, e.g. ibus related variables when using Gnome.

### Checklist


- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
