### PR TITLE
vscode: fix erroneous application of lib.optional

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -221,7 +221,7 @@ in {
             builtins.attrNames (builtins.readDir (ext + "/${subDir}")));
       in if cfg.mutableExtensionsDir then
         mkMerge (concatMap toPaths cfg.extensions
-          ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0") [{
+          ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0") {
             # Whenever our immutable extensions.json changes, force VSCode to regenerate
             # extensions.json with both mutable and immutable extensions.
             "${extensionPath}/.extensions-immutable.json" = {
@@ -232,14 +232,14 @@ in {
                 $DRY_RUN_CMD ${getExe cfg.package} --list-extensions > /dev/null
               '';
             };
-          }])
+          })
       else {
         "${extensionPath}".source = let
           combinedExtensionsDrv = pkgs.buildEnv {
             name = "vscode-extensions";
             paths = cfg.extensions
               ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0")
-              [ extensionJsonFile ];
+              extensionJsonFile;
           };
         in "${combinedExtensionsDrv}/${subDir}";
       }))


### PR DESCRIPTION
### Description

I made an error in my previous PR and didn't test it, meaning it didn't have the functionality it was supposed to. This fixes that error.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
