### PR TITLE
blesh: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,6 +81,9 @@ Makefile                                              @thiagokokada
 
 /modules/programs/beets.nix                           @rycee
 
+/modules/programs/blesh.nix                           @aiotter
+/tests/modules/programs/blesh                         @aiotter
+
 /modules/programs/bottom.nix                          @polykernel
 /tests/modules/programs/bottom                        @polykernel
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -698,6 +698,13 @@ in
       }
 
       {
+        time = "2022-09-19T11:03:53+00:00";
+        message = ''
+          A new module is available: 'programs.blesh'.
+        '';
+      }
+
+      {
         time = "2022-09-21T22:42:42+00:00";
         condition = hostPlatform.isLinux;
         message = ''

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -57,6 +57,7 @@ let
     ./programs/bashmount.nix
     ./programs/bat.nix
     ./programs/beets.nix
+    ./programs/blesh.nix
     ./programs/bottom.nix
     ./programs/broot.nix
     ./programs/browserpass.nix

--- a/modules/programs/blesh.nix
+++ b/modules/programs/blesh.nix
@@ -1,0 +1,96 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.programs.blesh;
+in {
+  meta.maintainers = [ maintainers.aiotter ];
+
+  options.programs.blesh = {
+    enable = mkEnableOption "ble.sh";
+
+    package = mkPackageOption pkgs "ble.sh" { default = [ "blesh" ]; };
+
+    enableBashIntegration = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Load ble.sh at the beginning of `~/.bashrc` and attach it at the end.
+        No effect if <code>programs.bash.enable</code> is false.
+      '';
+    };
+
+    options = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = ''
+        Change setting variables with <code>bleopt</code> function.
+      '';
+      example = { complete_auto_delay = "300"; };
+    };
+
+    faces = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = ''
+        Change graphic settings with <code>ble-face</code> function.
+      '';
+      example = { region = "bg=60,fg=white"; };
+    };
+
+    imports = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Search listed script files and sources them with <code>ble-import</code> if they are not yet sourced. Scripts are searched from <code>import_path</code> setting variables.
+        Use <xref linkend="opt-programs.blesh.blercExtra"/> for delayed imports.
+      '';
+      example = [ "contrib/bash-preexec" ];
+    };
+
+    blercExtra = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        Extra configlations to be added at the end of <filename>~/.blerc</filename>.
+      '';
+      example = ''
+        function my/complete-load-hook {
+          bleopt complete_auto_delay=300
+        }
+
+        blehook/eval-after-load complete my/complete-load-hook
+      '';
+    };
+  };
+
+  config = let
+    stringifyAttrs = cmd: options:
+      concatStringsSep "\n"
+      (mapAttrsToList (k: v: "${cmd} ${k}=${escapeShellArg v}") options);
+    stringifyLists = cmd: options:
+      concatStringsSep "\n" (map (v: "${cmd} ${escapeShellArg v}") options);
+    optionsStr = stringifyAttrs "bleopt" cfg.options;
+    facesStr = stringifyAttrs "ble-face" cfg.faces;
+    importsStr = stringifyLists "ble-import" cfg.imports;
+  in mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.file.".blerc".source = pkgs.writeTextFile {
+      name = "blerc";
+      text =
+        concatStringsSep "\n" [ optionsStr facesStr importsStr cfg.blercExtra ];
+      checkPhase = ''
+        ${pkgs.stdenv.shellDryRun} "$target"
+      '';
+    };
+
+    programs.bash.bashrcExtra = mkIf cfg.enableBashIntegration (mkBefore ''
+      [[ $- == *i* ]] && source '${config.programs.blesh.package}/share/blesh/ble.sh' --noattach
+    '');
+
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkAfter ''
+      [[ ''${BLE_VERSION-} ]] && ble-attach
+    '');
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -61,6 +61,7 @@ import nmt {
     ./modules/programs/autojump
     ./modules/programs/bash
     ./modules/programs/bat
+    ./modules/programs/blesh
     ./modules/programs/bottom
     ./modules/programs/broot
     ./modules/programs/browserpass

--- a/tests/modules/programs/blesh/basic.nix
+++ b/tests/modules/programs/blesh/basic.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.blesh = {
+      enable = true;
+      options = {
+        prompt_ps1_transient = "trim:same-dir";
+        prompt_ruler = "empty-line";
+      };
+      faces = { auto_complete = "fg=240"; };
+      imports = [ "contrib/bash-preexec" ];
+      blercExtra = ''
+        function my/complete-load-hook {
+          bleopt complete_auto_history=
+          bleopt complete_ambiguous=
+          bleopt complete_menu_maxlines=10
+        };
+        blehook/eval-after-load complete my/complete-load-hook
+      '';
+    };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.blerc \
+        ${./blerc-basic}
+    '';
+  };
+}

