### PR TITLE
Fix 22.11 tests

### DIFF
--- a/tests/modules/programs/broot/broot.nix
+++ b/tests/modules/programs/broot/broot.nix
@@ -1,30 +1,26 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ ... }:
 
 {
-  config = {
-    programs.broot = {
-      enable = true;
-      settings.modal = true;
-    };
-
-    nmt.script = ''
-      assertFileExists home-files/.config/broot/conf.toml
-      assertFileContent home-files/.config/broot/conf.toml ${
-        pkgs.writeText "broot.expected" ''
-          content_search_max_file_size = "10MB"
-          imports = ["verbs.hjson", {file = "dark-blue-skin.hjson", luma = ["dark", "unknown"]}, {file = "white-skin.hjson", luma = "light"}]
-          modal = true
-          show_selection_mark = true
-          verbs = []
-
-          [skin]
-
-          [special_paths]
-          "/media" = "no-enter"
-        ''
-      }
-    '';
+  programs.broot = {
+    enable = true;
+    settings.modal = true;
   };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/broot/conf.toml
+    assertFileContent home-files/.config/broot/conf.toml ${
+      builtins.toFile "broot.expected" ''
+        content_search_max_file_size = "10MB"
+        imports = ["verbs.hjson", {file = "dark-blue-skin.hjson", luma = ["dark", "unknown"]}, {file = "white-skin.hjson", luma = "light"}]
+        modal = true
+        show_selection_mark = true
+        verbs = []
+
+        [skin]
+
+        [special_paths]
+        "/media" = "no-enter"
+      ''
+    }
+  '';
 }

--- a/tests/modules/programs/broot/broot.nix
+++ b/tests/modules/programs/broot/broot.nix
@@ -13,12 +13,16 @@ with lib;
       assertFileExists home-files/.config/broot/conf.toml
       assertFileContent home-files/.config/broot/conf.toml ${
         pkgs.writeText "broot.expected" ''
+          content_search_max_file_size = "10MB"
           imports = ["verbs.hjson", {file = "dark-blue-skin.hjson", luma = ["dark", "unknown"]}, {file = "white-skin.hjson", luma = "light"}]
           modal = true
           show_selection_mark = true
           verbs = []
 
           [skin]
+
+          [special_paths]
+          "/media" = "no-enter"
         ''
       }
     '';

--- a/tests/modules/programs/i3status-rust/with-custom.nix
+++ b/tests/modules/programs/i3status-rust/with-custom.nix
@@ -102,14 +102,14 @@ with lib;
             icons = "awesome5"
             theme = "gruvbox-dark"
             [[block]]
-            alert = 10
+            alert = 10.0
             alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
             path = "/"
             unit = "GB"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-default.nix
+++ b/tests/modules/programs/i3status-rust/with-default.nix
@@ -16,14 +16,14 @@ with lib;
             icons = "none"
             theme = "plain"
             [[block]]
-            alert = 10
+            alert = 10.0
             alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
             path = "/"
             unit = "GB"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-extra-settings.nix
+++ b/tests/modules/programs/i3status-rust/with-extra-settings.nix
@@ -111,14 +111,14 @@ with lib;
           pkgs.writeText "i3status-rust-expected-config" ''
             icons = "awesome5"
             [[block]]
-            alert = 10
+            alert = 10.0
             alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
             path = "/"
             unit = "GB"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-multiple-bars.nix
+++ b/tests/modules/programs/i3status-rust/with-multiple-bars.nix
@@ -62,14 +62,14 @@ with lib;
             icons = "none"
             theme = "plain"
             [[block]]
-            alert = 10
+            alert = 10.0
             alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
             path = "/"
             unit = "GB"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"


### PR DESCRIPTION
### Description

Make tests green again.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```