### PR TITLE
firefox: fix search options without a default engine

### DIFF
--- a/tests/modules/programs/firefox/profile-settings-expected-search-without-default.json
+++ b/tests/modules/programs/firefox/profile-settings-expected-search-without-default.json
@@ -1,0 +1,41 @@
+{
+  "engines": [
+    {
+      "_isAppProvided": true,
+      "_metaData": {
+        "order": 1
+      },
+      "_name": "Google"
+    },
+    {
+      "_definedAliases": [
+        "@np"
+      ],
+      "_isAppProvided": false,
+      "_loadPath": "[home-manager]/programs.firefox.profiles.searchWithoutDefault.search.engines.\"Nix Packages\"",
+      "_metaData": {
+        "order": 2
+      },
+      "_name": "Nix Packages",
+      "_urls": [
+        {
+          "params": [
+            {
+              "name": "type",
+              "value": "packages"
+            },
+            {
+              "name": "query",
+              "value": "{searchTerms}"
+            }
+          ],
+          "template": "https://search.nixos.org/packages"
+        }
+      ]
+    }
+  ],
+  "metaData": {
+    "useSavedOrder": true
+  },
+  "version": 6
+}

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -109,6 +109,33 @@ lib.mkIf config.test.enableBig {
         };
       };
     };
+
+    profiles.searchWithoutDefault = {
+      id = 4;
+      search = {
+        force = true;
+        order = [ "Google" "Nix Packages" ];
+        engines = {
+          "Nix Packages" = {
+            urls = [{
+              template = "https://search.nixos.org/packages";
+              params = [
+                {
+                  name = "type";
+                  value = "packages";
+                }
+                {
+                  name = "query";
+                  value = "{searchTerms}";
+                }
+              ];
+            }];
+
+            definedAliases = [ "@np" ];
+          };
+        };
+      };
+    };
   };
 
   nixpkgs.overlays = [
@@ -151,14 +178,23 @@ lib.mkIf config.test.enableBig {
       $bookmarksFile \
       ${./profile-settings-expected-bookmarks.html}
 
-    compressedSearch=$(normalizeStorePaths \
-      home-files/.mozilla/firefox/search/search.json.mozlz4)
+    function assertFirefoxSearchContent() {
+      compressedSearch=$(normalizeStorePaths "$1")
 
-    decompressedSearch=$(dirname $compressedSearch)/search.json
-    ${pkgs.mozlz4a}/bin/mozlz4a -d "$compressedSearch" >(${pkgs.jq}/bin/jq . > "$decompressedSearch")
+      decompressedSearch=$(dirname $compressedSearch)/search.json
+      ${pkgs.mozlz4a}/bin/mozlz4a -d "$compressedSearch" >(${pkgs.jq}/bin/jq . > "$decompressedSearch")
 
-    assertFileContent \
-      $decompressedSearch \
+      assertFileContent \
+        $decompressedSearch \
+        "$2"
+    }
+
+    assertFirefoxSearchContent \
+      home-files/.mozilla/firefox/search/search.json.mozlz4 \
       ${./profile-settings-expected-search.json}
+
+    assertFirefoxSearchContent \
+      home-files/.mozilla/firefox/searchWithoutDefault/search.json.mozlz4 \
+      ${./profile-settings-expected-search-without-default.json}
   '';
 }


### PR DESCRIPTION
### Description

Fixes a bug where you couldn't define firefox search engine settings without a default engine specified.

Fixes #3569

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
