### PR TITLE
starship: re-add ion integration

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -124,6 +124,12 @@ in {
       end
     '';
 
+    programs.ion.initExtra = mkIf cfg.enableIonIntegration ''
+      if test $TERM != "dumb" && not exists -s INSIDE_EMACS || test $INSIDE_EMACS = "vterm"
+        eval $(${starshipCmd} init ion)
+      end
+    '';
+
     programs.nushell = mkIf cfg.enableNushellIntegration {
       # Unfortunately nushell doesn't allow conditionally sourcing nor
       # conditionally setting (global) environment variables, which is why the


### PR DESCRIPTION
which was apparently mistakenly removed in commit 7ae7250

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
