### PR TITLE
neovim: allow disabling NodeJS when CoC is enabled

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -138,11 +138,14 @@ in {
       };
 
       withNodeJs = mkOption {
-        type = types.bool;
+        type = types.nullOr types.bool;
         default = false;
         description = ''
           Enable node provider. Set to <literal>true</literal> to
           use Node plugins.
+
+          This will be automatically enabled if <varname>coc.enable</varname> is set,
+          which can be circumvented by setting this option to <literal>null</literal>.
         '';
       };
 
@@ -341,9 +344,13 @@ in {
 
     neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
       inherit (cfg) extraPython3Packages withPython3 withRuby viAlias vimAlias;
-      withNodeJs = cfg.withNodeJs || cfg.coc.enable;
       plugins = map suppressNotVimlConfig pluginsNormalized;
       customRC = cfg.extraConfig;
+      withNodeJs = if (cfg.withNodeJs == true || cfg.coc.enable
+        && cfg.withNodeJs != null) then
+        true
+      else
+        false;
     };
 
   in mkIf cfg.enable {


### PR DESCRIPTION

### Description


Previously enabling CoC would unconditionally add the latest version of NodeJS to the environment, without allowing the user to override it. That is a problem in the case a different plugin does not support the latest version of NodeJS, and only works on an 
older release.


I encountered this problem with github-copilot, which only supports NodeJS 14-17. It is entirely broken if used in combination with CoC right now.

This PR fixes the problem by allowing you to provide any version of NodeJS. You can set `withNodeJs = null` and `extraPackages = [ nodejs-16_x ]`.

Fixes https://github.com/nix-community/home-manager/issues/3175


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
