### PR TITLE
fix: nushell supports darwin config file locations

### DIFF
--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -6,6 +6,11 @@ let
 
   cfg = config.programs.nushell;
 
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Application Support/nushell"
+  else
+    "${config.xdg.configHome}/nushell";
+
   linesOrSource = name:
     types.submodule ({ config, ... }: {
       options = {
@@ -110,16 +115,15 @@ in {
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
-
-    xdg.configFile = mkMerge [
+    home.file = mkMerge [
       (mkIf (cfg.configFile != null || cfg.extraConfig != "") {
-        "nushell/config.nu".text = mkMerge [
+        "${configDir}/config.nu".text = mkMerge [
           (mkIf (cfg.configFile != null) cfg.configFile.text)
           cfg.extraConfig
         ];
       })
       (mkIf (cfg.envFile != null || cfg.extraEnv != "") {
-        "nushell/env.nu".text = mkMerge [
+        "${configDir}/env.nu".text = mkMerge [
           (mkIf (cfg.envFile != null) cfg.envFile.text)
           cfg.extraEnv
         ];

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ pkgs, ... }:
 
 {
   programs.nushell = {
@@ -19,12 +19,17 @@
 
   test.stubs.nushell = { };
 
-  nmt.script = ''
+  nmt.script = let
+    configDir = if pkgs.stdenv.isDarwin then
+      "home-files/Library/Application Support/nushell"
+    else
+      "home-files/.config/nushell";
+  in ''
     assertFileContent \
-      home-files/.config/nushell/config.nu \
+      "${configDir}/config.nu" \
       ${./config-expected.nu}
     assertFileContent \
-      home-files/.config/nushell/env.nu \
+      "${configDir}/env.nu" \
       ${./env-expected.nu}
   '';
 }


### PR DESCRIPTION
### Description

Updates the nushell program to support the correct config file locations on Darwin systems.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  - No existing tests exist, none added

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
