### PR TITLE
flake.nix: Allow homeManagerConfiguration to accept a list of modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,10 @@
           import ./modules {
             inherit pkgs lib check extraSpecialArgs;
             configuration = { ... }: {
-              imports = [ configuration ] ++ extraModules;
+              imports = (if builtins.isList configuration then
+                configuration
+              else
+                [ configuration ]) ++ extraModules;
               home = { inherit homeDirectory stateVersion username; };
               nixpkgs = { inherit (pkgs) config overlays; };
             };


### PR DESCRIPTION
### Description

This allows users to pass through multiple modules to function `homeManagerConfiguration` in their `flake.nix`. The use cases include NixOS-configuration-like

```Nix
{
  outputs = inputs: {
     configuration =  [
      (import ./home.nix)
      ({ config, ... }: { _module.args =  {
        # Pass extra arguments here
      };})
    ];
  };
}
```

Fixes #2717

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`. (not applicable)

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
