### PR TITLE
treewide: use liberachat in examples

### DIFF
--- a/modules/programs/hexchat.nix
+++ b/modules/programs/hexchat.nix
@@ -170,7 +170,7 @@ let
         servers = mkOption {
           type = listOf str;
           default = [ ];
-          example = [ "chat.freenode.net" "irc.freenode.net" ];
+          example = [ "irc.oftc.net" ];
           description = "IRC Server Address List.";
         };
       };
@@ -239,11 +239,10 @@ in {
       default = { };
       example = literalExpression ''
         {
-          freenode = {
+          oftc = {
             autojoin = [
               "#home-manager"
               "#linux"
-              "#nixos"
             ];
             charset = "UTF-8 (Unicode)";
             commands = [
@@ -263,8 +262,7 @@ in {
             password = "my_password";
             realName = "my_realname";
             servers = [
-              "chat.freenode.net"
-              "irc.freenode.net"
+              "irc.oftc.net"
             ];
             userName = "my_username";
           };

--- a/modules/programs/irssi.nix
+++ b/modules/programs/irssi.nix
@@ -185,10 +185,10 @@ in {
         default = { };
         example = literalExpression ''
           {
-            freenode = {
+            liberachat = {
               nick = "hmuser";
               server = {
-                address = "chat.freenode.net";
+                address = "irc.libera.chat";
                 port = 6697;
                 autoConnect = true;
               };

--- a/tests/modules/programs/hexchat/basic-configuration-expected-serverlist-config
+++ b/tests/modules/programs/hexchat/basic-configuration-expected-serverlist-config
@@ -8,7 +8,7 @@ S=irc.mzima.net
 S=irc.prison.net
 J=#computers
 
-N=freenode
+N=oftc
 L=6
 E=UTF-8 (Unicode)
 F=12
@@ -17,8 +17,6 @@ i=user_
 R=real_user
 U=user
 P=password
-S=chat.freenode.net
-S=irc.freenode.net
+S=irc.oftc.net
 J=#home-manager
-J=#nixos
 

--- a/tests/modules/programs/hexchat/basic-configuration.nix
+++ b/tests/modules/programs/hexchat/basic-configuration.nix
@@ -6,7 +6,7 @@
       enable = true;
       overwriteConfigFiles = true;
       channels = {
-        freenode = {
+        oftc = {
           charset = "UTF-8 (Unicode)";
           userName = "user";
           password = "password";
@@ -18,8 +18,8 @@
             autoconnect = true;
             forceSSL = true;
           };
-          servers = [ "chat.freenode.net" "irc.freenode.net" ];
-          autojoin = [ "#home-manager" "#nixos" ];
+          servers = [ "irc.oftc.net" ];
+          autojoin = [ "#home-manager" ];
         };
         efnet = {
           options = { forceSSL = true; };


### PR DESCRIPTION

### Description

<!--

Please provide a brief description of your change.

-->
Freenode was taken over by a wannabe bitcoin millionaire [1], which prompted the migration of communities to Libera Chat [2].

[1] https://blog.bofh.it/debian/id_461
[2] https://hackaday.com/2021/05/20/freenode-debacle-prompts-staff-exodus-new-network/

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
