### PR TITLE
i3-sway: allow "container" and "output" in focus.mouseWarping

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -508,7 +508,10 @@ in {
         };
 
         mouseWarping = mkOption {
-          type = types.bool;
+          type = if isSway then
+            types.oneOf [ types.bool (types.enum [ "container" "output" ]) ]
+          else
+            types.bool;
           default = true;
           description = ''
             Whether mouse cursor should be warped to the center of the window when switching focus

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -273,7 +273,14 @@ let
         "focus_wrapping ${lib.hm.booleans.yesNo focus.forceWrapping}"
         "focus_follows_mouse ${focus.followMouse}"
         "focus_on_window_activation ${focus.newWindow}"
-        "mouse_warping ${if focus.mouseWarping then "output" else "none"}"
+        "mouse_warping ${
+          if builtins.isString (focus.mouseWarping) then
+            focus.mouseWarping
+          else if focus.mouseWarping then
+            "output"
+          else
+            "none"
+        }"
         "workspace_layout ${workspaceLayout}"
         "workspace_auto_back_and_forth ${
           lib.hm.booleans.yesNo workspaceAutoBackAndForth


### PR DESCRIPTION
### Description

Allow setting "container" and "output" as options for [`wayland.windowManager.sway.config.focus.mouseWarping`](https://nix-community.github.io/home-manager/options.html#opt-wayland.windowManager.sway.config.focus.mouseWarping).

Fixes #2956

### Checklist

- [X] Change is backwards compatible.
  (Yes, `true` and `false` are still accepted as value)

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.
  (Kinda --  I've actually put this in my system and tested `true` and `container`)

- [ ] Test cases updated/added.

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

- If this PR adds a new module

  - [ ] Added myself as module maintainer.

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
