### PR TITLE
git-sync: added ssh to path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -345,7 +345,7 @@ Makefile                                              @thiagokokada
 /modules/services/fnott.nix                           @polykernel
 /tests/modules/services/fnott                         @polykernel
 
-/modules/services/git-sync.nix                        @IvanMalison
+/modules/services/git-sync.nix                        @IvanMalison @cab404
 
 /modules/services/gnome-keyring.nix                   @rycee
 

--- a/modules/services/git-sync.nix
+++ b/modules/services/git-sync.nix
@@ -13,6 +13,7 @@ let
 
     Service = {
       Environment = [
+        "PATH=${lib.makeBinPath (with pkgs; [ openssh git ])}"
         "GIT_SYNC_DIRECTORY=${repo.path}"
         "GIT_SYNC_COMMAND=${cfg.package}/bin/git-sync"
         "GIT_SYNC_REPOSITORY=${repo.uri}"
@@ -65,7 +66,7 @@ let
   });
 
 in {
-  meta.maintainers = [ maintainers.imalison ];
+  meta.maintainers = [ maintainers.imalison maintainers.cab404 ];
 
   options = {
     services.git-sync = {

--- a/tests/modules/services/git-sync/basic.nix
+++ b/tests/modules/services/git-sync/basic.nix
@@ -11,16 +11,24 @@
       };
     };
 
+    test.stubs = {
+      git = { name = "git"; };
+      openssh = { name = "openssh"; };
+    };
+
     nmt.script = ''
       serviceFile=home-files/.config/systemd/user/git-sync-test.service
 
       assertFileExists $serviceFile
+
+      serviceFile=$(normalizeStorePaths $serviceFile)
       assertFileContent $serviceFile ${
         builtins.toFile "expected" ''
           [Install]
           WantedBy=default.target
 
           [Service]
+          Environment=PATH=/nix/store/00000000000000000000000000000000-openssh/bin:/nix/store/00000000000000000000000000000000-git/bin
           Environment=GIT_SYNC_DIRECTORY=/a/path
           Environment=GIT_SYNC_COMMAND=@git-sync@/bin/git-sync
           Environment=GIT_SYNC_REPOSITORY=git+ssh://user@example.com:/~user/path/to/repo.git


### PR DESCRIPTION
### Description
This fixed automated pushing to repository

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
