### PR TITLE
scmpuff: clean up tests

### DIFF
--- a/tests/modules/programs/scmpuff/bash.nix
+++ b/tests/modules/programs/scmpuff/bash.nix
@@ -1,15 +1,17 @@
-{ pkgs, ... }: {
-  config = {
-    programs = {
-      scmpuff.enable = true;
-      bash.enable = true;
-    };
+{ ... }:
 
-    nmt.script = ''
-      assertFileExists home-files/.bashrc
-      assertFileContains \
-        home-files/.bashrc \
-        'eval "$(${pkgs.scmpuff}/bin/scmpuff init -s)"'
-    '';
+{
+  programs = {
+    scmpuff.enable = true;
+    bash.enable = true;
   };
+
+  test.stubs.scmpuff = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileContains \
+      home-files/.bashrc \
+      'eval "$(@scmpuff@/bin/scmpuff init -s)"'
+  '';
 }

--- a/tests/modules/programs/scmpuff/fish.nix
+++ b/tests/modules/programs/scmpuff/fish.nix
@@ -1,4 +1,6 @@
-{ pkgs, lib, ... }: {
+{ lib, ... }:
+
+{
   programs = {
     scmpuff.enable = true;
     fish.enable = true;

--- a/tests/modules/programs/scmpuff/no-bash.nix
+++ b/tests/modules/programs/scmpuff/no-bash.nix
@@ -1,15 +1,17 @@
-{ pkgs, ... }: {
-  config = {
-    programs = {
-      scmpuff = {
-        enable = true;
-        enableBashIntegration = false;
-      };
-      bash.enable = true;
-    };
+{ ... }:
 
-    nmt.script = ''
-      assertFileNotRegex home-files/.bashrc '${pkgs.scmpuff}/bin/scmpuff'
-    '';
+{
+  programs = {
+    scmpuff = {
+      enable = true;
+      enableBashIntegration = false;
+    };
+    bash.enable = true;
   };
+
+  test.stubs.scmpuff = { };
+
+  nmt.script = ''
+    assertFileNotRegex home-files/.bashrc '@scmpuff@/bin/scmpuff'
+  '';
 }

--- a/tests/modules/programs/scmpuff/no-fish.nix
+++ b/tests/modules/programs/scmpuff/no-fish.nix
@@ -1,4 +1,6 @@
-{ pkgs, lib, ... }: {
+{ lib, ... }:
+
+{
   programs = {
     scmpuff = {
       enable = true;

--- a/tests/modules/programs/scmpuff/no-shell.nix
+++ b/tests/modules/programs/scmpuff/no-shell.nix
@@ -1,20 +1,23 @@
-{ pkgs, ... }: {
-  config = {
-    programs = {
-      scmpuff = {
-        enable = true;
-        enableBashIntegration = false;
-        enableZshIntegration = false;
-      };
-      bash.enable = true;
-      zsh.enable = true;
+{ ... }:
+
+{
+  programs = {
+    scmpuff = {
+      enable = true;
+      enableBashIntegration = false;
+      enableZshIntegration = false;
     };
-
-    test.stubs.zsh = { };
-
-    nmt.script = ''
-      assertFileNotRegex home-files/.zshrc '${pkgs.scmpuff} init -s'
-      assertFileNotRegex home-files/.bashrc '${pkgs.scmpuff} init -s'
-    '';
+    bash.enable = true;
+    zsh.enable = true;
   };
+
+  test.stubs = {
+    zsh = { };
+    scmpuff = { };
+  };
+
+  nmt.script = ''
+    assertFileNotRegex home-files/.zshrc '@scmpuff@ init -s'
+    assertFileNotRegex home-files/.bashrc '@scmpuff@ init -s'
+  '';
 }

--- a/tests/modules/programs/scmpuff/no-zsh.nix
+++ b/tests/modules/programs/scmpuff/no-zsh.nix
@@ -1,17 +1,20 @@
-{ pkgs, ... }: {
-  config = {
-    programs = {
-      scmpuff = {
-        enable = true;
-        enableZshIntegration = false;
-      };
-      zsh.enable = true;
+{ ... }:
+
+{
+  programs = {
+    scmpuff = {
+      enable = true;
+      enableZshIntegration = false;
     };
-
-    test.stubs.zsh = { };
-
-    nmt.script = ''
-      assertFileNotRegex home-files/.zshrc '${pkgs.scmpuff} init -s'
-    '';
+    zsh.enable = true;
   };
+
+  test.stubs = {
+    zsh = { };
+    scmpuff = { };
+  };
+
+  nmt.script = ''
+    assertFileNotRegex home-files/.zshrc '@scmpuff@ init -s'
+  '';
 }

--- a/tests/modules/programs/scmpuff/zsh.nix
+++ b/tests/modules/programs/scmpuff/zsh.nix
@@ -1,17 +1,20 @@
-{ pkgs, ... }: {
-  config = {
-    programs = {
-      scmpuff.enable = true;
-      zsh.enable = true;
-    };
+{ ... }:
 
-    test.stubs.zsh = { };
-
-    nmt.script = ''
-      assertFileExists home-files/.zshrc
-      assertFileContains \
-        home-files/.zshrc \
-        'eval "$(${pkgs.scmpuff}/bin/scmpuff init -s)"'
-    '';
+{
+  programs = {
+    scmpuff.enable = true;
+    zsh.enable = true;
   };
+
+  test.stubs = {
+    zsh = { };
+    scmpuff = { };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+    assertFileContains \
+      home-files/.zshrc \
+      'eval "$(@scmpuff@/bin/scmpuff init -s)"'
+  '';
 }


### PR DESCRIPTION
### Description

Stub the scmpuff package. Also remove unnecessary `config` wrapping.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```