### PR TITLE
mpd-mpris: init

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -447,6 +447,9 @@ Makefile                                              @thiagokokada
 
 /modules/services/mpdris2.nix                         @pjones
 
+/modules/services/mpd-mpris.nix                       @olmokramer
+/tests/modules/services/mpd-mpris                     @olmokramer
+
 /modules/services/mpd-discord-rpc.nix                 @Kranzes
 
 /modules/services/mpris-proxy.nix                     @ThibautMarty

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -915,6 +915,14 @@ in
           A new module is available: 'services.autorandr'.
         '';
       }
+
+      {
+        time = "2023-02-20T22:31:23+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.mpd-mpris'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -250,6 +250,7 @@ let
     ./services/mpd.nix
     ./services/mpdris2.nix
     ./services/mpd-discord-rpc.nix
+    ./services/mpd-mpris.nix
     ./services/mpris-proxy.nix
     ./services/muchsync.nix
     ./services/network-manager-applet.nix

--- a/modules/services/mpd-mpris.nix
+++ b/modules/services/mpd-mpris.nix
@@ -1,0 +1,110 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.mpd-mpris;
+
+  ignoreIfLocalMpd = value: if cfg.mpd.useLocal then null else value;
+
+  renderArg = name: value:
+    if lib.isBool value && value then
+      "-${name}"
+    else if lib.isInt value then
+      "-${name} ${toString value}"
+    else if lib.isString value then
+      "-${name} ${lib.escapeShellArg value}"
+    else
+      "";
+
+  concatArgs = strings:
+    lib.concatStringsSep " " (lib.filter (s: s != "") strings);
+
+  renderArgs = args: concatArgs (lib.mapAttrsToList renderArg args);
+
+  renderCmd = pkg: args: "${pkg}/bin/mpd-mpris ${renderArgs args}";
+in {
+  meta.maintainers = [ lib.hm.maintainers.olmokramer ];
+
+  options.services.mpd-mpris = {
+    enable = lib.mkEnableOption
+      "mpd-mpris: An implementation of the MPRIS protocol for MPD";
+
+    package = lib.mkPackageOption pkgs "mpd-mpris" { };
+
+    mpd = {
+      useLocal = lib.mkOption {
+        type = lib.types.bool;
+        default = config.services.mpd.enable;
+        defaultText = lib.literalExpression "config.services.mpd.enable";
+        description = ''
+          Whether to configure for the local MPD daemon. If
+          <literal>true</literal> the <literal>network</literal>,
+          <literal>host</literal>, and <literal>port</literal>
+          settings are ignored.
+        '';
+      };
+
+      network = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = ''
+          The network used to dial to the MPD server. Check
+          <link xlink:href="https://golang.org/pkg/net/#Dial" />
+          for available values (most common are "tcp" and "unix")
+        '';
+      };
+
+      host = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        example = "192.168.1.1";
+        description = "The address where MPD is listening for connections.";
+      };
+
+      port = lib.mkOption {
+        type = with lib.types; nullOr port;
+        default = null;
+        description = ''
+          The port number where MPD is listening for connections.
+        '';
+      };
+
+      password = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = ''
+          The password to connect to MPD.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.mpd-mpris" pkgs
+        lib.platforms.linux)
+    ];
+
+    systemd.user.services.mpd-mpris = {
+      Install = { WantedBy = [ "default.target" ]; };
+
+      Unit = {
+        Description =
+          "mpd-mpris: An implementation of the MPRIS protocol for MPD";
+        After = [ "mpd.service" ];
+        Requires = lib.mkIf cfg.mpd.useLocal [ "mpd.service" ];
+      };
+
+      Service = {
+        Type = "simple";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        ExecStart = renderCmd cfg.package {
+          no-instance = true;
+          network = ignoreIfLocalMpd cfg.mpd.network;
+          host = ignoreIfLocalMpd cfg.mpd.host;
+          port = ignoreIfLocalMpd cfg.mpd.port;
+          pwd = cfg.mpd.password;
+        };
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -188,6 +188,7 @@ import nmt {
     ./modules/services/mopidy
     ./modules/services/mpd
     ./modules/services/mpdris2
+    ./modules/services/mpd-mpris
     ./modules/services/pantalaimon
     ./modules/services/parcellite
     ./modules/services/pass-secret-service

--- a/tests/modules/services/mpd-mpris/configuration-basic.nix
+++ b/tests/modules/services/mpd-mpris/configuration-basic.nix
@@ -1,0 +1,12 @@
+{ ... }:
+
+{
+  services.mpd-mpris = { enable = true; };
+
+  test.stubs.mpd-mpris = { };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/mpd-mpris.service
+    assertFileContent "$serviceFile" ${./configuration-basic.service}
+  '';
+}

--- a/tests/modules/services/mpd-mpris/configuration-basic.service
+++ b/tests/modules/services/mpd-mpris/configuration-basic.service
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=@mpd-mpris@/bin/mpd-mpris -no-instance
+Restart=on-failure
+RestartSec=5s
+Type=simple
+
+[Unit]
+After=mpd.service
+Description=mpd-mpris: An implementation of the MPRIS protocol for MPD

--- a/tests/modules/services/mpd-mpris/configuration-with-local-mpd.nix
+++ b/tests/modules/services/mpd-mpris/configuration-with-local-mpd.nix
@@ -1,0 +1,15 @@
+{ ... }:
+
+{
+  services.mpd-mpris = {
+    enable = true;
+    mpd.useLocal = true;
+  };
+
+  test.stubs.mpd-mpris = { };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/mpd-mpris.service
+    assertFileContent "$serviceFile" ${./configuration-with-local-mpd.service}
+  '';
+}

--- a/tests/modules/services/mpd-mpris/configuration-with-local-mpd.service
+++ b/tests/modules/services/mpd-mpris/configuration-with-local-mpd.service
@@ -1,0 +1,13 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=@mpd-mpris@/bin/mpd-mpris -no-instance
+Restart=on-failure
+RestartSec=5s
+Type=simple
+
+[Unit]
+After=mpd.service
+Description=mpd-mpris: An implementation of the MPRIS protocol for MPD
+Requires=mpd.service

--- a/tests/modules/services/mpd-mpris/configuration-with-password.nix
+++ b/tests/modules/services/mpd-mpris/configuration-with-password.nix
@@ -1,0 +1,20 @@
+{ ... }:
+
+{
+  services.mpd-mpris = {
+    enable = true;
+    mpd = {
+      network = "tcp";
+      host = "example.com";
+      port = 1234;
+      password = "my_password";
+    };
+  };
+
+  test.stubs.mpd-mpris = { };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/mpd-mpris.service
+    assertFileContent "$serviceFile" ${./configuration-with-password.service}
+  '';
+}

--- a/tests/modules/services/mpd-mpris/configuration-with-password.service
+++ b/tests/modules/services/mpd-mpris/configuration-with-password.service
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=@mpd-mpris@/bin/mpd-mpris -host 'example.com' -network 'tcp' -no-instance -port 1234 -pwd 'my_password'
+Restart=on-failure
+RestartSec=5s
+Type=simple
+
+[Unit]
+After=mpd.service
+Description=mpd-mpris: An implementation of the MPRIS protocol for MPD

--- a/tests/modules/services/mpd-mpris/default.nix
+++ b/tests/modules/services/mpd-mpris/default.nix
@@ -1,0 +1,5 @@
+{
+  mpd-mpris-configuration-basic = ./configuration-basic.nix;
+  mpd-mpris-configuration-with-local-mpd = ./configuration-with-local-mpd.nix;
+  mpd-mpris-configuration-with-password = ./configuration-with-password.nix;
+}


### PR DESCRIPTION
### Description

Adds a module for [mpd-mpris](https://github.com/natsukagami/mpd-mpris).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
