### PR TITLE
docs/contributing.adoc: fix generated manpages filename, fix seven rules guideline

### DIFF
--- a/docs/contributing.adoc
+++ b/docs/contributing.adoc
@@ -105,7 +105,7 @@ When you have made changes to a module, it is a good idea to check that the man 
 
 [source,console]
 $ nix-build -A docs.manPages
-$ man ./result/share/man/man5/home-configuration.nix.5
+$ man ./result/share/man/man5/home-configuration.nix.5.gz
 
 ==== Add yourself as a module maintainer
 
@@ -155,7 +155,7 @@ A potential gotcha with respect to licensing are option descriptions. Often it i
 
 The commits in your pull request should be reasonably self-contained, that is, each commit should make sense in isolation. In particular, you will be asked to amend any commit that introduces syntax errors or similar problems even if they are fixed in a later commit.
 
-The commit messages should follow the {seven-rules}[seven rules]. We also ask you to include the affected code component or module in the first line. That is, a commit message should follow the template
+The commit messages should follow the {seven-rules}[seven rules], except for "Capitalize the subject line". We also ask you to include the affected code component or module in the first line. That is, a commit message should follow the template
 
 ----
 {component}: {description}


### PR DESCRIPTION
### Description
<!--

Please provide a brief description of your change.

-->
- docs/contributing.adoc: fix name of file generated by `$ nix-build -A docs.manPages`
- docs/contributing.adoc#Commits: add exception to seven rules
      - why: most commits have not followed "Capitalize the subject line". Not even the example commit message (closely below this change) follows this rule.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
