### PR TITLE
ci: use the right Nixpkgs channel for 22.05 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v18
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
+        nix_path: nixpkgs=channel:nixos-22.05
     - uses: cachix/cachix-action@v12
       with:
         name: nix-community


### PR DESCRIPTION
Seems we've been using the wrong Nixpkgs channel for all this time…