### PR TITLE
darwin: use full path to commands in activation script

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -162,12 +162,12 @@ in {
               fi
               if [[ -f "$dstPath" ]]; then
                 for (( i = 0; i < bootout_retries; i++ )); do
-                  $DRY_RUN_CMD launchctl bootout "$domain/$agentName" || err=$?
+                  $DRY_RUN_CMD /bin/launchctl bootout "$domain/$agentName" || err=$?
                   if [[ -v DRY_RUN ]]; then
                     break
                   fi
                   if (( err != 9216 )) &&
-                    ! launchctl print "$domain/$agentName" &> /dev/null; then
+                    ! /bin/launchctl print "$domain/$agentName" &> /dev/null; then
                     break
                   fi
                   sleep 1
@@ -178,7 +178,7 @@ in {
                 fi
               fi
               $DRY_RUN_CMD install -Dm444 -T "$srcPath" "$dstPath"
-              $DRY_RUN_CMD launchctl bootstrap "$domain" "$dstPath"
+              $DRY_RUN_CMD /bin/launchctl bootstrap "$domain" "$dstPath"
             done
 
             if [[ ! -e "$oldDir" ]]; then
@@ -194,7 +194,7 @@ in {
                 continue
               fi
 
-              $DRY_RUN_CMD launchctl bootout "$domain/$agentName" || :
+              $DRY_RUN_CMD /bin/launchctl bootout "$domain/$agentName" || :
               if [[ ! -e "$dstPath" ]]; then
                 continue
               fi

--- a/modules/targets/darwin/user-defaults/default.nix
+++ b/modules/targets/darwin/user-defaults/default.nix
@@ -13,9 +13,9 @@ let
       cliFlags = lib.optionalString isLocal "-currentHost";
 
       toActivationCmd = domain: attrs:
-        "$DRY_RUN_CMD defaults ${cliFlags} import ${escapeShellArg domain} ${
-          toDefaultsFile domain attrs
-        }";
+        "$DRY_RUN_CMD /usr/bin/defaults ${cliFlags} import ${
+          escapeShellArg domain
+        } ${toDefaultsFile domain attrs}";
 
       nonNullDefaults =
         mapAttrs (domain: attrs: (filterAttrs (n: v: v != null) attrs))

--- a/tests/modules/targets-darwin/user-defaults.nix
+++ b/tests/modules/targets-darwin/user-defaults.nix
@@ -10,9 +10,9 @@
 
     nmt.script = ''
       assertFileRegex activate \
-        "defaults  import 'com.apple.desktopservices' /nix/store/[a-z0-9]\\{32\\}-com\\.apple\\.desktopservices\\.plist"
+        "/usr/bin/defaults  import 'com.apple.desktopservices' /nix/store/[a-z0-9]\\{32\\}-com\\.apple\\.desktopservices\\.plist"
       assertFileRegex activate \
-        "defaults -currentHost import 'com.apple.controlcenter' /nix/store/[a-z0-9]\\{32\\}-com\\.apple\\.controlcenter\\.plist"
+        "/usr/bin/defaults -currentHost import 'com.apple.controlcenter' /nix/store/[a-z0-9]\\{32\\}-com\\.apple\\.controlcenter\\.plist"
     '';
   };
 }


### PR DESCRIPTION
### Description

Addresses https://github.com/nix-community/home-manager/pull/3381#issuecomment-1302716716.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
