### PR TITLE
polybar: fix restart trigger

### DIFF
--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -55,11 +55,17 @@ let
       in "${key}=${value'}";
   };
 
-  configFile = pkgs.writeText "polybar.conf" ''
-    ${toPolybarIni cfg.config}
-    ${toPolybarIni (mapAttrs convertPolybarSection cfg.settings)}
-    ${cfg.extraConfig}
-  '';
+  configFile = let
+    isDeclarativeConfig = cfg.settings != opt.settings.default || cfg.config
+      != opt.config.default || cfg.extraConfig != opt.extraConfig.default;
+  in if isDeclarativeConfig then
+    pkgs.writeText "polybar.conf" ''
+      ${toPolybarIni cfg.config}
+      ${toPolybarIni (mapAttrs convertPolybarSection cfg.settings)}
+      ${cfg.extraConfig}
+    ''
+  else
+    null;
 
 in {
   options = {
@@ -202,16 +208,14 @@ in {
     meta.maintainers = with maintainers; [ h7x4 ];
 
     home.packages = [ cfg.package ];
-    xdg.configFile."polybar/config.ini" = let
-      isDeclarativeConfig = cfg.settings != opt.settings.default || cfg.config
-        != opt.config.default || cfg.extraConfig != opt.extraConfig.default;
-    in mkIf isDeclarativeConfig { source = configFile; };
+    xdg.configFile."polybar/config.ini" =
+      mkIf (configFile != null) { source = configFile; };
 
     systemd.user.services.polybar = {
       Unit = {
         Description = "Polybar status bar";
         PartOf = [ "tray.target" ];
-        X-Restart-Triggers = [ "${config.xdg.configHome}/polybar/config.ini" ];
+        X-Restart-Triggers = mkIf (configFile != null) "${configFile}";
       };
 
       Service = {

--- a/tests/modules/services/polybar/basic-configuration.nix
+++ b/tests/modules/services/polybar/basic-configuration.nix
@@ -47,7 +47,7 @@
       serviceFile=home-files/.config/systemd/user/polybar.service
 
       assertFileExists $serviceFile
-      assertFileRegex $serviceFile 'X-Restart-Triggers=.*/.config/polybar/config.ini'
+      assertFileRegex $serviceFile 'X-Restart-Triggers=/nix/store/.*-polybar.conf$'
       assertFileRegex $serviceFile 'ExecStart=.*/bin/polybar-start'
 
       assertFileExists home-files/.config/polybar/config.ini

--- a/tests/modules/services/polybar/empty-configuration.nix
+++ b/tests/modules/services/polybar/empty-configuration.nix
@@ -12,7 +12,7 @@
       serviceFile=home-files/.config/systemd/user/polybar.service
 
       assertFileExists $serviceFile
-      assertFileRegex $serviceFile 'X-Restart-Triggers=.*/.config/polybar/config.ini'
+      assertFileNotRegex $serviceFile 'X-Restart-Triggers=/nix/store/.*-polybar.conf$'
       assertFileRegex $serviceFile 'ExecStart=.*/bin/polybar-start'
 
       assertPathNotExists home-files/.config/polybar/config.ini


### PR DESCRIPTION
### Description

The old trigger would actually never cause a restart since the path doesn't change. With this change the trigger is now using the actual configuration path in the Nix store, which depends on the content.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```