### PR TITLE
Zimfw

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -561,3 +561,6 @@ Makefile                                              @thiagokokada
 /modules/xresources.nix                               @rycee
 
 /modules/xsession.nix                                 @rycee
+
+/modules/zimfw.nix                                    @joedevivo
+/tests/modules/zimfw                                  @joedevivo

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -354,4 +354,10 @@
     keys =
       [{ fingerprint = "7944 74B7 D236 DAB9 C9EF  E7F9 5CCE 6F14 66D4 7C9E"; }];
   };
+  joedevivo = {
+    name = "Joe DeVivo";
+    email = "55951+joedevivo@users.noreply.github.com";
+    github = "joedevivo";
+    githubId = 55951;
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -888,7 +888,7 @@ in
       }
 
       {
-        time = "2023-01-09T14:24:28+00:00";
+        time = "2023-01-18T14:24:28+00:00";
         condition = config.programs.zsh.enable;
         message = ''
           A new module is available: 'programs.zsh.zimfw'.

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -869,6 +869,14 @@ in
           A new module is available: 'services.cachix-agent'.
         '';
       }
+
+      {
+        time = "2022-12-28T014:24:28+00:00";
+        condition = config.programs.zsh.enable;
+        message = ''
+          A new module is available: 'programs.zsh.zimfw'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -196,6 +196,7 @@ let
     ./programs/z-lua.nix
     ./programs/zathura.nix
     ./programs/zellij.nix
+    ./programs/zimfw.nix
     ./programs/zoxide.nix
     ./programs/zplug.nix
     ./programs/zsh.nix

--- a/modules/programs/zimfw.nix
+++ b/modules/programs/zimfw.nix
@@ -1,0 +1,157 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.zsh;
+
+  ## copied relToDotDir from ./zsh.nix. Probably should import it, but I don't
+  ## know how.
+  relToDotDir = file:
+    (optionalString (cfg.dotDir != null) (cfg.dotDir + "/")) + file;
+
+  ## zimfw doesn't exist in nixpkgs. I'm open to adding it there, but I'm not
+  ## quite sure how to configure it without home-manager, so the following
+  ## derivation may not be correct for a more generic case.
+  zimPkg = pkgs.stdenv.mkDerivation rec {
+    pname = "zimfw";
+    version = "v1.11.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "zimfw";
+      repo = pname;
+      rev = version;
+      ## zim only needs this one file to be installed.
+      sparseCheckout = [ "zimfw.zsh" ];
+      sha256 = "sha256-BmzYAgP5Z77VqcpAB49cQLNuvQX1qcKmAh9BuXsy2pA=";
+    };
+    strictDeps = true;
+    dontConfigure = true;
+    dontBuild = true;
+    dontPatch = true;
+
+    installPhase = ''
+      mkdir -p $out
+      cp -r $src/zimfw.zsh $out/
+    '';
+
+    ## zim automates the downloading of any plugins you specify in the `.zimrc`
+    ## file. To do that with Nix, you'll need $ZIM_HOME to be writable.
+    ## `~/.cache/zim` is a good place for that. The problem is that zim also
+    ## looks for `zimfw.zsh` there, so we're going to tell it here to look for
+    ## the `zimfw.zsh` where we currently are.
+    postFixup = ''
+      echo "POSTINSTALL"
+      substituteInPlace $out/zimfw.zsh \
+        --replace "\''${ZIM_HOME}/zimfw.zsh" "$out/zimfw.zsh"
+    '';
+
+    meta = with lib; {
+      description =
+        "The Zsh configuration framework with blazing speed and modular extensions";
+      homepage = "https://zimfw.sh";
+      license = licenses.mit;
+      platforms = platforms.all;
+    };
+  };
+in {
+  meta.maintainers = [ maintainers.joedevivo ];
+
+  options = {
+    programs.zsh.zimfw = {
+      enable = mkEnableOption "Zim - ${zimPkg.meta.description}";
+
+      homeDir = mkOption {
+        default = "$HOME/.zim";
+        example = "$HOME/.cache/zim";
+        type = types.str;
+        description = ''
+          Working directory for zim. It stores downloaded plugins here.
+        '';
+      };
+
+      configFile = mkOption {
+        default = if cfg.dotDir != null then
+          "$HOME/${cfg.dotDir}/.zimrc"
+        else
+          "$HOME/.zimrc";
+        type = types.str;
+        description = ''
+          Location of zimrc file
+        '';
+      };
+
+      degit = mkOption {
+        default = true;
+        example = false;
+        type = types.bool;
+        description = ''
+          Use zim's degit tool for faster module installation.
+        '';
+      };
+
+      disableVersionCheck = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          disables 30 day version check
+        '';
+      };
+
+      zmodules = mkOption {
+        default = [ "environment" "git" "input" "termtitle" "utility" ];
+        example = [
+          "environment"
+          "git"
+          "input"
+          "termtitle"
+          "utility"
+          "exa"
+          "$PATH_TO_LOCAL_MODULE"
+          "duration-info"
+          "git-info"
+        ];
+        type = types.listOf types.str;
+        description = ''
+          List of zimfw modules. These are added to `.zimrc` verbatim,
+          so ENV vars will work for paths to local modules.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.zimfw.enable {
+    home.packages = [ zimPkg ];
+    programs.zsh.localVariables = {
+      ZIM_HOME = cfg.zimfw.homeDir;
+      ZIM_CONFIG_FILE = cfg.zimfw.configFile;
+    };
+    programs.zsh.initExtra = concatStringsSep "\n" ([
+      (optionalString (cfg.zimfw.degit) ''
+        zstyle ':zim:zmodule' use 'degit'
+      '')
+      (optionalString (cfg.zimfw.disableVersionCheck) ''
+        zstyle ':zim' disable-version-check yes
+      '')
+      ''
+        if [[ ! -e ${zimPkg}/zimfw.zsh ]]; then
+          echo "Zim is missing, this is a nix issue."
+        fi
+        if [[ ! -e ''${ZIM_HOME} ]]; then
+          mkdir -p ''${ZIM_HOME}
+        fi
+        # Install missing modules, and update ''${ZIM_HOME}/init.zsh
+        # if missing or outdated.
+        if [[ ! ''${ZIM_HOME}/init.zsh -nt ''${ZIM_CONFIG_FILE} ]]; then
+          source ${zimPkg}/zimfw.zsh init -q
+        fi
+        source ''${ZIM_HOME}/init.zsh
+      ''
+    ]);
+    home.file."${relToDotDir ".zimrc"}".text = concatStringsSep "\n"
+      ((map (zmodule: "zmodule ${zmodule}") cfg.zimfw.zmodules));
+    home.activation.zimfw = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      zsh -c "export ZIM_HOME="${cfg.zimfw.homeDir}" && source ${zimPkg}/zimfw.zsh init -q && zimfw install && zimfw compile"
+    '';
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -124,6 +124,7 @@ import nmt {
     ./modules/programs/vscode
     ./modules/programs/watson
     ./modules/programs/wezterm
+    ./modules/programs/zimfw
     ./modules/programs/zplug
     ./modules/programs/zsh
     ./modules/xresources

--- a/tests/modules/programs/zimfw/default.nix
+++ b/tests/modules/programs/zimfw/default.nix
@@ -1,0 +1,5 @@
+{
+  zimfw-modules = ./modules.nix;
+  zimfw-degit = ./degit.nix;
+  zimfw-disable-version-check = ./disable-version-check.nix;
+}

--- a/tests/modules/programs/zimfw/degit.nix
+++ b/tests/modules/programs/zimfw/degit.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.zsh = {
+      enable = true;
+      zimfw = {
+        enable = true;
+        homeDir = toString pkgs.emptyDirectory;
+        degit = false;
+      };
+    };
+
+    test.stubs = {
+      zimfw = { };
+      zsh = { };
+    };
+
+    nmt.script = ''
+      assertFileNotRegex home-files/.zshrc "zstyle ':zim:zmodule' use 'degit'"
+
+      assertFileContains home-files/.zshrc \
+        'ZIM_CONFIG_FILE="${config.programs.zsh.zimfw.configFile}"'
+
+      assertFileContains home-files/.zshrc \
+        'ZIM_HOME="${config.programs.zsh.zimfw.homeDir}"'
+    '';
+  };
+}

--- a/tests/modules/programs/zimfw/disable-version-check.nix
+++ b/tests/modules/programs/zimfw/disable-version-check.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.zsh = {
+      enable = true;
+      zimfw = {
+        enable = true;
+        homeDir = toString pkgs.emptyDirectory;
+        disableVersionCheck = true;
+      };
+    };
+
+    test.stubs = {
+      zimfw = { };
+      zsh = { };
+    };
+
+    nmt.script = ''
+      assertFileContains home-files/.zshrc \
+        "zstyle ':zim' disable-version-check yes"
+
+      assertFileContains home-files/.zshrc \
+        'ZIM_CONFIG_FILE="${config.programs.zsh.zimfw.configFile}"'
+
+      assertFileContains home-files/.zshrc \
+        'ZIM_HOME="${config.programs.zsh.zimfw.homeDir}"'
+    '';
+  };
+}

--- a/tests/modules/programs/zimfw/modules.nix
+++ b/tests/modules/programs/zimfw/modules.nix
@@ -1,0 +1,44 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.zsh = {
+      enable = true;
+      zimfw = {
+        enable = true;
+        homeDir = toString pkgs.emptyDirectory;
+        zmodules = [ "environment" "git" "input" ];
+      };
+    };
+
+    test.stubs = {
+      zimfw = { };
+      zsh = { };
+    };
+
+    nmt.script = ''
+      assertFileContains home-files/.zshrc \
+        'zimfw.zsh init -q'
+
+      assertFileContains home-files/.zimrc \
+        'zmodule environment'
+
+      assertFileContains home-files/.zimrc \
+        'zmodule git'
+
+      assertFileContains home-files/.zimrc \
+        'zmodule input'
+
+      assertFileContains home-files/.zshrc \
+        "zstyle ':zim:zmodule' use 'degit'"
+
+      assertFileContains home-files/.zshrc \
+        'ZIM_CONFIG_FILE="${config.programs.zsh.zimfw.configFile}"'
+
+      assertFileContains home-files/.zshrc \
+        'ZIM_HOME="${config.programs.zsh.zimfw.homeDir}"'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Added [zimfw](https://zimfw.sh).

[zimfw](https://zimfw.sh) is "The Zsh configuration framework with blazing speed and modular extensions."

This module allows it to be configured via home-manager.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
