### PR TITLE
release 21.05 backport gen linux fix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,6 +84,8 @@
 
 /modules/programs/i3status-rust.nix                   @workflow
 
+/modules/programs/java.nix                            @ShamrockLee
+
 /modules/programs/keychain.nix                        @marsam
 
 /modules/programs/lazygit.nix                         @kalhauge

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 
-Please check if there already exists a relevant issue before creating
-a new one.
+Don't forget to check if there already exists a relevant issue before
+creating a new one.
 
 -->
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,15 +1,7 @@
 <!--
 
-If you are encountering the error
-
-  element xref: validity error : IDREF attribute linkend references an unknown ID "opt-home.file._name__.source"
-
-then it means that you are using an old version of Home Manager, such
-as the release-20.03 branch, with a recent version of Nixpkgs, such as
-version 20.09 or master. See https://git.io/JTb6K for more.
-
-In general, please check if there already exists a relevant issue
-before creating a new one.
+Please check if there already exists a relevant issue before creating
+a new one.
 
 -->
 
@@ -17,7 +9,8 @@ before creating a new one.
 
 <!--
 Please describe the issue. For support and help please use the IRC
-channel #home-manager @ freenode.net instead.
+channel #home-manager at irc.oftc.net or Matrix room
+https://matrix.to/#/#hm:rycee.net instead.
 -->
 
 ### Meta

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v13
+    - uses: cachix/install-nix-action@v14
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v10

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v14
+    - uses: cachix/install-nix-action@v15
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v10

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v15
+    - uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v16
       with:
         install_url: https://releases.nixos.org/nix/nix-2.3.16/install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v14.1
       with:
+        install_url: https://releases.nixos.org/nix/nix-2.3.16/install
         nix_path: nixpkgs=channel:nixos-21.05
     - uses: cachix/cachix-action@v10
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v15
+    - uses: cachix/install-nix-action@v16
       with:
         install_url: https://releases.nixos.org/nix/nix-2.3.16/install
         nix_path: nixpkgs=channel:nixos-21.05

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v14
+    - uses: cachix/install-nix-action@v14.1
       with:
         nix_path: nixpkgs=channel:nixos-21.05
     - uses: cachix/cachix-action@v10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v13
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
+        nix_path: nixpkgs=channel:nixos-21.05
     - uses: cachix/cachix-action@v10
       with:
         name: nix-community

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v14.1
+    - uses: cachix/install-nix-action@v15
       with:
         install_url: https://releases.nixos.org/nix/nix-2.3.16/install
         nix_path: nixpkgs=channel:nixos-21.05

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v13
+    - uses: cachix/install-nix-action@v14
       with:
         nix_path: nixpkgs=channel:nixos-21.05
     - uses: cachix/cachix-action@v10

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ will write to your dconf store and cannot tell whether a configuration
 that it is about to be overwritten was from a previous Home Manager
 generation or from manual configuration.
 
