### PR TITLE
zsh: fix enableCompletion not working properly with frameworks

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -269,13 +269,18 @@ in
 
       enableCompletion = mkOption {
         default = true;
-        description = ''
-          Enable zsh completion. Don't forget to add
-          <programlisting language="nix">
-            environment.pathsToLink = [ "/share/zsh" ];
-          </programlisting>
-          to your system configuration to get completion for system packages (e.g. systemd).
-        '';
+        description =
+          "Enable zsh completion." +
+          # calling compinit multiple times causes slight startup slowdown, as $fpath entries are unnecessarily
+          # traversed again
+          " If enabling completion through a framework, disable this for a slight speedup in start up." +
+          ''
+             Don't forget to add
+            <programlisting language="nix">
+              environment.pathsToLink = [ "/share/zsh" ];
+            </programlisting>
+            to your system configuration to get completion for system packages (e.g. systemd).
+          '';
         type = types.bool;
       };
 
@@ -489,10 +494,7 @@ in
           fpath+="$HOME/${pluginsDir}/${plugin.name}"
         '') cfg.plugins)}
 
-        # Oh-My-Zsh/Prezto calls compinit during initialization,
-        # calling it twice causes slight start up slowdown
-        # as all $fpath entries will be traversed again.
-        ${optionalString (cfg.enableCompletion && !cfg.oh-my-zsh.enable && !cfg.prezto.enable)
+        ${optionalString cfg.enableCompletion
           cfg.completionInit
         }
 


### PR DESCRIPTION
### Description
completion does not work when:
```nix
with programs.zsh;
enableCompletion
&& (
  (prezto.enable && !(builtins.elem "completion" prezto.pmodules))
  || oh-my-zsh.enable # and no oh-my-zsh plugins that provide completion
)
```
The cause of the bug was a flawed check whose purpose was to avoid multiple calls to `compinit`. The fix informs the user of the slowdown and lets them decide.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
