### PR TITLE
zsh: add option for `zsh-history-substring-search`

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -188,6 +188,28 @@ let
     };
   };
 
+  historySubstringSearchModule = types.submodule {
+    options = {
+      enable = mkEnableOption "history substring search";
+      searchUpKey = mkOption {
+        type = types.str;
+        default = "^[[A";
+        description = ''
+          The key code to be used when searching up.
+          The default of <literal>^[[A</literal> corresponds to the UP key.
+        '';
+      };
+      searchDownKey = mkOption {
+        type = types.str;
+        default = "^[[B";
+        description = ''
+          The key code to be used when searching down.
+          The default of <literal>^[[B</literal> corresponds to the DOWN key.
+        '';
+      };
+    };
+  };
+
 in
 
 {
@@ -293,6 +315,12 @@ in
       enableSyntaxHighlighting = mkOption {
         default = false;
         description = "Enable zsh syntax highlighting";
+      };
+
+      historySubstringSearch = mkOption {
+        type = historySubstringSearchModule;
+        default = {};
+        description = "Options related to zsh-history-substring-search.";
       };
 
       history = mkOption {
@@ -555,10 +583,18 @@ in
         ${dirHashesStr}
 
         ${optionalString cfg.enableSyntaxHighlighting
-          # Load zsh-syntax-highlighting last, after all custom widgets have been created
+          # Load zsh-syntax-highlighting after all custom widgets have been created
           # https://github.com/zsh-users/zsh-syntax-highlighting#faq
           "source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
         }
+        ${optionalString (cfg.historySubstringSearch.enable or false)
+          # Load zsh-history-substring-search after zsh-syntax-highlighting
+          # https://github.com/zsh-users/zsh-history-substring-search#usage
+        ''
+          source ${pkgs.zsh-history-substring-search}/share/zsh-history-substring-search/zsh-history-substring-search.zsh
+          bindkey '${cfg.historySubstringSearch.searchUpKey}' history-substring-search-up
+          bindkey '${cfg.historySubstringSearch.searchDownKey}' history-substring-search-down
+        ''}
       '';
     }
 


### PR DESCRIPTION
### Description

Add an option for installing [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search) outside of `prezto`.

I added it as a submodule of `zsh` but perhaps it would make more sense within the `zsh.history` module?

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
