### PR TITLE
firefox: make it possible to have nested folders (for boomarks)

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -288,7 +288,7 @@ in {
                     };
 
                     bookmarks = mkOption {
-                      type = types.listOf bookmarkType;
+                      type = types.listOf nodeType;
                       default = [ ];
                       description = "Bookmarks within directory.";
                     };

--- a/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
+++ b/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
@@ -16,5 +16,11 @@
   <DL><p>
     <DT><A HREF="https://nixos.org/" ADD_DATE="0" LAST_MODIFIED="0">homepage</A>
     <DT><A HREF="https://nixos.wiki/" ADD_DATE="0" LAST_MODIFIED="0">wiki</A>
+    <DT><H3>Nix sites</H3>
+      <DL><p>
+        <DT><A HREF="https://nixos.org/" ADD_DATE="0" LAST_MODIFIED="0">homepage</A>
+        <DT><A HREF="https://nixos.wiki/" ADD_DATE="0" LAST_MODIFIED="0">wiki</A>
+      </p></DL>
+    </p></DL>
   </p></DL>
 </p></DL>

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -43,6 +43,19 @@ lib.mkIf config.test.enableBig {
               name = "wiki";
               url = "https://nixos.wiki/";
             }
+            {
+              name = "Nix sites";
+              bookmarks = [
+                {
+                  name = "homepage";
+                  url = "https://nixos.org/";
+                }
+                {
+                  name = "wiki";
+                  url = "https://nixos.wiki/";
+                }
+              ];
+            }
           ];
         }
       ];


### PR DESCRIPTION
### Description

This makes it possible to have a dir in a dir. This is needed to have a dir in the bookmark toolbar since that is already a dir.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
