### PR TITLE
yambar: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1642,6 +1642,20 @@ in {
           https://github.com/hyprwm/hyprpaper for more.
         '';
       }
+
+      {
+        time = "2024-05-10T21:28:38+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'programs.yambar'.
+
+          Yambar is a lightweight and configurable status panel for X11 and
+          Wayland, that goes to great lengths to be both CPU and battery
+          efficient - polling is only done when absolutely necessary.
+
+          See https://codeberg.org/dnkl/yambar for more.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -254,6 +254,7 @@ let
     ./programs/wpaperd.nix
     ./programs/xmobar.nix
     ./programs/xplr.nix
+    ./programs/yambar.nix
     ./programs/yazi.nix
     ./programs/yt-dlp.nix
     ./programs/z-lua.nix

--- a/modules/programs/yambar.nix
+++ b/modules/programs/yambar.nix
@@ -1,0 +1,55 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  cfg = config.programs.yambar;
+  yamlFormat = pkgs.formats.yaml { };
+
+in {
+  meta.maintainers = [ lib.maintainers.carpinchomug ];
+
+  options.programs.yambar = {
+    enable = lib.mkEnableOption "Yambar";
+
+    package = lib.mkPackageOption pkgs "yambar" { };
+
+    settings = lib.mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        bar = {
+          location = "top";
+          height = 26;
+          background = "00000066";
+
+          right = [
+            {
+              clock.content = [
+                {
+                  string.text = "{time}";
+                }
+              ];
+            }
+          ];
+        };
+      '';
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/yambar/config.yml`.
+        See {manpage}`yambar(5)` for options.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.yambar" pkgs
+        lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."yambar/config.yml" = lib.mkIf (cfg.settings != { }) {
+      source = yamlFormat.generate "config.yml" cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -219,6 +219,7 @@ in import nmtSrc {
     ./modules/programs/wofi
     ./modules/programs/wpaperd
     ./modules/programs/xmobar
+    ./modules/programs/yambar
     ./modules/programs/yt-dlp
     ./modules/services/activitywatch
     ./modules/services/avizo

--- a/tests/modules/programs/yambar/default.nix
+++ b/tests/modules/programs/yambar/default.nix
@@ -1,0 +1,4 @@
+{
+  yambar-empty-settings = ./empty-settings.nix;
+  yambar-example-settings = ./example-settings.nix;
+}

--- a/tests/modules/programs/yambar/empty-settings.nix
+++ b/tests/modules/programs/yambar/empty-settings.nix
@@ -1,0 +1,11 @@
+{ ... }:
+
+{
+  programs.yambar.enable = true;
+
+  test.stubs.yambar = { };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/yambar
+  '';
+}

--- a/tests/modules/programs/yambar/example-settings-expected.yml
+++ b/tests/modules/programs/yambar/example-settings-expected.yml
@@ -1,0 +1,9 @@
+bar:
+  background: '00000066'
+  height: 26
+  location: top
+  right:
+  - clock:
+      content:
+      - string:
+          text: '{time}'

--- a/tests/modules/programs/yambar/example-settings.nix
+++ b/tests/modules/programs/yambar/example-settings.nix
@@ -1,0 +1,35 @@
+{ config, ... }:
+
+{
+  programs.yambar = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    settings = {
+      bar = {
+        location = "top";
+        height = 26;
+        background = "00000066";
+        right = [{ clock.content = [{ string.text = "{time}"; }]; }];
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/yambar/config.yml \
+      ${
+        builtins.toFile "yambar-expected.yml" ''
+          bar:
+            background: '00000066'
+            height: 26
+            location: top
+            right:
+            - clock:
+                content:
+                - string:
+                    text: '{time}'
+        ''
+      }
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This adds a module for [Yamber](https://codeberg.org/dnkl/yambar), a modular status panel for X11 and Wayland.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
