### PR TITLE
clipmenu: add launcher option

### DIFF
--- a/modules/services/clipmenu.nix
+++ b/modules/services/clipmenu.nix
@@ -18,6 +18,16 @@ in {
       defaultText = "pkgs.clipmenu";
       description = "clipmenu derivation to use.";
     };
+
+    launcher = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "rofi";
+      description = ''
+        Launcher command, if not set, <command>dmenu</command>
+        will be used by default.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -27,6 +37,9 @@ in {
     ];
 
     home.packages = [ cfg.package ];
+
+    home.sessionVariables =
+      mkIf (cfg.launcher != null) { CM_LAUNCHER = cfg.launcher; };
 
     systemd.user.services.clipmenu = {
       Unit = {


### PR DESCRIPTION
### Description

This adds an option to set the launcher command for Clipmenu (which is set with the `CM_LAUNCHER` session variable).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
