### PR TITLE
programs.neovim: default to init.lua

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -368,13 +368,11 @@ in {
           "nvim/init.vim" = mkIf (neovimConfig.neovimRcContent != "") {
             text = neovimConfig.neovimRcContent;
           };
-          "nvim/init.lua" =
-            mkIf (hasLuaConfig || neovimConfig.neovimRcContent != "") {
-              text = lib.optionalString hasLuaConfig
-                "vim.cmd.source ${config.xdg.configFile."nvim/init.vim"}"
-                + lib.optionalString hasLuaConfig
-                config.programs.neovim.generatedConfigs.lua;
-            };
+          "nvim/init.lua".text =
+            lib.optionalString (neovimConfig.neovimRcContent != "")
+            "vim.cmd.source ${config.xdg.configHome}/nvim/init.vim"
+            + lib.optionalString hasLuaConfig
+            config.programs.neovim.generatedConfigs.lua;
           "nvim/coc-settings.json" = mkIf cfg.coc.enable {
             source = jsonFormat.generate "coc-settings.json" cfg.coc.settings;
           };

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -368,11 +368,14 @@ in {
           "nvim/init.vim" = mkIf (neovimConfig.neovimRcContent != "") {
             text = neovimConfig.neovimRcContent;
           };
-          "nvim/init.lua".text =
-            lib.optionalString (neovimConfig.neovimRcContent != "")
-            "vim.cmd.source ${config.xdg.configHome}/nvim/init.vim"
-            + lib.optionalString hasLuaConfig
-            config.programs.neovim.generatedConfigs.lua;
+          "nvim/init.lua" = let
+            luaRcContent =
+              lib.optionalString (neovimConfig.neovimRcContent != "")
+              "vim.cmd.source ${config.xdg.configHome}/nvim/init.vim"
+              + lib.optionalString hasLuaConfig
+              config.programs.neovim.generatedConfigs.lua;
+          in mkIf (luaRcContent != "") { text = luaRcContent; };
+
           "nvim/coc-settings.json" = mkIf cfg.coc.enable {
             source = jsonFormat.generate "coc-settings.json" cfg.coc.settings;
           };

--- a/tests/modules/programs/neovim/no-init.nix
+++ b/tests/modules/programs/neovim/no-init.nix
@@ -17,8 +17,9 @@ with lib;
       plugins = with pkgs.vimPlugins; [ fugitive ({ plugin = vim-sensible; }) ];
     };
     nmt.script = ''
-      vimrc="home-files/.config/nvim/init.vim"
-      assertPathNotExists "$vimrc"
+      nvimFolder="home-files/.config/nvim"
+      assertPathNotExists "$nvimFolder/init.vim"
+      assertPathNotExists "$nvimFolder/init.lua"
     '';
   };
 }

--- a/tests/modules/programs/neovim/no-init.nix
+++ b/tests/modules/programs/neovim/no-init.nix
@@ -12,6 +12,9 @@ with lib;
       withRuby = false;
 
       extraPython3Packages = (ps: with ps; [ jedi pynvim ]);
+
+      # plugins without associated config should not trigger the creation of init.vim
+      plugins = with pkgs.vimPlugins; [ fugitive ({ plugin = vim-sensible; }) ];
     };
     nmt.script = ''
       vimrc="home-files/.config/nvim/init.vim"

--- a/tests/modules/programs/neovim/plugin-config.vim
+++ b/tests/modules/programs/neovim/plugin-config.vim
@@ -1,4 +1,3 @@
-
 " plugin-specific config
 autocmd FileType c setlocal commentstring=//\ %s
 autocmd FileType c setlocal comments=://


### PR DESCRIPTION
We change the current logic: instead of writing an init.vim which loads lua/init-home-manager.lua, we write an init.lua that sources init.vim

This commit also avoids writing any of these files if the plugins have no config.

Should fix https://github.com/nix-community/home-manager/issues/1907

Needs some tests

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
