### PR TITLE
firefox: make it possible that bookmarks are shown on toolbar

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -71,7 +71,12 @@ let
           }>${escapeXML bookmark.name}</A>'';
 
       directoryToHTML = indentLevel: directory: ''
-        ${indent indentLevel}<DT><H3>${escapeXML directory.name}</H3>
+        ${indent indentLevel}<DT>${
+          if directory.toolbar then
+            ''<H3 PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar''
+          else
+            "<H3>${escapeXML directory.name}"
+        }</H3>
         ${indent indentLevel}<DL><p>
         ${allItemsToHTML (indentLevel + 1) directory.bookmarks}
         ${indent indentLevel}</p></DL>'';
@@ -286,6 +291,12 @@ in {
                       type = types.listOf bookmarkType;
                       default = [ ];
                       description = "Bookmarks within directory.";
+                    };
+
+                    toolbar = mkOption {
+                      type = types.bool;
+                      default = false;
+                      description = "If directory should be shown in toolbar.";
                     };
                   };
                 }) // {

--- a/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
+++ b/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
@@ -6,6 +6,10 @@
 <TITLE>Bookmarks</TITLE>
 <H1>Bookmarks Menu</H1>
 <DL><p>
+  <DT><H3 PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
+  <DL><p>
+    <DT><A HREF="https://nixos.wiki/wiki/Home_Manager" ADD_DATE="0" LAST_MODIFIED="0">Home Manager</A>
+  </p></DL>
   <DT><A HREF="https://en.wikipedia.org/wiki/Special:Search?search=%s&amp;go=Go" ADD_DATE="0" LAST_MODIFIED="0" SHORTCUTURL="wiki">wikipedia</A>
   <DT><A HREF="https://www.kernel.org" ADD_DATE="0" LAST_MODIFIED="0">kernel.org</A>
   <DT><H3>Nix sites</H3>

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -17,6 +17,13 @@ lib.mkIf config.test.enableBig {
       settings = { "general.smoothScroll" = false; };
       bookmarks = [
         {
+          toolbar = true;
+          bookmarks = [{
+            name = "Home Manager";
+            url = "https://nixos.wiki/wiki/Home_Manager";
+          }];
+        }
+        {
           name = "wikipedia";
           keyword = "wiki";
           url = "https://en.wikipedia.org/wiki/Special:Search?search=%s&go=Go";


### PR DESCRIPTION
### Description

With this change, the `toolbar` dir will be shown in the browser toolbar.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

