### PR TITLE
programs.gpg: update references to respective manpages

### DIFF
--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -168,8 +168,13 @@ in {
       '';
       description = ''
         GnuPG configuration options. Available options are described
-        in the gpg manpage:
-        <link xlink:href="https://gnupg.org/documentation/manpage.html"/>.
+        in
+        <link xlink:href="https://gnupg.org/documentation/manpage.html">
+          <citerefentry>
+              <refentrytitle>gpg</refentrytitle>
+              <manvolnum>1</manvolnum>
+          </citerefentry>
+        </link>.
         </para>
         <para>
         Note that lists are converted to duplicate keys.
@@ -186,8 +191,13 @@ in {
       '';
       description = ''
         SCdaemon configuration options. Available options are described
-        in the gpg scdaemon manpage:
-        <link xlink:href="https://www.gnupg.org/documentation/manuals/gnupg/Scdaemon-Options.html"/>.
+        in
+        <link xlink:href="https://www.gnupg.org/documentation/manuals/gnupg/Scdaemon-Options.html">
+          <citerefentry>
+              <refentrytitle>scdaemon</refentrytitle>
+              <manvolnum>1</manvolnum>
+          </citerefentry>
+        </link>.
       '';
     };
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

The [document that is previously linked encourages to refer to the respective manpage that came with the package](https://gnupg.org/documentation/manpage.html) so I replace the references of the web version with the manpages.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.

This is only an update on the module option description so I didn't test the modules and only built the documents (e.g., `nix-build -A docs.html`, `nix-build -A docs.manPages`) to see how it looks.