### PR TITLE
i3-sway: config.focus.wrapping deprecates forceWrapping

### DIFF
--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -161,7 +161,7 @@ let
         "floating_modifier ${floating.modifier}"
         (windowBorderString window floating)
         "hide_edge_borders ${window.hideEdgeBorders}"
-        "force_focus_wrapping ${lib.hm.booleans.yesNo focus.forceWrapping}"
+        "focus_wrapping ${focus.wrapping}"
         "focus_follows_mouse ${lib.hm.booleans.yesNo focus.followMouse}"
         "focus_on_window_activation ${focus.newWindow}"
         "mouse_warping ${if focus.mouseWarping then "output" else "none"}"
@@ -271,16 +271,15 @@ in {
         ++ flatten (map (b:
           optional (isList b.fonts)
           "Specifying i3.config.bars[].fonts as a list is deprecated. Use the attrset version instead.")
-          cfg.config.bars);
+          cfg.config.bars) ++ [
+            (mkIf (any (s: s.workspace != null) cfg.config.startup)
+              ("'xsession.windowManager.i3.config.startup.*.workspace' is deprecated, "
+                + "use 'xsession.windowManager.i3.config.assigns' instead."
+                + "See https://github.com/nix-community/home-manager/issues/265."))
+            (mkIf cfg.config.focus.forceWrapping
+              ("'xsession.windowManager.i3.config.focus.forceWrapping' is deprecated, "
+                + "use 'xsession.windowManager.i3.config.focus.wrapping' instead."))
+          ];
     })
-
-    (mkIf (cfg.config != null
-      && (any (s: s.workspace != null) cfg.config.startup)) {
-        warnings = [
-          ("'xsession.windowManager.i3.config.startup.*.workspace' is deprecated, "
-            + "use 'xsession.windowManager.i3.config.assigns' instead."
-            + "See https://github.com/nix-community/home-manager/issues/265.")
-        ];
-      })
   ]);
 }

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -497,13 +497,28 @@ in {
             if (isSway && isBool val) then (lib.hm.booleans.yesNo val) else val;
         };
 
+        wrapping = mkOption {
+          type = types.enum [ "yes" "no" "force" "workspace" ];
+          default = {
+            i3 = if cfg.config.focus.forceWrapping then "force" else "yes";
+            # the sway module's logic was inverted and incorrect,
+            # so preserve it for backwards compatibility purposes
+            sway = if cfg.config.focus.forceWrapping then "yes" else "no";
+          }.${moduleName};
+          description = ''
+            Whether the window focus commands automatically wrap around the edge of containers.
+
+            See <link xlink:href="https://i3wm.org/docs/userguide.html#_focus_wrapping"/>
+          '';
+        };
+
         forceWrapping = mkOption {
           type = types.bool;
           default = false;
           description = ''
-            Whether to force focus wrapping in tabbed or stacked container.
+            Whether to force focus wrapping in tabbed or stacked containers.
 
-            See <link xlink:href="https://i3wm.org/docs/userguide.html#_focus_wrapping"/>
+            This option is deprecated, use <option>focus.wrapping</option> instead.
           '';
         };
 

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -271,7 +271,7 @@ let
           "floating_modifier ${floating.modifier}"
           (windowBorderString window floating)
           "hide_edge_borders ${window.hideEdgeBorders}"
-          "focus_wrapping ${lib.hm.booleans.yesNo focus.forceWrapping}"
+          "focus_wrapping ${focus.wrapping}"
           "focus_follows_mouse ${focus.followMouse}"
           "focus_on_window_activation ${focus.newWindow}"
           "mouse_warping ${
@@ -442,7 +442,10 @@ in {
         ++ flatten (map (b:
           optional (isList b.fonts)
           "Specifying sway.config.bars[].fonts as a list is deprecated. Use the attrset version instead.")
-          cfg.config.bars);
+          cfg.config.bars) ++ [
+            (mkIf cfg.config.focus.forceWrapping
+              "sway.config.focus.forceWrapping is deprecated, use focus.wrapping instead.")
+          ];
     })
 
     {

--- a/tests/modules/services/window-managers/i3/i3-bar-focused-colors-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-bar-focused-colors-expected.conf
@@ -3,7 +3,7 @@ floating_modifier Mod1
 default_border normal 2
 default_floating_border normal 2
 hide_edge_borders none
-force_focus_wrapping no
+focus_wrapping yes
 focus_follows_mouse yes
 focus_on_window_activation smart
 mouse_warping output

--- a/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
@@ -3,7 +3,7 @@ floating_modifier Mod1
 default_border normal 2
 default_floating_border normal 2
 hide_edge_borders none
-force_focus_wrapping no
+focus_wrapping yes
 focus_follows_mouse no
 focus_on_window_activation smart
 mouse_warping output

--- a/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
@@ -3,7 +3,7 @@ floating_modifier Mod1
 default_border normal 2
 default_floating_border normal 2
 hide_edge_borders none
-force_focus_wrapping no
+focus_wrapping yes
 focus_follows_mouse yes
 focus_on_window_activation smart
 mouse_warping output

--- a/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
@@ -3,7 +3,7 @@ floating_modifier Mod1
 default_border normal 2
 default_floating_border normal 2
 hide_edge_borders none
-force_focus_wrapping no
+focus_wrapping yes
 focus_follows_mouse yes
 focus_on_window_activation smart
 mouse_warping output

--- a/tests/modules/services/window-managers/i3/i3-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-workspace-default-expected.conf
@@ -3,7 +3,7 @@ floating_modifier Mod1
 default_border normal 2
 default_floating_border normal 2
 hide_edge_borders none
-force_focus_wrapping no
+focus_wrapping yes
 focus_follows_mouse yes
 focus_on_window_activation smart
 mouse_warping output

--- a/tests/modules/services/window-managers/i3/i3-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-workspace-output-expected.conf
@@ -3,7 +3,7 @@ floating_modifier Mod1
 default_border normal 2
 default_floating_border normal 2
 hide_edge_borders none
-force_focus_wrapping no
+focus_wrapping yes
 focus_follows_mouse yes
 focus_on_window_activation smart
 mouse_warping output


### PR DESCRIPTION


### Description
Stop using the [legacy syntax](https://i3wm.org/docs/userguide.html#_focus_wrapping) for focus wrapping.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
