### PR TITLE
fish: always run fish_indent

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -146,14 +146,11 @@ let
     (mapAttrsToList (k: v: "alias ${k} ${escapeShellArg v}") cfg.shellAliases);
 
   fishIndent = name: text:
-    if cfg.formatFishScripts then
-      pkgs.runCommand name {
-        nativeBuildInputs = [ cfg.package ];
-        inherit text;
-        passAsFile = [ "text" ];
-      } "fish_indent < $textPath > $out"
-    else
-      pkgs.writeText name text;
+    pkgs.runCommand name {
+      nativeBuildInputs = [ cfg.package ];
+      inherit text;
+      passAsFile = [ "text" ];
+    } "fish_indent < $textPath > $out";
 
 in {
   imports = [
@@ -288,16 +285,6 @@ in {
         <link xlink:href="https://fishshell.com/docs/current/cmds/function.html"/>.
       '';
     };
-
-    programs.fish.formatFishScripts = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Whether to process fish configuration and scripts with
-        <literal>fish_indent</literal>.
-      '';
-    };
-
   };
 
   config = mkIf cfg.enable (mkMerge [

--- a/tests/modules/programs/atuin/fish.nix
+++ b/tests/modules/programs/atuin/fish.nix
@@ -13,7 +13,6 @@
   test.stubs = {
     atuin = { };
     bash-preexec = { };
-    fish = { };
   };
 
   nmt.script = ''

--- a/tests/modules/programs/atuin/no-shell.nix
+++ b/tests/modules/programs/atuin/no-shell.nix
@@ -20,7 +20,6 @@
   test.stubs = {
     atuin = { };
     bash-preexec = { };
-    fish = { };
   };
 
   nmt.script = ''

--- a/tests/modules/programs/fish/functions.nix
+++ b/tests/modules/programs/fish/functions.nix
@@ -6,13 +6,13 @@ let
 
   func = pkgs.writeText "func.fish" ''
     function func
-      echo "Hello"
+        echo Hello
     end
   '';
 
   funcEvent = pkgs.writeText "func-event.fish" ''
     function func-event --on-event="fish_command_not_found"
-      echo "Not found!"
+        echo "Not found!"
     end
   '';
 
@@ -33,8 +33,6 @@ in {
     # Needed to avoid error with dummy fish package.
     xdg.dataFile."fish/home-manager_generated_completions".source =
       lib.mkForce (builtins.toFile "empty" "");
-
-    test.stubs.fish = { };
 
     nmt = {
       description =

--- a/tests/modules/programs/fish/no-functions.nix
+++ b/tests/modules/programs/fish/no-functions.nix
@@ -14,8 +14,6 @@ with lib;
     xdg.dataFile."fish/home-manager_generated_completions".source =
       lib.mkForce (builtins.toFile "empty" "");
 
-    test.stubs.fish = { };
-
     nmt = {
       description =
         "if fish.functions is blank, the functions folder should not exist.";

--- a/tests/modules/programs/fish/plugins.nix
+++ b/tests/modules/programs/fish/plugins.nix
@@ -12,26 +12,26 @@ let
 
     # Set paths to import plugin components
     if test -d $plugin_dir/functions
-      set fish_function_path $fish_function_path[1] $plugin_dir/functions $fish_function_path[2..-1]
+        set fish_function_path $fish_function_path[1] $plugin_dir/functions $fish_function_path[2..-1]
     end
 
     if test -d $plugin_dir/completions
-      set fish_complete_path $fish_complete_path[1] $plugin_dir/completions $fish_complete_path[2..-1]
+        set fish_complete_path $fish_complete_path[1] $plugin_dir/completions $fish_complete_path[2..-1]
     end
 
     # Source initialization code if it exists.
     if test -d $plugin_dir/conf.d
-      for f in $plugin_dir/conf.d/*.fish
-        source $f
-      end
+        for f in $plugin_dir/conf.d/*.fish
+            source $f
+        end
     end
 
     if test -f $plugin_dir/key_bindings.fish
-      source $plugin_dir/key_bindings.fish
+        source $plugin_dir/key_bindings.fish
     end
 
     if test -f $plugin_dir/init.fish
-      source $plugin_dir/init.fish
+        source $plugin_dir/init.fish
     end
   '';
 
@@ -49,8 +49,6 @@ in {
     # Needed to avoid error with dummy fish package.
     xdg.dataFile."fish/home-manager_generated_completions".source =
       lib.mkForce (builtins.toFile "empty" "");
-
-    test.stubs.fish = { };
 
     nmt = {
       description =

--- a/tests/modules/programs/nix-index/assert-on-command-not-found.nix
+++ b/tests/modules/programs/nix-index/assert-on-command-not-found.nix
@@ -12,10 +12,7 @@
     xdg.dataFile."fish/home-manager_generated_completions".source =
       lib.mkForce (builtins.toFile "empty" "");
 
-    test.stubs = {
-      zsh = { };
-      fish = { };
-    };
+    test.stubs.zsh = { };
 
     programs.nix-index.enable = true;
 

--- a/tests/modules/programs/nix-index/integrations.nix
+++ b/tests/modules/programs/nix-index/integrations.nix
@@ -16,10 +16,7 @@ in {
     xdg.dataFile."fish/home-manager_generated_completions".source =
       lib.mkForce (builtins.toFile "empty" "");
 
-    test.stubs = {
-      zsh = { };
-      fish = { };
-    };
+    test.stubs.zsh = { };
 
     programs.nix-index.enable = true;
 

--- a/tests/modules/programs/oh-my-posh/fish.nix
+++ b/tests/modules/programs/oh-my-posh/fish.nix
@@ -14,10 +14,7 @@
   xdg.dataFile."fish/home-manager_generated_completions".source =
     lib.mkForce (builtins.toFile "empty" "");
 
-  test.stubs = {
-    oh-my-posh = { };
-    fish = { };
-  };
+  test.stubs.oh-my-posh = { };
 
   nmt.script = ''
     assertFileExists home-files/.config/fish/config.fish

--- a/tests/modules/programs/pls/fish.nix
+++ b/tests/modules/programs/pls/fish.nix
@@ -18,10 +18,7 @@ with lib;
     xdg.dataFile."fish/home-manager_generated_completions".source =
       mkForce (builtins.toFile "empty" "");
 
-    test.stubs = {
-      pls = { };
-      fish = { };
-    };
+    test.stubs.pls = { };
 
     nmt.script = ''
       assertFileExists home-files/.config/fish/config.fish

--- a/tests/modules/programs/powerline-go/fish.nix
+++ b/tests/modules/programs/powerline-go/fish.nix
@@ -22,10 +22,7 @@ with lib;
     xdg.dataFile."fish/home-manager_generated_completions".source =
       mkForce (builtins.toFile "empty" "");
 
-    test.stubs = {
-      powerline-go = { };
-      fish = { };
-    };
+    test.stubs.powerline-go = { };
 
     nmt.script = ''
       assertFileExists home-files/.config/fish/config.fish

--- a/tests/modules/programs/scmpuff/fish.nix
+++ b/tests/modules/programs/scmpuff/fish.nix
@@ -8,7 +8,6 @@
   xdg.dataFile."fish/home-manager_generated_completions".source =
     lib.mkForce (builtins.toFile "empty" "");
 
-  test.stubs.fish = { };
   test.stubs.scmpuff = { };
 
   nmt.script = ''

--- a/tests/modules/programs/scmpuff/no-fish.nix
+++ b/tests/modules/programs/scmpuff/no-fish.nix
@@ -11,7 +11,6 @@
   xdg.dataFile."fish/home-manager_generated_completions".source =
     lib.mkForce (builtins.toFile "empty" "");
 
-  test.stubs.fish = { };
   test.stubs.scmpuff = { };
 
   nmt.script = ''


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Always run fish_indent, remove option, and remove test stubs

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
