### PR TITLE
gallery-dl: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,6 +109,9 @@ Makefile                                              @thiagokokada
 /modules/services/fusuma.nix                          @iosmanthus
 /tests/modules/services/fusuma                        @iosmanthus
 
+/modules/programs/gallery-dl.nix                      @marsam
+/tests/modules/programs/gallery-dl                    @marsam
+
 /modules/programs/gh.nix                              @Gerschtli @berbiche
 /tests/modules/programs/gh                            @Gerschtli @berbiche
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -689,6 +689,13 @@ in
           A new module is available: 'programs.yt-dlp'.
         '';
       }
+
+      {
+        time = "2022-09-09T09:55:50+00:00";
+        message = ''
+          A new module is available: 'programs.gallery-dl'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -74,6 +74,7 @@ let
     ./programs/fish.nix
     ./programs/foot.nix
     ./programs/fzf.nix
+    ./programs/gallery-dl.nix
     ./programs/getmail.nix
     ./programs/gh.nix
     ./programs/git.nix

--- a/modules/programs/gallery-dl.nix
+++ b/modules/programs/gallery-dl.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.gallery-dl;
+
+  jsonFormat = pkgs.formats.json { };
+
+in {
+  meta.maintainers = [ maintainers.marsam ];
+
+  options.programs.gallery-dl = {
+    enable = mkEnableOption "gallery-dl";
+
+    settings = mkOption {
+      type = jsonFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          extractor.base-directory = "~/Downloads";
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>$XDG_CONFIG_HOME/gallery-dl/config.json</filename>. See
+        <link xlink:href="https://github.com/mikf/gallery-dl#configuration"/>
+        for supported values.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.gallery-dl ];
+
+    xdg.configFile."gallery-dl/config.json" = mkIf (cfg.settings != { }) {
+      source = jsonFormat.generate "gallery-dl-settings" cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -70,6 +70,7 @@ import nmt {
     ./modules/programs/emacs
     ./modules/programs/feh
     ./modules/programs/fish
+    ./modules/programs/gallery-dl
     ./modules/programs/gh
     ./modules/programs/git
     ./modules/programs/gpg

--- a/tests/modules/programs/gallery-dl/default.nix
+++ b/tests/modules/programs/gallery-dl/default.nix
@@ -1,0 +1,1 @@
+{ gallery-dl = ./gallery-dl.nix; }

--- a/tests/modules/programs/gallery-dl/gallery-dl.nix
+++ b/tests/modules/programs/gallery-dl/gallery-dl.nix
@@ -1,0 +1,28 @@
+{ ... }:
+
+{
+  programs.gallery-dl = {
+    enable = true;
+
+    settings = {
+      cache.file = "~/gallery-dl/cache.sqlite3";
+      extractor.base-directory = "~/gallery-dl/";
+    };
+  };
+
+  test.stubs.gallery-dl = { };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/gallery-dl/config.json \
+    ${builtins.toFile "gallery-dl-expected-settings.json" ''
+      {
+        "cache": {
+          "file": "~/gallery-dl/cache.sqlite3"
+        },
+        "extractor": {
+          "base-directory": "~/gallery-dl/"
+        }
+      }
+    ''}
+  '';
+}


### PR DESCRIPTION
[gallery-dl](https://github.com/mikf/gallery-dl) is a cli to download image galleries from several image
hosting sites.


### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
