### PR TITLE
firefox: add support for nested bookmarks

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -42,7 +42,7 @@ let
 
   mkUserJs = prefs: extraPrefs: bookmarks:
     let
-      prefs' = lib.optionalAttrs ({ } != bookmarks) {
+      prefs' = lib.optionalAttrs ([ ] != bookmarks) {
         "browser.bookmarks.file" = toString (firefoxBookmarksFile bookmarks);
         "browser.places.importBookmarksHTML" = true;
       } // prefs;
@@ -65,13 +65,37 @@ let
         "&gt;"
         "&amp;"
       ];
-      mapper = _: entry: ''
-        <DT><A HREF="${escapeXML entry.url}" ADD_DATE="0" LAST_MODIFIED="0"${
-          lib.optionalString (entry.keyword != null)
-          " SHORTCUTURL=\"${escapeXML entry.keyword}\""
-        }>${escapeXML entry.name}</A>
-      '';
-      bookmarksEntries = lib.attrsets.mapAttrsToList mapper bookmarks;
+
+      indent = level:
+        lib.concatStringsSep "" (map (lib.const "  ") (lib.range 1 level));
+
+      bookmarkToHTML = indentLevel: bookmark:
+        ''
+          ${indent indentLevel}<DT><A HREF="${
+            escapeXML bookmark.url
+          }" ADD_DATE="0" LAST_MODIFIED="0"${
+            lib.optionalString (bookmark.keyword != null)
+            " SHORTCUTURL=\"${escapeXML bookmark.keyword}\""
+          }>${escapeXML bookmark.name}</A>'';
+
+      directoryToHTML = indentLevel: directory: ''
+        ${indent indentLevel}<DT><H3>${escapeXML directory.name}</H3>
+        ${indent indentLevel}<DL><p>
+        ${allItemsToHTML (indentLevel + 1) directory.bookmarks}
+        ${indent indentLevel}</p></DL>'';
+
+      itemToHTMLOrRecurse = indentLevel: item:
+        if item ? "url" then
+          bookmarkToHTML indentLevel item
+        else
+          directoryToHTML indentLevel item;
+
+      allItemsToHTML = indentLevel: bookmarks:
+        lib.concatStringsSep "\n"
+        (map (itemToHTMLOrRecurse indentLevel) bookmarks);
+
+      bookmarkEntries = allItemsToHTML 1
+        (if isAttrs bookmarks then lib.attrValues bookmarks else bookmarks);
     in pkgs.writeText "firefox-bookmarks.html" ''
       <!DOCTYPE NETSCAPE-Bookmark-file-1>
       <!-- This is an automatically generated file.
@@ -81,7 +105,7 @@ let
       <TITLE>Bookmarks</TITLE>
       <H1>Bookmarks Menu</H1>
       <DL><p>
-      ${concatStrings bookmarksEntries}
+      ${bookmarkEntries}
       </p></DL>
     '';
 
