### PR TITLE
i3: remove i3/i3-gaps distinction

### DIFF
--- a/docs/release-notes/rl-2305.adoc
+++ b/docs/release-notes/rl-2305.adoc
@@ -16,4 +16,8 @@ This release has the following notable changes:
 The state version in this release includes the changes below.
 These changes are only active if the `home.stateVersion` option is set to "23.05" or later.
 
-* No changes.
+* The <<opt-xsession.windowManager.i3.config.window.titlebar>>,
+<<opt-xsession.windowManager.i3.config.floating.titlebar>>,
+<<opt-wayland.windowManager.sway.config.window.titlebar>>,
+<<opt-wayland.windowManager.sway.config.floating.titlebar>>, options now default to `true` which
+is consistent with the default values for those options used by `i3` and `sway`.

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -877,6 +877,15 @@ in
           A new module is available: 'services.clipman'.
         '';
       }
+
+      {
+        time = "2023-01-07T10:47:03+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          'xsession.windowManager.i3.config.[window|floating].titlebar' and
+          'wayland.windowManager.sway.config.[window|floating].titlebar' now default to 'true'.
+        '';
+      }
     ];
   };
 }

--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -9,7 +9,6 @@ let
   commonOptions = import ./lib/options.nix {
     inherit config lib cfg pkgs;
     moduleName = "i3";
-    isGaps = cfg.package == pkgs.i3-gaps;
   };
 
   configModule = types.submodule {
@@ -209,16 +208,7 @@ in {
     xsession.windowManager.i3 = {
       enable = mkEnableOption "i3 window manager";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.i3;
-        defaultText = literalExpression "pkgs.i3";
-        example = literalExpression "pkgs.i3-gaps";
-        description = ''
-          i3 package to use.
-          If 'i3.config.gaps' settings are specified, 'pkgs.i3-gaps' will be set as a default package.
-        '';
-      };
+      package = mkPackageOption pkgs "i3" { };
 
       config = mkOption {
         type = types.nullOr configModule;
@@ -260,10 +250,7 @@ in {
       };
     }
 
-    (mkIf (cfg.config != null) {
-      xsession.windowManager.i3.package =
-        mkDefault (if (cfg.config.gaps != null) then pkgs.i3-gaps else pkgs.i3);
-    })
+    (mkIf (cfg.config != null) { xsession.windowManager.i3.package = pkgs.i3; })
 
     (mkIf (cfg.config != null) {
       warnings = (optional (isList cfg.config.fonts)


### PR DESCRIPTION
### Description

[i3 4.22 has been released](https://i3wm.org/downloads/RELEASE-NOTES-4.22.txt). The main change is the merge of i3-gaps features.
This (now merged) [PR](https://github.com/NixOS/nixpkgs/pull/208861) brings this update to nixpkgs/NixOS.

Hence, we should update the `services.window-managers.i3` module by removing all the "`i3` vs `i3-gaps`" distinctions.

My only interrogation is the default value of the [`i3.config.floating.titlebar`](https://nix-community.github.io/home-manager/options.html#opt-xsession.windowManager.i3.config.floating.titlebar) and [`i3.config.window.titlebar`](https://nix-community.github.io/home-manager/options.html#opt-xsession.windowManager.i3.config.window.titlebar) options.
Before, there were set to `false` by default when using `i3-gaps`. The i3 documentation suggests that setting them to `true` is still valid so this is what I have done... **TO BE TESTED**
I didn't updated the test cases in consequence. Hence, some are failing because of this change of default value.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
