### PR TITLE
urxvt: fix package name

### DIFF
--- a/modules/programs/urxvt.nix
+++ b/modules/programs/urxvt.nix
@@ -12,8 +12,8 @@ in {
 
     package = mkOption {
       type = types.package;
-      default = pkgs.rxvt_unicode;
-      defaultText = literalExpression "pkgs.rxvt_unicode";
+      default = pkgs.rxvt-unicode;
+      defaultText = literalExpression "pkgs.rxvt-unicode";
       description = "rxvt-unicode package to install.";
     };
 


### PR DESCRIPTION
At nixpkgs, `rxvt_unicode` alias was deprecated in favor of `rxvt-unicode`. Updating accordingly.

https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/aliases.nix#L1005