### PR TITLE
flake: correct nix-darwin flake description

### DIFF
--- a/docs/nix-flakes.adoc
+++ b/docs/nix-flakes.adoc
@@ -200,7 +200,7 @@ is similar to that of NixOS. The `flake.nix` would be:
 [source,nix]
 ----
 {
-  description = "NixOS configuration";
+  description = "Darwin configuration";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";

--- a/templates/nix-darwin/flake.nix
+++ b/templates/nix-darwin/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "NixOS configuration";
+  description = "Darwin configuration";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";


### PR DESCRIPTION
### Description

Corrects copy/paste mistake in the nix-darwin flake description.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.