### PR TITLE
git: gpg sign tags with signing.signByDefault set

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -73,7 +73,7 @@ let
       signByDefault = mkOption {
         type = types.bool;
         default = false;
-        description = "Whether commits should be signed by default.";
+        description = "Whether commits and tags should be signed by default.";
       };
 
       gpgPath = mkOption {
@@ -444,6 +444,7 @@ in {
       programs.git.iniContent = {
         user.signingKey = mkIf (cfg.signing.key != null) cfg.signing.key;
         commit.gpgSign = cfg.signing.signByDefault;
+        tag.gpgSign = cfg.signing.signByDefault;
         gpg.program = cfg.signing.gpgPath;
       };
     })

--- a/tests/modules/programs/git/git-expected.conf
+++ b/tests/modules/programs/git/git-expected.conf
@@ -43,6 +43,9 @@
 [interactive]
 	diffFilter = "@delta@/bin/delta --color-only"
 
+[tag]
+	gpgSign = true
+
 [user]
 	email = "user@example.org"
 	name = "John Doe"

--- a/tests/modules/programs/git/git-with-signing-key-id-expected.conf
+++ b/tests/modules/programs/git/git-with-signing-key-id-expected.conf
@@ -4,6 +4,9 @@
 [gpg]
 	program = "path-to-gpg"
 
+[tag]
+	gpgSign = true
+
 [user]
 	email = "user@example.org"
 	name = "John Doe"

--- a/tests/modules/programs/git/git-without-signing-key-id-expected.conf
+++ b/tests/modules/programs/git/git-without-signing-key-id-expected.conf
@@ -4,6 +4,9 @@
 [gpg]
 	program = "path-to-gpg"
 
+[tag]
+	gpgSign = true
+
 [user]
 	email = "user@example.org"
 	name = "John Doe"


### PR DESCRIPTION
### Description

The `tag.gpgSign` config option was added in Git 2.23.0 and seems like it should be set in addition to `commit.gpgSign` when `programs.git.signing.signByDefault` is enabled

This does introduce a minor change in behavior, but it seems a reasonable one to take. Do you have any thoughts on that @rycee or other maintainers?

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
