### PR TITLE
hypr: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -527,6 +527,8 @@ Makefile                                              @thiagokokada
 /modules/services/window-managers/herbstluftwm        @olmokramer
 /tests/modules/services/window-managers/herbstluftwm  @olmokramer
 
+/modules/services/window-managers/hypr                @AndersonTorres
+
 /modules/services/window-managers/i3-sway/i3.nix      @sumnerevans @sebtm
 /tests/modules/services/window-managers/i3            @sumnerevans @sebtm
 

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -292,6 +292,7 @@ let
     ./services/window-managers/bspwm/default.nix
     ./services/window-managers/fluxbox.nix
     ./services/window-managers/herbstluftwm.nix
+    ./services/window-managers/hypr/default.nix
     ./services/window-managers/i3-sway/i3.nix
     ./services/window-managers/i3-sway/sway.nix
     ./services/window-managers/i3-sway/swaynag.nix

--- a/modules/services/window-managers/hypr/default.nix
+++ b/modules/services/window-managers/hypr/default.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  inherit (lib) hm types mkEnableOption mkIf mkOption mkPackageOption platforms;
+
+  cfg = config.xsession.windowManager.hypr;
+
+in {
+  meta.maintainers = with lib.maintainers; [ AndersonTorres ];
+
+  options = import ./options.nix { inherit config lib pkgs; };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "xsession.windowManager.hypr" pkgs
+        platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."hypr/hypr.conf" =
+      mkIf (cfg.extraConfig != "") { text = cfg.extraConfig; };
+
+    xsession.windowManager.command = ''
+      "${cfg.package}/bin/Hypr"
+    '';
+  };
+}

--- a/modules/services/window-managers/hypr/options.nix
+++ b/modules/services/window-managers/hypr/options.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    hm types mkEnableOption mdDoc mkIf mkOption mkPackageOption platforms;
+in {
+  xsession.windowManager.hypr = {
+    enable = mkEnableOption "Hypr window manager";
+
+    package = mkPackageOption pkgs "hypr" { };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Configuration written to
+        <filename>$XDG_CONFIG_HOME/hypr/hypr.conf</filename>. See
+        <link xlink:href="https://github.com/hyprwm/Hypr/wiki/Configuring-Hypr" />
+        for explanation about possible values.
+      '';
+    };
+  };
+}


### PR DESCRIPTION
Now that @AndersonTorres added Hypr X11 window manager to Nixpkgs, it is a good time to add it to Home Manager too!

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
