### PR TITLE
vim,neovim: add `defaultEditor`

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -229,6 +229,15 @@ in {
         description = "Resulting customized neovim package.";
       };
 
+      defaultEditor = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to configure <command>nvim</command> as the default
+          editor using the <envar>EDITOR</envar> environment variable.
+        '';
+      };
+
       extraConfig = mkOption {
         type = types.lines;
         default = "";
@@ -359,6 +368,8 @@ in {
     grouped;
 
     home.packages = [ cfg.finalPackage ];
+
+    home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };
 
     xdg.configFile =
       let hasLuaConfig = hasAttr "lua" config.programs.neovim.generatedConfigs;

--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -127,9 +127,19 @@ in {
 
       packageConfigurable = mkOption {
         type = types.package;
-        description = "Configurable vim package";
-        default = pkgs.vim_configurable;
-        defaultText = "pkgs.vim_configurable";
+        description = "Vim package to customize";
+        default = pkgs.vim-full or pkgs.vim_configurable;
+        defaultText = literalExpression "pkgs.vim-full";
+        example = literalExpression "pkgs.vim";
+      };
+
+      defaultEditor = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to configure <command>vim</command> as the default
+          editor using the <envar>EDITOR</envar> environment variable.
+        '';
       };
     };
   };
@@ -169,6 +179,8 @@ in {
     '';
 
     home.packages = [ cfg.package ];
+
+    home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "vim"; };
 
     programs.vim = {
       package = vim;


### PR DESCRIPTION
Also rename `vim_configurable` to `vim-full` per https://github.com/NixOS/nixpkgs/pull/204438

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
