### PR TITLE
mpv: add scriptOpts option, fix tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -203,8 +203,8 @@ Makefile                                              @thiagokokada
 /modules/programs/micro.nix                           @MForster
 /tests/modules/programs/micro                         @MForster
 
-/modules/programs/mpv.nix                             @tadeokondrak @thiagokokada
-/tests/modules/programs/mpv                           @thiagokokada
+/modules/programs/mpv.nix                             @tadeokondrak @thiagokokada @chuangzhu
+/tests/modules/programs/mpv                           @thiagokokada @chuangzhu
 
 /modules/programs/mu.nix                              @KarlJoad
 

--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -34,6 +34,12 @@ let
     listsAsDuplicateKeys = true;
   };
 
+  renderScriptOptions = generators.toKeyValue {
+    mkKeyValue =
+      generators.mkKeyValueDefault { mkValueString = renderOption; } "=";
+    listsAsDuplicateKeys = true;
+  };
+
   renderProfiles = generators.toINI {
     mkKeyValue =
       generators.mkKeyValueDefault { mkValueString = renderOptionValue; } "=";
@@ -83,6 +89,27 @@ in {
         description = ''
           List of scripts to use with mpv.
         '';
+      };
+
+      scriptOpts = mkOption {
+        description = ''
+          Script options added to
+          <filename>$XDG_CONFIG_HOME/mpv/script-opts/</filename>. See
+          <citerefentry>
+            <refentrytitle>mpv</refentrytitle>
+            <manvolnum>1</manvolnum>
+          </citerefentry>
+          for the full list of options of builtin scripts.
+        '';
+        type = types.attrsOf mpvOptions;
+        default = { };
+        example = {
+          osc = {
+            scalewindowed = 2.0;
+            vidscale = false;
+            visibility = "always";
+          };
+        };
       };
 
       config = mkOption {
@@ -184,7 +211,13 @@ in {
     (mkIf (cfg.bindings != { }) {
       xdg.configFile."mpv/input.conf".text = renderBindings cfg.bindings;
     })
+    {
+      xdg.configFile = mapAttrs' (name: value:
+        nameValuePair "mpv/script-opts/${name}.conf" {
+          text = renderScriptOptions value;
+        }) cfg.scriptOpts;
+    }
   ]);
 
-  meta.maintainers = with maintainers; [ tadeokondrak thiagokokada ];
+  meta.maintainers = with maintainers; [ tadeokondrak thiagokokada chuangzhu ];
 }

--- a/tests/modules/programs/mpv/default.nix
+++ b/tests/modules/programs/mpv/default.nix
@@ -1,5 +1,5 @@
 {
   # Temporarily commented until fixed for recent changes in Nixpkgs.
-  # mpv-example-settings = ./mpv-example-settings.nix;
-  # mpv-invalid-settings = ./mpv-invalid-settings.nix;
+  mpv-example-settings = ./mpv-example-settings.nix;
+  mpv-invalid-settings = ./mpv-invalid-settings.nix;
 }

--- a/tests/modules/programs/mpv/mpv-example-settings-expected-osc-opts
+++ b/tests/modules/programs/mpv/mpv-example-settings-expected-osc-opts
@@ -1,0 +1,3 @@
+scalewindowed=2.000000
+vidscale=no
+visibility=always

--- a/tests/modules/programs/mpv/mpv-example-settings.nix
+++ b/tests/modules/programs/mpv/mpv-example-settings.nix
@@ -18,6 +18,14 @@
         cache-default = 4000000;
       };
 
+      scriptOpts = {
+        osc = {
+          scalewindowed = 2.0;
+          vidscale = false;
+          visibility = "always";
+        };
+      };
+
       profiles = {
         fast = { vo = "vdpau"; };
         "protocol.dvd" = {
@@ -38,6 +46,9 @@
       assertFileContent \
          home-files/.config/mpv/input.conf \
          ${./mpv-example-settings-expected-bindings}
+      assertFileContent \
+         home-files/.config/mpv/script-opts/osc.conf \
+         ${./mpv-example-settings-expected-osc-opts}
     '';
   };
 

--- a/tests/modules/programs/mpv/mpv-invalid-settings.nix
+++ b/tests/modules/programs/mpv/mpv-invalid-settings.nix
@@ -10,24 +10,12 @@
 
     nixpkgs.overlays = [
       (self: super: {
-        mpv-unwrapped = pkgs.runCommandLocal "mpv" {
-          version = "0";
-          passthru = {
-            lua.luaversion = "0";
-            luaEnv = "/dummy";
-            vapoursynthSupport = false;
-          };
-        } ''
-          mkdir -p $out/bin $out/Applications/mpv.app/Contents/MacOS
-          touch $out/bin/{,u}mpv $out/Applications/mpv.app/Contents/MacOS/mpv
-          chmod 755 $out/bin/{,u}mpv $out/Applications/mpv.app/Contents/MacOS/mpv
-        '';
-        mpvDummy = config.lib.test.mkStubPackage { };
         mpvScript =
           pkgs.runCommandLocal "mpvScript" { scriptName = "something"; }
           "mkdir $out";
       })
     ];
+    test.stubs.mpvDummy = { };
 
     test.asserts.assertions.expected = [
       ''


### PR DESCRIPTION
### Description

Manage mpv script-opts files declaratively.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
