### PR TITLE
nushell: fix non-nullable configFile and envFile, fixes #3050

### DIFF
--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -58,7 +58,8 @@ in {
     };
 
     configFile = mkOption {
-      type = linesOrSource "config.nu";
+      type = types.nullOr (linesOrSource "config.nu");
+      default = null;
       example = literalExpression ''
         { text = '''
             let $config = {
@@ -78,7 +79,8 @@ in {
     };
 
     envFile = mkOption {
-      type = linesOrSource "env.nu";
+      type = types.nullOr (linesOrSource "env.nu");
+      default = null;
       example = ''
         let-env FOO = 'BAR'
       '';
@@ -94,7 +96,9 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."nushell/config.nu" = cfg.configFile;
-    xdg.configFile."nushell/env.nu" = cfg.envFile;
+    xdg.configFile = mkMerge [
+      (mkIf (cfg.configFile != null) { "nushell/config.nu" = cfg.configFile; })
+      (mkIf (cfg.envFile != null) { "nushell/env.nu" = cfg.envFile; })
+    ];
   };
 }


### PR DESCRIPTION
### Description

Allows null/non-defined `configFile` and `envFile`
fixes #3050
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
