### PR TITLE
cachix-agent: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -861,6 +861,14 @@ in
           A new module is available: 'services.megasync'.
         '';
       }
+
+      {
+        time = "2022-12-25T08:41:32+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.cachix-agent'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -204,6 +204,7 @@ let
     ./services/betterlockscreen.nix
     ./services/blueman-applet.nix
     ./services/borgmatic.nix
+    ./services/cachix-agent.nix
     ./services/caffeine.nix
     ./services/cbatticon.nix
     ./services/clipmenu.nix

--- a/modules/services/cachix-agent.nix
+++ b/modules/services/cachix-agent.nix
@@ -1,0 +1,84 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.cachix-agent;
+
+in {
+  meta.maintainers = [ maintainers.rycee ];
+
+  options.services.cachix-agent = {
+    enable = mkEnableOption ''
+      Cachix Deploy Agent: <link xlink:href="https://docs.cachix.org/deploy/"/>'';
+
+    name = mkOption {
+      type = types.str;
+      description = "The unique agent name.";
+    };
+
+    verbose = mkEnableOption "verbose output";
+
+    profile = mkOption {
+      type = types.str;
+      default = "home-manager";
+      description = ''
+        The Nix profile name.
+      '';
+    };
+
+    host = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Cachix URI to use.";
+    };
+
+    package = mkPackageOption pkgs "cachix" { };
+
+    credentialsFile = mkOption {
+      type = types.path;
+      default = "${config.xdg.configHome}/cachix-agent.token";
+      defaultText =
+        literalExpression ''"''${config.xdg.configHome}/cachix-agent.token"'';
+      description = ''
+        Required file that needs to contain
+        <literal>CACHIX_AGENT_TOKEN=...</literal>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.cachix-agent" pkgs
+        lib.platforms.linux)
+    ];
+
+    systemd.user.services.cachix-agent = {
+      Unit.Description = "Cachix Deploy Agent";
+
+      Service = {
+        Environment = [
+          "PATH=${
+            if config.nix.enable && config.nix.package != null then
+              config.nix.package
+            else
+              pkgs.nix
+          }/bin"
+        ];
+        EnvironmentFile = cfg.credentialsFile;
+
+        # We don't want to kill children processes as those are deployments.
+        KillMode = "process";
+        Restart = "on-failure";
+        ExecStart = escapeShellArgs ([ "${cfg.package}/bin/cachix" ]
+          ++ optional cfg.verbose "--verbose"
+          ++ optional (cfg.host != null) "--host ${cfg.host}"
+          ++ [ "deploy" "agent" cfg.name ]
+          ++ optional (cfg.profile != null) cfg.profile);
+      };
+
+      Install.WantedBy = [ "default.target" ];
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -166,6 +166,7 @@ import nmt {
     ./modules/programs/yt-dlp
     ./modules/services/barrier
     ./modules/services/borgmatic
+    ./modules/services/cachix-agent
     ./modules/services/devilspie2
     ./modules/services/dropbox
     ./modules/services/emacs

--- a/tests/modules/services/cachix-agent/basic-setup.nix
+++ b/tests/modules/services/cachix-agent/basic-setup.nix
@@ -1,0 +1,32 @@
+{ config, ... }:
+
+{
+  services.cachix-agent = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@cachix-agent@"; };
+    name = "test-agent";
+  };
+
+  test.stubs.nix = { };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/systemd/user/cachix-agent.service \
+      ${
+        builtins.toFile "cachix-agent.service" ''
+          [Install]
+          WantedBy=default.target
+
+          [Service]
+          Environment=PATH=@nix@/bin
+          EnvironmentFile=/home/hm-user/.config/cachix-agent.token
+          ExecStart='@cachix-agent@/bin/cachix' 'deploy' 'agent' 'test-agent' 'home-manager'
+          KillMode=process
+          Restart=on-failure
+
+          [Unit]
+          Description=Cachix Deploy Agent
+        ''
+      }
+  '';
+}

--- a/tests/modules/services/cachix-agent/default.nix
+++ b/tests/modules/services/cachix-agent/default.nix
@@ -1,0 +1,1 @@
+{ cachix = ./basic-setup.nix; }


### PR DESCRIPTION
### Description

Add support for running a Cachix Deploy Agent as a user service.

CC @domenkozar

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```