### PR TITLE
xdg-desktop-entries: allow icon path type

### DIFF
--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -38,7 +38,7 @@ let
 
       icon = mkOption {
         description = "Icon to display in file manager, menus, etc.";
-        type = types.nullOr types.str;
+        type = types.nullOr (types.either types.str types.path);
         default = null;
       };
 
@@ -133,7 +133,7 @@ let
             description = "Program to execute, possibly with arguments.";
           };
           options.icon = mkOption {
-            type = types.nullOr types.str;
+            type = types.nullOr (types.either types.str types.path);
             default = null;
             description = "Icon to display in file manager, menus, etc.";
           };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

The [XDG desktop spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html#key-icon) allows an icon value to be an absolute path. Since the `xdg.desktopEntries` config passes the `icon` value, unmodified, to [`makeDesktopIcon`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/make-desktopitem/default.nix) a `path` type is valid.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
