### PR TITLE
gammastep: wait on geoclue-agent when configured

### DIFF
--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -182,10 +182,14 @@ in {
       settingsFormat.generate xdgConfigFilePath cfg.settings;
 
     systemd.user.services.${moduleName} = {
-      Unit = {
+      Unit = let
+        geoclueAgentService =
+          lib.optional (cfg.provider == "geoclue2") "geoclue-agent.service";
+      in {
         Description = "${programName} colour temperature adjuster";
         Documentation = serviceDocumentation;
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session-pre.target" ] ++ geoclueAgentService;
+        Wants = geoclueAgentService;
         PartOf = [ "graphical-session.target" ];
       };
 


### PR DESCRIPTION
### Description

When configured with geoclue2 as a provider, gammastep should wait for the agent
to come up, otherwise it cannot determine your location and produces an annoying
error message.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
