### PR TITLE
sbt: cache `passwordCommand` output

### DIFF
--- a/modules/programs/sbt.nix
+++ b/modules/programs/sbt.nix
@@ -8,13 +8,16 @@ let
     addSbtPlugin("${plugin.org}" % "${plugin.artifact}" % "${plugin.version}")
   '';
 
-  renderCredential = cred: ''
-    credentials += Credentials("${cred.realm}", "${cred.host}", "${cred.user}", "${cred.passwordCommand}".!!.trim)
-  '';
+  renderCredential = idx: cred:
+    let symbol = "credential_${toString idx}";
+    in ''
+      lazy val ${symbol} = "${cred.passwordCommand}".!!.trim
+      credentials += Credentials("${cred.realm}", "${cred.host}", "${cred.user}", ${symbol})
+    '';
 
   renderCredentials = creds: ''
     import scala.sys.process._
-    ${concatStrings (map renderCredential creds)}'';
+    ${concatStrings (imap0 renderCredential creds)}'';
 
   renderRepository = value:
     if isString value then ''

--- a/tests/modules/programs/sbt/credentials.nix
+++ b/tests/modules/programs/sbt/credentials.nix
@@ -19,8 +19,10 @@ let
   ];
   expectedCredentialsSbt = pkgs.writeText "credentials.sbt" ''
     import scala.sys.process._
-    credentials += Credentials("Sonatype Nexus Repository Manager", "example.com", "user", "echo password".!!.trim)
-    credentials += Credentials("Sonatype Nexus Repository Manager X", "v2.example.com", "user1", "echo password1".!!.trim)
+    lazy val credential_0 = "echo password".!!.trim
+    credentials += Credentials("Sonatype Nexus Repository Manager", "example.com", "user", credential_0)
+    lazy val credential_1 = "echo password1".!!.trim
+    credentials += Credentials("Sonatype Nexus Repository Manager X", "v2.example.com", "user1", credential_1)
   '';
   credentialsSbtPath = ".sbt/1.0/credentials.sbt";
 in {


### PR DESCRIPTION
### Description

This will cache the output of `passwordCommand` per authentication realm.

Context: the `credentials` key in `sbt` is a `TaskKey[Seq[Credentials]]`. In `sbt`, tasks are evaluated on-demand and their output is not cached. This particular key is referenced by all submodules in a project. When the command is relatively expensive (e.g.: `pass show foo`), this results in several seconds of delay when doing basic things like `compile` or `test` which makes this unusable without some kind of caching.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - ~[ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~

  - ~[ ] Added myself and the module files to `.github/CODEOWNERS`.~
