### PR TITLE
parcellite: Add extraOptions option

### DIFF
--- a/modules/services/parcellite.nix
+++ b/modules/services/parcellite.nix
@@ -12,6 +12,15 @@ in {
   options.services.parcellite = {
     enable = mkEnableOption "Parcellite";
 
+    extraOptions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "--no-icon" ];
+      description = ''
+        Command line arguments passed to Parcellite.
+      '';
+    };
+
     package = mkOption {
       type = types.package;
       default = pkgs.parcellite;
@@ -40,7 +49,9 @@ in {
       Install = { WantedBy = [ "graphical-session.target" ]; };
 
       Service = {
-        ExecStart = "${cfg.package}/bin/${cfg.package.pname}";
+        ExecStart = "${cfg.package}/bin/${cfg.package.pname} ${
+            lib.concatStringsSep " " cfg.extraOptions
+          }";
         Restart = "on-abort";
       };
     };

--- a/modules/services/parcellite.nix
+++ b/modules/services/parcellite.nix
@@ -50,7 +50,7 @@ in {
 
       Service = {
         ExecStart = "${cfg.package}/bin/${cfg.package.pname} ${
-            lib.concatStringsSep " " cfg.extraOptions
+            escapeShellArgs cfg.extraOptions
           }";
         Restart = "on-abort";
       };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -185,6 +185,7 @@ import nmt {
     ./modules/services/mpd
     ./modules/services/mpdris2
     ./modules/services/pantalaimon
+    ./modules/services/parcellite
     ./modules/services/pbgopy
     ./modules/services/picom
     ./modules/services/playerctld

--- a/tests/modules/services/parcellite/default.nix
+++ b/tests/modules/services/parcellite/default.nix
@@ -1,0 +1,1 @@
+{ parcellite = ./parcellite.nix; }

--- a/tests/modules/services/parcellite/parcellite-expected.service
+++ b/tests/modules/services/parcellite/parcellite-expected.service
@@ -1,0 +1,13 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@parcellite@/bin/parcellite '--no-icon'
+Restart=on-abort
+
+[Unit]
+After=graphical-session-pre.target
+After=tray.target
+Description=Lightweight GTK+ clipboard manager
+PartOf=graphical-session.target
+Requires=tray.target

--- a/tests/modules/services/parcellite/parcellite.nix
+++ b/tests/modules/services/parcellite/parcellite.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, ... }:
+
+{
+  services.parcellite = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "parcellite";
+      outPath = "@parcellite@";
+    };
+    extraOptions = [ "--no-icon" ];
+  };
+
+  nmt.script = ''
+    assertFileContent \
+        "home-files/.config/systemd/user/parcellite.service" \
+        ${./parcellite-expected.service}
+  '';
+}


### PR DESCRIPTION
### Description

Add `extraOptions` option to Parcellite service.

Even though `--no-icon` is currently the only viable option for both `parcellite` and `clipit`, other options may be added to later releases.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
