### PR TITLE
Add a package option to services.owncloud-client

### DIFF
--- a/modules/services/owncloud-client.nix
+++ b/modules/services/owncloud-client.nix
@@ -2,12 +2,20 @@
 
 with lib;
 
-{
+let
+
+  cfg = config.services.owncloud-client;
+
+in {
   options = {
-    services.owncloud-client = { enable = mkEnableOption "Owncloud Client"; };
+    services.owncloud-client = {
+      enable = mkEnableOption "Owncloud Client";
+
+      package = mkPackageOption pkgs "owncloud-client" { };
+    };
   };
 
-  config = mkIf config.services.owncloud-client.enable {
+  config = mkIf cfg.enable {
     assertions = [
       (hm.assertions.assertPlatform "services.owncloud-client" pkgs
         platforms.linux)
@@ -22,7 +30,7 @@ with lib;
 
       Service = {
         Environment = "PATH=${config.home.profileDirectory}/bin";
-        ExecStart = "${pkgs.owncloud-client}/bin/owncloud";
+        ExecStart = "${cfg.package}/bin/owncloud";
       };
 
       Install = { WantedBy = [ "graphical-session.target" ]; };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add a `package` option to `services.owncloud-client` module.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
