### PR TITLE
hstr: hstr module added

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -587,3 +587,5 @@ Makefile                                              @thiagokokada
 /modules/xresources.nix                               @rycee
 
 /modules/xsession.nix                                 @rycee
+
+/modules/programs/hstr.nix                            @Dines97

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -47,6 +47,12 @@
       fingerprint = "4C92 E3B0 21B5 5562 A1E0  CE3D B1C0 12F0 E769 7195";
     }];
   };
+  Dines97 = {
+    name = "Denis Kaynar";
+    email = "19364873+Dines97@users.noreply.github.com";
+    github = "Dines97";
+    githubId = 19364873;
+  };
   dwagenk = {
     email = "dwagenk@mailbox.org";
     github = "dwagenk";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -972,6 +972,13 @@ in
           A new module is available: 'services.syncthing'.
         '';
       }
+
+      {
+        time = "2023-03-25T14:53:57+00:00";
+        message = ''
+          A new module is available: 'programs.hstr'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -90,6 +90,7 @@ let
     ./programs/hexchat.nix
     ./programs/himalaya.nix
     ./programs/home-manager.nix
+    ./programs/hstr.nix
     ./programs/htop.nix
     ./programs/hyfetch.nix
     ./programs/i3status-rust.nix

--- a/modules/programs/hstr.nix
+++ b/modules/programs/hstr.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.hstr;
+
+in {
+  meta.maintainers = [ hm.maintainers.Dines97 ];
+
+  options.programs.hstr = {
+    enable = mkEnableOption ''
+      Bash And Zsh shell history suggest box - easily view, navigate, search and
+      manage your command history'';
+
+    package = mkPackageOption pkgs "hstr" { };
+
+    enableBashIntegration = mkEnableOption "Bash integration" // {
+      default = true;
+    };
+
+    enableZshIntegration = mkEnableOption "Zsh integration" // {
+      default = true;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
+      eval "$(${cfg.package}/bin/hstr --show-configuration)"
+    '';
+
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      eval "$(${cfg.package}/bin/hstr --show-zsh-configuration)"
+    '';
+  };
+}


### PR DESCRIPTION
### Description
This adds options to configure hstr. bash and zsh shell history suggest box - easily view, navigate, search and manage your command history.


### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
