### PR TITLE
batsignal: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -358,6 +358,9 @@ Makefile                                              @thiagokokada
 /modules/services/barrier.nix                         @Kritnich
 /tests/modules/services/barrier                       @Kritnich
 
+/modules/services/batsignal.nix                       @loicreynier
+/tests/modules/services/batsignal                     @loicreynier
+
 /modules/services/betterlockscreen.nix                @SebTM
 
 /modules/programs/borgmatic.nix                       @DamienCassou

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -698,6 +698,13 @@ in
       }
 
       {
+        time = "2022-09-20T11:32:06+00:00";
+        message = ''
+          A new module is available: 'services.batsignal'.
+        '';
+      }
+
+      {
         time = "2022-09-21T22:42:42+00:00";
         condition = hostPlatform.isLinux;
         message = ''

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -201,6 +201,7 @@ let
     ./programs/zsh.nix
     ./programs/zsh/prezto.nix
     ./services/barrier.nix
+    ./services/batsignal.nix
     ./services/betterlockscreen.nix
     ./services/blueman-applet.nix
     ./services/borgmatic.nix

--- a/modules/services/batsignal.nix
+++ b/modules/services/batsignal.nix
@@ -1,0 +1,183 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.batsignal;
+
+  commandLine = concatStringsSep " " ([ "${cfg.package}/bin/batsignal" ]
+    ++ optional (cfg.warningLevelPercent != null)
+    "-w ${toString cfg.warningLevelPercent}"
+    ++ optional (cfg.criticalLevelPercent != null)
+    "-c ${toString cfg.criticalLevelPercent}"
+    ++ optional (cfg.criticalLevelPercent != null)
+    "-d ${toString cfg.dangerLevelPercent}"
+    ++ optional (cfg.fullLevelPercent != null)
+    "-f ${toString cfg.fullLevelPercent}"
+    ++ optional (cfg.warningLevelMessage != null)
+    "-W '${cfg.warningLevelMessage}'"
+    ++ optional (cfg.criticalLevelMessage != null)
+    "-C '${cfg.criticalLevelMessage}'"
+    ++ optional (cfg.dangerLevelCommand != null) (let
+      cmd = pkgs.writeShellScript "batsignal-dangercmd" cfg.dangerLevelCommand;
+    in "-D ${cmd}")
+    ++ optional (cfg.fullLevelMessage != null) "-F '${cfg.fullLevelMessage}'"
+    ++ optional (cfg.batteryNames != null)
+    "-n '${concatStringsSep "," cfg.batteryNames}'"
+    ++ optional (cfg.updateIntervalSeconds != null)
+    "-m ${toString cfg.updateIntervalSeconds}"
+    ++ optional (cfg.appName != null) "-a '${cfg.appName}'"
+    ++ optional (cfg.icon != null) "-I ${cfg.icon}");
+
+in {
+  meta.maintainers = with maintainers; [ loicreynier ];
+
+  options.services.batsignal = {
+    enable = mkEnableOption "batsignal battery monitor daemon";
+    package = mkPackageOption pkgs "batsignal" { };
+
+    warningLevelPercent = mkOption {
+      type = types.nullOr (types.ints.between 0 100);
+      default = 15;
+      example = 20;
+      description = ''
+        Warning level percentage of the battery capacity.
+        0 disables this level.
+      '';
+    };
+
+    criticalLevelPercent = mkOption {
+      type = types.nullOr (types.ints.between 0 100);
+      default = 5;
+      example = 10;
+      description = ''
+        Critical level percentage of the battery capacity.
+        0 disables this level.
+      '';
+    };
+
+    dangerLevelPercent = mkOption {
+      type = types.nullOr (types.ints.between 0 100);
+      default = 2;
+      example = 5;
+      description = ''
+        Danger level percentage of the battery capacity.
+        0 disables this level.
+      '';
+    };
+
+    fullLevelPercent = mkOption {
+      type = types.nullOr (types.ints.between 0 100);
+      default = 0;
+      example = 95;
+      description = ''
+        Full level percentage of the battery capacity.
+        0 disables this level.
+      '';
+    };
+
+    warningLevelMessage = mkOption {
+      type = types.nullOr types.lines;
+      default = null;
+      example = literalExpression ''
+        Battery low
+      '';
+      description =
+        "The message to show when the battery reaches the warning level.";
+    };
+
+    criticalLevelMessage = mkOption {
+      type = types.nullOr types.lines;
+      default = null;
+      example = literalExpression ''
+        Battery at critical level
+      '';
+      description =
+        "The message to show when the battery reaches the critical level.";
+    };
+
+    dangerLevelCommand = mkOption {
+      type = types.nullOr types.lines;
+      default = null;
+      example = ''
+        notify-send "Battery at danger level"
+      '';
+      description = ''
+        Command to execute when the battery capacity danger level is reached.
+      '';
+    };
+
+    fullLevelMessage = mkOption {
+      type = types.nullOr types.lines;
+      default = null;
+      example = literalExpression ''
+        Battery full
+      '';
+      description = "Full level message.";
+    };
+
+    batteryNames = mkOption {
+      type = types.listOf types.string;
+      default = null;
+      example = literalExpression ''
+        [ "BAT0" ]
+      '';
+      description = "List of battery names";
+    };
+
+    updateIntervalSeconds = mkOption {
+      type = types.nullOr types.ints.positive;
+      default = null;
+      example = 60;
+      description = ''
+        Number of seconds between updates of the battery information.
+      '';
+    };
+
+    appName = mkOption {
+      type = types.nullOr types.string;
+      default = null;
+      example = "batsignal";
+      description = ''
+        Application name used in notifications.
+      '';
+    };
+
+    icon = mkOption {
+      type = types.nullOr types.string;
+      default = null;
+      example = "battery";
+      description = ''
+        Icon used in notifications.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.batsignal" pkgs
+        lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    systemd.user.services.batsignal = {
+      Unit = {
+        Description = "Battery monitor daemon";
+        Documentation = "man:batsignal(1)";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+
+      Service = {
+        Type = "simple";
+        ExecStart = commandLine;
+        Restart = "on-failure";
+        RestartSec = 1;
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -165,6 +165,7 @@ import nmt {
     ./modules/programs/xmobar
     ./modules/programs/yt-dlp
     ./modules/services/barrier
+    ./modules/services/batsignal
     ./modules/services/borgmatic
     ./modules/services/devilspie2
     ./modules/services/dropbox

--- a/tests/modules/services/batsignal/batsignal-simple-config-expected.service
+++ b/tests/modules/services/batsignal/batsignal-simple-config-expected.service
@@ -1,0 +1,14 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@batsignal@/bin/batsignal -w 15 -c 5 -d 2 -f 90 -W 'Battery low' -C 'Battery at critical level' -D /nix/store/00000000000000000000000000000000-batsignal-dangercmd -F 'Battery full' -n 'BAT0,BAT1' -m 120 -a 'Batsignal daemon' -I battery
+Restart=on-failure
+RestartSec=1
+Type=simple
+
+[Unit]
+After=graphical-session-pre.target
+Description=Battery monitor daemon
+Documentation=man:batsignal(1)
+PartOf=graphical-session.target

--- a/tests/modules/services/batsignal/batsignal-simple-config.nix
+++ b/tests/modules/services/batsignal/batsignal-simple-config.nix
@@ -1,0 +1,29 @@
+{ ... }:
+
+{
+  services.batsignal = {
+    enable = true;
+    warningLevelPercent = 15;
+    criticalLevelPercent = 5;
+    dangerLevelPercent = 2;
+    fullLevelPercent = 90;
+    warningLevelMessage = "Battery low";
+    criticalLevelMessage = "Battery at critical level";
+    fullLevelMessage = "Battery full";
+    dangerLevelCommand = ''
+      notify-send "Battery at danger level"
+    '';
+    batteryNames = [ "BAT0" "BAT1" ];
+    updateIntervalSeconds = 120;
+    appName = "Batsignal daemon";
+    icon = "battery";
+  };
+
+  test.stubs.batsignal = { };
+
+  nmt.script = ''
+    assertFileContent \
+      $(normalizeStorePaths home-files/.config/systemd/user/batsignal.service) \
+      ${./batsignal-simple-config-expected.service}
+  '';
+}

--- a/tests/modules/services/batsignal/default.nix
+++ b/tests/modules/services/batsignal/default.nix
@@ -1,0 +1,1 @@
+{ batsignal-simple-config = ./batsignal-simple-config.nix; }


### PR DESCRIPTION
### Description

Adds [batsignal](https://github.com/electrickite/batsignal) module.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
