### PR TITLE
pipewire: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -473,6 +473,9 @@ Makefile                                              @thiagokokada
 /modules/services/picom.nix                           @thiagokokada
 /tests/modules/services/picom                         @thiagokokada
 
+/modules/services/pipewire.nix                        @Scrumplex
+/tests/modules/services/pipewire                      @Scrumplex
+
 /modules/services/pbgopy.nix                          @ivarwithoutbones
 /tests/modules/services/pbgopy                        @ivarwithoutbones
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -915,6 +915,14 @@ in
           A new module is available: 'services.autorandr'.
         '';
       }
+
+      {
+        time = "2023-02-09T22:11:02+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.pipewire'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -264,6 +264,7 @@ let
     ./services/pasystray.nix
     ./services/pbgopy.nix
     ./services/picom.nix
+    ./services/pipewire.nix
     ./services/plan9port.nix
     ./services/playerctld.nix
     ./services/plex-mpv-shim.nix

--- a/modules/services/pipewire.nix
+++ b/modules/services/pipewire.nix
@@ -1,0 +1,96 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    types literalExpression isStorePath nameValuePair makeSearchPath;
+  inherit (lib.attrsets) mapAttrs';
+  inherit (lib.options) mkEnableOption mkPackageOption mkOption;
+  inherit (lib.modules) mkIf;
+
+  cfg = config.services.pipewire;
+
+  instanceOpts = with types;
+    submodule {
+      options = {
+        config = mkOption {
+          type = either path str;
+          default = null;
+          example = literalExpression "./compressor.conf";
+          description = ''
+            Configuration file for the PipeWire instance. See <citerefentry>
+            <refentrytitle>pipewire.conf</refentrytitle><manvolnum>5</manvolnum>
+            </citerefentry>
+          '';
+        };
+        extraPackages = mkOption {
+          type = listOf package;
+          default = [ ];
+          example = literalExpression "[ pkgs.calf ]";
+          description = "Extra packages available to this PipeWire instance.";
+        };
+      };
+    };
+in {
+  options.services.pipewire = with types; {
+    enable = mkEnableOption "pipewire-instances";
+
+    package = mkPackageOption pkgs "pipewire" { };
+
+    instances = mkOption {
+      type = attrsOf (instanceOpts);
+      default = { };
+      example = literalExpression ''
+        {
+          compressor = {
+            config = ./compressor.conf;
+            extraPackages = [ pkgs.calf ];
+          };
+        }
+      '';
+      description = "Definition of PipeWire instances";
+    };
+  };
+  config = let
+    mkPipeWireInstance = name: instance:
+      let
+        fullName = "pipewire-instance-${name}";
+        pwConfig =
+          if builtins.isPath instance.config || isStorePath instance.config then
+            instance.config
+          else
+            pkgs.writeText "${fullName}.conf" instance.config;
+      in nameValuePair fullName {
+        Unit = {
+          Description = "PipeWire instance ${name}";
+          After = "pipewire.service";
+          BindsTo = "pipewire.service";
+        };
+        Service = {
+          Environment = let
+            # pipewire-filter-chain allows loading LADSPA and LV2 filters, add them to the search path here
+            extraPackages = instance.extraPackages ++ [ cfg.package ];
+            bins = makeSearchPath "bin" extraPackages;
+            libs = makeSearchPath "lib" extraPackages;
+            ladspaLibs = makeSearchPath "lib/ladspa" extraPackages;
+            lv2Libs = makeSearchPath "lib/lv2" extraPackages;
+          in [
+            "PATH=${bins}"
+            "LD_LIBRARY_PATH=${libs}"
+            "LADSPA_PATH=${ladspaLibs}"
+            "LV2_PATH=${lv2Libs}"
+          ];
+          ExecStart = ''
+            ${cfg.package}/bin/pipewire -c ${pwConfig}
+          '';
+        };
+        Install.WantedBy = [ "pipewire.service" ];
+      };
+  in mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.pipewire" pkgs
+        lib.platforms.linux)
+    ];
+
+    systemd.user.services = mapAttrs' mkPipeWireInstance cfg.instances;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -193,6 +193,7 @@ import nmt {
     ./modules/services/pass-secret-service
     ./modules/services/pbgopy
     ./modules/services/picom
