### PR TITLE
neovim: Source neovimRcContent directly from store

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -365,15 +365,13 @@ in {
       in mkMerge (
         # writes runtime
         (map (x: x.runtime) pluginsNormalized) ++ [{
-          "nvim/init-home-manager.vim" =
-            mkIf (neovimConfig.neovimRcContent != "") {
-              text = neovimConfig.neovimRcContent;
-            };
           "nvim/init.lua" = let
             luaRcContent =
               lib.optionalString (neovimConfig.neovimRcContent != "")
-              "vim.cmd [[source ${config.xdg.configHome}/nvim/init-home-manager.vim]]"
-              + lib.optionalString hasLuaConfig
+              "vim.cmd [[source ${
+                pkgs.writeText "nvim-init-home-manager.vim"
+                neovimConfig.neovimRcContent
+              }]]" + lib.optionalString hasLuaConfig
               config.programs.neovim.generatedConfigs.lua;
           in mkIf (luaRcContent != "") { text = luaRcContent; };
 

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -7,16 +7,14 @@ with lib;
     programs.neovim = {
       enable = true;
       extraConfig = ''
-        " This 'extraConfig' should be present in vimrc
+        let g:hmExtraConfig='HM_EXTRA_CONFIG'
       '';
       plugins = with pkgs.vimPlugins; [
         vim-nix
         {
           plugin = vim-commentary;
           config = ''
-            " plugin-specific config
-            autocmd FileType c setlocal commentstring=//\ %s
-            autocmd FileType c setlocal comments=://
+            let g:hmPlugins='HM_PLUGINS_CONFIG'
           '';
         }
       ];
@@ -24,11 +22,12 @@ with lib;
     };
 
     nmt.script = ''
-      vimrc="$TESTED/home-files/.config/nvim/init-home-manager.vim"
-      vimrcNormalized="$(normalizeStorePaths "$vimrc")"
-
-      assertFileExists "$vimrc"
-      assertFileContent "$vimrcNormalized" "${./plugin-config.vim}"
+      vimout=$(mktemp)
+      echo "redir >> /dev/stdout | echo g:hmExtraConfig | echo g:hmPlugins | redir END" \
+        | ${pkgs.neovim}/bin/nvim -es -u "$TESTED/home-files/.config/nvim/init.lua" \
+        > "$vimout"
+      assertFileContains "$vimout" "HM_EXTRA_CONFIG"
+      assertFileContains "$vimout" "HM_PLUGINS_CONFIG"
     '';
   };
 }

--- a/tests/modules/programs/neovim/plugin-config.vim
+++ b/tests/modules/programs/neovim/plugin-config.vim
@@ -1,5 +1,0 @@
-" plugin-specific config
-autocmd FileType c setlocal commentstring=//\ %s
-autocmd FileType c setlocal comments=://
-
-" This 'extraConfig' should be present in vimrc


### PR DESCRIPTION
### Description

The previous version linked the file into home, then sourced that. Since
nothing else expects that file to be there, this is unnecessary.
Additionally, doing so made it impossible to test a built config without
switching, e.g. using `XDG_CONFIG_HOME=… nvim` or `nvim -u`. This
remedies that, at least for this particular reference.

To test this, change from asserting contents of the config file to
actually starting nvim, outputting sentinel values, and then asserting
their values are present. This way it’s tested that nvim loaded the
config, rather than that some config is in a specific place.

This is all in one commit as the test, as written now, would not have
worked before since the previously hard-coded home path was not an
actual file in the test environment.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
