### PR TITLE
Revert "mbsync: make passwordCommand escaping consistent"

### DIFF
--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -84,7 +84,7 @@ let
     genSection "IMAPAccount ${name}" ({
       Host = imap.host;
       User = userName;
-      PassCmd = lib.escapeShellArgs passwordCommand;
+      PassCmd = toString passwordCommand;
     } // genTlsConfig imap.tls
       // optionalAttrs (imap.port != null) { Port = toString imap.port; }
       // mbsync.extraConfig.account) + "\n"

--- a/tests/modules/programs/mbsync/mbsync-expected.conf
+++ b/tests/modules/programs/mbsync/mbsync-expected.conf
@@ -3,7 +3,7 @@
 IMAPAccount hm-account
 CertificateFile /etc/ssl/certs/ca-certificates.crt
 Host imap.example.org
-PassCmd "'password-command' '2'"
+PassCmd "password-command 2"
 SSLType IMAPS
 User home.manager.jr
 
@@ -55,7 +55,7 @@ Channel hm-account-strangeHostBoxName
 IMAPAccount hm@example.com
 CertificateFile /etc/ssl/certs/ca-certificates.crt
 Host imap.example.com
-PassCmd 'password-command'
+PassCmd password-command
 SSLType IMAPS
 SSLVersions TLSv1.3 TLSv1.2
 User home.manager


### PR DESCRIPTION
Reverts nix-community/home-manager#3630

See https://github.com/nix-community/home-manager/issues/3650, https://github.com/nix-community/home-manager/commit/e2c1756e3ae001ca8696912016dd31cb1503ccf3#commitcomment-99863177