### PR TITLE
himalaya: update config format

### DIFF
--- a/modules/programs/himalaya.nix
+++ b/modules/programs/himalaya.nix
@@ -11,10 +11,10 @@ let
     toHimalayaConfig = account:
       {
         email = account.address;
-        name = account.realName;
+        display-name = account.realName;
         default = account.primary;
 
-        mailboxes = {
+        folder-aliases = {
           inbox = account.folders.inbox;
           sent = account.folders.sent;
           draft = account.folders.drafts;
@@ -23,12 +23,16 @@ let
 
         # FIXME: does not support disabling TLS altogether
         # NOTE: does not accept sequence of strings for password commands
+        # TODO: Support different backends (imap, +maildir, +notmuch)
+        backend = "imap";
         imap-login = account.userName;
         imap-passwd-cmd = lib.escapeShellArgs account.passwordCommand;
         imap-host = account.imap.host;
         imap-port = account.imap.port;
         imap-starttls = account.imap.tls.useStartTls;
 
+        # TODO: Support different senders (smtp, sendmail)
+        sender = "smtp";
         smtp-login = account.userName;
         smtp-passwd-cmd = lib.escapeShellArgs account.passwordCommand;
         smtp-host = account.smtp.host;

--- a/tests/modules/programs/himalaya/himalaya-expected.toml
+++ b/tests/modules/programs/himalaya/himalaya-expected.toml
@@ -1,23 +1,26 @@
 downloads-dir = "/data/download"
-name = ""
+folder-listing-page-size = 50
+email-listing-page-size = 50
 
 ["hm@example.com"]
 default = true
 default-page-size = 50
 email = "hm@example.com"
+backend = "imap"
 imap-host = "imap.example.com"
 imap-login = "home.manager"
 imap-passwd-cmd = "'password-command'"
 imap-port = 995
 imap-starttls = false
-name = "H. M. Test"
+display-name = "H. M. Test"
+sender = "smtp"
 smtp-host = "smtp.example.com"
 smtp-login = "home.manager"
 smtp-passwd-cmd = "'password-command'"
 smtp-port = 465
 smtp-starttls = false
 
-["hm@example.com".mailboxes]
+["hm@example.com".folder-aliases]
 draft = "Drafts"
 inbox = "In"
 sent = "Out"

--- a/tests/modules/programs/himalaya/himalaya.nix
+++ b/tests/modules/programs/himalaya/himalaya.nix
@@ -26,7 +26,11 @@ with lib;
 
   programs.himalaya = {
     enable = true;
-    settings = { downloads-dir = "/data/download"; };
+    settings = {
+      downloads-dir = "/data/download";
+      folder-listing-page-size = 50;
+      email-listing-page-size = 50;
+    };
   };
 
   test.stubs.himalaya = { };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

The configuration format for himalaya has updated with version 0.6, and the change is breaking, as reported by this issue: https://github.com/nix-community/home-manager/issues/3330

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible. (Not desirable)

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`. (Crashes at `/home/simon/home-manager/modules/programs/bash.nix:12:9` which I haven't touvhed)

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
