### PR TITLE
neovim: fix a typo in the generated init.lua

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -365,13 +365,14 @@ in {
       in mkMerge (
         # writes runtime
         (map (x: x.runtime) pluginsNormalized) ++ [{
-          "nvim/init.vim" = mkIf (neovimConfig.neovimRcContent != "") {
-            text = neovimConfig.neovimRcContent;
-          };
+          "nvim/init-home-manager.vim" =
+            mkIf (neovimConfig.neovimRcContent != "") {
+              text = neovimConfig.neovimRcContent;
+            };
           "nvim/init.lua" = let
             luaRcContent =
               lib.optionalString (neovimConfig.neovimRcContent != "")
-              "vim.cmd [[source ${config.xdg.configHome}/nvim/init.vim]]"
+              "vim.cmd [[source ${config.xdg.configHome}/nvim/init-home-manager.vim]]"
               + lib.optionalString hasLuaConfig
               config.programs.neovim.generatedConfigs.lua;
           in mkIf (luaRcContent != "") { text = luaRcContent; };

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -371,7 +371,7 @@ in {
           "nvim/init.lua" = let
             luaRcContent =
               lib.optionalString (neovimConfig.neovimRcContent != "")
-              "vim.cmd.source ${config.xdg.configHome}/nvim/init.vim"
+              "vim.cmd [[source ${config.xdg.configHome}/nvim/init.vim]]"
               + lib.optionalString hasLuaConfig
               config.programs.neovim.generatedConfigs.lua;
           in mkIf (luaRcContent != "") { text = luaRcContent; };

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -24,7 +24,7 @@ with lib;
     };
 
     nmt.script = ''
-      vimrc="$TESTED/home-files/.config/nvim/init.vim"
+      vimrc="$TESTED/home-files/.config/nvim/init-home-manager.vim"
       vimrcNormalized="$(normalizeStorePaths "$vimrc")"
 
       assertFileExists "$vimrc"


### PR DESCRIPTION
### Description

Fixes a syntax error that prevents neovim from loading the vimscript configuration file.
closes #3250

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