-Home Manager targets [NixOS][] unstable and NixOS version 20.09 (the
+Home Manager targets [NixOS][] unstable and NixOS version 21.05 (the
 current stable version), it may or may not work on other Linux
 distributions and NixOS versions.
 
@@ -75,10 +75,10 @@ Currently the easiest way to install Home Manager is as follows:
     $ nix-channel --update
     ```
 
-    and if you follow a Nixpkgs version 20.09 channel you can run
+    and if you follow a Nixpkgs version 21.05 channel you can run
 
     ```console
-    $ nix-channel --add https://github.com/nix-community/home-manager/archive/release-20.09.tar.gz home-manager
+    $ nix-channel --add https://github.com/nix-community/home-manager/archive/release-21.05.tar.gz home-manager
     $ nix-channel --update
     ```
 
@@ -366,7 +366,7 @@ Home Manager is developed against `nixpkgs-unstable` branch, which
 often causes it to contain tweaks for changes/packages not yet
 released in stable NixOS. To avoid breaking users' configurations,
 Home Manager is released in branches corresponding to NixOS releases
-(e.g. `release-20.09`). These branches get fixes, but usually not new
+(e.g. `release-21.05`). These branches get fixes, but usually not new
 modules. If you need a module to be backported, then feel free to open
 an issue.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ configuration generations.
 As an example, let us expand the initial configuration file from the
 installation above to install the htop and fortune packages, install
 Emacs with a few extra packages enabled, install Firefox with
-smooth scrolling enabled, and enable the user gpg-agent service.
+smooth scrolling disabled, and enable the user gpg-agent service.
 
 To satisfy the above setup we should elaborate the
 `~/.config/nixpkgs/home.nix` file as follows:
@@ -279,7 +279,7 @@ then result in
 $ home-manager switch
 …
 Activating checkLinkTargets
-Existing file '/home/jdoe/.gitconfig' is in the way
+Existing file '/home/jdoe/.config/git/config' is in the way
 Please move the above files and try again
 ```
 

--- a/doc/faq.adoc
+++ b/doc/faq.adoc
@@ -92,7 +92,7 @@ error: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name ca.desrt.
 The solution on NixOS is to add
 
 [source,nix]
-services.dbus.packages = with pkgs; [ gnome3.dconf ];
+services.dbus.packages = with pkgs; [ gnome.dconf ];
 
 to your system configuration.
 

--- a/doc/installation.adoc
+++ b/doc/installation.adoc
@@ -47,11 +47,11 @@ $ nix-channel --add https://github.com/nix-community/home-manager/archive/master
 $ nix-channel --update
 ----
 +
-and if you follow a Nixpkgs version 20.09 channel, you can run
+and if you follow a Nixpkgs version 21.05 channel, you can run
 +
 [source,console]
 ----
-$ nix-channel --add https://github.com/nix-community/home-manager/archive/release-20.09.tar.gz home-manager
+$ nix-channel --add https://github.com/nix-community/home-manager/archive/release-21.05.tar.gz home-manager
 $ nix-channel --update
 ----
 +
@@ -125,11 +125,11 @@ or an unstable channel, you can run
 # nix-channel --update
 ----
 
-and if you follow a Nixpkgs version 20.09 channel, you can run
+and if you follow a Nixpkgs version 21.05 channel, you can run
 
 [source,console]
 ----
-# nix-channel --add https://github.com/nix-community/home-manager/archive/release-20.09.tar.gz home-manager
+# nix-channel --add https://github.com/nix-community/home-manager/archive/release-21.05.tar.gz home-manager
 # nix-channel --update
 ----
 
@@ -203,11 +203,11 @@ or an unstable channel, you can run
 # nix-channel --update
 ----
 
-and if you follow a Nixpkgs version 20.09 channel, you can run
+and if you follow a Nixpkgs version 21.05 channel, you can run
 
 [source,console]
 ----
-# nix-channel --add https://github.com/nix-community/home-manager/archive/release-20.09.tar.gz home-manager
+# nix-channel --add https://github.com/nix-community/home-manager/archive/release-21.05.tar.gz home-manager
 # nix-channel --update
 ----
 

--- a/doc/man-home-manager.xml
+++ b/doc/man-home-manager.xml
@@ -12,47 +12,47 @@
  </refnamediv>
  <refsynopsisdiv>
   <cmdsynopsis>
-   <command>home-manager</command> <group choice="req"> 
+   <command>home-manager</command> <group choice="req">
    <arg choice="plain">
     build
    </arg>
-    
+
    <arg choice="plain">
     instantiate
    </arg>
-    
+
    <arg choice="plain">
     edit
    </arg>
-    
+
    <arg choice="plain">
     expire-generations <replaceable>timestamp</replaceable>
    </arg>
-    
+
    <arg choice="plain">
     generations
    </arg>
-    
+
    <arg choice="plain">
     help
    </arg>
-    
+
    <arg choice="plain">
     news
    </arg>
-    
+
    <arg choice="plain">
     packages
    </arg>
-    
+
    <arg choice="plain">
     remove-generations <replaceable>ID …</replaceable>
    </arg>
-    
+
    <arg choice="plain">
     switch
    </arg>
-    
+
    <arg choice="plain">
     uninstall
    </arg>
@@ -61,63 +61,63 @@
    <arg>
     -A <replaceable>attrPath</replaceable>
    </arg>
-    
+
    <arg>
     -I <replaceable>path</replaceable>
    </arg>
-    
+
    <arg>
     --flake <replaceable>flake-uri</replaceable>
    </arg>
-    
+
    <arg>
     -b <replaceable>ext</replaceable>
    </arg>
-    
+
    <arg>
-    <group choice="req"> 
+    <group choice="req">
     <arg choice="plain">
      -f
     </arg>
-     
+
     <arg choice="plain">
      --file
     </arg>
      </group> <replaceable>path</replaceable>
    </arg>
-    
+
    <arg>
-    <group choice="req"> 
+    <group choice="req">
     <arg choice="plain">
      -h
     </arg>
-     
+
     <arg choice="plain">
      --help
     </arg>
      </group>
    </arg>
-    
+
    <arg>
-    <group choice="req"> 
+    <group choice="req">
     <arg choice="plain">
      -n
     </arg>
-     
+
     <arg choice="plain">
      --dry-run
     </arg>
      </group>
    </arg>
-    
+
    <arg>
     --option <replaceable>name</replaceable> <replaceable>value</replaceable>
    </arg>
-    
+
    <arg>
     --cores <replaceable>number</replaceable>
    </arg>
-    
+
    <arg>
      <group choice="req">
        <arg choice="plain">
@@ -130,29 +130,33 @@
      </group>
      <replaceable>number</replaceable>
    </arg>
-    
+
+   <arg>
+    --debug
+   </arg>
+
    <arg>
     --keep-failed
    </arg>
-    
+
    <arg>
     --keep-going
    </arg>
-    
+
    <arg>
     --show-trace
    </arg>
-    
+
    <arg>
     --(no-)substitute
    </arg>
-    
+
    <arg>
-    <group choice="req"> 
+    <group choice="req">
     <arg choice="plain">
      -v
     </arg>
-     
+
     <arg choice="plain">
      --verbose
     </arg>
@@ -447,6 +451,18 @@
     </term>
     <term>
      <option>--max-jobs <replaceable>number</replaceable></option>
+    </term>
+    <listitem>
+     <para>
+      Passed on to <citerefentry>
+      <refentrytitle>nix-build</refentrytitle>
+      <manvolnum>1</manvolnum> </citerefentry>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>--debug</option>
     </term>
     <listitem>
      <para>

--- a/doc/release-notes/rl-2105.adoc
+++ b/doc/release-notes/rl-2105.adoc
@@ -1,8 +1,7 @@
 [[sec-release-21.05]]
 == Release 21.05
 
-This is the current unstable branch and the information in this
-section is therefore not final.
+The 21.05 release branch became the stable branch in May, 2021.
 
 [[sec-release-21.05-highlights]]
 === Highlights

--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -285,8 +285,8 @@ _home-manager_completions ()
     #--------------------------#
 
     local Options
-    Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" "--verbose" "--show-trace" \
-              "-j" "--max-jobs" )
+    Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" "--verbose" \
+              "--cores" "--debug" "--keep-failed" "--keep-going" "-j" "--max-jobs" "--no-substitute" "--show-trace" "--substitute")
 
     # ^ « home-manager »'s options.
 

--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -7,6 +7,7 @@ _arguments \
   '-I[search path]:PATH:_files -/' \
   '-b[backup files]:EXT:()' \
   '--cores[cores]:NUM:()' \
+  '--debug[debug]' \
   '--keep-failed[keep failed]' \
   '--keep-going[keep going]' \
   '(-h --help)'{--help,-h}'[help]' \
@@ -42,11 +43,14 @@ case "$state" in
       build|switch)
         _arguments \
           '--cores[cores]:NUM:()' \