+    ./modules/services/pipewire
     ./modules/services/playerctld
     ./modules/services/polybar
     ./modules/services/recoll

--- a/tests/modules/services/pipewire/basic-configuration-path.conf
+++ b/tests/modules/services/pipewire/basic-configuration-path.conf
@@ -1,0 +1,1 @@
+this is a dumb config

--- a/tests/modules/services/pipewire/basic-configuration-path.nix
+++ b/tests/modules/services/pipewire/basic-configuration-path.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+{
+  home.stateVersion = "23.05";
+
+  services.pipewire = {
+    enable = true;
+    instances.bar.config = ./basic-configuration-path.conf;
+  };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/pipewire-instance-bar.service)
+    assertFileContent "$serviceFile" ${./basic-configuration-path.service}
+
+    confFile=$(grep -o \
+        '/nix/store/.*-basic-configuration-path.conf' \
+        $TESTED/home-files/.config/systemd/user/pipewire-instance-bar.service | cut -d' ' -f3)
+    assertFileContent "$confFile" ${./basic-configuration-path.conf}
+  '';
+}

--- a/tests/modules/services/pipewire/basic-configuration-path.service
+++ b/tests/modules/services/pipewire/basic-configuration-path.service
@@ -1,0 +1,15 @@
+[Install]
+WantedBy=pipewire.service
+
+[Service]
+Environment=PATH=/nix/store/00000000000000000000000000000000-pipewire/bin
+Environment=LD_LIBRARY_PATH=/nix/store/00000000000000000000000000000000-pipewire/lib
+Environment=LADSPA_PATH=/nix/store/00000000000000000000000000000000-pipewire/lib/ladspa
+Environment=LV2_PATH=/nix/store/00000000000000000000000000000000-pipewire/lib/lv2
+ExecStart=/nix/store/00000000000000000000000000000000-pipewire/bin/pipewire -c /nix/store/00000000000000000000000000000000-basic-configuration-path.conf
+
+
+[Unit]
+After=pipewire.service
+BindsTo=pipewire.service
+Description=PipeWire instance bar

--- a/tests/modules/services/pipewire/basic-configuration.conf
+++ b/tests/modules/services/pipewire/basic-configuration.conf
@@ -1,0 +1,1 @@
+this is a dummy config

--- a/tests/modules/services/pipewire/basic-configuration.nix
+++ b/tests/modules/services/pipewire/basic-configuration.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+{
+  home.stateVersion = "23.05";
+
+  services.pipewire = {
+    enable = true;
+    instances.foo.config = ''
+      this is a dummy config
+    '';
+  };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/pipewire-instance-foo.service)
+    assertFileContent "$serviceFile" ${./basic-configuration.service}
+
+    confFile=$(grep -o \
+        '/nix/store/.*-pipewire-instance-foo.conf' \
+        $TESTED/home-files/.config/systemd/user/pipewire-instance-foo.service | cut -d' ' -f3)
+    assertFileContent "$confFile" ${./basic-configuration.conf}
+  '';
+}

--- a/tests/modules/services/pipewire/basic-configuration.service
+++ b/tests/modules/services/pipewire/basic-configuration.service
@@ -1,0 +1,15 @@
+[Install]
+WantedBy=pipewire.service
+
+[Service]
+Environment=PATH=/nix/store/00000000000000000000000000000000-pipewire/bin
+Environment=LD_LIBRARY_PATH=/nix/store/00000000000000000000000000000000-pipewire/lib
+Environment=LADSPA_PATH=/nix/store/00000000000000000000000000000000-pipewire/lib/ladspa
+Environment=LV2_PATH=/nix/store/00000000000000000000000000000000-pipewire/lib/lv2
+ExecStart=/nix/store/00000000000000000000000000000000-pipewire/bin/pipewire -c /nix/store/00000000000000000000000000000000-pipewire-instance-foo.conf
+
+
+[Unit]
+After=pipewire.service
+BindsTo=pipewire.service
+Description=PipeWire instance foo

--- a/tests/modules/services/pipewire/default.nix
+++ b/tests/modules/services/pipewire/default.nix
@@ -1,0 +1,5 @@
+{
+  pipewire-basic-config = ./basic-configuration.nix;
+  pipewire-basic-config-path = ./basic-configuration-path.nix;
+  pipewire-extra-packages = ./extra-packages.nix;
+}

