### PR TITLE
gpg-agent: invert grab and no-grab behavior

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -216,7 +216,7 @@ in {
     {
       home.file."${homedir}/gpg-agent.conf".text = concatStringsSep "\n"
         (optional (cfg.enableSshSupport) "enable-ssh-support"
-          ++ optional (!cfg.grabKeyboardAndMouse) "no-grab"
+          ++ optional (cfg.grabKeyboardAndMouse) "grab"
           ++ optional (!cfg.enableScDaemon) "disable-scdaemon"
           ++ optional (cfg.defaultCacheTtl != null)
           "default-cache-ttl ${toString cfg.defaultCacheTtl}"


### PR DESCRIPTION
Home-manager should explicitly output `grab` when `cfg.grabKeyboardAndMouse` is true.  Previously home-manager emitted `no-grab` when `cfg.grabKeyboardAndMouse` was false.

### Description

The GNU Privacy Guard 2.3 man page for `gpg-agent` describes the `--grab` and `--no-grab` options as follows:

> Tell the pinentry to grab the  keyboard  and mouse.   This  option  should  be used on X-Servers to avoid X-sniffing attacks. Any use of  the  option --grab overrides an used option --no-grab.  The default is --no-grab.

### Checklist

- [X] Change is backwards compatible.

This may be "more" backwards compatible if `cfg.grabKeyboardAndMouse` defaulted to false.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

Spurious warning: 

> In file /home/jim/downloads/me/home-manager/tests/lib/types/list-or-dag-merge.nixa list is being assigned to the option 'tested.dag'.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
