### PR TITLE
docs: remove bit about Nix 2.4 not being supported

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -41,9 +41,6 @@ root user. For a multi-user install of Nix this means that your user
 must be covered by the {nix-allowed-users}[`allowed-users`] Nix
 option. On NixOS you can control this option using the
 {nixos-allowed-users}[`nix.allowedUsers`] system option.
-+
-Note that Nix 2.4 is not yet fully supported. Most significantly, Home
-Manager is incompatible with the new `nix profile`.
 
 2. Add the appropriate Home Manager channel. If you are following
 Nixpkgs master or an unstable channel you can run

--- a/docs/nix-flakes.adoc
+++ b/docs/nix-flakes.adoc
@@ -9,7 +9,7 @@ The support is still experimental and may change in backwards incompatible ways.
 [[sec-flakes-prerequisties]]
 === Prerequisties
 
-* Install Nix 2.4 or have it in `nix-shell`.
+* Install Nix 2.4 or later, or have it in `nix-shell`.
 
 * Enable experimental features `nix-command` and `flakes`.
 +


### PR DESCRIPTION
### Description
With #2840, Nix 2.4 is supported.
This resolves #3061.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
