### PR TITLE
ISSUE_TEMPLATE/issue.yaml: ensure using the right branch of home-manager

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -10,6 +10,17 @@ assignees: [rycee, berbiche, sumnerevans]
 body:
 - type: checkboxes
   attributes:
+    label: Are you following the right branch?
+    description: |
+      You should follow the branch of Home Manager that corresponds to your
+      version of Nixpkgs; see
+      [the README](https://github.com/nix-community/home-manager#releases)
+      for details.
+    options:
+    - label: My Nixpkgs and Home Manager versions are in sync
+      required: true
+- type: checkboxes
+  attributes:
     label: Is there an existing issue for this?
     description: |
       Please search to see if an issue already exists for the bug you encountered.


### PR DESCRIPTION
We seem to be getting a [lot](https://github.com/nix-community/home-manager/issues/3011) [of](https://github.com/nix-community/home-manager/issues/3057) [bug](https://github.com/nix-community/home-manager/issues/3101) [reports](https://github.com/nix-community/home-manager/issues/3102) coming from people using `home-manager/master` with `nixpkgs/nixos-22.05` or similar scenarios. (currently exacerbated by https://github.com/nix-community/home-manager/pull/3013)

Let's add a checkbox in the issue template to warn people about that. Wording suggestions welcome.

[Preview](https://github.com/ncfavier/home-manager/blob/issue-template-branch/.github/ISSUE_TEMPLATE/issue.yaml)