### PR TITLE
mcfly: don't install widget on limited terminals

### DIFF
--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -78,11 +78,15 @@ in {
       home.packages = [ pkgs.mcfly ];
 
       programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-        eval "$(${pkgs.mcfly}/bin/mcfly init bash)"
+        if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
+          eval "$(${pkgs.mcfly}/bin/mcfly init bash)"
+        fi
       '';
 
       programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-        eval "$(${pkgs.mcfly}/bin/mcfly init zsh)"
+        if [[ $options[zle] = on ]]; then
+          eval "$(${pkgs.mcfly}/bin/mcfly init zsh)"
+        fi
       '';
 
       programs.fish.shellInit = mkIf cfg.enableFishIntegration ''


### PR DESCRIPTION


### Description

<!--

Please provide a brief description of your change.

-->
Otherwise we get the following warning for terminals with limited capabilities:

    bash: bind: warning: line editing not enabled
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
