### PR TITLE
bugfix and slighty improved behavior on the "files" module

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -8,26 +8,26 @@ let
 
   homeDirectory = config.home.homeDirectory;
 
-  fileType = (import lib/file-type.nix {
-    inherit homeDirectory lib pkgs;
-  }).fileType;
+  fileType =
+    (import lib/file-type.nix { inherit homeDirectory lib pkgs; }).fileType;
 
   sourceStorePath = file:
     let
       sourcePath = toString file.source;
       sourceName = config.lib.strings.storeFileName (baseNameOf sourcePath);
-    in
-      if builtins.hasContext sourcePath
-      then file.source
-      else builtins.path { path = file.source; name = sourceName; };
+    in if builtins.hasContext sourcePath then
+      file.source
+    else
+      builtins.path {
+        path = file.source;
+        name = sourceName;
+      };
 
-in
-
-{
+in {
   options = {
     home.file = mkOption {
       description = "Attribute set of files to link into the user home.";
-      default = {};
+      default = { };
       type = fileType "<envar>HOME</envar>" homeDirectory;
     };
 
@@ -39,24 +39,24 @@ in
   };
 
   config = {
-    assertions = [(
-      let
-        dups =
-          attrNames
-            (filterAttrs
-             (n: v: (v.count > 1 && v.nonrec > 0))
-             (foldAttrs (acc: v: {
-                 count=acc.count + v.count; nonrec= acc.nonrec+v.nonrec;
-              })
-              {count=0;nonrec=0;}
-              (mapAttrsToList (n: v: {
-                  ${v.target} = {count=1;nonrec= (! v.recursive) };
-               })
-               cfg)
-            ));
+    assertions = [
+      (let
+        dups = attrNames (filterAttrs (n: v: (v.count > 1 && v.nonrec > 0))
+          (foldAttrs (acc: v: {
+            count = acc.count + v.count;
+            nonrec = acc.nonrec + v.nonrec;
+          }) {
+            count = 0;
+            nonrec = 0;
+          } (mapAttrsToList (n: v: {
+            ${v.target} = {
+              count = 1;
+              nonrec = (!v.recursive);
+            };
+          }) cfg)));
         dupsStr = concatStringsSep ", " (attrNames dups);
       in {
-        assertion = dups == [];
+        assertion = dups == [ ];
         message = ''
           Conflicting managed target files: ${dupsStr}
 
@@ -71,7 +71,7 @@ in
                 conflict1 = { source = ./foo.nix; target = "baz"; recursive=true; allowRecursiveMerge=true;};
                 conflict2 = { source = ./bar.nix; target = "baz"; }; # missing "recursive=true" and "allowRecursiveMerge=true"
               }'';
-           
+
       })
     ];
 
@@ -79,19 +79,17 @@ in
       let
         pathStr = toString path;
         name = hm.strings.storeFileName (baseNameOf pathStr);
-      in
-        pkgs.runCommandLocal name {} ''ln -s ${escapeShellArg pathStr} $out'';
+      in pkgs.runCommandLocal name { } "ln -s ${escapeShellArg pathStr} $out";
 
     # This verifies that the links we are about to create will not
     # overwrite an existing file.
-    home.activation.checkLinkTargets = hm.dag.entryBefore ["writeBoundary"] (
-      let
+    home.activation.checkLinkTargets = hm.dag.entryBefore [ "writeBoundary" ]
+      (let
         # Paths that should be forcibly overwritten by Home Manager.
         # Caveat emptor!
         forcedPaths =
           concatMapStringsSep " " (p: ''"$HOME"/${escapeShellArg p}'')
-            (mapAttrsToList (n: v: v.target)
-            (filterAttrs (n: v: v.force) cfg));
+          (mapAttrsToList (n: v: v.target) (filterAttrs (n: v: v.force) cfg));
 
         check = pkgs.writeText "check" ''
           ${config.lib.bash.initHomeManagerLib}
@@ -99,7 +97,9 @@ in
           # A symbolic link whose target path matches this pattern will be
           # considered part of a Home Manager generation.
           function isHomeFilePattern() {
-            return "$(realpath -m "$1") == \"$(realpath -e ${escapeShellArg builtins.storeDir})\"/*-home-manager-files/*"
+            return "$(realpath -m "$1") == \"$(realpath -e ${
+              escapeShellArg builtins.storeDir
+            })\"/*-home-manager-files/*"
           }
 
           forcedPaths=(${forcedPaths})
@@ -148,8 +148,7 @@ in
             exit 1
           fi
         '';
-      in
-      ''
+      in ''
         function checkNewGenCollision() {
           local newGenFiles
           newGenFiles="$(readlink -e "$newGenPath/home-files")"
@@ -158,8 +157,7 @@ in
         }
 
         checkNewGenCollision || exit 1
-      ''
-    );
+      '');
 
     # This activation script will
     #
@@ -182,126 +180,124 @@ in
     # and a failure during the intermediate state FA ∩ FB will not
     # result in lost links because this set of links are in both the
     # source and target generation.
-    home.activation.linkGeneration = hm.dag.entryAfter ["writeBoundary"] (
-      let
-        link = pkgs.writeShellScript "link" ''
-          newGenFiles="$1"
-          shift
-          for sourcePath in "$@" ; do
-            relativePath="''${sourcePath#$newGenFiles/}"
-            targetPath="$HOME/$relativePath"
-            if [[ -e "$targetPath" && ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
-              # The target exists, back it up
-              backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
-              $DRY_RUN_CMD mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
-            fi
-
-            if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath" ; then
-              # The target exists but is identical – don't do anything.
-              $VERBOSE_ECHO "Skipping '$targetPath' as it is identical to '$sourcePath'"
-            else
-              # Place that symlink, --force
-              $DRY_RUN_CMD mkdir -p $VERBOSE_ARG "$(dirname "$targetPath")"
-              $DRY_RUN_CMD ln -nsf $VERBOSE_ARG "$sourcePath" "$targetPath"
-            fi
-          done
-        '';
-
-        cleanup = pkgs.writeShellScript "cleanup" ''
-          ${config.lib.bash.initHomeManagerLib}
-
-          # A symbolic link whose target path matches this pattern will be
-          # considered part of a Home Manager generation.
-
-          function isHomeFilePattern() {
-            return "$(realpath -m "$1") == \"$(realpath -e ${escapeShellArg builtins.storeDir})\"/*-home-manager-files/*"
-          }
-
-          newGenFiles="$1"
-          shift 1
-          for relativePath in "$@" ; do
-            targetPath="$HOME/$relativePath"
-            if [[ -e "$newGenFiles/$relativePath" ]] ; then
-              $VERBOSE_ECHO "Checking $targetPath: exists"
-            elif [[ ! $isHomeFilePattern $targetPath ]] ; then
-              warnEcho "Path '$targetPath' does not link into a Home Manager generation. Skipping delete."
-            else
-              $VERBOSE_ECHO "Checking $targetPath: gone (deleting)"
-              $DRY_RUN_CMD rm $VERBOSE_ARG "$targetPath"
-
-              # Recursively delete empty parent directories.
-              targetDir="$(dirname "$relativePath")"
-              if [[ "$targetDir" != "." ]] ; then
-                pushd "$HOME" > /dev/null
-
-                # Call rmdir with a relative path excluding $HOME.
-                # Otherwise, it might try to delete $HOME and exit
-                # with a permission error.
-                $DRY_RUN_CMD rmdir $VERBOSE_ARG \
-                    -p --ignore-fail-on-non-empty \
-                    "$targetDir"
-
-                popd > /dev/null
-              fi
-            fi
-          done
-        '';
-      in
-        ''
-          function linkNewGen() {
-            _i "Creating home file links in %s" "$HOME"
-
-            local newGenFiles
-            newGenFiles="$(readlink -e "$newGenPath/home-files")"
-            find "$newGenFiles" \( -type f -or -type l \) \
-              -exec bash ${link} "$newGenFiles" {} +
-          }
-
-          function cleanOldGen() {
-            if [[ ! -v oldGenPath || ! -e "$oldGenPath/home-files" ]] ; then
-              return
-            fi
-
-            _i "Cleaning up orphan links from %s" "$HOME"
-
-            local newGenFiles oldGenFiles
-            newGenFiles="$(readlink -e "$newGenPath/home-files")"
-            oldGenFiles="$(readlink -e "$oldGenPath/home-files")"
-
-            # Apply the cleanup script on each leaf in the old
-            # generation. The find command below will print the
-            # relative path of the entry.
-            find "$oldGenFiles" '(' -type f -or -type l ')' -printf '%P\0' \
-              | xargs -0 bash ${cleanup} "$newGenFiles"
-          }
-
-          cleanOldGen
-
-          if [[ ! -v oldGenPath || "$oldGenPath" != "$newGenPath" ]] ; then
-            _i "Creating profile generation %s" $newGenNum
-            if [[ -e "$genProfilePath"/manifest.json ]] ; then
-              # Remove all packages from "$genProfilePath"
-              # `nix profile remove '.*' --profile "$genProfilePath"` was not working, so here is a workaround:
-              nix profile list --profile "$genProfilePath" \
-                | cut -d ' ' -f 4 \
-                | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG --profile "$genProfilePath"
-              $DRY_RUN_CMD nix profile install $VERBOSE_ARG --profile "$genProfilePath" "$newGenPath"
-            else
-              $DRY_RUN_CMD nix-env $VERBOSE_ARG --profile "$genProfilePath" --set "$newGenPath"
-            fi
-
-            $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG "$newGenPath" "$newGenGcPath"
-          else
-            _i "No change so reusing latest profile generation %s" "$oldGenNum"
+    home.activation.linkGeneration = hm.dag.entryAfter [ "writeBoundary" ] (let
+      link = pkgs.writeShellScript "link" ''
+        newGenFiles="$1"
+        shift
+        for sourcePath in "$@" ; do
+          relativePath="''${sourcePath#$newGenFiles/}"
+          targetPath="$HOME/$relativePath"
+          if [[ -e "$targetPath" && ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
+            # The target exists, back it up
+            backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
+            $DRY_RUN_CMD mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
           fi
 
-          linkNewGen
-        ''
-    );
+          if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath" ; then
+            # The target exists but is identical – don't do anything.
+            $VERBOSE_ECHO "Skipping '$targetPath' as it is identical to '$sourcePath'"
+          else
+            # Place that symlink, --force
+            $DRY_RUN_CMD mkdir -p $VERBOSE_ARG "$(dirname "$targetPath")"
+            $DRY_RUN_CMD ln -nsf $VERBOSE_ARG "$sourcePath" "$targetPath"
+          fi
+        done
+      '';
 
-    home.activation.checkFilesChanged = hm.dag.entryBefore ["linkGeneration"] (
-      let
-        homeDirArg = escapeShellArg homeDirectory;
+      cleanup = pkgs.writeShellScript "cleanup" ''
+        ${config.lib.bash.initHomeManagerLib}
+
+        # A symbolic link whose target path matches this pattern will be
+        # considered part of a Home Manager generation.
+
+        function isHomeFilePattern() {
+          return "$(realpath -m "$1") == \"$(realpath -e ${
+            escapeShellArg builtins.storeDir
+          })\"/*-home-manager-files/*"
+        }
+
+        newGenFiles="$1"
+        shift 1
+        for relativePath in "$@" ; do
+          targetPath="$HOME/$relativePath"
+          if [[ -e "$newGenFiles/$relativePath" ]] ; then
+            $VERBOSE_ECHO "Checking $targetPath: exists"
+          elif [[ ! $isHomeFilePattern $targetPath ]] ; then
+            warnEcho "Path '$targetPath' does not link into a Home Manager generation. Skipping delete."
+          else
+            $VERBOSE_ECHO "Checking $targetPath: gone (deleting)"
+            $DRY_RUN_CMD rm $VERBOSE_ARG "$targetPath"
+
+            # Recursively delete empty parent directories.
+            targetDir="$(dirname "$relativePath")"
+            if [[ "$targetDir" != "." ]] ; then
+              pushd "$HOME" > /dev/null
+
+              # Call rmdir with a relative path excluding $HOME.
+              # Otherwise, it might try to delete $HOME and exit
+              # with a permission error.
+              $DRY_RUN_CMD rmdir $VERBOSE_ARG \
+                  -p --ignore-fail-on-non-empty \
+                  "$targetDir"
+
+              popd > /dev/null
+            fi
+          fi
+        done
+      '';
+    in ''
+      function linkNewGen() {
+        _i "Creating home file links in %s" "$HOME"
+
+        local newGenFiles
+        newGenFiles="$(readlink -e "$newGenPath/home-files")"
+        find "$newGenFiles" \( -type f -or -type l \) \
+          -exec bash ${link} "$newGenFiles" {} +
+      }
+
+      function cleanOldGen() {
+        if [[ ! -v oldGenPath || ! -e "$oldGenPath/home-files" ]] ; then
+          return
+        fi
+
+        _i "Cleaning up orphan links from %s" "$HOME"
+
+        local newGenFiles oldGenFiles
+        newGenFiles="$(readlink -e "$newGenPath/home-files")"
+        oldGenFiles="$(readlink -e "$oldGenPath/home-files")"
+
+        # Apply the cleanup script on each leaf in the old
+        # generation. The find command below will print the
+        # relative path of the entry.
+        find "$oldGenFiles" '(' -type f -or -type l ')' -printf '%P\0' \
+          | xargs -0 bash ${cleanup} "$newGenFiles"
+      }
+
+      cleanOldGen
+
+      if [[ ! -v oldGenPath || "$oldGenPath" != "$newGenPath" ]] ; then
+        _i "Creating profile generation %s" $newGenNum
+        if [[ -e "$genProfilePath"/manifest.json ]] ; then
+          # Remove all packages from "$genProfilePath"
+          # `nix profile remove '.*' --profile "$genProfilePath"` was not working, so here is a workaround:
+          nix profile list --profile "$genProfilePath" \
+            | cut -d ' ' -f 4 \
+            | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG --profile "$genProfilePath"
+          $DRY_RUN_CMD nix profile install $VERBOSE_ARG --profile "$genProfilePath" "$newGenPath"
+        else
+          $DRY_RUN_CMD nix-env $VERBOSE_ARG --profile "$genProfilePath" --set "$newGenPath"
+        fi
+
+        $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG "$newGenPath" "$newGenGcPath"
+      else
+        _i "No change so reusing latest profile generation %s" "$oldGenNum"
+      fi
+
+      linkNewGen
+    '');
+
+    home.activation.checkFilesChanged = hm.dag.entryBefore [ "linkGeneration" ]
+      (let homeDirArg = escapeShellArg homeDirectory;
       in ''
         function _cmp() {
           if [[ -d $1 && -d $2 ]]; then
@@ -319,14 +315,12 @@ in
           _cmp ${sourceArg} ${homeDirArg}/${targetArg} \
             && changedFiles[${targetArg}]=0 \
             || changedFiles[${targetArg}]=1
-        '') (filter (v: v.onChange != "") (attrValues cfg))
-      + ''
-        unset -f _cmp
-      ''
-    );
+        '') (filter (v: v.onChange != "") (attrValues cfg)) + ''
+          unset -f _cmp
+        '');
 
-    home.activation.onFilesChange = hm.dag.entryAfter ["linkGeneration"] (
-      concatMapStrings (v: ''
+    home.activation.onFilesChange = hm.dag.entryAfter [ "linkGeneration" ]
+      (concatMapStrings (v: ''
         if (( ''${changedFiles[${escapeShellArg v.target}]} == 1 )); then
           if [[ -v DRY_RUN || -v VERBOSE ]]; then
             echo "Running onChange hook for" ${escapeShellArg v.target}
@@ -335,96 +329,89 @@ in
             ${v.onChange}
           fi
         fi
-      '') (filter (v: v.onChange != "") (attrValues cfg))
-    );
+      '') (filter (v: v.onChange != "") (attrValues cfg)));
 
     # Symlink directories and files that have the right execute bit.
     # Copy files that need their execute bit changed.
-    home-files = pkgs.runCommandLocal
-      "home-manager-files"
-      {
-        nativeBuildInputs = [ pkgs.xorg.lndir ];
-      }
-      (''
-        mkdir -p $out
+    home-files = pkgs.runCommandLocal "home-manager-files" {
+      nativeBuildInputs = [ pkgs.xorg.lndir ];
+    } (''
+      mkdir -p $out
 
-        # Needed in case /nix is a symbolic link.
-        realOut="$(realpath -m "$out")"
+      # Needed in case /nix is a symbolic link.
+      realOut="$(realpath -m "$out")"
 
-        function insertFile() {
-          local source="$1"
-          local relTarget="$2"
-          local executable="$3"
-          local recursive="$4"
-          local allowrecursivedirmerge="$5"
+      function insertFile() {
+        local source="$1"
+        local relTarget="$2"
+        local executable="$3"
+        local recursive="$4"
+        local allowrecursivedirmerge="$5"
 
-          # If the target already exists then we have a collision.
-          # If it is a "simple copy", justdrop out of it. If it's a recursive dir copy,
-          # we need to merge the source and destination, and check for collisions for each file.
-          # If this is a "simple collision", simply log the conflict and otherwise ignore it,
-          # mainly to make the `files-target-config` test work as expected.
-          if [[ -d "$realOut/$relTarget" ]] && [[ $recursive ]] && [[ $allowrecursivedirmerge ]]; then
-            # pass
-          elif [[ -e "$realOut/$relTarget" ]]; then
-            echo "File conflict for file '$relTarget'" >&2
-            return
-          fi
+        # If the target already exists then we have a collision.
+        # If it is a "simple copy", justdrop out of it. If it's a recursive dir copy,
+        # we need to merge the source and destination, and check for collisions for each file.
+        # If this is a "simple collision", simply log the conflict and otherwise ignore it,
+        # mainly to make the `files-target-config` test work as expected.
+        if [[ -d "$realOut/$relTarget" ]] && [[ $recursive ]] && [[ $allowrecursivedirmerge ]]; then
+          # pass
+        elif [[ -e "$realOut/$relTarget" ]]; then
+          echo "File conflict for file '$relTarget'" >&2
+          return
+        fi
 
-          # Figure out the real absolute path to the target.
-          local target
-          target="$(realpath -m "$realOut/$relTarget")"
+        # Figure out the real absolute path to the target.
+        local target
+        target="$(realpath -m "$realOut/$relTarget")"
 
-          # Target path must be within $HOME.
-          if [[ ! $target == $realOut* ]] ; then
-            echo "Error installing file '$relTarget' outside \$HOME" >&2
-            exit 1
-          fi
+        # Target path must be within $HOME.
+        if [[ ! $target == $realOut* ]] ; then
+          echo "Error installing file '$relTarget' outside \$HOME" >&2
+          exit 1
+        fi
 
-          mkdir -p "$(dirname "$target")"
-          if [[ -d $source ]]; then
-            if [[ $recursive ]]; then
-              mkdir -p "$target"
-              # note: lndir does not override existing files/symlinks with newer symlinks
-              lndir -silent "$source" "$target"
-            else
-              ln -s "$source" "$target"
-            fi
+        mkdir -p "$(dirname "$target")"
+        if [[ -d $source ]]; then
+          if [[ $recursive ]]; then
+            mkdir -p "$target"
+            # note: lndir does not override existing files/symlinks with newer symlinks
+            lndir -silent "$source" "$target"
           else
-            [[ -x $source ]] && isExecutable=1 || isExecutable=""
+            ln -s "$source" "$target"
+          fi
+        else
+          [[ -x $source ]] && isExecutable=1 || isExecutable=""
 
-            # Link the file into the home file directory if possible,
-            # i.e., if the executable bit of the source is the same we
-            # expect for the target. Otherwise, we copy the file and
-            # set the executable bit to the expected value.
-            if [[ $executable == inherit || $isExecutable == $executable ]]; then
-              ln -s "$source" "$target"
+          # Link the file into the home file directory if possible,
+          # i.e., if the executable bit of the source is the same we
+          # expect for the target. Otherwise, we copy the file and
+          # set the executable bit to the expected value.
+          if [[ $executable == inherit || $isExecutable == $executable ]]; then
+            ln -s "$source" "$target"
+          else
+            cp "$source" "$target"
+
+            if [[ $executable == inherit ]]; then
+              # Don't change file mode if it should match the source.
+              :
+            elif [[ $executable ]]; then
+              chmod +x "$target"
             else
-              cp "$source" "$target"
-
-              if [[ $executable == inherit ]]; then
-                # Don't change file mode if it should match the source.
-                :
-              elif [[ $executable ]]; then
-                chmod +x "$target"
-              else
-                chmod -x "$target"
-              fi
+              chmod -x "$target"
             fi
           fi
-        }
-      '' + concatStrings (
-        mapAttrsToList (n: v: ''
-          insertFile ${
-            escapeShellArgs [
-              (sourceStorePath v)
-              v.target
-              (if v.executable == null
-               then "inherit"
-               else toString v.executable)
-              (toString v.recursive)
-              (toString v.allowrecursivemerge)
-            ]}
-        '') cfg
-      ));
+        fi
+      }
+    '' + concatStrings (mapAttrsToList (n: v: ''
+      insertFile ${
+        escapeShellArgs [
+          (sourceStorePath v)
+          v.target
+          (if v.executable == null then "inherit" else toString v.executable)
+          (toString v.recursive)
+          (toString v.allowrecursivemerge)
+        ]
+      }
+    '') cfg));
   };
 }

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -75,6 +75,22 @@ in
           '';
         };
 
