### PR TITLE
papis: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -249,6 +249,9 @@ Makefile                                              @thiagokokada
 /modules/programs/pandoc.nix                          @kirelagin
 /tests/modules/programs/pandoc                        @kirelagin
 
+/modules/programs/papis.nix                           @marsam
+/tests/modules/programs/papis                         @marsam
+
 /modules/programs/password-store.nix                  @pacien
 
 /modules/programs/pazi.nix                            @marsam

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -886,6 +886,13 @@ in
           'wayland.windowManager.sway.config.[window|floating].titlebar' now default to 'true'.
         '';
       }
+
+      {
+        time = "2023-01-28T17:35:49+00:00";
+        message = ''
+          A new module is available: 'programs.papis'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -144,6 +144,7 @@ let
     ./programs/oh-my-posh.nix
     ./programs/opam.nix
     ./programs/pandoc.nix
+    ./programs/papis.nix
     ./programs/password-store.nix
     ./programs/pazi.nix
     ./programs/pet.nix

--- a/modules/programs/papis.nix
+++ b/modules/programs/papis.nix
@@ -1,0 +1,91 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.papis;
+
+  defaultLibraries = remove null
+    (mapAttrsToList (n: v: if v.isDefault then n else null) cfg.libraries);
+
+  settingsIni = (lib.mapAttrs (n: v: v.settings) cfg.libraries) // {
+    settings = cfg.settings // { "default-library" = head defaultLibraries; };
+  };
+
+in {
+  meta.maintainers = [ maintainers.marsam ];
+
+  options.programs.papis = {
+    enable = mkEnableOption "papis";
+
+    settings = mkOption {
+      type = with types; attrsOf (oneOf [ bool int str ]);
+      default = { };
+      example = literalExpression ''
+        {
+          editor = "nvim";
+          file-browser = "ranger"
+          add-edit = true;
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>$XDG_CONFIG_HOME/papis/config</filename>. See
+        <link xlink:href="https://papis.readthedocs.io/en/latest/configuration.html"/>
+        for supported values.
+      '';
+    };
+
+    libraries = mkOption {
+      type = types.attrsOf (types.submodule ({ config, name, ... }: {
+        options = {
+          name = mkOption {
+            type = types.str;
+            default = name;
+            readOnly = true;
+            description = "This library's name.";
+          };
+
+          isDefault = mkOption {
+            type = types.bool;
+            default = false;
+            example = true;
+            description = ''
+              Whether this is a default library. There must be exactly one
+              default library.
+            '';
+          };
+
+          settings = mkOption {
+            type = with types; attrsOf (oneOf [ bool int str ]);
+            default = { };
+            example = literalExpression ''
+              {
+                dir = "~/papers/";
+              }
+            '';
+            description = ''
+              Configuration for this library.
+            '';
+          };
+        };
+      }));
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = cfg.libraries == { } || length defaultLibraries == 1;
+      message = "Must have exactly one default papis library, but found "
+        + toString (length defaultLibraries)
+        + optionalString (length defaultLibraries > 1)
+        (", namely " + concatStringsSep "," defaultLibraries);
+    }];
+
+    home.packages = [ pkgs.papis ];
+
+    xdg.configFile."papis/config" =
+      mkIf (cfg.libraries != { }) { text = generators.toINI { } settingsIni; };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -102,6 +102,7 @@ import nmt {
     ./modules/programs/nushell
     ./modules/programs/oh-my-posh
     ./modules/programs/pandoc
+    ./modules/programs/papis
     ./modules/programs/pet
     ./modules/programs/pistol
     ./modules/programs/pls

--- a/tests/modules/programs/papis/default.nix
+++ b/tests/modules/programs/papis/default.nix
@@ -1,0 +1,1 @@
+{ papis = ./papis.nix; }

--- a/tests/modules/programs/papis/papis.nix
+++ b/tests/modules/programs/papis/papis.nix
@@ -1,0 +1,46 @@
+{ ... }:
+
+{
+  programs.papis = {
+    enable = true;
+    settings = {
+      picktool = "fzf";
+      file-browser = "ranger";
+      add-edit = true;
+    };
+    libraries = {
+      papers = {
+        isDefault = true;
+        settings = {
+          dir = "~/papers";
+          opentool = "okular";
+        };
+      };
+      books.settings = {
+        dir = "~/books";
+        opentool = "firefox";
+      };
+    };
+  };
+
+  test.stubs.papis = { };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/papis/config \
+    ${builtins.toFile "papis-expected-settings.ini" ''
+      [books]
+      dir=~/books
+      opentool=firefox
+
+      [papers]
+      dir=~/papers
+      opentool=okular
+
+      [settings]
+      add-edit=true
+      default-library=papers
+      file-browser=ranger
+      picktool=fzf
+    ''}
+  '';
+}


### PR DESCRIPTION
### Description

Add module for https://papis.readthedocs.io/

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
