### PR TITLE
broot: fix build

### DIFF
--- a/tests/modules/programs/broot/broot.nix
+++ b/tests/modules/programs/broot/broot.nix
@@ -13,39 +13,10 @@ with lib;
       assertFileExists home-files/.config/broot/conf.toml
       assertFileContent home-files/.config/broot/conf.toml ${
         pkgs.writeText "broot.expected" ''
+          imports = ["verbs.hjson", {file = "dark-blue-skin.hjson", luma = ["dark", "unknown"]}, {file = "white-skin.hjson", luma = "light"}]
           modal = true
           show_selection_mark = true
-
-          [[verbs]]
-          execution = "$EDITOR +{line} {file}"
-          invocation = "edit"
-          leave_broot = false
-          shortcut = "e"
-
-          [[verbs]]
-          execution = "$EDITOR {directory}/{subpath}"
-          invocation = "create {subpath}"
-          leave_broot = false
-
-          [[verbs]]
-          execution = "git difftool -y {file}"
-          invocation = "git_diff"
-          leave_broot = false
-          shortcut = "gd"
-
-          [[verbs]]
-          auto_exec = false
-          execution = "cp -r {file} {parent}/{file-stem}-{version}{file-dot-extension}"
-          invocation = "backup {version}"
-          key = "ctrl-b"
-          leave_broot = false
-
-          [[verbs]]
-          execution = "$SHELL"
-          invocation = "terminal"
-          key = "ctrl-t"
-          leave_broot = false
-          set_working_dir = true
+          verbs = []
 
           [skin]
         ''


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Fix `conf.hjson` path in `broot.nix`, unblocking builds.

For broot version >= 1.14.0, the default config file should be at
[`resources/default-conf/conf.hjson`](https://github.com/Canop/broot/blob/master/resources/default-conf/conf.hjson).

This PR fixes this error:

    FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/dikbik0phcq4lf7al6s1g6imcx2grfqs-broot-1.15.0.tar.gz/resources/default-conf.hjson'

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.broot`.
  `btop` test fails on master as well.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.