### PR TITLE
Unflake nmt and nmd

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,16 +1,6 @@
 { pkgs ? import <nixpkgs> { } }:
 
-let
-
-  flake = (import
-    (let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-    in fetchTarball {
-      url =
-        "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-      sha256 = lock.nodes.flake-compat.locked.narHash;
-    }) { src = ./.; }).defaultNix;
-
-in rec {
+rec {
   docs = with import ./docs { inherit pkgs; }; {
     html = manual.html;
     manPages = manPages;
@@ -26,6 +16,4 @@ in rec {
   nixos = import ./nixos;
 
   path = ./.;
-
-  inherit (flake) inputs;
 }

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,9 +1,15 @@
-{ pkgs, nmdSrc ? (import ./.. { }).inputs.nmd
+{ pkgs
 
-  # Note, this should be "the standard library" + HM extensions.
+# Note, this should be "the standard library" + HM extensions.
 , lib ? import ../modules/lib/stdlib-extended.nix pkgs.lib }:
 
 let
+
+  nmdSrc = fetchTarball {
+    url =
+      "https://gitlab.com/api/v4/projects/rycee%2Fnmd/repository/archive.tar.gz?sha=91dee681dd1c478d6040a00835d73c0f4a4c5c29";
+    sha256 = "07szg39wmna287hv5w9hl45wvm04zbh0k54br59nv3yzvg9ymlj4";
+  };
 
   nmd = import nmdSrc { inherit lib pkgs; };
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1654953433,
@@ -32,44 +16,9 @@
         "type": "github"
       }
     },
-    "nmd": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1653339422,
-        "narHash": "sha256-RNLq09vfj21TyYuUCeD6BNTNC6Ew8bLhQULZytN4Xx8=",
-        "owner": "rycee",
-        "repo": "nmd",
-        "rev": "91dee681dd1c478d6040a00835d73c0f4a4c5c29",
-        "type": "gitlab"
-      },
-      "original": {
-        "owner": "rycee",
-        "repo": "nmd",
-        "type": "gitlab"
-      }
-    },
-    "nmt": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1648075362,
-        "narHash": "sha256-u36WgzoA84dMVsGXzml4wZ5ckGgfnvS0ryzo/3zn/Pc=",
-        "owner": "rycee",
-        "repo": "nmt",
-        "rev": "d83601002c99b78c89ea80e5e6ba21addcfe12ae",
-        "type": "gitlab"
-      },
-      "original": {
-        "owner": "rycee",
-        "repo": "nmt",
-        "type": "gitlab"
-      }
-    },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
-        "nmd": "nmd",
-        "nmt": "nmt",
         "utils": "utils"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,16 +2,9 @@
   description = "Home Manager for Nix";
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-  inputs.nmd.url = "gitlab:rycee/nmd";
-  inputs.nmd.flake = false;
-  inputs.nmt.url = "gitlab:rycee/nmt";
-  inputs.nmt.flake = false;
-
   inputs.utils.url = "github:numtide/flake-utils";
-  inputs.flake-compat.url = "github:edolstra/flake-compat";
-  inputs.flake-compat.flake = false;
 
-  outputs = { self, nixpkgs, nmd, utils, ... }:
+  outputs = { self, nixpkgs, utils, ... }:
     {
       nixosModules = rec {
         home-manager = import ./nixos;
@@ -67,10 +60,7 @@
     } // utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        docs = import ./docs {
-          inherit pkgs;
-          nmdSrc = nmd;
-        };
+        docs = import ./docs { inherit pkgs; };
       in {
         packages = rec {
           home-manager = pkgs.callPackage ./home-manager { };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4,7 +4,11 @@ let
 
   lib = import ../modules/lib/stdlib-extended.nix pkgs.lib;
 
-  inherit ((import ./.. { }).inputs) nmt;
+  nmt = fetchTarball {
+    url =
+      "https://gitlab.com/api/v4/projects/rycee%2Fnmt/repository/archive.tar.gz?sha=d83601002c99b78c89ea80e5e6ba21addcfe12ae";
+    sha256 = "1xzwwxygzs1cmysg97hzd285r7n1g1lwx5y1ar68gwq07a1rczmv";
+  };
 
   modules = import ../modules/modules.nix {
     inherit lib pkgs;


### PR DESCRIPTION
### Description

This simplifies the code a bit and avoids using experimental Flake functionality. If Flakes become stable before NixOS 22.11 then we can consider having nmd and nmt as Flake inputs. Maybe could then also avoid the need for flake-compat.

Note, instead of `pkgs.fetchFromGitLab` this commit uses the builtin function `fetchTarball` to avoid the `pkgs` dependency.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```