### PR TITLE
git: unset `pager` while using difftastic

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -527,10 +527,7 @@ in {
           "--background ${cfg.difftastic.background}"
           "--display ${cfg.difftastic.display}"
         ];
-      in {
-        diff.external = difftCommand;
-        core.pager = "${pkgs.less}/bin/less -XF";
-      };
+      in { diff.external = difftCommand; };
     })
 
     (mkIf cfg.delta.enable {


### PR DESCRIPTION
### Description

Remove `core.pager = "${pkgs.less}/bin/less -XF"` since Git already sets `LESS=FRX` and it prevents from using another pager while difftastic does not require a specific pager.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
