### PR TITLE
tests: fix impurity of _module.args.pkgsPath

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -15,6 +15,10 @@ let
     check = false;
   } ++ [
     {
+      # Bypass <nixpkgs> reference inside modules/modules.nix to make the test
+      # suite more pure.
+      _module.args.pkgsPath = pkgs.path;
+
       # Fix impurities. Without these some of the user's environment
       # will leak into the tests through `builtins.getEnv`.
       xdg.enable = true;


### PR DESCRIPTION
### Description

This patch fixes the impurity caused by the last element of the above `modules` (i.e. `pkgsModule`) setting `pkgsPath` with `mkDefault` to `<nixpkgs>` if `config.home.stateVersion` is before 20.09.

Considering that this piece of configuration is used for testing, it should be fine to specify pkgsPath directly.

If applied, it will allow the flake-based test  running (provided by by #3024) work without the `--impure` flag.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible. (I should think so)

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
