### PR TITLE
picom: remove experimentalBackends, add extraArgs

### DIFF
--- a/modules/services/picom.nix
+++ b/modules/services/picom.nix
@@ -54,6 +54,8 @@ in {
   imports = [
     (mkRemovedOptionModule [ "services" "picom" "refreshRate" ]
       "The option `refresh-rate` has been deprecated by upstream.")
+    (mkRemovedOptionModule [ "services" "picom" "experimentalBackends" ]
+      "The option `--experimental-backends` has been removed by upstream.")
     (mkRemovedOptionModule [ "services" "picom" "extraOptions" ]
       "This option has been replaced by `services.picom.settings`.")
     (mkRenamedOptionModule [ "services" "picom" "opacityRule" ] [
@@ -65,8 +67,6 @@ in {
 
   options.services.picom = {
     enable = mkEnableOption "Picom X11 compositor";
-
-    experimentalBackends = mkEnableOption "the new experimental backends";
 
     fade = mkOption {
       type = types.bool;
@@ -213,6 +213,15 @@ in {
       '';
     };
 
+    extraArgs = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      example = literalExpression ''[ "--legacy-backends" ]'';
+      description = ''
+        Extra arguments to be passed to the picom executable.
+      '';
+    };
+
     package = mkOption {
       type = types.package;
       default = pkgs.picom;
@@ -306,7 +315,7 @@ in {
         ExecStart = concatStringsSep " " ([
           "${cfg.package}/bin/picom"
           "--config ${config.xdg.configFile."picom/picom.conf".source}"
-        ] ++ optional cfg.experimentalBackends "--experimental-backends");
+        ] ++ cfg.extraArgs);
         Restart = "always";
         RestartSec = 3;
       };

--- a/tests/modules/services/picom/picom-basic-configuration-expected.service
+++ b/tests/modules/services/picom/picom-basic-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@picom@/bin/picom --config /nix/store/00000000000000000000000000000000-hm_picompicom.conf --experimental-backends
+ExecStart=@picom@/bin/picom --config /nix/store/00000000000000000000000000000000-hm_picompicom.conf --legacy-backends
 Restart=always
 RestartSec=3
 

--- a/tests/modules/services/picom/picom-basic-configuration.nix
+++ b/tests/modules/services/picom/picom-basic-configuration.nix
@@ -19,7 +19,7 @@
       "unredir-if-possible" = true;
       "dbe" = true;
     };
-    experimentalBackends = true;
+    extraArgs = [ "--legacy-backends" ];
   };
 
   test.stubs.picom = { };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

`--experimental-backends` flag was removed in the recent released picom v10. Using it now will result in the program exiting.

v10 also introduces its counter-part, `--legacy-backends`. However this will be removed soon. Instead of adding this as an separate option, add `extraArgs` option so for those that they want they can pass it manuall. It is also more future proof.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.
  + Removal of option, but it will trigger a proper warning.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
