### PR TITLE
sbt: allow managing the `~/.sbt/repositories` file

### DIFF
--- a/modules/programs/sbt.nix
+++ b/modules/programs/sbt.nix
@@ -16,6 +16,17 @@ let
     import scala.sys.process._
     ${concatStrings (map renderCredential creds)}'';
 
+  renderRepository = value:
+    if isString value then ''
+      ${value}
+    '' else ''
+      ${concatStrings (mapAttrsToList (name: value: "${name}: ${value}") value)}
+    '';
+
+  renderRepositories = repos: ''
+    [repositories]
+    ${concatStrings (map renderRepository cfg.repositories)}'';
+
   sbtTypes = {
     plugin = types.submodule {
       options = {
@@ -68,6 +79,11 @@ let
   cfg = config.programs.sbt;
 
 in {
+  imports = [
+    (mkRemovedOptionModule [ "programs" "sbt" "baseConfigPath" ]
+      "Use programs.sbt.baseUserConfigPath instead, but note that the semantics are slightly different.")
+  ];
+
   meta.maintainers = [ maintainers.kubukoz ];
 
   options.programs.sbt = {
@@ -80,10 +96,13 @@ in {
       description = "The package with sbt to be installed.";
     };
 
-    baseConfigPath = mkOption {
+    baseUserConfigPath = mkOption {
       type = types.str;
-      default = ".sbt/1.0";
-      description = "Where the plugins and credentials should be located.";
+      default = ".sbt";
+      description = ''
+        Where the sbt configuration files should be located, relative
+        <envar>HOME</envar>.
+      '';
     };
 
     plugins = mkOption {
@@ -123,19 +142,63 @@ in {
         A list of credentials to define in the sbt configuration directory.
       '';
     };
+
+    repositories = mkOption {
+      type = with types;
+        listOf
+        (either (enum [ "local" "maven-central" "maven-local" ]) (attrsOf str));
+      default = [ ];
+      example = literalExpression ''
+        [
+          "local"
+          { my-ivy-proxy-releases = "http://repo.company.com/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]" }
+          { my-maven-proxy-releases = "http://repo.company.com/maven-releases/" }
+          "maven-central"
+        ]
+      '';
+      description = ''
+        A list of repositories to use when resolving dependencies. Defined as a
+        list of pre-defined repository or custom repository as a set of name to
+        URL. The list will be used populate the <code>~/.sbt/repositories</code>
+        file in the order specified.
+
+        </para><para>
+
+        Pre-defined repositories must be one of <code>local</code>,
+        <code>maven-local</code>, <code>maven-central</code>.
+
+        </para><para>
+
+        Custom repositories are defined as
+        <code language="nix">{ name-of-repo = "https://url.to.repo.com"}</code>.
+
+        </para><para>
+
+        See
+        <link xlink:href="https://www.scala-sbt.org/1.x/docs/Launcher-Configuration.html#3.+Repositories+Section"/>
+        about this configuration section and
+        <link xlink:href="https://www.scala-sbt.org/1.x/docs/Proxy-Repositories.html"/>
+        to read about proxy repositories.
+      '';
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
     { home.packages = [ cfg.package ]; }
 
     (mkIf (cfg.plugins != [ ]) {
-      home.file."${cfg.baseConfigPath}/plugins/plugins.sbt".text =
+      home.file."${cfg.baseUserConfigPath}/1.0/plugins/plugins.sbt".text =
         concatStrings (map renderPlugin cfg.plugins);
     })
 
     (mkIf (cfg.credentials != [ ]) {
-      home.file."${cfg.baseConfigPath}/credentials.sbt".text =
+      home.file."${cfg.baseUserConfigPath}/1.0/credentials.sbt".text =
         renderCredentials cfg.credentials;
+    })
+
+    (mkIf (cfg.repositories != [ ]) {
+      home.file."${cfg.baseUserConfigPath}/repositories".text =
+        renderRepositories cfg.repositories;
     })
   ]);
 }

--- a/tests/modules/programs/sbt/default.nix
+++ b/tests/modules/programs/sbt/default.nix
@@ -1,4 +1,7 @@
 {
-  sbt-plugins = ./plugins.nix;
   sbt-credentials = ./credentials.nix;
+  sbt-deprecated-options = ./deprecated-options.nix;
+  sbt-plugins = ./plugins.nix;
+  sbt-repositories = ./repositories.nix;
+  sbt-user-config-path = ./user-config-path.nix;
 }

--- a/tests/modules/programs/sbt/deprecated-options.nix
+++ b/tests/modules/programs/sbt/deprecated-options.nix
@@ -1,0 +1,18 @@
+{ ... }:
+
+{
+  programs.sbt = {
+    enable = true;
+    baseConfigPath = "gone";
+  };
+
+  test.stubs.sbt = { };
+
+  test.asserts.assertions.expected = [
+    (let offendingFile = toString ./deprecated-options.nix;
+    in ''
+      The option definition `programs.sbt.baseConfigPath' in `${offendingFile}' no longer has any effect; please remove it.
+      Use programs.sbt.baseUserConfigPath instead, but note that the semantics are slightly different.
+    '')
+  ];
+}

--- a/tests/modules/programs/sbt/repositories.nix
+++ b/tests/modules/programs/sbt/repositories.nix
@@ -1,0 +1,38 @@
+{ pkgs, ... }:
+
+let
+  repositories = [
+    "local"
+    { my-maven-proxy = "http://repo.mavenproxy.io/a/b/c/d"; }
+    "maven-local"
+    {
+      my-ivy-proxy =
+        "http://repo.company.com/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]";
+    }
+    "maven-central"
+  ];
+
+  expectedRepositories = builtins.toFile "repositories" ''
+    [repositories]
+    local
+    my-maven-proxy: http://repo.mavenproxy.io/a/b/c/d
+    maven-local
+    my-ivy-proxy: http://repo.company.com/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+    maven-central
+  '';
+
+  repositoriesSbtPath = ".sbt/repositories";
+in {
+  config = {
+    programs.sbt = {
+      enable = true;
+      repositories = repositories;
+      package = pkgs.writeScriptBin "sbt" "";
+    };
+
+    nmt.script = ''
+      assertFileExists "home-files/${repositoriesSbtPath}"
+      assertFileContent "home-files/${repositoriesSbtPath}" "${expectedRepositories}"
+    '';
+  };
+}

--- a/tests/modules/programs/sbt/user-config-path.nix
+++ b/tests/modules/programs/sbt/user-config-path.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  plugins = [{
+    org = "a";
+    artifact = "b";
+    version = "c";
+  }];
+
+  credentials = [{
+    realm = "a";
+    host = "b";
+    user = "c";
+    passwordCommand = "d";
+  }];
+
+  repositories = [ "local" ];
+
+  baseSbtPath = ".config/sbt";
+in {
+  config = {
+    programs.sbt = {
+      enable = true;
+      plugins = plugins;
+      credentials = credentials;
+      repositories = repositories;
+      baseUserConfigPath = ".config/sbt";
+      package = pkgs.writeScriptBin "sbt" "";
+    };
+
+    nmt.script = ''
+      assertFileExists "home-files/${baseSbtPath}/1.0/plugins/plugins.sbt"
+      assertFileExists "home-files/${baseSbtPath}/1.0/credentials.sbt"
+      assertFileExists "home-files/${baseSbtPath}/repositories"
+    '';
+  };
+}


### PR DESCRIPTION
### Description

`sbt` allows overriding the default repositories to use to resolve
dependencies. This is often used with proxies and/or private
repositories to host internal packages.

This change adds a `repositories` attribute to `sbt` to allow specifying
the values that will go in `~/.sbt/repositories` file.

NOTE: I had to use `${baseConfigPath}/../repositories` to place the file in the right place. This seems brittle, but I can't find a better way without breaking compatibility (which seems worse).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - ~[ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~

  - ~[ ] Added myself and the module files to `.github/CODEOWNERS`.~
