### PR TITLE
nushell: Add shellAliases option

### DIFF
--- a/tests/modules/programs/nushell/config-expected.nu
+++ b/tests/modules/programs/nushell/config-expected.nu
@@ -4,3 +4,6 @@ let $config = {
   use_ls_colors: true
 }
 
+
+alias ll = ls -a
+alias lsname = (ls | get name)

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -15,6 +15,11 @@
     envFile.text = ''
       let-env FOO = 'BAR'
     '';
+
+    shellAliases = {
+      "lsname" = "(ls | get name)";
+      "ll" = "ls -a";
+    };
   };
 
   test.stubs.nushell = { };


### PR DESCRIPTION
### Description

This PR adds a `programs.nushell.shellAliases` option to allow nushell users to define shell aliases which are inserted into nushell's config.nu. It also integrates it with the general `home.shellAliases` configuration option, similar to bash/zsh/fish.

Closes #3525

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
