### PR TITLE
password-store: allow shell integrations

### DIFF
--- a/modules/programs/password-store.nix
+++ b/modules/programs/password-store.nix
@@ -53,6 +53,18 @@ in {
         available keys.
       '';
     };
+
+    enableBashIntegration = mkEnableOption "pass bash integration" // {
+      default = true;
+    };
+
+    enableZshIntegration = mkEnableOption "pass zsh integration" // {
+      default = true;
+    };
+
+    enableFishIntegration = mkEnableOption "pass fish integration" // {
+      default = true;
+    };
   };
 
   config = mkIf cfg.enable {
@@ -61,5 +73,17 @@ in {
 
     xsession.importedVariables = mkIf config.xsession.enable
       (mapAttrsToList (name: value: name) cfg.settings);
+
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
+      source ${cfg.package}/share/bash-completion/completions/pass
+    '';
+
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      source ${cfg.package}/share/zsh/site-functions/_pass
+    '';
+
+    programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
+      source ${cfg.package}/share/fish/vendor_completions.d/pass.fish
+    '';
   };
 }


### PR DESCRIPTION
### Description

Options to source password-store shell integrations

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
