### PR TITLE
i3blocks: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -145,6 +145,8 @@ Makefile                                              @thiagokokada
 /modules/programs/hyfetch.nix                         @lilyinstarlight
 /tests/modules/programs/hyfetch                       @lilyinstarlight
 
+/modules/programs/i3blocks.nix                        @VAWVAW
+
 /modules/programs/i3status.nix                        @JustinLovinger
 
 /modules/programs/i3status-rust.nix                   @workflow

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -329,4 +329,10 @@
     github = "lukasngl";
     githubId = 69244516;
   };
+  vawvaw = {
+    name = "VAWVAW";
+    email = "94846592+VAWVAW@users.noreply.github.com";
+    github = "VAWVAW";
+    githubId = 94846592;
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -93,6 +93,7 @@ let
     ./programs/hyfetch.nix
     ./programs/i3status-rust.nix
     ./programs/i3status.nix
+    ./programs/i3blocks.nix
     ./programs/info.nix
     ./programs/ion.nix
     ./programs/irssi.nix

--- a/modules/programs/i3blocks.nix
+++ b/modules/programs/i3blocks.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.i3blocks;
+
+  mapAttrsToList = f: attrs: map (name: f name attrs.${name}) (attrNames attrs);
+
+  formatSet = s:
+    let formatArg = name: value: "${name}=${toString value}";
+    in mapAttrsToList formatArg s;
+  formatBlocks = blocks:
+    let formatBlock = name: value: [ "[${name}]" ] ++ (formatSet value);
+    in builtins.concatLists (mapAttrsToList formatBlock blocks);
+
+in {
+  meta.maintainers = [ hm.maintainers.vawvaw ];
+
+  options.programs.i3blocks = {
+    enable = mkEnableOption "i3blocks";
+
+    globalVars = mkOption {
+      type = with types; attrsOf (oneOf [ str number ]);
+      default = { };
+      description = ''
+        Variables to set globally at the beginning of the
+        <filename>config</filename> file.
+        See <link xlink:href="https://github.com/vivien/i3blocks#blocks" />
+      '';
+      example = literalExpression ''
+        SCRIPT_DIR = "$HOME/i3blocks";
+      '';
+    };
+
+    blocks = mkOption {
+      type = types.attrsOf (with types; attrsOf (oneOf [ str number ]));
+      default = { };
+      description = ''
+        Blocks to add to i3blocks <filename>config</filename> file. See
+        <link xlink:href="https://github.com/vivien/i3blocks#i3blocks-properties" />
+        for options.
+      '';
+      example = literalExpression ''
+        {
+          time = {
+            command = "date '+%d.%m.%4Y %T'";
+            interval = 5;
+          };
+        }
+      '';
+    };
+
+    package = mkPackageOption pkgs "i3blocks" { };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."i3blocks/config".text = concatStringsSep "\n"
+      ((formatSet cfg.globalVars) ++ (formatBlocks cfg.blocks));
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -78,6 +78,7 @@ import nmt {
     ./modules/programs/himalaya
     ./modules/programs/htop
     ./modules/programs/hyfetch
+    ./modules/programs/i3blocks
     ./modules/programs/i3status
     ./modules/programs/irssi
     ./modules/programs/k9s

--- a/tests/modules/programs/i3blocks/default.nix
+++ b/tests/modules/programs/i3blocks/default.nix
@@ -1,0 +1,1 @@
+{ i3blocks-with-custom = ./with-custom.nix; }

--- a/tests/modules/programs/i3blocks/with-custom.nix
+++ b/tests/modules/programs/i3blocks/with-custom.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.i3blocks = {
+      enable = true;
+      globalVars = {
+        a = "foo";
+        zz = "bar";
+      };
+      blocks = {
+        time = {
+          command = "date '+%d.%m.%4Y %T'";
+          interval = 2;
+          value1 = 2.5;
+        };
+        asdf = { command = "fdsa"; };
+      };
+    };
+
+    test.stubs.i3blocks = { };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/i3blocks/config
+      assertFileContent home-files/.config/i3blocks/config \
+        ${
+          pkgs.writeText "i3blocks-expected-config" ''
+            a=foo
+            zz=bar
+            [asdf]
+            command=fdsa
+            [time]
+            command=date '+%d.%m.%4Y %T'
+            interval=2
+            value1=2.500000''
+        }'';
+  };
+}


### PR DESCRIPTION
### Description

Adds a module for [i3blocks](https://github.com/vivien/i3blocks) a modular status command for bars.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
