### PR TITLE
programs.neovim: add extraLuaConfig

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -261,6 +261,17 @@ in {
         '';
       };
 
+      extraLuaConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          vim.opt.nobackup = true
+        '';
+        description = ''
+          Custom lua lines.
+        '';
+      };
+
       extraPackages = mkOption {
         type = with types; listOf package;
         default = [ ];
@@ -394,8 +405,9 @@ in {
               "vim.cmd [[source ${
                 pkgs.writeText "nvim-init-home-manager.vim"
                 neovimConfig.neovimRcContent
-              }]]" + lib.optionalString hasLuaConfig
-              config.programs.neovim.generatedConfigs.lua;
+              }]]" + config.programs.neovim.extraLuaConfig
+              + (lib.optionalString hasLuaConfig
+                config.programs.neovim.generatedConfigs.lua);
           in mkIf (luaRcContent != "") { text = luaRcContent; };
 
           "nvim/coc-settings.json" = mkIf cfg.coc.enable {

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -406,8 +406,8 @@ in {
                 pkgs.writeText "nvim-init-home-manager.vim"
                 neovimConfig.neovimRcContent
               }]]" + config.programs.neovim.extraLuaConfig
-              + (lib.optionalString hasLuaConfig
-                config.programs.neovim.generatedConfigs.lua);
+              + lib.optionalString hasLuaConfig
+              config.programs.neovim.generatedConfigs.lua;
           in mkIf (luaRcContent != "") { text = luaRcContent; };
 
           "nvim/coc-settings.json" = mkIf cfg.coc.enable {

--- a/tests/modules/programs/neovim/default.nix
+++ b/tests/modules/programs/neovim/default.nix
@@ -5,4 +5,5 @@
 
   # waiting for a nixpkgs patch
   neovim-no-init = ./no-init.nix;
+  neovim-extra-lua-init = ./extra-lua-init.nix;
 }

--- a/tests/modules/programs/neovim/extra-lua-init.nix
+++ b/tests/modules/programs/neovim/extra-lua-init.nix
@@ -13,11 +13,9 @@ with lib;
     };
     nmt.script = ''
       nvimFolder="home-files/.config/nvim"
-        assertFileContent "$nvimFolder/init.lua" ${
-          pkgs.writeText "init.lua-expected" ''
-            -- extraLuaConfig
-          ''
-        }
+      assertFileContent "$nvimFolder/init.lua" ${
+        pkgs.writeText "init.lua-expected" "-- extraLuaConfig "
+      }
     '';
   };
 }

--- a/tests/modules/programs/neovim/extra-lua-init.nix
+++ b/tests/modules/programs/neovim/extra-lua-init.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.neovim = {
+      enable = true;
+
+      extraLuaConfig = ''
+        -- extraLuaConfig
+      '';
+    };
+    nmt.script = ''
+      nvimFolder="home-files/.config/nvim"
+        assertFileContent "$nvimFolder/init.lua" ${
+          pkgs.writeText "init.lua-expected" ''
+            -- extraLuaConfig
+          ''
+        }
+    '';
+  };
+}

--- a/tests/modules/programs/neovim/extra-lua-init.nix
+++ b/tests/modules/programs/neovim/extra-lua-init.nix
@@ -14,7 +14,9 @@ with lib;
     nmt.script = ''
       nvimFolder="home-files/.config/nvim"
       assertFileContent "$nvimFolder/init.lua" ${
-        pkgs.writeText "init.lua-expected" "-- extraLuaConfig "
+        pkgs.writeText "init.lua-expected" ''
+          -- extraLuaConfig
+        ''
       }
     '';
   };


### PR DESCRIPTION
### Description

Suggestion to fix: https://github.com/nix-community/home-manager/issues/3457

Adds a configuration `programs.neovim.extraLuaConfig` that is added to the `init.lua` generated by home-manager.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
