### PR TITLE
vim-vint: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -330,6 +330,9 @@ Makefile                                              @thiagokokada
 /modules/programs/topgrade.nix                        @msfjarvis
 /tests/modules/programs/topgrade                      @msfjarvis
 
+/modules/programs/vim-vint.nix                        @tomodachi94
+/tests/modules/programs/vim-vint                      @tomodachi94
+
 /modules/programs/watson.nix                          @polykernel
 /tests/modules/programs/watson                        @polykernel
 

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -360,4 +360,11 @@
     keys =
       [{ fingerprint = "7944 74B7 D236 DAB9 C9EF  E7F9 5CCE 6F14 66D4 7C9E"; }];
   };
+  tomodachi94 = {
+    email = "tomodachi94+nixpkgs@protonmail.com";
+    matrix = "@tomodachi94:matrix.org";
+    github = "tomodachi94";
+    githubId = 68489118;
+    name = "tomodachi94";
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -185,6 +185,7 @@ let
     ./programs/topgrade.nix
     ./programs/urxvt.nix
     ./programs/vim.nix
+    ./programs/vim-vint.nix
     ./programs/vscode.nix
     ./programs/vscode/haskell.nix
     ./programs/pywal.nix

--- a/modules/programs/vim-vint.nix
+++ b/modules/programs/vim-vint.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.vim-vint;
+
+  yamlFormat = pkgs.formats.yaml { };
+
+in {
+  meta.maintainers = [ maintainers.tomodachi94 ];
+
+  options = {
+    programs.vim-vint = {
+      enable = mkEnableOption "the Vint linter for Vimscript";
+      package = mkPackageOption pkgs "vim-vint" { };
+
+      settings = mkOption {
+        type = yamlFormat.type;
+        default = { };
+        description = ''
+          Configuration written to
+          <filename>$XDG_CONFIG_HOME/.vintrc.yaml</filename>
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile.".vintrc.yaml".source =
+      yamlFormat.generate "vim-vint-config" cfg.settings;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -121,6 +121,7 @@ import nmt {
     ./modules/programs/tmate
     ./modules/programs/tmux
     ./modules/programs/topgrade
+	./modules/programs/vim-vint
     ./modules/programs/vscode
     ./modules/programs/watson
     ./modules/programs/wezterm

--- a/tests/modules/programs/vim-vint/basic-configuration.nix
+++ b/tests/modules/programs/vim-vint/basic-configuration.nix
@@ -1,0 +1,25 @@
+{ config, pkgs, lib, xdg, ... }:
+
+{
+  config.programs.vim-vint = {
+    enable = true;
+    settings = {
+      cmdargs = {
+        severity = "error";
+        color = true;
+        env = { neovim = true; };
+      };
+      policies = {
+        ProhibitEqualTildeOperator.enabled = false;
+        ProhibitUsingUndeclaredVariable.enabled = false;
+        ProhibitAbbreviationOption.enabled = false;
+        ProhibitImplicitScopeVariable.enabled = false;
+        ProhibitSetNoCompatible.enabled = false;
+      };
+    };
+    config.nmt.script = let configFile = xdg.configFile.".vintrc.yaml";
+    in "	  assertFileContent \\\n	  \"${configFile}\" \\\n	  ${
+         ./basic-configuration.yaml
+       }\n  ";
+  };
+}

--- a/tests/modules/programs/vim-vint/basic-configuration.nix
+++ b/tests/modules/programs/vim-vint/basic-configuration.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, xdg, ... }:
 
 {
-  config.programs.vim-vint = {
+  programs.vim-vint = {
     enable = true;
     settings = {
       cmdargs = {
@@ -17,9 +17,11 @@
         ProhibitSetNoCompatible.enabled = false;
       };
     };
-    config.nmt.script = let configFile = xdg.configFile.".vintrc.yaml";
-    in "	  assertFileContent \\\n	  \"${configFile}\" \\\n	  ${
-         ./basic-configuration.yaml
-       }\n  ";
   };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/.vintrc.yaml ${
+      ./basic-configuration.yaml
+    }
+  '';
 }

--- a/tests/modules/programs/vim-vint/basic-configuration.yaml
+++ b/tests/modules/programs/vim-vint/basic-configuration.yaml
@@ -1,0 +1,16 @@
+cmdargs:
+  color: true
+  env:
+    neovim: true
+  severity: error
+policies:
+  ProhibitAbbreviationOption:
+    enabled: false
+  ProhibitEqualTildeOperator:
+    enabled: false
+  ProhibitImplicitScopeVariable:
+    enabled: false
+  ProhibitSetNoCompatible:
+    enabled: false
+  ProhibitUsingUndeclaredVariable:
+    enabled: false

--- a/tests/modules/programs/vim-vint/default.nix
+++ b/tests/modules/programs/vim-vint/default.nix
@@ -1,0 +1,1 @@
+{ vim-vint-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

Adds the [Vint](https://github.com/Vimjas/vint) Vimscript linter as a module.

This is my first PR to Home-Manager; if I've done something wrong please tell me!

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all`.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
  - [x] Added myself and the module files to `.github/CODEOWNERS`.
