### PR TITLE
docs: bump nmd

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -7,8 +7,8 @@ let
 
   nmdSrc = fetchTarball {
     url =
-      "https://gitlab.com/api/v4/projects/rycee%2Fnmd/repository/archive.tar.gz?sha=06c80103396a1a950586c23da1882c977b24bbda";
-    sha256 = "15axmplkl7m7fs4c8m53dawhgwkb64hm2v67m59xdknbjjgfrpqb";
+      "https://gitlab.com/api/v4/projects/rycee%2Fnmd/repository/archive.tar.gz?sha=f6ca9dfbae290e2133b4ff567e1a48c0eaf9d681";
+    sha256 = "1ivikjlh6vs0131fb945bjal7xrp2wxblbbk1zbz0yqi41xbvny8";
   };
 
   nmd = import nmdSrc { inherit lib pkgs; };


### PR DESCRIPTION
### Description

- Fix paragraphs in option field texts containing Markdown.

- Fix generation of documentation for options with Markdown in multiple fields.

- Support AsciiDoc in module option documentation.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.