### PR TITLE
git: add config helper for hooks

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -201,6 +201,21 @@ in {
         '';
       };
 
+      hooks = mkOption {
+        type = types.attrsOf types.path;
+        default = { };
+        example = literalExpression ''
+          {
+            pre-commit = ./pre-commit-script;
+          }
+        '';
+        description = ''
+          Configuration helper for Git hooks.
+          See <link xlink:href="https://git-scm.com/docs/githooks" />
+          for reference.
+        '';
+      };
+
       iniContent = mkOption {
         type = gitIniType;
         internal = true;
@@ -446,6 +461,15 @@ in {
         commit.gpgSign = cfg.signing.signByDefault;
         tag.gpgSign = cfg.signing.signByDefault;
         gpg.program = cfg.signing.gpgPath;
+      };
+    })
+
+    (mkIf (cfg.hooks != { }) {
+      programs.git.iniContent = {
+        core.hooksPath = let
+          entries =
+            mapAttrsToList (name: path: { inherit name path; }) cfg.hooks;
+        in toString (pkgs.linkFarm "git-hooks" entries);
       };
     })
 

--- a/tests/modules/programs/git/default.nix
+++ b/tests/modules/programs/git/default.nix
@@ -5,4 +5,5 @@
   git-with-str-extra-config = ./git-with-str-extra-config.nix;
   git-with-signing-key-id = ./git-with-signing-key-id.nix;
   git-without-signing-key-id = ./git-without-signing-key-id.nix;
+  git-with-hooks = ./git-with-hooks.nix;
 }

--- a/tests/modules/programs/git/git-pre-commit-hook.sh
+++ b/tests/modules/programs/git/git-pre-commit-hook.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "pre-commit hook..."

--- a/tests/modules/programs/git/git-with-hooks.nix
+++ b/tests/modules/programs/git/git-with-hooks.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+
+{
+  programs.git = {
+    enable = true;
+    hooks = { pre-commit = ./git-pre-commit-hook.sh; };
+  };
+
+  nmt.script = ''
+    function getGitConfig() {
+      ${pkgs.gitMinimal}/bin/git config \
+        --file $TESTED/home-files/.config/git/config \
+        --get $1
+    }
+
+    assertFileExists home-files/.config/git/config
+    hookPath=$(getGitConfig core.hooksPath)
+    assertLinkExists $hookPath/pre-commit
+
+    actual="$(readlink "$hookPath/pre-commit")"
+    expected="${./git-pre-commit-hook.sh}"
+    if [[ $actual != $expected ]]; then
+      fail "Symlink $hookPath/pre-commit should point to $expected via the Nix store, but it actually points to $actual."
+    fi
+  '';
+}


### PR DESCRIPTION
### Description

This adds a configuration option to `programs.git` that aids in the configuration of custom Git [hooks](https://git-scm.com/docs/githooks). 

###### Example Usage
```nix
{
  programs.git = {
    enable = true;
    hooks = {
      pre-commit = ./path-to-hook.sh;
    };
  };
}
```

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`.
This seems to be failing with an unrelated error?
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted
