### PR TITLE
specialization: add default specialization option

### DIFF
--- a/tests/modules/misc/specialisation/default-specialisation.nix
+++ b/tests/modules/misc/specialisation/default-specialisation.nix
@@ -1,0 +1,10 @@
+{ config, ... }: {
+  home.file.testfile.text = "not special";
+  specialisation = { test.default = true; };
+
+  nmt.script = ''
+    assertFileExists activate
+    assertFileContains activate \
+      "${config.specialisation.test.configuration.home.activationPackage}/activate"
+  '';
+}

--- a/tests/modules/misc/specialisation/default.nix
+++ b/tests/modules/misc/specialisation/default.nix
@@ -1,1 +1,4 @@
-{ specialisation = ./specialisation.nix; }
+{
+  specialisation = ./specialisation.nix;
+  default-specialisation = ./default-specialisation.nix;
+}

--- a/tests/modules/misc/specialisation/specialisation.nix
+++ b/tests/modules/misc/specialisation/specialisation.nix
@@ -1,7 +1,3 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
-
 {
   home.file.testfile.text = "not special";
   specialisation.test.configuration = {
@@ -14,5 +10,6 @@ with lib;
 
     assertFileExists specialisation/test/home-files/testfile
     assertFileContains specialisation/test/home-files/testfile "not special"
+    assertFileContains specialisation/test/home-files/testfile "very special"
   '';
 }


### PR DESCRIPTION
### Description

Add the option `specialization.<name>.default`, which activates this specialization by default.
There can only be one default specialization.
If a default specialization is specified then the default activation script will be overwritten, making it impossible to *not* activate any specialization.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
