### PR TITLE
home-manager: Add home-manager search path to EXTRA_NIX_PATH

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -58,16 +58,6 @@ and if you follow a Nixpkgs version 22.11 channel you can run
 $ nix-channel --add https://github.com/nix-community/home-manager/archive/release-22.11.tar.gz home-manager
 $ nix-channel --update
 ----
-+
-On non-NixOS, you may have to add
-+
-[source,bash]
-export NIX_PATH=$HOME/.nix-defexpr/channels:/nix/var/nix/profiles/per-user/root/channels${NIX_PATH:+:$NIX_PATH}
-+
-to your shell (see https://github.com/NixOS/nix/issues/2033[nix#2033]
-and
-https://discourse.nixos.org/t/where-is-nix-path-supposed-to-be-set/16434/8[this
-reply on the Nix Discourse]).
 
 3. Run the Home Manager installation command and create the first Home
 Manager generation:

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -87,7 +87,7 @@ function setHomeManagerNixPath() {
                 "${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home-manager" \
                 "$HOME/.nixpkgs/home-manager" ; do
         if [[ -e "$path" || "$path" =~ ^https?:// ]] ; then
-            export NIX_PATH="home-manager=$path${NIX_PATH:+:}$NIX_PATH"
+            EXTRA_NIX_PATH+=("home-manager=$path")
             return
         fi
     done
@@ -130,7 +130,6 @@ function doInspectOption() {
         exit 1
     fi
     setConfigFile
-    setHomeManagerNixPath
 
     local extraArgs=("$@")
 
@@ -170,7 +169,6 @@ function doInstantiate() {
         exit 1
     fi
     setConfigFile
-    setHomeManagerNixPath
 
     local extraArgs=()
 
@@ -192,7 +190,6 @@ function doInstantiate() {
 
 function doBuildAttr() {
     setConfigFile
-    setHomeManagerNixPath
 
     local extraArgs=("$@")
 
@@ -601,6 +598,8 @@ PASSTHROUGH_OPTS=()
 COMMAND=""
 COMMAND_ARGS=()
 FLAKE_ARG=""
+
+setHomeManagerNixPath
 
 while [[ $# -gt 0 ]]; do
     opt="$1"


### PR DESCRIPTION


### Description

Since 2.4, the Nix installer [no longer](https://github.com/NixOS/nix/commit/ec9dd9a5aeb9b7fca170d86b8906ffac7e5ef057) adds the `NIX_PATH` environment variable to shell profiles, because Nix now has a built-in search path if it's unset. However, home-manager still relies on it being set and prepends search paths for `home-manager`. Even though the documentations have been updated to include instructions for non-NixOS users, this is a bad first-time experience (https://github.com/nix-community/home-manager/issues/2564, https://github.com/nix-community/home-manager/issues/3020, https://github.com/nix-community/home-manager/issues/2580).

Instead of relying on NIX_PATH being set and prepending to it, let's not touch it at all and add our paths as `-I` arguments. We trust that Nix will use a sensible default.

Tested by installing home-manager on Ubuntu 22.04 with a fresh multi-user Nix installation.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
