### PR TITLE
kakoune: allow custom package

### DIFF
--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -489,9 +489,8 @@ let
     };
   };
 
-  kakouneWithPlugins = pkgs.wrapKakoune pkgs.kakoune-unwrapped {
-    configure = { plugins = cfg.plugins; };
-  };
+  kakouneWithPlugins =
+    pkgs.wrapKakoune cfg.package { configure = { plugins = cfg.plugins; }; };
 
   configFile = let
     wrapOptions = with cfg.config.wrapLines;
@@ -623,6 +622,8 @@ in {
   options = {
     programs.kakoune = {
       enable = mkEnableOption "the kakoune text editor";
+
+      package = mkPackageOption pkgs "kakoune-unwrapped" { };
 
       config = mkOption {
         type = types.nullOr configModule;


### PR DESCRIPTION
### Description

Other tools such as neovim allow a custom package to be defined. This PR aims to allow the same for kakoune.

This is handy, especially when kakoune is not up to date with the latest version in nixpkgs. It allows you to override it to use the latest one for example, or when developing using a fork.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.kakoune-{no-plugins,use-plugins,whitespace-highlighter,whitespace-highlighter-corner-cases}`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.