### PR TITLE
picom: use `types.numbers.between`

### DIFF
--- a/modules/services/picom.nix
+++ b/modules/services/picom.nix
@@ -16,16 +16,6 @@ let
       description = "pair of ${x.description}";
     };
 
-  floatBetween = a: b:
-    with types;
-    let
-      # toString prints floats with hardcoded high precision
-      floatToString = f: toJSON f;
-    in addCheck float (x: x <= b && x >= a) // {
-      description = "a floating point number in "
-        + "range [${floatToString a}, ${floatToString b}]";
-    };
-
   mkDefaultAttrs = mapAttrs (n: v: mkDefault v);
 
   # Basically a tinkered lib.generators.mkKeyValueDefault
@@ -96,7 +86,7 @@ in {
     };
 
     fadeSteps = mkOption {
-      type = pairOf (floatBetween 1.0e-2 1);
+      type = pairOf (types.numbers.between 1.0e-2 1);
       default = [ 2.8e-2 3.0e-2 ];
       example = [ 4.0e-2 4.0e-2 ];
       description = ''
@@ -132,7 +122,7 @@ in {
     };
 
     shadowOpacity = mkOption {
-      type = floatBetween 0 1;
+      type = types.numbers.between 0 1;
       default = 0.75;
       example = 0.8;
       description = ''
@@ -151,7 +141,7 @@ in {
     };
 
     activeOpacity = mkOption {
-      type = floatBetween 0 1;
+      type = types.numbers.between 0 1;
       default = 1.0;
       example = 0.8;
       description = ''
@@ -160,7 +150,7 @@ in {
     };
 
     inactiveOpacity = mkOption {
-      type = floatBetween 0.1 1;
+      type = types.numbers.between 0.1 1;
       default = 1.0;
       example = 0.8;
       description = ''
@@ -169,7 +159,7 @@ in {
     };
 
     menuOpacity = mkOption {
-      type = floatBetween 0 1;
+      type = types.numbers.between 0 1;
       default = 1.0;
       example = 0.8;
       description = ''


### PR DESCRIPTION
Mirrors https://github.com/NixOS/nixpkgs/commit/77307fcff86d3e56285b006b3e9204c6b45d90f0

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
