### PR TITLE
fix #2848: clean home path from profile to ensure replacement 

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -102,6 +102,7 @@ function setFlakeAttribute() {
     if [[ -n "$FLAKE_ARG" ]]; then
         local flake="${FLAKE_ARG%#*}"
         case $FLAKE_ARG in
+
             *#*)
                 local name="${FLAKE_ARG#*#}"
             ;;

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -592,10 +592,21 @@ in
         ''
       else
         ''
+          function hm-internal-replace-profile {
+
+            nix profile list \
+              | { grep 'home-manager-path$' || test $? = 1; } \
+              | awk -F ' ' '{ print $4 }' \
+              | cut -d ' ' -f 4 \
+              | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
+
+            $DRY_RUN_CMD nix profile install $1
+          }
+
           if [[ -e "$nixProfilePath"/manifest.json ]] ; then
-            INSTALL_CMD="nix profile install"
+            INSTALL_CMD="hm-internal-replace-profile"
             LIST_CMD="nix profile list"
-            REMOVE_CMD_SYNTAX='nix profile remove {number | store path}'
+            REMOVE_CMD_SYNTAX='nix profile remove  dd {number | store path}'
           else
             INSTALL_CMD="nix-env -i"
             LIST_CMD="nix-env -q"


### PR DESCRIPTION

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.


fixes #2848