### PR TITLE
neovim: fix extraLuaPackages type.

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -13,25 +13,6 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
-  extraPython3PackageType = mkOptionType {
-    name = "extra-python3-packages";
-    description = "python3 packages in python.withPackages format";
-    check = with types;
-      (x: if isFunction x then isList (x pkgs.python3Packages) else false);
-    merge = mergeOneOption;
-  };
-
-  # Currently, upstream Neovim is pinned on Lua 5.1 for LuaJIT support.
-  # This will need to be updated if Neovim ever migrates to a newer
-  # version of Lua.
-  extraLua51PackageType = mkOptionType {
-    name = "extra-lua51-packages";
-    description = "lua5.1 packages in lua5_1.withPackages format";
-    check = with types;
-      (x: if isFunction x then isList (x pkgs.lua51Packages) else false);
-    merge = mergeOneOption;
-  };
-
   pluginWithConfigType = types.submodule {
     options = {
       config = mkOption {
@@ -80,19 +61,23 @@ let
     optional = false;
   };
 
+  luaPackages = cfg.finalPackage.unwrapped.lua.pkgs;
+  resolvedExtraLuaPackages = cfg.extraLuaPackages luaPackages;
+
   extraMakeWrapperArgs = lib.optionalString (cfg.extraPackages != [ ])
     ''--suffix PATH : "${lib.makeBinPath cfg.extraPackages}"'';
-  extraMakeWrapperLuaCArgs = lib.optionalString (cfg.extraLuaPackages != [ ]) ''
-    --suffix LUA_CPATH ";" "${
-      lib.concatMapStringsSep ";" pkgs.lua51Packages.getLuaCPath
-      cfg.extraLuaPackages
-    }"'';
-  extraMakeWrapperLuaArgs = lib.optionalString (cfg.extraLuaPackages != [ ]) ''
-    --suffix LUA_PATH ";" "${
-      lib.concatMapStringsSep ";" pkgs.lua51Packages.getLuaPath
-      cfg.extraLuaPackages
-    }"'';
-
+  extraMakeWrapperLuaCArgs =
+    lib.optionalString (resolvedExtraLuaPackages != [ ]) ''
+      --suffix LUA_CPATH ";" "${
+        lib.concatMapStringsSep ";" luaPackages.getLuaCPath
+        resolvedExtraLuaPackages
+      }"'';
+  extraMakeWrapperLuaArgs = lib.optionalString (resolvedExtraLuaPackages != [ ])
+    ''
+      --suffix LUA_PATH ";" "${
+        lib.concatMapStringsSep ";" luaPackages.getLuaPath
+        resolvedExtraLuaPackages
+      }"'';
 in {
   imports = [
     (mkRemovedOptionModule [ "programs" "neovim" "withPython" ]
@@ -164,24 +149,51 @@ in {
       };
 
       extraPython3Packages = mkOption {
-        type = with types; either extraPython3PackageType (listOf package);
-        default = (_: [ ]);
+        # In case we get a plain list, we need to turn it into a function,
+        # as expected by the function in nixpkgs.
+        # The only way to do so is to call `const`, which will ignore its input.
+        type = with types;
+          let fromType = listOf package;
+          in coercedTo fromType (flip warn const ''
+            Assigning a plain list to extraPython3Packages is deprecated.
+                   Please assign a function taking a package set as argument, so
+                     extraPython3Packages = [ pkgs.python3Packages.xxx ];
+                   should become
+                     extraPython3Packages = ps: [ ps.xxx ];
+          '') (functionTo fromType);
+        default = _: [ ];
         defaultText = literalExpression "ps: [ ]";
-        example = literalExpression "(ps: with ps; [ python-language-server ])";
+        example =
+          literalExpression "pyPkgs: with pyPkgs; [ python-language-server ]";
         description = ''
-          A function in python.withPackages format, which returns a
-          list of Python 3 packages required for your plugins to work.
+          The extra Python 3 packages required for your plugins to work.
+          This option accepts a function that takes a Python 3 package set as an argument,
+          and selects the required Python 3 packages from this package set.
+          See the example for more info.
         '';
       };
 
+      # We get the Lua package from the final package and use its
+      # Lua packageset to evaluate the function that this option was set to.
+      # This ensures that we always use the same Lua version as the Neovim package.
       extraLuaPackages = mkOption {
-        type = with types; either extraLua51PackageType (listOf package);
-        default = [ ];
-        defaultText = literalExpression "[ ]";
-        example = literalExpression "(ps: with ps; [ luautf8 ])";
+        type = with types;
+          let fromType = listOf package;
+          in coercedTo fromType (flip warn const ''
+            Assigning a plain list to extraLuaPackages is deprecated.
+                   Please assign a function taking a package set as argument, so
+                     extraLuaPackages = [ pkgs.lua51Packages.xxx ];
+                   should become
+                     extraLuaPackages = ps: [ ps.xxx ];
+          '') (functionTo fromType);
+        default = _: [ ];
+        defaultText = literalExpression "ps: [ ]";
+        example = literalExpression "luaPkgs: with luaPkgs; [ luautf8 ]";
         description = ''
-          A function in lua5_1.withPackages format, which returns a
-          list of Lua packages required for your plugins to work.
+          The extra Lua packages required for your plugins to work.
+          This option accepts a function that takes a Lua package set as an argument,
+          and selects the required Lua packages from this package set.
+          See the example for more info.
         '';
       };
 
@@ -280,7 +292,7 @@ in {
         };
 
         settings = mkOption {
-          type = jsonFormat.type;
+          inherit (jsonFormat) type;
           default = { };
           example = literalExpression ''
             {
@@ -354,7 +366,7 @@ in {
       grouped = lib.lists.groupBy (x: x.type) pluginsNormalized;
       concatConfigs = lib.concatMapStrings (p: p.config);
       configsOnly = lib.foldl
-        (acc: p: if p.config != null then acc ++ [ (p.config) ] else acc) [ ];
+        (acc: p: if p.config != null then acc ++ [ p.config ] else acc) [ ];
     in mapAttrs (name: vals: lib.concatStringsSep "\n" (configsOnly vals))
     grouped;
 

--- a/tests/modules/programs/neovim/runtime.nix
+++ b/tests/modules/programs/neovim/runtime.nix
@@ -4,28 +4,36 @@ with lib;
 
 {
   config = {
-    programs.neovim = {
-      enable = true;
-      plugins = with pkgs.vimPlugins; [
-        vim-nix
-        {
-          plugin = vim-commentary;
-          runtime = {
-            "after/ftplugin/c.vim".text = ''
-              " plugin-specific config
-              setlocal commentstring=//\ %s
-              setlocal comments=://
-            '';
-          };
-        }
-      ];
+    programs.neovim = lib.mkMerge [
+      {
+        enable = true;
+        plugins = with pkgs.vimPlugins; [
+          vim-nix
+          {
+            plugin = vim-commentary;
+            runtime = {
+              "after/ftplugin/c.vim".text = ''
+                " plugin-specific config
+                setlocal commentstring=//\ %s
+                setlocal comments=://
+              '';
+            };
+          }
+        ];
+      }
+      {
+        extraPython3Packages = ps: with ps; [ jedi pynvim ];
+        extraLuaPackages = ps: with ps; [ luacheck ];
+      }
+      {
+        extraPython3Packages = with pkgs.python3Packages; [ jedi pynvim ];
+        extraLuaPackages = with pkgs.lua51Packages; [ luacheck ];
+      }
+    ];
 
-      extraPython3Packages = (ps: with ps; [ jedi pynvim ]);
-    };
     nmt.script = ''
       ftplugin="home-files/.config/nvim/after/ftplugin/c.vim"
       assertFileExists "$ftplugin"
     '';
   };
 }
-


### PR DESCRIPTION
### Description

Assigning to `programs.neovim.extraLuaPackages` a function taking a lua package set as input and returning a list of packages, as described in the documentation, threw an error because the rest of the code assumed that the value was always a plain list.
Using `lib.types.coercedTo`, we can accept such functions, as per the documentation, as well as plain lists, which we then convert to a function ignoring its input argument.
We print a warning when a plain list is assigned, since the function form is preferred, as it ensures that the right lua package set is used.

For the lua packages, we also get the lua package set from the finalPackage, to make sure that we are always using the same package set as the actual unwrapped neovim package being built.

For `programs.neovim.extraPythonPackages` I did the same.

I updated the test case so that we test both ways of setting these options.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
