### PR TITLE
services/swayidle: fix examples

### DIFF
--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -73,7 +73,7 @@ in {
       default = [ ];
       example = literalExpression ''
         [
-          { timeout = 60; command = "swaylock -fF"; }
+          { timeout = 60; command = "${pkgs.swaylock}/bin/swaylock -fF"; }
         ]
       '';
       description = "List of commands to run after idle timeout.";
@@ -84,7 +84,7 @@ in {
       default = [ ];
       example = literalExpression ''
         [
-          { event = "before-sleep"; command = "swaylock"; }
+          { event = "before-sleep"; command = "${pkgs.swaylock}/bin/swaylock"; }
           { event = "lock"; command = "lock"; }
         ]
       '';


### PR DESCRIPTION

### Description
The example did not work before, since the systemd service does not have swayidle in its $PATH.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

  did not go through, but error is unrelated?
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
