### PR TITLE
mpd-discord-rpc: restart on failure

### DIFF
--- a/modules/services/mpd-discord-rpc.nix
+++ b/modules/services/mpd-discord-rpc.nix
@@ -48,7 +48,10 @@ in {
         After = [ "graphical-session-pre.target" ];
         PartOf = [ "graphical-session.desktop" ];
       };
-      Service.ExecStart = "${cfg.package}/bin/mpd-discord-rpc";
+      Service = {
+        ExecStart = "${cfg.package}/bin/mpd-discord-rpc";
+        Restart = "on-failure";
+      };
       Install.WantedBy = [ "graphical-session.target" ];
     };
   };


### PR DESCRIPTION
### Description

The service now restarts if it crashes which usually happens when it starts before `mpd` initializes.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

~~[ ] Code tested through `nix-shell --pure tests -A run.all.`~~ No tests for my change.

~~[ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~~

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.