### PR TITLE
sway: import dbus env vars and explicitly specify them 

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -309,7 +309,7 @@ let
       )
     else
       [ ]) ++ (optional cfg.systemdIntegration ''
-        exec "systemctl --user import-environment; systemctl --user start sway-session.target"'')
+        exec "${pkgs.dbus}/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"'')
       ++ (optional (!cfg.xwayland) "xwayland disable") ++ [ cfg.extraConfig ]));
 
   defaultSwayPackage = pkgs.sway.override {
@@ -320,7 +320,7 @@ let
   };
 
 in {
-  meta.maintainers = with maintainers; [ alexarice sumnerevans sebtm ];
+  meta.maintainers = with maintainers; [ alexarice sumnerevans sebtm oxalica ];
 
   options.wayland.windowManager.sway = {
     enable = mkEnableOption "sway wayland compositor";
@@ -346,6 +346,14 @@ in {
         Whether to enable <filename>sway-session.target</filename> on
         sway startup. This links to
         <filename>graphical-session.target</filename>.
+        Some important environment variables will be imported to systemd
+        and dbus user environment before reaching the target, including
+        <itemizedlist>
+          <listitem><para><literal>DISPLAY</literal></para></listitem>
+          <listitem><para><literal>WAYLAND_DISPLAY</literal></para></listitem>
+          <listitem><para><literal>SWAYSOCK</literal></para></listitem>
+          <listitem><para><literal>XDG_CURRENT_DESKTOP</literal></para></listitem>
+        </itemizedlist>
       '';
     };
 

--- a/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
+++ b/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
@@ -106,4 +106,4 @@ bar {
 }
 }
 
-exec "systemctl --user import-environment; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-bar-focused-colors.nix
+++ b/tests/modules/services/window-managers/sway/sway-bar-focused-colors.nix
@@ -18,7 +18,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
       ${./sway-bar-focused-colors.conf}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-bindkeys-to-code.conf
+++ b/tests/modules/services/window-managers/sway/sway-bindkeys-to-code.conf
@@ -103,4 +103,4 @@ bar {
 }
 }
 
-exec "systemctl --user import-environment; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-bindkeys-to-code.nix
+++ b/tests/modules/services/window-managers/sway/sway-bindkeys-to-code.nix
@@ -13,7 +13,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
       ${./sway-bindkeys-to-code.conf}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -103,4 +103,4 @@ bar {
 }
 }
 
-exec "systemctl --user import-environment; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-default.nix
+++ b/tests/modules/services/window-managers/sway/sway-default.nix
@@ -12,7 +12,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
       ${./sway-default.conf}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
@@ -81,4 +81,4 @@ mode "resize" {
   bindsym l resize grow width 10 px
 }
 
-exec "systemctl --user import-environment; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
@@ -81,4 +81,4 @@ mode "resize" {
   bindsym l resize grow width 10 px
 }
 
-exec "systemctl --user import-environment; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy.nix
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy.nix
@@ -18,7 +18,7 @@ with lib;
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
       ${./sway-followmouse-legacy-expected.conf}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-followmouse.nix
+++ b/tests/modules/services/window-managers/sway/sway-followmouse.nix
@@ -16,7 +16,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
       ${./sway-followmouse-expected.conf}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-modules.conf
+++ b/tests/modules/services/window-managers/sway/sway-modules.conf
@@ -115,4 +115,4 @@ bar {
 }
 }
 
-exec "systemctl --user import-environment; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-modules.nix
+++ b/tests/modules/services/window-managers/sway/sway-modules.nix
@@ -18,7 +18,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
       ${./sway-modules.conf}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-no-xwayland.nix
+++ b/tests/modules/services/window-managers/sway/sway-no-xwayland.nix
@@ -13,7 +13,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
         ${
           pkgs.writeText "expected" ''
             xwayland disable

--- a/tests/modules/services/window-managers/sway/sway-null-config.nix
+++ b/tests/modules/services/window-managers/sway/sway-null-config.nix
@@ -12,7 +12,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
       ${pkgs.writeText "expected" ""}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-null-package.conf
+++ b/tests/modules/services/window-managers/sway/sway-null-package.conf
@@ -103,4 +103,4 @@ bar {
 }
 }
 
-exec "systemctl --user import-environment; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-null-package.nix
+++ b/tests/modules/services/window-managers/sway/sway-null-package.nix
@@ -21,7 +21,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
       ${./sway-null-package.conf}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-post-2003.nix
+++ b/tests/modules/services/window-managers/sway/sway-post-2003.nix
@@ -14,7 +14,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
       ${./sway-default.conf}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
@@ -102,4 +102,4 @@ bar {
 }
 }
 
-exec "systemctl --user import-environment; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-workspace-default.nix
+++ b/tests/modules/services/window-managers/sway/sway-workspace-default.nix
@@ -13,7 +13,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
       ${./sway-workspace-default-expected.conf}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
@@ -107,4 +107,4 @@ workspace "1" output eDP
 workspace "ABC" output DP
 workspace "3: Test" output HDMI
 workspace "!"§$%&/(){}[]=?\*#<>-_.:,;²³" output DVI
-exec "systemctl --user import-environment; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-workspace-output.nix
+++ b/tests/modules/services/window-managers/sway/sway-workspace-output.nix
@@ -39,7 +39,7 @@ in {
 
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
-    assertFileContent home-files/.config/sway/config \
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
       ${./sway-workspace-output-expected.conf}
   '';
 }


### PR DESCRIPTION
### Description

Supersede and closes #2385 
Fix #2806 and #2028

- Importing all environment variables is considered deprecated for
  `systemdctl import-environment`. The list of variables are picked
  from:
  https://github.com/swaywm/sway/wiki/Systemd-integration#managing-user-applications-with-systemd

  The `XDG_CURRENT_DESKTOP` is said to be required for portals, see:
  https://github.com/nix-community/home-manager/pull/2385#issuecomment-1026454162

- DBus activation environment should also be updated. Otherwise, DBus
  activated programs, without a coresponding systemd service, cannot get a
  correct environment and would fail, eg. `mako`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
