### PR TITLE
qt: auto-detect style package from name

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -6,6 +6,24 @@ let
 
   cfg = config.qt;
 
+  # Maps known lowercase style names to style packages. Non-exhaustive.
+  stylePackages = with pkgs; {
+    bb10bright = libsForQt5.qtstyleplugins;
+    bb10dark = libsForQt5.qtstyleplugins;
+    cleanlooks = libsForQt5.qtstyleplugins;
+    gtk2 = libsForQt5.qtstyleplugins;
+    motif = libsForQt5.qtstyleplugins;
+    cde = libsForQt5.qtstyleplugins;
+    plastique = libsForQt5.qtstyleplugins;
+
+    adwaita = adwaita-qt;
+    adwaita-dark = adwaita-qt;
+    adwaita-highcontrast = adwaita-qt;
+    adwaita-highcontrastinverse = adwaita-qt;
+
+    breeze = libsForQt5.breeze-qt5;
+  };
+
 in {
   meta.maintainers = [ maintainers.rycee ];
 
@@ -26,7 +44,7 @@ in {
         relatedPackages =
           [ "qgnomeplatform" [ "libsForQt5" "qtstyleplugins" ] ];
         description = ''
-          Selects the platform theme to use for Qt applications.</para>
+          Platform theme to use for Qt applications.</para>
           <para>The options are
           <variablelist>
             <varlistentry>
@@ -52,17 +70,29 @@ in {
           example = "adwaita-dark";
           relatedPackages = [ "adwaita-qt" [ "libsForQt5" "qtstyleplugins" ] ];
           description = ''
-            Selects the style to use for Qt5 applications.</para>
-            <para>The options are
+            Style to use for Qt5 applications. Case-insensitive.
+            </para>
+            <para>Some examples are
             <variablelist>
               <varlistentry>
                 <term><literal>adwaita</literal></term>
                 <term><literal>adwaita-dark</literal></term>
-                <listitem><para>Use Adwaita Qt style with
+                <term><literal>adwaita-highcontrast</literal></term>
+                <term><literal>adwaita-highcontrastinverse</literal></term>
+                <listitem><para>Use the Adwaita style from
                   <link xlink:href="https://github.com/FedoraQt/adwaita-qt">adwaita</link>
                 </para></listitem>
               </varlistentry>
               <varlistentry>
+                <term><literal>breeze</literal></term>
+                <listitem><para>Use the Breeze style from
+                  <link xlink:href="https://github.com/KDE/breeze">breeze</link>
+                </para></listitem>
+              </varlistentry>
+              <varlistentry>
+                <term><literal>bb10bright</literal></term>
+                <term><literal>bb10dark</literal></term>
+                <term><literal>cde</literal></term>
                 <term><literal>cleanlooks</literal></term>
                 <term><literal>gtk2</literal></term>
                 <term><literal>motif</literal></term>
@@ -79,7 +109,10 @@ in {
           type = types.nullOr types.package;
           default = null;
           example = literalExpression "pkgs.adwaita-qt";
-          description = "Theme package to be used in Qt5 applications.";
+          description = ''
+            Theme package to be used in Qt5 applications.
+            Auto-detected from <option>qt.style.name</option> if possible.
+          '';
         };
       };
     };
@@ -87,20 +120,23 @@ in {
 
   config = mkIf (cfg.enable && cfg.platformTheme != null) {
     assertions = [{
-      assertion = (cfg.platformTheme == "gnome")
-        -> ((cfg.style.name != null) && (cfg.style.package != null));
+      assertion = cfg.platformTheme == "gnome" -> cfg.style.name != null
+        && cfg.style.package != null;
       message = ''
         `qt.platformTheme` "gnome" must have `qt.style` set to a theme that
-        supports both Qt and Gtk, for example "adwaita" or "adwaita-dark".
+        supports both Qt and Gtk, for example "adwaita", "adwaita-dark", or "breeze".
       '';
     }];
 
-    # Necessary because home.sessionVariables is of types.attrs
-    home.sessionVariables = (filterAttrs (n: v: v != null) {
+    qt.style.package = mkIf (cfg.style.name != null)
+      (mkDefault (stylePackages.${toLower cfg.style.name} or null));
+
+    # Necessary because home.sessionVariables doesn't support mkIf
+    home.sessionVariables = filterAttrs (n: v: v != null) {
       QT_QPA_PLATFORMTHEME =
         if cfg.platformTheme == "gnome" then "gnome" else "gtk2";
       QT_STYLE_OVERRIDE = cfg.style.name;
-    });
+    };
 
     home.packages = if cfg.platformTheme == "gnome" then
       [ pkgs.qgnomeplatform ]
@@ -109,7 +145,7 @@ in {
       [ pkgs.libsForQt5.qtstyleplugins ];
 
     xsession.importedVariables = [ "QT_QPA_PLATFORMTHEME" ]
-      ++ lib.optionals (cfg.style != null) [ "QT_STYLE_OVERRIDE" ];
+      ++ lib.optionals (cfg.style.name != null) [ "QT_STYLE_OVERRIDE" ];
 
     # Enable GTK+ style for Qt4 in either case.
     # It doesn’t support the platform theme packages.

--- a/tests/modules/misc/qt/qt-platform-theme-gnome.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gnome.nix
@@ -5,10 +5,7 @@
     qt = {
       enable = true;
       platformTheme = "gnome";
-      style = {
-        name = "adwaita";
-        package = config.lib.test.mkStubPackage { };
-      };
+      style.name = "adwaita";
     };
 
     test.stubs.qgnomeplatform = { };


### PR DESCRIPTION
### Description

Auto-detect style package from style name. Fixes https://github.com/nix-community/home-manager/issues/3691

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.