### PR TITLE
dunst: fix settings example

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -108,7 +108,10 @@ in {
         example = literalExpression ''
           {
             global = {
-              geometry = "300x5-30+50";
+              width = 300;
+              height = 300;
+              offset = "30x50";
+              origin = "top-right";
               transparency = 10;
               frame_color = "#eceff1";
               font = "Droid Sans 9";


### PR DESCRIPTION
### Description
Dunst has deprecated the `geometry` setting and introduced some other settings replacing `geometry`. The documentation of Home Manager is still using the old `geometry` setting.

This small PR fixes the example of `services.dunst.settings`.
