### PR TITLE
gitui: update default theme to match upstream

### DIFF
--- a/modules/programs/gitui.nix
+++ b/modules/programs/gitui.nix
@@ -41,6 +41,8 @@ in {
           selected_tab: Reset,
           command_fg: White,
           selection_bg: Blue,
+          selection_fg: White,
+          cmdbar_bg: Blue,
           cmdbar_extra_lines_bg: Blue,
           disabled_fg: DarkGray,
           diff_line_add: Green,
@@ -55,6 +57,8 @@ in {
           danger_fg: Red,
           push_gauge_bg: Blue,
           push_gauge_fg: Reset,
+          tag_fg: LightMagenta,
+          branch_fg: LightYellow,
         )
       '';
       description = ''


### PR DESCRIPTION
### Description

Update gitui default theme to match [upstream values](https://github.com/extrawurst/gitui/blob/761cb104050ef622765ec739e2c6e9c551830913/src/ui/style.rs#L308-L328).

Fixes #3506
CC @Mifom

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```