### PR TITLE
neovim: fix tests

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -55,15 +55,6 @@ let
     };
   };
 
-  # A function to get the configuration string (if any) from an element of 'plugins'
-  pluginConfig = p:
-    if p ? plugin && (p.config or "") != "" then ''
-      " ${p.plugin.pname or p.plugin.name} {{{
-      ${p.config}
-      " }}}
-    '' else
-      "";
-
   allPlugins = cfg.plugins ++ optional cfg.coc.enable {
     type = "viml";
     plugin = cfg.coc.package;
@@ -394,12 +385,10 @@ in {
     home.packages = [ cfg.finalPackage ];
 
     xdg.configFile."nvim/init.vim" = mkIf (neovimConfig.neovimRcContent != "") {
-      text = if hasAttr "lua" config.programs.neovim.generatedConfigs then
-        neovimConfig.neovimRcContent + ''
-
-          lua require('init-home-manager')''
-      else
-        neovimConfig.neovimRcContent;
+      text = neovimConfig.neovimRcContent + (optionalString
+        (hasAttr "lua" config.programs.neovim.generatedConfigs) ''
+          lua require('init-home-manager')
+        '');
     };
     xdg.configFile."nvim/lua/init-home-manager.lua" =
       mkIf (hasAttr "lua" config.programs.neovim.generatedConfigs) {

--- a/tests/modules/programs/neovim/plugin-config.vim
+++ b/tests/modules/programs/neovim/plugin-config.vim
@@ -1,10 +1,4 @@
-set packpath^=/nix/store/00000000000000000000000000000000-vim-pack-dir
-set runtimepath^=/nix/store/00000000000000000000000000000000-vim-pack-dir
-
-" vim-commentary {{{
 " This should be present too
 autocmd FileType c setlocal commentstring=//\ %s
 autocmd FileType c setlocal comments=://
-
-" }}}
 " This should be present in vimrc


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/184364 broke the tests

Closes #3146

Signed-off-by: Sumner Evans <me@sumnerevans.com>

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
