### PR TITLE
kdeconnect: stop using removed alias

### DIFF
--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   cfg = config.services.kdeconnect;
-  package = pkgs.kdeconnect;
+  package = pkgs.plasma5Packages.kdeconnect-kde;
 
 in {
   meta.maintainers = [ maintainers.adisbladis ];


### PR DESCRIPTION
### Description

Since https://github.com/NixOS/nixpkgs/commit/d06207386df9a53fe01f8a30130dfc9a839fc8fc, the kdeconnect package cannot be used by its alias.
Other packages might be affected.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```