### PR TITLE
feat(scmpuff): add fish integration flag

### DIFF
--- a/modules/programs/scmpuff.nix
+++ b/modules/programs/scmpuff.nix
@@ -31,6 +31,14 @@ in {
         Whether to enable Zsh integration.
       '';
     };
+
+    enableFishIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable fish integration.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -43,5 +51,10 @@ in {
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
       eval "$(${cfg.package}/bin/scmpuff init -s)"
     '';
+
+    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration
+      (mkAfter ''
+        ${cfg.package}/bin/scmpuff init -s --shell=fish | source
+      '');
   };
 }

--- a/tests/modules/programs/scmpuff/default.nix
+++ b/tests/modules/programs/scmpuff/default.nix
@@ -4,4 +4,6 @@
   scmpuff-no-shell = ./no-shell.nix;
   scmpuff-no-zsh = ./no-zsh.nix;
   scmpuff-zsh = ./zsh.nix;
+  scmpuff-fish = ./fish.nix;
+  scmpuff-no-fish = ./no-fish.nix;
 }

--- a/tests/modules/programs/scmpuff/fish.nix
+++ b/tests/modules/programs/scmpuff/fish.nix
@@ -1,0 +1,20 @@
+{ pkgs, lib, ... }: {
+  programs = {
+    scmpuff.enable = true;
+    fish.enable = true;
+  };
+
+  # Needed to avoid error with dummy fish package.
+  xdg.dataFile."fish/home-manager_generated_completions".source =
+    lib.mkForce (builtins.toFile "empty" "");
+
+  test.stubs.fish = { };
+  test.stubs.scmpuff = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      '@scmpuff@/bin/scmpuff init -s --shell=fish | source'
+  '';
+}

--- a/tests/modules/programs/scmpuff/no-fish.nix
+++ b/tests/modules/programs/scmpuff/no-fish.nix
@@ -1,0 +1,20 @@
+{ pkgs, lib, ... }: {
+  programs = {
+    scmpuff = {
+      enable = true;
+      enableFishIntegration = false;
+    };
+    fish.enable = true;
+  };
+
+  # Needed to avoid error with dummy fish package.
+  xdg.dataFile."fish/home-manager_generated_completions".source =
+    lib.mkForce (builtins.toFile "empty" "");
+
+  test.stubs.fish = { };
+  test.stubs.scmpuff = { };
+
+  nmt.script = ''
+    assertFileNotRegex home-files/.config/fish/config.fish '@scmpuff@'
+  '';
+}


### PR DESCRIPTION
### Description

Add fish integration to the `scmpuff` program

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
