### PR TITLE
ssh: install an ssh client

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -103,7 +103,7 @@ in
       entries = mkOption {
         internal = true;
         type = types.listOf entryModule;
-        default = [];
+        default = [ ];
         description = "News entries.";
       };
     };
@@ -1021,6 +1021,16 @@ in
         condition = hostPlatform.isLinux;
         message = ''
           A new module is available: 'programs.fuzzel'.
+        '';
+      }
+
+      {
+        time = "2023-05-13T14:34:21+00:00";
+        condition = config.programs.ssh.enable;
+        message = ''
+          The module 'programs.ssh' now installs an SSH client. The installed
+          client is controlled by the 'programs.ssh.package` option, which
+          defaults to 'pkgs.openssh'.
         '';
       }
     ];

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -361,6 +361,8 @@ in
   options.programs.ssh = {
     enable = mkEnableOption "SSH client configuration";
 
+    package = mkPackageOption pkgs "openssh" { };
+
     forwardAgent = mkOption {
       default = false;
       type = types.bool;
@@ -524,6 +526,8 @@ in
         message = "Forwarded paths cannot have ports.";
       }
     ];
+
+    home.packages = [ cfg.package ];
 
     home.file.".ssh/config".text =
       let

--- a/tests/modules/programs/ssh/default-config.nix
+++ b/tests/modules/programs/ssh/default-config.nix
@@ -6,6 +6,8 @@ with lib;
   config = {
     programs.ssh = { enable = true; };
 
+    test.stubs.openssh = { };
+
     home.file.assertions.text = builtins.toJSON
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 

--- a/tests/modules/programs/ssh/forwards-dynamic-bind-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-dynamic-bind-path-with-port-asserts.nix
@@ -17,6 +17,8 @@ with lib;
       };
     };
 
+    test.stubs.openssh = { };
+
     test.asserts.assertions.expected = [ "Forwarded paths cannot have ports." ];
   };
 }

--- a/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts.nix
@@ -27,6 +27,8 @@ with lib;
     home.file.result.text = builtins.toJSON
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
+    test.stubs.openssh = { };
+
     nmt.script = ''
       assertFileExists home-files/.ssh/config
       assertFileContent \

--- a/tests/modules/programs/ssh/forwards-local-bind-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-local-bind-path-with-port-asserts.nix
@@ -21,6 +21,8 @@ with lib;
       };
     };
 
+    test.stubs.openssh = { };
+
     test.asserts.assertions.expected = [ "Forwarded paths cannot have ports." ];
   };
 }

--- a/tests/modules/programs/ssh/forwards-local-host-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-local-host-path-with-port-asserts.nix
@@ -21,6 +21,8 @@ with lib;
       };
     };
 
+    test.stubs.openssh = { };
+
     test.asserts.assertions.expected = [ "Forwarded paths cannot have ports." ];
   };
 }

--- a/tests/modules/programs/ssh/forwards-remote-bind-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-remote-bind-path-with-port-asserts.nix
@@ -21,6 +21,8 @@ with lib;
       };
     };
 
+    test.stubs.openssh = { };
+
     test.asserts.assertions.expected = [ "Forwarded paths cannot have ports." ];
   };
 }

--- a/tests/modules/programs/ssh/forwards-remote-host-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-remote-host-path-with-port-asserts.nix
@@ -21,6 +21,8 @@ with lib;
       };
     };
 
+    test.stubs.openssh = { };
+
     test.asserts.assertions.expected = [ "Forwarded paths cannot have ports." ];
   };
 }

--- a/tests/modules/programs/ssh/includes.nix
+++ b/tests/modules/programs/ssh/includes.nix
@@ -7,6 +7,8 @@
       includes = [ "config.d/*" "other/dir" ];
     };
 
+    test.stubs.openssh = { };
+
     nmt.script = ''
       assertFileExists home-files/.ssh/config
       assertFileContains home-files/.ssh/config "Include config.d/* other/dir"

--- a/tests/modules/programs/ssh/match-blocks-attrs.nix
+++ b/tests/modules/programs/ssh/match-blocks-attrs.nix
@@ -51,6 +51,8 @@ with lib;
     home.file.assertions.text = builtins.toJSON
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
+    test.stubs.openssh = { };
+
     nmt.script = ''
       assertFileExists home-files/.ssh/config
       assertFileContent \

--- a/tests/modules/programs/ssh/match-blocks-match-and-hosts.nix
+++ b/tests/modules/programs/ssh/match-blocks-match-and-hosts.nix
@@ -21,6 +21,8 @@ with lib;
     home.file.assertions.text = builtins.toJSON
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
+    test.stubs.openssh = { };
+
     nmt.script = ''
       assertFileExists home-files/.ssh/config
       assertFileContent \


### PR DESCRIPTION
Fixes: #3667

### Description

Add `programs.ssh.package` option and install the ssh client. It's not clear to me if this change is backwards-compatible or not, but at least we have something concrete to look at now.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
