### PR TITLE
gh: add `extensions` option

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -95,6 +95,15 @@ in {
       mkEnableOption "the gh git credential helper for github.com" // {
         default = true;
       };
+
+    extensions = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      description = ''
+        gh extensions, see <link xlink:href="https://cli.github.com/manual/gh_extension"/>.
+      '';
+      example = literalExpression "[ pkgs.gh-eco ]";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -106,5 +115,12 @@ in {
     programs.git.extraConfig.credential."https://github.com".helper =
       mkIf cfg.enableGitCredentialHelper
       "${cfg.package}/bin/gh auth git-credential";
+
+    xdg.dataFile."gh/extensions" = mkIf (cfg.extensions != [ ]) {
+      source = pkgs.linkFarm "gh-extensions" (builtins.map (p: {
+        name = p.pname;
+        path = "${p}/bin";
+      }) cfg.extensions);
+    };
   };
 }

--- a/tests/modules/programs/gh/default.nix
+++ b/tests/modules/programs/gh/default.nix
@@ -1,5 +1,6 @@
 {
   gh-config-file = ./config-file.nix;
   gh-credential-helper = ./credential-helper.nix;
+  gh-extensions = ./extensions.nix;
   gh-warnings = ./warnings.nix;
 }

--- a/tests/modules/programs/gh/extensions.nix
+++ b/tests/modules/programs/gh/extensions.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+{
+  programs.gh = {
+    enable = true;
+    extensions = [ pkgs.gh-eco ];
+  };
+
+  test.stubs = {
+    gh = { };
+    gh-eco = {
+      name = "gh-eco";
+      buildScript = ''
+        mkdir -p $out/bin
+        touch $out/bin/gh-eco
+        chmod +x $out/bin/gh-eco
+      '';
+      outPath = null;
+    };
+  };
+
+  nmt.script = ''
+    gh_eco=home-files/.local/share/gh/extensions/gh-eco/gh-eco
+    assertFileExists "$gh_eco"
+    assertFileIsExecutable "$gh_eco"
+  '';
+}

--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -40,7 +40,7 @@ let
       pkg = if name == "dummy" && buildScript == defaultBuildScript then
         dummyPackage
       else
-        pkgs.runCommandLocal name { } buildScript;
+        pkgs.runCommandLocal name { pname = name; } buildScript;
     in pkg // optionalAttrs (outPath != null) { inherit outPath; }
     // optionalAttrs (version != null) { inherit version; };
 


### PR DESCRIPTION
### Description

Allows to configure [gh extensions](https://cli.github.com/manual/gh_extension). Naturally, the imperative commands such as `gh extension install` and `gh extension remove` then stop working as expected.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

