### PR TITLE
xsuspender: fix typo that made debug option a noop

### DIFF
--- a/modules/services/xsuspender.nix
+++ b/modules/services/xsuspender.nix
@@ -191,7 +191,7 @@ in {
 
       Service = {
         ExecStart = "${pkgs.xsuspender}/bin/xsuspender";
-        Environment = mkIf cfg.debug [ "G_MESSAGE_DEBUG=all" ];
+        Environment = mkIf cfg.debug [ "G_MESSAGES_DEBUG=all" ];
       };
 
       Install = { WantedBy = [ "graphical-session.target" ]; };


### PR DESCRIPTION
### Description

It's G\_MESSAGE**S**\_DEBUG, not "G_MESSAGE_DEBUG".

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
