### PR TITLE
[Backport release-22.11] starship: add nushell integration #3701

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -58,44 +58,24 @@ in {
       '';
     };
 
-    enableBashIntegration = mkOption {
+    enableBashIntegration = mkEnableOption "Bash integration" // {
       default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
     };
 
-    enableZshIntegration = mkOption {
+    enableZshIntegration = mkEnableOption "Zsh integration" // {
       default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
     };
 
-    enableFishIntegration = mkOption {
+    enableFishIntegration = mkEnableOption "Fish integration" // {
       default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
     };
 
-    enableIonIntegration = mkOption {
+    enableIonIntegration = mkEnableOption "Ion integration" // {
       default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Ion integration.
-      '';
     };
 
-    enableNushellIntegration = mkOption {
+    enableNushellIntegration = mkEnableOption "Nushell integration" // {
       default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Nushell integration.
-      '';
     };
   };
 

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -124,6 +124,12 @@ in {
       end
     '';
 
+    programs.ion.initExtra = mkIf cfg.enableIonIntegration ''
+      if test $TERM != "dumb" && not exists -s INSIDE_EMACS || test $INSIDE_EMACS = "vterm"
+        eval $(${starshipCmd} init ion)
+      end
+    '';
+
     programs.nushell = mkIf cfg.enableNushellIntegration {
       # Unfortunately nushell doesn't allow conditionally sourcing nor
       # conditionally setting (global) environment variables, which is why the

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -134,7 +134,7 @@ in {
         if not ($starship_cache | path exists) {
           mkdir $starship_cache
         }
-        ${starshipCmd} init nu | save ${config.xdg.cacheHome}/starship/init.nu
+        ${starshipCmd} init nu | save --force ${config.xdg.cacheHome}/starship/init.nu
       '';
       extraConfig = ''
         source ${config.xdg.cacheHome}/starship/init.nu

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -89,6 +89,14 @@ in {
         Whether to enable Ion integration.
       '';
     };
+
+    enableNushellIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Nushell integration.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -116,10 +124,21 @@ in {
       end
     '';
 
-    programs.ion.initExtra = mkIf cfg.enableIonIntegration ''
-      if test $TERM != "dumb" && not exists -s INSIDE_EMACS || test $INSIDE_EMACS = "vterm"
-        eval $(${starshipCmd} init ion)
-      end
-    '';
+    programs.nushell = mkIf cfg.enableNushellIntegration {
+      # Unfortunately nushell doesn't allow conditionally sourcing nor
+      # conditionally setting (global) environment variables, which is why the
+      # check for terminal compatibility (as seen above for the other shells) is
+      # not done here.
+      extraEnv = ''
+        let starship_cache = "${config.xdg.cacheHome}/starship"
+        if not ($starship_cache | path exists) {
+          mkdir $starship_cache
+        }
+        ${starshipCmd} init nu | save ${config.xdg.cacheHome}/starship/init.nu
+      '';
+      extraConfig = ''
+        source ${config.xdg.cacheHome}/starship/init.nu
+      '';
+    };
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Backport #3347, #3519, #3528, #3701 to `release-22.11`.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
