### PR TITLE
Documentation: Fix typo in nix-darwin flake example

### DIFF
--- a/docs/nix-flakes.adoc
+++ b/docs/nix-flakes.adoc
@@ -191,15 +191,15 @@ is similar to that of NixOS. The `flake.nix` would be:
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nix-darwin.url = "github:lnl7/nix-darwin";
+    darwin.url = "github:lnl7/nix-darwin";
     darwin.inputs.nixpkgs.follows = "nixpkgs";
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = inputs@{ nixpkgs, home-manager, nix-darwin, ... }: {
+  outputs = inputs@{ nixpkgs, home-manager, darwin, ... }: {
     darwinConfigurations = {
-      hostname = nix-darwin.lib.darwinSystem {
+      hostname = darwin.lib.darwinSystem {
         system = "x86_64-darwin";
         modules = [
           ./configuration.nix


### PR DESCRIPTION
### Description

The nix-darwin documentation uses `darwin` not `nix-darwin` to refer to its own flake, and so this is now consistent (and correct) and uses `darwin`.

There are no code changes.

### Checklist

- [x] Change is backwards compatible.

- [ ] ~~Code formatted with `./format`.~~

- [ ] ~~Code tested through `nix-shell --pure tests -A run.all`.~~

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] ~~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~~

  - [ ] ~~Added myself and the module files to `.github/CODEOWNERS`.~~
