### PR TITLE
syncthing: add platform assertion

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -57,6 +57,11 @@ in {
 
   config = mkMerge [
     (mkIf cfg.enable {
+      assertions = [
+        (lib.hm.assertions.assertPlatform "services.syncthing" pkgs
+          lib.platforms.linux)
+      ];
+
       home.packages = [ (getOutput "man" pkgs.syncthing) ];
 
       systemd.user.services = {


### PR DESCRIPTION
### Description

Make sure syncthing is only enabled on GNU/Linux.

### Checklist

- [x] Change is backwards compatible.

    - Well, technically the service would be successfully generated on e.g. Darwin but I think it is best to fail here.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
