### PR TITLE
vifm: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -7,6 +7,12 @@
 # [1] https://github.com/NixOS/nixpkgs/blob/fca0d6e093c82b31103dc0dacc48da2a9b06e24b/maintainers/maintainer-list.nix#LC1
 
 {
+  aabccd021 = {
+    name = "Muhamad Abdurahman";
+    email = "aabccd021@gmail.com";
+    github = "aabccd021";
+    githubId = 33031950;
+  };
   abayomi185 = {
     name = "Yomi";
     email = "yomi+nix@yomitosh.com";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1760,6 +1760,16 @@ in {
           Eyes in i3, lxde or mate.
         '';
       }
+
+      {
+        time = "2024-10-11T08:23:19+00:00";
+        message = ''
+          A new module is available: 'programs.vifm'.
+
+          Vifm is a curses based Vim-like file manager extended with some useful
+          ideas from mutt.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -241,8 +241,9 @@ let
     ./programs/translate-shell.nix
     ./programs/urxvt.nix
     ./programs/vdirsyncer.nix
-    ./programs/vim.nix
+    ./programs/vifm.nix
     ./programs/vim-vint.nix
+    ./programs/vim.nix
     ./programs/vscode.nix
     ./programs/vscode/haskell.nix
     ./programs/pywal.nix

--- a/modules/programs/vifm.nix
+++ b/modules/programs/vifm.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  inherit (lib) mkIf mkOption types;
+
+  cfg = config.programs.vifm;
+
+in {
+  meta.maintainers = [ lib.hm.maintainers.aabccd021 ];
+
+  options.programs.vifm = {
+    enable = lib.mkEnableOption "vifm, a Vim-like file manager";
+
+    package = lib.mkPackageOption pkgs "vifm" { };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = "mark h ~/";
+      description = ''
+        Extra lines added to the {file}`$XDG_CONFIG_HOME/vifm/vifmrc` file.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."vifm/vifmrc" =
+      mkIf (cfg.extraConfig != "") { text = cfg.extraConfig; };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -155,6 +155,7 @@ in import nmtSrc {
     ./modules/programs/tmux
     ./modules/programs/topgrade
     ./modules/programs/translate-shell
+    ./modules/programs/vifm
     ./modules/programs/vim-vint
     ./modules/programs/vscode
     ./modules/programs/watson

--- a/tests/modules/programs/vifm/default.nix
+++ b/tests/modules/programs/vifm/default.nix
@@ -1,0 +1,4 @@
+{
+  vifm-example-settings = ./example-settings.nix;
+  vifm-empty-settings = ./empty-settings.nix;
+}

--- a/tests/modules/programs/vifm/empty-settings.nix
+++ b/tests/modules/programs/vifm/empty-settings.nix
@@ -1,0 +1,11 @@
+{ ... }:
+
+{
+  programs.vifm.enable = true;
+
+  test.stubs.vifm = { };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/vifm
+  '';
+}

--- a/tests/modules/programs/vifm/example-settings.nix
+++ b/tests/modules/programs/vifm/example-settings.nix
@@ -1,0 +1,21 @@
+{ config, ... }:
+
+{
+  programs.vifm = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    extraConfig = ''
+      mark h ~/
+    '';
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/vifm/vifmrc \
+      ${
+        builtins.toFile "vifm-expected.conf" ''
+          mark h ~/
+        ''
+      }
+  '';
+}


### PR DESCRIPTION
### Description

Add new module for program [`vifm`](https://github.com/vifm/vifm).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
