### PR TITLE
qutebrowser: allow for specifying multiple commands in bindings

### DIFF
--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -131,7 +131,7 @@ in {
     };
 
     keyBindings = mkOption {
-      type = types.attrsOf (types.attrsOf types.str);
+      type = with types; attrsOf (attrsOf (separatedString " ;; "));
       default = { };
       description = ''
         Key bindings mapping keys to commands in different modes. This setting
@@ -245,6 +245,11 @@ in {
             "<Ctrl-v>" = "spawn mpv {url}";
             ",p" = "spawn --userscript qute-pass";
             ",l" = '''config-cycle spellcheck.languages ["en-GB"] ["en-US"]''';
+            "<F1>" = mkMerge [
+              "config-cycle tabs.show never always"
+              "config-cycle statusbar.show in-mode always"
+              "config-cycle scrolling.bar never always"
+            ];
           };
           prompt = {
             "<Ctrl-y>" = "prompt-yes";

--- a/tests/modules/programs/qutebrowser/keybindings.nix
+++ b/tests/modules/programs/qutebrowser/keybindings.nix
@@ -13,6 +13,11 @@ with lib;
         normal = {
           "<Ctrl-v>" = "spawn mpv {url}";
           ",l" = ''config-cycle spellcheck.languages ["en-GB"] ["en-US"]'';
+          "<F1>" = mkMerge [
+            "config-cycle tabs.show never always"
+            "config-cycle statusbar.show in-mode always"
+            "config-cycle scrolling.bar never always"
+          ];
         };
         prompt = { "<Ctrl-y>" = "prompt-yes"; };
       };
@@ -34,6 +39,7 @@ with lib;
             c.bindings.default = {}
             config.bind(",l", "config-cycle spellcheck.languages [\"en-GB\"] [\"en-US\"]", mode="normal")
             config.bind("<Ctrl-v>", "spawn mpv {url}", mode="normal")
+            config.bind("<F1>", "config-cycle tabs.show never always ;; config-cycle statusbar.show in-mode always ;; config-cycle scrolling.bar never always", mode="normal")
             config.bind("<Ctrl-y>", "prompt-yes", mode="prompt")''
         }
     '';


### PR DESCRIPTION
### Description

This command adds the ability to specify lists of qutebrowser commands as values for key bindings,
which avoids the need for concatenating commands with ` ;; `.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
