### PR TITLE
ssh: add addKeysToAgent option

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -361,6 +361,17 @@ in
       '';
     };
 
+    addKeysToAgent = mkOption {
+      type = types.str;
+      default = "no";
+      description = ''
+        When enabled, a private key that is used during authentication will be
+        added to ssh-agent if it is running (with confirmation enabled if
+        set to 'confirm'). The argument must be 'no' (the default), 'yes', 'confirm'
+        (optionally followed by a time interval), 'ask' or a time interval (e.g. '1h').
+      '';
+    };
+
     compression = mkOption {
       default = false;
       type = types.bool;
@@ -528,6 +539,7 @@ in
 
       Host *
         ForwardAgent ${lib.hm.booleans.yesNo cfg.forwardAgent}
+        AddKeysToAgent ${cfg.addKeysToAgent}
         Compression ${lib.hm.booleans.yesNo cfg.compression}
         ServerAliveInterval ${toString cfg.serverAliveInterval}
         ServerAliveCountMax ${toString cfg.serverAliveCountMax}

--- a/tests/modules/programs/ssh/default-config-expected.conf
+++ b/tests/modules/programs/ssh/default-config-expected.conf
@@ -2,6 +2,7 @@
 
 Host *
   ForwardAgent no
+  AddKeysToAgent no
   Compression no
   ServerAliveInterval 0
   ServerAliveCountMax 3

--- a/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts-expected.conf
+++ b/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts-expected.conf
@@ -5,6 +5,7 @@ Host dynamicBindPathNoPort
 
 Host *
   ForwardAgent no
+  AddKeysToAgent no
   Compression no
   ServerAliveInterval 0
   ServerAliveCountMax 3

--- a/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
+++ b/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
@@ -18,6 +18,7 @@ Host ordered
 
 Host *
   ForwardAgent no
+  AddKeysToAgent no
   Compression no
   ServerAliveInterval 0
   ServerAliveCountMax 3

--- a/tests/modules/programs/ssh/match-blocks-match-and-hosts-expected.conf
+++ b/tests/modules/programs/ssh/match-blocks-match-and-hosts-expected.conf
@@ -7,6 +7,7 @@ Match host xyz canonical
 
 Host *
   ForwardAgent no
+  AddKeysToAgent no
   Compression no
   ServerAliveInterval 0
   ServerAliveCountMax 3


### PR DESCRIPTION
### Description

add addKeysToAgent option to ssh module

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
