### PR TITLE
files: allow disabling creation of a file

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
 
-  cfg = config.home.file;
+  cfg = filterAttrs (n: f: f.enable) config.home.file;
 
   homeDirectory = config.home.homeDirectory;
 

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -15,6 +15,14 @@ in
   fileType = basePathDesc: basePath: types.attrsOf (types.submodule (
     { name, config, ... }: {
       options = {
+        enable = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Whether this file should be generated. This
+            option allows specific files to be disabled.
+          '';
+        };
         target = mkOption {
           type = types.str;
           apply = p:

--- a/tests/modules/files/default.nix
+++ b/tests/modules/files/default.nix
@@ -6,4 +6,5 @@
   files-target-conflict = ./target-conflict.nix;
   files-target-with-shellvar = ./target-with-shellvar.nix;
   files-text = ./text.nix;
+  files-disabled = ./disabled.nix;
 }

--- a/tests/modules/files/disabled.nix
+++ b/tests/modules/files/disabled.nix
@@ -1,0 +1,17 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  config = {
+    home.file."disabled" = {
+      text = ''
+        This file should not exist
+      '';
+      enable = false;
+    };
+    nmt.script = ''
+      assertPathNotExists home-files/disabled
+    '';
+  };
+}


### PR DESCRIPTION
### Description
Sometimes it might be necessary to disable a file created by some other module. A similar option exists in NixOS.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
