### PR TITLE
himalaya: fix broken config to support 0.6.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -136,8 +136,8 @@ Makefile                                              @thiagokokada
 /modules/programs/hexchat.nix                         @thiagokokada
 /tests/modules/programs/hexchat                       @thiagokokada
 
-/modules/programs/himalaya.nix                        @ambroisie
-/tests/modules/programs/himalaya                      @ambroisie
+/modules/programs/himalaya.nix                        @toastal
+/tests/modules/programs/himalaya                      @toastal
 
 /modules/programs/home-manager.nix                    @rycee
 

--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -44,6 +44,19 @@ let
         '';
       };
 
+      delimiter = mkOption {
+        type = types.str;
+        default = ''
+          --
+        '';
+        example = literalExpression ''
+          ~*~*~*~*~*~*~*~*~*~*~*~
+        '';
+        description = ''
+          The delimiter used between the document and the signature.
+        '';
+      };
+
       command = mkOption {
         type = with types; nullOr path;
         default = null;

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -345,4 +345,13 @@
     github = "lukasngl";
     githubId = 69244516;
   };
+  toastal = {
+    email = "toastal+nix@posteo.net";
+    matrix = "@toastal:matrix.org";
+    github = "toastal";
+    githubId = 561087;
+    name = "toastal";
+    keys =
+      [{ fingerprint = "7944 74B7 D236 DAB9 C9EF  E7F9 5CCE 6F14 66D4 7C9E"; }];
+  };
 }

--- a/tests/modules/programs/himalaya/himalaya-expected.toml
+++ b/tests/modules/programs/himalaya/himalaya-expected.toml
@@ -1,16 +1,18 @@
+display-name = ""
 downloads-dir = "/data/download"
-name = ""
 
 ["hm@example.com"]
+backend = "imap"
 default = true
-default-page-size = 50
+display-name = "H. M. Test"
 email = "hm@example.com"
+email-listing-page-size = 50
 imap-host = "imap.example.com"
 imap-login = "home.manager"
 imap-passwd-cmd = "'password-command'"
 imap-port = 995
 imap-starttls = false
-name = "H. M. Test"
+sender = "smtp"
 smtp-host = "smtp.example.com"
 smtp-login = "home.manager"
 smtp-passwd-cmd = "'password-command'"

--- a/tests/modules/programs/himalaya/himalaya.nix
+++ b/tests/modules/programs/himalaya/himalaya.nix
@@ -10,7 +10,9 @@ with lib;
       himalaya = {
         enable = true;
 
-        settings = { default-page-size = 50; };
+        backend = "imap";
+        sender = "smtp";
+        settings = { email-listing-page-size = 50; };
       };
 
       folders = {
@@ -38,4 +40,3 @@ with lib;
     }
   '';
 }
-


### PR DESCRIPTION
### Description

Himalaya had breaking config changes from 0.5.x to 0.6.x. @ambroisie mentioned wanting to step down from maintaining the module.

This isn't backwards compatible because the new config isn't. It now explicitly requires `backend` and `sender` are set to an enum which requires certain properties. I suppose `backend = "imap"` and `sender = "smtp"` could be `default` values to follow what was previously set as the only and required options, but I believe it would be better to be explicit moving forwards--just like `himalaya`.

This fix allowed me to verify that the Vim plugin still worked too https://github.com/NixOS/nixpkgs/pull/195927/files

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`. (failed with `neovim`)
- [x] Code tested through `nix-shell --pure tests -A run.himalaya`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.

### Comments

Please offer a non-proprietary option for contribution instead of being limited to the Microsoft-owned GitHub forge. Identity is tied to a Microsoft GitHub account too which is as barrier to contribution and requires giving away ones data.

I don't like the use of `nixfmt` because it makes changes that break `git` diffs. I prefer `nixpkgs-fmt` as it has a philosophy of "expand, never contract" and so lines never get pulled up and cuddled if the string or set is now shorter making it harder to review.