### PR TITLE
rofi: allow to actually override package

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -266,9 +266,9 @@ in {
       rofiWithPlugins = cfg.package.override
         (old: rec { plugins = (old.plugins or [ ]) ++ cfg.plugins; });
     in if builtins.hasAttr "override" cfg.package then
-      rofiWithPlugins
+      cfg.package
     else
-      cfg.package;
+      rofiWithPlugins;
 
     home.packages = [ cfg.finalPackage ];
 


### PR DESCRIPTION
allow to override the rofi-package and not strip the override

### Description

allow to override the rofi-package and not strip the override.
before, when a custom package with override was set, the own override was added, but not when no override was set

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
