### PR TITLE
herbstluftwm: Fix evaluation error when no tags are set

### DIFF
--- a/modules/services/window-managers/herbstluftwm.nix
+++ b/modules/services/window-managers/herbstluftwm.nix
@@ -145,15 +145,17 @@ in {
 
         ${renderSettings cfg.settings}
 
-        if ${cfg.package}/bin/herbstclient object_tree tags.by-name | ${pkgs.gnugrep}/bin/grep default; then
-          herbstclient rename default ${
-            lib.escapeShellArg (builtins.head cfg.tags)
-          }
-        fi
+        ${lib.optionalString (cfg.tags != [ ]) ''
+          if ${cfg.package}/bin/herbstclient object_tree tags.default &>/dev/null; then
+            herbstclient rename default ${
+              lib.escapeShellArg (builtins.head cfg.tags)
+            }
+          fi
 
-        for tag in ${lib.escapeShellArgs cfg.tags}; do
-          herbstclient add "$tag"
-        done
+          for tag in ${lib.escapeShellArgs cfg.tags}; do
+            herbstclient add "$tag"
+          done
+        ''}
 
         ${renderKeybinds cfg.keybinds}
 

--- a/modules/services/window-managers/herbstluftwm.nix
+++ b/modules/services/window-managers/herbstluftwm.nix
@@ -141,6 +141,7 @@ in {
         herbstclient attr theme.tiling.reset 1
         herbstclient attr theme.floating.reset 1
         herbstclient keyunbind --all
+        herbstclient mouseunbind --all
         herbstclient unrule --all
 
         ${renderSettings cfg.settings}

--- a/tests/modules/services/window-managers/herbstluftwm/default.nix
+++ b/tests/modules/services/window-managers/herbstluftwm/default.nix
@@ -1,1 +1,4 @@
-{ herbstluftwm-simple-config = ./herbstluftwm-simple-config.nix; }
+{
+  herbstluftwm-simple-config = ./herbstluftwm-simple-config.nix;
+  herbstluftwm-no-tags = ./herbstluftwm-no-tags.nix;
+}

--- a/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-no-tags-autostart
+++ b/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-no-tags-autostart
@@ -1,0 +1,31 @@
+#!/nix/store/00000000000000000000000000000000-bash/bin/bash
+shopt -s expand_aliases
+
+# shellcheck disable=SC2142
+alias herbstclient='set -- "$@" ";"'
+set --
+
+herbstclient emit_hook reload
+
+# Reset everything.
+herbstclient attr theme.tiling.reset 1
+herbstclient attr theme.floating.reset 1
+herbstclient keyunbind --all
+herbstclient unrule --all
+
+
+
+
+
+
+
+
+
+
+
+
+
+herbstclient unlock
+
+@herbstluftwm@/bin/herbstclient chain ";" "$@"
+

--- a/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-no-tags-autostart
+++ b/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-no-tags-autostart
@@ -11,6 +11,7 @@ herbstclient emit_hook reload
 herbstclient attr theme.tiling.reset 1
 herbstclient attr theme.floating.reset 1
 herbstclient keyunbind --all
+herbstclient mouseunbind --all
 herbstclient unrule --all
 
 

--- a/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-no-tags.nix
+++ b/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-no-tags.nix
@@ -1,0 +1,16 @@
+{ lib, pkgs, ... }:
+
+{
+  xsession.windowManager.herbstluftwm = { enable = true; };
+
+  test.stubs.herbstluftwm = { };
+
+  nmt.script = ''
+    autostart=home-files/.config/herbstluftwm/autostart
+    assertFileExists "$autostart"
+    assertFileIsExecutable "$autostart"
+
+    normalizedAutostart=$(normalizeStorePaths "$autostart")
+    assertFileContent "$normalizedAutostart" ${./herbstluftwm-no-tags-autostart}
+  '';
+}

--- a/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config-autostart
+++ b/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config-autostart
@@ -19,13 +19,14 @@ herbstclient set frame_bg_active_color '#000000'
 herbstclient set frame_gap '12'
 herbstclient set frame_padding '-12'
 
-if @herbstluftwm@/bin/herbstclient object_tree tags.by-name | /nix/store/00000000000000000000000000000000-gnugrep/bin/grep default; then
+if @herbstluftwm@/bin/herbstclient object_tree tags.default &>/dev/null; then
   herbstclient rename default '1'
 fi
 
 for tag in '1' 'with space' 'wə1rd#ch@rs'\'''; do
   herbstclient add "$tag"
 done
+
 
 herbstclient keybind Mod4-1 use 1
 herbstclient keybind Mod4-2 use 2

--- a/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config-autostart
+++ b/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config-autostart
@@ -11,6 +11,7 @@ herbstclient emit_hook reload
 herbstclient attr theme.tiling.reset 1
 herbstclient attr theme.floating.reset 1
 herbstclient keyunbind --all
+herbstclient mouseunbind --all
 herbstclient unrule --all
 
 herbstclient set always_show_frame true

--- a/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config.nix
+++ b/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config.nix
@@ -39,6 +39,8 @@
     assertFileIsExecutable "$autostart"
 
     normalizedAutostart=$(normalizeStorePaths "$autostart")
-    assertFileContent "$normalizedAutostart" ${./autostart}
+    assertFileContent "$normalizedAutostart" ${
+      ./herbstluftwm-simple-config-autostart
+    }
   '';
 }


### PR DESCRIPTION
### Description

The default value for `xsession.windowManager.herbstluftwm.tags` is an
empty list, but the config file uses `builtins.head` on it, which causes
an error upon evaluation. With this change the tags configuration is
skipped if the list is empty.

Also included a minor change to reset mousebinds on reload for
consistency with the keybinds. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
