### PR TITLE
bash: support bash completion

### DIFF
--- a/tests/modules/programs/atuin/bash.nix
+++ b/tests/modules/programs/atuin/bash.nix
@@ -3,7 +3,10 @@
 {
   programs = {
     atuin.enable = true;
-    bash.enable = true;
+    bash = {
+      enable = true;
+      enableCompletion = false;
+    };
   };
 
   test.stubs = {

--- a/tests/modules/programs/bash/completion.nix
+++ b/tests/modules/programs/bash/completion.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  programs.bash.enable = true;
+
+  test.stubs.bash-completion = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+
+    assertFileContains \
+      home-files/.bashrc \
+      'if [[ ! -v BASH_COMPLETION_VERSINFO ]]; then'
+    assertFileContains \
+      home-files/.bashrc \
+      '  . "@bash-completion@/etc/profile.d/bash_completion.sh"'
+    assertFileContains \
+      home-files/.bashrc \
+      'fi'
+  '';
+}

--- a/tests/modules/programs/bash/default.nix
+++ b/tests/modules/programs/bash/default.nix
@@ -1,4 +1,5 @@
 {
+  bash-completion = ./completion.nix;
   bash-logout = ./logout.nix;
   bash-session-variables = ./session-variables.nix;
 }

--- a/tests/modules/programs/bash/logout.nix
+++ b/tests/modules/programs/bash/logout.nix
@@ -6,6 +6,7 @@ with lib;
   config = {
     programs.bash = {
       enable = true;
+      enableCompletion = false;
 
       logoutExtra = ''
         clear-console

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -6,6 +6,7 @@ with lib;
   config = {
     programs.bash = {
       enable = true;
+      enableCompletion = false;
 
       sessionVariables = {
         V1 = "v1";


### PR DESCRIPTION
### Description

Add option to enable Bash completion. It is true by default as it doesn't interfere with the NixOS completion option (the system one is used when both are enabled).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```