### PR TITLE
bash: escape historyIgnore value

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -202,7 +202,7 @@ in
             HISTCONTROL = concatStringsSep ":" cfg.historyControl;
           }
           // optionalAttrs (cfg.historyIgnore != []) {
-            HISTIGNORE = concatStringsSep ":" cfg.historyIgnore;
+            HISTIGNORE = escapeShellArg (concatStringsSep ":" cfg.historyIgnore);
           }
         ));
     in mkIf cfg.enable {


### PR DESCRIPTION
### Description

Since this option is very unlikely to contain a shell variable we should be safe doing a full shell escaping.

Fixes #3249

### Checklist

- [ ] Change is backwards compatible. Not quite but I think it should be safe.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```