### PR TITLE
just: deprecate since completions work out of the box now

### DIFF
--- a/modules/programs/just.nix
+++ b/modules/programs/just.nix
@@ -9,44 +9,14 @@ let
 in {
   meta.maintainers = [ hm.maintainers.maximsmol ];
 
-  options.programs.just = {
-    enable = mkEnableOption
-      "just, a handy way to save and run project-specific commands";
-
-    package = mkOption {
-      type = types.package;
-      default = pkgs.just;
-      defaultText = literalExpression "pkgs.just";
-      description = "Package providing the <command>just</command> tool.";
-    };
-
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = true;
-    };
-
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
-
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
-  };
-
-  config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
-
-    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      source ${cfg.package}/share/bash-completion/completions/just.bash
-    '';
-
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      source ${cfg.package}/share/zsh/site-functions/_just
-    '';
-
-    programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
-      source ${cfg.package}/share/fish/vendor_completions.d/just.fish
-    '';
-
-  };
+  imports = let
+    msg = ''
+      'program.just' is deprecated, simply add 'pkgs.just' to 'home.packages' instead.
+      See https://github.com/nix-community/home-manager/issues/3449#issuecomment-1329823502'';
+  in [
+    (mkRemovedOptionModule [ "programs" "just" "enable" ] msg)
+    (mkRemovedOptionModule [ "programs" "just" "enableBashIntegration" ] msg)
+    (mkRemovedOptionModule [ "programs" "just" "enableZshIntegration" ] msg)
+    (mkRemovedOptionModule [ "programs" "just" "enableFishIntegration" ] msg)
+  ];
 }


### PR DESCRIPTION
### Description

Closes #3449. Also deprecates the entire thing as completions work out of the box now! Also removes the old completions implementation to avoid double-initializing them

Note: there are no tests for this module and the tests fail with unrelated `No such file or directory: '/nix/store/61h76ya021588gp3g6my168pib7in8w9-broot-1.12.0.tar.gz/resources/default-conf/conf.hjson'` so I'm just ignoring that requirement

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [X] Added myself and the module files to `.github/CODEOWNERS`.
