### PR TITLE
nix: fix package assertion

### DIFF
--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -212,29 +212,28 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
-    assertions = [{
-      assertion = cfg.settings == { } || cfg.package != null;
-      message = ''
-        A corresponding Nix package must be specified via `nix.package` for generating
-        nix.conf.
-      '';
-    }];
-
-    xdg.configFile = {
-      "nix/registry.json" = mkIf (cfg.registry != { }) {
-        source = jsonFormat.generate "registry.json" {
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf (cfg.registry != { }) {
+      xdg.configFile."nix/registry.json".source =
+        jsonFormat.generate "registry.json" {
           version = cfg.registryVersion;
           flakes =
             mapAttrsToList (n: v: { inherit (v) from to exact; }) cfg.registry;
         };
-      };
+    })
 
-      "nix/nix.conf" = mkIf (cfg.settings != { } || cfg.extraOptions != "") {
-        source = nixConf;
-      };
-    };
-  };
+    (mkIf (cfg.settings != { } || cfg.extraOptions != "") {
+      assertions = [{
+        assertion = cfg.package != null;
+        message = ''
+          A corresponding Nix package must be specified via `nix.package` for generating
+          nix.conf.
+        '';
+      }];
+
+      xdg.configFile."nix/nix.conf".source = nixConf;
+    })
+  ]);
 
   meta.maintainers = [ maintainers.polykernel ];
 }


### PR DESCRIPTION
Sync it with the condition for generating nix.conf so that it triggers if `extraOptions` is set but `package` isn't. See https://github.com/nix-community/home-manager/pull/2718#discussion_r1097082480

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
