### PR TITLE
systemd: make unit files with `runCommand`

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -38,11 +38,16 @@ let
 
       # Needed because systemd derives unit names from the ultimate
       # link target.
-      source = pkgs.writeTextFile {
-        name = pathSafeName;
+      source' = pkgs.runCommand pathSafeName {
+        preferLocalBuild = true;
+        allowSubstitutes = false;
         text = toSystemdIni serviceCfg;
-        destination = "/${filename}";
-      } + "/${filename}";
+      } ''
+        mkdir -p $out
+        echo -n "$text" > $out/${filename}
+      '';
+
+      source = "${source'}/${filename}";
 
       install = variant: target: {
         name = "systemd/user/${target}.${variant}/${filename}";


### PR DESCRIPTION
### Description 

Fixes #3217

Avoids errors of the following sort when /tmp is mounted on a different drive.

```
mv: inter-device move failed: '/tmp/nix-build-emacs.service.drv-0/.attr-1' to "/nix/store/xyz-emacs.service'/emacs.service'"; unable to remove target: Permission denied
```

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
