### PR TITLE
treewide: remove trailing white spaces and tabs (test cases excluded)

### DIFF
--- a/modules/programs/mangohud.nix
+++ b/modules/programs/mangohud.nix
@@ -39,7 +39,7 @@ in {
         type = types.bool;
         default = false;
         description = ''
-          Sets environment variables so that 
+          Sets environment variables so that
           MangoHud is started on any application that supports it.
         '';
       };

--- a/modules/programs/tiny.nix
+++ b/modules/programs/tiny.nix
@@ -29,9 +29,9 @@ in {
         example = literalExpression ''
           {
             servers = [
-              { 
-                addr = "irc.libera.chat"; 
-                port = 6697; 
+              {
+                addr = "irc.libera.chat";
+                port = 6697;
                 tls = true;
                 realname = "John Doe";
                 nicks = [ "tinyuser" ];

--- a/modules/services/fnott.nix
+++ b/modules/services/fnott.nix
@@ -42,7 +42,7 @@ in {
           </para><para>
           Note that environment variables in the path won't be properly expanded.
           </para><para>
-          The configuration specified under 
+          The configuration specified under
           <option>services.fnott.settings</option> will be generated and
           written to <filename>$XDG_CONFIG_HOME/fnott/fnott.ini</filename>
           regardless of this option. This allows using a mutable configuration file

--- a/modules/services/mpd-discord-rpc.nix
+++ b/modules/services/mpd-discord-rpc.nix
@@ -26,7 +26,7 @@ in {
       '';
       description = ''
         Configuration included in <literal>config.toml</literal>.
-        For available options see <link xlink:href="https://github.com/JakeStanger/mpd-discord-rpc#configuration"/> 
+        For available options see <link xlink:href="https://github.com/JakeStanger/mpd-discord-rpc#configuration"/>
       '';
     };
 

--- a/tests/modules/programs/i3status-rust/with-extra-settings.nix
+++ b/tests/modules/programs/i3status-rust/with-extra-settings.nix
@@ -105,7 +105,7 @@ with lib;
     test.stubs.i3status-rust = { };
 
     nmt.script = ''
-      assertFileExists home-files/.config/i3status-rust/config-extra-settings.toml 
+      assertFileExists home-files/.config/i3status-rust/config-extra-settings.toml
       assertFileContent home-files/.config/i3status-rust/config-extra-settings.toml \
         ${
           pkgs.writeText "i3status-rust-expected-config" ''


### PR DESCRIPTION
### Description

This patch removes the trailing white spaces from the files with the help of VSCode regex search and replace (pattern `[ \t]+$`).

Reference files and strings that would probably affect the test results are manually excluded.

We may want to modify the ./format file to prevent such problem, but I'm not sure how to do it properly.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
