### PR TITLE
kakoune: update hooks

### DIFF
--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -10,13 +10,9 @@ let
     options = {
       name = mkOption {
         type = types.enum [
-          "NormalBegin"
           "NormalIdle"
-          "NormalEnd"
           "NormalKey"
-          "InsertBegin"
           "InsertIdle"
-          "InsertEnd"
           "InsertKey"
           "InsertChar"
           "InsertDelete"
@@ -48,8 +44,11 @@ let
           "RawKey"
           "InsertCompletionShow"
           "InsertCompletionHide"
-          "InsertCompletionSelect"
           "ModuleLoaded"
+          "ClientCreate"
+          "ClientClose"
+          "RegisterModified"
+          "User"
         ];
         example = "SetOption";
         description = ''


### PR DESCRIPTION
### Description

Some hooks were removed in Kakoune, and some were added. This PR updates the list so they are aligned with the latest version of Kakoune.

#### Removed

https://github.com/mawww/kakoune/commit/e4fb70ebec80edcd17f0e00823780e4798a3fb1a

- `NormalBegin`
- `NormalEnd`
- `InsertBegin`
- `InsertEnd`

https://github.com/mawww/kakoune/commit/78419bc76f833b493b700bf3262c52fd93544744

- `InsertCompletionSelect`

#### Added

https://github.com/mawww/kakoune/commit/c8839e79041ef37849a4cb8ac5017eadc8ec9653

- `ClientCreate`
- `ClientClose`

https://github.com/mawww/kakoune/commit/47ba36c66e0e38c5bb5c832bfa751d553f769baa

- `RegisterModified`

https://github.com/mawww/kakoune/commit/f2cc7bc891922ad48c4372c0b69239ef74bce004

- `User`

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.kakoune-{no-plugins,use-plugins,whitespace-highlighter,whitespace-highlighter-corner-cases}`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.