### PR TITLE
neovim: support for additional configuration languages

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -54,8 +54,7 @@ let
 
       plugin = mkOption {
         type = types.package;
-        description =
-          "Package providing the plugin";
+        description = "Package providing the plugin";
       };
 
       runtime = mkOption {
@@ -89,7 +88,8 @@ let
         description = "Lua packages required to support this language.";
       };
       vimPlugins = mkOption {
-        type = with types; listOf (coercedTo package (v: { plugin = v; }) pluginWithConfigType);
+        type = with types;
+          listOf (coercedTo package (v: { plugin = v; }) pluginWithConfigType);
         default = [ ];
         description = "Vim plugins required to support this language.";
         example = literalExpression ''
@@ -99,7 +99,8 @@ let
       enableScript = mkOption {
         type = with types; nullOr str;
         default = null;
-        description = "Lua script required to enable support for this language.";
+        description =
+          "Lua script required to enable support for this language.";
         example = literalExpression ''
           require("moonwalk").add_loader("fnl", function(src, path)
               return require("fennel").compileString(src, { filename = path })
@@ -125,7 +126,8 @@ let
     };
   };
 
-  langVimPlugins = flatten (mapAttrsToList (_: lang: lang.vimPlugins) cfg.configLanguages);
+  langVimPlugins =
+    flatten (mapAttrsToList (_: lang: lang.vimPlugins) cfg.configLanguages);
   allPlugins = cfg.plugins ++ langVimPlugins ++ optional cfg.coc.enable {
     type = "viml";
     plugin = cfg.coc.package;
@@ -134,25 +136,24 @@ let
     runtime = { };
   };
 
-  langLuaPackages = flatten (mapAttrsToList (_: lang: lang.luaPackages) cfg.configLanguages);
+  langLuaPackages =
+    flatten (mapAttrsToList (_: lang: lang.luaPackages) cfg.configLanguages);
   allLuaPackages = cfg.extraLuaPackages ++ langLuaPackages;
 
   extraMakeWrapperArgs = optionalString (cfg.extraPackages != [ ])
     ''--suffix PATH : "${makeBinPath cfg.extraPackages}"'';
   extraMakeWrapperLuaCArgs = optionalString (allLuaPackages != [ ]) ''
     --suffix LUA_CPATH ";" "${
-      concatMapStringsSep ";" pkgs.lua51Packages.getLuaCPath
-      allLuaPackages
+      concatMapStringsSep ";" pkgs.lua51Packages.getLuaCPath allLuaPackages
     }"'';
   extraMakeWrapperLuaArgs = optionalString (allLuaPackages != [ ]) ''
     --suffix LUA_PATH ";" "${
