### PR TITLE
rtorrent: change settings to extraConfig

### DIFF
--- a/modules/programs/rtorrent.nix
+++ b/modules/programs/rtorrent.nix
@@ -9,10 +9,16 @@ let
 in {
   meta.maintainers = [ maintainers.marsam ];
 
+  imports = [
+    (mkRenamedOptionModule # \
+      [ "programs" "rtorrent" "settings" ] # \
+      [ "programs" "rtorrent" "extraConfig" ])
+  ];
+
   options.programs.rtorrent = {
     enable = mkEnableOption "rTorrent";
 
-    settings = mkOption {
+    extraConfig = mkOption {
       type = types.lines;
       default = "";
       description = ''
@@ -29,6 +35,6 @@ in {
     home.packages = [ pkgs.rtorrent ];
 
     xdg.configFile."rtorrent/rtorrent.rc" =
-      mkIf (cfg.settings != "") { text = cfg.settings; };
+      mkIf (cfg.extraConfig != "") { text = cfg.extraConfig; };
   };
 }


### PR DESCRIPTION
Per NixOS RFC #42, settings should be reserved to structured configuration
settings, whereas extraConfig is used for stringly configuration.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
