### PR TITLE
integration-common: set hmModule's description directly

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654230545,
-        "narHash": "sha256-8Vlwf0x8ow6pPOK2a04bT+pxIeRnM1+O0Xv9/CuDzRs=",
+        "lastModified": 1654953433,
+        "narHash": "sha256-TwEeh4r50NdWHFAHQSyjCk2cZxgwUfcCCAJOhPdXB28=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "236cc2971ac72acd90f0ae3a797f9f83098b17ec",
+        "rev": "90cd5459a1fd707819b9a3fb9c852beaaac3b79a",
         "type": "github"
       },
       "original": {

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -11,7 +11,8 @@ let
 
   extendedLib = import ../modules/lib/stdlib-extended.nix pkgs.lib;
 
-  hmModule' = types.submoduleWith {
+  hmModule = types.submoduleWith {
+    description = "Home Manager module";
     specialArgs = {
       lib = extendedLib;
       osConfig = config;
@@ -38,16 +39,6 @@ let
         };
       })
     ] ++ cfg.sharedModules;
-  } // {
-    description = "Home Manager module";
-  };
-
-  # TODO: hack until https://github.com/NixOS/nixpkgs/pull/173621 lands
-  hmModule = hmModule' // {
-    substSubModules = m:
-      hmModule'.substSubModules m // {
-        inherit (hmModule') description;
-      };
   };
 
 in {


### PR DESCRIPTION
Depends on https://github.com/NixOS/nixpkgs/pull/173621 which just landed, let's wait a couple weeks before merging.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
