### PR TITLE
home-manager: Provide necessary experimental feature flags

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -11,16 +11,20 @@ export TEXTDOMAINDIR=@OUT@/share/locale
 # shellcheck disable=1091
 source @HOME_MANAGER_LIB@
 
+# Use this instead of `nix` directly to ensure we have the nix-command feature
+# set regardless of local config.
+NIX_COMMAND="nix --extra-experimental-features nix-command"
+
 function removeByName() {
-  nix profile list \
+  $NIX_COMMAND profile list \
       | { grep "$1" || test $? = 1; } \
       | cut -d ' ' -f 4 \
-      | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
+      | xargs -t $DRY_RUN_CMD $NIX_COMMAND profile remove $VERBOSE_ARG
 }
 
 function setNixProfileCommands() {
     if [[ -e ~/.nix-profile/manifest.json ]] ; then
-        LIST_OUTPATH_CMD="nix profile list"
+        LIST_OUTPATH_CMD="$NIX_COMMAND profile list"
         REMOVE_CMD="removeByName"
     else
         LIST_OUTPATH_CMD="nix-env -q --out-path"
@@ -110,7 +114,10 @@ function setFlakeAttribute() {
                 # Check both long and short hostnames; long first to preserve
                 # pre-existing behaviour in case both happen to be defined.
                 for n in "$USER@$(hostname)" "$USER@$(hostname -s)"; do
-                    if [[ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$n\"")" == "true" ]]; then
+                    if [[ "$($NIX_COMMAND --extra-experimental-features 'flakes' \
+                        --no-warn-dirty \
+                        eval "$flake#homeConfigurations" --apply "x: x ? \"$n\"")" == "true" \
+                    ]]; then
                         name="$n"
                         if [[ -v VERBOSE ]]; then
                             echo "Using flake homeConfiguration for $name"
@@ -219,7 +226,7 @@ function doBuildFlake() {
         extraArgs=("${extraArgs[@]}" "--verbose")
     fi
 
-    nix build \
+    $NIX_COMMAND --extra-experimental-features 'flakes' build \
         "${extraArgs[@]}" \
         "${PASSTHROUGH_OPTS[@]}"
 }


### PR DESCRIPTION
### Description

Enable nix-command whenever using new `nix` commands, and flakes when looking up flake configs. This should fix bootstrapping when these settings might not yet have been added to nix.conf.

While in the neighbourhood, also specify --no-warn-dirty when resolving the flake configuration name.

fixes https://github.com/nix-community/home-manager/issues/3546

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.*
‌* the `broot` test fails on my machine, but it failed before this commit too.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
