### PR TITLE
borgmatic: allow lists in extraConfig

### DIFF
--- a/modules/programs/borgmatic.nix
+++ b/modules/programs/borgmatic.nix
@@ -20,7 +20,7 @@ let
     };
 
   extraConfigOption = mkOption {
-    type = with types; attrsOf (oneOf [ str bool path int ]);
+    type = with types; attrsOf (oneOf [ str bool path int (listOf str) ]);
     default = { };
     description = "Extra settings.";
   };

--- a/tests/modules/programs/borgmatic/basic-configuration.nix
+++ b/tests/modules/programs/borgmatic/basic-configuration.nix
@@ -12,7 +12,10 @@ in {
           location = {
             sourceDirectories = [ "/my-stuff-to-backup" ];
             repositories = [ "/mnt/disk1" "/mnt/disk2" ];
-            extraConfig = { one_file_system = true; };
+            extraConfig = {
+              one_file_system = true;
+              exclude_patterns = [ "*.swp" ];
+            };
           };
 
           storage = {
@@ -63,6 +66,9 @@ in {
       }"
       expectations[location.one_file_system]="${
         boolToString backups.main.location.extraConfig.one_file_system
+      }"
+      expectations[location.exclude_patterns[0]]="${
+        builtins.elemAt backups.main.location.extraConfig.exclude_patterns 0
       }"
 
       expectations[storage.encryption_passcommand]="${backups.main.storage.encryptionPasscommand}"


### PR DESCRIPTION
### Description

In particular, we should be able to specify `exclude_backups` in our configuration.
This fixes #3489.


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
