### PR TITLE
starship: Use mkEnableOption

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -58,44 +58,24 @@ in {
       '';
     };
 
-    enableBashIntegration = mkOption {
+    enableBashIntegration = mkEnableOption "Bash integration" // {
       default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
     };
 
-    enableZshIntegration = mkOption {
+    enableZshIntegration = mkEnableOption "Zsh integration" // {
       default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
     };
 
-    enableFishIntegration = mkOption {
+    enableFishIntegration = mkEnableOption "Fish integration" // {
       default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
     };
 
-    enableIonIntegration = mkOption {
+    enableIonIntegration = mkEnableOption "Ion integration" // {
       default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Ion integration.
-      '';
     };
 
-    enableNushellIntegration = mkOption {
+    enableNushellIntegration = mkEnableOption "Nushell integration" // {
       default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Nushell integration.
-      '';
     };
   };
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Some enable options were not using `mkEnableOption`. This PR corrects this.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
