### PR TITLE
files: allow target conflicts between recursively-linked directories (exclusively)

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -8,26 +8,26 @@ let
 
   homeDirectory = config.home.homeDirectory;
 
-  fileType = (import lib/file-type.nix {
-    inherit homeDirectory lib pkgs;
-  }).fileType;
+  fileType =
+    (import lib/file-type.nix { inherit homeDirectory lib pkgs; }).fileType;
 
   sourceStorePath = file:
     let
       sourcePath = toString file.source;
       sourceName = config.lib.strings.storeFileName (baseNameOf sourcePath);
-    in
-      if builtins.hasContext sourcePath
-      then file.source
-      else builtins.path { path = file.source; name = sourceName; };
+    in if builtins.hasContext sourcePath then
+      file.source
+    else
+      builtins.path {
+        path = file.source;
+        name = sourceName;
+      };
 
-in
-
-{
+in {
   options = {
     home.file = mkOption {
       description = "Attribute set of files to link into the user home.";
-      default = {};
+      default = { };
       type = fileType "<envar>HOME</envar>" homeDirectory;
     };
 
@@ -39,47 +39,47 @@ in
   };
 
   config = {
-    assertions = [(
-      let
-        dups =
-          attrNames
-            (filterAttrs (n: v: ((v.count > 1) && (v.nonrec || v.hasfile) ))
+    assertions = [
+      (let
+        dups = attrNames
+          (filterAttrs (n: v: ((v.count > 1) && (v.nonrec || v.hasfile)))
             (foldAttrs (v: acc: {
-                count = add acc.count v.count;
-                nonrec = acc.nonrec || v.nonrec;
-		hasfile = acc.hasfile || v.hasfile;
-          }) {
-            count = 0;
-            nonrec = false; hasfile = false;
-          } (mapAttrsToList (n: v: {
-            ${v.target} = {
-              count = 1;
-              nonrec = (!v.recursive);
-	      hasfile = !(pathExists "${sourceStorePath v}/..");
-            };
-          }) cfg)));
+              count = add acc.count v.count;
+              nonrec = acc.nonrec || v.nonrec;
+              hasfile = acc.hasfile || v.hasfile;
+            }) {
+              count = 0;
+              nonrec = false;
+              hasfile = false;
+            } (mapAttrsToList (n: v: {
+              ${v.target} = {
+                count = 1;
+                nonrec = (!v.recursive);
+                hasfile = !(pathExists "${sourceStorePath v}/..");
+              };
+            }) cfg)));
         dupsStr = concatStringsSep ", " dups;
       in {
-        assertion = dups == [];
+        assertion = dups == [ ];
         message = ''
           Conflicting managed target files: ${dupsStr}
 
           This may happen, for example, if you have a configuration similar to
 
               home.file = {
-	        # classic example of conflict
+                # classic example of conflict
                 conflict1 = { source = ./foo.nix; target = "baz"; };
                 conflict2 = { source = ./bar.nix; target = "baz"; };
               }
           or
               home.file = {
-	        # missing "recursive = true"
+                # missing "recursive = true"
                 conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
                 conflict2 = { source = ./other-directory; target = "baz"; };  # error here
               }
-	  or
+          or
               home.file = {
-	        # conflict with at least a file among the recursively-linked directories
+                # conflict with at least a file among the recursively-linked directories
                 conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
                 conflict2 = { source = ./a-file.nix; target = "baz"; recursive=true;};  # error here
               }'';
@@ -90,26 +90,26 @@ in
       let
         pathStr = toString path;
         name = hm.strings.storeFileName (baseNameOf pathStr);
-      in
-        pkgs.runCommandLocal name {} ''ln -s ${escapeShellArg pathStr} $out'';
+      in pkgs.runCommandLocal name { } "ln -s ${escapeShellArg pathStr} $out";
 
     # This verifies that the links we are about to create will not
     # overwrite an existing file.
-    home.activation.checkLinkTargets = hm.dag.entryBefore ["writeBoundary"] (
-      let
+    home.activation.checkLinkTargets = hm.dag.entryBefore [ "writeBoundary" ]
+      (let
         # Paths that should be forcibly overwritten by Home Manager.
         # Caveat emptor!
         forcedPaths =
           concatMapStringsSep " " (p: ''"$HOME"/${escapeShellArg p}'')
-            (mapAttrsToList (n: v: v.target)
-            (filterAttrs (n: v: v.force) cfg));
+          (mapAttrsToList (n: v: v.target) (filterAttrs (n: v: v.force) cfg));
 
         check = pkgs.writeText "check" ''
           ${config.lib.bash.initHomeManagerLib}
 
           # A symbolic link whose target path matches this pattern will be
           # considered part of a Home Manager generation.
-          homeFilePattern="$(readlink -e ${escapeShellArg builtins.storeDir})/*-home-manager-files/*"
+          homeFilePattern="$(readlink -e ${
+            escapeShellArg builtins.storeDir
+          })/*-home-manager-files/*"
 
           forcedPaths=(${forcedPaths})
 
@@ -157,8 +157,7 @@ in
             exit 1
           fi
         '';
-      in
-      ''
+      in ''
         function checkNewGenCollision() {
           local newGenFiles
           newGenFiles="$(readlink -e "$newGenPath/home-files")"
@@ -167,8 +166,7 @@ in
         }
 
         checkNewGenCollision || exit 1
-      ''
-    );
+      '');
 
     # This activation script will
     #
@@ -191,123 +189,121 @@ in
     # and a failure during the intermediate state FA ∩ FB will not
     # result in lost links because this set of links are in both the
     # source and target generation.
-    home.activation.linkGeneration = hm.dag.entryAfter ["writeBoundary"] (
-      let
-        link = pkgs.writeShellScript "link" ''
-          newGenFiles="$1"
-          shift
-          for sourcePath in "$@" ; do
-            relativePath="''${sourcePath#$newGenFiles/}"
-            targetPath="$HOME/$relativePath"
-            if [[ -e "$targetPath" && ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
-              # The target exists, back it up
-              backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
-              $DRY_RUN_CMD mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
-            fi
-
-            if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath" ; then
-              # The target exists but is identical – don't do anything.
-              $VERBOSE_ECHO "Skipping '$targetPath' as it is identical to '$sourcePath'"
-            else
-              # Place that symlink, --force
-              $DRY_RUN_CMD mkdir -p $VERBOSE_ARG "$(dirname "$targetPath")"
-              $DRY_RUN_CMD ln -nsf $VERBOSE_ARG "$sourcePath" "$targetPath"
-            fi
-          done
-        '';
-
-        cleanup = pkgs.writeShellScript "cleanup" ''
-          ${config.lib.bash.initHomeManagerLib}
-
-          # A symbolic link whose target path matches this pattern will be
-          # considered part of a Home Manager generation.
-          homeFilePattern="$(readlink -e ${escapeShellArg builtins.storeDir})/*-home-manager-files/*"
-
-          newGenFiles="$1"
-          shift 1
-          for relativePath in "$@" ; do
-            targetPath="$HOME/$relativePath"
-            if [[ -e "$newGenFiles/$relativePath" ]] ; then
-              $VERBOSE_ECHO "Checking $targetPath: exists"
-            elif [[ ! "$(readlink "$targetPath")" == $homeFilePattern ]] ; then
-              warnEcho "Path '$targetPath' does not link into a Home Manager generation. Skipping delete."
-            else
-              $VERBOSE_ECHO "Checking $targetPath: gone (deleting)"
-              $DRY_RUN_CMD rm $VERBOSE_ARG "$targetPath"
-
-              # Recursively delete empty parent directories.
-              targetDir="$(dirname "$relativePath")"
-              if [[ "$targetDir" != "." ]] ; then
-                pushd "$HOME" > /dev/null
-
-                # Call rmdir with a relative path excluding $HOME.
-                # Otherwise, it might try to delete $HOME and exit
-                # with a permission error.
-                $DRY_RUN_CMD rmdir $VERBOSE_ARG \
-                    -p --ignore-fail-on-non-empty \
-                    "$targetDir"
-
-                popd > /dev/null
-              fi
-            fi
-          done
-        '';
-      in
-        ''
-          function linkNewGen() {
-            _i "Creating home file links in %s" "$HOME"
-
-            local newGenFiles
-            newGenFiles="$(readlink -e "$newGenPath/home-files")"
-            find "$newGenFiles" \( -type f -or -type l \) \
-              -exec bash ${link} "$newGenFiles" {} +
-          }
-
-          function cleanOldGen() {
-            if [[ ! -v oldGenPath || ! -e "$oldGenPath/home-files" ]] ; then
-              return
-            fi
-
-            _i "Cleaning up orphan links from %s" "$HOME"
-
-            local newGenFiles oldGenFiles
-            newGenFiles="$(readlink -e "$newGenPath/home-files")"
-            oldGenFiles="$(readlink -e "$oldGenPath/home-files")"
-
-            # Apply the cleanup script on each leaf in the old
-            # generation. The find command below will print the
-            # relative path of the entry.
-            find "$oldGenFiles" '(' -type f -or -type l ')' -printf '%P\0' \
-              | xargs -0 bash ${cleanup} "$newGenFiles"
-          }
-
-          cleanOldGen
-
-          if [[ ! -v oldGenPath || "$oldGenPath" != "$newGenPath" ]] ; then
-            _i "Creating profile generation %s" $newGenNum
-            if [[ -e "$genProfilePath"/manifest.json ]] ; then
-              # Remove all packages from "$genProfilePath"
-              # `nix profile remove '.*' --profile "$genProfilePath"` was not working, so here is a workaround:
-              nix profile list --profile "$genProfilePath" \
-                | cut -d ' ' -f 4 \
-                | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG --profile "$genProfilePath"
-              $DRY_RUN_CMD nix profile install $VERBOSE_ARG --profile "$genProfilePath" "$newGenPath"
-            else
-              $DRY_RUN_CMD nix-env $VERBOSE_ARG --profile "$genProfilePath" --set "$newGenPath"
-            fi
-
-            $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG "$newGenPath" "$newGenGcPath"
-          else
-            _i "No change so reusing latest profile generation %s" "$oldGenNum"
+    home.activation.linkGeneration = hm.dag.entryAfter [ "writeBoundary" ] (let
+      link = pkgs.writeShellScript "link" ''
+        newGenFiles="$1"
+        shift
+        for sourcePath in "$@" ; do
+          relativePath="''${sourcePath#$newGenFiles/}"
+          targetPath="$HOME/$relativePath"
+          if [[ -e "$targetPath" && ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
+            # The target exists, back it up
+            backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
+            $DRY_RUN_CMD mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
           fi
 
-          linkNewGen
-        ''
-    );
+          if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath" ; then
+            # The target exists but is identical – don't do anything.
+            $VERBOSE_ECHO "Skipping '$targetPath' as it is identical to '$sourcePath'"
+          else
+            # Place that symlink, --force
+            $DRY_RUN_CMD mkdir -p $VERBOSE_ARG "$(dirname "$targetPath")"
+            $DRY_RUN_CMD ln -nsf $VERBOSE_ARG "$sourcePath" "$targetPath"
+          fi
+        done
+      '';
 
-    home.activation.checkFilesChanged = hm.dag.entryBefore ["linkGeneration"] (
-      let
-        homeDirArg = escapeShellArg homeDirectory;
+      cleanup = pkgs.writeShellScript "cleanup" ''
+        ${config.lib.bash.initHomeManagerLib}
+
+        # A symbolic link whose target path matches this pattern will be
+        # considered part of a Home Manager generation.
+        homeFilePattern="$(readlink -e ${
+          escapeShellArg builtins.storeDir
+        })/*-home-manager-files/*"
+
+        newGenFiles="$1"
+        shift 1
+        for relativePath in "$@" ; do
+          targetPath="$HOME/$relativePath"
+          if [[ -e "$newGenFiles/$relativePath" ]] ; then
+            $VERBOSE_ECHO "Checking $targetPath: exists"
+          elif [[ ! "$(readlink "$targetPath")" == $homeFilePattern ]] ; then
+            warnEcho "Path '$targetPath' does not link into a Home Manager generation. Skipping delete."
+          else
+            $VERBOSE_ECHO "Checking $targetPath: gone (deleting)"
+            $DRY_RUN_CMD rm $VERBOSE_ARG "$targetPath"
+
+            # Recursively delete empty parent directories.
+            targetDir="$(dirname "$relativePath")"
+            if [[ "$targetDir" != "." ]] ; then
+              pushd "$HOME" > /dev/null
+
+              # Call rmdir with a relative path excluding $HOME.
+              # Otherwise, it might try to delete $HOME and exit
+              # with a permission error.
+              $DRY_RUN_CMD rmdir $VERBOSE_ARG \
+                  -p --ignore-fail-on-non-empty \
+                  "$targetDir"
+
+              popd > /dev/null
+            fi
+          fi
+        done
+      '';
+    in ''
+      function linkNewGen() {
+        _i "Creating home file links in %s" "$HOME"
+
+        local newGenFiles
+        newGenFiles="$(readlink -e "$newGenPath/home-files")"
+        find "$newGenFiles" \( -type f -or -type l \) \
+          -exec bash ${link} "$newGenFiles" {} +
+      }
+
+      function cleanOldGen() {
+        if [[ ! -v oldGenPath || ! -e "$oldGenPath/home-files" ]] ; then
+          return
+        fi
+
+        _i "Cleaning up orphan links from %s" "$HOME"
+
+        local newGenFiles oldGenFiles
+        newGenFiles="$(readlink -e "$newGenPath/home-files")"
+        oldGenFiles="$(readlink -e "$oldGenPath/home-files")"
+
+        # Apply the cleanup script on each leaf in the old
+        # generation. The find command below will print the
+        # relative path of the entry.
+        find "$oldGenFiles" '(' -type f -or -type l ')' -printf '%P\0' \
+          | xargs -0 bash ${cleanup} "$newGenFiles"
+      }
+
+      cleanOldGen
+
+      if [[ ! -v oldGenPath || "$oldGenPath" != "$newGenPath" ]] ; then
+        _i "Creating profile generation %s" $newGenNum
+        if [[ -e "$genProfilePath"/manifest.json ]] ; then
+          # Remove all packages from "$genProfilePath"
+          # `nix profile remove '.*' --profile "$genProfilePath"` was not working, so here is a workaround:
+          nix profile list --profile "$genProfilePath" \
+            | cut -d ' ' -f 4 \
+            | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG --profile "$genProfilePath"
+          $DRY_RUN_CMD nix profile install $VERBOSE_ARG --profile "$genProfilePath" "$newGenPath"
+        else
+          $DRY_RUN_CMD nix-env $VERBOSE_ARG --profile "$genProfilePath" --set "$newGenPath"
+        fi
+
+        $DRY_RUN_CMD ln -Tsf $VERBOSE_ARG "$newGenPath" "$newGenGcPath"
+      else
+        _i "No change so reusing latest profile generation %s" "$oldGenNum"
+      fi
+
+      linkNewGen
+    '');
+
+    home.activation.checkFilesChanged = hm.dag.entryBefore [ "linkGeneration" ]
+      (let homeDirArg = escapeShellArg homeDirectory;
       in ''
         function _cmp() {
           if [[ -d $1 && -d $2 ]]; then
@@ -325,14 +321,12 @@ in
           _cmp ${sourceArg} ${homeDirArg}/${targetArg} \
             && changedFiles[${targetArg}]=0 \
             || changedFiles[${targetArg}]=1
-        '') (filter (v: v.onChange != "") (attrValues cfg))
-      + ''
-        unset -f _cmp
-      ''
-    );
+        '') (filter (v: v.onChange != "") (attrValues cfg)) + ''
+          unset -f _cmp
+        '');
 
-    home.activation.onFilesChange = hm.dag.entryAfter ["linkGeneration"] (
-      concatMapStrings (v: ''
+    home.activation.onFilesChange = hm.dag.entryAfter [ "linkGeneration" ]
+      (concatMapStrings (v: ''
         if (( ''${changedFiles[${escapeShellArg v.target}]} == 1 )); then
           if [[ -v DRY_RUN || -v VERBOSE ]]; then
             echo "Running onChange hook for" ${escapeShellArg v.target}
@@ -341,110 +335,102 @@ in
             ${v.onChange}
           fi
         fi
-      '') (filter (v: v.onChange != "") (attrValues cfg))
-    );
+      '') (filter (v: v.onChange != "") (attrValues cfg)));
 
     # Symlink directories and files that have the right execute bit.
     # Copy files that need their execute bit changed.
     home-files = let
-        targetRefCounts = (foldAttrs
-          (v: acc: v+acc) 0
-          (mapAttrsToList
-            (n: v: {${v.target} = 1;})
-	  cfg));
-        newCfg = (mapAttrs (n: v: v//{hasTargetConflict=(targetRefCounts.${v.target}>1);} ) cfg);
-    in pkgs.runCommandLocal
-      "home-manager-files"
-      {
-        nativeBuildInputs = [ pkgs.xorg.lndir ];
-      }
-      (''
-        mkdir -p $out
+      targetRefCounts = (foldAttrs (v: acc: v + acc) 0
+        (mapAttrsToList (n: v: { ${v.target} = 1; }) cfg));
+      newCfg = (mapAttrs
+        (n: v: v // { hasTargetConflict = (targetRefCounts.${v.target} > 1); })
+        cfg);
+    in pkgs.runCommandLocal "home-manager-files" {
+      nativeBuildInputs = [ pkgs.xorg.lndir ];
+    } (''
+      mkdir -p $out
 
-        # Needed in case /nix is a symbolic link.
-        realOut="$(realpath -m "$out")"
+      # Needed in case /nix is a symbolic link.
+      realOut="$(realpath -m "$out")"
 
-        function insertFile() {
-          local source="$1"
-          local relTarget="$2"
-          local executable="$3"
-          local recursive="$4"
-          local hasTargetConflict="$5"
+      function insertFile() {
+        local source="$1"
+        local relTarget="$2"
+        local executable="$3"
+        local recursive="$4"
+        local hasTargetConflict="$5"
 
-          # If the target already exists then we have a collision.
-          # If it is a "simple copy", justdrop out of it. If it's a recursive dir copy,
-          # we need to merge the source and destination, and check for collisions for each file.
-          # If this is a "simple collision", simply log the conflict and otherwise ignore it,
-          # mainly to make the `files-target-config` test work as expected.
-          if [[ -d "$realOut/$relTarget" ]] && [[ $recursive ]] ; then
-            :
-          elif [[ -e "$realOut/$relTarget" ]]; then
-            echo "File conflict for file '$relTarget'" >&2
+        # If the target already exists then we have a collision.
+        # If it is a "simple copy", justdrop out of it. If it's a recursive dir copy,
+        # we need to merge the source and destination, and check for collisions for each file.
+        # If this is a "simple collision", simply log the conflict and otherwise ignore it,
+        # mainly to make the `files-target-config` test work as expected.
+        if [[ -d "$realOut/$relTarget" ]] && [[ $recursive ]] ; then
+          :
+        elif [[ -e "$realOut/$relTarget" ]]; then
+          echo "File conflict for file '$relTarget'" >&2
+          return
+        fi
+
+        # Figure out the real absolute path to the target.
+        local target
+        target="$(realpath -m "$realOut/$relTarget")"
+
+        # Target path must be within $HOME.
+        if [[ ! $target == $realOut* ]] ; then
+          echo "Error installing file '$relTarget' outside \$HOME" >&2
+          exit 1
+        fi
+
+        mkdir -p "$(dirname "$target")"
+        if [[ -d $source ]]; then
+          if [[ $recursive ]]; then
+            mkdir -p "$target"
+            # note: lndir does not override existing files/symlinks with newer symlinks
+            lndir -silent "$source" "$target"
+          else
+            ln -s "$source" "$target"
+          fi
+        else
+          # no need to hard crash because this will be taken care of by the assertions.
+          # however, there is a need to return early, because otherwise there is a risk of
+          # *mutating source files*. yes, it's *that* bad.
+          if [[ $recursive && ($hasTargetConflict == "true") ]]; then
+            echo "At least one *file* is attempting to be installed at '$relTarget', a location where multiple 'home.file' directives install something. This is disallowed." >&2
             return
           fi
+          [[ -x $source ]] && isExecutable=1 || isExecutable=""
 
-          # Figure out the real absolute path to the target.
-          local target
-          target="$(realpath -m "$realOut/$relTarget")"
-
-          # Target path must be within $HOME.
-          if [[ ! $target == $realOut* ]] ; then
-            echo "Error installing file '$relTarget' outside \$HOME" >&2
-            exit 1
-          fi
-
-          mkdir -p "$(dirname "$target")"
-          if [[ -d $source ]]; then
-            if [[ $recursive ]]; then
-              mkdir -p "$target"
-              # note: lndir does not override existing files/symlinks with newer symlinks
-              lndir -silent "$source" "$target"
-            else
-              ln -s "$source" "$target"
-            fi
+          # Link the file into the home file directory if possible,
+          # i.e., if the executable bit of the source is the same we
+          # expect for the target. Otherwise, we copy the file and
+          # set the executable bit to the expected value.
+          if [[ $executable == inherit || $isExecutable == $executable ]]; then
+            ln -s "$source" "$target"
           else
-	    # no need to hard crash because this will be taken care of by the assertions.
-	    # however, there is a need to return early, because otherwise there is a risk of
-	    # *mutating source files*. yes, it's *that* bad.
-	    if [[ $recursive && ($hasTargetConflict == "true") ]]; then
-              echo "At least one *file* is attempting to be installed at '$relTarget', a location where multiple 'home.file' directives install something. This is disallowed." >&2
-              return
-	    fi
-            [[ -x $source ]] && isExecutable=1 || isExecutable=""
+            cp "$source" "$target"
 
-            # Link the file into the home file directory if possible,
-            # i.e., if the executable bit of the source is the same we
-            # expect for the target. Otherwise, we copy the file and
-            # set the executable bit to the expected value.
-            if [[ $executable == inherit || $isExecutable == $executable ]]; then
-              ln -s "$source" "$target"
+            if [[ $executable == inherit ]]; then
+              # Don't change file mode if it should match the source.
+              :
+            elif [[ $executable ]]; then
+              chmod +x "$target"
             else
-              cp "$source" "$target"
-
-              if [[ $executable == inherit ]]; then
-                # Don't change file mode if it should match the source.
-                :
-              elif [[ $executable ]]; then
-                chmod +x "$target"
-              else
-                chmod -x "$target"
-              fi
+              chmod -x "$target"
             fi
           fi
-        }
-      '' + concatStrings (
-        mapAttrsToList (n: v: ''
-          insertFile ${
-            escapeShellArgs [
-              (sourceStorePath v)
-              v.target
-              (if v.executable == null
-               then "inherit"
-               else toString v.executable)
-              (toString v.recursive)
-              (if v.hasTargetConflict then "true" else "false")
-            ]}
-        '') newCfg
-      ));
+        fi
+      }
+    '' + concatStrings (mapAttrsToList (n: v: ''
+      insertFile ${
+        escapeShellArgs [
+          (sourceStorePath v)
+          v.target
+          (if v.executable == null then "inherit" else toString v.executable)
+          (toString v.recursive)
+          (if v.hasTargetConflict then "true" else "false")
+        ]
+      }
+    '') newCfg));
   };
 }

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -393,9 +393,9 @@ in
               ln -s "$source" "$target"
             fi
           else
-	    if [ $hasTargetConflict == "true" ]; then
+	    if [[ $recursive && ($hasTargetConflict == "true") ]]; then
               echo "At least one *file* is attempting to be installed at '$relTarget', a location where multiple 'home.file' directives install something. This is disallowed." >&2
-              exit 1	    
+              exit 1
 	    fi
             [[ -x $source ]] && isExecutable=1 || isExecutable=""
 

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -72,6 +72,11 @@ in
             <literal>true</literal> then the target will be a
             directory structure matching the source's but whose leafs
             are symbolic links to the files of the source directory.
+	    </para><para>
+	    Marking several
+	    <link linkend="opt-home.file._name_.source">home.file.&lt;name?&gt;.source</link>
+	    directives as recursive allow them to point towards the same target directory.
+	    However, in that case, none of the directives may use a file as their source.
           '';
         };
 

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -1,9 +1,9 @@
 { homeDirectory, lib, pkgs }:
 
 let
-  inherit (lib) hasPrefix hm literalExpression mkDefault mkIf mkOption removePrefix types;
-in
-{
+  inherit (lib)
+    hasPrefix hm literalExpression mkDefault mkIf mkOption removePrefix types;
+in {
   # Constructs a type suitable for a `home.file` like option. The
   # target path may be either absolute or relative, in which case it
   # is relative the `basePath` argument (which itself must be an
@@ -12,16 +12,14 @@ in
   # Arguments:
   #   - basePathDesc   docbook compatible description of the base path
   #   - basePath       the file base path
-  fileType = basePathDesc: basePath: types.attrsOf (types.submodule (
-    { name, config, ... }: {
+  fileType = basePathDesc: basePath:
+    types.attrsOf (types.submodule ({ name, config, ... }: {
       options = {
         target = mkOption {
           type = types.str;
           apply = p:
-            let
-              absPath = if hasPrefix "/" p then p else "${basePath}/${p}";
-            in
-              removePrefix (homeDirectory + "/") absPath;
+            let absPath = if hasPrefix "/" p then p else "${basePath}/${p}";
+            in removePrefix (homeDirectory + "/") absPath;
           defaultText = literalExpression "<name>";
           description = ''
             Path to target file relative to ${basePathDesc}.
@@ -62,21 +60,21 @@ in
           type = types.bool;
           default = false;
           description = ''
-            If the file source is a directory, then this option
-            determines whether the directory should be recursively
-            linked to the target location. This option has no effect
-            if the source is a file.
-            </para><para>
-            If <literal>false</literal> (the default) then the target
-            will be a symbolic link to the source directory. If
-            <literal>true</literal> then the target will be a
-            directory structure matching the source's but whose leafs
-            are symbolic links to the files of the source directory.
-	    </para><para>
-	    Marking several
-	    <link linkend="opt-home.file._name_.source">home.file.&lt;name?&gt;.source</link>
-	    directives as recursive allow them to point towards the same target directory.
-	    However, in that case, none of the directives may use a file as their source.
+                        If the file source is a directory, then this option
+                        determines whether the directory should be recursively
+                        linked to the target location. This option has no effect
+                        if the source is a file.
+                        </para><para>
+                        If <literal>false</literal> (the default) then the target
+                        will be a symbolic link to the source directory. If
+                        <literal>true</literal> then the target will be a
+                        directory structure matching the source's but whose leafs
+                        are symbolic links to the files of the source directory.
+            	    </para><para>
+            	    Marking several
+            	    <link linkend="opt-home.file._name_.source">home.file.&lt;name?&gt;.source</link>
+            	    directives as recursive allow them to point towards the same target directory.
+            	    However, in that case, none of the directives may use a file as their source.
           '';
         };
 
@@ -109,13 +107,10 @@ in
 
       config = {
         target = mkDefault name;
-        source = mkIf (config.text != null) (
-          mkDefault (pkgs.writeTextFile {
-            inherit (config) executable text;
-            name = hm.strings.storeFileName name;
-          })
-        );
+        source = mkIf (config.text != null) (mkDefault (pkgs.writeTextFile {
+          inherit (config) executable text;
+          name = hm.strings.storeFileName name;
+        }));
       };
-    }
-  ));
+    }));
 }

--- a/tests/modules/files/default.nix
+++ b/tests/modules/files/default.nix
@@ -5,6 +5,7 @@
   files-source-with-spaces = ./source-with-spaces.nix;
   files-target-conflict = ./target-conflict.nix;
   files-target-conflict-avoided = ./target-conflict-avoided.nix;
+  files-target-conflict-because-file = ./target-conflict-because-file.nix;
   files-target-with-shellvar = ./target-with-shellvar.nix;
   files-text = ./text.nix;
 }

--- a/tests/modules/files/default.nix
+++ b/tests/modules/files/default.nix
@@ -4,6 +4,7 @@
   files-out-of-store-symlink = ./out-of-store-symlink.nix;
   files-source-with-spaces = ./source-with-spaces.nix;
   files-target-conflict = ./target-conflict.nix;
+  files-target-conflict-avoided = ./target-conflict-avoided.nix;
   files-target-with-shellvar = ./target-with-shellvar.nix;
   files-text = ./text.nix;
 }

--- a/tests/modules/files/target-conflict-avoided.nix
+++ b/tests/modules/files/target-conflict-avoided.nix
@@ -6,18 +6,18 @@
       conflict1 = {
         source = ../home-environment;
         target = "baz";
-	recursive = true;
+        recursive = true;
       };
       conflict2 = {
         source = ./.;
         target = "baz";
-	recursive = true;
+        recursive = true;
       };
     };
 
     nmt.script = ''
       assertFileExists home-files/baz/target-conflict-avoided.nix;
       assertFileExists home-files/baz/session-variables.nix;
-      '';
+    '';
   };
 }

--- a/tests/modules/files/target-conflict-avoided.nix
+++ b/tests/modules/files/target-conflict-avoided.nix
@@ -1,0 +1,23 @@
+{ ... }:
+
+{
+  config = {
+    home.file = {
+      conflict1 = {
+        source = ../home-environment;
+        target = "baz";
+	recursive = true;
+      };
+      conflict2 = {
+        source = ./.;
+        target = "baz";
+	recursive = true;
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/baz/target-conflict-avoided.nix;
+      assertFileExists home-files/baz/session-variables.nix;
+      '';
+  };
+}

--- a/tests/modules/files/target-conflict-because-file.nix
+++ b/tests/modules/files/target-conflict-because-file.nix
@@ -1,0 +1,42 @@
+{ ... }:
+
+{
+  config = {
+    home.file = {
+      conflict1 = {
+        source = ./.;
+        target = "baz";
+	recursive = true;
+      };
+      conflict2 = {
+        source = ./target-conflict.nix;
+        target = "baz";
+	recursive = true;
+      };
+    };
+
+    test.asserts.assertions.expected = [''
+	  Conflicting managed target files: baz
+
+	  This may happen, for example, if you have a configuration similar to
+
+	      home.file = {
+		# classic example of conflict
+		conflict1 = { source = ./foo.nix; target = "baz"; };
+		conflict2 = { source = ./bar.nix; target = "baz"; };
+	      }
+	  or
+	      home.file = {
+		# missing "recursive = true"
+		conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
+		conflict2 = { source = ./other-directory; target = "baz"; };  # error here
+	      }
+	  or
+	      home.file = {
+		# conflict with at least a file among the recursively-linked directories
+		conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
+		conflict2 = { source = ./a-file.nix; target = "baz"; recursive=true;};  # error here
+	      }''];
+
+  };
+}

--- a/tests/modules/files/target-conflict-because-file.nix
+++ b/tests/modules/files/target-conflict-because-file.nix
@@ -6,37 +6,37 @@
       conflict1 = {
         source = ./.;
         target = "baz";
-	recursive = true;
+        recursive = true;
       };
       conflict2 = {
         source = ./target-conflict.nix;
         target = "baz";
-	recursive = true;
+        recursive = true;
       };
     };
 
     test.asserts.assertions.expected = [''
-	  Conflicting managed target files: baz
+      Conflicting managed target files: baz
 
-	  This may happen, for example, if you have a configuration similar to
+      This may happen, for example, if you have a configuration similar to
 
-	      home.file = {
-		# classic example of conflict
-		conflict1 = { source = ./foo.nix; target = "baz"; };
-		conflict2 = { source = ./bar.nix; target = "baz"; };
-	      }
-	  or
-	      home.file = {
-		# missing "recursive = true"
-		conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
-		conflict2 = { source = ./other-directory; target = "baz"; };  # error here
-	      }
-	  or
-	      home.file = {
-		# conflict with at least a file among the recursively-linked directories
-		conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
-		conflict2 = { source = ./a-file.nix; target = "baz"; recursive=true;};  # error here
-	      }''];
+          home.file = {
+            # classic example of conflict
+            conflict1 = { source = ./foo.nix; target = "baz"; };
+            conflict2 = { source = ./bar.nix; target = "baz"; };
+          }
+      or
+          home.file = {
+            # missing "recursive = true"
+            conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
+            conflict2 = { source = ./other-directory; target = "baz"; };  # error here
+          }
+      or
+          home.file = {
+            # conflict with at least a file among the recursively-linked directories
+            conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
+            conflict2 = { source = ./a-file.nix; target = "baz"; recursive=true;};  # error here
+          }''];
 
   };
 }

--- a/tests/modules/files/target-conflict.nix
+++ b/tests/modules/files/target-conflict.nix
@@ -18,14 +18,23 @@
 
       This may happen, for example, if you have a configuration similar to
 
-          home.file = {
-            conflict1 = { source = ./foo.nix; target = "baz"; };
-            conflict2 = { source = ./bar.nix; target = "baz"; };
-          }
+	  home.file = {
+	    # classic example of conflict
+	    conflict1 = { source = ./foo.nix; target = "baz"; };
+	    conflict2 = { source = ./bar.nix; target = "baz"; };
+	  }
       or
-          home.file = {
-            conflict1 = { source = ./foo.nix; target = "baz"; recursive=true;};
-            conflict2 = { source = ./bar.nix; target = "baz"; }; # missing "recursive=true"
-          }''];
-  };
+	  home.file = {
+	    # missing "recursive = true"
+	    conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
+	    conflict2 = { source = ./other-directory; target = "baz"; };  # error here
+	  }
+      or
+	  home.file = {
+	    # conflict with at least a file among the recursively-linked directories
+	    conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
+	    conflict2 = { source = ./a-file.nix; target = "baz"; recursive=true;};  # error here
+	  }''];
+
+};
 }

--- a/tests/modules/files/target-conflict.nix
+++ b/tests/modules/files/target-conflict.nix
@@ -21,6 +21,11 @@
           home.file = {
             conflict1 = { source = ./foo.nix; target = "baz"; };
             conflict2 = { source = ./bar.nix; target = "baz"; };
+          }
+      or
+          home.file = {
+            conflict1 = { source = ./foo.nix; target = "baz"; recursive=true;};
+            conflict2 = { source = ./bar.nix; target = "baz"; }; # missing "recursive=true"
           }''];
   };
 }

--- a/tests/modules/files/target-conflict.nix
+++ b/tests/modules/files/target-conflict.nix
@@ -18,23 +18,23 @@
 
       This may happen, for example, if you have a configuration similar to
 
-	  home.file = {
-	    # classic example of conflict
-	    conflict1 = { source = ./foo.nix; target = "baz"; };
-	    conflict2 = { source = ./bar.nix; target = "baz"; };
-	  }
+          home.file = {
+            # classic example of conflict
+            conflict1 = { source = ./foo.nix; target = "baz"; };
+            conflict2 = { source = ./bar.nix; target = "baz"; };
+          }
       or
-	  home.file = {
-	    # missing "recursive = true"
-	    conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
-	    conflict2 = { source = ./other-directory; target = "baz"; };  # error here
-	  }
+          home.file = {
+            # missing "recursive = true"
+            conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
+            conflict2 = { source = ./other-directory; target = "baz"; };  # error here
+          }
       or
-	  home.file = {
-	    # conflict with at least a file among the recursively-linked directories
-	    conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
-	    conflict2 = { source = ./a-file.nix; target = "baz"; recursive=true;};  # error here
-	  }''];
+          home.file = {
+            # conflict with at least a file among the recursively-linked directories
+            conflict1 = { source = ./some-directory; target = "baz"; recursive=true;};
+            conflict2 = { source = ./a-file.nix; target = "baz"; recursive=true;};  # error here
+          }''];
 
-};
+  };
 }


### PR DESCRIPTION
### Description

Loosened the "no two home.file directives may have the same target" constraint:
Multiple directives may share a target if and only if they are recursively-linked directories

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.
  note: one bout of weirdness is the use of `pathExists "${sourceStorePath v}/.."` to detect if the source path is a directory. This might warrant a double check for cross-platform compatibility

- [X] Code formatted with `./format`.
  note: due to the large changes caused by this, formatting was done in a separate, reproducible commit.

- [X] Code tested through `nix-shell --pure tests -A run.all`.
   (note: the line in the tests about neovim was disabled, as that test failed both before and after my changes. this is however not committed)

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
