### PR TITLE
docs: explain how to enable flakes on NixOs

### DIFF
--- a/docs/nix-flakes.adoc
+++ b/docs/nix-flakes.adoc
@@ -13,12 +13,24 @@ The support is still experimental and may change in backwards incompatible ways.
 
 * Enable experimental features `nix-command` and `flakes`.
 +
-Either set in `nix.conf`
+** When using NixOS, add the following to your `configuration.nix` and rebuild your system.
++
+[source,nix]
+nix = {
+  package = pkgs.nixFlakes;
+  extraOptions = ''
+    experimental-features = nix-command flakes
+  '';
+};
++
+** If you are not using NixOS, add the following to `nix.conf` (located at `~/.config/nix/` or `/etc/nix/nix.conf`).
 +
 [source,bash]
 experimental-features = nix-command flakes
 +
-or pass them to `nix` and `home-manager` by
+You may need to restart the Nix daemon with, for example, `sudo systemctl restart nix-daemon.service`.
++
+** Alternatively, you can enable flakes on a per-command basis with the following additional flags to `nix` and `home-manager`:
 +
 [source,console]
 ----


### PR DESCRIPTION
### Description

- Added documentation how to enable flakes on NixOs
- Slightly extended non-NixOs instructions

Changes inspired by [Xe's article on flakes](https://xeiaso.net/blog/nix-flakes-1-2022-02-21).

### Checklist

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

