### PR TITLE
neovim/coc: fix `withNodeJs` value when enabling coc

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -368,7 +368,7 @@ in {
 
     neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
       inherit (cfg) extraPython3Packages withPython3 withRuby viAlias vimAlias;
-      withNodeJs = cfg.withNodeJs or cfg.coc.enable;
+      withNodeJs = cfg.withNodeJs || cfg.coc.enable;
       configure = cfg.configure // moduleConfigure;
       plugins = map suppressNotVimlConfig pluginsNormalized;
       customRC = cfg.extraConfig;


### PR DESCRIPTION
### Description

Coc needs nodejs. This changes the enabling logic to use 'boolean or' instead of an 'attr or default' expression.

Currently, nodejs is enabled by a 'select attrpath or default' expression:

> withNodeJs = cfg.withNodeJs or cfg.coc.enable;

However, the option `neovim.withNodeJs` defaults to false and will exist, which means if you only set `neovim.coc.enable = true;` then node will be missing.


I don't know how to test for this from the test suite, but am willing to try if someone can suggest how to proceed.

CC @sumnerevans Looks like a very minor oversight from nix-community/home-manager#2801
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.