+          '--debug[debug]' \
           '--keep-failed[keep failed]' \
           '--keep-going[keep going]' \
           '--max-jobs[max jobs]:NUM:()' \
+          '--no-substitute[no substitute]' \
           '--option[option]:NAME VALUE:()' \
-          '--show-trace[show trace]'
+          '--show-trace[show trace]' \
+          '--substitute[substitute]'
         ;;
     esac
 esac

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -473,6 +473,7 @@ function doHelp() {
     echo
     echo "  --arg(str) NAME VALUE    Override inputs passed to home-manager.nix"
     echo "  --cores NUM"
+    echo "  --debug"
     echo "  --keep-failed"
     echo "  --keep-going"
     echo "  -j, --max-jobs NUM"
@@ -572,7 +573,7 @@ while [[ $# -gt 0 ]]; do
             PASSTHROUGH_OPTS+=("$opt" "$1")
             shift
             ;;
-        --keep-failed|--keep-going|--show-trace\
+        --debug|--keep-failed|--keep-going|--show-trace\
             |--substitute|--no-substitute)
             PASSTHROUGH_OPTS+=("$opt")
             ;;

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -39,17 +39,6 @@ in
   };
 
   config = {
-    assertions = [(
-      let
-        conflicts = mapAttrsToList (n: v: n)
-          (filterAttrs (n: v: v.recursive && v.onChange != "") cfg);
-      in {
-        assertion = conflicts == [];
-        message = ''
-          Cannot use 'home.file.<name>.onChange' when 'home.file.<name>.recursive' is enabled:
-              ${concatStringsSep ", " conflicts}'';
-      })];
-
     lib.file.mkOutOfStoreSymlink = path:
       let
         pathStr = toString path;

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -82,6 +82,9 @@ with lib;
             generations. The script will be run
             <emphasis>after</emphasis> the new files have been linked
             into place.
+            </para><para>
+            Note, this option cannot be used when <literal>recursive</literal>
+            is enabled.
           '';
         };
 

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -83,8 +83,8 @@ with lib;
             <emphasis>after</emphasis> the new files have been linked
             into place.
             </para><para>
-            Note, this option cannot be used when <literal>recursive</literal>
-            is enabled.
+            Note, this code is always run when <literal>recursive</literal> is
+            enabled.
           '';
         };
 

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -33,7 +33,7 @@ let
       package = mkOption {
         type = types.nullOr types.package;
         default = null;
-        example = literalExample "pkgs.gnome3.gnome_themes_standard";
+        example = literalExample "pkgs.gnome.gnome_themes_standard";
         description = ''
           Package providing the theme. This package will be installed
           to your profile. If <literal>null</literal> then the theme

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2047,6 +2047,13 @@ in
           configuration file.
         '';
       }
+
+      {
+        time = "2021-10-03T20:00:52+00:00";
+        message = ''
+          A new module is available: 'programs.java'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -83,6 +83,7 @@ let
     (loadModule ./programs/info.nix { })
     (loadModule ./programs/irssi.nix { })
     (loadModule ./programs/lieer.nix { })
+    (loadModule ./programs/java.nix { })
     (loadModule ./programs/jq.nix { })
     (loadModule ./programs/kakoune.nix { })
     (loadModule ./programs/keychain.nix { })

--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -114,10 +114,12 @@ let
         brave = "BraveSoftware/Brave-Browser";
       };
 
+      linuxDirs = { brave = "BraveSoftware/Brave-Browser"; };
+
       configDir = if pkgs.stdenv.isDarwin then
-        "Library/Application Support/${getAttr browser darwinDirs}"
+        "Library/Application Support/" + (darwinDirs."${browser}" or browser)
       else
-        "${config.xdg.configHome}/${browser}";
+        "${config.xdg.configHome}/" + (linuxDirs."${browser}" or browser);
 
       extensionJson = ext:
         assert ext.crxPath != null -> ext.version != null;

