### PR TITLE
kakoune: update ui options

### DIFF
--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -268,30 +268,6 @@ let
               '';
             };
 
-            changeColors = mkOption {
-              type = types.bool;
-              default = true;
-              description = ''
-                Change color palette.
-              '';
-            };
-
-            wheelDownButton = mkOption {
-              type = types.nullOr types.str;
-              default = null;
-              description = ''
-                Button to send for wheel down events.
-              '';
-            };
-
-            wheelUpButton = mkOption {
-              type = types.nullOr types.str;
-              default = null;
-              description = ''
-                Button to send for wheel up events.
-              '';
-            };
-
             shiftFunctionKeys = mkOption {
               type = types.nullOr types.ints.unsigned;
               default = null;
@@ -302,18 +278,39 @@ let
               '';
             };
 
-            useBuiltinKeyParser = mkOption {
+            paddingChar = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = ''
+                Set the character used to indicate the area out of the displayed buffer.
+                The kakoune default is <literal>"~"</literal>.
+              '';
+            };
+
+            paddingFill = mkOption {
               type = types.bool;
               default = false;
               description = ''
-                Bypass ncurses key parser and use an internal one.
+                Whether to fill the padding area with the padding 
+                character instead of displaying a single character 
+                at the beginning of the padding line.
+              '';
+            };
+
+            synchronized = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Whether to emit synchronized output escape sequences 
+                and reduce terminal output with sequences that could 
+                trigger flickering if unsynchronized.
               '';
             };
           };
         });
         default = null;
         description = ''
-          Settings for the ncurses interface.
+          Settings for the terminal interface.
         '';
       };
 
@@ -536,16 +533,12 @@ let
         }"
         "terminal_assistant=${assistant}"
         "terminal_enable_mouse=${if enableMouse then "true" else "false"}"
-        "terminal_change_colors=${if changeColors then "true" else "false"}"
-        "${optionalString (wheelDownButton != null)
-        "terminal_wheel_down_button=${wheelDownButton}"}"
-        "${optionalString (wheelUpButton != null)
-        "terminal_wheel_up_button=${wheelUpButton}"}"
         "${optionalString (shiftFunctionKeys != null)
         "terminal_shift_function_key=${toString shiftFunctionKeys}"}"
-        "terminal_builtin_key_parser=${
-          if useBuiltinKeyParser then "true" else "false"
-        }"
+        "${optionalString (paddingChar != null)
+        "terminal_padding_char=${paddingChar}"}"
+        "terminal_padding_fill=${if paddingFill then "true" else "false"}"
+        "terminal_synchronized=${if synchronized then "true" else "false"}"
       ];
 
     userModeString = mode:
@@ -620,6 +613,17 @@ let
   (optionalString (cfg.config != null) cfgStr + "\n" + cfg.extraConfig);
 
 in {
+  imports = let
+    mkRemovedOptionUI = option:
+      (mkRemovedOptionModule [ "programs" "kakoune" "config" "ui" option ]
+        "Kakoune dropped ncurses so this option has been removed.");
+  in map mkRemovedOptionUI [
+    "changeColors"
+    "wheelDownButton"
+    "wheelUpButton"
+    "useBuiltinKeyParser"
+  ];
+
   options = {
     programs.kakoune = {
       enable = mkEnableOption "the kakoune text editor";


### PR DESCRIPTION
### Description

As ncurses was totally removed from kakoune, the 3 following options don’t exist anymore.

- terminal_change_colors (see: https://github.com/mawww/kakoune/commit/3acf85f2679a548236796a594b3871799957318d)
- terminal_wheel_down_button/terminal_wheel_up_button (see: https://github.com/mawww/kakoune/commit/b841f3a2142b7a77d29b70b2afda3e9ef471fa93)
- ncurses_builtin_key_parser (see: https://github.com/mawww/kakoune/commit/4dd0b432ab3d56da5a37b9e7ed02e878c738b7a3)

However, 3 new options exist now (https://github.com/mawww/kakoune/blob/bfa3c568ccdc39910e5f9a0cbcc73ed05275087a/doc/pages/options.asciidoc)

- terminal_padding_char
- terminal_padding_fill
- terminal_synchronized

I added those in this PR.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.kakoune-{no-plugins,use-plugins,whitespace-highlighter,whitespace-highlighter-corner-cases}`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.