### PR TITLE
home.pointerCursor: remove backend specific `enable` options

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -28,22 +28,12 @@ let
       };
 
       x11 = {
-        enable = mkEnableOption ''
-          x11 config generation for <option>home.pointerCursor</option>
-        '';
-
         defaultCursor = mkOption {
           type = types.str;
           default = "left_ptr";
           example = "X_cursor";
           description = "The default cursor file to use within the package.";
         };
-      };
-
-      gtk = {
-        enable = mkEnableOption ''
-          gtk config generation for <option>home.pointerCursor</option>
-        '';
       };
     };
   };
@@ -77,17 +67,6 @@ in {
       "x11"
       "defaultCursor"
     ])
-
-    ({ ... }: {
-      warnings = optional (any (x:
-        getAttrFromPath
-        ([ "xsession" "pointerCursor" ] ++ [ x ] ++ [ "isDefined" ])
-        options) [ "package" "name" "size" "defaultCursor" ]) ''
-          The option `xsession.pointerCursor` has been merged into `home.pointerCursor` and will be removed
-          in the future. Please change to set `home.pointerCursor` directly and enable `home.pointerCursor.x11.enable`
-          to generate x11 specific cursor configurations. You can refer to the documentation for more details.
-        '';
-    })
   ];
 
   options = {
@@ -100,10 +79,12 @@ in {
         Top-level options declared under this submodule are backend indepedent
         options. Options declared under namespaces such as <literal>x11</literal>
         are backend specific options. By default, only backend independent cursor
-        configurations are generated. If you need configurations for specific
-        backends, you can toggle them via the enable option. For example,
-        <xref linkend="opt-home.pointerCursor.x11.enable"/>
-        will enable x11 cursor configurations.
+        configurations are generated.
+        </para><para>
+        X11 specific cursor configurations are enabled when the X session is enabled via
+        <xref linkend="opt-xsession.enable"/>.
+        GTK specific cursor configurations are enabled when GTK configurations are enabled via
+        <xref linkend="opt-gtk.enable"/>.
       '';
     };
   };
@@ -136,7 +117,7 @@ in {
       };
     }
 
-    (mkIf cfg.x11.enable {
+    (mkIf config.xsession.enable {
       xsession.initExtra = ''
         ${pkgs.xorg.xsetroot}/bin/xsetroot -xcf ${cursorPath} ${
           toString cfg.size
@@ -149,7 +130,7 @@ in {
       };
     })
 
-    (mkIf cfg.gtk.enable {
+    (mkIf config.gtk.enable {
       gtk.cursorTheme = mkDefault { inherit (cfg) package name size; };
     })
   ]);


### PR DESCRIPTION
This PR removes the `home.pointerCursor.<backend>.enable` options for each backend in favour of using global options to toggle backend specific cursor configurations. This change was motivated by https://github.com/nix-community/home-manager/pull/3545 and improves integration of `home.pointerCursor` with other home-manager modules.

### Description

cc: @rycee @ncfavier 



<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
