### PR TITLE
home-manager: Try short hostname in flake config lookup

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -106,10 +106,17 @@ function setFlakeAttribute() {
                 local name="${FLAKE_ARG#*#}"
             ;;
             *)
-                local name="$USER@$(hostname)"
-                if [ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$name\"")" = "false" ]; then
-                    name="$USER"
-                fi
+                local name="$USER"
+                # Check both long and short hostnames; long first to preserve
+                # pre-existing behaviour in case both happen to be defined.
+                for n in "$USER@$(hostname)" "$USER@$(hostname -s)"; do
+                    if [[ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$n\"")" == "true" ]]; then
+                        name="$n"
+                        if [[ -v VERBOSE ]]; then
+                            echo "Using flake homeConfiguration for $name"
+                        fi
+                    fi
+                done
             ;;
         esac
         export FLAKE_CONFIG_URI="$flake#homeConfigurations.\"$name\""


### PR DESCRIPTION
### Description

Depending on DHCP settings you might end up with different output from running `hostname`. Eg, your local hostname is `mylaptop`, and your home router is configured with a local domain of `.home.arpa`. In this case:

    $ hostname
    mylaptop.home.arpa
    $ hostname -s
    mylaptop

If you then go to cafe which has its router configured with `.lan` as its local domain. Then, if your DHCP settings accept the local domain from the router,

    $ hostname
    myalaptop.lan
    $ hostname -s
    mylaptop

With the pre-existing behaviour, if you had a `"me@mylaptop.home.arpa"` entry in `outputs.homeConfigurations`, running `home-manager switch` would fail:

    $ home-manager switch
    error: flake 'git+file:///home/me/.config/nixpkgs' does not provide
    attribute 'packages.aarch64-darwin.homeConfigurations."me".activationPackage',
    'legacyPackages.aarch64-darwin.homeConfigurations."me".activationPackage'
    or 'homeConfigurations."me".activationPackage'

After this commit, you can put configuration in a `"me@mylaptop"` entry in `outputs.homeConfigurations`, and everything will work on either network.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.


- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.