### PR TITLE
xdg-user-dirs: `createXdgUserDirectories` after `linkGeneration`

### DIFF
--- a/modules/misc/xdg-user-dirs.nix
+++ b/modules/misc/xdg-user-dirs.nix
@@ -120,12 +120,10 @@ in {
 
     home.sessionVariables = directories;
 
-    home.activation = mkIf cfg.createDirectories {
-      createXdgUserDirectories = let
-        directoriesList = attrValues directories;
-        mkdir = (dir: ''$DRY_RUN_CMD mkdir -p $VERBOSE_ARG "${dir}"'');
-      in lib.hm.dag.entryAfter [ "writeBoundary" ]
-      (strings.concatMapStringsSep "\n" mkdir directoriesList);
-    };
+    home.activation.createXdgUserDirectories = mkIf cfg.createDirectories (let
+      directoriesList = attrValues directories;
+      mkdir = (dir: ''$DRY_RUN_CMD mkdir -p $VERBOSE_ARG "${dir}"'');
+    in lib.hm.dag.entryAfter [ "linkGeneration" ]
+    (strings.concatMapStringsSep "\n" mkdir directoriesList));
   };
 }


### PR DESCRIPTION
In the scenario where some XDG user directory is a symlink defined by `home.file`, we want the symlink to be created before we try to `mkdir -p` that directory, as it will then silently succeed.

On the other hand, if we create the directory first, creating the symlink will fail (in a surprising way, see https://github.com/nix-community/home-manager/pull/3018).

We lose nothing by doing this as `linkGeneration` creates the directories it needs.

We can also fix the `mkIf` weirdness since https://github.com/nix-community/home-manager/pull/2822.

cc @thiagokokada 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
