### PR TITLE
Add Jujutsu

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -163,6 +163,9 @@ Makefile                                              @thiagokokada
 
 /modules/programs/just.nix                            @maximsmol
 
+/modules/programs/jujutsu.nix                         @shikanime
+/tests/modules/programs/jujutsu                       @shikanime
+
 /modules/programs/k9s.nix                             @katexochen
 /tests/modules/programs/k9s                           @katexochen
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -994,6 +994,13 @@ in
           A new module is available: 'programs.mr'.
         '';
       }
+
+      {
+        time = "2023-04-28T19:59:23+00:00";
+        message = ''
+          A new module is available: 'programs.jujutsu'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -100,6 +100,7 @@ let
     ./programs/irssi.nix
     ./programs/java.nix
     ./programs/jq.nix
+    ./programs/jujutsu.nix
     ./programs/just.nix
     ./programs/k9s.nix
     ./programs/kakoune.nix

--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -1,0 +1,76 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.jujutsu;
+  tomlFormat = pkgs.formats.toml { };
+
+in {
+  meta.maintainers = [ maintainers.shikanime ];
+
+  options.programs.jujutsu = {
+    enable =
+      mkEnableOption "a Git-compatible DVCS that is both simple and powerful";
+
+    package = mkPackageOption pkgs "jujutsu" { };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          user = {
+            name = "John Doe";
+            email = "jdoe@example.org";
+          };
+        }
+      '';
+      description = ''
+        Options to add to the <filename>.jjconfig.toml</filename> file. See
+        <link xlink:href="https://github.com/martinvonz/jj/blob/main/docs/config.md"/>
+        for options.
+      '';
+    };
+
+    enableBashIntegration = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to enable Bash integration.";
+    };
+
+    enableZshIntegration = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to enable Zsh integration.";
+    };
+
+    enableFishIntegration = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to enable Fish integration.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.file.".jjconfig.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "jujutsu-config" cfg.settings;
+    };
+
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
+      source <(${pkgs.jujutsu}/bin/jj debug completion)
+    '';
+
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      source <(${pkgs.jujutsu}/bin/jj debug completion --zsh | sed '$d')
+      compdef _jj ${pkgs.jujutsu}/bin/jj
+    '';
+
+    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
+      ${pkgs.jujutsu}/bin/jj debug completion --fish | source
+    '';
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -81,6 +81,7 @@ import nmt {
     ./modules/programs/hyfetch
     ./modules/programs/i3status
     ./modules/programs/irssi
+    ./modules/programs/jujutsu
     ./modules/programs/k9s
     ./modules/programs/kakoune
     ./modules/programs/kitty

--- a/tests/modules/programs/jujutsu/default.nix
+++ b/tests/modules/programs/jujutsu/default.nix
@@ -1,0 +1,4 @@
+{
+  jujutsu-example-config = ./example-config.nix;
+  jujutsu-empty-config = ./empty-config.nix;
+}

--- a/tests/modules/programs/jujutsu/empty-config.nix
+++ b/tests/modules/programs/jujutsu/empty-config.nix
@@ -1,0 +1,11 @@
+{ ... }:
+
+{
+  programs.jujutsu.enable = true;
+
+  test.stubs.jujutsu = { };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.jjconfig.toml
+  '';
+}

--- a/tests/modules/programs/jujutsu/example-config.nix
+++ b/tests/modules/programs/jujutsu/example-config.nix
@@ -1,0 +1,27 @@
+{ config, ... }:
+
+{
+  programs.jujutsu = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    settings = {
+      user = {
+        name = "John Doe";
+        email = "jdoe@example.org";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.jjconfig.toml
+    assertFileContent \
+      home-files/.jjconfig.toml \
+      ${
+        builtins.toFile "expected.toml" ''
+          [user]
+          email = "jdoe@example.org"
+          name = "John Doe"
+        ''
+      }
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adding Jujutsu with config and completions.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
