### PR TITLE
fix #2848: delete home-path before re-adding on modern nix profiles

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -581,7 +581,6 @@ in
           if [[ -e "$nixProfilePath"/manifest.json ]] ; then
             nix profile list \
               | { grep 'home-manager-path$' || test $? = 1; } \
-              | awk -F ' ' '{ print $4 }' \
               | cut -d ' ' -f 4 \
               | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
           else
@@ -593,11 +592,10 @@ in
       else
         ''
           function nixReplaceProfile() {
-            local oldNix="$(which nix)"
+            local oldNix="$(command -v nix)"
 
             nix profile list \
               | { grep 'home-manager-path$' || test $? = 1; } \
-              | awk -F ' ' '{ print $4 }' \
               | cut -d ' ' -f 4 \
               | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
 

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -592,22 +592,37 @@ in
         ''
       else
         ''
+          function nixReplaceProfile() {
+            local oldNix="$(which nix)"
+
+            nix profile list \
+              | { grep 'home-manager-path$' || test $? = 1; } \
+              | awk -F ' ' '{ print $4 }' \
+              | cut -d ' ' -f 4 \
+              | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
+
+            $DRY_RUN_CMD $oldNix profile install $1
+          }
+
           if [[ -e "$nixProfilePath"/manifest.json ]] ; then
             INSTALL_CMD="nix profile install"
+            INSTALL_CMD_ACTUAL="nixReplaceProfile"
             LIST_CMD="nix profile list"
             REMOVE_CMD_SYNTAX='nix profile remove {number | store path}'
           else
             INSTALL_CMD="nix-env -i"
+            INSTALL_CMD_ACTUAL="$DRY_RUN_CMD nix-env -i"
             LIST_CMD="nix-env -q"
             REMOVE_CMD_SYNTAX='nix-env -e {package name}'
           fi
 
-          if ! $DRY_RUN_CMD $INSTALL_CMD ${cfg.path} ; then
+          if ! $INSTALL_CMD_ACTUAL ${cfg.path} ; then
             echo
             _iError $'Oops, Nix failed to install your new Home Manager profile!\n\nPerhaps there is a conflict with a package that was installed using\n"%s"? Try running\n\n    %s\n\nand if there is a conflicting package you can remove it with\n\n    %s\n\nThen try activating your Home Manager configuration again.' "$INSTALL_CMD" "$LIST_CMD" "$REMOVE_CMD_SYNTAX"
             exit 1
           fi
-          unset INSTALL_CMD LIST_CMD REMOVE_CMD_SYNTAX
+          unset -f nixReplaceProfile
+          unset INSTALL_CMD INSTALL_CMD_ACTUAL LIST_CMD REMOVE_CMD_SYNTAX
         ''
     );
 


### PR DESCRIPTION
this is a hackish workaround for https://github.com/NixOS/nix/issues/6349
(nix profile does not yet have a equivalent for nix-env --set)

supersedes: https://github.com/nix-community/home-manager/pull/3210 (a bit stalled)
