### PR TITLE
herbstluftwm: Fix default tag renaming

### DIFF
--- a/modules/services/window-managers/herbstluftwm.nix
+++ b/modules/services/window-managers/herbstluftwm.nix
@@ -29,6 +29,8 @@ let
 
   settingType = lib.types.oneOf [ lib.types.bool lib.types.int lib.types.str ];
 
+  escapedTags = map lib.escapeShellArg cfg.tags;
+
 in {
   meta.maintainers = [ lib.hm.maintainers.olmokramer ];
 
@@ -147,15 +149,14 @@ in {
         ${renderSettings cfg.settings}
 
         ${lib.optionalString (cfg.tags != [ ]) ''
-          if ${cfg.package}/bin/herbstclient object_tree tags.default &>/dev/null; then
-            herbstclient rename default ${
-              lib.escapeShellArg (builtins.head cfg.tags)
-            }
-          fi
-
-          for tag in ${lib.escapeShellArgs cfg.tags}; do
+          for tag in ${lib.concatStringsSep " " escapedTags}; do
             herbstclient add "$tag"
           done
+
+          if ${cfg.package}/bin/herbstclient object_tree tags.by-name.default &>/dev/null; then
+            herbstclient use ${lib.head escapedTags}
+            herbstclient merge_tag default ${lib.head escapedTags}
+          fi
         ''}
 
         ${renderKeybinds cfg.keybinds}

--- a/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config-autostart
+++ b/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config-autostart
@@ -20,13 +20,14 @@ herbstclient set frame_bg_active_color '#000000'
 herbstclient set frame_gap '12'
 herbstclient set frame_padding '-12'
 
-if @herbstluftwm@/bin/herbstclient object_tree tags.default &>/dev/null; then
-  herbstclient rename default '1'
-fi
-
 for tag in '1' 'with space' 'wə1rd#ch@rs'\'''; do
   herbstclient add "$tag"
 done
+
+if @herbstluftwm@/bin/herbstclient object_tree tags.by-name.default &>/dev/null; then
+  herbstclient use '1'
+  herbstclient merge_tag default '1'
+fi
 
 
 herbstclient keybind Mod4-1 use 1


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

The previous implementation tried to rename the tag named "default" to the first tag in `cfg.tags`. This was a wrong approach because if a tag with the same name already existed, the renaming failed and the default tag would continue to exist.

The looking up of the default tag also contained a bug (introduced in #3509) because it should have used `by-name` in the path.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible. **Technically it is not, because the tag named "default" was never removed, but that is considered a bug. And technically #3509 (which introduced the bug) was also not backwards compatible.**

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
