### PR TITLE
direnv: nushell integration should not be read only

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -83,7 +83,6 @@ in {
     enableNushellIntegration = mkOption {
       default = true;
       type = types.bool;
-      readOnly = true;
       description = ''
         Whether to enable Nushell integration.
       '';


### PR DESCRIPTION
### Description

Fixes #3689

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```