### PR TITLE
gpg-agent: set Environment to a list

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -271,7 +271,7 @@ in {
           ExecStart = "${gpgPkg}/bin/gpg-agent --supervised"
             + optionalString cfg.verbose " --verbose";
           ExecReload = "${gpgPkg}/bin/gpgconf --reload gpg-agent";
-          Environment = "GNUPGHOME=${homedir}";
+          Environment = [ "GNUPGHOME=${homedir}" ];
         };
       };
 


### PR DESCRIPTION
### Description
In my specific setup, due to the merge of https://github.com/nix-community/home-manager/pull/3031, the environment variable `GTK2_RC_FILES` is no longer visible to `gpg-agent.service`, thus the `pinentry` it launches no longer follows the system gtk theme. In order to restore the previous behavior, I set
```nix
systemd.user.services.gpg-agent.Service.Environment = [ "GTK2_RC_FILES=${config.home.sessionVariables.GTK2_RC_FILES}" ];
```
However the `Environment` attr is a string instead of a list in the `gpg-agent` module, causing an evaluation failure. This change restores the possibility to set custom environment variables in this service.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
