### PR TITLE
Add Haskell module for GHC, Stack & Cabal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -124,6 +124,8 @@ Makefile                                              @thiagokokada
 
 /modules/programs/go.nix                              @rvolosatovs
 
+/modules/programs/haskell.nix                         @schuelermine
+
 /modules/programs/helix.nix                           @Philipp-M
 /tests/modules/programs/helix                         @Philipp-M
 

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -82,6 +82,7 @@ let
     ./programs/gnome-terminal.nix
     ./programs/go.nix
     ./programs/gpg.nix
+    ./programs/haskell.nix
     ./programs/helix.nix
     ./programs/hexchat.nix
     ./programs/himalaya.nix

--- a/modules/programs/haskell.nix
+++ b/modules/programs/haskell.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let cfg = config.programs.haskell;
+in {
+  meta.maintainers = with lib.maintainers; [ anselmschueler ];
+  options.programs.haskell = {
+    haskellPackages = mkOption {
+      type = with types; attrsOf package;
+      description = "The Haskell package set to use";
+      default = pkgs.haskellPackages;
+      defaultText = literalExpression "pkgs.haskellPackages";
+      example = literalExpression "pkgs.haskell.packages.ghc923";
+    };
+    ghc = {
+      enable = mkEnableOption
+        "the Glorious Glasgow Haskell Compilation System (compiler)";
+      package = mkPackageOption config.programs.haskell.haskellPackages "GHC" {
+        default = [ "ghc" ];
+      };
+      installedPackages = mkOption {
+        type = with types;
+          either (functionTo (listOf package)) (listOf package);
+        apply = x: if !builtins.isFunction x then _: x else x;
+        description = "The Haskell library packages to install for GHC";
+        default = hkgs: [ ];
+        defaultText = literalExpression "hkgs: [ ]";
+        example = literalExpression "hkgs: [ hkgs.primes ]";
+      };
+      interactiveConfig = mkOption {
+        type = with types; nullOr lines;
+        description = "The contents of the <code>.ghci</code> file";
+        default = null;
+        defaultText = literalExpression "null";
+        example = literalExpression ''
+          :set +m
+        '';
+      };
+    };
+    stack = {
+      enable = mkEnableOption "the Haskell Tool Stack";
+      package = mkPackageOption pkgs "Stack" { default = [ "stack" ]; };
+    };
+    cabal = {
+      enable = mkEnableOption "the Haskell Cabal (build system)";
+      package = mkPackageOption pkgs "Cabal" { default = [ "cabal-install" ]; };
+    };
+  };
+  config = {
+    home.packages = optional cfg.ghc.enable
+      (if cfg.ghc.package ? withPackages then
+        cfg.ghc.package.withPackages cfg.ghc.installedPackages
+      else
+        cfg.ghc.package) ++ optional cfg.stack.enable cfg.stack.package
+      ++ optional cfg.cabal.enable cfg.cabal.package;
+    xdg.configFile.".ghci" = mkIf (cfg.ghc.interactiveConfig != null) {
+      text = cfg.ghc.interactiveConfig;
+    };
+    warnings = mkIf (!cfg.ghc.package ? withPackages) [''
+      You have provided a package as programs.haskell.ghc.package that doesn't have the withPackages utility function.
+      This disables specifying packages via programs.haskell.ghc.packages.
+    ''];
+  };
+}


### PR DESCRIPTION
### Description

I added a Haskell module providing options for GHC, Stack, and Cabal.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
