### PR TITLE
neovim: separate init.lua parts with newlines

### DIFF
--- a/tests/modules/programs/neovim/default.nix
+++ b/tests/modules/programs/neovim/default.nix
@@ -6,4 +6,5 @@
   # waiting for a nixpkgs patch
   neovim-no-init = ./no-init.nix;
   neovim-extra-lua-init = ./extra-lua-init.nix;
+  neovim-multiple-rc-sources = ./multiple-rc-sources.nix;
 }

--- a/tests/modules/programs/neovim/multiple-rc-sources.expected
+++ b/tests/modules/programs/neovim/multiple-rc-sources.expected
@@ -1,0 +1,5 @@
+vim.cmd [[source /nix/store/00000000000000000000000000000000-nvim-init-home-manager.vim]]
+
+vim.opt.expandtab = false
+
+vim.g.test_plugin2 = 1

--- a/tests/modules/programs/neovim/multiple-rc-sources.nix
+++ b/tests/modules/programs/neovim/multiple-rc-sources.nix
@@ -1,0 +1,30 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    programs.neovim = {
+      enable = true;
+      extraConfig = ''
+        set sw=4
+      '';
+      extraLuaConfig = ''
+        vim.opt.expandtab = false
+      '';
+      plugins = [{
+        plugin = pkgs.emptyDirectory;
+        type = "lua";
+        config = ''
+          vim.g.test_plugin2 = 1
+        '';
+      }];
+    };
+
+    nmt.script = ''
+      initLua="$TESTED/home-files/.config/nvim/init.lua"
+      initLuaNormalized="$(normalizeStorePaths "$initLua")"
+      assertFileExists "$initLua"
+      assertFileContent "$initLuaNormalized" "${./multiple-rc-sources.expected}"
+    '';
+  };
+}
+


### PR DESCRIPTION
Parts of init.lua are now separated with newlines.

### Description

Previously all parts of `init.lua` was joined without newlines.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
