### PR TITLE
dircolors: Implement `terminalTypes` option (fix #3658)

### DIFF
--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -43,6 +43,42 @@ in {
       '';
     };
 
+    terminalTypes = mkOption {
+      type = with types; listOf str;
+      # Default terminal types from `dircolors --print-database`.
+      default = [
+        "Eterm"
+        "ansi"
+        "*color*"
+        "con[0-9]*x[0-9]*"
+        "cons25"
+        "console"
+        "cygwin"
+        "dtterm"
+        "gnome"
+        "hurd"
+        "jfbterm"
+        "konsole"
+        "kterm"
+        "linux"
+        "linux-c"
+        "mlterm"
+        "putty"
+        "rxvt*"
+        "screen*"
+        "st"
+        "terminator"
+        "tmux*"
+        "vt100"
+        "xterm*"
+      ];
+      description = ''
+        List of terminal types for which
+        <xref linkend="opt-programs.dircolors.settings"/> should be applied.
+        If empty, settings are applied regardless of terminal type.
+      '';
+    };
+
     settings = mkOption {
       type = with types; attrsOf str;
       default = { };
@@ -204,6 +240,7 @@ in {
     };
 
     home.file.".dir_colors".text = concatStringsSep "\n" ([ ]
+      ++ map (t: "TERM ${t}") cfg.terminalTypes
       ++ mapAttrsToList formatLine cfg.settings ++ [ "" ]
       ++ optional (cfg.extraConfig != "") cfg.extraConfig);
 

--- a/tests/modules/programs/dircolors/settings-expected.conf
+++ b/tests/modules/programs/dircolors/settings-expected.conf
@@ -1,3 +1,5 @@
+TERM xterm*
+TERM ansi
 .7z 01;31
 .aac 00;36
 .ace 01;31

--- a/tests/modules/programs/dircolors/settings.nix
+++ b/tests/modules/programs/dircolors/settings.nix
@@ -6,6 +6,7 @@ with lib;
   config = {
     programs.dircolors = {
       enable = true;
+      terminalTypes = [ "xterm*" "ansi" ];
 
       settings = {
         OTHER_WRITABLE = "30;46";


### PR DESCRIPTION
### Description

In the default `dircolors -p` configuration, `LS_COLORS` is set only on specific terminals.

This will allow the user to set which terminals should have `LS_COLORS` set. If not set, the default list of supported terminals taken from `dircolors -p` will be used. Because the supported terminals list has to precede settings, this isn't possible to set through `extraConfig`. 

Fixes #3658

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
