### PR TITLE
Set the SHELL environment variable for keychain in .xsession

### DIFF
--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -120,7 +120,7 @@ in {
       ${shellCommand} | parse -r '(\w+)=(.*); export \1' | transpose -ird | load-env
     '';
     xsession.initExtra = mkIf cfg.enableXsessionIntegration ''
-      eval "$(${shellCommand})"
+      eval "$(SHELL=bash ${shellCommand})"
     '';
   };
 }


### PR DESCRIPTION


### Description

Xsession (and hence ~/.xsession) is executed in bash but does not set SHELL to the full path to bash. In case the user's login shell is something other than bash then SHELL is set to that shell. Keychain inspects the SHELL variable to find out what shell it has to generate code for, so in .xsession it generates code for the user's login shell instead for bash.

This change forces SHELL to bash for keychain when invoked from .xsession, the same way it's done when generating keychain's code for bash integration.

Closes #3693

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
