### PR TITLE
megasync: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -427,6 +427,8 @@ Makefile                                              @thiagokokada
 
 /modules/services/mbsync.nix                          @pjones
 
+/modules/services/megasync.nix                        @GaetanLepage
+
 /modules/services/mopidy.nix                          @foo-dogsquared
 /tests/modules/services/mopidy                        @foo-dogsquared
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -853,6 +853,14 @@ in
           'Host' blocks
         '';
       }
+
+      {
+        time = "2022-12-16T15:01:20+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.megasync'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -238,6 +238,7 @@ let
     ./services/lorri.nix
     ./services/mako.nix
     ./services/mbsync.nix
+    ./services/megasync.nix
     ./services/mopidy.nix
     ./services/mpd.nix
     ./services/mpdris2.nix

--- a/modules/services/megasync.nix
+++ b/modules/services/megasync.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.megasync;
+
+in {
+  meta.maintainers = [ maintainers.GaetanLepage ];
+
+  options = {
+    services.megasync = {
+      enable = mkEnableOption "Megasync client";
+
+      package = mkPackageOption pkgs "megasync" { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.megasync" pkgs
+        lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    systemd.user.services.megasync = {
+      Unit = {
+        Description = "megasync";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+
+      Service = { ExecStart = "${cfg.package}/bin/megasync"; };
+    };
+  };
+}


### PR DESCRIPTION
### Description

Add the `megasync` module.
It basically starts the megasync client through a systemd service.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
