### PR TITLE
ranger: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -147,6 +147,7 @@ let
     ./programs/pylint.nix
     ./programs/qutebrowser.nix
     ./programs/rbw.nix
+    ./programs/ranger.nix
     ./programs/readline.nix
     ./programs/rofi-pass.nix
     ./programs/rofi.nix

--- a/modules/programs/ranger.nix
+++ b/modules/programs/ranger.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.programs.ranger;
+
+  renderAttrs = attrs:
+    concatStringsSep "\n"
+    (mapAttrsToList (name: value: "${name} ${value}") attrs);
+in {
+  options = {
+    programs.ranger = {
+      enable = mkEnableOption
+        "ranger is a console file manager with VI key bindings.";
+
+      package = mkOption {
+        default = pkgs.ranger;
+        defaultText = literalExpression "pkgs.ranger";
+        type = types.package;
+        description = "Package providing the ranger binary";
+      };
+
+      bindings = mkOption {
+        description = ''
+          Input configuration written to
+          <filename>$XDG_CONFIG_HOME/sioyek/keys_user.config</filename>.
+          See <link xlink:href="https://github.com/ahrm/sioyek/blob/main/pdf_viewer/keys.config"/>.
+        '';
+        type = types.attrsOf types.str;
+        default = { };
+        example = literalExpression ''
+          {
+            "move_up" = "k";
+            "move_down" = "j";
+            "move_left" = "h";
+            "move_right" = "l";
+          }
+        '';
+      };
+
+      config = mkOption {
+        description = ''
+          Input configuration written to
+          <filename>$XDG_CONFIG_HOME/sioyek/prefs_user.config</filename>.
+          See <link xlink:href="https://github.com/ahrm/sioyek/blob/main/pdf_viewer/prefs.config"/>.
+        '';
+        type = types.attrsOf types.str;
+        default = { };
+        example = literalExpression ''
+          {
+            "background_color" = "1.0 1.0 1.0";
+            "text_highlight_color" = "1.0 0.0 0.0";
+          }
+        '';
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    { home.packages = [ cfg.package ]; }
+    # (mkIf (cfg.config != { }) {
+    #   xdg.configFile."sioyek/prefs_user.config".text = renderAttrs cfg.config;
+    # })
+    # (mkIf (cfg.bindings != { }) {
+    #   xdg.configFile."sioyek/keys_user.config".text = renderAttrs cfg.bindings;
+    # })
+  ]);
+
+  meta.maintainers = [ hm.maintainers.podocarp ];
+}

--- a/modules/programs/ranger.nix
+++ b/modules/programs/ranger.nix
@@ -1,12 +1,11 @@
 { config, lib, pkgs, ... }:
 with lib;
-let
-  cfg = config.programs.ranger;
+let cfg = config.programs.ranger;
 in {
   options = {
     programs.ranger = {
-      enable = mkEnableOption
-        "ranger is a console file manager with VI key bindings.";
+      enable =
+        mkEnableOption "ranger is a console file manager with VI key bindings.";
 
       package = mkOption {
         default = pkgs.ranger;
@@ -16,7 +15,7 @@ in {
       };
 
       extraPackages = mkOption {
-        default = [];
+        default = [ ];
         defaultText = literalExpression "[ ueberzug ]";
         type = types.listOf types.package;
         description = "Extra packages available to ranger.";
@@ -78,22 +77,18 @@ in {
           <filename>$XDG_CONFIG_HOME/ranger/plugins/</filename>.
           See <link xlink:href="https://github.com/ranger/ranger/wiki/Plugins"/>.
         '';
-        type =
-          let
-            pluginType = types.submodule ({ name, ... }: {
-              options = {
-                name = mkOption {
-                  type = types.str;
-                  default = name;
-                };
-                path = mkOption {
-                  type = types.path;
-                };
+        type = let
+          pluginType = types.submodule ({ name, ... }: {
+            options = {
+              name = mkOption {
+                type = types.str;
+                default = name;
               };
-            });
-          in
-          types.listOf pluginType;
-        default = [];
+              path = mkOption { type = types.path; };
+            };
+          });
+        in types.listOf pluginType;
+        default = [ ];
         example = literalExpression ''
           [
             {
@@ -106,17 +101,15 @@ in {
     };
   };
 
-  config =
-    let
-      pluginToAttrList = p: {
-        name = "ranger/plugins/${p.name}";
-        value.source = p.path;
-      };
-      rangerPackage = cfg.package.overrideAttrs (super: {
-        propagatedBuildInputs = super.propagatedBuildInputs ++ cfg.extraPackages;
-      });
-    in
-    mkIf cfg.enable (mkMerge [
+  config = let
+    pluginToAttrList = p: {
+      name = "ranger/plugins/${p.name}";
+      value.source = p.path;
+    };
+    rangerPackage = cfg.package.overrideAttrs (super: {
+      propagatedBuildInputs = super.propagatedBuildInputs ++ cfg.extraPackages;
+    });
+  in mkIf cfg.enable (mkMerge [
     {
       home.packages = [ rangerPackage ];
       home.sessionVariables."RANGER_LOAD_DEFAULT_RC" = cfg.loadDefaultRc;
@@ -124,23 +117,22 @@ in {
     (mkIf (cfg.config != null) {
       xdg.configFile."ranger/rc.conf".source = cfg.config;
     })
-    (mkIf (cfg.commands!= null) {
+    (mkIf (cfg.commands != null) {
       xdg.configFile."ranger/commands.py".source = cfg.commands;
     })
     (mkIf (cfg.rifle != null) {
       xdg.configFile."ranger/rifle.conf".source = cfg.rifle;
     })
-    (mkIf (cfg.scope!= null) {
+    (mkIf (cfg.scope != null) {
       xdg.configFile."ranger/scope.sh" = {
         source = cfg.scope;
         executable = true;
       };
     })
-    (mkIf (cfg.plugins != []) {
+    (mkIf (cfg.plugins != [ ]) {
       xdg.configFile = (listToAttrs (map pluginToAttrList cfg.plugins));
     })
-  ]
-  );
+  ]);
 
   meta.maintainers = [ hm.maintainers.podocarp ];
 }


### PR DESCRIPTION
### Description
Adds a module for the file manager ranger!

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
