### PR TITLE
keychain: set SHELL correctly in bash

### DIFF
--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -100,13 +100,13 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      SHELL=bash eval "$(${shellCommand})"
+      eval "$(SHELL=bash ${shellCommand})"
     '';
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
       SHELL=fish eval (${shellCommand})
     '';
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      SHELL=zsh eval "$(${shellCommand})"
+      eval "$(SHELL=zsh ${shellCommand})"
     '';
     xsession.initExtra = mkIf cfg.enableXsessionIntegration ''
       eval "$(${shellCommand})"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

bash apparently handles command substitution slightly differently than
fish and zsh. in bash:

```console
$ export FOO=x
$ FOO=y echo $(sh -c 'echo $FOO')
x
```

whereas in zsh:

```console
$ export FOO=x
$ FOO=y echo $(sh -c 'echo $FOO')
y
```

so we have to assign $SHELL within the substitution in bash.

see #2256 and #2880.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
