### PR TITLE
git: Add option to use difftastic in side-by-side or inline view

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -265,6 +265,16 @@ in {
             Determines when difftastic should color its output.
           '';
         };
+
+        display = mkOption {
+          type =
+            types.enum [ "side-by-side" "side-by-side-show-both" "inline" ];
+          default = "side-by-side";
+          example = "inline";
+          description = ''
+            Determines how the output displays - in one column or two columns.
+          '';
+        };
       };
 
       delta = {
@@ -476,8 +486,11 @@ in {
       home.packages = [ pkgs.difftastic ];
 
       programs.git.iniContent = let
-        difftCommand =
-          "${pkgs.difftastic}/bin/difft --color ${cfg.difftastic.color} --background ${cfg.difftastic.background}";
+        difftCommand = "${pkgs.difftastic}/bin/difft" + concatStringsSep " " [
+          "--color ${cfg.difftastic.color}"
+          "--background ${cfg.difftastic.background}"
+          "--display ${cfg.difftastic.display}"
+        ];
       in {
         diff.external = difftCommand;
         core.pager = "${pkgs.less}/bin/less -XF";


### PR DESCRIPTION
### Description
Currently there's no way to see a unified view of `git diff` output with difftastic. This PR enables it.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.
   pandoc-defaults: FAILED
   helix-example-settings: FAILED

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
