### PR TITLE
[backport 22.11] tests: fix gnupg stub

### DIFF
--- a/tests/modules/programs/gpg/mutable-keyfiles.nix
+++ b/tests/modules/programs/gpg/mutable-keyfiles.nix
@@ -14,6 +14,7 @@
   };
 
   test.stubs.gnupg = { };
+  test.stubs.systemd = { }; # depends on gnupg.override
 
   nmt.script = ''
     assertFileContains activate "export GNUPGHOME='/home/hm-user/.gnupg'"

--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -9,6 +9,7 @@ with lib;
     programs.gpg.enable = true;
 
     test.stubs.gnupg = { };
+    test.stubs.systemd = { }; # depends on gnupg.override
 
     nmt.script = ''
       in="${config.systemd.user.sockets.gpg-agent.Socket.ListenStream}"

--- a/tests/modules/services/gpg-agent/override-homedir.nix
+++ b/tests/modules/services/gpg-agent/override-homedir.nix
@@ -12,6 +12,7 @@ with lib;
     };
 
     test.stubs.gnupg = { };
+    test.stubs.systemd = { }; # depends on gnupg.override
 
     nmt.script = ''
       in="${config.systemd.user.sockets.gpg-agent.Socket.ListenStream}"


### PR DESCRIPTION
Backport https://github.com/nix-community/home-manager/pull/3685

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
