### PR TITLE
fluxbox: Fixed a typo, windowMenu -> windowmenu

### DIFF
--- a/modules/services/window-managers/fluxbox.nix
+++ b/modules/services/window-managers/fluxbox.nix
@@ -112,7 +112,7 @@ in {
       ".fluxbox/menu" = mkIf (cfg.menu != "") { text = cfg.menu; };
       ".fluxbox/slitlist" = mkIf (cfg.slitlist != "") { text = cfg.slitlist; };
       ".fluxbox/windowmenu" =
-        mkIf (cfg.windowMenu != "") { text = cfg.windowmenu; };
+        mkIf (cfg.windowmenu != "") { text = cfg.windowmenu; };
     };
 
     xsession.windowManager.command = concatStringsSep " "


### PR DESCRIPTION
### Description

This issue causes my nixos update (nixos-rebuild switch) to fail with the following error:

```
error: attribute 'windowMenu' missing

at /nix/store/[...]-source/modules/services/window-managers/fluxbox.nix:115:15:

114| ".fluxbox/windowmenu" = 
115| mkIf (cfg.windowMenu != "") { text = cfg.windowmenu; };
   |       ^
116| };
Did you mean windowmenu?
```

Closes #3559 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
