### PR TITLE
docs: revert to `#` prompt on NixOS

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -132,16 +132,16 @@ or an unstable channel, you can run
 
 [source,console]
 ----
-$ nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
-$ nix-channel --update
+# nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
+# nix-channel --update
 ----
 
 and if you follow a Nixpkgs version 22.05 channel, you can run
 
 [source,console]
 ----
-$ nix-channel --add https://github.com/nix-community/home-manager/archive/release-22.05.tar.gz home-manager
-$ nix-channel --update
+# nix-channel --add https://github.com/nix-community/home-manager/archive/release-22.05.tar.gz home-manager
+# nix-channel --update
 ----
 
 It is then possible to add


### PR DESCRIPTION
See https://github.com/nix-community/home-manager/pull/3025#issuecomment-1159565524, sorry about that.

I don't understand how nix-darwin works so I'm not sure how the channels should be added there.