### PR TITLE
home-cursor: use `mkRenamedOptionModule` for `xsession.pointerCursor`

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -30,7 +30,10 @@ let
       x11 = {
         enable = mkEnableOption ''
           x11 config generation for <option>home.pointerCursor</option>
-        '';
+        '' // {
+          default = config.xsession.enable;
+          defaultText = literalExpression "config.xsession.enable";
+        };
 
         defaultCursor = mkOption {
           type = types.str;
@@ -43,7 +46,10 @@ let
       gtk = {
         enable = mkEnableOption ''
           gtk config generation for <option>home.pointerCursor</option>
-        '';
+        '' // {
+          default = config.gtk.enable;
+          defaultText = literalExpression "config.gtk.enable";
+        };
       };
     };
   };
@@ -56,38 +62,27 @@ in {
   meta.maintainers = [ maintainers.polykernel maintainers.league ];
 
   imports = [
-    (mkAliasOptionModule [ "xsession" "pointerCursor" "package" ] [
+    (mkRenamedOptionModule [ "xsession" "pointerCursor" "package" ] [
       "home"
       "pointerCursor"
       "package"
     ])
-    (mkAliasOptionModule [ "xsession" "pointerCursor" "name" ] [
+    (mkRenamedOptionModule [ "xsession" "pointerCursor" "name" ] [
       "home"
       "pointerCursor"
       "name"
     ])
-    (mkAliasOptionModule [ "xsession" "pointerCursor" "size" ] [
+    (mkRenamedOptionModule [ "xsession" "pointerCursor" "size" ] [
       "home"
       "pointerCursor"
       "size"
     ])
-    (mkAliasOptionModule [ "xsession" "pointerCursor" "defaultCursor" ] [
+    (mkRenamedOptionModule [ "xsession" "pointerCursor" "defaultCursor" ] [
       "home"
       "pointerCursor"
       "x11"
       "defaultCursor"
     ])
-
-    ({ ... }: {
-      warnings = optional (any (x:
-        getAttrFromPath
-        ([ "xsession" "pointerCursor" ] ++ [ x ] ++ [ "isDefined" ])
-        options) [ "package" "name" "size" "defaultCursor" ]) ''
-          The option `xsession.pointerCursor` has been merged into `home.pointerCursor` and will be removed
-          in the future. Please change to set `home.pointerCursor` directly and enable `home.pointerCursor.x11.enable`
-          to generate x11 specific cursor configurations. You can refer to the documentation for more details.
-        '';
-    })
   ];
 
   options = {


### PR DESCRIPTION
This hides the obsolete options from the manual, at the cost of displaying two warnings: the one from `mkRenamedOptionModule` and the generic migration instructions for `xsession.pointerCursor`.

Fixes (superficially) https://github.com/nix-community/home-manager/issues/3543, though it does not address the underlying [issue](https://github.com/NixOS/nixpkgs/issues/175586#issuecomment-1368012288) with `mkAliasOptionModule`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
