### PR TITLE
ncmpcpp: Allow `str` type values for `mpdMusicDir` option

### DIFF
--- a/modules/programs/ncmpcpp.nix
+++ b/modules/programs/ncmpcpp.nix
@@ -62,7 +62,7 @@ in {
     };
 
     mpdMusicDir = mkOption {
-      type = types.nullOr types.path;
+      type = with types; nullOr (coercedTo path toString str);
       default = let mpdCfg = config.services.mpd;
       in if pkgs.stdenv.hostPlatform.isLinux && mpdCfg.enable then
         mpdCfg.musicDirectory
@@ -123,7 +123,7 @@ in {
     xdg.configFile = {
       "ncmpcpp/config" = let
         settings = cfg.settings // optionalAttrs (cfg.mpdMusicDir != null) {
-          mpd_music_dir = toString cfg.mpdMusicDir;
+          mpd_music_dir = cfg.mpdMusicDir;
         };
       in mkIf (settings != { }) { text = renderSettings settings + "\n"; };
 

--- a/tests/modules/programs/ncmpcpp-linux/default.nix
+++ b/tests/modules/programs/ncmpcpp-linux/default.nix
@@ -1,1 +1,4 @@
-{ ncmpcpp-use-mpd-config = ./ncmpcpp-use-mpd-config.nix; }
+{
+  ncmpcpp-use-mpd-config = ./ncmpcpp-use-mpd-config.nix;
+  ncmpcpp-issue-3560 = ./ncmpcpp-issue-3560.nix;
+}

--- a/tests/modules/programs/ncmpcpp-linux/ncmpcpp-issue-3560-expected-config
+++ b/tests/modules/programs/ncmpcpp-linux/ncmpcpp-issue-3560-expected-config
@@ -1,0 +1,1 @@
+mpd_music_dir=~/music

--- a/tests/modules/programs/ncmpcpp-linux/ncmpcpp-issue-3560.nix
+++ b/tests/modules/programs/ncmpcpp-linux/ncmpcpp-issue-3560.nix
@@ -1,0 +1,25 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    # Minimal config reproducing
+    # https://github.com/nix-community/home-manager/issues/3560
+    programs.ncmpcpp.enable = true;
+
+    services.mpd.enable = true;
+    services.mpd.musicDirectory = "~/music";
+
+    test.stubs = {
+      ncmpcpp = { };
+      mpd = { };
+    };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/ncmpcpp/config \
+        ${./ncmpcpp-issue-3560-expected-config}
+
+      assertPathNotExists home-files/.config/ncmpcpp/bindings
+    '';
+  };
+}


### PR DESCRIPTION
### Description

The default value of `programs.ncmpcpp.mpdMusicDir` is taken from `services.mpd.musicDirectory` if the mpd module is enabled, which has type `either path str`. `programs.ncmpcpp.mpdMusicDir` did not accept `str` values, though, so an error was raised when the default value was used and `services.mpd.musicDirectory` was set to a value of type `str`.

This commit changes the type of `programs.ncmpcpp.mpdMusicDir` to also accept `str` to reflect the type of `services.mpd.musicDirectory`.

Fixes the ncmpcpp part of #3560

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
