### PR TITLE
programs/lieer: use lieer package

### DIFF
--- a/modules/programs/lieer.nix
+++ b/modules/programs/lieer.nix
@@ -238,8 +238,8 @@ in {
 
       package = mkOption {
         type = types.package;
-        default = pkgs.gmailieer;
-        defaultText = "pkgs.gmailieer";
+        default = pkgs.lieer;
+        defaultText = "pkgs.lieer";
         description = ''
           lieer package to use.
         '';

--- a/tests/modules/services/lieer/lieer-service-expected.service
+++ b/tests/modules/services/lieer/lieer-service-expected.service
@@ -1,6 +1,6 @@
 [Service]
 Environment=NOTMUCH_CONFIG=/home/hm-user/.config/notmuch/default/config
-ExecStart=@gmailieer@/bin/gmi sync
+ExecStart=@lieer@/bin/gmi sync
 Type=oneshot
 WorkingDirectory=/home/hm-user/Mail/hm@example.com
 

--- a/tests/modules/services/lieer/lieer-service.nix
+++ b/tests/modules/services/lieer/lieer-service.nix
@@ -19,7 +19,7 @@ with lib;
       };
     };
 
-    test.stubs.gmailieer = { };
+    test.stubs.lieer = { };
 
     nmt.script = ''
       assertFileExists home-files/.config/systemd/user/lieer-hm-example-com.service


### PR DESCRIPTION
### Description

Fixes #3261 

The gmailieer attribute was aliased to lieer in nixpkgs.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
