### PR TITLE
flake: Expose tests to allow running purely

### DIFF
--- a/docs/contributing.adoc
+++ b/docs/contributing.adoc
@@ -256,3 +256,8 @@ and run an individual test, for example `alacritty-empty-settings`, through
 
 [source,console]
 $ nix-shell --pure tests -A run.alacritty-empty-settings
+
+However, those invocations will impurely source the system’s nixpkgs, and may cause failures. To run against the nixpkgs from the flake.lock, use instead e.g.
+
+[source,console]
+$ nix develop --ignore-environment .#tests.all

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,9 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         docs = import ./docs { inherit pkgs; };
+        tests = import ./tests { inherit pkgs; };
       in {
+        devShells.tests = tests.run;
         packages = rec {
           home-manager = pkgs.callPackage ./home-manager { };
           docs-html = docs.manual.html;

--- a/tests/modules/programs/zplug/modules.nix
+++ b/tests/modules/programs/zplug/modules.nix
@@ -8,7 +8,7 @@ with lib;
       enable = true;
       zplug = {
         enable = true;
-        zplugHome = ~/.customZplugHome;
+        zplugHome = pkgs.emptyDirectory;
         plugins = [
           {
             name = "plugins/git";


### PR DESCRIPTION
### Description

The existing way to run tests with `nix-shell` relies on impure usage of `<nixpkgs>`. This can lead to failures when the local nixpkgs is incompatible with the locked one. I.e., where CI is passing but a contributor may experience a failure.

So, expose tests as `devShells.tests` to use the locked nixpkgs and allow easy invocation via `nix develop`.

I did not change the existing `nix-shell` docs or usage in CI, as unsure if that’s wanted at this point as flakes are still technically experimental, but of course can if desired.

This change was born out of me trying to contribute and run the tests, but them failing because my local nixpkgs is nixos-22.05 and home-manager master is nixos-unstable. Compare e.g. right now on a nixos-22.05 system:

```
$ nix-shell --pure tests -A run.broot
building '/nix/store/4zinsw301sd8dwwh69mc6j427f4rzs5r-default-conf.json.drv'...
Traceback (most recent call last):
  File "/nix/store/0zzvjh5gnz0ny7ckilzyn9hmg5lypszf-python3-3.9.13/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/nix/store/0zzvjh5gnz0ny7ckilzyn9hmg5lypszf-python3-3.9.13/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/nix/store/ddi3xxg7cz9lf2lm6nai8qzbwarrk7js-python3.9-hjson-3.0.2/lib/python3.9/site-packages/hjson/tool.py", line 80, in <module>
    main()
  File "/nix/store/ddi3xxg7cz9lf2lm6nai8qzbwarrk7js-python3.9-hjson-3.0.2/lib/python3.9/site-packages/hjson/tool.py", line 58, in main
    infile = open(args[0], 'r')
FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/61h76ya021588gp3g6my168pib7in8w9-broot-1.12.0.tar.gz/resources/default-conf/conf.hjson'
error: builder for '/nix/store/4zinsw301sd8dwwh69mc6j427f4rzs5r-default-conf.json.drv' failed with exit code 1;
       last 10 log lines:
       > Traceback (most recent call last):
       >   File "/nix/store/0zzvjh5gnz0ny7ckilzyn9hmg5lypszf-python3-3.9.13/lib/python3.9/runpy.py", line 197, in _run_module_as_main
       >     return _run_code(code, main_globals, None,
       >   File "/nix/store/0zzvjh5gnz0ny7ckilzyn9hmg5lypszf-python3-3.9.13/lib/python3.9/runpy.py", line 87, in _run_code
       >     exec(code, run_globals)
       >   File "/nix/store/ddi3xxg7cz9lf2lm6nai8qzbwarrk7js-python3.9-hjson-3.0.2/lib/python3.9/site-packages/hjson/tool.py", line 80, in <module>
       >     main()
       >   File "/nix/store/ddi3xxg7cz9lf2lm6nai8qzbwarrk7js-python3.9-hjson-3.0.2/lib/python3.9/site-packages/hjson/tool.py", line 58, in main
       >     infile = open(args[0], 'r')
       > FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/61h76ya021588gp3g6my168pib7in8w9-broot-1.12.0.tar.gz/resources/default-conf/conf.hjson'
       For full logs, run 'nix log /nix/store/4zinsw301sd8dwwh69mc6j427f4rzs5r-default-conf.json.drv'.
(use '--show-trace' to show detailed location information)
```

vs.

```
$ nix develop --ignore-environment .#tests.broot
broot: OK
```

Note that, despite this change, the `firefox-profile-settings` test still fails both with `nix-shell` and `nix develop` on master.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
