### PR TITLE
i3-sway: Use foot as default terminal on sway

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -835,10 +835,7 @@ in {
 
   terminal = mkOption {
     type = types.str;
-    default = if isI3 then
-      "i3-sensible-terminal"
-    else
-      "${pkgs.rxvt-unicode-unwrapped}/bin/urxvt";
+    default = if isI3 then "i3-sensible-terminal" else "${pkgs.foot}/bin/foot";
     description = "Default terminal to run.";
     example = "alacritty";
   };

--- a/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
+++ b/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
@@ -27,7 +27,7 @@ bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
 bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
-bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2

--- a/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.conf
+++ b/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.conf
@@ -29,7 +29,7 @@ bindsym --to-code Mod1+8 workspace number 8
 bindsym --to-code Mod1+9 workspace number 9
 bindsym --to-code Mod1+Down focus down
 bindsym --to-code Mod1+Left focus left
-bindsym --to-code Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym --to-code Mod1+Return exec @foot@/bin/foot
 bindsym --to-code Mod1+Right focus right
 bindsym --to-code Mod1+Shift+1 move container to workspace number 1
 bindsym --to-code Mod1+Shift+2 move container to workspace number 2

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -27,7 +27,7 @@ bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
 bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
-bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2

--- a/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
@@ -27,7 +27,7 @@ bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
 bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
-bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
@@ -27,7 +27,7 @@ bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
 bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
-bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2

--- a/tests/modules/services/window-managers/sway/sway-modules.conf
+++ b/tests/modules/services/window-managers/sway/sway-modules.conf
@@ -27,7 +27,7 @@ bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
 bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
-bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2

--- a/tests/modules/services/window-managers/sway/sway-null-package.conf
+++ b/tests/modules/services/window-managers/sway/sway-null-package.conf
@@ -27,7 +27,7 @@ bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
 bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
-bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2

--- a/tests/modules/services/window-managers/sway/sway-stubs.nix
+++ b/tests/modules/services/window-managers/sway/sway-stubs.nix
@@ -3,7 +3,7 @@
   # not containing hashes, version numbers etc.
   test.stubs = {
     dmenu = { };
-    rxvt-unicode-unwrapped = { };
+    foot = { };
     i3status = { };
     sway = { };
     sway-unwrapped = { version = "1"; };

--- a/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
@@ -26,7 +26,7 @@ bindsym Mod1+7 workspace number 7
 bindsym Mod1+8 workspace number 8
 bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
-bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2

--- a/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
@@ -27,7 +27,7 @@ bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
 bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
-bindsym Mod1+Return exec @rxvt-unicode-unwrapped@/bin/urxvt
+bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2


### PR DESCRIPTION
Sway recommends foot as the default terminal emulator. It runs natively on wayland, which urxvt does not.

### Description

Replace urxvt with foot as the default terminal for sway.

https://github.com/swaywm/sway/commit/009c58fc9529e284569bf58b73964cb3dc7c5baf

Also aligns with http://github.com/nixos/nixpkgs/commit/2e719d1cdab9e81750c19425a1f5c7678b5e73ad.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
