### PR TITLE
home-environment: explicitly use coreutils

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -679,7 +679,6 @@ in
             gnused
             ncurses             # For `tput`.
           ]
-          ++ optional (config.nix.enable && config.nix.package != null) config.nix.package
           ++ config.home.extraActivationPath
         )
         + (
@@ -688,7 +687,7 @@ in
           if config.nix.enable && config.nix.package != null then
             ":${config.nix.package}/bin"
           else
-            ":$(dirname $(readlink -m $(type -p nix-env)))"
+            ":$(${pkgs.coreutils}/bin/dirname $(${pkgs.coreutils}/bin/readlink -m $(type -p nix-env)))"
         )
         + optionalString (!cfg.emptyActivationPath) "\${PATH:+:}$PATH";
 


### PR DESCRIPTION
### Description

Before we used dirname and readlink from the ambient environment, which caused problems when they don't behave as expected.

Fixes #3516

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```