### PR TITLE
irssi: add option for SASL external authentication

### DIFF
--- a/modules/programs/irssi.nix
+++ b/modules/programs/irssi.nix
@@ -23,6 +23,11 @@ let
         type = "${v.type}";
         nick = "${quoteStr v.nick}";
         autosendcmd = "${concatMapStringsSep ";" quoteStr v.autoCommands}";
+        ${
+          lib.optionalString (v.saslExternal) ''
+            sasl_username = "${quoteStr v.nick}";
+              sasl_mechanism = "EXTERNAL";''
+        }
       };
     ''));
 
@@ -36,7 +41,7 @@ let
         ssl_verify = "${lib.hm.booleans.yesNo v.server.ssl.verify}";
         autoconnect = "${lib.hm.booleans.yesNo v.server.autoConnect}";
         ${
-          lib.optionalString (v.server.ssl.certificateFile != null) ''
+          optionalString (v.server.ssl.certificateFile != null) ''
             ssl_cert = "${v.server.ssl.certificateFile}";
           ''
         }
@@ -141,6 +146,15 @@ let
         description = "Channels for the given network.";
         type = types.attrsOf channelType;
         default = { };
+      };
+
+      saslExternal = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable SASL external authentication. This requires setting a path in
+          <xref linkend="opt-programs.irssi.networks._name_.server.ssl.certificateFile"/>.
+        '';
       };
     };
   });

--- a/tests/modules/programs/irssi/example-settings-expected.config
+++ b/tests/modules/programs/irssi/example-settings-expected.config
@@ -13,6 +13,8 @@ oftc = {
   type = "IRC";
   nick = "nick";
   autosendcmd = "";
+  sasl_username = "nick";
+  sasl_mechanism = "EXTERNAL";
 };
 
 };

--- a/tests/modules/programs/irssi/example-settings.nix
+++ b/tests/modules/programs/irssi/example-settings.nix
@@ -8,6 +8,7 @@ with lib;
       enable = true;
       networks.oftc = {
         nick = "nick";
+        saslExternal = true;
         server = {
           address = "irc.oftc.net";
           port = 6697;


### PR DESCRIPTION
### Description

Add option `programs.irssi.networks.<name>.saslExternal`. When enabled, this sets `sasl_username` for the network to the same value as `programs.irssi.networks.<name>.nick`, and sets `sasl_mechanism` to `EXTERNAL` (this means irssi will authenticate using SASL + certFP, the latter being configured with `programs.irssi.networks.<name>.server.ssl.certificateFile`).

An alternative would be to add three separate options for setting `sasl_username`, `sasl_password` and `sasl_mechanism` (which can be `PLAIN` to use `sasl_password`, or` EXTERNAL` to use certFP), but the approach I have taken avoids duplicating the nick/username, and prevents people from putting passwords in their config.

SASL + certFP is quite popular now, and LiberaChat restricts connecting without using SASL (i.e. depending on your IP, you can only connect this way), so I think this would be a very useful addition, instead of needing to add an entry for each network to extraConfig.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

