### PR TITLE
home-environment: use `lazyAttrsOf` for `home.sessionVariables`

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -256,7 +256,7 @@ in
 
     home.sessionVariables = mkOption {
       default = {};
-      type = types.lazyAttrsOf types.anything;
+      type = with types; lazyAttrsOf (oneOf [ str path int float ]);
       example = { EDITOR = "emacs"; GS_OPTIONS = "-sPAPERSIZE=a4"; };
       description = ''
         Environment variables to always set at login.

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -256,7 +256,7 @@ in
 
     home.sessionVariables = mkOption {
       default = {};
-      type = types.attrs;
+      type = types.lazyAttrsOf types.anything;
       example = { EDITOR = "emacs"; GS_OPTIONS = "-sPAPERSIZE=a4"; };
       description = ''
         Environment variables to always set at login.


### PR DESCRIPTION
`attrs` has unreasonable merge semantics and is deprecated. `attrsOf` doesn't support variables depending on each other as is recommended in the option's description.

Context:
- https://github.com/NixOS/nixpkgs/pull/97119
- https://github.com/NixOS/nixpkgs/pull/70138
- https://github.com/nix-community/home-manager/pull/1595 (cc @berbiche)
- https://github.com/nix-community/home-manager/pull/1769 
- https://github.com/nix-community/home-manager/pull/3496#issuecomment-1367534054

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
