### PR TITLE
zsh: source zsh-syntax-highlighting at the end of .zshrc

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -500,10 +500,6 @@ in
           "source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
         }
 
-        ${optionalString cfg.enableSyntaxHighlighting
-          "source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-        }
-
         ${optionalString cfg.oh-my-zsh.enable ''
             # oh-my-zsh extra settings for plugins
             ${cfg.oh-my-zsh.extraConfig}
@@ -557,6 +553,12 @@ in
 
         # Named Directory Hashes
         ${dirHashesStr}
+
+        ${optionalString cfg.enableSyntaxHighlighting
+          # Load zsh-syntax-highlighting last, after all custom widgets have been created
+          # https://github.com/zsh-users/zsh-syntax-highlighting#faq
+          "source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+        }
       '';
     }
 


### PR DESCRIPTION
### Description

`zsh-syntax-highlighting.zsh` must be sourced at the end of the `.zshrc` file, otherwise widgets created after are not properly highlighted (e.g. from oh-my-zsh...): https://github.com/zsh-users/zsh-syntax-highlighting#faq

~I moved `zsh-autosuggestions` with it for style only, I think it is good to keep these 2 plugins grouped, and it should not cause any issue.~

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
