### PR TITLE
sioyek: enable multiple bindings for the same command

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -110,6 +110,7 @@ import nmt {
     ./modules/programs/sagemath
     ./modules/programs/sbt
     ./modules/programs/scmpuff
+    ./modules/programs/sioyek
     ./modules/programs/sm64ex
     ./modules/programs/ssh
     ./modules/programs/starship

--- a/tests/modules/programs/sioyek/default.nix
+++ b/tests/modules/programs/sioyek/default.nix
@@ -1,0 +1,1 @@
+{ sioyek = ./sioyek-basic-configuration.nix; }

--- a/tests/modules/programs/sioyek/sioyek-basic-configuration.nix
+++ b/tests/modules/programs/sioyek/sioyek-basic-configuration.nix
@@ -1,0 +1,36 @@
+{ config, pkgs, ... }:
+
+{
+  programs.sioyek = {
+    enable = true;
+    bindings = {
+      "move_down" = "j";
+      "move_left" = "h";
+      "move_right" = "l";
+      "move_up" = "k";
+      "screen_down" = [ "d" "<C-d>" ];
+      "screen_up" = [ "u" "<C-u>" ];
+    };
+    config = {
+      "dark_mode_background_color" = "0.0 0.0 0.0";
+      "dark_mode_contrast" = "0.8";
+    };
+  };
+
+  test.stubs.sioyek = { };
+
+  nmt = {
+    description = "Sioyek basic setup with sample configuration";
+    script = ''
+      assertFileExists home-files/.config/sioyek/prefs_user.config
+      assertFileContent home-files/.config/sioyek/prefs_user.config ${
+        ./test_prefs_user.config
+      }
+
+      assertFileExists home-files/.config/sioyek/keys_user.config
+      assertFileContent home-files/.config/sioyek/keys_user.config ${
+        ./test_keys_user.config
+      }
+    '';
+  };
+}

--- a/tests/modules/programs/sioyek/test_keys_user.config
+++ b/tests/modules/programs/sioyek/test_keys_user.config
@@ -1,0 +1,8 @@
+move_down j
+move_left h
+move_right l
+move_up k
+screen_down d
+screen_down <C-d>
+screen_up u
+screen_up <C-u>

--- a/tests/modules/programs/sioyek/test_prefs_user.config
+++ b/tests/modules/programs/sioyek/test_prefs_user.config
@@ -1,0 +1,2 @@
+dark_mode_background_color 0.0 0.0 0.0
+dark_mode_contrast 0.8


### PR DESCRIPTION
### Description

In Sioyek, [multiple keybindings can be set for the same command](https://github.com/ahrm/sioyek/blob/749a88fb927419ec85f795881c8f0c76600a06b3/pdf_viewer/keys.config#L26-L27). It would be nice for home-manager to be able to set that as well.

Since the configuration is getting a teeeeeny more complex, I also added a test.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
