### PR TITLE
fish: source hm-session-vars.sh only for interactive shells

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -354,9 +354,11 @@ in {
         set -q __fish_home_manager_config_sourced; and exit
         set -g __fish_home_manager_config_sourced 1
 
-        set --prepend fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish/vendor_functions.d
-        fenv source ${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh > /dev/null
-        set -e fish_function_path[1]
+        if status is-interactive
+          set --prepend fish_function_path ${pkgs.fishPlugins.foreign-env}/share/fish/vendor_functions.d
+          fenv source ${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh > /dev/null
+          set -e fish_function_path[1]
+        end
 
         ${cfg.shellInit}
 


### PR DESCRIPTION
### Description

Unlike bash **fish** executes all commands from `config.fish`. Bash executes `.bash_profile` or `.profile` for login shells and `.bashrc` for interactive shells. In my opinion environment variables should be set only for login shells. Simple `fish` command shouldn't change global variables like `PATH`. Right now in bash `hm-session-vars.sh` is sourced in `.profile` (login shells). Also it is sourced in `.bashrc`, but only when `targets.genericLinux.enable` is enabled:

https://github.com/nix-community/home-manager/blob/cbacdaba3c7b361defb36e1cdfa03ae4e74eb4a8/modules/targets/generic-linux.nix#L66-L71

The linked comment mentions a tmux issue, but it's not the case at least for modern tmux: in tmux by default shell is a login shell.

If you are wary that it won't be sourced in some cases, we can change condition to `status is-interactive` instead.

I'm pretty sure that one of the conditions (is-login or is-interactive) are desirable, because commands like `fish -c '<something>'` should be as quick as possible, because many tools may need to run some shell commands and they are using `$SHELL` variable for it. Right now in _home-manager_ `fish -c exit` is pretty slow (30 ms vs 8 ms for me) because **fenv** is slow (it runs external commands like bash/sed/tr multiple times).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
