### PR TITLE
opam: fix enableFishIntegration

### DIFF
--- a/modules/programs/opam.nix
+++ b/modules/programs/opam.nix
@@ -56,7 +56,7 @@ in {
     '';
 
     programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
-      eval "$(${cfg.package}/bin/opam env --shell=fish)"
+      eval (${cfg.package}/bin/opam env --shell=fish)
     '';
   };
 }


### PR DESCRIPTION
Fixes #3595.

Fish shell doesn't require arguments to `eval` to be double quoted like in a bash shell. At the moment doing so gives us the following error:

```
~/.config/fish/config.fish (line 12): $(...) is not supported. In fish, please use '(/nix/store/8asq…)'. eval "$(/nix/store/8asqgnhs89wzyjvs8p1n5hvxn7lkn9wa-opam-2.1.3/bin/opam env --shell=fish)"
      ^
from sourcing file ~/.config/fish/config.fish
	called during startup
source: Error while reading file “/home/user/.config/fish/config.fish”
```

This commit fixes the above error.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
