### PR TITLE
mention `sudo nixos-rebuild switch` uses root user channels

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -124,21 +124,21 @@ deployed through NixOps.
 
 To make the NixOS module available for use you must `import` it into
 your system configuration. This is most conveniently done by adding a
-Home Manager channel. For example, if you are following Nixpkgs master
-or an unstable channel, you can run
+Home Manager channel to the root user. For example, if you are
+following Nixpkgs master or an unstable channel, you can run
 
 [source,console]
 ----
-# nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
-# nix-channel --update
+$ sudo nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
+$ sudo nix-channel --update
 ----
 
 and if you follow a Nixpkgs version 22.05 channel, you can run
 
 [source,console]
 ----
-# nix-channel --add https://github.com/nix-community/home-manager/archive/release-22.05.tar.gz home-manager
-# nix-channel --update
+$ sudo nix-channel --add https://github.com/nix-community/home-manager/archive/release-22.05.tar.gz home-manager
+$ sudo nix-channel --update
 ----
 
 It is then possible to add
@@ -161,7 +161,7 @@ home-manager.users.eve = { pkgs, ... }: {
 };
 ----
 
-and after a `nixos-rebuild switch` the user eve's environment should
+and after a `sudo nixos-rebuild switch` the user eve's environment should
 include a basic Bash configuration and the packages atool and httpie.
 
 [NOTE]

--- a/docs/manual.xml
+++ b/docs/manual.xml
@@ -24,7 +24,7 @@
   </para>
   <note>
    <para>
-    Commands prefixed with <literal>#</literal> have to be run as root, either
+    Commands prefixed with <literal>$ sudo</literal> have to be run as root, either
     requiring to login as root user or temporarily switching to it using
     <literal>sudo</literal> for example.
    </para>


### PR DESCRIPTION
To me it was not obvious that when using home-manager as a module in the nixos config it will use the channels of the root user when running `sudo nixos-rebuild switch`.

### Description

 `sudo nixos-rebuild switch` uses the channels configured for the root user. The instructions should contain a Note pointing this out so new users are aware of this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
