### PR TITLE
systemd: name slice units correctly

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -125,9 +125,9 @@ in {
 
       slices = mkOption {
         default = { };
-        type = unitType "slices";
-        description = unitDescription "slices";
-        example = unitExample "Slices";
+        type = unitType "slice";
+        description = unitDescription "slice";
+        example = unitExample "Slice";
       };
 
       sockets = mkOption {
@@ -263,7 +263,7 @@ in {
     (mkIf (pkgs.stdenv.isLinux && config.home.username != "root") {
       xdg.configFile = mkMerge [
         (lib.listToAttrs ((buildServices "service" cfg.services)
-          ++ (buildServices "slices" cfg.slices)
+          ++ (buildServices "slice" cfg.slices)
           ++ (buildServices "socket" cfg.sockets)
           ++ (buildServices "target" cfg.targets)
           ++ (buildServices "timer" cfg.timers)

--- a/tests/modules/systemd/default.nix
+++ b/tests/modules/systemd/default.nix
@@ -2,5 +2,6 @@
   systemd-services = ./services.nix;
   systemd-services-disabled-for-root = ./services-disabled-for-root.nix;
   systemd-session-variables = ./session-variables.nix;
+  systemd-slices = ./slices.nix;
   systemd-timers = ./timers.nix;
 }

--- a/tests/modules/systemd/slices.nix
+++ b/tests/modules/systemd/slices.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    systemd.user.slices.app-test = {
+      Unit = { Description = "Slice for a test app"; };
+
+      Slice = {
+        MemoryHigh = "30%";
+        MemoryMax = "40%";
+      };
+    };
+
+    nmt.script = ''
+      sliceFile=home-files/.config/systemd/user/app-test.slice
+      assertFileExists $sliceFile
+      assertFileContent $sliceFile ${
+        builtins.toFile "app-test-expected.conf" ''
+          [Slice]
+          MemoryHigh=30%
+          MemoryMax=40%
+
+          [Unit]
+          Description=Slice for a test app
+        ''
+      }
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Systemd slices should have names like `app.slice` (singular slice) instead of `app.slices` (plural)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
