### PR TITLE
modules: java: fix setting JAVA_HOME

### DIFF
--- a/modules/programs/java.nix
+++ b/modules/programs/java.nix
@@ -36,6 +36,8 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    home.sessionVariables.JAVA_HOME = cfg.package.home;
+    # some instances of `jdk-linux-base.nix` pass through `result` without turning it onto a path-string.
+    # while I suspect this is incorrect, the documentation is unclear.
+    home.sessionVariables.JAVA_HOME = "${cfg.package.home}";
   };
 }


### PR DESCRIPTION
### Description

Some JVMs pass through `home` as a derivation rather than as a string, as `openjdk` does. Since the module option for session variables expects a string, this is a type error. I suspect that this incorrect, and have changed the assignment here to coerce the `cfg.package.home` attribute to a string to be safe.

After discussing with @NobbZ, we have decided it is best to mitigate this problem in HM rather than to make potentially breaking changes to Nixpkgs.

Please do mention if you think we ought to propose a change to Nixpkgs instead.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [ ] ~~Code formatted with `./format`.~~

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.

