### PR TITLE
home-manager: edit `homeManagerConfiguration` err

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,19 +46,17 @@
           , username ? null, homeDirectory ? null, system ? null }@args:
           let
             msgForRemovedArg = ''
-                            The 'homeManagerConfiguration' arguments
+              The 'homeManagerConfiguration' arguments
 
-                              - 'configuration',
-                              - 'username',
-                              - 'homeDirectory'
-                              - 'stateVersion',
-                              - 'extraModules', and
-                              - 'system'
+                - 'configuration',
+                - 'username',
+                - 'homeDirectory'
+                - 'stateVersion',
+                - 'extraModules', and
+                - 'system'
 
-                            have been removed. Instead use the arguments 'pkgs' and
-                            'modules'. See the 22.11 release notes for more.
-
-              	      https://nix-community.github.io/home-manager/release-notes.html#sec-release-22.11-highlights 
+              have been removed. Instead use the arguments 'pkgs' and
+              'modules'. See the 22.11 release notes for more: https://nix-community.github.io/home-manager/release-notes.html#sec-release-22.11-highlights 
             '';
 
             throwForRemovedArgs = v:

--- a/flake.nix
+++ b/flake.nix
@@ -46,17 +46,19 @@
           , username ? null, homeDirectory ? null, system ? null }@args:
           let
             msgForRemovedArg = ''
-              The 'homeManagerConfiguration' arguments
+                            The 'homeManagerConfiguration' arguments
 
-                - 'configuration',
-                - 'username',
-                - 'homeDirectory'
-                - 'stateVersion',
-                - 'extraModules', and
-                - 'system'
+                              - 'configuration',
+                              - 'username',
+                              - 'homeDirectory'
+                              - 'stateVersion',
+                              - 'extraModules', and
+                              - 'system'
 
-              have been removed. Instead use the arguments 'pkgs' and
-              'modules'. See the 22.11 release notes for more.
+                            have been removed. Instead use the arguments 'pkgs' and
+                            'modules'. See the 22.11 release notes for more.
+
+              	      https://nix-community.github.io/home-manager/release-notes.html#sec-release-22.11-highlights 
             '';
 
             throwForRemovedArgs = v:


### PR DESCRIPTION
### Description


Add link https://nix-community.github.io/home-manager/release-notes.html#sec-release-22.11-highlights to the 'homeManagerConfiguration' argument deprecation message

New Message:
```

The 'homeManagerConfiguration' arguments

         - 'configuration',
         - 'username',
         - 'homeDirectory'
         - 'stateVersion',
         - 'extraModules', and
         - 'system'

       have been removed. Instead use the arguments 'pkgs' and
       'modules'. See the 22.11 release notes for more.

       https://nix-community.github.io/home-manager/release-notes.html#sec-release-22.11-highlights
```

Justification: I just ran into this problem and it would have been helpful to have this link in the command line output instead of having to search around. 

Notes: I did not intentionally adjust the spaces in front of the message. './format' added them.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`. (but some tests failed like i3status and broot)

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