+        allowRecursiveMerge = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+	    By default, two or more file sources cannot be linked to
+	    the same target path, even if they are all directories and
+	    all recursively linked.
+	    </para><para>
+            This option, when set to <literal>true</literal> on all
+	    conflicting recursive file sources, allows said sources
+	    to be merged then recursively linked to their common
+	    target path (see documentation for the
+	    <literal>recursive</literal> option).
+          '';
+        };
+
         onChange = mkOption {
           type = types.lines;
           default = "";


### PR DESCRIPTION
### Description

- fixed a(n assumed) bug where hidden files directly in `$STORE/$HASH-home-manager-files` are not symlinked into the home directory

- allow recursive `home.file` directive to be merged in an existing directory in the home directory (managed files are still "weaker" than already-present files unless `force` is used)
- similarly, add an option (`allowRecursiveMerge`) to have two recursive `home.file` directives to have the same target directory
  (although I'm not sure what is to happend if there is an actually conficting file in those directories)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Fully determine behavior
  - what happens when recursive+allowRecursiveMerge is used, and one of the merged sources is a single file?
  - what takes precedence when there is a single file/file (or file/folder) conflict when merging when constructing home-manager-files?

- [ ] Change is backwards compatible.
  - Does "backwards compatible" include the fact that users might have relied on what is here assumed to be a bug?
    (todo: fully determine what footguns there would be in doing so)
  - users relying on recursive+force overriding the full target directory might experience surprises: test whether it is the case

- [ ] Code formatted with `./format`.
  - whoops, probably undone with subsequent commits :')

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