@@ -233,37 +257,78 @@ in {
             };
 
             bookmarks = mkOption {
-              type = types.attrsOf (types.submodule ({ config, name, ... }: {
-                options = {
-                  name = mkOption {
-                    type = types.str;
-                    default = name;
-                    description = "Bookmark name.";
-                  };
+              type = let
+                bookmarkSubmodule = types.submodule ({ config, name, ... }: {
+                  options = {
+                    name = mkOption {
+                      type = types.str;
+                      default = name;
+                      description = "Bookmark name.";
+                    };
 
-                  keyword = mkOption {
-                    type = types.nullOr types.str;
-                    default = null;
-                    description = "Bookmark search keyword.";
-                  };
+                    keyword = mkOption {
+                      type = types.nullOr types.str;
+                      default = null;
+                      description = "Bookmark search keyword.";
+                    };
 
-                  url = mkOption {
-                    type = types.str;
-                    description = "Bookmark url, use %s for search terms.";
+                    url = mkOption {
+                      type = types.str;
+                      description = "Bookmark url, use %s for search terms.";
+                    };
                   };
+                }) // {
+                  description = "bookmark submodule";
                 };
-              }));
-              default = { };
+
+                bookmarkType = types.addCheck bookmarkSubmodule (x: x ? "url");
+
+                directoryType = types.submodule ({ config, name, ... }: {
+                  options = {
+                    name = mkOption {
+                      type = types.str;
+                      default = name;
+                      description = "Directory name.";
+                    };
+
+                    bookmarks = mkOption {
+                      type = types.listOf bookmarkType;
+                      default = [ ];
+                      description = "Bookmarks within directory.";
+                    };
+                  };
+                }) // {
+                  description = "directory submodule";
+                };
+              in with types;
+              either (attrsOf bookmarkType)
+              (listOf (either bookmarkType directoryType));
+              default = [ ];
               example = literalExpression ''
-                {
-                  wikipedia = {
+                [
+                  {
+                    name = "wikipedia";
                     keyword = "wiki";
                     url = "https://en.wikipedia.org/wiki/Special:Search?search=%s&go=Go";
-                  };
-                  "kernel.org" = {
+                  }
+                  {
+                    name = "kernel.org";
                     url = "https://www.kernel.org";
-                  };
-                }
+                  }
+                  {
+                    name = "Nix sites";
+                    bookmarks = [
+                      {
+                        name = "homepage";
+                        url = "https://nixos.org/";
+                      }
+                      {
+                        name = "wiki";
+                        url = "https://nixos.wiki/";
+                      }
+                    ];
+                  }
+                ]
               '';
               description = ''
                 Preloaded bookmarks. Note, this may silently overwrite any

--- a/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
+++ b/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
@@ -6,7 +6,11 @@
 <TITLE>Bookmarks</TITLE>
 <H1>Bookmarks Menu</H1>
 <DL><p>
-<DT><A HREF="https://www.kernel.org" ADD_DATE="0" LAST_MODIFIED="0">kernel.org</A>
-<DT><A HREF="https://en.wikipedia.org/wiki/Special:Search?search=%s&amp;go=Go" ADD_DATE="0" LAST_MODIFIED="0" SHORTCUTURL="wiki">wikipedia</A>
-
+  <DT><A HREF="https://en.wikipedia.org/wiki/Special:Search?search=%s&amp;go=Go" ADD_DATE="0" LAST_MODIFIED="0" SHORTCUTURL="wiki">wikipedia</A>
+  <DT><A HREF="https://www.kernel.org" ADD_DATE="0" LAST_MODIFIED="0">kernel.org</A>
+  <DT><H3>Nix sites</H3>
+  <DL><p>
+    <DT><A HREF="https://nixos.org/" ADD_DATE="0" LAST_MODIFIED="0">homepage</A>
+    <DT><A HREF="https://nixos.wiki/" ADD_DATE="0" LAST_MODIFIED="0">wiki</A>
+  </p></DL>
 </p></DL>

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -15,13 +15,30 @@ lib.mkIf config.test.enableBig {
     profiles.bookmarks = {
       id = 2;
       settings = { "general.smoothScroll" = false; };
-      bookmarks = {
-        wikipedia = {
+      bookmarks = [
+        {
+          name = "wikipedia";
           keyword = "wiki";
           url = "https://en.wikipedia.org/wiki/Special:Search?search=%s&go=Go";
-        };
-        "kernel.org" = { url = "https://www.kernel.org"; };
-      };
+        }
+        {
+          name = "kernel.org";
+          url = "https://www.kernel.org";
+        }
+        {
+          name = "Nix sites";
+          bookmarks = [
+            {
+              name = "homepage";
+              url = "https://nixos.org/";
+            }
+            {
+              name = "wiki";
+              url = "https://nixos.wiki/";
+            }
+          ];
+        }
+      ];
     };
   };
 


### PR DESCRIPTION
### Description

Change type of `firefox.profile.<name>.bookmarks` to
allow for nested bookmarks with user defined order.

The old format is still available.

Closes #2577 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.