### PR TITLE
polybar: allow service to read from systemd PATH variable

### DIFF
--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -211,7 +211,6 @@ in {
 
       Service = {
         Type = "forking";
-        Environment = "";
         ExecStart =
           let scriptPkg = pkgs.writeShellScriptBin "polybar-start" cfg.script;
           in "${scriptPkg}/bin/polybar-start";

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -211,6 +211,7 @@ in {
 
       Service = {
         Type = "forking";
+        Environment = "$PATH";
         ExecStart =
           let scriptPkg = pkgs.writeShellScriptBin "polybar-start" cfg.script;
           in "${scriptPkg}/bin/polybar-start";

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -211,7 +211,7 @@ in {
 
       Service = {
         Type = "forking";
-        Environment = "PATH=${cfg.package}/bin:/run/wrappers/bin";
+        Environment = "";
         ExecStart =
           let scriptPkg = pkgs.writeShellScriptBin "polybar-start" cfg.script;
           in "${scriptPkg}/bin/polybar-start";

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -211,7 +211,6 @@ in {
 
       Service = {
         Type = "forking";
-        Environment = "$PATH";
         ExecStart =
           let scriptPkg = pkgs.writeShellScriptBin "polybar-start" cfg.script;
           in "${scriptPkg}/bin/polybar-start";


### PR DESCRIPTION
### Description

Removed hard coded **PATH** variable in order to read from systemd directly. 
This is necessary as it will allow user created scripts to be able to run when using polybar.service.
Currently there is a hard coded variable for **PATH** that does not point to all the programs on the system, causing programs called in scripts to not be found.

<!--

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
