### PR TITLE
i18n.inputMethod.fcitx5: Add GLFW_IM_MODULE session variable for kitty support

### DIFF
--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -24,6 +24,7 @@ in {
     i18n.inputMethod.package = fcitx5Package;
 
     home.sessionVariables = {
+      GLFW_IM_MODULE = "ibus"; # IME support in kitty
       GTK_IM_MODULE = "fcitx";
       QT_IM_MODULE = "fcitx";
       XMODIFIERS = "@im=fcitx";


### PR DESCRIPTION
### Description

The fcitx5 module doesn't add the appropriate `GLFW_IM_MODULE=ibus` session variable required for use of the input engine within the kitty terminal emulator (and presumably anything using GLFW). This fix is documented [here on the Arch Wiki](https://wiki.archlinux.org/title/Kitty#Enable_IME_support). I've added this variable.

Setting it to `ibus` works because fcitx5 apparently has an ibus-comaptible interface. I don't know if legacy fcitx has this, I haven't tried.

This is my first Nix/NixOS PR! I'm sorry if I've missed anything.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.