### PR TITLE
qutebrowser: add greasemonkey userscript option

### DIFF
--- a/tests/modules/programs/qutebrowser/default.nix
+++ b/tests/modules/programs/qutebrowser/default.nix
@@ -2,4 +2,5 @@
   qutebrowser-settings = ./settings.nix;
   qutebrowser-keybindings = ./keybindings.nix;
   qutebrowser-quickmarks = ./quickmarks.nix;
+  qutebrowser-greasemonkey = ./greasemonkey.nix;
 }

--- a/tests/modules/programs/qutebrowser/greasemonkey.nix
+++ b/tests/modules/programs/qutebrowser/greasemonkey.nix
@@ -1,0 +1,44 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.qutebrowser = {
+      enable = true;
+
+      greasemonkey = [
+        (pkgs.writeText "qutebrowser-greasemonkey.js" ''
+          // ==UserScript==
+          // @name        foo
+          // @namespace   foo
+          // @match       https://example.com/*
+          // @grant       none
+          // ==/UserScript==
+        '')
+      ];
+    };
+
+    test.stubs.qutebrowser = { };
+
+    nmt.script = let
+      scriptDir = if pkgs.stdenv.hostPlatform.isDarwin then
+        ".qutebrowser/greasemonkey"
+      else
+        ".config/qutebrowser/greasemonkey";
+    in ''
+      assertFileContent \
+        home-files/${scriptDir}/qutebrowser-greasemonkey.js \
+        ${
+          pkgs.writeText "qutebrowser-expected-greasemonkey" ''
+            // ==UserScript==
+            // @name        foo
+            // @namespace   foo
+            // @match       https://example.com/*
+            // @grant       none
+            // ==/UserScript==
+          ''
+        }
+    '';
+  };
+}


### PR DESCRIPTION
### Description
This adds the `programs.qutebrowser.greasemonkey` option, a list of packages that represent greasemonkey userscripts.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
