### PR TITLE
codeowners: cleanup alphabetization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,13 @@
 
 /flake.nix                                            @bqv @kisik21
 
+Makefile                                              @thiagokokada
+
+/modules/config/home-cursor.nix                       @polykernel @league
+
+/modules/config/i18n.nix                              @midchildan
+/tests/modules/config/i18n                            @midchildan
+
 /modules/home-environment.nix                         @rycee
 
 /modules/i18n/input-method                            @Kranzes
@@ -15,11 +22,6 @@
 /tests/modules/misc/fontconfig                        @rycee
 
 /modules/misc/gtk.nix                                 @rycee
-
-/modules/config/home-cursor.nix                       @polykernel @league
-
-/modules/config/i18n.nix                              @midchildan
-/tests/modules/config/i18n                            @midchildan
 
 /modules/misc/news.nix                                @rycee
 
@@ -124,6 +126,8 @@
 /modules/programs/i3status.nix                        @JustinLovinger
 
 /modules/programs/i3status-rust.nix                   @workflow
+
+/modules/programs/ion.nix                             @jo1gi
 
 /modules/programs/java.nix                            @ShamrockLee
 
@@ -267,6 +271,8 @@
 
 /modules/programs/timidity.nix                        @amesgen
 
+/modules/programs/tint2.nix                           @CarlosLoboxyz
+
 /modules/programs/tiny.nix                            @kmaasrud
 
 /modules/programs/topgrade.nix                        @msfjarvis
@@ -397,6 +403,8 @@
 /modules/services/playerctld.nix                      @fendse
 /tests/modules/playerctld                             @fendse
 
+/modules/services/plex-mpv-shim.nix                   @starcraft66
+
 /modules/services/poweralertd.nix                     @ThibautMarty
 
 /modules/services/pulseeffects.nix                    @jonringer
@@ -409,9 +417,16 @@
 /modules/services/screen-locker.nix                   @jrobsonchase @rszamszur
 /tests/modules/services/screen-locker                 @jrobsonchase @rszamszur
 
+/modules/services/sctd.nix                            @somasis
+
 /modules/services/status-notifier-watcher.nix         @pltanton
 
+/modules/services/swayidle.nix                        @c0deaddict
+/tests/modules/services/swayidle                      @c0deaddict
+
 /modules/services/syncthing.nix                       @rycee
+
+/modules/services/systembus-notify.nix                @asymmetric
 
 /modules/services/taffybar.nix                        @rycee
 
@@ -428,6 +443,8 @@
 /modules/services/udiskie.nix                         @rycee
 
 /modules/services/unison.nix                          @pacien
+
+/modules/services/volnoti.nix                         @IvanMalison
 
 /modules/services/window-managers/bspwm               @ncfavier
 /tests/modules/services/window-managers/bspwm         @ncfavier
@@ -460,26 +477,9 @@
 
 /modules/systemd.nix                                  @rycee
 
-/modules/xresources.nix                               @rycee
-
-/modules/xsession.nix                                 @rycee
-
-/modules/services/volnoti.nix                         @IvanMalison
-
-/modules/services/systembus-notify.nix                @asymmetric
-
 /modules/targets/darwin                               @midchildan
 /tests/modules/targets-darwin                         @midchildan
 
-/modules/programs/tint2.nix                           @CarlosLoboxyz
+/modules/xresources.nix                               @rycee
 
-Makefile                                              @thiagokokada
-
-/modules/services/swayidle.nix                        @c0deaddict
-/tests/modules/services/swayidle                      @c0deaddict
-
-/modules/programs/ion.nix                             @jo1gi
-
-/modules/services/plex-mpv-shim.nix                   @starcraft66
-
-/modules/services/sctd.nix                            @somasis
+/modules/xsession.nix                                 @rycee


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
We've tried to keep the CODEOWNERS file alphabetized, but it's drifted some with people accidentally adding to the bottom. This fixes all of those issues.

One question that I have is whether the few at the top were intentionally clustered (they are mainly @rycee). If they need to be clustered together, maybe it's worth adding "sections" to the file and noting the exceptions. Alternatively, we just go with what I have right now which aggressively alphabetizes everything.

Signed-off-by: Sumner Evans <me@sumnerevans.com>

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
