### PR TITLE
hexchat: add channel.passwordFile option

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,8 +118,8 @@ Makefile                                              @thiagokokada
 /modules/programs/helix.nix                           @Philipp-M
 /tests/modules/programs/helix                         @Philipp-M
 
-/modules/programs/hexchat.nix                         @thiagokokada
-/tests/modules/programs/hexchat                       @thiagokokada
+/modules/programs/hexchat.nix                         @superherointj @thiagokokada
+/tests/modules/programs/hexchat                       @superherointj @thiagokokada
 
 /modules/programs/himalaya.nix                        @ambroisie
 /tests/modules/programs/himalaya                      @ambroisie

--- a/modules/programs/hexchat.nix
+++ b/modules/programs/hexchat.nix
@@ -239,7 +239,7 @@ let
     ]);
 
 in {
-  meta.maintainers = with maintainers; [ thiagokokada ];
+  meta.maintainers = with maintainers; [ superherointj thiagokokada ];
 
   options.programs.hexchat = with types; {
     enable = mkEnableOption "HexChat, a graphical IRC client";

--- a/modules/programs/hexchat.nix
+++ b/modules/programs/hexchat.nix
@@ -144,9 +144,16 @@ let
           type = nullOr str;
           default = null;
           description = ''
-            Password to use. Note this password will be readable by all user's
-            in the Nix store.
+            Clear text password, unsafe, readable by all users from nix store.
+            Prefer to use passwordFile option instead.
           '';
+        };
+
+        passwordFile = mkOption {
+          type = nullOr path;
+          default = null;
+          description = "Absolute path to password file.";
+          example = "/etc/nixos/keys/passwordFileName";
         };
 
         realName = mkOption {
@@ -222,7 +229,10 @@ let
       (transformField "i" channel.nickname2)
       (transformField "R" channel.realName)
       (transformField "U" channel.userName)
-      (transformField "P" channel.password)
+      (transformField "P" (if (channel.passwordFile != null) then
+        (config.lib.file.mkOutOfStoreSymlink channel.passwordFile)
+      else
+        channel.password))
       (listChar "S" channel.servers)
       (listChar "J" channel.autojoin)
       (listChar "C" channel.commands)


### PR DESCRIPTION
### Description
 
[WIP]

I'm having trouble converting path to value. (I did try builtins.readFile but errors as `error: access to canonical path '/run/secrets.d/3/irc/servers/oftc/password' is forbidden in restricted mode`)

hexchat:
* add channel.passwordFile option
* add superherointj as maintainer

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
