### PR TITLE
home-environment: reset PATH in activation script

### DIFF
--- a/docs/release-notes/rl-2211.adoc
+++ b/docs/release-notes/rl-2211.adoc
@@ -97,3 +97,17 @@ These changes are only active if the `home.stateVersion` option is set to "22.11
 value of <<opt-xdg.userDirs.music>> if <<opt-xdg.userDirs.enable>> is
 enabled. Otherwise it is undefined and must be specified in the user
 configuration.
+
+* The activation script now resets `PATH` before running. Before, the
+user's `PATH` environment variable would be used in the script and
+this made it possible for commands in the activation script to run
+arbitrary commands accessible to the user. We now restrict the
+activation script to commands that are explicitly specified.
++
+There is no official way to restore the old behavior. We attempt to
+make the activation script as reproducible as possible and honoring
+the user's `PATH` reduces reproducibility.
++
+If you need to run a command in an activation script block then refer
+to the command by its absolute command path, such as
+`${pkgs.hello}/bin/hello`.

--- a/modules/programs/mu.nix
+++ b/modules/programs/mu.nix
@@ -52,7 +52,7 @@ in {
       # In theory, mu is the only thing that creates that directory, and it is
       # only created during the initial index.
       if [[ ! -d "${dbLocation}" ]]; then
-        $DRY_RUN_CMD mu init ${maildirOption} ${myAddresses} $VERBOSE_ARG;
+        $DRY_RUN_CMD ${pkgs.mu}/bin/mu init ${maildirOption} ${myAddresses} $VERBOSE_ARG;
       fi
     '';
   };

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -107,7 +107,7 @@ in {
     systemd.user = {
       systemctlPath = mkOption {
         default = "${pkgs.systemd}/bin/systemctl";
-        defaultText = "\${pkgs.systemd}/bin/systemctl";
+        defaultText = literalExpression ''"''${pkgs.systemd}/bin/systemctl"'';
         type = types.str;
         description = ''
           Absolute path to the <command>systemctl</command> tool. This

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -35,7 +35,7 @@ let
 
           # Make activation script use same version of Nix as system as a whole.
           # This avoids problems with Nix not being in PATH.
-          home.extraActivationPath = [ config.nix.package ];
+          nix.package = config.nix.package;
         };
       })
     ] ++ cfg.sharedModules;

--- a/tests/modules/programs/mu/basic-configuration.nix
+++ b/tests/modules/programs/mu/basic-configuration.nix
@@ -19,6 +19,6 @@
       'if [[ ! -d "/home/hm-user/.cache/mu" ]]; then'
 
     assertFileContains activate \
-      '$DRY_RUN_CMD mu init --maildir=/home/hm-user/Mail --my-address=hm@example.com --my-address=foo@example.com $VERBOSE_ARG;'
+      '$DRY_RUN_CMD @mu@/bin/mu init --maildir=/home/hm-user/Mail --my-address=hm@example.com --my-address=foo@example.com $VERBOSE_ARG;'
   '';
 }


### PR DESCRIPTION
### Description

Starting with state version 22.11 we completely reset the PATH variable in the activation script. This is to avoid impurities and unexpected results if the activation script accidentally uses a command found in the user's PATH.

### Checklist

- [x] Change is backwards compatible. _Should be backwards compatible due to the state version guard_

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```