### PR TITLE
programs.zathura: added 'mappings' option

### DIFF
--- a/modules/programs/zathura.nix
+++ b/modules/programs/zathura.nix
@@ -12,6 +12,8 @@ let
         if isBool v then (if v then "true" else "false") else toString v;
     in ''set ${n}	"${formatValue v}"'';
 
+  formatMapLine = n: v: "map ${n}   ${toString v}";
+
 in {
   meta.maintainers = [ maintainers.rprospero ];
 
@@ -45,6 +47,24 @@ in {
       };
     };
 
+    mappings = mkOption {
+      default = { };
+      type = with types; attrsOf str;
+      description = ''
+        Add <option>:map</option> mappings to zathura and make
+        them permanent. See
+        <citerefentry>
+          <refentrytitle>zathurarc</refentrytitle>
+          <manvolnum>5</manvolnum>
+        </citerefentry>
+        for the full list of possible mappings.
+      '';
+      example = {
+        D = "toggle_page_mode";
+        "<Right>" = "navigate next";
+      };
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";
@@ -60,6 +80,7 @@ in {
 
     xdg.configFile."zathura/zathurarc".text = concatStringsSep "\n" ([ ]
       ++ optional (cfg.extraConfig != "") cfg.extraConfig
-      ++ mapAttrsToList formatLine cfg.options) + "\n";
+      ++ mapAttrsToList formatLine cfg.options
+      ++ mapAttrsToList formatMapLine cfg.mappings) + "\n";
   };
 }


### PR DESCRIPTION
### Description

added 'mappings' option for zathura.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
