### PR TITLE
xdg-user-dirs: Allow setting to null to skip setting

### DIFF
--- a/modules/misc/xdg-user-dirs.nix
+++ b/modules/misc/xdg-user-dirs.nix
@@ -33,7 +33,7 @@ in {
     # https://gitlab.freedesktop.org/xdg/xdg-user-dirs/blob/master/man/user-dirs.dirs.xml
 
     desktop = mkOption {
-      type = with types; coercedTo path toString str;
+      type = with types; nullOr (coercedTo path toString str);
       default = "${config.home.homeDirectory}/Desktop";
       defaultText =
         literalExpression ''"''${config.home.homeDirectory}/Desktop"'';
@@ -41,7 +41,7 @@ in {
     };
 
     documents = mkOption {
-      type = with types; coercedTo path toString str;
+      type = with types; nullOr (coercedTo path toString str);
       default = "${config.home.homeDirectory}/Documents";
       defaultText =
         literalExpression ''"''${config.home.homeDirectory}/Documents"'';
@@ -49,7 +49,7 @@ in {
     };
 
     download = mkOption {
-      type = with types; coercedTo path toString str;
+      type = with types; nullOr (coercedTo path toString str);
       default = "${config.home.homeDirectory}/Downloads";
       defaultText =
         literalExpression ''"''${config.home.homeDirectory}/Downloads"'';
@@ -57,7 +57,7 @@ in {
     };
 
     music = mkOption {
-      type = with types; coercedTo path toString str;
+      type = with types; nullOr (coercedTo path toString str);
       default = "${config.home.homeDirectory}/Music";
       defaultText =
         literalExpression ''"''${config.home.homeDirectory}/Music"'';
@@ -65,7 +65,7 @@ in {
     };
 
     pictures = mkOption {
-      type = with types; coercedTo path toString str;
+      type = with types; nullOr (coercedTo path toString str);
       default = "${config.home.homeDirectory}/Pictures";
       defaultText =
         literalExpression ''"''${config.home.homeDirectory}/Pictures"'';
@@ -73,7 +73,7 @@ in {
     };
 
     publicShare = mkOption {
-      type = with types; coercedTo path toString str;
+      type = with types; nullOr (coercedTo path toString str);
       default = "${config.home.homeDirectory}/Public";
       defaultText =
         literalExpression ''"''${config.home.homeDirectory}/Public"'';
@@ -81,7 +81,7 @@ in {
     };
 
     templates = mkOption {
-      type = with types; coercedTo path toString str;
+      type = with types; nullOr (coercedTo path toString str);
       default = "${config.home.homeDirectory}/Templates";
       defaultText =
         literalExpression ''"''${config.home.homeDirectory}/Templates"'';
@@ -89,7 +89,7 @@ in {
     };
 
     videos = mkOption {
-      type = with types; coercedTo path toString str;
+      type = with types; nullOr (coercedTo path toString str);
       default = "${config.home.homeDirectory}/Videos";
       defaultText =
         literalExpression ''"''${config.home.homeDirectory}/Videos"'';
@@ -113,7 +113,7 @@ in {
   };
 
   config = let
-    directories = {
+    directories = (filterAttrs (n: v: !isNull v) {
       XDG_DESKTOP_DIR = cfg.desktop;
       XDG_DOCUMENTS_DIR = cfg.documents;
       XDG_DOWNLOAD_DIR = cfg.download;
@@ -122,7 +122,7 @@ in {
       XDG_PUBLICSHARE_DIR = cfg.publicShare;
       XDG_TEMPLATES_DIR = cfg.templates;
       XDG_VIDEOS_DIR = cfg.videos;
-    } // cfg.extraConfig;
+    }) // cfg.extraConfig;
   in mkIf cfg.enable {
     assertions =
       [ (hm.assertions.assertPlatform "xdg.userDirs" pkgs platforms.linux) ];

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -4,4 +4,5 @@
   xdg-desktop-entries = ./desktop-entries.nix;
   xdg-file-gen = ./file-gen.nix;
   xdg-default-locations = ./default-locations.nix;
+  xdg-user-dirs-null = ./user-dirs-null.nix;
 }

--- a/tests/modules/misc/xdg/user-dirs-null.nix
+++ b/tests/modules/misc/xdg/user-dirs-null.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    xdg.userDirs = {
+      enable = true;
+      desktop = null;
+    };
+
+    nmt.script = ''
+      configFile=home-files/.config/user-dirs.dirs
+      assertFileExists $configFile
+      assertFileContent $configFile ${
+        pkgs.writeText "expected" ''
+          XDG_DOCUMENTS_DIR="/home/hm-user/Documents"
+          XDG_DOWNLOAD_DIR="/home/hm-user/Downloads"
+          XDG_MUSIC_DIR="/home/hm-user/Music"
+          XDG_PICTURES_DIR="/home/hm-user/Pictures"
+          XDG_PUBLICSHARE_DIR="/home/hm-user/Public"
+          XDG_TEMPLATES_DIR="/home/hm-user/Templates"
+          XDG_VIDEOS_DIR="/home/hm-user/Videos"
+        ''
+      }
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Previously, this module was all-or-nothing with its pre-defined user dirs. This allows e.g. `xdg.userDirs.desktop = null;` to opt-out of some configuration while still benefiting from the rest.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

I did not run the full test suite, but ran `run.xdg-user-dirs-null` and `run.mpd-xdg-music-dir` as those are the only tests that appear to exercise `xdg.userDirs`.

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
