### PR TITLE
home.pointerCursor: set common XCURSOR_* environment variables by default

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -133,6 +133,8 @@ in {
       home.sessionVariables = {
         XCURSOR_PATH = mkDefault ("$XCURSOR_PATH\${XCURSOR_PATH:+:}"
           + "${config.home.profileDirectory}/share/icons");
+        XCURSOR_SIZE = mkDefault cfg.size;
+        XCURSOR_THEME = mkDefault cfg.name;
       };
     }
 


### PR DESCRIPTION
The `XCURSOR_*` environment variables specified in libxcursor
are used by many applications and libraries to load and configure
cursor settings. Setting these variables is a no-op if ignored but
is useful as a fallback when other sources of configuration are
unreliable.

This commit sets some commonly used `XCURSOR_*` environment variables
(i.e XCURSOR_THEME, XCURSOR_SIZE) by default when `home.pointerCursor`
is enabled.



### Description

<!--

Please provide a brief description of your change.

-->

Fixes https://github.com/nix-community/home-manager/issues/3645

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
