### PR TITLE
home.pointerCursor: use mkDefault to set XCURSOR_PATH

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -131,8 +131,8 @@ in {
       # https://github.com/nix-community/home-manager/issues/2812
       # https://wiki.archlinux.org/title/Cursor_themes#Environment_variable
       home.sessionVariables = {
-        XCURSOR_PATH = "$XCURSOR_PATH\${XCURSOR_PATH:+:}"
-          + "${config.home.profileDirectory}/share/icons";
+        XCURSOR_PATH = mkDefault ("$XCURSOR_PATH\${XCURSOR_PATH:+:}"
+          + "${config.home.profileDirectory}/share/icons");
       };
     }
 


### PR DESCRIPTION
This commit fixes conflicting definitions of the XCURSOR_PATH environment variable with the same priority under `home.sessionVariables` introduced in https://github.com/nix-community/home-manager/pull/2902. Rather than raising the priority of the XCURSOR_PATH set in `targets.genericLinux`, the priority of the environment variable set in `home.pointerCursor` is lowered via mkDefault. This is done to avoid the `target.genericLinux` module overriding user set values silently.

### Description

fixes https://github.com/nix-community/home-manager/issues/3551

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
