### PR TITLE
home-manager: Use `path:` URI type for flake default

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -156,7 +156,7 @@ function setFlakeAttribute() {
         fi
 
         if [[ -v configFlake ]]; then
-            FLAKE_ARG="$(dirname "$(readlink -f "$configFlake")")"
+            FLAKE_ARG="path:$(dirname "$(readlink -f "$configFlake")")"
         fi
     fi
 


### PR DESCRIPTION
```
Nix interprets a path-like URI as a git repository if any of the path's parents is a git repository. Since home-manager uses a default flake URI of ~/.config/nixpkgs/flake.nix, if you have a git repository as your home directory and a '*' .gitignore it leads to the following problems:

    evaluating derivation 'git+file:///Users/dongcarl?dir=.config%2fnixpkgs#homeConfigurations."dongcarl".activationPackage'
    The following paths are ignored by one of your .gitignore files:
    .config

This is solved by explicitly specifying the `path:` URI type prefix for the default flake URI argument.
```

I hope that this fix gets backported to release branches.