### PR TITLE
Support starship nushell integration

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -89,6 +89,14 @@ in {
         Whether to enable Ion integration.
       '';
     };
+
+    enableNushellIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Nushell integration.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -116,10 +124,21 @@ in {
       end
     '';
 
-    programs.ion.initExtra = mkIf cfg.enableIonIntegration ''
-      if test $TERM != "dumb" && not exists -s INSIDE_EMACS || test $INSIDE_EMACS = "vterm"
-        eval $(${starshipCmd} init ion)
-      end
-    '';
+    programs.nushell = mkIf cfg.enableNushellIntegration {
+      # Unfortunately nushell doesn't allow conditionally sourcing nor
+      # conditionally setting (global) environment variables, which is why the
+      # check for terminal compatibility (as seen above for the other shells) is
+      # not done here.
+      extraEnv = ''
+        let starship_cache = "${config.xdg.cacheHome}/starship"
+        if not ($starship_cache | path exists) {
+          mkdir $starship_cache
+        }
+        ${starshipCmd} init nu | save ${config.xdg.cacheHome}/starship/init.nu
+      '';
+      extraConfig = ''
+        source ${config.xdg.cacheHome}/starship/init.nu
+      '';
+    };
   };
 }

--- a/tests/modules/programs/nushell/config-expected.nu
+++ b/tests/modules/programs/nushell/config-expected.nu
@@ -3,3 +3,4 @@ let $config = {
   table_mode: rounded
   use_ls_colors: true
 }
+

--- a/tests/modules/programs/nushell/env-expected.nu
+++ b/tests/modules/programs/nushell/env-expected.nu
@@ -1,1 +1,2 @@
 let-env FOO = 'BAR'
+


### PR DESCRIPTION
### Description

This PR adds the two options `extraConfig` and `extraEnv` to nushell. These value of these options are appended/merged with `configFile` and `envFile`. This is to ensure backwards compatibility.


Motivation for this is the starship nushell integration, which requires to extend either env and config files.
Unfortunately nushell is limited in sourcing or conditionally setting global environment variables, which is why the terminal compatibility check isn't done compared to the other starship shell integrations.

Fixes #3058

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
