### PR TITLE
sctd: initial module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -478,3 +478,5 @@ Makefile                                              @thiagokokada
 /modules/programs/ion.nix                             @jo1gi
 
 /modules/services/plex-mpv-shim.nix                   @starcraft66
+
+/modules/services/sctd.nix                            @somasis

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -575,6 +575,14 @@ in
           A new module is available: 'programs.pistol'.
         '';
       }
+
+      {
+        time = "2022-06-26T19:29:25+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.sctd'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -246,6 +246,7 @@ let
     ./services/redshift-gammastep/redshift.nix
     ./services/rsibreak.nix
     ./services/screen-locker.nix
+    ./services/sctd.nix
     ./services/spotifyd.nix
     ./services/stalonetray.nix
     ./services/status-notifier-watcher.nix

--- a/modules/services/sctd.nix
+++ b/modules/services/sctd.nix
@@ -1,0 +1,74 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  meta.maintainers = [ maintainers.somasis ];
+
+  options = {
+    services.sctd = {
+      enable = mkEnableOption "sctd";
+
+      baseTemperature = mkOption {
+        type = types.ints.between 2500 9000;
+        default = 4500;
+        description = ''
+          The base color temperature used by sctd, which should be between 2500 and 9000.
+          See
+          <citerefentry>
+            <refentrytitle>sctd</refentrytitle>
+            <manvolnum>1</manvolnum>
+          </citerefentry>
+          for more details.
+        '';
+      };
+    };
+  };
+
+  config = mkIf config.services.sctd.enable {
+    assertions =
+      [ (hm.assertions.assertPlatform "services.sctd" pkgs platforms.linux) ];
+
+    systemd.user.services.sctd = {
+      Unit = {
+        Description =
+          "Dynamically adjust the screen color temperature twice every minute";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install.WantedBy = [ "graphical-session.target" ];
+
+      Service = {
+        ExecStart = "${pkgs.sct}/bin/sctd ${
+            toString config.services.sctd.baseTemperature
+          }";
+        ExecStopPost = "${pkgs.sct}/bin/sct";
+        Restart = "on-abnormal";
+        SuccessExitStatus = 1;
+
+        Environment = let
+          # HACK: Remove duplicate messages in the journal; `sctd` calls
+          #       both `logger -s` (which outputs the message to stderr)
+          #       *and* outputs to stderr itself. We can at least silence
+          #       `logger`'s output without hiding sctd's own stderr.
+          logger = pkgs.writeShellScriptBin "logger" ''
+            exec 2>/dev/null
+            exec ${pkgs.util-linux}/bin/logger "$@"
+          '';
+        in [
+          "PATH=${
+            lib.makeBinPath [
+              pkgs.bash
+              pkgs.coreutils
+              pkgs.gnused
+              pkgs.which
+              pkgs.sct
+              logger
+            ]
+          }"
+        ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Description

This adds a module for enabling the `sctd` daemon, as well as setting the preferred base temperature.

I'm not quite sure if a test should be added given the functionality of this module is basic enough, the only real thing it adds is a systemd user service.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
