### PR TITLE
Allows lists of strings in extra configuration of `mbsync` (mail accounts).

### DIFF
--- a/modules/programs/mbsync-accounts.nix
+++ b/modules/programs/mbsync-accounts.nix
@@ -4,7 +4,8 @@ with lib;
 
 let
 
-  extraConfigType = with lib.types; attrsOf (either (either str int) bool);
+  extraConfigType = with lib.types;
+    attrsOf (oneOf [ str int bool (listOf str) ]);
 
   perAccountGroups = { name, config, ... }: {
     options = {

--- a/tests/modules/programs/mbsync/mbsync-expected.conf
+++ b/tests/modules/programs/mbsync/mbsync-expected.conf
@@ -57,6 +57,7 @@ CertificateFile /etc/ssl/certs/ca-certificates.crt
 Host imap.example.com
 PassCmd password-command
 SSLType IMAPS
+SSLVersions TLSv1.3 TLSv1.2
 User home.manager
 
 IMAPStore hm@example.com-remote

--- a/tests/modules/programs/mbsync/mbsync.nix
+++ b/tests/modules/programs/mbsync/mbsync.nix
@@ -21,6 +21,7 @@ with lib;
     accounts.email.accounts = {
       "hm@example.com".mbsync = {
         enable = true;
+        extraConfig.account.SSLVersions = [ "TLSv1.3" "TLSv1.2" ];
         groups.inboxes = {
           channels = {
             inbox1 = {


### PR DESCRIPTION
### Description

This supports multi-string values, like `SSLVersions TLSv1.3 TLSv1.2`.

Fixes #3228 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.
    
    It uses `lib.types.oneOf`, introduced in 2019.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

    

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~~If this PR adds a new module~~

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
