### PR TITLE
udiskie: add note about needing to enable system-wide config

### DIFF
--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -25,7 +25,16 @@ in {
 
   options = {
     services.udiskie = {
-      enable = mkEnableOption "udiskie mount daemon";
+      enable = mkEnableOption "udiskie mount daemon" // {
+        description = ''
+          Whether to enable the udiskie mount daemon.
+          </para><para>
+          Note, if you use NixOS then you must add
+          <code>services.udisks2.enable = true</code>
+          to your system configuration. Otherwise mounting will fail because
+          the Udisk2 DBus service is not found.
+        '';
+      };
 
       settings = mkOption {
         type = yaml.type;


### PR DESCRIPTION
### Description

Closes #3153

Signed-off-by: Sumner Evans <me@sumnerevans.com>

FYI @dschrempf

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
