### PR TITLE
starship: fix nushell integration

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -134,7 +134,7 @@ in {
         if not ($starship_cache | path exists) {
           mkdir $starship_cache
         }
-        ${starshipCmd} init nu | save ${config.xdg.cacheHome}/starship/init.nu
+        ${starshipCmd} init nu | save --force ${config.xdg.cacheHome}/starship/init.nu
       '';
       extraConfig = ''
         source ${config.xdg.cacheHome}/starship/init.nu


### PR DESCRIPTION
### Description

Overwrite starship/init.nu if already exists, since this is a cache file for sourcing in `init.nu`.

This will be necessary when nushell 0.73 lands in nixpkgs.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
