### PR TITLE
discocss: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,6 +79,8 @@
 
 /modules/programs/direnv.nix                          @rycee
 
+/modules/programs/discocss.nix                        @fufexan
+
 /modules/programs/eclipse.nix                         @rycee
 
 /modules/programs/emacs.nix                           @rycee

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -583,6 +583,11 @@ in
           A new module is available: 'services.sctd'.
         '';
       }
+      { time = "2022-07-09T14:49:39+00:00";
+        message = ''
+          A new module is available: 'programs.discocss'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -61,6 +61,7 @@ let
     ./programs/command-not-found/command-not-found.nix
     ./programs/dircolors.nix
     ./programs/direnv.nix
+    ./programs/discocss.nix
     ./programs/eclipse.nix
     ./programs/emacs.nix
     ./programs/eww.nix

--- a/modules/programs/discocss.nix
+++ b/modules/programs/discocss.nix
@@ -1,0 +1,83 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.discocss;
+
+  discocssWrapper = { stdenvNoCC, fetchFromGitHub, lib, makeWrapper, runCommand
+    , discocss, discord, alias ? false }:
+    runCommand "discocss" {
+      buildInputs = [ makeWrapper ];
+      preferLocalBuild = true;
+    } ''
+      mkdir -p $out/{bin,share}
+
+      ${lib.optionalString alias ''
+        ln -s $out/bin/discocss $out/bin/Discord
+        ln -s ${discord}/share/* $out/share/
+      ''}
+
+      makeWrapper ${discocss}/bin/discocss $out/bin/discocss \
+        --set DISCOCSS_DISCORD_BIN ${discord}/bin/Discord
+    '';
+in {
+  meta.maintainers = with maintainers; [ fufexan ];
+
+  options = {
+    programs.discocss = {
+      enable = mkEnableOption "discocss";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.callPackage discocssWrapper { };
+        description = ''
+          Package to use for Discocss.
+        '';
+      };
+
+      discordPackage = mkOption {
+        type = types.package;
+        default = pkgs.discord;
+        description = ''
+          Discord package to apply Discocss to.
+        '';
+      };
+
+      alias = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to alias the <code>Discord</code> command to <code>discocss</code>.
+        '';
+      };
+
+      css = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Custom CSS to theme Discord.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = cfg.alias
+        -> !(builtins.any (p: p.name == cfg.discordPackage.name)
+          config.home.packages);
+      message =
+        "To use discocss with alias you have to remove discord from home.packages, or set alias = false;";
+    }];
+
+    home.packages = [
+      (cfg.package.override {
+        inherit (cfg) alias;
+        discord = cfg.discordPackage;
+      })
+    ];
+
+    xdg.configFile."discocss/custom.css".text = cfg.css;
+  };
+}


### PR DESCRIPTION
Adds support for discocss, a tiny Discord CSS injector.

### Description

Adds the module [here](https://github.com/mlvzk/discocss/tree/flake), extended [here](https://github.com/mlvzk/discocss/pull/16).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
