### PR TITLE
swiftbar: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -280,6 +280,9 @@ Makefile                                              @thiagokokada
 /modules/programs/swaylock.nix                        @rcerc
 /tests/modules/programs/swaylock                      @rcerc
 
+/modules/programs/swiftbar.nix                        @ivarwithoutbones
+/tests/modules/programs/swiftbar                      @ivarwithoutbones
+
 /modules/programs/tealdeer.nix                        @marsam
 
 /modules/programs/terminator.nix                      @chisui

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -157,6 +157,7 @@ let
     ./programs/skim.nix
     ./programs/sm64ex.nix
     ./programs/sqls.nix
+    ./programs/swiftbar.nix
     ./programs/ssh.nix
     ./programs/starship.nix
     ./programs/swaylock.nix

--- a/modules/programs/swiftbar.nix
+++ b/modules/programs/swiftbar.nix
@@ -1,0 +1,160 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.swiftbar;
+
+  refreshRateSuffixes = [ "ms" "s" "m" "h" "d" ];
+  validateRefreshRate = value:
+    (builtins.match "[0-9]+[${concatStringsSep "|" refreshRateSuffixes}]+"
+      value) != null;
+
+  metaAttrs = [ "swiftbar" "bitbar" ];
+  validateMetaAttrs = value:
+    (builtins.match (concatStringsSep "|" metaAttrs) value) != null;
+
+  # The interval a plugin refreshes at is defined by its filename. Create a bash script with the
+  # appropriate filename and metadata for each plugin, which executes the user-provided script.
+  mkPlugin = plugin:
+    let
+      format = value:
+        if isBool value then if value then "true" else "false" else value;
+
+      meta = concatStringsSep "\n" (mapAttrsToList (sectionName: attrs:
+        concatStringsSep "\n" (map (attrName:
+          let
+            key = "${sectionName}.${attrName}";
+            value = format attrs.${attrName};
+          in "# <${key}>${value}</${key}>") (attrNames attrs))) plugin.meta);
+
+      text = optionalString (plugin.meta != { }) (meta + "\n") + plugin.plugin;
+    in pkgs.writeShellScriptBin "${plugin.name}.${plugin.refreshRate}.sh" text;
+
+  joinedPlugins = pkgs.symlinkJoin {
+    name = "swiftbar-plugins";
+    paths = map (plugin: mkPlugin plugin) cfg.plugins;
+  };
+
+  # The plugin directory can only be set by writing to the preferences plist, which we
+  # want to do prior to starting swiftbar. This script is used in the launchd service.
+  swiftbarWithPlugins = pkgs.writeShellScriptBin "start-swiftbar-service" ''
+    defaults write com.ameba.SwiftBar PluginDirectory ${joinedPlugins}/bin
+    ${cfg.package}/bin/SwiftBar
+  '';
+in {
+  meta.maintainers = with maintainers; [ ivar ];
+
+  options.programs.swiftbar = {
+    enable = mkEnableOption "Swiftbar";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.swiftbar;
+      defaultText = literalExpression "pkgs.swiftbar";
+      description = "Swiftbar package to use.";
+    };
+
+    plugins = mkOption {
+      default = [ ];
+      example = literalExpression ''
+        [
+          {
+            name = "foo";
+            refreshRate = "100ms";
+            plugin = pkgs.writeShellScript "foo" "echo bar";
+            meta.bitbar = {
+              version = "v1.0";
+              desc = "Example description";
+            };
+          }
+        ]
+      '';
+      description = ''
+        The plugins to install.
+      '';
+
+      type = types.listOf (types.submodule {
+        options = {
+          name = mkOption {
+            type = types.str;
+            example = "foo";
+            description = ''
+              The name of the plugin.
+            '';
+          };
+
+          plugin = mkOption {
+            type = types.path;
+            example = literalExpression ''
+              pkgs.writeShellScript "foo" "echo foo"
+            '';
+            description = ''
+              Path to the plugin to execute. This can be any script printing to
+              standard output. See <link xlink:href="https://github.com/swiftbar/SwiftBar#script-output"/>.
+            '';
+          };
+
+          refreshRate = mkOption {
+            type = types.addCheck types.str (value: validateRefreshRate value)
+              // {
+                description = "number ending with '${
+                    concatStringsSep "' or '" refreshRateSuffixes
+                  }'";
+              };
+            example = "100ms";
+            description = ''
+              The interval to refresh the plugin at.
+            '';
+          };
+
+          meta = mkOption {
+            type = with types;
+              addCheck (attrsOf (attrsOf (either bool str))) (value:
+                builtins.all (v: v)
+                (map (name: validateMetaAttrs name) (attrNames value))) // {
+                  description = "attrset named '${
+                      concatStringsSep "' or '" metaAttrs
+                    }' containing bool or string";
+                };
+            default = { };
+            example = literalExpression ''
+              {
+                bitbar.title = "My menu bar plugin";
+                swiftbar.hideRunInTerminal = true;
+              }
+            '';
+            description = ''
+              Metadata to be added to the plugin.
+              See <link xlink:href="https://github.com/swiftbar/SwiftBar#script-metadata"/>.
+            '';
+          };
+        };
+      });
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.swiftbar" pkgs platforms.darwin)
+    ];
+
+    launchd.agents.swiftbar = {
+      enable = true;
+      config = {
+        ProgramArguments = toList (if (cfg.plugins != [ ]) then
+          "${swiftbarWithPlugins}/bin/start-swiftbar-service"
+        else
+          cfg.package.outPath);
+        KeepAlive = true;
+        ProcessType = "Interactive";
+      };
+    };
+
+    home.packages = if (cfg.plugins != [ ]) then [
+      swiftbarWithPlugins
+      cfg.package
+    ] else
+      toList cfg.package;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -121,6 +121,7 @@ import nmt {
     ./modules/programs/zsh
     ./modules/xresources
   ] ++ lib.optionals isDarwin [
+    ./modules/programs/swiftbar
     ./modules/launchd
     ./modules/targets-darwin
   ] ++ lib.optionals isLinux [

--- a/tests/modules/programs/swiftbar/basic-configuration.nix
+++ b/tests/modules/programs/swiftbar/basic-configuration.nix
@@ -1,0 +1,17 @@
+{ config, pkgs, ... }:
+
+let package = pkgs.swiftbar;
+in {
+  programs.swiftbar = {
+    enable = true;
+    inherit package;
+  };
+
+  nmt.script = ''
+    serviceFile=LaunchAgents/org.nix-community.home.swiftbar.plist
+
+    assertFileExists $serviceFile
+    assertFileContains $serviceFile ${package.outPath}
+    assertFileExists home-path/Applications/SwiftBar.app/Contents/MacOS/SwiftBar
+  '';
+}

--- a/tests/modules/programs/swiftbar/default.nix
+++ b/tests/modules/programs/swiftbar/default.nix
@@ -1,0 +1,1 @@
+{ swiftbar = import ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

This adds a module for [SwiftBar](https://github.com/swiftbar/SwiftBar#script-metadata), an app that allows you to define scriptable menu bar items on MacOS. I recently PR'd it to nixpkgs, figured a home-manager module would make it a lot nicer to use. 

### Checklist


- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
