### PR TITLE
yt-dlp: fix settings example

### DIFF
--- a/modules/programs/yt-dlp.nix
+++ b/modules/programs/yt-dlp.nix
@@ -29,11 +29,13 @@ in {
       type = with types; attrsOf (oneOf [ bool int str ]);
       default = { };
       example = literalExpression ''
-        embed-thumbnail = true;
-        embed-subs = true;
-        sub-langs = "all";
-        downloader = "aria2c";
-        downloader-args = "aria2c:'-c -x8 -s8 -k1M'";
+        {
+          embed-thumbnail = true;
+          embed-subs = true;
+          sub-langs = "all";
+          downloader = "aria2c";
+          downloader-args = "aria2c:'-c -x8 -s8 -k1M'";
+        }
       '';
       description = ''
         Configuration written to


### PR DESCRIPTION


### Description

<!--

Please provide a brief description of your change.

-->
The yt-dlp settings should be an attribute set.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
