### PR TITLE
fzf: add colors option

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -6,6 +6,10 @@ let
 
   cfg = config.programs.fzf;
 
+  renderedColors = colors:
+    concatStringsSep ","
+    (mapAttrsToList (name: value: "${name}:${value}") colors);
+
 in {
   imports = [
     (mkRemovedOptionModule [ "programs" "fzf" "historyWidgetCommand" ]
@@ -88,6 +92,24 @@ in {
       '';
     };
 
+    colors = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = literalExpression ''
+        {
+          bg = "#1e1e1e";
+          "bg+" = "#1e1e1e";
+          fg = "#d4d4d4";
+          "fg+" = "#d4d4d4";
+        }
+      '';
+      description = ''
+        Color scheme options added to <code>FZF_DEFAULT_OPTS</code>. See
+        <link xlink:href="https://github.com/junegunn/fzf/wiki/Color-schemes"/>
+        for documentation.
+      '';
+    };
+
     tmux = {
       enableShellIntegration = mkEnableOption ''
         setting <literal>FZF_TMUX=1</literal> which causes shell integration to use fzf-tmux
@@ -141,7 +163,9 @@ in {
         FZF_CTRL_T_COMMAND = cfg.fileWidgetCommand;
         FZF_CTRL_T_OPTS = cfg.fileWidgetOptions;
         FZF_DEFAULT_COMMAND = cfg.defaultCommand;
-        FZF_DEFAULT_OPTS = cfg.defaultOptions;
+        FZF_DEFAULT_OPTS = cfg.defaultOptions
+          ++ lib.optionals (cfg.colors != { })
+          [ "--color ${renderedColors cfg.colors}" ];
         FZF_TMUX = if cfg.tmux.enableShellIntegration then "1" else null;
         FZF_TMUX_OPTS = cfg.tmux.shellIntegrationOptions;
       });


### PR DESCRIPTION
### Description

Add an option to specify fzf colors with an attribute set rather than writing the entire option string.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
