### PR TITLE
polybar: use add `.ini` suffix to configuration file

### DIFF
--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -199,14 +199,14 @@ in {
     ];
 
     home.packages = [ cfg.package ];
-    xdg.configFile."polybar/config".source = configFile;
+    xdg.configFile."polybar/config.ini".source = configFile;
 
     systemd.user.services.polybar = {
       Unit = {
         Description = "Polybar status bar";
         PartOf = [ "tray.target" ];
         X-Restart-Triggers =
-          [ "${config.xdg.configFile."polybar/config".source}" ];
+          [ "${config.xdg.configFile."polybar/config.ini".source}" ];
       };
 
       Service = {

--- a/tests/modules/services/polybar/basic-configuration.nix
+++ b/tests/modules/services/polybar/basic-configuration.nix
@@ -50,8 +50,8 @@
       assertFileRegex $serviceFile 'X-Restart-Triggers=.*polybar\.conf'
       assertFileRegex $serviceFile 'ExecStart=.*/bin/polybar-start'
 
-      assertFileExists home-files/.config/polybar/config
-      assertFileContent home-files/.config/polybar/config \
+      assertFileExists home-files/.config/polybar/config.ini
+      assertFileContent home-files/.config/polybar/config.ini \
           ${./basic-configuration.conf}
     '';
   };


### PR DESCRIPTION
### Description

The old name is deprecated and causes a warning to be logged.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```