### PR TITLE
firefox: manage add-ons per-profile

### DIFF
--- a/docs/release-notes/rl-2305.adoc
+++ b/docs/release-notes/rl-2305.adoc
@@ -8,7 +8,16 @@ This is the current unstable branch and the information in this section is there
 
 This release has the following notable changes:
 
-* No highlights.
+* Firefox add-ons are now managed per-profile.
+That is, if you are currently having
++
+[source,nix]
+programs.firefox.extensions = [ foo bar ];
++
+in your configuration then you must change it to
++
+[source,nix]
+programs.firefox.profiles.myprofile.extensions = [ foo bar ];
 
 [[sec-release-23.05-state-version-changes]]
 === State Version Changes


### PR DESCRIPTION
### Description

Internally we already managed them per-profile but exposed a global option to maintain backwards compatibility. The benefit to having per-profile extensions is quite large though, so it is time to switch.

Users of the global extensions option will get an error message that indicates how to edit their configuration to work again.

### Checklist

- [ ] Change is backwards compatible. No, see description.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.