### PR TITLE
docs: use `$` prompts for nix-channel commands

### DIFF
--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -143,8 +143,8 @@ You can add the `nixpkgs-unstable` channel by running
 
 [source,console]
 ----
-# nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs-unstable
-# nix-channel --update
+$ nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs-unstable
+$ nix-channel --update
 ----
 
 Note, the package will not be affected by any package overrides, overlays, etc.

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -132,16 +132,16 @@ or an unstable channel, you can run
 
 [source,console]
 ----
-# nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
-# nix-channel --update
+$ nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
+$ nix-channel --update
 ----
 
 and if you follow a Nixpkgs version 22.05 channel, you can run
 
 [source,console]
 ----
-# nix-channel --add https://github.com/nix-community/home-manager/archive/release-22.05.tar.gz home-manager
-# nix-channel --update
+$ nix-channel --add https://github.com/nix-community/home-manager/archive/release-22.05.tar.gz home-manager
+$ nix-channel --update
 ----
 
 It is then possible to add
@@ -243,16 +243,16 @@ or an unstable channel, you can run
 
 [source,console]
 ----
-# nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
-# nix-channel --update
+$ nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
+$ nix-channel --update
 ----
 
 and if you follow a Nixpkgs version 22.05 channel, you can run
 
 [source,console]
 ----
-# nix-channel --add https://github.com/nix-community/home-manager/archive/release-22.05.tar.gz home-manager
-# nix-channel --update
+$ nix-channel --add https://github.com/nix-community/home-manager/archive/release-22.05.tar.gz home-manager
+$ nix-channel --update
 ----
 
 It is then possible to add


### PR DESCRIPTION
Channels should be added for the normal user, not for root, because the home-manager configuration is not supposed to be evaluated as root.

Fixes https://github.com/nix-community/home-manager/issues/2985