### PR TITLE
broot: update test to match upstream changes

### DIFF
--- a/tests/modules/programs/broot/broot.nix
+++ b/tests/modules/programs/broot/broot.nix
@@ -1,30 +1,26 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ ... }:
 
 {
-  config = {
-    programs.broot = {
-      enable = true;
-      settings.modal = true;
-    };
-
-    nmt.script = ''
-      assertFileExists home-files/.config/broot/conf.toml
-      assertFileContent home-files/.config/broot/conf.toml ${
-        pkgs.writeText "broot.expected" ''
-          content_search_max_file_size = "10MB"
-          imports = ["verbs.hjson", {file = "dark-blue-skin.hjson", luma = ["dark", "unknown"]}, {file = "white-skin.hjson", luma = "light"}]
-          modal = true
-          show_selection_mark = true
-          verbs = []
-
-          [skin]
-
-          [special_paths]
-          "/media" = "no-enter"
-        ''
-      }
-    '';
+  programs.broot = {
+    enable = true;
+    settings.modal = true;
   };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/broot/conf.toml
+    assertFileContent home-files/.config/broot/conf.toml ${
+      builtins.toFile "broot.expected" ''
+        content_search_max_file_size = "10MB"
+        imports = ["verbs.hjson", {file = "dark-blue-skin.hjson", luma = ["dark", "unknown"]}, {file = "white-skin.hjson", luma = "light"}]
+        modal = true
+        show_selection_mark = true
+        verbs = []
+
+        [skin]
+
+        [special_paths]
+        "/media" = "no-enter"
+      ''
+    }
+  '';
 }

--- a/tests/modules/programs/broot/broot.nix
+++ b/tests/modules/programs/broot/broot.nix
@@ -13,12 +13,16 @@ with lib;
       assertFileExists home-files/.config/broot/conf.toml
       assertFileContent home-files/.config/broot/conf.toml ${
         pkgs.writeText "broot.expected" ''
+          content_search_max_file_size = "10MB"
           imports = ["verbs.hjson", {file = "dark-blue-skin.hjson", luma = ["dark", "unknown"]}, {file = "white-skin.hjson", luma = "light"}]
           modal = true
           show_selection_mark = true
           verbs = []
 
           [skin]
+
+          [special_paths]
+          "/media" = "no-enter"
         ''
       }
     '';


### PR DESCRIPTION
### Description

Make test match new result.

Fixes #3527
CC @aheaume 

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```