### PR TITLE
systemd: Install.RequiredBy

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -44,14 +44,15 @@ let
         destination = "/${filename}";
       } + "/${filename}";
 
-      wantedBy = target: {
-        name = "systemd/user/${target}.wants/${filename}";
+      install = variant: target: {
+        name = "systemd/user/${target}.${variant}/${filename}";
         value = { inherit source; };
       };
     in lib.singleton {
       name = "systemd/user/${filename}";
       value = { inherit source; };
-    } ++ map wantedBy (serviceCfg.Install.WantedBy or [ ]);
+    } ++ map (install "wants") (serviceCfg.Install.WantedBy or [ ])
+    ++ map (install "requires") (serviceCfg.Install.RequiredBy or [ ]);
 
   buildServices = style: serviceCfgs:
     lib.concatLists (lib.mapAttrsToList (buildService style) serviceCfgs);


### PR DESCRIPTION
### Description

Units with `Install.RequiredBy` set will now set up `unit.requires/` links, in the same way that `Install.WantedBy` already sets up `unit.wants/`


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
