### PR TITLE
xsession: cleanup systemd variables

### DIFF
--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -78,6 +78,7 @@ in {
 
       importedVariables = mkOption {
         type = types.listOf (types.strMatching "[a-zA-Z_][a-zA-Z0-9_]*");
+        apply = unique;
         example = [ "GDK_PIXBUF_ICON_LOADER" ];
         visible = false;
         description = ''
@@ -184,7 +185,7 @@ in {
 
       ${optionalString (cfg.importedVariables != [ ])
       ("systemctl --user import-environment "
-        + toString (unique cfg.importedVariables))}
+        + escapeShellArgs cfg.importedVariables)}
 
       ${cfg.profileExtra}
 
@@ -212,6 +213,10 @@ in {
         while [ -n "$(systemctl --user --no-legend --state=deactivating list-units)" ]; do
           sleep 0.5
         done
+
+        ${optionalString (cfg.importedVariables != [ ])
+        ("systemctl --user unset-environment "
+          + escapeShellArgs cfg.importedVariables)}
       '';
     };
   };

--- a/tests/modules/misc/xsession/basic-xprofile-expected.txt
+++ b/tests/modules/misc/xsession/basic-xprofile-expected.txt
@@ -9,7 +9,7 @@ fi
 # script starts up graphical-session.target.
 systemctl --user stop graphical-session.target graphical-session-pre.target
 
-systemctl --user import-environment DBUS_SESSION_BUS_ADDRESS DISPLAY SSH_AUTH_SOCK XAUTHORITY XDG_DATA_DIRS XDG_RUNTIME_DIR XDG_SESSION_ID EXTRA_IMPORTED_VARIABLE
+systemctl --user import-environment 'DBUS_SESSION_BUS_ADDRESS' 'DISPLAY' 'SSH_AUTH_SOCK' 'XAUTHORITY' 'XDG_DATA_DIRS' 'XDG_RUNTIME_DIR' 'XDG_SESSION_ID' 'EXTRA_IMPORTED_VARIABLE'
 
 profile extra commands
 

--- a/tests/modules/misc/xsession/basic-xsession-expected.txt
+++ b/tests/modules/misc/xsession/basic-xsession-expected.txt
@@ -16,3 +16,5 @@ systemctl --user stop graphical-session-pre.target
 while [ -n "$(systemctl --user --no-legend --state=deactivating list-units)" ]; do
   sleep 0.5
 done
+
+systemctl --user unset-environment 'DBUS_SESSION_BUS_ADDRESS' 'DISPLAY' 'SSH_AUTH_SOCK' 'XAUTHORITY' 'XDG_DATA_DIRS' 'XDG_RUNTIME_DIR' 'XDG_SESSION_ID' 'EXTRA_IMPORTED_VARIABLE'


### PR DESCRIPTION
### Description

The xsession module imports variables into the systemd user session, but does not clean up after itself once the session ends. This can lead to issues where a `DISPLAY` variable remains set for services while X is not available or running anymore.

In one particular case when using xresources, [it can cause unnecessary switch failures](https://github.com/nix-community/home-manager/blob/782cb855b2f23c485011a196c593e2d7e4fce746/modules/xresources.nix#L96).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
