### PR TITLE
swaylock: add enable and package option

### DIFF
--- a/modules/programs/swaylock.nix
+++ b/modules/programs/swaylock.nix
@@ -40,6 +40,11 @@ in {
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.swaylock" pkgs
+        lib.platforms.linux)
+    ];
+
     home.packages = [ cfg.package ];
 
     xdg.configFile."swaylock/config" = mkIf (cfg.settings != { }) {

--- a/modules/programs/swaylock.nix
+++ b/modules/programs/swaylock.nix
@@ -1,32 +1,54 @@
-{ config, lib, ... }:
+{ pkgs, config, lib, ... }:
+
+with lib;
 
 let cfg = config.programs.swaylock;
 in {
-  meta.maintainers = [ lib.hm.maintainers.rcerc ];
+  meta.maintainers = [ hm.maintainers.rcerc ];
 
-  options.programs.swaylock.settings = lib.mkOption {
-    type = with lib.types; attrsOf (oneOf [ bool float int str ]);
-    default = { };
-    description = ''
-      Default arguments to <command>swaylock</command>. An empty set
-      disables configuration generation.
-    '';
-    example = {
-      color = "808080";
-      font-size = 24;
-      indicator-idle-visible = false;
-      indicator-radius = 100;
-      line-color = "ffffff";
-      show-failed-attempts = true;
+  options.programs.swaylock = {
+    enable = mkOption {
+      type = lib.types.bool;
+      default = versionOlder config.home.stateVersion "23.05"
+        && (cfg.settings != { });
+      defaultText = literalExpression ''
+        true  if state version < 23.05 and settings ≠ { },
+        false otherwise
+      '';
+      example = true;
+      description = "Whether to enable swaylock.";
+    };
+
+    package = mkPackageOption pkgs "swaylock" { };
+
+    settings = mkOption {
+      type = with types; attrsOf (oneOf [ bool float int str ]);
+      default = { };
+      description = ''
+        Default arguments to <command>swaylock</command>. An empty set
+        disables configuration generation.
+      '';
+      example = {
+        color = "808080";
+        font-size = 24;
+        indicator-idle-visible = false;
+        indicator-radius = 100;
+        line-color = "ffffff";
+        show-failed-attempts = true;
+      };
     };
   };
 
-  config.xdg.configFile."swaylock/config" = lib.mkIf (cfg.settings != { }) {
-    text = lib.concatStrings (lib.mapAttrsToList (n: v:
-      if v == false then
-        ""
-      else
-        (if v == true then n else n + "=" + builtins.toString v) + "\n")
-      cfg.settings);
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."swaylock/config" = mkIf (cfg.settings != { }) {
+      text = concatStrings (mapAttrsToList (n: v:
+        if v == false then
+          ""
+        else
+          (if v == true then n else n + "=" + builtins.toString v) + "\n")
+        cfg.settings);
+    };
   };
 }

--- a/tests/modules/programs/swaylock/default.nix
+++ b/tests/modules/programs/swaylock/default.nix
@@ -1,4 +1,6 @@
 {
   swaylock-disabled = import ./disabled.nix;
   swaylock-settings = import ./settings.nix;
+  swaylock-enabled = import ./enabled.nix;
+  swaylock-legacy = import ./legacy.nix;
 }

--- a/tests/modules/programs/swaylock/enabled.nix
+++ b/tests/modules/programs/swaylock/enabled.nix
@@ -1,0 +1,10 @@
+{ config, ... }: {
+  programs.swaylock = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/swaylock/config
+  '';
+}

--- a/tests/modules/programs/swaylock/legacy.nix
+++ b/tests/modules/programs/swaylock/legacy.nix
@@ -1,6 +1,6 @@
 {
+  home.stateVersion = "20.09";
   programs.swaylock = {
-    enable = true;
     settings = {
       color = "808080";
       font-size = 24;

--- a/tests/modules/services/git-sync/basic.nix
+++ b/tests/modules/services/git-sync/basic.nix
@@ -10,10 +10,7 @@
     };
   };
 
-  test.stubs = {
-    git = { name = "git"; };
-    openssh = { name = "openssh"; };
-  };
+  test.stubs.openssh = { name = "openssh"; };
 
   nmt.script = ''
     serviceFile=home-files/.config/systemd/user/git-sync-test.service


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

### Description

Adding `enable` and `package` options to the swaylock module. 

:warning: These changes are not fully backwards compatible, as the config file from `settings` won't be written if enable isn't set. We could write the settings file when non-empty even if the module isn't enabled to retain backwards compatibility, but I couldn't find another module that does this, so I didn't implement it for now.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
