### PR TITLE
Backport hm-version generation

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -676,41 +676,6 @@ in
 
           ${activationCmds}
         '';
-
-        getVersion = pkgs.writeShellScript "get-hm-version" ''
-          set -euo pipefail
-
-          dir="${../.}"
-
-          # Apparently, dir is not always set to the Home Manager directory.
-          if [[ ! -d $dir ]]; then
-            echo ""
-            exit 0
-          fi
-
-          cd "$dir" || exit 1
-
-          # Get the base release and initialize an empty version suffix.
-          release=$(< .release)
-          suffix=""
-
-          # If we are in a Git repo then update the suffix to be
-          #
-          #   .git.HASH
-          #
-          # where HASH are the first 8 characters of the commit hash.
-          if [[ -f .git/HEAD ]]; then
-            ref=$(sed '/ref:/ { s/.* //; }' .git/HEAD)
-            if [[ -f ".git/$ref" ]]; then
-              hash=$(< ".git/$ref")
-              if [[ -n "$hash" ]]; then
-                suffix=".git.''${hash:0:8}"
-              fi
-            fi
-          fi
-
-          echo "$release$suffix"
-        '';
       in
         pkgs.runCommand
           "home-manager-generation"
@@ -720,7 +685,7 @@ in
           ''
             mkdir -p $out
 
-            ${getVersion} > $out/hm-version
+            echo "${config.home.version.full}" > $out/hm-version
 
             cp ${activationScript} $out/activate
 

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -676,6 +676,33 @@ in
 
           ${activationCmds}
         '';
+
+        getVersion = pkgs.writeShellScript "get-hm-version" ''
+          set -euo pipefail
+
+          cd "${../.}" || exit 1
+
+          # Get the base release and initialize an empty version suffix.
+          release=$(< .release)
+          suffix=""
+
+          # If we are in a Git repo then update the suffix to be
+          #
+          #   .git.HASH
+          #
+          # where HASH are the first 8 characters of the commit hash.
+          if [[ -f .git/HEAD ]]; then
+            ref=$(sed '/ref:/ { s/.* //; }' .git/HEAD)
+            if [[ -f ".git/$ref" ]]; then
+              hash=$(< ".git/$ref")
+              if [[ -n "$hash" ]]; then
+                suffix=".git.''${hash:0:8}"
+              fi
+            fi
+          fi
+
+          echo "$release$suffix"
+        '';
       in
         pkgs.runCommand
           "home-manager-generation"
@@ -684,6 +711,8 @@ in
           }
           ''
             mkdir -p $out
+
+            ${getVersion} > $out/hm-version
 
             cp ${activationScript} $out/activate
 

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -680,7 +680,15 @@ in
         getVersion = pkgs.writeShellScript "get-hm-version" ''
           set -euo pipefail
 
-          cd "${../.}" || exit 1
+          dir="${../.}"
+
+          # Apparently, dir is not always set to the Home Manager directory.
+          if [[ ! -d $dir ]]; then
+            echo ""
+            exit 0
+          fi
+
+          cd "$dir" || exit 1
 
           # Get the base release and initialize an empty version suffix.
           release=$(< .release)

--- a/modules/misc/version.nix
+++ b/modules/misc/version.nix
@@ -30,5 +30,39 @@ with lib;
         conversion or moving files.
       '';
     };
+
+    home.version = {
+      full = mkOption {
+        internal = true;
+        readOnly = true;
+        type = types.str;
+        default = let
+          inherit (config.home.version) release revision;
+          suffix =
+            optionalString (revision != null) "+${substring 0 8 revision}";
+        in "${release}${suffix}";
+        example = "22.05+213a0629";
+        description = "The full Home Manager version.";
+      };
+
+      release = mkOption {
+        internal = true;
+        readOnly = true;
+        type = types.str;
+        default = fileContents ../../.release;
+        example = "22.05";
+        description = "The Home Manager release.";
+      };
+
+      revision = mkOption {
+        internal = true;
+        type = types.nullOr types.str;
+        default = let gitRepo = "${toString ./../..}/.git";
+        in if pathIsGitRepo gitRepo then commitIdFromGitRepo gitRepo else null;
+        description = ''
+          The Git revision from which this Home Manager configuration was built.
+        '';
+      };
+    };
   };
 }


### PR DESCRIPTION
### Description

Generate hm-version file in HM 22.05.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```