### PR TITLE
keychain: add nushell integration

### DIFF
--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -87,6 +87,14 @@ in {
       '';
     };
 
+    enableNushellIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Nushell integration.
+      '';
+    };
+
     enableXsessionIntegration = mkOption {
       default = true;
       type = types.bool;
@@ -107,6 +115,9 @@ in {
     '';
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
       eval "$(SHELL=zsh ${shellCommand})"
+    '';
+    programs.nushell.extraConfig = mkIf cfg.enableNushellIntegration ''
+      ${shellCommand} | parse -r '(\w+)=(.*); export \1' | transpose -ird | load-env
     '';
     xsession.initExtra = mkIf cfg.enableXsessionIntegration ''
       eval "$(${shellCommand})"


### PR DESCRIPTION
### Description

There is [no equivalent](https://www.nushell.sh/book/thinking_in_nu.html#think-of-nushell-as-a-compiled-language) of `eval` in nushell. Instead, this commit parses the output of keychain and pipes it directly into `load-env`, inspired by the recommendation for [`ssh-agent`](https://www.nushell.sh/cookbook/misc.html#manage-ssh-passphrases).

I also haven't set the `SHELL` variable as I don't see why? `keychain` only seems to [check](https://github.com/funtoo/keychain/blob/master/keychain.sh#L437-L439) for `fish` and `csh`.

I've tested the functionality of this commit on my own computer and it works.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
