### PR TITLE
lazygit: add package option

### DIFF
--- a/modules/programs/lazygit.nix
+++ b/modules/programs/lazygit.nix
@@ -16,6 +16,8 @@ in {
   options.programs.lazygit = {
     enable = mkEnableOption "lazygit, a simple terminal UI for git commands";
 
+    package = mkPackageOption pkgs "lazygit" { };
+
     settings = mkOption {
       type = yamlFormat.type;
       default = { };
@@ -41,7 +43,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.lazygit ];
+    home.packages = [ cfg.package ];
 
     home.file."Library/Application Support/lazygit/config.yml" =
       mkIf (cfg.settings != { } && isDarwin) {


### PR DESCRIPTION
### Description

Added a package option for lazygit
Tested locally using:
```
  programs.lazygit = {
    enable = true;
    package = (pkgs.lazygit.overrideAttrs (oldAttrs: {
      patches = (oldAttrs.patches or [ ]) ++ [
        (pkgs.fetchpatch {
          name = "fix-credential-prompt.patch";
          url = "https://patch-diff.githubusercontent.com/raw/jesseduffield/lazygit/pull/2239.patch";
          sha256 = "sha256-olj4xV1AU93R76drDuISQRNpxv/85GBfXJe6WgO33xc=";
        })
      ];
    }));
    settings = {
      git.autoFetch = false;
    };
  };

```


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
NOTE: there was no test-case available, should I add one?

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.