### PR TITLE
polybar: don't generate config if no options are set

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -263,6 +263,9 @@ Makefile                                              @thiagokokada
 /modules/programs/pls.nix                             @arjan-s
 /tests/modules/programs/pls                           @arjan-s
 
+/modules/programs/polybar.nix                         @h7x4
+/tests/modules/programs/polybar                       @h7x4
+
 /modules/programs/powerline-go.nix                    @DamienCassou
 
 /modules/programs/pubs.nix                            @loicreynier

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -199,6 +199,8 @@ in {
         lib.platforms.linux)
     ];
 
+    meta.maintainers = with maintainers; [ h7x4 ];
+
     home.packages = [ cfg.package ];
     xdg.configFile."polybar/config.ini" = let
       isDeclarativeConfig = cfg.settings != opt.settings.default || cfg.config

--- a/tests/modules/services/polybar/basic-configuration.nix
+++ b/tests/modules/services/polybar/basic-configuration.nix
@@ -47,7 +47,7 @@
       serviceFile=home-files/.config/systemd/user/polybar.service
 
       assertFileExists $serviceFile
-      assertFileRegex $serviceFile 'X-Restart-Triggers=.*polybar\.conf'
+      assertFileRegex $serviceFile 'X-Restart-Triggers=.*/.config/polybar/config.ini'
       assertFileRegex $serviceFile 'ExecStart=.*/bin/polybar-start'
 
       assertFileExists home-files/.config/polybar/config.ini

--- a/tests/modules/services/polybar/default.nix
+++ b/tests/modules/services/polybar/default.nix
@@ -1,1 +1,4 @@
-{ polybar-basic-configuration = ./basic-configuration.nix; }
+{
+  polybar-basic-configuration = ./basic-configuration.nix;
+  polybar-empty-configuration = ./empty-configuration.nix;
+}

--- a/tests/modules/services/polybar/empty-configuration.nix
+++ b/tests/modules/services/polybar/empty-configuration.nix
@@ -1,0 +1,21 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.polybar = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { };
+      script = "polybar bar &";
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/polybar.service
+
+      assertFileExists $serviceFile
+      assertFileRegex $serviceFile 'X-Restart-Triggers=.*/.config/polybar/config.ini'
+      assertFileRegex $serviceFile 'ExecStart=.*/bin/polybar-start'
+
+      assertPathNotExists home-files/.config/polybar/config.ini
+    '';
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

The polybar module will no longer assume you want a declarative config unless you have configured either `services.polybar.settings`, `services.polybar.config` or `services.polybar.extraConfig`. This closes #3326

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~If this PR adds a new module~

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
