### PR TITLE
`exa`: add more options

### DIFF
--- a/modules/programs/exa.nix
+++ b/modules/programs/exa.nix
@@ -46,6 +46,8 @@ with lib;
       ++ optional cfg.git "--git" ++ cfg.extraOptions);
 
     aliases = {
+      # Use `command` instead of hardcoding the path to exa so that aliases don't
+      # go stale after a system update.
       exa = "command ${cmd}";
       ls = "exa";
       ll = "exa -l";
@@ -61,5 +63,9 @@ with lib;
     programs.zsh.shellAliases = mkIf cfg.enableAliases aliases;
 
     programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
+
+    # ion doesn't support the standard `command` built-in. Or recursive alias expansion.
+    programs.ion.shellAliases =
+      mkIf cfg.enableAliases (aliases // { exa = cmd; });
   };
 }

--- a/modules/programs/exa.nix
+++ b/modules/programs/exa.nix
@@ -42,9 +42,8 @@ with lib;
   config = let
     cfg = config.programs.exa;
 
-    cmd = escapeShellArgs ([ "${cfg.package}/bin/exa" ]
-      ++ optional cfg.icons "--icons" ++ optional cfg.git "--git"
-      ++ cfg.extraOptions);
+    cmd = escapeShellArgs ([ "exa" ] ++ optional cfg.icons "--icons"
+      ++ optional cfg.git "--git" ++ cfg.extraOptions);
 
     aliases = {
       exa = cmd;

--- a/modules/programs/exa.nix
+++ b/modules/programs/exa.nix
@@ -46,12 +46,12 @@ with lib;
       ++ optional cfg.git "--git" ++ cfg.extraOptions);
 
     aliases = {
-      exa = cmd;
-      ls = cmd;
-      ll = "${cmd} -l";
-      la = "${cmd} -a";
-      lt = "${cmd} --tree";
-      lla = "${cmd} -la";
+      exa = "command ${cmd}";
+      ls = "exa";
+      ll = "exa -l";
+      la = "exa -a";
+      lt = "exa --tree";
+      lla = "exa -la";
     };
   in mkIf cfg.enable {
     home.packages = [ cfg.package ];
@@ -61,7 +61,5 @@ with lib;
     programs.zsh.shellAliases = mkIf cfg.enableAliases aliases;
 
     programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
-
-    programs.ion.shellAliases = mkIf cfg.enableAliases aliases;
   };
 }

--- a/modules/programs/exa.nix
+++ b/modules/programs/exa.nix
@@ -42,7 +42,7 @@ with lib;
   config = let
     cfg = config.programs.exa;
 
-    cmd = concatStringsSep " " ([ "${cfg.package}/bin/exa" ]
+    cmd = escapeShellArgs ([ "${cfg.package}/bin/exa" ]
       ++ optional cfg.icons "--icons" ++ optional cfg.git "--git"
       ++ cfg.extraOptions);
 

--- a/modules/programs/exa.nix
+++ b/modules/programs/exa.nix
@@ -42,13 +42,13 @@ with lib;
   config = let
     cfg = config.programs.exa;
 
-    cmd = escapeShellArgs ([ "exa" ] ++ optional cfg.icons "--icons"
+    args = escapeShellArgs (optional cfg.icons "--icons"
       ++ optional cfg.git "--git" ++ cfg.extraOptions);
 
     aliases = {
       # Use `command` instead of hardcoding the path to exa so that aliases don't
       # go stale after a system update.
-      exa = "command ${cmd}";
+      exa = "exa ${args}";
       ls = "exa";
       ll = "exa -l";
       la = "exa -a";
@@ -64,8 +64,6 @@ with lib;
 
     programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
 
-    # ion doesn't support the standard `command` built-in. Or recursive alias expansion.
-    programs.ion.shellAliases =
-      mkIf cfg.enableAliases (aliases // { exa = cmd; });
+    programs.ion.shellAliases = mkIf cfg.enableAliases aliases;
   };
 }


### PR DESCRIPTION
### Description

This PR adds more configuration options for the `exa` module.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`
- [x] Test cases updated/added (doesn't appear like any exist)
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
