### PR TITLE
Kodi: fixed syntax error in example

### DIFF
--- a/modules/programs/kodi.nix
+++ b/modules/programs/kodi.nix
@@ -131,9 +131,8 @@ in {
       type = types.package;
       default = pkgs.kodi;
       defaultText = literalExpression "pkgs.kodi";
-      example = literalExpression ''
-        { pkgs.kodi.withPackages (exts: [ exts.pvr-iptvsimple ]) }
-      '';
+      example = literalExpression
+        "pkgs.kodi.withPackages (exts: [ exts.pvr-iptvsimple ])";
       description = ''
         The <literal>kodi</literal> package to use.
         Can be used to specify extensions.


### PR DESCRIPTION
### Description

syntax error. corrected the error in the example kodi plugins config together with helpfull irc chat :)


### Checklist

<!--

I think i dont have to fill out the check list because its just a syntax error in a example who got corrrected :)


Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
