### PR TITLE
firefox: Reuse `escapeXML` from Nixpkgs

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -58,13 +58,6 @@ let
 
   firefoxBookmarksFile = bookmarks:
     let
-      escapeXML = replaceStrings [ ''"'' "'" "<" ">" "&" ] [
-        "&quot;"
-        "&apos;"
-        "&lt;"
-        "&gt;"
-        "&amp;"
-      ];
       mapper = _: entry: ''
         <DT><A HREF="${escapeXML entry.url}" ADD_DATE="0" LAST_MODIFIED="0"${
           lib.optionalString (entry.keyword != null)


### PR DESCRIPTION
### Description

This uses the `escapeXML` function provided by Nixpkgs instead of redefining it in the Firefox module.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
