### PR TITLE
kdeconnect: use new path to the package in nixpkgs

### DIFF
--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   cfg = config.services.kdeconnect;
-  package = pkgs.kdeconnect;
+  package = pkgs.plasma5Packages.kdeconnect;
 
 in {
   meta.maintainers = [ maintainers.adisbladis ];

--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   cfg = config.services.kdeconnect;
-  package = pkgs.plasma5Packages.kdeconnect;
+  package = pkgs.plasma5Packages.kdeconnect-kde;
 
 in {
   meta.maintainers = [ maintainers.adisbladis ];


### PR DESCRIPTION
### Description

As of [`nixpkgs d062073`](https://github.com/NixOS/nixpkgs/commit/d06207386df9a53fe01f8a30130dfc9a839fc8fc#diff-29ed0f5fda84c91253503c1664d60a194a324e29518d472adf846f30b8db52e3L667), the `kdeconnect` package is not available through `pkgs.kdeconnect` anymore. The new path is `pkgs.plasma5Packages.kdeconnect-kde`. 

This pull request uses the new path in the definition of the `kdeconnect` service.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
