### PR TITLE
redshift/gammastep logging verbosity

### DIFF
--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -110,6 +110,8 @@ in {
       '';
     };
 
+    enableVerboseLogging = mkEnableOption "verbose service logging";
+
     tray = mkOption {
       type = types.bool;
       default = false;
@@ -199,7 +201,10 @@ in {
         ExecStart = let
           command = if cfg.tray then appletExecutable else mainExecutable;
           configFullPath = config.xdg.configHome + "/${xdgConfigFilePath}";
-        in "${cfg.package}/bin/${command} -v -c ${configFullPath}";
+        in "${cfg.package}/bin/${command} " + cli.toGNUCommandLineShell { } {
+          v = cfg.enableVerboseLogging;
+          c = configFullPath;
+        };
         RestartSec = 3;
         Restart = "on-failure";
       };

--- a/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@gammastep@/bin/gammastep -v -c /home/hm-user/.config/gammastep/config.ini
+ExecStart=@gammastep@/bin/gammastep '-c' '/home/hm-user/.config/gammastep/config.ini'
 Restart=on-failure
 RestartSec=3
 

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@redshift@/bin/redshift -v -c /home/hm-user/.config/redshift/redshift.conf
+ExecStart=@redshift@/bin/redshift '-c' '/home/hm-user/.config/redshift/redshift.conf'
 Restart=on-failure
 RestartSec=3
 


### PR DESCRIPTION
### Description

redshift spams the systemd journal since the module enables `-v` verbose mode by default, every few seconds reporting things like `Period: Transition (99.62% day)`. This adds an option that configures it to be quieter, but leaves the default as-is for compatibility with existing configs.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.


CC @thiagokokada 