### PR TITLE
tests: fix gnupg stub

### DIFF
--- a/tests/modules/programs/gpg/mutable-keyfiles.nix
+++ b/tests/modules/programs/gpg/mutable-keyfiles.nix
@@ -14,6 +14,7 @@
   };
 
   test.stubs.gnupg = { };
+  test.stubs.systemd = { }; # depends on gnupg.override
 
   nmt.script = ''
     assertFileContains activate "export GNUPGHOME='/home/hm-user/.gnupg'"

--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -9,6 +9,7 @@ with lib;
     programs.gpg.enable = true;
 
     test.stubs.gnupg = { };
+    test.stubs.systemd = { }; # depends on gnupg.override
 
     nmt.script = ''
       in="${config.systemd.user.sockets.gpg-agent.Socket.ListenStream}"

--- a/tests/modules/services/gpg-agent/override-homedir.nix
+++ b/tests/modules/services/gpg-agent/override-homedir.nix
@@ -12,6 +12,7 @@ with lib;
     };
 
     test.stubs.gnupg = { };
+    test.stubs.systemd = { }; # depends on gnupg.override
 
     nmt.script = ''
       in="${config.systemd.user.sockets.gpg-agent.Socket.ListenStream}"


### PR DESCRIPTION
The gpg-agent tests fail to eval: https://github.com/nix-community/home-manager/actions/runs/4213809304/jobs/7316649158

systemd now depends on `gnupg.override`, so we need a stub for systemd too.

This is a quick workaround to fix the tests, not a long-term solution. Ideas:

- use the old package as a base instead of a dummy package so that we keep its `override`. This causes evaluation problems with unfree packages like `dropbox`.
- add an `override` (and `overrideAttrs`?) to the dummy package.
- add stubs for *all* packages by default, and only whitelist the ones that are needed for evaluation (?)