### PR TITLE
hyfetch: prevent writing config with default/empty settings

### DIFF
--- a/modules/programs/hyfetch.nix
+++ b/modules/programs/hyfetch.nix
@@ -37,7 +37,8 @@ in {
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
-    xdg.configFile."hyfetch.json".source =
-      jsonFormat.generate "hyfetch.json" cfg.settings;
+    xdg.configFile."hyfetch.json" = mkIf (cfg.settings != { }) {
+      source = jsonFormat.generate "hyfetch.json" cfg.settings;
+    };
   };
 }

--- a/tests/modules/programs/hyfetch/default.nix
+++ b/tests/modules/programs/hyfetch/default.nix
@@ -1,1 +1,4 @@
-{ hyfetch-settings = ./settings.nix; }
+{
+  hyfetch-settings = ./settings.nix;
+  hyfetch-empty-settings = ./empty-settings.nix;
+}

--- a/tests/modules/programs/hyfetch/empty-settings.nix
+++ b/tests/modules/programs/hyfetch/empty-settings.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.hyfetch.enable = true;
+
+    test.stubs.hyfetch = { };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/hyfetch.json
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Follow-up to #3123

cc: @rycee @luxus

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
