### PR TITLE
format: remove bash from exceptions and format it

### DIFF
--- a/format
+++ b/format
@@ -21,7 +21,6 @@ find . -name '*.nix' \
   ! -path ./modules/lib/default.nix \
   ! -path ./modules/lib/file-type.nix \
   ! -path ./modules/misc/news.nix \
-  ! -path ./modules/programs/bash.nix \
   ! -path ./modules/programs/ssh.nix \
   ! -path ./modules/programs/zsh.nix \
   ! -path ./tests/default.nix \


### PR DESCRIPTION
### Description
There is no open pr against bash now.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
