### PR TITLE
borgmatic: Do not inhibit idle in service

### DIFF
--- a/modules/services/borgmatic.nix
+++ b/modules/services/borgmatic.nix
@@ -63,6 +63,7 @@ in {
           ExecStart = ''
             ${pkgs.systemd}/bin/systemd-inhibit \
               --who="borgmatic" \
+              --what="sleep:shutdown" \
               --why="Prevent interrupting scheduled backup" \
               ${programConfig.package}/bin/borgmatic \
                 --stats \

--- a/tests/modules/services/borgmatic/basic-configuration.service
+++ b/tests/modules/services/borgmatic/basic-configuration.service
@@ -2,6 +2,7 @@
 CPUSchedulingPolicy=batch
 ExecStart=/nix/store/00000000000000000000000000000000-systemd/bin/systemd-inhibit \
   --who="borgmatic" \
+  --what="sleep:shutdown" \
   --why="Prevent interrupting scheduled backup" \
   @borgmatic@/bin/borgmatic \
     --stats \


### PR DESCRIPTION


### Description

This reflects a systemd service sample file change made in [borgmatic 1.7.6](https://github.com/borgmatic-collective/borgmatic/releases/tag/1.7.6), commit [2e9f70d49647d47fb4ca05f428c592b0e4319544](https://github.com/borgmatic-collective/borgmatic/commit/2e9f70d49647d47fb4ca05f428c592b0e4319544):

    When backing up a machine with a monitor using logind to control
    idle timeout and things like DPMS, borgmatic can block the screen
    from turning on/off with systemd-inhibit. This is because by
    default systemd-inhibit will block
    "idle:sleep:shutdown". Borgmatic does not need to care about idle,
    only about suspend and shutdown. So, add an explicit `--what` flag
    for what borgmatic should inhibit.

    For more information see systemd-inhibit(1).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
