### PR TITLE
home-manager: use `hostname` from Nixpkgs

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -1,5 +1,5 @@
 { runCommand, lib, bash, callPackage, coreutils, findutils, gettext, gnused
-, less, ncurses
+, less, ncurses, unixtools
 # used for pkgs.path for nixos-option
 , pkgs
 
@@ -39,6 +39,7 @@ in runCommand "home-manager" {
         less
         ncurses
         nixos-option
+        unixtools.hostname
       ]
     }" \
     --subst-var-by HOME_MANAGER_LIB '${../lib/bash/home-manager.sh}' \


### PR DESCRIPTION
### Description

Before the home-manager tool got hostname from the system, which was not declarative or reproducible.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```