### PR TITLE
tests/immutable-keyfiles: update sha256

### DIFF
--- a/tests/modules/programs/gpg/immutable-keyfiles.nix
+++ b/tests/modules/programs/gpg/immutable-keyfiles.nix
@@ -12,7 +12,7 @@
         source = pkgs.fetchurl {
           url =
             "https://keybase.io/rycee/pgp_keys.asc?fingerprint=36cacf52d098cc0e78fb0cb13573356c25c424d4";
-          sha256 = "082mjy6llvrdry6i9r5gx97nw9d89blnam7bghza4ynsjk1mmx6c";
+          hash = "sha256-5z2kTUXQp0f7kyP0Id6NS3rCdzGGrrkIYzGK42Qy9Sw=";
         };
         trust = 1; # "unknown"
       }


### PR DESCRIPTION
### Description

The tests are failing:
`nix-shell --pure tests -A run.all` gives
```
building '/nix/store/85gsm9z5y0ihh87nmc3pqrlbwfvdpwbn-pgp_keys.asc?fingerprint=36cacf52d098cc0e78fb0cb13573356c25c424d4.drv'...
building '/nix/store/0y5b1apdsilck5dcgahhi1rhxb3kjxnv-pubkey.txt.drv'...
created 296 symlinks in user environment

trying https://www.rsync.net/resources/pubkey.txt
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

trying https://keybase.io/rycee/pgp_keys.asc?fingerprint=36cacf52d098cc0e78fb0cb13573356c25c424d4
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1855  100  1855    0     0   1757      0  0:00:01  0:00:01 --:--:--  1756
100 18048  100 18048    0     0  16947      0  0:00:01  0:00:01 --:--:-- 16946
error: hash mismatch in fixed-output derivation '/nix/store/85gsm9z5y0ihh87nmc3pqrlbwfvdpwbn-pgp_keys.asc?fingerprint=36cacf52d098cc0e78fb0cb13573356c25c424d4.drv':
         specified: sha256-zPRaw5TaeqI+fOtUZelKqCVuT+qv5BSNzy1vSo2XVSA=
            got:    sha256-5z2kTUXQp0f7kyP0Id6NS3rCdzGGrrkIYzGK42Qy9Sw=
error: 1 dependencies of derivation '/nix/store/kzjw244jnaf3jvqyd0k2c96rk1583g1f-gpg-pubring.drv' failed to build
error: 1 dependencies of derivation '/nix/store/bx0v7gs752y9y16vjzv69rnk77n30rl2-activation-script.drv' failed to build
error: 1 dependencies of derivation '/nix/store/974w425iqv04va1s7g2hxzf0pqspg9zs-home-manager-generation.drv' failed to build
error: 1 dependencies of derivation '/nix/store/9dnzdjl2w898kcfycr195l0a59y1im2z-nmt-report-gpg-immutable-keyfiles.drv' failed to build
(use '--show-trace' to show detailed location information)
```

This PR updates the expected sha256 in `tests/modules/programs/gpg/immutable-keyfiles.nix`

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
