### PR TITLE
files: avoid surprises when linking files

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -185,8 +185,9 @@ in
               $VERBOSE_ECHO "Skipping '$targetPath' as it is identical to '$sourcePath'"
             else
               # Place that symlink, --force
+              # This can still fail if the target is a directory, in which case we bail out.
               $DRY_RUN_CMD mkdir -p $VERBOSE_ARG "$(dirname "$targetPath")"
-              $DRY_RUN_CMD ln -nsf $VERBOSE_ARG "$sourcePath" "$targetPath"
+              $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG "$sourcePath" "$targetPath" || exit 1
             fi
           done
         '';


### PR DESCRIPTION
In the unlikely (but possible) event that a directory is created in place of a target file *after* `checkLinkTargets` but *before* `linkGeneration`, currently the link is created *inside* the directory, which is surprising (see https://github.com/nix-community/home-manager/pull/3017 for context).

To avoid this, use `ln -T` and bail if it fails.

~Also bail if backing up the target fails.~

Ideally, `checkLinkTargets` and `linkGeneration` should be more tightly coupled.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