--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -9,6 +9,14 @@ let
   tomlFormat = pkgs.formats.toml { };
 
 in {
+  imports = [
+    (mkRenamedOptionModule [
+      "programs"
+      "direnv"
+      "enableNixDirenvIntegration"
+    ] [ "programs" "direnv" "nix-direnv" "enable" ])
+  ];
+
   meta.maintainers = [ maintainers.rycee ];
 
   options.programs.direnv = {
@@ -63,10 +71,14 @@ in {
       '';
     };
 
-    enableNixDirenvIntegration = mkEnableOption ''
-      <link
-          xlink:href="https://github.com/nix-community/nix-direnv">nix-direnv</link>,
-          a fast, persistent use_nix implementation for direnv'';
+    nix-direnv = {
+      enable = mkEnableOption ''
+        <link
+            xlink:href="https://github.com/nix-community/nix-direnv">nix-direnv</link>,
+            a fast, persistent use_nix implementation for direnv'';
+      enableFlakes = mkEnableOption "Flake support in nix-direnv";
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -77,9 +89,11 @@ in {
     };
 
     xdg.configFile."direnv/direnvrc" = let
+      package =
+        pkgs.nix-direnv.override { inherit (cfg.nix-direnv) enableFlakes; };
       text = concatStringsSep "\n" (optional (cfg.stdlib != "") cfg.stdlib
-        ++ optional cfg.enableNixDirenvIntegration
-        "source ${pkgs.nix-direnv}/share/nix-direnv/direnvrc");
+        ++ optional cfg.nix-direnv.enable
+        "source ${package}/share/nix-direnv/direnvrc");
     in mkIf (text != "") { inherit text; };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -315,7 +315,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.gnome3.gnome-terminal ];
+    home.packages = [ pkgs.gnome.gnome-terminal ];
 
     dconf.settings = let dconfPath = "org/gnome/terminal/legacy";
     in {

--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -623,45 +623,53 @@ in {
       rightModes = deprecate "right_meter_modes" "meters.right"
         (ifNonNull cfg.meters (map (m: m.mode) cfg.meters.right));
 
-      settings' = cfg.settings // (filterAttrs (_: v: !isNull v) {
-        fields = deprecate "fields" "fields"
-          (ifNonNull cfg.fields (map (n: fields.${n}) cfg.fields));
-        sort_key = deprecate "sort_key" "sortKey"
-          (ifNonNull cfg.sortKey fields.${cfg.sortKey});
-        sort_direction = deprecate' "sort_direction" "sortDescending";
-        hide_threads = deprecate' "hide_threads" "hideThreads";
-        hide_kernel_threads =
-          deprecate' "hide_kernel_threads" "hideKernelThreads";
-        hide_userland_threads =
-          deprecate' "hide_userland_threads" "hideUserlandThreads";
-        shadow_other_users = deprecate' "shadow_other_users" "shadowOtherUsers";
-        show_thread_names = deprecate' "show_thread_names" "showThreadNames";
-        show_program_path = deprecate' "show_program_path" "showProgramPath";
-        highlight_base_name =
-          deprecate' "highlight_base_name" "highlightBaseName";
-        highlight_megabytes =
-          deprecate' "highlight_megabytes" "highlightMegabytes";
-        highlight_threads = deprecate' "highlight_threads" "highlightThreads";
-        tree_view = deprecate' "tree_view" "treeView";
-        header_margin = deprecate' "header_margin" "headerMargin";
-        detailed_cpu_time = deprecate' "detailed_cpu_time" "detailedCpuTime";
-        cpu_count_from_zero =
-          deprecate' "cpu_count_from_zero" "cpuCountFromZero";
-        show_cpu_usage = deprecate' "show_cpu_usage" "showCpuUsage";
-        show_cpu_frequency = deprecate' "show_cpu_frequency" "showCpuFrequency";
-        update_process_names =
-          deprecate' "update_process_names" "updateProcessNames";
-        account_guest_in_cpu_meter =
-          deprecate' "account_guest_in_cpu_meter" "accountGuestInCpuMeter";
-        color_scheme = deprecate' "color_scheme" "colorScheme";
-        enable_mouse = deprecate' "enable_mouse" "enableMouse";
-        delay = deprecate' "delay" "delay";
-        left_meters = leftMeters;
-        left_meter_modes = leftModes;
-        right_meters = rightMeters;
-        right_meter_modes = rightModes;
-        vim_mode = deprecate' "vim_mode" "vimMode";
-      });
-    in concatStringsSep "\n" (mapAttrsToList formatOption settings');
+      before = optionalAttrs (cfg.settings ? header_layout) {
+        inherit (cfg.settings) header_layout;
+      };
+
+      settings' = (removeAttrs cfg.settings (attrNames before))
+        // (filterAttrs (_: v: !isNull v) {
+          fields = deprecate "fields" "fields"
+            (ifNonNull cfg.fields (map (n: fields.${n}) cfg.fields));
+          sort_key = deprecate "sort_key" "sortKey"
+            (ifNonNull cfg.sortKey fields.${cfg.sortKey});
+          sort_direction = deprecate' "sort_direction" "sortDescending";
+          hide_threads = deprecate' "hide_threads" "hideThreads";
+          hide_kernel_threads =
+            deprecate' "hide_kernel_threads" "hideKernelThreads";
+          hide_userland_threads =
+            deprecate' "hide_userland_threads" "hideUserlandThreads";
+          shadow_other_users =
+            deprecate' "shadow_other_users" "shadowOtherUsers";
+          show_thread_names = deprecate' "show_thread_names" "showThreadNames";
+          show_program_path = deprecate' "show_program_path" "showProgramPath";
+          highlight_base_name =
+            deprecate' "highlight_base_name" "highlightBaseName";
+          highlight_megabytes =
+            deprecate' "highlight_megabytes" "highlightMegabytes";
+          highlight_threads = deprecate' "highlight_threads" "highlightThreads";
+          tree_view = deprecate' "tree_view" "treeView";
+          header_margin = deprecate' "header_margin" "headerMargin";
+          detailed_cpu_time = deprecate' "detailed_cpu_time" "detailedCpuTime";
+          cpu_count_from_zero =
+            deprecate' "cpu_count_from_zero" "cpuCountFromZero";
+          show_cpu_usage = deprecate' "show_cpu_usage" "showCpuUsage";
+          show_cpu_frequency =
+            deprecate' "show_cpu_frequency" "showCpuFrequency";
+          update_process_names =
+            deprecate' "update_process_names" "updateProcessNames";
+          account_guest_in_cpu_meter =
+            deprecate' "account_guest_in_cpu_meter" "accountGuestInCpuMeter";
+          color_scheme = deprecate' "color_scheme" "colorScheme";
+          enable_mouse = deprecate' "enable_mouse" "enableMouse";
+          delay = deprecate' "delay" "delay";
+          left_meters = leftMeters;
+          left_meter_modes = leftModes;
+          right_meters = rightMeters;
+          right_meter_modes = rightModes;
+          vim_mode = deprecate' "vim_mode" "vimMode";
+        });
+    in concatStringsSep "\n" (mapAttrsToList formatOption before
+      ++ mapAttrsToList formatOption settings');
   };
 }

