### PR TITLE
fish: warn of shell init

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }@moduleArgs:
 
 with lib;
 
@@ -289,6 +289,9 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
+      warnings = optional (!(moduleArgs.osConfig.programs.fish.enable or true))
+        "Enable os-level programs.fish.enable for proper shell initialization.";
+
       home.packages = [ cfg.package ];
 
       # Support completion for `man` by building a cache for `apropos`.


### PR DESCRIPTION
### Description
bash is always enabled in nixos (`programs.bash.enable` has been removed since 2014) and defaults to enable in nix-darwin, so it is not added in this pr. 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
