### PR TITLE
swayidle: allow wayland targets other than sway-session.target

### DIFF
--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -96,6 +96,15 @@ in {
       default = [ ];
       description = "Extra arguments to pass to swayidle.";
     };
+
+    systemdTarget = mkOption {
+      type = types.str;
+      default = "sway-session.target";
+      description = ''
+        Systemd target to bind to.
+      '';
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -114,7 +123,7 @@ in {
           "${cfg.package}/bin/swayidle -w ${concatStringsSep " " args}";
       };
 
-      Install = { WantedBy = [ "sway-session.target" ]; };
+      Install = { WantedBy = [ cfg.systemdTarget ]; };
     };
   };
 }


### PR DESCRIPTION
### Description

Allow another Wayland targets, as river-session.target or hyprland-session.target, to use swayidle.service which is  
 hard-coded to sway-session.target.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
