### PR TITLE
backport to 22.05: mujmap: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -163,6 +163,9 @@
 
 /modules/programs/mu.nix                              @KarlJoad
 
+/modules/programs/mujmap.nix                          @elizagamedev
+/tests/modules/programs/mujmap                        @elizagamedev
+
 /modules/programs/navi.nix                            @marsam
 
 /modules/programs/ncmpcpp.nix                         @olmokramer

--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -123,6 +123,38 @@ let
     };
   };
 
+  jmapModule = types.submodule {
+    options = {
+      host = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "jmap.example.org";
+        description = ''
+          Hostname of JMAP server.
+          </para><para>
+          If both this option and <xref
+          linkend="opt-accounts.email.accounts._name_.jmap.sessionUrl"/> are specified,
+          <code>host</code> is preferred by applications when establishing a
+          session.
+        '';
+      };
+
+      sessionUrl = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "https://jmap.example.org:443/.well-known/jmap";
+        description = ''
+          URL for the JMAP Session resource.
+          </para><para>
+          If both this option and <xref
+          linkend="opt-accounts.email.accounts._name_.jmap.host"/> are specified,
+          <code>host</code> is preferred by applications when establishing a
+          session.
+        '';
+      };
+    };
+  };
+
   smtpModule = types.submodule {
     options = {
       host = mkOption {
@@ -205,7 +237,7 @@ let
           indicate the nature of the provider.
           </para><para>
           When this indicates a specific provider then, for example,
-          the IMAP and SMTP server configuration may be set
+          the IMAP, SMTP, and JMAP server configuration may be set
           automatically.
         '';
       };
@@ -234,7 +266,7 @@ let
         default = null;
         description = ''
           The server username of this account. This will be used as
-          the SMTP and IMAP user name.
+          the SMTP, IMAP, and JMAP user name.
         '';
       };
 
@@ -299,6 +331,14 @@ let
         '';
       };
 
+      jmap = mkOption {
+        type = types.nullOr jmapModule;
+        default = null;
+        description = ''
+          The JMAP configuration to use for this account.
+        '';
+      };
+
       signature = mkOption {
         type = signatureModule;
         default = { };
@@ -343,9 +383,15 @@ let
           host = "smtp.fastmail.com";
           port = if config.smtp.tls.useStartTls then 587 else 465;
         };
+
         imap = {
           host = "imap.fastmail.com";
           port = 993;
+        };
+
+        jmap = {
+          host = "fastmail.com";
+          sessionUrl = "https://jmap.fastmail.com/.well-known/jmap";
         };
       })
       (mkIf (config.flavor == "gmail.com") {

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -554,6 +554,13 @@ in
           A new module is available: 'services.mopidy'.
         '';
       }
+
+      {
+        time = "2022-06-21T22:29:37+00:00";
+        message = ''
+          A new module is available: 'programs.mujmap'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -109,6 +109,7 @@ let
     ./programs/mpv.nix
     ./programs/msmtp.nix
     ./programs/mu.nix
+    ./programs/mujmap.nix
     ./programs/navi.nix
     ./programs/ncmpcpp.nix
     ./programs/ncspot.nix

--- a/modules/programs/mujmap.nix
+++ b/modules/programs/mujmap.nix
@@ -1,0 +1,315 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.mujmap;
+
+  mujmapAccounts =
+    filter (a: a.mujmap.enable) (attrValues config.accounts.email.accounts);
+
+  missingNotmuchAccounts = map (a: a.name)
+    (filter (a: !a.notmuch.enable && a.mujmap.notmuchSetupWarning)
+      mujmapAccounts);
+
+  notmuchConfigHelp =
+    map (name: "accounts.email.accounts.${name}.notmuch.enable = true;")
+    missingNotmuchAccounts;
+
+  settingsFormat = pkgs.formats.toml { };
+
+  filterNull = attrs: attrsets.filterAttrs (n: v: v != null) attrs;
+
+  configFile = account:
+    let
+      settings'' = if (account.jmap == null) then
+        { }
+      else
+        filterNull {
+          fqdn = account.jmap.host;
+          session_url = account.jmap.sessionUrl;
+        };
+
+      settings' = settings'' // {
+        username = account.userName;
+        password_command = escapeShellArgs account.passwordCommand;
+      } // filterNull account.mujmap.settings;
+
+      settings = if (hasAttr "fqdn" settings') then
+        (removeAttrs settings' [ "session_url" ])
+      else
+        settings';
+    in {
+      name = "${account.maildir.absPath}/mujmap.toml";
+      value.source = settingsFormat.generate
+        "mujmap-${lib.replaceStrings [ "@" ] [ "_at_" ] account.address}.toml"
+        settings;
+    };
+
+  tagsOpts = {
+    lowercase = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If true, translate all mailboxes to lowercase names when mapping to notmuch
+        tags.
+      '';
+    };
+
+    directory_separator = mkOption {
+      type = types.str;
+      default = "/";
+      example = ".";
+      description = ''
+        Directory separator for mapping notmuch tags to maildirs.
+      '';
+    };
+
+    inbox = mkOption {
+      type = types.str;
+      default = "inbox";
+      description = ''
+        Tag for notmuch to use for messages stored in the mailbox labeled with the
+        <code>Inbox</code> name attribute.
+        </para><para>
+        If set to an empty string, this mailbox <emphasis>and its child
+        mailboxes</emphasis> are not synchronized with a tag.
+      '';
+    };
+
+    deleted = mkOption {
+      type = types.str;
+      default = "deleted";
+      description = ''
+        Tag for notmuch to use for messages stored in the mailbox labeled with the
+        <code>Trash</code> name attribute.
+        </para><para>
+        If set to an empty string, this mailbox <emphasis>and its child
+        mailboxes</emphasis> are not synchronized with a tag.
+      '';
+    };
+
+    sent = mkOption {
+      type = types.str;
+      default = "sent";
+      description = ''
+        Tag for notmuch to use for messages stored in the mailbox labeled with the
+        <code>Sent</code> name attribute.
+        </para><para>
+        If set to an empty string, this mailbox <emphasis>and its child
+        mailboxes</emphasis> are not synchronized with a tag.
+      '';
+    };
+
+    spam = mkOption {
+      type = types.str;
+      default = "spam";
+      description = ''
+        Tag for notmuch to use for messages stored in the mailbox labeled with the
+        <code>Junk</code> name attribute and/or with the <code>$Junk</code> keyword,
+        <emphasis>except</emphasis> for messages with the <code>$NotJunk</code> keyword.
+        </para><para>
+        If set to an empty string, this mailbox, <emphasis>its child
+        mailboxes</emphasis>, and these keywords are not synchronized with a tag.
+      '';
+    };
+
+    important = mkOption {
+      type = types.str;
+      default = "important";
+      description = ''
+        Tag for notmuch to use for messages stored in the mailbox labeled with the
+        <code>Important</code> name attribute and/or with the <code>$Important</code>
+        keyword.
+        </para><para>
+        If set to an empty string, this mailbox, <emphasis>its child
+        mailboxes</emphasis>, and these keywords are not synchronized with a tag.
+      '';
+    };
+
+    phishing = mkOption {
+      type = types.str;
+      default = "phishing";
+      description = ''
+        Tag for notmuch to use for the IANA <code>$Phishing</code> keyword.
+        </para><para>
+        If set to an empty string, this keyword is not synchronized with a tag.
+      '';
+    };
+  };
+
+  rootOpts = {
+    username = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "alice@example.com";
+      description = ''
+        Username for basic HTTP authentication.
+        </para><para>
+        If <literal>null</literal>, defaults to
+        <xref linkend="opt-accounts.email.accounts._name_.userName"/>.
+      '';
+    };
+
+    password_command = mkOption {
+      type = types.nullOr (types.either types.str (types.listOf types.str));
+      default = null;
+      apply = p: if isList p then escapeShellArgs p else p;
+      example = "pass alice@example.com";
+      description = ''
+        Shell command which will print a password to stdout for basic HTTP
+        authentication.
+        </para><para>
+        If <literal>null</literal>, defaults to
+        <xref linkend="opt-accounts.email.accounts._name_.passwordCommand"/>.
+      '';
+    };
+
+    fqdn = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "example.com";
+      description = ''
+        Fully qualified domain name of the JMAP service.
+        </para><para>
+        mujmap looks up the JMAP SRV record for this host to determine the JMAP session
+        URL. Mutually exclusive with
+        <xref linkend="opt-accounts.email.accounts._name_.mujmap.settings.session_url"/>.
+        </para><para>
+        If <literal>null</literal>, defaults to
+        <xref linkend="opt-accounts.email.accounts._name_.jmap.host"/>.
+      '';
+    };
+
+    session_url = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "https://jmap.example.com/.well-known/jmap";
+      description = ''
+        Sesion URL to connect to.
+        </para><para>
+        Mutually exclusive with
+        <xref linkend="opt-accounts.email.accounts._name_.mujmap.settings.fqdn"/>.
+        </para><para>
+        If <literal>null</literal>, defaults to
+        <xref linkend="opt-accounts.email.accounts._name_.jmap.sessionUrl"/>.
+      '';
+    };
+
+    auto_create_new_mailboxes = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to create new mailboxes automatically on the server from notmuch
+        tags.
+      '';
+    };
+
+    cache_dir = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        The cache directory in which to store mail files while they are being
+        downloaded. The default is operating-system specific.
+      '';
+    };
+
+    tags = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+        options = tagsOpts;
+      };
+      default = { };
+      description = ''
+        Tag configuration.
+        </para><para>
+        Beware that there are quirks that require manual consideration if changing the
+        values of these files; please see
+        <link xlink:href="https://github.com/elizagamedev/mujmap/blob/main/mujmap.toml.example"/>
+        for more details.
+      '';
+    };
+  };
+
+  mujmapOpts = {
+    enable = mkEnableOption "mujmap JMAP synchronization for notmuch";
+
+    notmuchSetupWarning = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Warn if Notmuch is not also enabled for this account.
+        </para><para>
+        This can safely be disabled if <filename>mujmap.toml</filename> is managed
+        outside of Home Manager.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+        options = rootOpts;
+      };
+      default = { };
+      description = ''
+        Settings which are applied to <filename>mujmap.toml</filename>
+        for the account.
+        </para><para>
+        See the <link xlink:href="https://github.com/elizagamedev/mujmap">mujmap project</link>
+        for documentation of settings not explicitly covered by this module.
+      '';
+    };
+  };
+
+  mujmapModule = types.submodule { options = { mujmap = mujmapOpts; }; };
+in {
+  meta.maintainers = with maintainers; [ elizagamedev ];
+
+  options = {
+    programs.mujmap = {
+      enable = mkEnableOption "mujmap Gmail synchronization for notmuch";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.mujmap;
+        defaultText = "pkgs.mujmap";
+        description = ''
+          mujmap package to use.
+        '';
+      };
+    };
+
+    accounts.email.accounts =
+      mkOption { type = with types; attrsOf mujmapModule; };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf (missingNotmuchAccounts != [ ]) {
+      warnings = [''
+        mujmap is enabled for the following email accounts, but notmuch is not:
+
+            ${concatStringsSep "\n    " missingNotmuchAccounts}
+
+        Notmuch can be enabled with:
+
+            ${concatStringsSep "\n    " notmuchConfigHelp}
+
+        If you have configured notmuch outside of Home Manager, you can suppress this
+        warning with:
+
+            programs.mujmap.notmuchSetupWarning = false;
+      ''];
+    })
+
+    {
+      warnings = flatten (map (account: account.warnings) mujmapAccounts);
+
+      home.packages = [ cfg.package ];
+
+      # Notmuch should ignore non-mail files created by mujmap.
+      programs.notmuch.new.ignore = [ "/.*[.](toml|json|lock)$/" ];
+
+      home.file = listToAttrs (map configFile mujmapAccounts);
+    }
+  ]);
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -79,6 +79,7 @@ import nmt {
     ./modules/programs/mbsync
     ./modules/programs/mpv
     ./modules/programs/mu
+    ./modules/programs/mujmap
     ./modules/programs/ncmpcpp
     ./modules/programs/ne
     ./modules/programs/neomutt

--- a/tests/modules/programs/mujmap/default.nix
+++ b/tests/modules/programs/mujmap/default.nix
@@ -1,0 +1,5 @@
+{
+  mujmap-defaults = ./mujmap-defaults.nix;
+  mujmap-fqdn-and-session-url-specified =
+    ./mujmap-fqdn-and-session-url-specified.nix;
+}

--- a/tests/modules/programs/mujmap/mujmap-defaults-expected.toml
+++ b/tests/modules/programs/mujmap/mujmap-defaults-expected.toml
@@ -1,0 +1,14 @@
+auto_create_new_mailboxes = true
+fqdn = "example.com"
+password_command = "'password-command'"
+username = "home.manager"
+
+[tags]
+deleted = "deleted"
+directory_separator = "/"
+important = "important"
+inbox = "inbox"
+lowercase = false
+phishing = "phishing"
+sent = "sent"
+spam = "spam"

--- a/tests/modules/programs/mujmap/mujmap-defaults.nix
+++ b/tests/modules/programs/mujmap/mujmap-defaults.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  config = {
+    programs.mujmap.enable = true;
+    programs.mujmap.package = config.lib.test.mkStubPackage { };
+
+    accounts.email.accounts."hm@example.com" = {
+      jmap.host = "example.com";
+      mujmap.enable = true;
+      notmuch.enable = true;
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/Mail/hm@example.com/mujmap.toml
+      assertFileContent home-files/Mail/hm@example.com/mujmap.toml ${
+        ./mujmap-defaults-expected.toml
+      }
+    '';
+  };
+}

--- a/tests/modules/programs/mujmap/mujmap-fqdn-and-session-url-specified.nix
+++ b/tests/modules/programs/mujmap/mujmap-fqdn-and-session-url-specified.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  config = {
+    programs.mujmap.enable = true;
+    programs.mujmap.package = config.lib.test.mkStubPackage { };
+
+    accounts.email.accounts."hm@example.com" = {
+      jmap.host = "example.com";
+      jmap.sessionUrl = "https://jmap.example.com/";
+      mujmap.enable = true;
+      notmuch.enable = true;
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/Mail/hm@example.com/mujmap.toml
+      assertFileContent home-files/Mail/hm@example.com/mujmap.toml ${
+        ./mujmap-defaults-expected.toml
+      }
+    '';
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Backports #2960.

mujmap is available as a package in NixOS 22.05, so I thought this module should also be available.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.