-      concatMapStringsSep ";" pkgs.lua51Packages.getLuaPath
-      allLuaPackages
+      concatMapStringsSep ";" pkgs.lua51Packages.getLuaPath allLuaPackages
     }"'';
 
 in {
   imports = [
-    (mkRemovedOptionModule [ "programs" "neovim" "generatedConfigViml" ] 
+    (mkRemovedOptionModule [ "programs" "neovim" "generatedConfigViml" ]
       "programs.neovim.generatedConfigViml has been replaced with programs.neovim.generatedConfigs.viml")
     (mkRemovedOptionModule [ "programs" "neovim" "withPython" ]
       "Python2 support has been removed from neovim.")
@@ -282,7 +283,7 @@ in {
 
       extraConfig = mkOption {
         type = with types; coercedTo lines (x: { viml = x; }) (attrsOf lines);
-        default = {};
+        default = { };
         example = literalExpression ''
           {
             viml = "set nobackup";
@@ -326,9 +327,7 @@ in {
               vim.cmd 'runtime vim/${file}.vim'
             '';
           };
-          lua = {
-            extension = "lua";
-          };
+          lua = { extension = "lua"; };
         };
         example = literalExpression ''
           lib.mkOptionDefault {
@@ -367,7 +366,8 @@ in {
       };
 
       plugins = mkOption {
-        type = with types; listOf (coercedTo package (v: { plugin = v; }) pluginWithConfigType);
+        type = with types;
+          listOf (coercedTo package (v: { plugin = v; }) pluginWithConfigType);
         default = [ ];
         example = literalExpression ''
           with pkgs.vimPlugins; [
@@ -449,9 +449,7 @@ in {
 
   config = let
     suppressNotVimlConfig = plugin:
-      if plugin.type != "viml"
-      then plugin // { config = null; }
-      else plugin;
+      if plugin.type != "viml" then plugin // { config = null; } else plugin;
 
     neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
       inherit (cfg) extraPython3Packages withPython3 withRuby viAlias vimAlias;
@@ -461,18 +459,18 @@ in {
     };
   in mkIf cfg.enable {
     assertions = let
-      undefinedLangs = subtractLists (attrNames cfg.configLanguages) (attrNames cfg.generatedConfigs);
+      undefinedLangs = subtractLists (attrNames cfg.configLanguages)
+        (attrNames cfg.generatedConfigs);
     in [{
       assertion = undefinedLangs == [ ];
-      message =
-        if (any (l: l == "lua" || l == "viml") undefinedLangs)
-        then ''
-          The neovim configuration is using vimscript or lua, but they are not present in `programs.neovim.configLanguages`.
-          You probably meant to use lib.mkOptionDefault when setting it.
-        ''
-        else ''
-          Languages [${concatStringsSep "," undefinedLangs}] found in neovim configuration, but not defined in `programs.neovim.configLanguages`.
-        '';
+      message = if (any (l: l == "lua" || l == "viml") undefinedLangs) then ''
+        The neovim configuration is using vimscript or lua, but they are not present in `programs.neovim.configLanguages`.
+        You probably meant to use lib.mkOptionDefault when setting it.
+      '' else ''
+        Languages [${
+          concatStringsSep "," undefinedLangs
+        }] found in neovim configuration, but not defined in `programs.neovim.configLanguages`.
+      '';
     }];
 
     # Generate config for each supported config language
@@ -480,37 +478,33 @@ in {
       concatLines = concatStringsSep "\n";
       getCfgs = plugins: filter (c: c != null) (map (p: p.config) plugins);
       groupedPlugins = lists.groupBy (p: p.type) allPlugins;
-      pluginConfigs = mapAttrs (_: plugins: concatLines (getCfgs plugins)) groupedPlugins;
-    in
-      zipAttrsWith (_: concatLines) [ pluginConfigs cfg.extraConfig ];
+      pluginConfigs =
+        mapAttrs (_: plugins: concatLines (getCfgs plugins)) groupedPlugins;
+    in zipAttrsWith (_: concatLines) [ pluginConfigs cfg.extraConfig ];
 
     home.packages = [ cfg.finalPackage ];
 
-    xdg.configFile = mkMerge
-      (
-        (map (plugin: plugin.runtime) allPlugins) ++ [(cfg.extraRuntime)] ++
-        # Make a config file for each configLang (if it's not empty) and import it on init.lua
-        (mapAttrsToList
-          (langName: langConfig: let
-            langExtension = cfg.configLanguages.${langName}.extension;
-            langImportScript =  cfg.configLanguages.${langName}.importScript;
-            langFilePath = "nvim/${langExtension}/home-manager-${langName}.${langExtension}";
-          in
-          mkIf (langConfig != "") {
-            ${langFilePath}.text = langConfig;
-            "nvim/init.lua".text = ''
-              -- ${config.xdg.configFile.${langFilePath}.source}
-              ${langImportScript "home-manager-${langName}"}
-            '';
-          }) cfg.generatedConfigs
-        ) ++
-        # Add support for all configLanguages
-        (mapAttrsToList
-          (langName: langOpts: mkIf (langOpts.enableScript != null) {
-            "nvim/init.lua".text = langOpts.enableScript;
-          }) cfg.configLanguages
-        ) ++
-        [{
+    xdg.configFile = mkMerge ((map (plugin: plugin.runtime) allPlugins)
+      ++ [ (cfg.extraRuntime) ] ++
+      # Make a config file for each configLang (if it's not empty) and import it on init.lua
+      (mapAttrsToList (langName: langConfig:
+        let
+          langExtension = cfg.configLanguages.${langName}.extension;
+          langImportScript = cfg.configLanguages.${langName}.importScript;
+          langFilePath =
+            "nvim/${langExtension}/home-manager-${langName}.${langExtension}";
+        in mkIf (langConfig != "") {
+          ${langFilePath}.text = langConfig;
+          "nvim/init.lua".text = ''
+            -- ${config.xdg.configFile.${langFilePath}.source}
+            ${langImportScript "home-manager-${langName}"}
+          '';
+        }) cfg.generatedConfigs) ++
+      # Add support for all configLanguages
+      (mapAttrsToList (langName: langOpts:
+        mkIf (langOpts.enableScript != null) {
+          "nvim/init.lua".text = langOpts.enableScript;
+        }) cfg.configLanguages) ++ [{
           "nvim/coc-settings.json" = mkIf cfg.coc.enable {
             source = jsonFormat.generate "coc-settings.json" cfg.coc.settings;
           };

--- a/tests/modules/programs/neovim/default.nix
+++ b/tests/modules/programs/neovim/default.nix
@@ -2,6 +2,7 @@
   neovim-plugin-config = ./plugin-config.nix;
   neovim-coc-config = ./coc-config.nix;
   neovim-runtime = ./runtime.nix;
+  neovim-multi-lang = ./multi-lang.nix;
 
   # waiting for a nixpkgs patch
   neovim-no-init = ./no-init.nix;

--- a/tests/modules/programs/neovim/multi-lang.nix
+++ b/tests/modules/programs/neovim/multi-lang.nix
@@ -50,24 +50,21 @@ with lib;
       };
     };
 
-    nmt.script =
-      let
-        nvim = "${config.programs.neovim.finalPackage}/bin/nvim";
-        dos2unix = "${pkgs.dos2unix}/bin/dos2unix";
-      in
-      ''
-        cp $TESTED/home-files/.config . -r --no-preserve=mode
+    nmt.script = let
+      nvim = "${config.programs.neovim.finalPackage}/bin/nvim";
+      dos2unix = "${pkgs.dos2unix}/bin/dos2unix";
+    in ''
+      cp $TESTED/home-files/.config . -r --no-preserve=mode
 
-        export HOME=/build
-        ${nvim} -c ':q' --headless 2>&1 | ${dos2unix} > nvim_output
-        output="$(normalizeStorePaths /build/nvim_output)"
+      export HOME=/build
+      ${nvim} -c ':q' --headless 2>&1 | ${dos2unix} > nvim_output
+      output="$(normalizeStorePaths /build/nvim_output)"
 
-        assertFileRegex "$output" "Hello from vimscript"
-        assertFileRegex "$output" "Hello from lua"
-        assertFileRegex "$output" "Hello from fennel"
-        assertFileRegex "$output" "Hello from teal"
-      '';
+      assertFileRegex "$output" "Hello from vimscript"
+      assertFileRegex "$output" "Hello from lua"
+      assertFileRegex "$output" "Hello from fennel"
+      assertFileRegex "$output" "Hello from teal"
+    '';
   };
 }
-
 

--- a/tests/modules/programs/neovim/multi-lang.nix
+++ b/tests/modules/programs/neovim/multi-lang.nix
@@ -1,0 +1,73 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.neovim = {
+      enable = true;
+      configLanguages = lib.mkOptionDefault {
+        fennel = {
+          extension = "fnl";
+          luaPackages = with pkgs.lua51Packages; [ fennel ];
+          vimPlugins = with pkgs.vimPlugins; [ nvim-moonwalk ];
+          enableScript = ''
+            require("moonwalk").add_loader("fnl", function(src, path)
+                return require("fennel").compileString(src, { filename = path })
+            end)
+          '';
+        };
+        teal = {
+          extension = "tl";
+          luaPackages = with pkgs.lua51Packages; [ tl ];
+          vimPlugins = with pkgs.vimPlugins; [ nvim-moonwalk ];
+          enableScript = ''
+            require("moonwalk").add_loader("tl", function(src, path)
+                local tl = require("tl")
+                local errs = {}
+                local _, program = tl.parse_program(tl.lex(src), errs)
+                if #errs > 0 then
+                    error(path .. ":" .. errs[1].y .. ":" .. errs[1].x .. ": " .. errs[1].msg, 0)
+                end
+                return tl.pretty_print_ast(program)
+            end)
+          '';
+        };
+      };
+      extraConfig = {
+        viml = ''
+          echo 'Hello from vimscript'
+        '';
+        lua = ''
+          print("Hello from lua\n")
+        '';
+        fennel = ''
+          (print "Hello from fennel\n")
+        '';
+        teal = ''
+          print("Hello from teal\n")
+        '';
+      };
+    };
+
+    nmt.script =
+      let
+        nvim = "${config.programs.neovim.finalPackage}/bin/nvim";
+        dos2unix = "${pkgs.dos2unix}/bin/dos2unix";
+      in
+      ''
+        cp $TESTED/home-files/.config . -r --no-preserve=mode
+
+        export HOME=/build
+        ${nvim} -c ':q' --headless 2>&1 | ${dos2unix} > nvim_output
+        output="$(normalizeStorePaths /build/nvim_output)"
+
+        assertFileRegex "$output" "Hello from vimscript"
+        assertFileRegex "$output" "Hello from lua"
+        assertFileRegex "$output" "Hello from fennel"
+        assertFileRegex "$output" "Hello from teal"
+      '';
+  };
+}
+
+

--- a/tests/modules/programs/neovim/no-init.nix
+++ b/tests/modules/programs/neovim/no-init.nix
@@ -18,7 +18,7 @@ with lib;
     };
     nmt.script = ''
       nvimFolder="home-files/.config/nvim"
-      assertPathNotExists "$nvimFolder/init.vim"
+      assertPathNotExists "$nvimFolder/vim/home-manager-viml.vim"
       assertPathNotExists "$nvimFolder/init.lua"
     '';
   };

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -19,16 +19,34 @@ with lib;
             autocmd FileType c setlocal comments=://
           '';
         }
+        {
+          plugin = range-highlight-nvim;
+          type = "lua";
+          config = ''
+            -- lua config
+            require('range-highlight').setup{}
+          '';
+        }
       ];
       extraLuaPackages = [ pkgs.lua51Packages.luautf8 ];
     };
 
     nmt.script = ''
-      vimrc="$TESTED/home-files/.config/nvim/init-home-manager.vim"
-      vimrcNormalized="$(normalizeStorePaths "$vimrc")"
+      viml="$(normalizeStorePaths "$TESTED/home-files/.config/nvim/vim/home-manager-viml.vim")"
+      lua="$(normalizeStorePaths "$TESTED/home-files/.config/nvim/lua/home-manager-lua.lua")"
 
-      assertFileExists "$vimrc"
-      assertFileContent "$vimrcNormalized" "${./plugin-config.vim}"
+      assertFileContent "$viml" "${builtins.toFile "exepected-viml.vim" ''
+        " plugin-specific config
+        autocmd FileType c setlocal commentstring=//\ %s
+        autocmd FileType c setlocal comments=://
+
+        " This 'extraConfig' should be present in vimrc
+      ''}"
+
+      assertFileContent "$lua" "${builtins.toFile "exepected-lua.lua" ''
+        -- lua config
+        require('range-highlight').setup{}
+      ''}"
     '';
   };
 }

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -35,18 +35,22 @@ with lib;
       viml="$(normalizeStorePaths "$TESTED/home-files/.config/nvim/vim/home-manager-viml.vim")"
       lua="$(normalizeStorePaths "$TESTED/home-files/.config/nvim/lua/home-manager-lua.lua")"
 
-      assertFileContent "$viml" "${builtins.toFile "exepected-viml.vim" ''
-        " plugin-specific config
-        autocmd FileType c setlocal commentstring=//\ %s
-        autocmd FileType c setlocal comments=://
+      assertFileContent "$viml" "${
+        builtins.toFile "exepected-viml.vim" ''
+          " plugin-specific config
+          autocmd FileType c setlocal commentstring=//\ %s
+          autocmd FileType c setlocal comments=://
 
-        " This 'extraConfig' should be present in vimrc
-      ''}"
+          " This 'extraConfig' should be present in vimrc
+        ''
+      }"
 
