### PR TITLE
dircolors: add the option `configPath`

### DIFF
--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -67,6 +67,19 @@ in {
         Extra lines added to <filename>.dir_colors</filename> file.
       '';
     };
+
+    configPath = mkOption {
+      type = types.path;
+      default = "${config.home.homeDirectory}/.dir_colors";
+      defaultText = "~/.dir_colors";
+      apply = toString;
+      description = ''
+        Path to the <filename>.dir_colors</filename> file.
+      '';
+      example = literalExpression ''
+        "''${config.home.homeDirectory}/.dir_colors"
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -203,21 +216,21 @@ in {
       ".xspf" = mkDefault "00;36";
     };
 
-    home.file.".dir_colors".text = concatStringsSep "\n" ([ ]
+    home.file."${cfg.configPath}".text = concatStringsSep "\n" ([ ]
       ++ mapAttrsToList formatLine cfg.settings ++ [ "" ]
       ++ optional (cfg.extraConfig != "") cfg.extraConfig);
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      eval $(${pkgs.coreutils}/bin/dircolors -b ~/.dir_colors)
+      eval $(${pkgs.coreutils}/bin/dircolors -b ${cfg.configPath})
     '';
 
     programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
-      eval (${pkgs.coreutils}/bin/dircolors -c ~/.dir_colors)
+      eval (${pkgs.coreutils}/bin/dircolors -c ${cfg.configPath})
     '';
 
     # Set `LS_COLORS` before Oh My Zsh and `initExtra`.
     programs.zsh.initExtraBeforeCompInit = mkIf cfg.enableZshIntegration ''
-      eval $(${pkgs.coreutils}/bin/dircolors -b ~/.dir_colors)
+      eval $(${pkgs.coreutils}/bin/dircolors -b ${cfg.configPath})
     '';
   };
 }

--- a/tests/modules/programs/dircolors/config-path-custom.nix
+++ b/tests/modules/programs/dircolors/config-path-custom.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.dircolors = {
+      enable = true;
+
+      configPath = "${config.xdg.configHome}/dircolors";
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/dircolors
+    '';
+  };
+}
+

--- a/tests/modules/programs/dircolors/config-path-default.nix
+++ b/tests/modules/programs/dircolors/config-path-default.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.dircolors = { enable = true; };
+
+    nmt.script = ''
+      assertFileExists home-files/.dir_colors
+    '';
+  };
+}
+

--- a/tests/modules/programs/dircolors/default.nix
+++ b/tests/modules/programs/dircolors/default.nix
@@ -1,1 +1,5 @@
-{ dircolors-settings = ./settings.nix; }
+{
+  dircolors-settings = ./settings.nix;
+  dircolors-config-path-default = ./config-path-default.nix;
+  dircolors-config-path-custom = ./config-path-custom.nix;
+}


### PR DESCRIPTION
### Description

Add the option `dircolors.configPath` so that the path of the dircolors file can be configurable.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
