### PR TITLE
git: fix missing space between difftastic and arguments

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -486,8 +486,7 @@ in {
       home.packages = [ pkgs.difftastic ];
 
       programs.git.iniContent = let
-        difftCommand = concatStringsSep " " [
-          "${pkgs.difftastic}/bin/difft"
+        difftCommand = "${pkgs.difftastic}/bin/difft " + concatStringsSep " " [
           "--color ${cfg.difftastic.color}"
           "--background ${cfg.difftastic.background}"
           "--display ${cfg.difftastic.display}"


### PR DESCRIPTION
### Description

fix https://github.com/nix-community/home-manager/pull/3076#discussion_r918716736

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
