### PR TITLE
easyeffects: add package option

### DIFF
--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -20,6 +20,13 @@ in {
       </programlisting>
       to your system configuration for the daemon to work correctly'';
 
+    package = mkOption {
+      type = types.package;
+      default = pkgs.easyeffects;
+      defaultText = literalExpression "pkgs.easyeffects";
+      description = "The <literal>easyeffects</literal> package to use.";
+    };
+
     preset = mkOption {
       type = types.str;
       default = "";
@@ -38,7 +45,7 @@ in {
     # running easyeffects will just attach itself to gapplication service
     # at-spi2-core is to minimize journalctl noise of:
     # "AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files"
-    home.packages = with pkgs; [ easyeffects at-spi2-core ];
+    home.packages = with pkgs; [ cfg.package at-spi2-core ];
 
     systemd.user.services.easyeffects = {
       Unit = {
@@ -52,8 +59,8 @@ in {
 
       Service = {
         ExecStart =
-          "${pkgs.easyeffects}/bin/easyeffects --gapplication-service ${presetOpts}";
-        ExecStop = "${pkgs.easyeffects}/bin/easyeffects --quit";
+          "${cfg.package}/bin/easyeffects --gapplication-service ${presetOpts}";
+        ExecStop = "${cfg.package}/bin/easyeffects --quit";
         Restart = "on-failure";
         RestartSec = 5;
       };


### PR DESCRIPTION
### Description

Add package option to `service.easyeffects'.

There is some bugs in package, that you may want to fix by overriding. F.e. https://github.com/NixOS/nixpkgs/issues/189481

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```


