### PR TITLE
lib: add two new gvariant types

### DIFF
--- a/docs/writing-modules.adoc
+++ b/docs/writing-modules.adoc
@@ -167,9 +167,11 @@ Builds a GVariant array containing the given list of elements, where each elemen
 - `hm.gvariant.type.int64`
 - `hm.gvariant.type.uint64`
 - `hm.gvariant.type.double`
+- `hm.gvariant.type.variant`
 - `hm.gvariant.type.arrayOf type`
 - `hm.gvariant.type.maybeOf type`
 - `hm.gvariant.type.tupleOf types`
+- `hm.gvariant.type.dictionaryEntryOf types`
 --
 +
 where `type` and `types` are themselves a type and list of types, respectively.
@@ -185,3 +187,9 @@ Builds a GVariant maybe value containing the given GVariant element.
 +
 `hm.gvariant.mkTuple elements`:::
 Builds a GVariant tuple containing the given list of elements, where each element is a GVariant value.
++
+`hm.gvariant.mkVariant element`:::
+Builds a GVariant variant which contains the value of a GVariant element.
++
+`hm.gvariant.mkDictionaryEntry elements`:::
+Builds a GVariant dictionary entry containing the given list of elements, where each element is a GVariant value.

--- a/modules/lib/types.nix
+++ b/modules/lib/types.nix
@@ -95,6 +95,10 @@ in rec {
         mergeOneOption loc defs
       else if gvar.isMaybe sharedDefType && allChecked then
         mergeOneOption loc defs
+      else if gvar.isDictionaryEntry sharedDefType && allChecked then
+        mergeOneOption loc defs
+      else if gvar.type.variant == sharedDefType && allChecked then
+        mergeOneOption loc defs
       else if gvar.type.string == sharedDefType && allChecked then
         types.str.merge loc defs
       else if gvar.type.double == sharedDefType && allChecked then

--- a/tests/lib/types/gvariant-merge.nix
+++ b/tests/lib/types/gvariant-merge.nix
@@ -50,6 +50,11 @@ in {
 
         { maybe1 = mkNothing type.string; }
         { maybe2 = mkJust (mkUint32 4); }
+
+        { variant1 = mkVariant "foo"; }
+        { variant2 = mkVariant 42; }
+
+        { dictionaryEntry = mkDictionaryEntry [ 1 [ "foo" ] ]; }
       ];
 
     home.file."result.txt".text = let
@@ -65,6 +70,7 @@ in {
             array1 = @as ['one','two']
             array2 = @au [1,2]
             bool = true
+            dictionaryEntry = @{ias} {1,@as ['foo']}
             emptyArray1 = @as []
             emptyArray2 = @au []
             escapedString = '\'\\\n'
@@ -79,6 +85,8 @@ in {
             uint16 = @q 42
             uint32 = @u 42
             uint64 = @t 42
+            variant1 = @v <'foo'>
+            variant2 = @v <42>
           ''
         }
     '';


### PR DESCRIPTION
Add GVariant variant and dictionary entry types

### Description

<!--

Please provide a brief description of your change.

-->

Added support for GVariant variant and dictionary entry types.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
