### PR TITLE
git: add option to define store names for generated include files

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -142,7 +142,8 @@ let
       };
     };
     config.path = mkIf (config.contents != { }) (mkDefault
-      (pkgs.writeText config.contentSuffix (gitToIni config.contents)));
+      (pkgs.writeText (hm.strings.storeFileName config.contentSuffix)
+        (gitToIni config.contents)));
   });
 
 in {

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -130,10 +130,19 @@ let
           </citerefentry>.
         '';
       };
-    };
 
-    config.path = mkIf (config.contents != { })
-      (mkDefault (pkgs.writeText "contents" (gitToIni config.contents)));
+      contentSuffix = mkOption {
+        type = types.str;
+        default = "gitconfig";
+        description = ''
+          Nix store name for the git configuration text file,
+          when generating the configuration text from nix options.
+        '';
+
+      };
+    };
+    config.path = mkIf (config.contents != { }) (mkDefault
+      (pkgs.writeText config.contentSuffix (gitToIni config.contents)));
   });
 
 in {

--- a/tests/modules/programs/git/git-expected.conf
+++ b/tests/modules/programs/git/git-expected.conf
@@ -56,3 +56,6 @@
 
 [includeIf "gitdir:~/src/dir"]
 	path = "@git_include_path@"
+
+[includeIf "gitdir:~/src/otherproject"]
+	path = "@git_named_include_path@"

--- a/tests/modules/programs/git/git.nix
+++ b/tests/modules/programs/git/git.nix
@@ -14,7 +14,9 @@ let
   substituteExpected = path:
     pkgs.substituteAll {
       src = path;
-      git_include_path = pkgs.writeText "contents"
+      git_include_path = pkgs.writeText "gitconfig"
+        (builtins.readFile ./git-expected-include.conf);
+      git_named_include_path = pkgs.writeText "gitconfig-work"
         (builtins.readFile ./git-expected-include.conf);
     };
 
@@ -45,6 +47,11 @@ in {
           {
             condition = "gitdir:~/src/dir";
             contents = gitInclude;
+          }
+          {
+            condition = "gitdir:~/src/otherproject";
+            contents = gitInclude;
+            contentSuffix = "gitconfig-work";
           }
         ];
         signing = {

--- a/tests/modules/programs/git/git.nix
+++ b/tests/modules/programs/git/git.nix
@@ -14,9 +14,9 @@ let
   substituteExpected = path:
     pkgs.substituteAll {
       src = path;
-      git_include_path = pkgs.writeText "gitconfig"
+      git_include_path = pkgs.writeText "hm_gitconfig"
         (builtins.readFile ./git-expected-include.conf);
-      git_named_include_path = pkgs.writeText "gitconfig-work"
+      git_named_include_path = pkgs.writeText "hm_gitconfigwork"
         (builtins.readFile ./git-expected-include.conf);
     };
 


### PR DESCRIPTION
### Description
* adds a option to set the store names for git inclues
* uses gitconfig instead of content  as default to help with the meaning of filenames

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
