### PR TITLE
kitty: silently drop darwin-specific options

### DIFF
--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -119,14 +119,6 @@ in {
   };
 
   config = mkIf cfg.enable {
-    assertions = [{
-      assertion = (cfg.darwinLaunchOptions != null)
-        -> pkgs.stdenv.hostPlatform.isDarwin;
-      message = ''
-        The 'programs.kitty.darwinLaunchOptions' option is only available on darwin.
-      '';
-    }];
-
     home.packages = [ cfg.package ] ++ optionalPackage cfg.font;
 
     xdg.configFile."kitty/kitty.conf" = {
@@ -158,8 +150,8 @@ in {
       '';
     };
 
-    xdg.configFile."kitty/macos-launch-services-cmdline" =
-      mkIf (cfg.darwinLaunchOptions != null) {
+    xdg.configFile."kitty/macos-launch-services-cmdline" = mkIf
+      (cfg.darwinLaunchOptions != null && pkgs.stdenv.hostPlatform.isDarwin) {
         text = concatStringsSep " " cfg.darwinLaunchOptions;
       };
   };


### PR DESCRIPTION
Rather than reject a configuration when this option is set, just silently ignore it when the platform isn't darwin. The name makes it obvious that it won't be applied outside of darwin, and this allows people to use the same configuration between hosts without any special concern.