--- a/modules/programs/java.nix
+++ b/modules/programs/java.nix
@@ -1,0 +1,46 @@
+# This module provides JAVA_HOME, with a different way to install java locally.
+# This module is modified from the NixOS module `programs.java`
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.java;
+
+in {
+  meta.maintainers = with maintainers; [ ShamrockLee ];
+
+  options = {
+    programs.java = {
+      enable = mkEnableOption "" // {
+        description = ''
+          Install the Java development kit and set the <envar>JAVA_HOME</envar>
+          variable.
+        '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.jdk;
+        defaultText = "pkgs.jdk";
+        description = ''
+          Java package to install. Typical values are
+          <literal>pkgs.jdk</literal> or <literal>pkgs.jre</literal>.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.sessionVariables = {
+      JAVA_HOME = fileContents (pkgs.runCommandLocal "java-home" { } ''
+        source "${cfg.package}/nix-support/setup-hook"
+        echo "$JAVA_HOME" > $out
+      '');
+    };
+  };
+}

--- a/modules/programs/jq.nix
+++ b/modules/programs/jq.nix
@@ -30,6 +30,13 @@ in {
     programs.jq = {
       enable = mkEnableOption "the jq command-line JSON processor";
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.jq;
+        defaultText = literalExample "pkgs.jq";
+        description = "jq package to use.";
+      };
+
       colors = mkOption {
         description = ''
           The colors used in colored JSON output.</para>
@@ -65,7 +72,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.jq ];
+    home.packages = [ cfg.package ];
 
     home.sessionVariables = let c = cfg.colors;
     in {

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -261,7 +261,7 @@ in {
       description = ''
         Path to the terminal which will be used to run console applications
       '';
-      example = "\${pkgs.gnome3.gnome_terminal}/bin/gnome-terminal";
+      example = "\${pkgs.gnome.gnome_terminal}/bin/gnome-terminal";
     };
 
     separator = mkOption {

--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -98,8 +98,6 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ pkgs.taskwarrior ];
 
-    home.file."${cfg.dataLocation}/.keep".text = "";
-
     home.file.".taskrc".text = ''
       data.location=${cfg.dataLocation}
       ${includeTheme cfg.colorTheme}

--- a/modules/programs/texlive.nix
+++ b/modules/programs/texlive.nix
@@ -13,7 +13,7 @@ in {
 
   options = {
     programs.texlive = {
-      enable = mkEnableOption "Texlive";
+      enable = mkEnableOption "TeX Live";
 
       extraPackages = mkOption {
         default = tpkgs: { inherit (tpkgs) collection-basic; };
@@ -21,12 +21,12 @@ in {
         example = literalExample ''
           tpkgs: { inherit (tpkgs) collection-fontsrecommended algorithms; }
         '';
-        description = "Extra packages available to Texlive.";
+        description = "Extra packages available to TeX Live.";
       };
 
       package = mkOption {
         type = types.package;
-        description = "Resulting customized Texlive package.";
+        description = "Resulting customized TeX Live package.";
         readOnly = true;
       };
     };

--- a/modules/programs/texlive.nix
+++ b/modules/programs/texlive.nix
@@ -6,7 +6,8 @@ let
 
   cfg = config.programs.texlive;
 
-  texlivePkgs = cfg.extraPackages pkgs.texlive;
+  texlive = cfg.packageSet;
+  texlivePkgs = cfg.extraPackages texlive;
 
 in {
   meta.maintainers = [ maintainers.rycee ];
@@ -14,6 +15,12 @@ in {
   options = {
     programs.texlive = {
       enable = mkEnableOption "TeX Live";
+
+      packageSet = mkOption {
+        default = pkgs.texlive;
+        defaultText = literalExample "pkgs.texlive";
+        description = "TeX Live package set to use.";
+      };
 
       extraPackages = mkOption {
         default = tpkgs: { inherit (tpkgs) collection-basic; };
@@ -41,6 +48,6 @@ in {
 
     home.packages = [ cfg.package ];
 
-    programs.texlive.package = pkgs.texlive.combine texlivePkgs;
+    programs.texlive.package = texlive.combine texlivePkgs;
   };
 }

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -279,6 +279,12 @@ in
         type = types.bool;
       };
 
+      completionInit = mkOption {
+        default = "autoload -U compinit && compinit";
+        description = "Initialization commands to run when completion is enabled.";
+        type = types.lines;
+      };
+
       enableAutosuggestions = mkOption {
         default = false;
         description = "Enable zsh autosuggestions";
@@ -469,7 +475,7 @@ in
         # calling it twice causes slight start up slowdown
         # as all $fpath entries will be traversed again.
         ${optionalString (cfg.enableCompletion && !cfg.oh-my-zsh.enable && !cfg.prezto.enable)
-          "autoload -U compinit && compinit"
+          cfg.completionInit
         }
 
         ${optionalString cfg.enableAutosuggestions
@@ -500,7 +506,7 @@ in
             (builtins.readFile "${pkgs.zsh-prezto}/share/zsh-prezto/runcoms/zshrc")}
 
         ${concatStrings (map (plugin: ''
-          if [ -f "$HOME/${pluginsDir}/${plugin.name}/${plugin.file}" ]; then
+          if [[ -f "$HOME/${pluginsDir}/${plugin.name}/${plugin.file}" ]]; then
             source "$HOME/${pluginsDir}/${plugin.name}/${plugin.file}"
           fi
         '') cfg.plugins)}

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -25,7 +25,7 @@ let
     options = {
       package = mkOption {
         type = types.package;
-        example = literalExample "pkgs.gnome3.adwaita-icon-theme";
+        example = literalExample "pkgs.gnome.adwaita-icon-theme";
         description = "Package providing the theme.";
       };
 

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -103,7 +103,7 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
-      home.packages = [ (getOutput "man" pkgs.dunst) ];
+      home.packages = [ cfg.package ];
 
       xdg.dataFile."dbus-1/services/org.knopwob.dunst.service".source =
         "${pkgs.dunst}/share/dbus-1/services/org.knopwob.dunst.service";

--- a/modules/services/etesync-dav.nix
+++ b/modules/services/etesync-dav.nix
@@ -35,7 +35,7 @@ in {
       example = literalExample ''
         {
           ETESYNC_LISTEN_ADDRESS = "localhost";
-          ETESYNC_LISTEN_PORT = 37385;
+          ETESYNC_LISTEN_PORT = 37358;
         }
       '';
       description = ''

--- a/modules/services/gnome-keyring.nix
+++ b/modules/services/gnome-keyring.nix
@@ -36,7 +36,7 @@ in {
           args = concatStringsSep " " ([ "--start" "--foreground" ]
             ++ optional (cfg.components != [ ])
             ("--components=" + concatStringsSep "," cfg.components));
-        in "${pkgs.gnome3.gnome-keyring}/bin/gnome-keyring-daemon ${args}";
+        in "${pkgs.gnome.gnome-keyring}/bin/gnome-keyring-daemon ${args}";
         Restart = "on-abort";
       };
 

--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -104,23 +104,26 @@ let
       };
 
       exec = mkOption {
-        type = types.nullOr types.str;
-        default = null;
+        type = with types; coercedTo str singleton (listOf str);
+        default = [ ];
         example =
-          "\${pkg.sway}/bin/swaymsg workspace 1, move workspace to eDP-1";
+          "[ \${pkg.sway}/bin/swaymsg workspace 1, move workspace to eDP-1 ]";
         description = ''
-          Command executed after the profile is succesfully applied.
+          Commands executed after the profile is succesfully applied.
+          Note that if you provide multiple commands, they will be
+          executed asynchronously with no guaranteed ordering.
         '';
       };
     };
   };
 
   profileStr = name:
-    { outputs, exec, ... }:
-    ''
+    { outputs, exec, ... }: ''
       profile ${name} {
-        ${concatStringsSep "\n  " (map outputStr outputs)}
-    '' + optionalString (exec != null) "  exec ${exec}\n" + ''
+        ${
+          concatStringsSep "\n  "
+          (map outputStr outputs ++ map (cmd: "exec ${cmd}") exec)
+        }
       }
     '';
 in {

--- a/modules/services/pulseeffects.nix
+++ b/modules/services/pulseeffects.nix
@@ -38,7 +38,7 @@ in {
     # "AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files"
     home.packages = [ cfg.package pkgs.at-spi2-core ];
 
-    # Will need to add `services.dbus.packages = with pkgs; [ gnome3.dconf ];`
+    # Will need to add `services.dbus.packages = with pkgs; [ gnome.dconf ];`
     # to /etc/nixos/configuration.nix for daemon to work correctly
 
     systemd.user.services.pulseeffects = {

--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -8,6 +8,8 @@ let
 
   profileDirectory = config.home.profileDirectory;
 
+  nixPkg = if config.nix.package == null then pkgs.nix else config.nix.package;
+
 in {
   imports = [
     (mkRenamedOptionModule [ "targets" "genericLinux" "extraXdgDataDirs" ] [
@@ -40,7 +42,7 @@ in {
     ];
 
     home.sessionVariablesExtra = ''
-      . "${pkgs.nix}/etc/profile.d/nix.sh"
+      . "${nixPkg}/etc/profile.d/nix.sh"
 
       # reset TERM with new TERMINFO available (if any)
       export TERM="$TERM"
@@ -49,7 +51,7 @@ in {
     # We need to source both nix.sh and hm-session-vars.sh as noted in
     # https://github.com/nix-community/home-manager/pull/797#issuecomment-544783247
     programs.bash.initExtra = ''
-      . "${pkgs.nix}/etc/profile.d/nix.sh"
+      . "${nixPkg}/etc/profile.d/nix.sh"
       . "${profileDirectory}/etc/profile.d/hm-session-vars.sh"
     '';
 

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -23,6 +23,8 @@ let
           toString v;
     in "${n}: ${formatValue v}";
 
+  xrdbMerge = "${pkgs.xorg.xrdb}/bin/xrdb -merge ~/.Xresources";
+
 in {
   meta.maintainers = [ maintainers.rycee ];
 
@@ -45,7 +47,7 @@ in {
         X server resources that should be set.
         Booleans are formatted as "true" or "false" respectively.
         List elements are recursively formatted as a string and joined by commas.
-        All other values are directly formatted using builtins.toString. 
+        All other values are directly formatted using builtins.toString.
         Note, that 2-dimensional lists are not supported and specifying one will throw an exception.
         If this and all other xresources options are
         <code>null</code>, then this feature is disabled and no
@@ -84,9 +86,11 @@ in {
           (mapAttrsToList formatLine cfg.properties)) + "\n";
         onChange = ''
           if [[ -v DISPLAY ]] ; then
-            $DRY_RUN_CMD ${pkgs.xorg.xrdb}/bin/xrdb -merge $HOME/.Xresources
+            $DRY_RUN_CMD ${xrdbMerge}
           fi
         '';
       };
+
+      xsession.initExtra = xrdbMerge;
     };
 }

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -23,7 +23,7 @@ let
           toString v;
     in "${n}: ${formatValue v}";
 
-  xrdbMerge = "${pkgs.xorg.xrdb}/bin/xrdb -merge ~/.Xresources";
+  xrdbMerge = "${pkgs.xorg.xrdb}/bin/xrdb -merge ${cfg.path}";
 
 in {
   meta.maintainers = [ maintainers.rycee ];
@@ -75,11 +75,19 @@ in {
         <filename>~/.Xresources</filename> link is produced.
       '';
     };
+
+    xresources.path = mkOption {
+      type = types.str;
+      default = "${config.home.homeDirectory}/.Xresources";
+      defaultText = "$HOME/.Xresources";
+      description =
+        "Path where Home Manager should link the <filename>.Xresources</filename> file.";
+    };
   };
 
   config = mkIf ((cfg.properties != null && cfg.properties != { })
     || cfg.extraConfig != "") {
-      home.file.".Xresources" = {
+      home.file.${cfg.path} = {
         text = concatStringsSep "\n" ([ ]
           ++ optional (cfg.extraConfig != "") cfg.extraConfig
           ++ optionals (cfg.properties != null)

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -104,7 +104,7 @@ in {
                 args = optional (layout != null) "-layout '${layout}'"
                   ++ optional (variant != null) "-variant '${variant}'"
                   ++ optional (model != null) "-model '${model}'"
-                  ++ map (v: "-option '${v}'") options;
+                  ++ [ "-option ''" ] ++ map (v: "-option '${v}'") options;
               in "${pkgs.xorg.setxkbmap}/bin/setxkbmap ${toString args}";
           };
         };

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -125,6 +125,7 @@ in {
         wantedBy = [ "multi-user.target" ];
         wants = [ "nix-daemon.socket" ];
         after = [ "nix-daemon.socket" ];
+        before = [ "systemd-user-sessions.service" ];
 
         environment = serviceEnvironment;
 

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -130,6 +130,8 @@ in {
 
         unitConfig = { RequiresMountsFor = usercfg.home.homeDirectory; };
 
+        stopIfChanged = false;
+
         serviceConfig = {
           User = usercfg.home.username;
           Type = "oneshot";

--- a/tests/modules/misc/xsession/basic-setxkbmap-expected.service
+++ b/tests/modules/misc/xsession/basic-setxkbmap-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@setxkbmap@/bin/setxkbmap -layout 'us' -variant ''
+ExecStart=@setxkbmap@/bin/setxkbmap -layout 'us' -variant '' -option ''
 RemainAfterExit=true
 Type=oneshot
 

--- a/tests/modules/misc/xsession/keyboard-without-layout-expected.service
+++ b/tests/modules/misc/xsession/keyboard-without-layout-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@setxkbmap@/bin/setxkbmap -option 'ctrl:nocaps' -option 'altwin:no_win'
+ExecStart=@setxkbmap@/bin/setxkbmap -option '' -option 'ctrl:nocaps' -option 'altwin:no_win'
 RemainAfterExit=true
 Type=oneshot
 

--- a/tests/modules/programs/direnv/nix-direnv.nix
+++ b/tests/modules/programs/direnv/nix-direnv.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     programs.bash.enable = true;
     programs.direnv.enable = true;
-    programs.direnv.enableNixDirenvIntegration = true;
+    programs.direnv.nix-direnv.enable = true;
 
     nmt.script = ''
       assertFileExists home-files/.bashrc

--- a/tests/modules/programs/direnv/stdlib-and-nix-direnv.nix
+++ b/tests/modules/programs/direnv/stdlib-and-nix-direnv.nix
@@ -7,7 +7,7 @@ in {
   config = {
     programs.bash.enable = true;
     programs.direnv.enable = true;
-    programs.direnv.enableNixDirenvIntegration = true;
+    programs.direnv.nix-direnv.enable = true;
     programs.direnv.stdlib = expectedContent;
 
     nmt.script = ''

--- a/tests/modules/programs/firefox/deprecated-native-messenger.nix
+++ b/tests/modules/programs/firefox/deprecated-native-messenger.nix
@@ -16,7 +16,7 @@ with lib;
           preferLocalBuild = true;
           allowSubstitutes = false;
         } ''
-          mkdir -p "$out/bin"
+          mkdir -p "$out"/{bin,lib}
           touch "$out/bin/firefox"
           chmod 755 "$out/bin/firefox"
         '';

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -21,7 +21,7 @@ with lib;
           preferLocalBuild = true;
           allowSubstitutes = false;
         } ''
-          mkdir -p "$out/bin"
+          mkdir -p "$out"/{bin,lib}
           touch "$out/bin/firefox"
           chmod 755 "$out/bin/firefox"
         '';

--- a/tests/modules/programs/firefox/state-version-19_09.nix
+++ b/tests/modules/programs/firefox/state-version-19_09.nix
@@ -15,7 +15,7 @@ with lib;
           preferLocalBuild = true;
           allowSubstitutes = false;
         } ''
-          mkdir -p "$out/bin"
+          mkdir -p "$out"/{bin,lib}
           touch "$out/bin/firefox"
           chmod 755 "$out/bin/firefox"
         '';

--- a/tests/modules/programs/htop/example-settings.nix
+++ b/tests/modules/programs/htop/example-settings.nix
@@ -27,18 +27,14 @@ with lib;
       highlight_megabytes = 1;
       highlight_threads = 1;
     } // (with config.lib.htop;
-      leftMeters {
-        AllCPUs2 = modes.Bar;
-        Memory = modes.Bar;
-        Swap = modes.Bar;
-        Zram = modes.Text;
-      }) // (with config.lib.htop;
-        rightMeters {
-          Tasks = modes.Text;
-          LoadAverage = modes.Text;
-          Uptime = modes.Text;
-          Systemd = modes.Text;
-        });
+      leftMeters [ (bar "AllCPUs2") (bar "Memory") (bar "Swap") (text "Zram") ])
+      // (with config.lib.htop;
+        rightMeters [
+          (text "Tasks")
+          (text "LoadAverage")
+          (text "Uptime")
+          (text "Systemd")
+        ]);
 
     nmt.script = ''
       assertFileExists home-files/.config/htop/htoprc

--- a/tests/modules/services/kanshi/basic-configuration.conf
+++ b/tests/modules/services/kanshi/basic-configuration.conf
@@ -1,8 +1,14 @@
+profile backwardsCompat {
+  output "LVDS-1" enable
+  exec echo "7 eight 9"
+}
+
 profile desktop {
   output "eDP-1" disable
   output "Iiyama North America PLE2483H-DP" enable position 0,0
   output "Iiyama North America PLE2483H-DP 1158765348486" enable mode 1920x1080 position 1920,0 scale 2.100000 transform flipped-270
   exec echo "1 two 3"
+  exec echo "4 five 6"
 }
 
 profile nomad {

--- a/tests/modules/services/kanshi/basic-configuration.nix
+++ b/tests/modules/services/kanshi/basic-configuration.nix
@@ -11,7 +11,7 @@
           }];
         };
         desktop = {
-          exec = ''echo "1 two 3"'';
+          exec = [ ''echo "1 two 3"'' ''echo "4 five 6"'' ];
           outputs = [
             {
               criteria = "eDP-1";
@@ -31,6 +31,13 @@
               transform = "flipped-270";
             }
           ];
+        };
+        backwardsCompat = {
+          outputs = [{
+            criteria = "LVDS-1";
+            status = "enable";
+          }];
+          exec = ''echo "7 eight 9"'';
         };
       };
       extraConfig = ''


### PR DESCRIPTION
- htop: fix preserving the order of meters (#2068) (backport)
- files: fix use of onChange with directory source
- files: remove assertion on recursive onChange
- jq: add `package` option
- docs: update issue template
- docs: minor additional issue template update
- Replace references to pkgs.gnome3 by pkgs.gnome
- texlive: "Texlive" -> "TeX Live"
- texlive: add `packageSet` option
- docs: mark 21.05 as stable version
- ci: run tests against nixos-21.05
- dunst: add the whole package to home.packages (#2079)
- home-manager: pass on `--debug` option (#2049)
- etesync-dav: fix typo (#2067)
- nixos: set stopIfChanged to false (#2105)
- direnv: add enableFlakes option for enableNixDirenvIntegration (#2089)
- README: fix outdated description (#2131)
- setxkbmap: reset options before setting new ones (#2160)
- taskwarrior: don't create dataLocation with home.file
- brave: fix config dir path (#2173)
- [nixos] Fix race condition with user units (#2286) (#2287)
- zsh: add `completionInit` option (#2046) (#2296)
- ci: bump cachix/install-nix-action from 13 to 14
- kanshi: allow multiple exec statements per profile
- java: add module
- xresources: load .Xresources in xsession.initExtra
- xresources: Add path configuration option (#2141)
- ci: update install-nix-action to v14.1
- ci: explicitly set Nix version
- ci: bump cachix/install-nix-action from 14 to 15
- ci: bump cachix/install-nix-action from 15 to 16
- firefox: fix tests
- firefox: fix test case
- htop: fix order or header_columns setting (backport) (#2443)
- ci: bump actions/checkout from 2 to 3
- targets/generic-linux: use the correct nix package
