### PR TITLE
pet: don't create file without snippets

### DIFF
--- a/modules/programs/pet.nix
+++ b/modules/programs/pet.nix
@@ -99,8 +99,9 @@ in {
         else {
           General = cfg.settings;
         });
-      "pet/snippet.toml".source =
-        format.generate "snippet.toml" { snippets = cfg.snippets; };
+      "pet/snippet.toml" = mkIf (cfg.snippets != [ ]) {
+        source = format.generate "snippet.toml" { snippets = cfg.snippets; };
+      };
     };
   };
 }


### PR DESCRIPTION
### Description

Pet snippets can be managed with HM or with Pet gist support.
This stops HM from generating an empty file if no snippets are provided in the configuration; allowing Pet to sync the snippet file with the gist.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
