### PR TITLE
services.autorandr: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -360,6 +360,8 @@ Makefile                                              @thiagokokada
 
 /modules/programs/zsh/prezto.nix                      @NickHu
 
+/modules/services/autorandr.nix                       @GaetanLepage
+
 /modules/services/barrier.nix                         @Kritnich
 /tests/modules/services/barrier                       @Kritnich
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -907,6 +907,14 @@ in
           A new module is available: 'programs.rbenv'.
         '';
       }
+
+      {
+        time = "2023-02-02T20:49:05+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.autorandr'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -203,6 +203,7 @@ let
     ./programs/zplug.nix
     ./programs/zsh.nix
     ./programs/zsh/prezto.nix
+    ./services/autorandr.nix
     ./services/barrier.nix
     ./services/betterlockscreen.nix
     ./services/blueman-applet.nix

--- a/modules/services/autorandr.nix
+++ b/modules/services/autorandr.nix
@@ -1,0 +1,53 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.autorandr;
+
+in {
+
+  meta.maintainers = [ maintainers.GaetanLepage ];
+
+  options = {
+    services.autorandr = {
+      enable = mkEnableOption "" // {
+        description = ''
+          Whether to enable the Autorandr systemd service.
+          This module is complementary to <code>programs.autorandr</code> which handles the
+          configuration (profiles).
+        '';
+      };
+
+      ignoreLid = mkOption {
+        default = false;
+        type = types.bool;
+        description =
+          "Treat outputs as connected even if their lids are closed.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.autorandr" pkgs
+        lib.platforms.linux)
+    ];
+
+    systemd.user.services.autorandr = {
+      Unit = {
+        Description = "autorandr";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.autorandr}/bin/autorandr --change ${
+            optionalString cfg.ignoreLid "--ignore-lid"
+          }";
+      };
+
+      Install.WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}


### PR DESCRIPTION
### Description

[autorandr](https://github.com/phillipberndt/autorandr) already has a home-manager module: [`programs.autorandr`](https://github.com/nix-community/home-manager/blob/master/modules/programs/autorandr.nix).
The latter configures the profiles and adds the package (`pkgs.autorandr`) to `home.packages`. This is meant for a CLI usage.

Meanwhile, the NixOS has a (unique) module for autorandr: [`services.autorandr`](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/misc/autorandr.nix) which does the same as the home-manager `programs.autorandr` module as well as adding a `systemd` service to run autorandr automatically.

This PR adds a second home-manager autorandr module: `service.autorandr` which simply adds a `systemd` user service that starts `autorandr` automatically.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
