### PR TITLE
git: allow tags to be unsigned when signing.signByDefault=true

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -466,8 +466,8 @@ in {
     (mkIf (cfg.signing != null) {
       programs.git.iniContent = {
         user.signingKey = mkIf (cfg.signing.key != null) cfg.signing.key;
-        commit.gpgSign = cfg.signing.signByDefault;
-        tag.gpgSign = cfg.signing.signByDefault;
+        commit.gpgSign = mkDefault cfg.signing.signByDefault;
+        tag.gpgSign = mkDefault cfg.signing.signByDefault;
         gpg.program = cfg.signing.gpgPath;
       };
     })


### PR DESCRIPTION
### Description

Before [this commit](https://github.com/nix-community/home-manager/commit/140aaed3dffbe33bb8b2e0cf333c67f36765c85e), tag signing wasn’t automatically enabled with `signing.signByDefault`. It’s now automatically enabled, which forces you to always use annotated tags (it seems like there’s no flag to tell git to use a lightweight tag).

This commit only sets tag and commit signing as defaults, allowing you to override them.

Unfortunately I wasn’t able to run the tests, the test command gave me the following error:

```
error: builder for '/nix/store/v8ny0pzdm47lsl8xxk3rnqa86mrv49j3-default-conf.json.drv' failed with exit code 1;
       last 10 log lines:
       > Traceback (most recent call last):
       >   File "/nix/store/xpwwghl72bb7f48m51amvqiv1l25pa01-python3-3.9.13/lib/python3.9/runpy.py", line 197, in _run_module_as_main
       >     return _run_code(code, main_globals, None,
       >   File "/nix/store/xpwwghl72bb7f48m51amvqiv1l25pa01-python3-3.9.13/lib/python3.9/runpy.py", line 87, in _run_code
       >     exec(code, run_globals)
       >   File "/nix/store/fdq9lyxhdswa327kzp39sz5zbiylchjw-python3.9-hjson-3.0.2/lib/python3.9/site-packages/hjson/tool.py", line 80, in <module>
       >     main()
       >   File "/nix/store/fdq9lyxhdswa327kzp39sz5zbiylchjw-python3.9-hjson-3.0.2/lib/python3.9/site-packages/hjson/tool.py", line 58, in main
       >     infile = open(args[0], 'r')
       > FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/61h76ya021588gp3g6my168pib7in8w9-broot-1.12.0.tar.gz/resources/default-conf/conf.hjson'
       For full logs, run 'nix log /nix/store/v8ny0pzdm47lsl8xxk3rnqa86mrv49j3-default-conf.json.drv'.
(use '--show-trace' to show detailed location information)
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` (no, see above)

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
