### PR TITLE
pistol: refactor

### DIFF
--- a/modules/programs/pistol.nix
+++ b/modules/programs/pistol.nix
@@ -3,31 +3,55 @@
 with lib;
 
 let
-
   cfg = config.programs.pistol;
 
-  configFile =
-    concatStringsSep "\n" (mapAttrsToList (k: v: "${k} ${v}") cfg.config);
+  configFile = concatStringsSep "\n" (map ({ fpath, mime, command }:
+    if fpath == "" then "${mime} ${command}" else "fpath ${fpath} ${command}")
+    cfg.associations);
 
+  association = types.submodule {
+    options = {
+      command = mkOption {
+        type = types.str;
+        description = "Preview command for files matched by this association.";
+      };
+
+      fpath = mkOption {
+        type = types.str;
+        default = "";
+        description = "File path regex that this association should match.";
+      };
+
+      mime = mkOption {
+        type = types.str;
+        default = "";
+        description = "Mime type regex that this association should match.";
+      };
+    };
+  };
 in {
+  imports = [
+    (mkRemovedOptionModule [ "programs" "pistol" "config" ]
+      "Pistol is now configured with programs.pistol.associations.")
+  ];
+
   meta.maintainers = [ hm.maintainers.mtoohey ];
 
   options.programs.pistol = {
-    enable = mkEnableOption ''
-      Pistol, a general purpose file previewer designed for terminal file
-      managers'';
+    enable = mkEnableOption "file previewer for terminal file managers";
 
-    config = mkOption {
-      type = with types; attrsOf str;
-      default = { };
+    associations = mkOption {
+      type = types.listOf association;
+      default = [ ];
       example = literalExpression ''
-        {
-          "text/*" = "bat --paging=never --color=always %pistol-filename%";
-          "inode/directory" = "ls -l --color %pistol-filename%";
-        }
+        [
+          { mime = "application/json"; command = "bat %pistol-filename%"; }
+          { mime = "application/*"; command = "hexyl %pistol-filename%"; }
+          { fpath = ".*.md$"; command = "sh: bat --paging=never --color=always %pistol-filename% | head -8"; }
+        ]
       '';
       description = ''
-        Pistol configuration written to
+        Associations written to the Pistol configuration at
         <filename>$XDG_CONFIG_HOME/pistol/pistol.conf</filename>.
       '';
     };
@@ -35,14 +59,26 @@ in {
   };
 
   config = mkIf cfg.enable (mkMerge [
-    { home.packages = [ pkgs.pistol ]; }
+    {
+      assertions = [{
+        assertion = all ({ fpath, mime, ... }:
+          (fpath != "" && mime == "") || (fpath == "" && mime != ""))
+          cfg.associations;
+        message = ''
+          Each entry in programs.pistol.associations must contain exactly one
+          of fpath or mime.
+        '';
+      }];
 
-    (mkIf (cfg.config != { } && pkgs.stdenv.hostPlatform.isDarwin) {
+      home.packages = [ pkgs.pistol ];
+    }
+
+    (mkIf (cfg.associations != [ ] && pkgs.stdenv.hostPlatform.isDarwin) {
       home.file."Library/Application Support/pistol/pistol.conf".text =
         configFile;
     })
 
-    (mkIf (cfg.config != { } && !pkgs.stdenv.hostPlatform.isDarwin) {
+    (mkIf (cfg.associations != [ ] && !pkgs.stdenv.hostPlatform.isDarwin) {
       xdg.configFile."pistol/pistol.conf".text = configFile;
     })
   ]);

--- a/tests/modules/programs/pistol/associations.nix
+++ b/tests/modules/programs/pistol/associations.nix
@@ -1,0 +1,38 @@
+{ pkgs, ... }:
+
+{
+  programs.pistol = {
+    enable = true;
+    associations = [
+      {
+        mime = "application/json";
+        command = "bat %pistol-filename%";
+      }
+      {
+        mime = "application/*";
+        command = "hexyl %pistol-filename%";
+      }
+      {
+        fpath = ".*.md$";
+        command =
+          "sh: bat --paging=never --color=always %pistol-filename% | head -8";
+      }
+    ];
+  };
+
+  test.stubs.pistol = { };
+
+  nmt.script = let
+    expected = builtins.toFile "config-expected" ''
+      application/json bat %pistol-filename%
+      application/* hexyl %pistol-filename%
+      fpath .*.md$ sh: bat --paging=never --color=always %pistol-filename% | head -8'';
+    path = if pkgs.stdenv.hostPlatform.isDarwin then
+      "home-files/Library/Application Support/pistol/pistol.conf"
+    else
+      "home-files/.config/pistol/pistol.conf";
+  in ''
+    assertFileExists '${path}'
+    assertFileContent '${path}' '${expected}'
+  '';
+}

--- a/tests/modules/programs/pistol/config.nix
+++ b/tests/modules/programs/pistol/config.nix
@@ -1,12 +1,4 @@
-{ pkgs, ... }:
-
-let
-
-  expected = builtins.toFile "settings-expected" ''
-    application/json bat --paging=never --color=always --style=auto --wrap=character --terminal-width=%pistol-extra0% --line-range=1:%pistol-extra1% %pistol-filename%
-    text/* bat --paging=never --color=always --style=auto --wrap=character --terminal-width=%pistol-extra0% --line-range=1:%pistol-extra1% %pistol-filename%'';
-
-in {
+{
   programs.pistol = {
     enable = true;
     config = {
@@ -19,13 +11,11 @@ in {
 
   test.stubs.pistol = { };
 
-  nmt.script = let
-    path = if pkgs.stdenv.hostPlatform.isDarwin then
-      "home-files/Library/Application Support/pistol/pistol.conf"
-    else
-      "home-files/.config/pistol/pistol.conf";
-  in ''
-    assertFileExists '${path}'
-    assertFileContent '${path}' '${expected}'
-  '';
+  test.asserts.assertions.expected = [
+    (let offendingFile = toString ./config.nix;
+    in ''
+      The option definition `programs.pistol.config' in `${offendingFile}' no longer has any effect; please remove it.
+      Pistol is now configured with programs.pistol.associations.
+    '')
+  ];
 }

--- a/tests/modules/programs/pistol/default.nix
+++ b/tests/modules/programs/pistol/default.nix
@@ -1,1 +1,6 @@
-{ pistol-config = ./config.nix; }
+{
+  pistol-associations = ./associations.nix;
+  pistol-config = ./config.nix;
+  pistol-double-association = ./double-association.nix;
+  pistol-missing-association = ./missing-association.nix;
+}

--- a/tests/modules/programs/pistol/double-association.nix
+++ b/tests/modules/programs/pistol/double-association.nix
@@ -1,0 +1,18 @@
+{
+  programs.pistol = {
+    enable = true;
+    # contains both fpath and mime
+    associations = [{
+      fpath = ".*.md$";
+      mime = "application/json";
+      command = "bat %pistol-filename%";
+    }];
+  };
+
+  test.stubs.pistol = { };
+
+  test.asserts.assertions.expected = [''
+    Each entry in programs.pistol.associations must contain exactly one
+    of fpath or mime.
+  ''];
+}

--- a/tests/modules/programs/pistol/missing-association.nix
+++ b/tests/modules/programs/pistol/missing-association.nix
@@ -1,0 +1,14 @@
+{
+  programs.pistol = {
+    enable = true;
+    # contains no fpath or mime value
+    associations = [{ command = "bat %pistol-filename%"; }];
+  };
+
+  test.stubs.pistol = { };
+
+  test.asserts.assertions.expected = [''
+    Each entry in programs.pistol.associations must contain exactly one
+    of fpath or mime.
+  ''];
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This pull requests refactors the pistol configuration options, since the current options are deficient in a few ways. Closes #3486.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.
      **No**, see https://github.com/nix-community/home-manager/issues/3486#issuecomment-1345354257

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
