### PR TITLE
thunderbird: allow using the module on Darwin

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -820,7 +820,27 @@ in
         time = "2022-11-04T14:56:46+00:00";
         condition = hostPlatform.isLinux;
         message = ''
-          A new module is available: 'programs.thunderbird';
+          A new module is available: 'programs.thunderbird'.
+        '';
+      }
+
+      {
+        time = "2022-11-13T09:05:51+00:00";
+        condition = hostPlatform.isDarwin;
+        message = ''
+          A new module is available: 'programs.thunderbird'.
+
+          Please note that the Thunderbird packages provided by Nix are
+          currently not working on macOS. The module can still be used to manage
+          configuration files by installing Thunderbird manually and setting the
+          'programs.thunderbird.package' option to a dummy package, for example
+          using 'pkgs.runCommand'.
+
+          This module requires you to set the following environment variables
+          when using an installation of Thunderbird that is not provided by Nix:
+
+            export MOZ_LEGACY_PROFILES=1
+            export MOZ_ALLOW_DOWNGRADE=1
         '';
       }
     ];


### PR DESCRIPTION
### Description

While the Nix packages for Thunderbird are not available for macOS, the module can still be used to manage profiles and configuration.

Fixes #3407.

Pinging @jkarlson for review, @gbrindisi for testing.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
