### PR TITLE
github actions: only run actions on the main repo

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -5,6 +5,7 @@ on:
       - master
 jobs:
   publish:
+    if: github.repository_owner == 'nix-community'
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     - cron: "30 2 * * *"
 jobs:
   tests:
+    if: github.repository_owner == 'nix-community'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update:
+    if: github.repository_owner == 'nix-community'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

My notification inbox for my home-manager fork looks like this:

![image](https://user-images.githubusercontent.com/14929991/203124554-db75819c-f564-472f-a7ee-73ee9eda5e2e.png)

I could just turn off actions in the forks repository settings, but I suspect I'm not the only one with this issue?

This PR turns off all actions for every repo except `nix-community/home-manager`

Please do tell me if there is a clear intention behind keeping the actions running for forks though. In that case, it should probably stated explicitly in the `Contributing` section of the manual.