### PR TITLE
email: add yandex and outlook.office365 email flavor

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -229,7 +229,14 @@ let
       };
 
       flavor = mkOption {
-        type = types.enum [ "plain" "gmail.com" "runbox.com" "fastmail.com" ];
+        type = types.enum [
+          "plain"
+          "gmail.com"
+          "runbox.com"
+          "fastmail.com"
+          "yandex.com"
+          "outlook.office365.com"
+        ];
         default = "plain";
         description = ''
           Some email providers have peculiar behavior that require
@@ -377,6 +384,41 @@ let
         name = name;
         maildir = mkOptionDefault { path = "${name}"; };
       }
+
+      (mkIf (config.flavor == "yandex.com") {
+        userName = mkDefault config.address;
+
+        imap = {
+          host = "imap.yandex.com";
+          port = 993;
+          tls.enable = true;
+        };
+
+        smtp = {
+          host = "smtp.yandex.com";
+          port = 465;
+          tls.enable = true;
+        };
+      })
+
+      (mkIf (config.flavor == "outlook.office365.com") {
+        userName = mkDefault config.address;
+
+        imap = {
+          host = "outlook.office365.com";
+          port = 993;
+          tls.enable = true;
+        };
+
+        smtp = {
+          host = "smtp-mail.outlook.com";
+          port = 587;
+          tls = {
+            enable = true;
+            useStartTls = true;
+          };
+        };
+      })
 
       (mkIf (config.flavor == "fastmail.com") {
         userName = mkDefault config.address;


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
