### PR TITLE
i3status-rust: fix test

### DIFF
--- a/tests/modules/programs/i3status-rust/with-custom.nix
+++ b/tests/modules/programs/i3status-rust/with-custom.nix
@@ -102,14 +102,14 @@ with lib;
             icons = "awesome5"
             theme = "gruvbox-dark"
             [[block]]
-            alert = 10
+            alert = 10.0
             alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
             path = "/"
             unit = "GB"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-default.nix
+++ b/tests/modules/programs/i3status-rust/with-default.nix
@@ -16,14 +16,14 @@ with lib;
             icons = "none"
             theme = "plain"
             [[block]]
-            alert = 10
+            alert = 10.0
             alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
             path = "/"
             unit = "GB"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-extra-settings.nix
+++ b/tests/modules/programs/i3status-rust/with-extra-settings.nix
@@ -111,14 +111,14 @@ with lib;
           pkgs.writeText "i3status-rust-expected-config" ''
             icons = "awesome5"
             [[block]]
-            alert = 10
+            alert = 10.0
             alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
             path = "/"
             unit = "GB"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-multiple-bars.nix
+++ b/tests/modules/programs/i3status-rust/with-multiple-bars.nix
@@ -62,14 +62,14 @@ with lib;
             icons = "none"
             theme = "plain"
             [[block]]
-            alert = 10
+            alert = 10.0
             alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
             path = "/"
             unit = "GB"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"


### PR DESCRIPTION
### Description

Nix 2.12.0 slightly changed the JSON output format. This updates the i3status-rust test cases to match.

### Checklist

- [ ] Change is backwards compatible. Not really, but since we are tracking Nixpkgs unstable, it should be fine.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```