### PR TITLE
vscode: add extensions.json file in extensions dir

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -220,23 +220,26 @@ in {
           else
             builtins.attrNames (builtins.readDir (ext + "/${subDir}")));
       in if cfg.mutableExtensionsDir then
-        mkMerge (concatMap toPaths cfg.extensions ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0") [{
-          # Whenever our immutable extensions.json changes, force VSCode to regenerate
-          # extensions.json with both mutable and immutable extensions.
-          "${extensionPath}/.extensions-immutable.json" = {
-            text = extensionJson;
-            onChange = ''
-              $DRY_RUN_CMD rm $VERBOSE_ARG -f ${extensionPath}/{extensions.json,.init-default-profile-extensions}
-              $VERBOSE_ECHO "Regenerating VSCode extensions.json"
-              $DRY_RUN_CMD ${getExe cfg.package} --list-extensions > /dev/null
-            '';
-          };
-        }])
+        mkMerge (concatMap toPaths cfg.extensions
+          ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0") [{
+            # Whenever our immutable extensions.json changes, force VSCode to regenerate
+            # extensions.json with both mutable and immutable extensions.
+            "${extensionPath}/.extensions-immutable.json" = {
+              text = extensionJson;
+              onChange = ''
+                $DRY_RUN_CMD rm $VERBOSE_ARG -f ${extensionPath}/{extensions.json,.init-default-profile-extensions}
+                $VERBOSE_ECHO "Regenerating VSCode extensions.json"
+                $DRY_RUN_CMD ${getExe cfg.package} --list-extensions > /dev/null
+              '';
+            };
+          }])
       else {
         "${extensionPath}".source = let
           combinedExtensionsDrv = pkgs.buildEnv {
             name = "vscode-extensions";
-            paths = cfg.extensions ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0") [ extensionJsonFile ];
+            paths = cfg.extensions
+              ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0")
+              [ extensionJsonFile ];
           };
         in "${combinedExtensionsDrv}/${subDir}";
       }))

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -247,8 +247,8 @@ in {
           else
             builtins.attrNames (builtins.readDir (ext + "/${subDir}")));
       in if cfg.mutableExtensionsDir then
-        mkMerge (concatMap toPaths cfg.extensions)
-        ++ [{ ".vscode/extensions/extensions.json".text = extensionsJson; }]
+        mkMerge (concatMap toPaths cfg.extensions
+        ++ [{ "${extensionPath}/extensions.json".text = extensionJson; }])
       else {
         "${extensionPath}".source = let
           combinedExtensionsDrv = pkgs.buildEnv {

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -253,7 +253,7 @@ in {
         "${extensionPath}".source = let
           combinedExtensionsDrv = pkgs.buildEnv {
             name = "vscode-extensions";
-            paths = builtins.trace extensionJsonFile cfg.extensions
+            paths = cfg.extensions
               ++ [ extensionJsonFile ];
           };
         in "${combinedExtensionsDrv}/${subDir}";

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -220,7 +220,7 @@ in {
           else
             builtins.attrNames (builtins.readDir (ext + "/${subDir}")));
       in if cfg.mutableExtensionsDir then
-        mkMerge (concatMap toPaths cfg.extensions ++ lib.optional (lib.version >= "1.74.0") [{
+        mkMerge (concatMap toPaths cfg.extensions ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0") [{
           # Whenever our immutable extensions.json changes, force VSCode to regenerate
           # extensions.json with both mutable and immutable extensions.
           "${extensionPath}/.extensions-immutable.json" = {
@@ -236,7 +236,7 @@ in {
         "${extensionPath}".source = let
           combinedExtensionsDrv = pkgs.buildEnv {
             name = "vscode-extensions";
-            paths = cfg.extensions ++ lib.optional (vscodeVersion >= "1.74.0") [ extensionJsonFile ];
+            paths = cfg.extensions ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0") [ extensionJsonFile ];
           };
         in "${combinedExtensionsDrv}/${subDir}";
       }))


### PR DESCRIPTION
### Description

Add `extensions.json` file in `.share/vscode/extensions`. This allows extensions to be used with vscode 1.74.1. See #3507.

I haven't thoroughly tested behaviour with `mutableExtensionsDir = false`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
