### PR TITLE
sway: import XDG_SESSION_TYPE in systemd user environment

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -317,7 +317,7 @@ let
         )
       else
         [ ]) ++ (optional cfg.systemdIntegration ''
-          exec "${pkgs.dbus}/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"'')
+          exec "${pkgs.dbus}/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE; systemctl --user start sway-session.target"'')
       ++ (optional (!cfg.xwayland) "xwayland disable") ++ [ cfg.extraConfig ]));
 
   defaultSwayPackage = pkgs.sway.override {

--- a/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
+++ b/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
@@ -106,4 +106,4 @@ bar {
 }
 }
 
-exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.conf
+++ b/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.conf
@@ -105,5 +105,5 @@ bar {
 }
 }
 
-exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE; systemctl --user start sway-session.target"
 exec_always pkill flashfocus; flasfocus &

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -103,4 +103,4 @@ bar {
 }
 }
 
-exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
@@ -81,4 +81,4 @@ mode "resize" {
   bindsym l resize grow width 10 px
 }
 
-exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
@@ -81,4 +81,4 @@ mode "resize" {
   bindsym l resize grow width 10 px
 }
 
-exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-modules.conf
+++ b/tests/modules/services/window-managers/sway/sway-modules.conf
@@ -115,4 +115,4 @@ bar {
 }
 }
 
-exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-null-package.conf
+++ b/tests/modules/services/window-managers/sway/sway-null-package.conf
@@ -103,4 +103,4 @@ bar {
 }
 }
 
-exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
@@ -102,4 +102,4 @@ bar {
 }
 }
 
-exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
@@ -107,4 +107,4 @@ workspace "1" output eDP
 workspace "ABC" output DP
 workspace "3: Test" output HDMI
 workspace "!"§$%&/(){}[]=?\*#<>-_.:,;²³" output DVI
-exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP; systemctl --user start sway-session.target"
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE; systemctl --user start sway-session.target"


### PR DESCRIPTION
- The `XDG_SESSION_TYPE` environment variable is used by some applications and frameworks to detect wayland sessions (i.e qt5/6, electron/chromium). It is set by wlroots since version 0.13.0 [1].

- Propagating `XDG_SESSION_TYPE` to the systemd user environment is necessary when processes launched by services (e.g emacs) need to inherit the environment variable.

[1] - https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/90c8452959470461497c4a83aac0bd93efb0a524

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
