### PR TITLE
version: remove default value

### DIFF
--- a/docs/release-notes/rl-2211.adoc
+++ b/docs/release-notes/rl-2211.adoc
@@ -8,7 +8,15 @@ This is the current unstable branch and the information in this section is there
 
 This release has the following notable changes:
 
-* No changes.
+* The <<opt-home.stateVersion>> option no longer has a default value.
+It used to default to ``18.09'', which was the Home Manager version
+that introduced the option. If your configuration does not explicitly
+set this option then you need to add
++
+[source,nix]
+home.stateVersion = "18.09";
++
+to your configuration.
 
 [[sec-release-22.11-state-version-changes]]
 === State Version Changes

--- a/modules/misc/version.nix
+++ b/modules/misc/version.nix
@@ -17,7 +17,6 @@ with lib;
         "22.05"
         "22.11"
       ];
-      default = "18.09";
       description = ''
         It is occasionally necessary for Home Manager to change
         configuration defaults in a way that is incompatible with

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -14,8 +14,11 @@ let
       # Fix impurities. Without these some of the user's environment
       # will leak into the tests through `builtins.getEnv`.
       xdg.enable = true;
-      home.username = "hm-user";
-      home.homeDirectory = "/home/hm-user";
+      home = {
+        username = "hm-user";
+        homeDirectory = "/home/hm-user";
+        stateVersion = lib.mkDefault "18.09";
+      };
 
       # Avoid including documentation since this will cause
       # unnecessary rebuilds of the tests.


### PR DESCRIPTION
### Description

The user should always explicitly set the state version they wish to use. Indeed, the configuration generated by the Home Manager install script has set this option for a long time. This removal should therefore not affect many users.

### Checklist

- [ ] Change is backwards compatible.

    Not backwards compatible, but easy to restore a working configuration by adding `home.stateVersion = "18.09";`.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```