### PR TITLE
Provide SHELL for sudo -s invocation of activation script

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -15,7 +15,7 @@ in {
       system.activationScripts.postActivation.text = concatStringsSep "\n"
         (mapAttrsToList (username: usercfg: ''
           echo Activating home-manager configuration for ${username}
-          SHELL=${pkgs.bash} sudo -u ${username} -s --set-home ${
+          sudo -u ${username} --set-home ${
             pkgs.writeShellScript "activation-${username}" ''
               ${lib.optionalString (cfg.backupFileExtension != null)
               "export HOME_MANAGER_BACKUP_EXT=${

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -15,7 +15,7 @@ in {
       system.activationScripts.postActivation.text = concatStringsSep "\n"
         (mapAttrsToList (username: usercfg: ''
           echo Activating home-manager configuration for ${username}
-          sudo -u ${username} -s --set-home ${
+          SHELL=${pkgs.bash} sudo -u ${username} -s --set-home ${
             pkgs.writeShellScript "activation-${username}" ''
               ${lib.optionalString (cfg.backupFileExtension != null)
               "export HOME_MANAGER_BACKUP_EXT=${


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

In #807 I changed the flag passed to `sudo` from `-i` to `-s` so `sudo`
wouldn't use a non-existent shell defined in the `passwd` file. kalbasit
also reported in that PR that `-i` didn't work for them anymore on an M1
Mac, presumably because Apple changed something in newer versions of
macOS.

Some users reported that this broke the behavior for them because
`SHELL` was set to a path that didn't even exist on their system. It's
unclear how this came to be but it shows that my assumption that `SHELL`
would be set to a reasonable shell by Home-Manager at this point in the
activation is false.

As a way around this problem we can explicitly set `SHELL` when running
the activation script to a value that we know will be good, like
`${pkgs.bash}`.

One change in behavior this causes is that the activation script will
always be run by bash, not the user's shell. If the script is generated
by Home-Manager this is fine since it can be generated taking into
account the supported set of functions and behaviors. If the intent is
for the activation script to possibly be run by non-bash and even
non-POSIX shells, like tcsh, ksh or Xonsh, then this fix will not
suffice.

Fixes #2900

**Note**: I'm not sure how to test this properly, advice appreciated.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [] Code formatted with `./format`.
   Couldn't do this because of a hash mismatch:
   ```
   error: ca hash mismatch importing path '/nix/store/rqc038b0jxgifl017wbmqanlp8ybk0k0-source';
         specified: sha256:0rbh9d0fskapgyzy812yxrzd87wj1jlzn46wi7ymyls2bpnbkw1g
         got:       sha256:19kaagb3ljgzhcyxcinqiskjbcasikfdbrrhvy8rj2wrxygcphmz
(use '--show-trace' to show detailed location information)
    ```

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
