### PR TITLE
xdg-mime-apps: fix regex in `mimeAssociations`

### DIFF
--- a/modules/misc/xdg-mime-apps.nix
+++ b/modules/misc/xdg-mime-apps.nix
@@ -94,7 +94,7 @@ in {
             for p in $ps ; do
               for path in "$p"/share/applications/*.desktop ; do
                 name="''${path##*/}"
-                sed -n "/^MimeType=/ { s/.*=//; s/;/;$name\n/g; p; }" "$path"
+                sed -n -E "/^MimeType=/ { s/.*=//; s/;?$|;/;$name\n/g; p; }" "$path"
               done
             done > "$out"
           '';


### PR DESCRIPTION
### Description

The XDG Desktop Entry spec mentions that multiple values per key may be optionally terminated by a semicolon. An example for this is the Firefox desktop file, which has no trailing semicolon. This breaks the sed regex used in `mimeAssociations`.

Fix the regex by matching the end of string, optionally preceded by a semicolon, or any other semicolon. This makes it work with both semicolon-terminated and non-semicolon-terminated desktop files.

Before:

```
❯ export name=firefox.desktop && sed -n "/^MimeType=/ { s/.*=//; s/;/;$name\n/g; p; }" /nix/store/rzmiq36p92i1arjfjxkvahmqdcka02gy-firefox-101.0.1/share/applications/firefox.desktop
text/html;firefox.desktop
text/xml;firefox.desktop
application/xhtml+xml;firefox.desktop
application/vnd.mozilla.xul+xml;firefox.desktop
x-scheme-handler/http;firefox.desktop
x-scheme-handler/https;firefox.desktop
x-scheme-handler/ftp

```

After:

```
❯ export name=firefox.desktop && sed -n -E "/^MimeType=/ { s/.*=//; s/;?$|;/;$name\n/g; p; }" /nix/store/rzmiq36p92i1arjfjxkvahmqdcka02gy-firefox-101.0.1/share/applications/firefox.desktop
text/html;firefox.desktop
text/xml;firefox.desktop
application/xhtml+xml;firefox.desktop
application/vnd.mozilla.xul+xml;firefox.desktop
x-scheme-handler/http;firefox.desktop
x-scheme-handler/https;firefox.desktop
x-scheme-handler/ftp;firefox.desktop

```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
