### PR TITLE
i3status: add missing `package` attribute

### DIFF
--- a/modules/programs/i3status.nix
+++ b/modules/programs/i3status.nix
@@ -138,6 +138,8 @@ in {
         }
       '';
     };
+
+    package = mkPackageOption pkgs "i3status" { };
   };
 
   config = mkIf cfg.enable {
@@ -197,7 +199,7 @@ in {
       };
     };
 
-    home.packages = [ pkgs.i3status ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."i3status/config".text = concatStringsSep "\n" ([ ]
       ++ optional (cfg.general != { }) (formatModule "general" cfg.general)

--- a/tests/modules/programs/i3status/with-custom.nix
+++ b/tests/modules/programs/i3status/with-custom.nix
@@ -16,6 +16,8 @@ with lib;
         interval = 1;
       };
 
+      package = config.lib.test.mkStubPackage { };
+
       modules = {
         "volume master" = {
           position = 1;


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
