### PR TITLE
i3: Do not set i3 package

### DIFF
--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -250,8 +250,6 @@ in {
       };
     }
 
-    (mkIf (cfg.config != null) { xsession.windowManager.i3.package = pkgs.i3; })
-
     (mkIf (cfg.config != null) {
       warnings = (optional (isList cfg.config.fonts)
         "Specifying i3.config.fonts as a list is deprecated. Use the attrset version instead.")


### PR DESCRIPTION
### Description

The previous code prevents one from specifying a custom i3 package with the error "`xsession.windowManager.i3.package` is defined multiple times".

`mkDefault` is another way to fix that, but it's not needed here as the package option definition already defaults to the i3 package (where `mkPackageOption` is called).

Resolves #3584

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
