### PR TITLE
direnv: enable nushell integration

### DIFF
--- a/tests/modules/programs/direnv/default.nix
+++ b/tests/modules/programs/direnv/default.nix
@@ -1,6 +1,7 @@
 {
   direnv-bash = ./bash.nix;
   direnv-nix-direnv = ./nix-direnv.nix;
+  direnv-nushell = ./nushell.nix;
   direnv-stdlib = ./stdlib.nix;
   direnv-stdlib-and-nix-direnv = ./stdlib-and-nix-direnv.nix;
 }

--- a/tests/modules/programs/direnv/nushell.nix
+++ b/tests/modules/programs/direnv/nushell.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+
+{
+  programs.nushell.enable = true;
+  programs.direnv.enable = true;
+
+  test.stubs.nushell = { };
+
+  nmt.script = let
+    configFile = if pkgs.stdenv.isDarwin then
+      "home-files/Library/Application Support/nushell/config.nu"
+    else
+      "home-files/.config/nushell/config.nu";
+  in ''
+    assertFileExists "${configFile}"
+    assertFileRegex "${configFile}" \
+      'let direnv = (/nix/store/.*direnv.*/bin/direnv export json | from json)'
+  '';
+}


### PR DESCRIPTION
### Description

This enables nushell integration by default for direnv, similar to bash/zsh/fish. The slightly verbose way of setting this is to ensure that peoples' existing nushell configuration isn't overwritten, only appended to, as would be the case if we just used the integration example from the nushell docs (https://www.nushell.sh/cookbook/direnv.html) to preserve backwards compatibility.

Closes #3520

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
