### PR TITLE
firefox: fix failing firefox-profile-settings test

### DIFF
--- a/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
+++ b/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
@@ -17,10 +17,9 @@
     <DT><A HREF="https://nixos.org/" ADD_DATE="0" LAST_MODIFIED="0">homepage</A>
     <DT><A HREF="https://nixos.wiki/" ADD_DATE="0" LAST_MODIFIED="0">wiki</A>
     <DT><H3>Nix sites</H3>
-      <DL><p>
-        <DT><A HREF="https://nixos.org/" ADD_DATE="0" LAST_MODIFIED="0">homepage</A>
-        <DT><A HREF="https://nixos.wiki/" ADD_DATE="0" LAST_MODIFIED="0">wiki</A>
-      </p></DL>
+    <DL><p>
+      <DT><A HREF="https://nixos.org/" ADD_DATE="0" LAST_MODIFIED="0">homepage</A>
+      <DT><A HREF="https://nixos.wiki/" ADD_DATE="0" LAST_MODIFIED="0">wiki</A>
     </p></DL>
   </p></DL>
 </p></DL>


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
