### PR TITLE
udiskie: avoid dependency on tray.target when tray is disabled

### DIFF
--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -109,8 +109,9 @@ in {
     systemd.user.services.udiskie = {
       Unit = {
         Description = "udiskie mount daemon";
-        Requires = [ "tray.target" ];
-        After = [ "graphical-session-pre.target" "tray.target" ];
+        Requires = lib.optional (cfg.tray != "never") "tray.target";
+        After = [ "graphical-session-pre.target" ]
+          ++ lib.optional (cfg.tray != "never") "tray.target";
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -41,7 +41,7 @@ in {
         '';
         description = ''
           Configuration written to
-          <filename>$XDG_CONFIG_HOME/udiskie/config.toml</filename>.
+          <filename>$XDG_CONFIG_HOME/udiskie/config.yml</filename>.
           </para><para>
           See <link xlink:href="https://github.com/coldfix/udiskie/blob/master/doc/udiskie.8.txt#configuration" />
           for the full list of options.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -182,6 +182,7 @@ import nmt {
     ./modules/services/syncthing
     ./modules/services/trayer
     ./modules/services/twmn
+    ./modules/services/udiskie
     ./modules/services/window-managers/bspwm
     ./modules/services/window-managers/herbstluftwm
     ./modules/services/window-managers/i3

--- a/tests/modules/services/udiskie/basic.nix
+++ b/tests/modules/services/udiskie/basic.nix
@@ -1,0 +1,15 @@
+{
+  config = {
+    services.udiskie.enable = true;
+
+    test.stubs.udiskie = { };
+
+    nmt.script = ''
+      serviceFile="home-files/.config/systemd/user/udiskie.service"
+      assertFileRegex "$serviceFile" 'After=tray\.target'
+      assertFileRegex "$serviceFile" 'Requires=tray\.target'
+      assertFileContent "home-files/.config/udiskie/config.yml" \
+          ${./basic.yml}
+    '';
+  };
+}

--- a/tests/modules/services/udiskie/basic.yml
+++ b/tests/modules/services/udiskie/basic.yml
@@ -1,0 +1,4 @@
+program_options:
+  automount: true
+  notify: true
+  tray: auto

--- a/tests/modules/services/udiskie/default.nix
+++ b/tests/modules/services/udiskie/default.nix
@@ -1,0 +1,4 @@
+{
+  udiskie-basic = ./basic.nix;
+  udiskie-no-tray = ./no-tray.nix;
+}

--- a/tests/modules/services/udiskie/no-tray.nix
+++ b/tests/modules/services/udiskie/no-tray.nix
@@ -1,0 +1,18 @@
+{
+  config = {
+    services.udiskie = {
+      enable = true;
+      tray = "never";
+    };
+
+    test.stubs.udiskie = { };
+
+    nmt.script = ''
+      serviceFile="home-files/.config/systemd/user/udiskie.service"
+      assertFileNotRegex "$serviceFile" 'After=tray\.target'
+      assertFileNotRegex "$serviceFile" 'Requires=tray\.target'
+      assertFileContent "home-files/.config/udiskie/config.yml" \
+          ${./no-tray.yml}
+    '';
+  };
+}

--- a/tests/modules/services/udiskie/no-tray.yml
+++ b/tests/modules/services/udiskie/no-tray.yml
@@ -1,0 +1,4 @@
+program_options:
+  automount: true
+  notify: true
+  tray: false


### PR DESCRIPTION
### Description

This PR removes the dependecy on `tray.target` when configuring udiskie to not use the system tray (motivated by me having `services.udiskie.tray = "never"` in my hm config but also no `tray.target` in my system, leading to errors even though `tray.target` is unnecessary)

I additionally added tests for the old and new behaviors for udiskie configuration (and made a drive-by typo fix). Quick question though: Do I need to add the `tests/modules/services/udiskie` directory to `.github/CODEOWNERS` and if so, should I add myself rather than the module maintainer or both of us or something else?

Edit: The test failure on Ubuntu in GHA seems unrelated to this PR and caused by neovim changes in nixpkgs. It looks like #3168 will fix that test, though

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.