### PR TITLE
imapnotify: Add launchd agent

### DIFF
--- a/modules/services/imapnotify.nix
+++ b/modules/services/imapnotify.nix
@@ -19,9 +19,7 @@ let
         Unit = { Description = "imapnotify for ${name}"; };
 
         Service = {
-          ExecStart = "${pkgs.goimapnotify}/bin/goimapnotify -conf ${
-              genAccountConfig account
-            }";
+          ExecStart = "${getExe cfg.package} -conf ${genAccountConfig account}";
           Restart = "always";
           RestartSec = 30;
           Type = "simple";
@@ -62,7 +60,17 @@ in {
   meta.maintainers = [ maintainers.nickhu ];
 
   options = {
-    services.imapnotify = { enable = mkEnableOption "imapnotify"; };
+    services.imapnotify = {
+      enable = mkEnableOption "imapnotify";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.goimapnotify;
+        defaultText = literalExpression "pkgs.goimapnotify";
+        example = literalExpression "pkgs.imapnotify";
+        description = "The imapnotify package to use";
+      };
+    };
 
     accounts.email.accounts = mkOption {
       type = with types; attrsOf (submodule (import ./imapnotify-accounts.nix));

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -141,6 +141,7 @@ import nmt {
   ] ++ lib.optionals isDarwin [
     ./modules/launchd
     ./modules/targets-darwin
+    ./modules/programs/goimapnotify
   ] ++ lib.optionals isLinux [
     ./modules/config/i18n
     ./modules/i18n/input-method

--- a/tests/modules/programs/goimapnotify/default.nix
+++ b/tests/modules/programs/goimapnotify/default.nix
@@ -1,0 +1,1 @@
+{ goimapnotify-launchd = ./launchd.nix; }

--- a/tests/modules/programs/goimapnotify/launchd.nix
+++ b/tests/modules/programs/goimapnotify/launchd.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  config = {
+    accounts.email.accounts = {
+      "hm@example.com" = {
+        notmuch.enable = true;
+        imap.port = 993;
+
+        imapnotify = {
+          enable = true;
+          boxes = [ "Inbox" ];
+          onNotify = ''
+            ${pkgs.notmuch}/bin/notmuch new
+          '';
+        };
+      };
+    };
+
+    services.imapnotify = {
+      enable = true;
+      package = (config.lib.test.mkStubPackage {
+        name = "goimapnotify";
+        outPath = "@goimapnotify@";
+      });
+    };
+
+    nmt.script = let
+      serviceFileName =
+        "org.nix-community.home.imapnotify-hm-example.com.plist";
+    in ''
+      serviceFile=LaunchAgents/${serviceFileName}
+      assertFileExists $serviceFile
+      assertFileContent $serviceFile ${./launchd.plist}
+    '';
+  };
+}

--- a/tests/modules/programs/goimapnotify/launchd.plist
+++ b/tests/modules/programs/goimapnotify/launchd.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>NOTMUCH_CONFIG</key>
+		<string>/home/hm-user/.config/notmuch/default/config</string>
+	</dict>
+	<key>ExitTimeOut</key>
+	<integer>0</integer>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Label</key>
+	<string>org.nix-community.home.imapnotify-hm-example.com</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>@goimapnotify@/bin/goimapnotify</string>
+		<string>-conf</string>
+		<string>/home/hm-user/.config/imapnotify/imapnotify-hm-example.com-config.json</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>ThrottleInterval</key>
+	<integer>30</integer>
+</dict>
+</plist>


### PR DESCRIPTION
### Description

This extends the imapnotify (goimapnotify) configuration with a launchd agent that matches the systemd unit (and shares as much code as possible).

~Annoyingly I'd forgotten that `goimapnotify` is malconfigured in `nixpkgs`, in that it works (and is supported) on macos, but the metadata `platforms` are linux only. So while this is blocked on that, I'm making the PR now, and I'll update it when the upstream change is merged.~

Edit: NixOS/nixpkgs#193797 (now merged, ~awaiting~ and deployed [deployment to nixos-unstable](https://nixpk.gs/pr-tracker.html?pr=193797))

~I added a semi-golden test: it uses the `goimapnotify` store path, so I've passed that as a parameter. I've seen the `pkgs.writeText` pattern used in other tests, but I didn't spot this case, so I hope it's ok.~

I've seen that #2915 is still open; if this is merged first, there'll be additonal redundant platform checking, from this.

I've a few comments that I'll put in a self-review.

### Checklist

- [x] Change is backwards compatible. (but the version of `goimapnotify` that lists darwin in platforms is only in `master`, at the moment)

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
