### PR TITLE
home-environment: add hm-version file

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -676,6 +676,33 @@ in
 
           ${activationCmds}
         '';
+
+        getVersion = pkgs.writeShellScript "get-hm-version" ''
+          set -euo pipefail
+
+          cd "${../.}" || exit 1
+
+          # Get the base release and initialize an empty version suffix.
+          release=$(< .release)
+          suffix=""
+
+          # If we are in a Git repo then update the suffix to be
+          #
+          #   .git.HASH
+          #
+          # where HASH are the first 8 characters of the commit hash.
+          if [[ -f .git/HEAD ]]; then
+            ref=$(sed '/ref:/ { s/.* //; }' .git/HEAD)
+            if [[ -f ".git/$ref" ]]; then
+              hash=$(< ".git/$ref")
+              if [[ -n "$hash" ]]; then
+                suffix=".git.''${hash:0:8}"
+              fi
+            fi
+          fi
+
+          echo "$release$suffix"
+        '';
       in
         pkgs.runCommand
           "home-manager-generation"
@@ -684,6 +711,8 @@ in
           }
           ''
             mkdir -p $out
+
+            ${getVersion} > $out/hm-version
 
             cp ${activationScript} $out/activate
 


### PR DESCRIPTION
### Description

This commits adds a file `hm-version` to the generated generation directory. This file will contain the release version, and if available, the Git commit hash.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```