### PR TITLE
Pass along -L/--print-build-logs when building from a flake

### DIFF
--- a/docs/man-home-manager.xml
+++ b/docs/man-home-manager.xml
@@ -156,6 +156,18 @@
    </arg>
 
    <arg>
+    <group choice="req">
+     <arg choice="plain">
+      -L
+     </arg>
+
+     <arg choice="plain">
+      --print-build-logs
+     </arg>
+    </group>
+   </arg>
+
+   <arg>
     --show-trace
    </arg>
 
@@ -543,6 +555,22 @@
       Passed on to <citerefentry>
       <refentrytitle>nix-build</refentrytitle>
       <manvolnum>1</manvolnum> </citerefentry>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option>-L</option>
+    </term>
+    <term>
+     <option>--print-build-logs</option>
+    </term>
+    <listitem>
+     <para>
+      Passed on to <citerefentry>
+      <refentrytitle>nix build</refentrytitle>
+      </citerefentry>
+      when building from a flake.
      </para>
     </listitem>
    </varlistentry>

--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -293,6 +293,7 @@ _home-manager_completions ()
     Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" \
               "--verbose" "--cores" "--debug" "--impure" "--keep-failed" \
               "--keep-going" "-j" "--max-jobs" "--no-substitute" "--no-out-link" \
+              "-L" "--print-build-logs" \
               "--show-trace" "--substitute" "--builders" "--version" \
               "--update-input" "--override-input" "--experimental-features" \
               "--extra-experimental-features" )

--- a/home-manager/completion.fish
+++ b/home-manager/completion.fish
@@ -60,6 +60,7 @@ complete -c home-manager -f -l "keep-going" -d "Keep going in case of failed bui
 complete -c home-manager -x -s j -l "max-jobs" -d "Max number of build jobs in parallel"
 complete -c home-manager -x -l "option" -d "Set Nix configuration option"
 complete -c home-manager -x -l "builders" -d "Remote builders"
+complete -c home-manager -f -s L -l "print-build-logs" -d "Print full build logs on standard error"
 complete -c home-manager -f -l "show-trace" -d "Print stack trace of evaluation errors"
 complete -c home-manager -f -l "substitute"
 complete -c home-manager -f -l "no-substitute"

--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -19,6 +19,7 @@ _arguments \
   '(-j --max-jobs)'{--max-jobs,-j}'[max jobs]:NUM:()' \
   '--option[option]:NAME VALUE:()' \
   '--builders[builders]:SPEC:()' \
+  '(-L --print-build-logs)'{--print-build-logs,-L}'[print build logs]' \
   '--show-trace[show trace]' \
   '--override-input[override flake input]:NAME VALUE:()' \
   '--update-input[update flake input]:NAME:()' \

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -289,6 +289,7 @@ function doBuild() {
             "$FLAKE_CONFIG_URI.activationPackage" \
             ${DRY_RUN+--dry-run} \
             ${NO_OUT_LINK+--no-link} \
+            ${PRINT_BUILD_LOGS+--print-build-logs} \
             || return
     else
         doBuildAttr \
@@ -319,6 +320,7 @@ function doSwitch() {
         doBuildFlake \
             "$FLAKE_CONFIG_URI.activationPackage" \
             --out-link "$generation" \
+            ${PRINT_BUILD_LOGS+--print-build-logs} \
             && "$generation/activate" || return
     else
         doBuildAttr \
@@ -551,6 +553,7 @@ function doHelp() {
     echo "  --keep-going"
     echo "  -j, --max-jobs NUM"
     echo "  --option NAME VALUE"
+    echo "  -L, --print-build-logs"
     echo "  --show-trace"
     echo "  --(no-)substitute"
     echo "  --no-out-link            Do not create a symlink to the output path"
@@ -647,6 +650,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         --no-out-link)
             NO_OUT_LINK=1
+            ;;
+        -L|--print-build-logs)
+            PRINT_BUILD_LOGS=1
             ;;
         -h|--help)
             doHelp


### PR DESCRIPTION
### Description

When building from a flake, `nix build` hides the build output by default, with a `-L`/`--print-build-logs` option to show it. Pass this option along from `home-manager` if the user provides it.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
