### PR TITLE
notmuch & neomutt: Control virtualboxes being set in NeoMutt for Notmuch integration

### DIFF
--- a/modules/programs/neomutt-accounts.nix
+++ b/modules/programs/neomutt-accounts.nix
@@ -21,6 +21,23 @@ let
   };
 
 in {
+  options.notmuch.neomutt = {
+    enable = mkEnableOption "Notmuch support in NeoMutt" // { default = true; };
+
+    virtualMailboxes = mkOption {
+      type = types.listOf (types.submodule ./notmuch-virtual-mailbox.nix);
+      example = [{
+        name = "My INBOX";
+        query = "tag:inbox";
+      }];
+      default = [{
+        name = "My INBOX";
+        query = "tag:inbox";
+      }];
+      description = "List of virtual mailboxes using Notmuch queries";
+    };
+  };
+
   options.neomutt = {
     enable = mkEnableOption "NeoMutt";
 

--- a/modules/programs/notmuch-virtual-mailbox.nix
+++ b/modules/programs/notmuch-virtual-mailbox.nix
@@ -1,0 +1,33 @@
+{ config, lib, ... }:
+with lib; {
+  options = {
+    name = mkOption {
+      type = types.str;
+      example = "My INBOX";
+      default = "My INBOX";
+      description = "Name to display";
+    };
+
+    query = mkOption {
+      type = types.str;
+      example = "tag:inbox";
+      default = "tag:inbox";
+      description = "Notmuch query";
+    };
+
+    limit = mkOption {
+      type = types.nullOr types.int;
+      example = 10;
+      default = null;
+      description = "Restricts number of messages/threads in the result.";
+    };
+
+    type = mkOption {
+      type = types.nullOr (types.enum ([ "threads" "messages" ]));
+      example = "threads";
+      default = null;
+      description =
+        "Reads all matching messages or whole-threads. The default is 'messages' or nm_query_type.";
+    };
+  };
+}

--- a/tests/modules/programs/neomutt/hm-example.com-expected
+++ b/tests/modules/programs/neomutt/hm-example.com-expected
@@ -35,4 +35,4 @@ color status cyan default
 unset signature
 # notmuch section
 set nm_default_uri = "notmuch:///home/hm-user/Mail"
-virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
+virtual-mailboxes "My INBOX" "notmuch://?query=tag%3Ainbox"

--- a/tests/modules/programs/neomutt/hm-example.com-signature-command-expected
+++ b/tests/modules/programs/neomutt/hm-example.com-signature-command-expected
@@ -35,4 +35,4 @@ color status cyan default
 set signature = "/nix/store/00000000000000000000000000000000-signature|"
 # notmuch section
 set nm_default_uri = "notmuch:///home/hm-user/Mail"
-virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
+virtual-mailboxes "My INBOX" "notmuch://?query=tag%3Ainbox"

--- a/tests/modules/programs/neomutt/hm-example.com-signature-expected
+++ b/tests/modules/programs/neomutt/hm-example.com-signature-expected
@@ -35,4 +35,4 @@ color status cyan default
 set signature = /nix/store/00000000000000000000000000000000-signature.txt
 # notmuch section
 set nm_default_uri = "notmuch:///home/hm-user/Mail"
-virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
+virtual-mailboxes "My INBOX" "notmuch://?query=tag%3Ainbox"


### PR DESCRIPTION
### Description

This enables the arbitrary control of Notmuch virtual mailboxes in NeoMutt, which was impossible before without extraConfig and tedious manipulations.

Plus, it makes it now possible to have Notmuch and remove "My INBOX" from NeoMutt.

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