--- a/tests/modules/services/pipewire/extra-packages.conf
+++ b/tests/modules/services/pipewire/extra-packages.conf
@@ -1,0 +1,1 @@
+this is a foobar config

--- a/tests/modules/services/pipewire/extra-packages.nix
+++ b/tests/modules/services/pipewire/extra-packages.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+{
+  home.stateVersion = "23.05";
+
+  services.pipewire = {
+    enable = true;
+    instances.baz = {
+      config = ''
+        this is a foobar config
+      '';
+      extraPackages = [ pkgs.calf ];
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/pipewire-instance-baz.service)
+    assertFileContent "$serviceFile" ${./extra-packages.service}
+
+    confFile=$(grep -o \
+        '/nix/store/.*-pipewire-instance-baz.conf' \
+        $TESTED/home-files/.config/systemd/user/pipewire-instance-baz.service | cut -d' ' -f3)
+    assertFileContent "$confFile" ${./extra-packages.conf}
+  '';
+}

--- a/tests/modules/services/pipewire/extra-packages.service
+++ b/tests/modules/services/pipewire/extra-packages.service
@@ -1,0 +1,15 @@
+[Install]
+WantedBy=pipewire.service
+
+[Service]
+Environment=PATH=/nix/store/00000000000000000000000000000000-calf/bin:/nix/store/00000000000000000000000000000000-pipewire/bin
+Environment=LD_LIBRARY_PATH=/nix/store/00000000000000000000000000000000-calf/lib:/nix/store/00000000000000000000000000000000-pipewire/lib
+Environment=LADSPA_PATH=/nix/store/00000000000000000000000000000000-calf/lib/ladspa:/nix/store/00000000000000000000000000000000-pipewire/lib/ladspa
+Environment=LV2_PATH=/nix/store/00000000000000000000000000000000-calf/lib/lv2:/nix/store/00000000000000000000000000000000-pipewire/lib/lv2
+ExecStart=/nix/store/00000000000000000000000000000000-pipewire/bin/pipewire -c /nix/store/00000000000000000000000000000000-pipewire-instance-baz.conf
+
+
+[Unit]
+After=pipewire.service
+BindsTo=pipewire.service
+Description=PipeWire instance baz


### PR DESCRIPTION
### Description

This adds a module to configure additional pipewire deamons. This can be used to run additional instances with different filter-chain configurations.

The following example would start an additional PipeWire daemon, that compresses incoming audio and pipes it back into the default sink.

```nix
  services.pipewire = {
    enable = true;
    instances = {
      compressor = {
        config = ''
          context.spa-libs = {
            audio.convert.* = audioconvert/libspa-audioconvert
            support.*       = support/libspa-support
          }

          context.modules = [
            {   name = libpipewire-module-rtkit
              args = {
                nice.level   = -11
                rt.prio      = 88
                rt.time.soft = 200000
                rt.time.hard = 200000
              }
              flags = [ ifexists nofail ]
            }
            { name = libpipewire-module-protocol-native }
            { name = libpipewire-module-client-node }
            { name = libpipewire-module-adapter }

            { name = libpipewire-module-filter-chain
              args = {
                node.name =  "voip_compressor"
                node.description =  "VoIP Compressor"
                media.name =  "VoIP Compressor"
                filter.graph = {
                  nodes = [
                    {
                      type = lv2
                      name = "Calf Compressor"
                      plugin = "http://calf.sourceforge.net/plugins/Compressor"
                      label = sc4
                      control = {
                        "bypass" 0.000000
                        "level_in" 1.000000
                        "threshold" 0.03125
                        "ratio" 4.000000
                        "attack" 1.500000
                        "release" 250.000000
                        "makeup" 3.000000
                        "knee" 1.500000
                        "detection" 0.000000
                        "stereo_link" 0.000000
                        "mix" 1.000000
                      }
                    }
                  ]
                }
                capture.props = {
                  node.passive = true
                  media.class = Audio/Sink
                  node.pause-on-idle = false
                }
                playback.props = {
                  node.pause-on-idle = false
                }
              }
            }
          ]
        '';
        extraPackages = [ pkgs.calf ];
      };
    };
  }
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
