### PR TITLE
firefox: Use `lib.types.coercedTo` to normalise the bookmarks declared

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -428,7 +428,7 @@ in {
         mkIf (profile.userContent != "") { text = profile.userContent; };
 
       "${profilesPath}/${profile.path}/user.js" = mkIf (profile.settings != { }
-        || profile.extraConfig != "" || profile.bookmarks != { }) {
+        || profile.extraConfig != "" || profile.bookmarks != [ ]) {
           text =
             mkUserJs profile.settings profile.extraConfig profile.bookmarks;
         };

--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -86,8 +86,7 @@ let
         lib.concatStringsSep "\n"
         (map (itemToHTMLOrRecurse indentLevel) bookmarks);
 
-      bookmarkEntries = allItemsToHTML 1
-        (if isAttrs bookmarks then lib.attrValues bookmarks else bookmarks);
+      bookmarkEntries = allItemsToHTML 1 bookmarks;
     in pkgs.writeText "firefox-bookmarks.html" ''
       <!DOCTYPE NETSCAPE-Bookmark-file-1>
       <!-- This is an automatically generated file.
@@ -292,9 +291,10 @@ in {
                 }) // {
                   description = "directory submodule";
                 };
+
+                nodeType = types.either bookmarkType directoryType;
               in with types;
-              either (attrsOf bookmarkType)
-              (listOf (either bookmarkType directoryType));
+              coercedTo (attrsOf nodeType) attrValues (listOf nodeType);
               default = [ ];
               example = literalExpression ''
                 [


### PR DESCRIPTION
### Description

This uses `coercedTo` to make a type for the `programs.firefox.profiles.<name>.bookmarks` option that automatically converts its value to a list. This simplifies the checks on the option value in the rest of the module. A comparison that tests whether any bookmarks are specified is also modified to compare the option value against `[ ]` instead of `{ }`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
