### PR TITLE
fish: Format fish code

### DIFF
--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -1,4 +1,5 @@
 {
+  fish-format-scripts = ./format-scripts.nix;
   fish-functions = ./functions.nix;
   fish-no-functions = ./no-functions.nix;
   fish-plugins = ./plugins.nix;

--- a/tests/modules/programs/fish/format-scripts.nix
+++ b/tests/modules/programs/fish/format-scripts.nix
@@ -1,0 +1,50 @@
+{ config, pkgs, ... }:
+
+let
+
+  expectedFunc = pkgs.writeText "func.fish" ''
+    function func
+        echo foo
+    end
+  '';
+
+  expectedFuncMulti = pkgs.writeText "func-multi.fish" ''
+    function func-multi
+        echo bar
+        if foo
+            bar
+            baz
+        end
+    end
+  '';
+
+in {
+  config = {
+    programs.fish = {
+      enable = true;
+
+      formatFishScripts = true;
+
+      functions = {
+        func = ''echo "foo"'';
+        func-multi = ''
+              echo bar
+          if foo
+              bar
+                  baz
+                end
+        '';
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/fish/functions/func.fish
+      echo ${expectedFunc}
+      assertFileContent home-files/.config/fish/functions/func.fish ${expectedFunc}
+
+      assertFileExists home-files/.config/fish/functions/func-multi.fish
+      echo ${expectedFuncMulti}
+      assertFileContent home-files/.config/fish/functions/func-multi.fish ${expectedFuncMulti}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Create a `runCommand` based wrapper to indent fish code using `fish_indent`.

Addresses #2303

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
