### PR TITLE
carapace: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1207,6 +1207,13 @@ in
           A new module is available: 'programs.yazi'.
         '';
       }
+
+      {
+        time = "2023-09-05T06:38:05+00:00";
+        message = ''
+          A new module is available: 'programs.carapace'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -67,6 +67,7 @@ let
     ./programs/broot.nix
     ./programs/browserpass.nix
     ./programs/btop.nix
+    ./programs/carapace.nix
     ./programs/chromium.nix
     ./programs/command-not-found/command-not-found.nix
     ./programs/comodoro.nix

--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -1,0 +1,98 @@
+{ config, pkgs, lib, ... }:
+
+let
+
+  inherit (lib)
+    mkEnableOption mkPackageOption mkIf pipe fileContents splitString;
+  cfg = config.programs.carapace;
+  bin = cfg.package + "/bin/carapace";
+
+in {
+  meta.maintainers = with lib.maintainers; [ weathercold bobvanderlinden ];
+
+  options.programs.carapace = {
+    enable =
+      mkEnableOption "carapace, a multi-shell multi-command argument completer";
+
+    package = mkPackageOption pkgs "carapace" { };
+
+    enableBashIntegration = mkEnableOption "Bash integration" // {
+      default = true;
+    };
+
+    enableZshIntegration = mkEnableOption "Zsh integration" // {
+      default = true;
+    };
+
+    enableFishIntegration = mkEnableOption "Fish integration" // {
+      default = true;
+    };
+
+    enableNushellIntegration = mkEnableOption "Nushell integration" // {
+      default = true;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs = {
+      bash.initExtra = mkIf cfg.enableBashIntegration ''
+        source <(${bin} _carapace bash)
+      '';
+
+      zsh.initExtra = mkIf cfg.enableZshIntegration ''
+        source <(${bin} _carapace zsh)
+      '';
+
+      fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
+        ${bin} _carapace fish | source
+      '';
+
+      nushell = mkIf cfg.enableNushellIntegration {
+        extraEnv = ''
+          let carapace_cache = "${config.xdg.cacheHome}/carapace"
+          if not ($carapace_cache | path exists) {
+            mkdir $carapace_cache
+          }
+          ${bin} _carapace nushell | save -f $"($carapace_cache)/init.nu"
+        '';
+        extraConfig = ''
+          source ${config.xdg.cacheHome}/carapace/init.nu
+        '';
+      };
+    };
+
+    xdg.configFile =
+      mkIf (config.programs.fish.enable && cfg.enableFishIntegration) (
+        # Convert the entries from `carapace --list` to empty
+        # xdg.configFile."fish/completions/NAME.fish" entries.
+        #
+        # This is to disable fish builtin completion for each of the
+        # carapace-supported completions It is in line with the instructions from
+        # carapace-bin:
+        #
+        #   carapace --list | awk '{print $1}' | xargs -I{} touch ~/.config/fish/completions/{}.fish
+        #
+        # See https://github.com/rsteube/carapace-bin#getting-started
+        let
+          carapaceListFile = pkgs.runCommandLocal "carapace-list" {
+            buildInputs = [ cfg.package ];
+          } ''
+            ${bin} --list > $out
+          '';
+        in pipe carapaceListFile [
+          fileContents
+          (splitString "\n")
+          (map (builtins.match "^([a-z0-9-]+) .*"))
+          (builtins.filter
+            (match: match != null && (builtins.length match) > 0))
+          (map (match: builtins.head match))
+          (map (name: {
+            name = "fish/completions/${name}.fish";
+            value = { text = ""; };
+          }))
+          builtins.listToAttrs
+        ]);
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -68,6 +68,7 @@ import nmt {
     ./modules/programs/broot
     ./modules/programs/browserpass
     ./modules/programs/btop
+    ./modules/programs/carapace
     ./modules/programs/comodoro
     ./modules/programs/darcs
     ./modules/programs/dircolors

--- a/tests/modules/programs/carapace/bash.nix
+++ b/tests/modules/programs/carapace/bash.nix
@@ -1,0 +1,14 @@
+{ ... }:
+
+{
+  programs = {
+    carapace.enable = true;
+    bash.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileRegex home-files/.bashrc \
+      'source <(/nix/store/.*carapace.*/bin/carapace _carapace bash)'
+  '';
+}

--- a/tests/modules/programs/carapace/default.nix
+++ b/tests/modules/programs/carapace/default.nix
@@ -1,0 +1,6 @@
+{
+  carapace-bash = ./bash.nix;
+  carapace-zsh = ./zsh.nix;
+  carapace-fish = ./fish.nix;
+  carapace-nushell = ./nushell.nix;
+}

--- a/tests/modules/programs/carapace/fish.nix
+++ b/tests/modules/programs/carapace/fish.nix
@@ -1,0 +1,18 @@
+{ ... }:
+
+{
+  programs = {
+    carapace.enable = true;
+    fish.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileRegex home-files/.config/fish/config.fish \
+      '/nix/store/.*carapace.*/bin/carapace _carapace fish \| source'
+
+    # Check whether completions are overridden.
+    assertFileExists home-files/.config/fish/completions/git.fish
+    assertFileContent home-files/.config/fish/completions/git.fish /dev/null
+  '';
+}

--- a/tests/modules/programs/carapace/nushell.nix
+++ b/tests/modules/programs/carapace/nushell.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+
+{
+  programs = {
+    carapace.enable = true;
+    nushell.enable = true;
+  };
+
+  nmt.script = let
+    configDir = if pkgs.stdenv.isDarwin then
+      "home-files/Library/Application Support/nushell"
+    else
+      "home-files/.config/nushell";
+  in ''
+    assertFileExists "${configDir}/env.nu"
+    assertFileRegex "${configDir}/env.nu" \
+      '/nix/store/.*carapace.*/bin/carapace _carapace nushell \| save -f \$"(\$carapace_cache)/init\.nu"'
+    assertFileExists "${configDir}/config.nu"
+    assertFileRegex "${configDir}/config.nu" \
+      'source /.*/\.cache/carapace/init\.nu'
+  '';
+}

--- a/tests/modules/programs/carapace/zsh.nix
+++ b/tests/modules/programs/carapace/zsh.nix
@@ -1,0 +1,14 @@
+{ ... }:
+
+{
+  programs = {
+    carapace.enable = true;
+    zsh.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+    assertFileRegex home-files/.zshrc \
+      'source <(/nix/store/.*carapace.*/bin/carapace _carapace zsh)'
+  '';
+}


### PR DESCRIPTION
This introduces the programs.carapace.* options to use carapace-bin as the way for bash, zsh and fish to handle shell autocompletion. This aligns completion support for different executables across the shells.

The integration of carapace-bin into the shells in this PR is based on the instructions from the carapace-bin readme:
https://github.com/rsteube/carapace-bin#getting-started

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