-      assertFileContent "$lua" "${builtins.toFile "exepected-lua.lua" ''
-        -- lua config
-        require('range-highlight').setup{}
-      ''}"
+      assertFileContent "$lua" "${
+        builtins.toFile "exepected-lua.lua" ''
+          -- lua config
+          require('range-highlight').setup{}
+        ''
+      }"
     '';
   };
 }

--- a/tests/modules/programs/neovim/plugin-config.vim
+++ b/tests/modules/programs/neovim/plugin-config.vim
@@ -1,5 +1,0 @@
-" plugin-specific config
-autocmd FileType c setlocal commentstring=//\ %s
-autocmd FileType c setlocal comments=://
-
-" This 'extraConfig' should be present in vimrc

--- a/tests/modules/programs/neovim/runtime.nix
+++ b/tests/modules/programs/neovim/runtime.nix
@@ -6,10 +6,16 @@ with lib;
   config = {
     programs.neovim = {
       enable = true;
+      extraRuntime = {
+        "colors/cool.vim".text = ''
+          "Very cool colorscheme
+        '';
+      };
       plugins = with pkgs.vimPlugins; [
         vim-nix
         {
           plugin = vim-commentary;
+          # Adding runtimes should not add anything to the config
           runtime = {
             "after/ftplugin/c.vim".text = ''
               " plugin-specific config
@@ -23,8 +29,11 @@ with lib;
       extraPython3Packages = (ps: with ps; [ jedi pynvim ]);
     };
     nmt.script = ''
-      ftplugin="home-files/.config/nvim/after/ftplugin/c.vim"
-      assertFileExists "$ftplugin"
+      nvimFolder="home-files/.config/nvim"
+
+      assertFileExists "$nvimFolder/after/ftplugin/c.vim"
+      assertFileExists "$nvimFolder/colors/cool.vim"
+      assertPathNotExists "$nvimFolder/init.lua"
     '';
   };
 }


### PR DESCRIPTION
Hello, folks!

Here's my attempt at making the neovim module support any configuration language.

This was mostly motivated by the fact that `extraConfig` currently only works with `viml` (forcing the user to (ab)use `plugins.*.config` to write lua config); as well as the listing of `fennel` and `teal` as supported languages when they're actually silently ignored.

Please let me know if there's anything to be improved (or even if this idea does not make any sense at all).

PS: I've run format in a second commit, hope it helps making reviewing a bit easier.

## Description

The main change is adding a `configLanguages` option. This option, that by default comes with `viml` and `lua` configured, allows the user to add support for any language they prefer, through whatever plugin and/or lua module. Anything that can be called by lua code works (although it's targeted at languages that compile to lua, such as fennel and teal). It includes an example on adding `fennel` support through `moonwalk`, there's also a test that uses both fennel, viml, lua, and teal simultaneously, pretty cool.

The other notable change is making `extraConfig` an attribute set (still compatible with strings by use of `coercedTo`, tests still pass as expected). It allows users to add configurations in any supported language (similarly to `plugins.*.config`).

### Smaller changes
There's a few smaller changes too (if required, I can get these into separate PRs):
- Added a `extraRuntime` option, for adding files similarly to `plugins.*.runtime`, for those that are not coupled to plugins (e.g. a custom colorscheme or ftplugin).
- `plugins` now uses the `coercedTo` type instead of being manually normalized. `coercedTo` gives us normalization for free!
- A few options had type `lines` when it worked exactly the same as `str`. AFAIK, `lines` only matters when regarding options that will merge. This does not apply to `generatedConfigs` (it's `readOnly`!) or `plugins.*.config` (it's impossible to specify configs to a single `plugins` element in two different modules). Changed them to `str`.
- `withRuby` was changed to `types.bool` to match its siblings (python and node).

### Tests

Changes:
- I've added a new test that (as mentioned) configures the editor using four different languages (viml, lua, teal, and fennel), and tests it.
- `no-init`'s viml file path was updated to match the new one. Similarly to the previous change (https://github.com/nix-community/home-manager/commit/bd83eab6220226085c82e637931a7ae3863d9893), this shouldn't affect existing configurations at all.
- `plugin-config` now also tests a lua plugin configuration. The expected files were inlined into the test, IMO it helps declutter the directory and makes understanding the test easier.
- `runtime` now also tests `extraRuntime`.

## Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.

