### PR TITLE
service.xidlehook: add detect-sleep option

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -489,7 +489,7 @@ Makefile                                              @thiagokokada
 
 /modules/services/xembed-sni-proxy.nix                @rycee
 
-/modules/services/xidlehook.nix                       @dschrempf
+/modules/services/xidlehook.nix                       @dschrempf @bertof
 
 /modules/services/xscreensaver.nix                    @rycee
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -25,6 +25,12 @@
     github = "blmhemu";
     githubId = 19410501;
   };
+  bertof = {
+    name = "bertof";
+    email = "berto.f@protonmail.com";
+    github = "bertof";
+    githubId = 9915675;
+  };
   CarlosLoboxyz = {
     name = "Carlos Lobo";
     email = "86011416+CarlosLoboxyz@users.noreply.github.com";

--- a/modules/services/xidlehook.nix
+++ b/modules/services/xidlehook.nix
@@ -23,13 +23,14 @@ let
     ${concatStringsSep " " (notEmpty [
       "${cfg.package}/bin/xidlehook"
       (optionalString cfg.once "--once")
+      (optionalString cfg.detect-sleep "--detect-sleep")
       (optionalString cfg.not-when-fullscreen "--not-when-fullscreen")
       (optionalString cfg.not-when-audio "--not-when-audio")
       timers
     ])}
   '';
 in {
-  meta.maintainers = [ maintainers.dschrempf ];
+  meta.maintainers = [ maintainers.dschrempf hm.maintainers.bertof ];
 
   options.services.xidlehook = {
     enable = mkEnableOption "xidlehook systemd service";
@@ -54,6 +55,9 @@ in {
         These options are passed unescaped as <code>export name=value</code>.
       '';
     };
+
+    detect-sleep = mkEnableOption
+      "detecting when the system wakes up from a suspended state and resetting the idle timer";
 
     not-when-fullscreen = mkOption {
       type = types.bool;


### PR DESCRIPTION
### Description
Add detect sleep configuration option. Allows to execute the specified commands with more accurate timings if the system wakes from a sleep state.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
