### PR TITLE
programs.neovim: remove 'configure' setting

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -99,6 +99,14 @@ in {
       "Python2 support has been removed from neovim.")
     (mkRemovedOptionModule [ "programs" "neovim" "extraPythonPackages" ]
       "Python2 support has been removed from neovim.")
+    (mkRemovedOptionModule [ "programs" "neovim" "configure" ] ''
+      programs.neovim.configure is deprecated.
+            Other programs.neovim options can override its settings or ignore them.
+            Please use the other options at your disposal:
+              configure.packages.*.opt  -> programs.neovim.plugins = [ { plugin = ...; optional = true; }]
+              configure.packages.*.start  -> programs.neovim.plugins = [ { plugin = ...; }]
+              configure.customRC -> programs.neovim.extraConfig
+    '')
   ];
 
   options = {
@@ -221,35 +229,6 @@ in {
         description = "Resulting customized neovim package.";
       };
 
-      configure = mkOption {
-        type = types.attrsOf types.anything;
-        default = { };
-        example = literalExpression ''
-          configure = {
-              customRC = $''''
-              " here your custom configuration goes!
-              $'''';
-              packages.myVimPackage = with pkgs.vimPlugins; {
-                # loaded on launch
-                start = [ fugitive ];
-                # manually loadable by calling `:packadd $plugin-name`
-                opt = [ ];
-              };
-            };
-        '';
-        description = ''
-          Deprecated. Please use the other options.
-
-          Generate your init file from your list of plugins and custom commands,
-          and loads it from the store via <command>nvim -u /nix/store/hash-vimrc</command>
-
-          </para><para>
-
-          This option is mutually exclusive with <varname>extraConfig</varname>
-          and <varname>plugins</varname>.
-        '';
-      };
-
       extraConfig = mkOption {
         type = types.lines;
         default = "";
@@ -258,10 +237,6 @@ in {
         '';
         description = ''
           Custom vimrc lines.
-
-          </para><para>
-
-          This option is mutually exclusive with <varname>configure</varname>.
         '';
       };
 
@@ -372,14 +347,6 @@ in {
     };
 
   in mkIf cfg.enable {
-    warnings = optional (cfg.configure != { }) ''
-      programs.neovim.configure is deprecated.
-      Other programs.neovim options can override its settings or ignore them.
-      Please use the other options at your disposal:
-        configure.packages.*.opt  -> programs.neovim.plugins = [ { plugin = ...; optional = true; }]
-        configure.packages.*.start  -> programs.neovim.plugins = [ { plugin = ...; }]
-        configure.customRC -> programs.neovim.extraConfig
-    '';
 
     programs.neovim.generatedConfigViml = neovimConfig.neovimRcContent;
 


### PR DESCRIPTION
everything is now covered by other settings that are more user friendly
than this big opaque attrset

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
