### PR TITLE
mbsync: make passwordCommand escaping consistent

### DIFF
--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -84,7 +84,7 @@ let
     genSection "IMAPAccount ${name}" ({
       Host = imap.host;
       User = userName;
-      PassCmd = lib.concatMapStringsSep " " lib.escapeShellArg passwordCommand;
+      PassCmd = lib.escapeShellArgs passwordCommand;
     } // genTlsConfig imap.tls
       // optionalAttrs (imap.port != null) { Port = toString imap.port; }
       // mbsync.extraConfig.account) + "\n"

--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -84,7 +84,7 @@ let
     genSection "IMAPAccount ${name}" ({
       Host = imap.host;
       User = userName;
-      PassCmd = toString passwordCommand;
+      PassCmd = lib.concatMapStringsSep " " lib.escapeShellArg passwordCommand;
     } // genTlsConfig imap.tls
       // optionalAttrs (imap.port != null) { Port = toString imap.port; }
       // mbsync.extraConfig.account) + "\n"

--- a/tests/modules/programs/mbsync/mbsync-expected.conf
+++ b/tests/modules/programs/mbsync/mbsync-expected.conf
@@ -3,7 +3,7 @@
 IMAPAccount hm-account
 CertificateFile /etc/ssl/certs/ca-certificates.crt
 Host imap.example.org
-PassCmd "password-command 2"
+PassCmd "'password-command' '2'"
 SSLType IMAPS
 User home.manager.jr
 
@@ -55,7 +55,7 @@ Channel hm-account-strangeHostBoxName
 IMAPAccount hm@example.com
 CertificateFile /etc/ssl/certs/ca-certificates.crt
 Host imap.example.com
-PassCmd password-command
+PassCmd 'password-command'
 SSLType IMAPS
 SSLVersions TLSv1.3 TLSv1.2
 User home.manager


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

`mbsync` treats option `accounts.email.accounts.<name>.passwordCommand` like a shell command, whereas other command like `himalaya`, `getmail` and `aerc` treat it like a command to be executed directly. This PR makes `mbsync`'s behavior consistent with other mail clients.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
