### PR TITLE
firefox: use different paths if librewolf is used

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -10,13 +10,21 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
-  mozillaConfigPath =
-    if isDarwin then "Library/Application Support/Mozilla" else ".mozilla";
+  isLibrewolf = cfg.package.meta.mainProgram == "librewolf";
 
-  firefoxConfigPath = if isDarwin then
-    "Library/Application Support/Firefox"
+  mozillaConfigPath =
+    if isLibrewolf then
+      (if isDarwin then "Library/Application Support/Librewolf" else ".librewolf")
+    else
+      (if isDarwin then "Library/Application Support/Mozilla" else ".mozilla");
+
+  firefoxConfigPath = if isLibrewolf then
+    mozillaConfigPath
   else
-    "${mozillaConfigPath}/firefox";
+    (if isDarwin then
+      "Library/Application Support/Firefox"
+    else
+      "${mozillaConfigPath}/firefox");
 
   profilesPath =
     if isDarwin then "${firefoxConfigPath}/Profiles" else firefoxConfigPath;


### PR DESCRIPTION
### Description
~~Makes the `mozillaConfigPath`, `firefoxConfigPath` and `profilesPath` available to the user
https://github.com/nix-community/home-manager/issues/2803#issuecomment-1276635894~~

Adds handling for the firefox module to use different profile paths if the package is changed to librewolf.  
This is kind of a solution for #2803 and #4179 

I'm currently not shure how good this solution is and will leave this as a draft and without tests until I used this for a bit and wrote tests.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
