### PR TITLE
Fix mako

### DIFF
--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -4,13 +4,16 @@ with lib;
 
 let
 
-  cfg = config.programs.mako;
+  cfg = config.services.mako;
 
 in {
   meta.maintainers = [ maintainers.onny ];
 
+  imports =
+    [ (mkRenamedOptionModule [ "programs" "mako" ] [ "services" "mako" ]) ];
+
   options = {
-    programs.mako = {
+    services.mako = {
       enable = mkEnableOption ''
         Mako, lightweight notification daemon for Wayland
       '';

--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -18,6 +18,14 @@ in {
         Mako, lightweight notification daemon for Wayland
       '';
 
+      autoStart = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Automaticly start mako with graphical-session.target.
+        '';
+      };
+
       package = mkOption {
         type = types.package;
         default = pkgs.mako;
@@ -367,6 +375,10 @@ in {
         ExecStart = getExe cfg.package;
         ExecReload = "${cfg.package}/bin/makoctl reload";
       };
-    };
+
+    } // (if autoStart then {
+      Install.WantedBy = [ "graphical-session.target" ];
+    } else
+      { });
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Enabling `mako` does not actually cause it to start for me or set anything up so that mako will handle notifications in any way, also its named `programs.mako` but in the `modules/services` folder and behaves more like a service anyway.

This changes `programs.mako` to `services.mako` and enable a mako systemd service when mako is enabled.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
