### PR TITLE
emacs: add note about `inhibit-startup-message`

### DIFF
--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -52,6 +52,10 @@ in {
           Configuration to include in the Emacs default init file. See
           <link xlink:href="https://www.gnu.org/software/emacs/manual/html_node/elisp/Init-File.html"/>
           for more.
+          </para><para>
+          Note, the <literal>inhibit-startup-message</literal> Emacs option
+          cannot be set here since Emacs disallows setting it from the default
+          initialization file.
         '';
       };
 


### PR DESCRIPTION
### Description

Hopefully this can avoid a bit of confusion.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```