### PR TITLE
borgmatic: specify where to find sleep

### DIFF
--- a/modules/services/borgmatic.nix
+++ b/modules/services/borgmatic.nix
@@ -58,7 +58,7 @@ in {
           LogRateLimitIntervalSec = 0;
 
           # Delay start to prevent backups running during boot:
-          ExecStartPre = "sleep 3m";
+          ExecStartPre = "${pkgs.coreutils}/bin/sleep 3m";
 
           ExecStart = ''
             ${pkgs.systemd}/bin/systemd-inhibit \

--- a/tests/modules/services/borgmatic/basic-configuration.service
+++ b/tests/modules/services/borgmatic/basic-configuration.service
@@ -9,7 +9,7 @@ ExecStart=/nix/store/00000000000000000000000000000000-systemd/bin/systemd-inhibi
     --list \
     --syslog-verbosity 1
 
-ExecStartPre=sleep 3m
+ExecStartPre=/nix/store/00000000000000000000000000000000-coreutils/bin/sleep 3m
 IOSchedulingClass=best-effort
 IOSchedulingPriority=7
 IOWeight=100


### PR DESCRIPTION
### Description
Fix issue #3348 by specifying the full path of `sleep` referenced in
borgmatic.service.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.