### PR TITLE
lib, zellij: move zellij configuration to the new KDL format

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,9 @@ Makefile                                              @thiagokokada
 
 /modules/launchd                                      @midchildan
 
+/modules/lib/generators.nix                           @h7x4
+/test/lib/generators                                  @h7x4
+
 /modules/misc/dconf.nix                               @rycee
 
 /modules/misc/editorconfig.nix                        @loicreynier

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -6,6 +6,7 @@ rec {
   assertions = import ./assertions.nix { inherit lib; };
 
   booleans = import ./booleans.nix { inherit lib; };
+  generators = import ./generators.nix { inherit lib; };
   gvariant = import ./gvariant.nix { inherit lib; };
   maintainers = import ./maintainers.nix;
   strings = import ./strings.nix { inherit lib; };

--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -1,0 +1,102 @@
+{ lib }:
+
+{
+  toKDL = { }:
+    let
+      inherit (lib) concatStringsSep splitString mapAttrsToList any;
+      inherit (builtins) typeOf replaceStrings elem;
+
+      # ListOf String -> String
+      indentStrings = let
+        # Although the input of this function is a list of strings,
+        # the strings themselves *will* contain newlines, so you need
+        # to normalize the list by joining and resplitting them.
+        unlines = lib.splitString "\n";
+        lines = lib.concatStringsSep "\n";
+        indentAll = lines: concatStringsSep "\n" (map (x: "	" + x) lines);
+      in stringsWithNewlines: indentAll (unlines (lines stringsWithNewlines));
+
+      # String -> String
+      sanitizeString = replaceStrings [ "\n" ''"'' ] [ "\\n" ''\"'' ];
+
+      # OneOf [Int Float String Bool Null] -> String
+      literalValueToString = element:
+        lib.throwIfNot
+        (elem (typeOf element) [ "int" "float" "string" "bool" "null" ])
+        "Cannot convert value of type ${typeOf element} to KDL literal."
+        (if typeOf element == "null" then
+          "null"
+        else if element == false then
+          "false"
+        else if element == true then
+          "true"
+        else if typeOf element == "string" then
+          ''"${sanitizeString element}"''
+        else
+          toString element);
+
+      # Attrset Conversion
+      # String -> AttrsOf Anything -> String
+      convertAttrsToKDL = name: attrs:
+        let
+          optArgsString = lib.optionalString (attrs ? "_args")
+            (lib.pipe attrs._args [
+              (map literalValueToString)
+              (lib.concatStringsSep " ")
+              (s: s + " ")
+            ]);
+
+          optPropsString = lib.optionalString (attrs ? "_props")
+            (lib.pipe attrs._props [
+              (lib.mapAttrsToList
+                (name: value: "${name}=${literalValueToString value}"))
+              (lib.concatStringsSep " ")
+              (s: s + " ")
+            ]);
+
+          children =
+            lib.filterAttrs (name: _: !(elem name [ "_args" "_props" ])) attrs;
+        in ''
+          ${name} ${optArgsString}${optPropsString}{
+          ${indentStrings (mapAttrsToList convertAttributeToKDL children)}
+          }'';
+
+      # List Conversion
+      # String -> ListOf (OneOf [Int Float String Bool Null])  -> String
+      convertListOfFlatAttrsToKDL = name: list:
+        let flatElements = map literalValueToString list;
+        in "${name} ${concatStringsSep " " flatElements}";
+
+      # String -> ListOf Anything -> String
+      convertListOfNonFlatAttrsToKDL = name: list: ''
+        ${name} {
+        ${indentStrings (map (x: convertAttributeToKDL "-" x) list)}
+        }'';
+
+      # String -> ListOf Anything  -> String
+      convertListToKDL = name: list:
+        let elementsAreFlat = !any (el: elem (typeOf el) [ "list" "set" ]) list;
+        in if elementsAreFlat then
+          convertListOfFlatAttrsToKDL name list
+        else
+          convertListOfNonFlatAttrsToKDL name list;
+
+      # Combined Conversion
+      # String -> Anything  -> String
+      convertAttributeToKDL = name: value:
+        let vType = typeOf value;
+        in if elem vType [ "int" "float" "bool" "null" "string" ] then
+          "${name} ${literalValueToString value}"
+        else if vType == "set" then
+          convertAttrsToKDL name value
+        else if vType == "list" then
+          convertListToKDL name value
+        else
+          throw ''
+            Cannot convert type `(${typeOf value})` to KDL:
+              ${name} = ${toString value}
+          '';
+    in attrs: ''
+      ${concatStringsSep "\n" (mapAttrsToList convertAttributeToKDL attrs)}
+    '';
+}

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -33,7 +33,7 @@ in {
       example = literalExpression ''
         {
           theme = "custom";
-          themes.custom.fg = 5;
+          themes.custom.fg = "#ffffff";
         }
       '';
       description = ''
@@ -49,8 +49,16 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    home.file."${configDir}/config.yaml" = mkIf (cfg.settings != { }) {
-      source = yamlFormat.generate "zellij.yaml" cfg.settings;
-    };
+    # Zellij switched from yaml to KDL in version 0.32.0:
+    # https://github.com/zellij-org/zellij/releases/tag/v0.32.0
+    home.file."${configDir}/config.yaml" = mkIf
+      (cfg.settings != { } && (versionOlder cfg.package.version "0.32.0")) {
+        source = yamlFormat.generate "zellij.yaml" cfg.settings;
+      };
+
+    home.file."${configDir}/config.kdl" = mkIf
+      (cfg.settings != { } && (versionAtleast cfg.package.version "0.32.0")) {
+        text = lib.hm.generators.toKDL { } cfg.settings;
+      };
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -47,6 +47,7 @@ import nmt {
   inherit lib pkgs modules;
   testedAttrPath = [ "home" "activationPackage" ];
   tests = builtins.foldl' (a: b: a // (import b)) { } ([
+    ./lib/generators
     ./lib/types
     ./modules/files
     ./modules/home-environment

--- a/tests/lib/generators/default.nix
+++ b/tests/lib/generators/default.nix
@@ -1,0 +1,1 @@
+{ generators-tokdl = ./tokdl.nix; }

--- a/tests/lib/generators/tokdl-result.txt
+++ b/tests/lib/generators/tokdl-result.txt
@@ -1,0 +1,41 @@
+a 1
+b "string"
+bigFlatItems 23847590283751 1.239000 "multiline \" \" \"\nstring\n" null
+c "multiline string\nwith special characters:\n\t \n \\" \"\n"
+extraAttrs 2 true arg1=1 arg2=false {
+	nested {
+		a 1
+		b null
+	}
+}
+flatItems 1 2 "asdf" true null
+listInAttrsInList {
+	list1 {
+		- {
+			a 1
+		}
+		- {
+			b true
+		}
+		- {
+			c null
+			d {
+				- {
+					e "asdfadfasdfasdf"
+				}
+			}
+		}
+	}
+	list2 {
+		- {
+			a 8
+		}
+	}
+}
+nested {
+	- 1 2
+	- true false
+	- 
+	- null
+}
+unsafeString " \" \n 	 "

--- a/tests/lib/generators/tokdl.nix
+++ b/tests/lib/generators/tokdl.nix
@@ -1,0 +1,53 @@
+{ config, lib, ... }:
+
+{
+  home.file."result.txt".text = lib.hm.generators.toKDL { } {
+    a = 1;
+    b = "string";
+    c = ''
+      multiline string
+      with special characters:
+      \t \n \" "
+    '';
+    unsafeString = " \" \n 	 ";
+    flatItems = [ 1 2 "asdf" true null ];
+    bigFlatItems = [
+      23847590283751
+      1.239
+      ''
+        multiline " " "
+        string
+      ''
+      null
+    ];
+    nested = [ [ 1 2 ] [ true false ] [ ] [ null ] ];
+    extraAttrs = {
+      _args = [ 2 true ];
+      _props = {
+        arg1 = 1;
+        arg2 = false;
+      };
+      nested = {
+        a = 1;
+        b = null;
+      };
+    };
+    listInAttrsInList = {
+      list1 = [
+        { a = 1; }
+        { b = true; }
+        {
+          c = null;
+          d = [{ e = "asdfadfasdfasdf"; }];
+        }
+      ];
+      list2 = [{ a = 8; }];
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/result.txt \
+      ${./tokdl-result.txt}
+  '';
+}


### PR DESCRIPTION
Added a generator for the KDL document language.
This is in order for home-manager to natively generate the new config format for zellij, as described in #3364.

There is not a one to one mapping between KDL and nix types, but I've used KDLs JSON-IN-KDL syntax to translate attrsets.

Closes #3364 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
