### PR TITLE
vscode: fix examples and add a test

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -82,7 +82,7 @@ in {
         default = { };
         example = literalExpression ''
           {
-            "files.autoSave" = "off"
+            "files.autoSave" = "off";
             "[nix]"."editor.tabSize" = 2;
           }
         '';
@@ -97,14 +97,14 @@ in {
         default = { };
         example = literalExpression ''
           {
-            "version": "2.0.0",
-            "tasks": [
+            version = "2.0.0";
+            tasks = [
               {
-                "type": "shell",
-                "label": "Hello task",
-                "command": "hello",
+                type = "shell";
+                label = "Hello task";
+                command = "hello";
               }
-            ]
+            ];
           }
         '';
         description = ''

--- a/tests/modules/programs/vscode/default.nix
+++ b/tests/modules/programs/vscode/default.nix
@@ -1,4 +1,5 @@
 {
   vscode-keybindings = ./keybindings.nix;
+  vscode-tasks = ./tasks.nix;
   vscode-update-checks = ./update-checks.nix;
 }

--- a/tests/modules/programs/vscode/tasks.nix
+++ b/tests/modules/programs/vscode/tasks.nix
@@ -1,0 +1,43 @@
+{ pkgs, config, ... }:
+
+let
+
+  tasksFilePath = if pkgs.stdenv.hostPlatform.isDarwin then
+    "Library/Application Support/Code/User/tasks.json"
+  else
+    ".config/Code/User/tasks.json";
+
+  tasks = {
+    version = "2.0.0";
+    tasks = [{
+      type = "shell";
+      label = "Hello task";
+      command = "hello";
+    }];
+  };
+
+  expectedTasks = pkgs.writeText "tasks-expected.json" ''
+    {
+      "tasks": [
+        {
+          "command": "hello",
+          "label": "Hello task",
+          "type": "shell"
+        }
+      ],
+      "version": "2.0.0"
+    }
+  '';
+
+in {
+  programs.vscode = {
+    enable = true;
+    package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
+    userTasks = tasks;
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/${tasksFilePath}"
+    assertFileContent "home-files/${tasksFilePath}" "${expectedTasks}"
+  '';
+}


### PR DESCRIPTION
### Description

I fixed invalid examples of userSettings and userTasks and added userTasks' test.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
