### PR TITLE
Files: Allow `target="."`, and add symlinkJoin to the documentation

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -343,8 +343,13 @@ in
           # We therefore simply log the conflict and otherwise ignore it, mainly
           # to make the `files-target-config` test work as expected.
           if [[ -e "$realOut/$relTarget" ]]; then
-            echo "File conflict for file '$relTarget'" >&2
-            return
+            if [[ -d "$realOut/$relTarget" && $(realpath "$realOut/$relTarget") == $realOut && $recursive ]]; then
+                # exception: allow a "collision" for a recureively linked home *directory*
+                :
+            else
+                echo "File conflict for file '$relTarget'" >&2
+                return
+            fi
           fi
 
           # Figure out the real absolute path to the target.

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -25,6 +25,13 @@ in
           defaultText = literalExpression "<name>";
           description = ''
             Path to target file relative to ${basePathDesc}.
+            </para><para>
+            Please note that only a single 
+            <xref linkend="opt-home.file"/> directive
+            may write to a given target.
+            In order to link several directories to the same place, you may use
+            <literal>symlinkJoin</literal> as such:</para><para>
+            <literal>source = pkgs.symlinkJoin{name="myjoin"; dirs=[ home-package /some/path ]; postBuild="echo custom shell script here";};</literal>
           '';
         };
 


### PR DESCRIPTION
### Description

- Allow the use the home directory as a target for *recursively-linked directories*
- Add `symlinkJoin` to the documentation for `home.file`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [ ] Code formatted with `./format`.
 -> wont fix just yet, changes are too big to be in a simple pull request (both files.nix and file-type.nix are on the ignore list of ./format)

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
 -> arguably not needed for this change
 -> would need more discussion anyway, as the previous behavior tripped a "this should have been caught earlier" check, which cannot be used in tests

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```