--- a/tests/modules/programs/blesh/basic.nix
+++ b/tests/modules/programs/blesh/basic.nix
@@ -24,7 +24,7 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.blerc \
+        ${config.programs.blesh.rcfile} \
         ${./blerc-basic}
     '';
   };

--- a/tests/modules/programs/blesh/blerc-basic
+++ b/tests/modules/programs/blesh/blerc-basic
@@ -1,0 +1,10 @@
+bleopt prompt_ps1_transient='trim:same-dir'
+bleopt prompt_ruler='empty-line'
+ble-face auto_complete='fg=240'
+ble-import 'contrib/bash-preexec'
+function my/complete-load-hook {
+  bleopt complete_auto_history=
+  bleopt complete_ambiguous=
+  bleopt complete_menu_maxlines=10
+};
+blehook/eval-after-load complete my/complete-load-hook

--- a/tests/modules/programs/blesh/default.nix
+++ b/tests/modules/programs/blesh/default.nix
@@ -1,0 +1,5 @@
+{
+  blesh-settings-basic = ./basic.nix;
+  blesh-settings-with-bashrc-support = ./with-bashrc.nix;
+  blesh-settings-with-starship = ./with-starship.nix;
+}

--- a/tests/modules/programs/blesh/with-bashrc.nix
+++ b/tests/modules/programs/blesh/with-bashrc.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.blesh.enable = true;
+    programs.bash = {
+      enable = true;
+      shellAliases = { ls = "ls -H --color=auto"; };
+    };
+
+    nmt.script = ''
+      assertFileRegex \
+      home-files/.bashrc \
+      $'^\[\[ \$- == \*i\* \]\] && source \'.*-blesh/share/ble.sh\' --noattach$'
+
+      assertFileContains \
+      home-files/.bashrc \
+      '[[ ''${BLE_VERSION-} ]] && ble-attach'
+    '';
+  };
+}

--- a/tests/modules/programs/blesh/with-bashrc.nix
+++ b/tests/modules/programs/blesh/with-bashrc.nix
@@ -13,7 +13,7 @@ with lib;
     nmt.script = ''
       assertFileRegex \
       home-files/.bashrc \
-      $'^\[\[ \$- == \*i\* \]\] && source \'.*-blesh/share/ble.sh\' --noattach$'
+      $'^\[\[ \$- == \*i\* \]\] && source \'.*-blesh/share/blesh/ble.sh\' --attach=none'
 
       assertFileContains \
       home-files/.bashrc \

--- a/tests/modules/programs/blesh/with-starship.nix
+++ b/tests/modules/programs/blesh/with-starship.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.blesh.enable = true;
+    programs.bash.enable = true;
+    programs.starship = {
+      enable = true;
+      enableBashIntegration = true;
+    };
+
+    nmt.script = ''
+      assertFileRegex \
+      home-files/.bashrc \
+      $'^\[\[ \$- == \*i\* \]\] && source \'.*-blesh/share/ble.sh\' --noattach$'
+
+      assertFileContains \
+      home-files/.bashrc \
+      '[[ ''${BLE_VERSION-} ]] && ble-attach'
+    '';
+  };
+}

--- a/tests/modules/programs/blesh/with-starship.nix
+++ b/tests/modules/programs/blesh/with-starship.nix
@@ -14,7 +14,7 @@ with lib;
     nmt.script = ''
       assertFileRegex \
       home-files/.bashrc \
-      $'^\[\[ \$- == \*i\* \]\] && source \'.*-blesh/share/ble.sh\' --noattach$'
+      $'^\[\[ \$- == \*i\* \]\] && source \'.*-blesh/share/blesh/ble.sh\' --attach=none'
 
       assertFileContains \
       home-files/.bashrc \


### PR DESCRIPTION
### Description

This PR implements @akinomyoga's [ble.sh](https://github.com/akinomyoga/ble.sh) module.
cf. https://github.com/akinomyoga/ble.sh/issues/216

~~In order to load ble.sh earlier than other programs like starship, I have to modify `home.file` module so that you can edit files from other modules.~~
~~The main implementation of this change resides in `modules/lib/file-overlay.nix`.~~
~~With `import modules/lib/file-overlay.nix { inherit pkgs config; }` you can get a simple function which takes original `home.file` config and returns modified one.~~

~~I'm not sure whether this is the best practice. Please let me know if you have better ideas.~~

I'll remove them and use `mkBefore` and `mkAfter` instead. While rewriting this PR is kept draft.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
