### PR TITLE
list deprecated args in throw

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,27 +45,37 @@
           , configuration ? null, extraModules ? null, stateVersion ? null
           , username ? null, homeDirectory ? null, system ? null }@args:
           let
-            throwForRemovedArg = v:
-              lib.throwIf (v != null) ''
-                The 'homeManagerConfiguration' arguments
+            msgForRemovedArg = ''
+              The 'homeManagerConfiguration' arguments
 
-                  - 'configuration',
-                  - 'username',
-                  - 'homeDirectory'
-                  - 'stateVersion',
-                  - 'extraModules', and
-                  - 'system'
+                - 'configuration',
+                - 'username',
+                - 'homeDirectory'
+                - 'stateVersion',
+                - 'extraModules', and
+                - 'system'
 
-                have been removed. Instead use the arguments 'pkgs' and
-                'modules'. See the 22.11 release notes for more.
-              '';
+              have been removed. Instead use the arguments 'pkgs' and
+              'modules'. See the 22.11 release notes for more.
+            '';
 
-            throwForRemovedArgs = throwForRemovedArg configuration # \
-              throwForRemovedArg username # \
-              throwForRemovedArg homeDirectory # \
-              throwForRemovedArg stateVersion # \
-              throwForRemovedArg extraModules # \
-              throwForRemovedArg system;
+            throwForRemovedArgs = v:
+              let
+                used = builtins.filter (n: (args.${n} or null) != null) [
+                  "configuration"
+                  "username"
+                  "homeDirectory"
+                  "stateVersion"
+                  "extraModules"
+                  "system"
+                ];
+                msg = msgForRemovedArg + ''
+
+
+                  Deprecated args passed: ''
+                  + builtins.concatStringsSep " " used;
+              in lib.throwIf (used != [ ]) msg v;
+
           in throwForRemovedArgs (import ./modules {
             inherit pkgs lib check extraSpecialArgs;
             configuration = { ... }: {


### PR DESCRIPTION
I retained the use of `throwIf` on the off chance that someone intentionally overrides it.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
