### PR TITLE
hyfetch: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,6 +123,9 @@ Makefile                                              @thiagokokada
 /modules/programs/htop.nix                            @bjpbakker
 /tests/modules/htop                                   @bjpbakker
 
+/modules/programs/hyfetch.nix                         @lilyinstarlight
+/tests/modules/programs/hyfetch                       @lilyinstarlight
+
 /modules/programs/i3status.nix                        @JustinLovinger
 
 /modules/programs/i3status-rust.nix                   @workflow

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -632,6 +632,13 @@ in
           A new module is available: 'services.recoll'.
         '';
       }
+
+      {
+        time = "2022-08-01T16:35:28+00:00";
+        message = ''
+          A new module is available: 'programs.hyfetch'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -82,6 +82,7 @@ let
     ./programs/himalaya.nix
     ./programs/home-manager.nix
     ./programs/htop.nix
+    ./programs/hyfetch.nix
     ./programs/i3status-rust.nix
     ./programs/i3status.nix
     ./programs/info.nix

--- a/modules/programs/hyfetch.nix
+++ b/modules/programs/hyfetch.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.hyfetch;
+
+  jsonFormat = pkgs.formats.json { };
+in {
+  meta.maintainers = [ maintainers.lilyinstarlight ];
+
+  options.programs.hyfetch = {
+    enable = mkEnableOption "hyfetch";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.hyfetch;
+      defaultText = literalExpression "pkgs.hyfetch";
+      description = "The hyfetch package to use.";
+    };
+
+    settings = mkOption {
+      type = jsonFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          preset = "rainbow";
+          mode = "rgb";
+          color_align = {
+            mode = "horizontal";
+          };
+        }
+      '';
+      description = "JSON config for HyFetch";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    xdg.configFile."hyfetch.json".source =
+      jsonFormat.generate "hyfetch.json" cfg.settings;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -74,6 +74,7 @@ import nmt {
     ./modules/programs/helix
     ./modules/programs/himalaya
     ./modules/programs/htop
+    ./modules/programs/hyfetch
     ./modules/programs/i3status
     ./modules/programs/irssi
     ./modules/programs/kakoune

--- a/tests/modules/programs/hyfetch/default.nix
+++ b/tests/modules/programs/hyfetch/default.nix
@@ -1,0 +1,1 @@
+{ hyfetch-settings = ./settings.nix; }

--- a/tests/modules/programs/hyfetch/hyfetch.json
+++ b/tests/modules/programs/hyfetch/hyfetch.json
@@ -1,0 +1,11 @@
+{
+  "color_align": {
+    "custom_colors": [],
+    "fore_back": null,
+    "mode": "horizontal"
+  },
+  "light_dark": "dark",
+  "lightness": 0.5,
+  "mode": "rgb",
+  "preset": "rainbow"
+}

--- a/tests/modules/programs/hyfetch/settings.nix
+++ b/tests/modules/programs/hyfetch/settings.nix
@@ -1,0 +1,25 @@
+{ ... }:
+
+{
+  programs.hyfetch = {
+    enable = true;
+
+    settings = {
+      preset = "rainbow";
+      mode = "rgb";
+      light_dark = "dark";
+      lightness = 0.5;
+      color_align = {
+        mode = "horizontal";
+        custom_colors = [ ];
+        fore_back = null;
+      };
+    };
+  };
+
+  test.stubs.hyfetch = { };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/hyfetch.json ${./hyfetch.json}
+  '';
+}


### PR DESCRIPTION
### Description

Adds a simple module for [hyfetch](https://github.com/hykilpikonna/hyfetch), which is in nixpkgs now (NixOS/nixpkgs#182944)

I've not actually contributed a module before and this one is pretty minimal, but I think I covered everything I saw in the contribution docs (except a news item which I'm happy to add if desired). Let me know if I'm missing something though!

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
