### PR TITLE
neovim: add missing literalExpression in module docs

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -161,7 +161,7 @@ in {
       extraPython3Packages = mkOption {
         type = with types; either extraPython3PackageType (listOf package);
         default = (_: [ ]);
-        defaultText = "ps: []";
+        defaultText = literalExpression "ps: [ ]";
         example = literalExpression "(ps: with ps; [ python-language-server ])";
         description = ''
           A function in python.withPackages format, which returns a
@@ -172,7 +172,7 @@ in {
       extraLuaPackages = mkOption {
         type = with types; either extraLua51PackageType (listOf package);
         default = [ ];
-        defaultText = "[]";
+        defaultText = literalExpression "[ ]";
         example = literalExpression "(ps: with ps; [ luautf8 ])";
         description = ''
           A function in lua5_1.withPackages format, which returns a
@@ -273,7 +273,7 @@ in {
       extraPackages = mkOption {
         type = with types; listOf package;
         default = [ ];
-        example = "[ pkgs.shfmt ]";
+        example = literalExpression "[ pkgs.shfmt ]";
         description = "Extra packages available to nvim.";
       };
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Saw some examples rendered wrong in the `neovim` docs. Easy fix.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
