### PR TITLE
yt-dlp: add `settings` option

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -314,6 +314,7 @@ Makefile                                              @thiagokokada
 /tests/modules/programs/xmobar                        @t4ccer
 
 /modules/programs/yt-dlp.nix                          @marsam
+/tests/modules/programs/yt-dlp                        @marsam
 
 /modules/programs/z-lua.nix                           @marsam
 

--- a/modules/programs/yt-dlp.nix
+++ b/modules/programs/yt-dlp.nix
@@ -6,6 +6,12 @@ let
 
   cfg = config.programs.yt-dlp;
 
+  renderSettings = mapAttrsToList (name: value:
+    if isBool value then
+      if value then "--${name}" else "--no-${name}"
+    else
+      "--${name} ${toString value}");
+
 in {
   meta.maintainers = [ maintainers.marsam ];
 
@@ -19,21 +25,38 @@ in {
       description = "Package providing the <command>yt-dlp</command> tool.";
     };
 
-    extraConfig = mkOption {
-      type = types.lines;
-      default = "";
+    settings = mkOption {
+      type = with types; attrsOf (oneOf [ bool int str ]);
+      default = { };
       example = literalExpression ''
-        --embed-thumbnail
-        --embed-subs
-        --sub-langs all
-        --downloader aria2c
-        --downloader-args aria2c:'-c -x8 -s8 -k1M'
+        embed-thumbnail = true;
+        embed-subs = true;
+        sub-langs = "all";
+        downloader = "aria2c";
+        downloader-args = "aria2c:'-c -x8 -s8 -k1M'";
       '';
       description = ''
         Configuration written to
-        <filename>$XDG_CONFIG_HOME/yt-dlp/config</filename>. See
-        <link xlink:href="https://github.com/yt-dlp/yt-dlp#configuration" />
+        <filename>$XDG_CONFIG_HOME/yt-dlp/config</filename>.
+        </para><para>
+        Options must be specified in their <quote>long form</quote>, for
+        example, <code>update = true;</code> instead of <code>U = true;</code>.
+        Short options can be specified in the <code>extraConfig</code> option.
+        See <link xlink:href="https://github.com/yt-dlp/yt-dlp#configuration"/>
         for explanation about possible values.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        --update
+        -F
+      '';
+      description = ''
+        Extra configuration to add to
+        <filename>$XDG_CONFIG_HOME/yt-dlp/config</filename>.
       '';
     };
   };
@@ -41,7 +64,9 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."yt-dlp/config" =
-      mkIf (cfg.extraConfig != "") { text = cfg.extraConfig; };
+    xdg.configFile."yt-dlp/config" = mkIf (cfg.settings != { }) {
+      text = concatStringsSep "\n"
+        (remove "" (renderSettings cfg.settings ++ [ cfg.extraConfig ])) + "\n";
+    };
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -155,6 +155,7 @@ import nmt {
     ./modules/programs/terminator
     ./modules/programs/waybar
     ./modules/programs/xmobar
+    ./modules/programs/yt-dlp
     ./modules/services/barrier
     ./modules/services/devilspie2
     ./modules/services/dropbox

--- a/tests/modules/programs/yt-dlp/default.nix
+++ b/tests/modules/programs/yt-dlp/default.nix
@@ -1,0 +1,1 @@
+{ yt-dlp-simple-config = ./yt-dlp-simple-config.nix; }

--- a/tests/modules/programs/yt-dlp/yt-dlp-simple-config-expected
+++ b/tests/modules/programs/yt-dlp/yt-dlp-simple-config-expected
@@ -1,0 +1,8 @@
+--downloader aria2c
+--downloader-args aria2c:'-c -x8 -s8 -k1M'
+--no-embed-subs
+--embed-thumbnail
+--sub-langs all
+--trim-filenames 30
+--config-locations /home/user/.yt-dlp.conf
+

--- a/tests/modules/programs/yt-dlp/yt-dlp-simple-config.nix
+++ b/tests/modules/programs/yt-dlp/yt-dlp-simple-config.nix
@@ -1,0 +1,27 @@
+{ ... }:
+
+{
+  programs.yt-dlp = {
+    enable = true;
+    settings = {
+      embed-thumbnail = true;
+      embed-subs = false;
+      sub-langs = "all";
+      downloader = "aria2c";
+      downloader-args = "aria2c:'-c -x8 -s8 -k1M'";
+      trim-filenames = 30;
+    };
+    extraConfig = ''
+      --config-locations /home/user/.yt-dlp.conf
+    '';
+  };
+
+  test.stubs.yt-dlp = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/yt-dlp/config
+    assertFileContent home-files/.config/yt-dlp/config ${
+      ./yt-dlp-simple-config-expected
+    }
+  '';
+}


### PR DESCRIPTION
### Description

Adds a structured `settings` option for the recently added `yt-dlp` module. Also adds a test for the generated configuration file.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
