### PR TITLE
fix: swaylock wait option removed

### DIFF
--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -124,7 +124,7 @@ in {
         # swayidle executes commands using "sh -c", so the PATH needs to contain a shell.
         Environment = [ "PATH=${makeBinPath [ pkgs.bash ]}" ];
         ExecStart =
-          "${cfg.package}/bin/swayidle -w ${concatStringsSep " " args}";
+          "${cfg.package}/bin/swayidle ${concatStringsSep " " args}";
       };
 
       Install = { WantedBy = [ cfg.systemdTarget ]; };


### PR DESCRIPTION
### Description

According to the manual:

>  -w      Wait for command to finish executing
>            before continuing, helpful for ensur‐
>            ing that a before-sleep command has
>            finished before the system goes to
>            sleep.

So this option doesn't allow execution of swaylock and dpms off as it will wait for the swaylock command to finish

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
