### PR TITLE
modules/git: make options passed to `less(1)` for `diff-so-fancy` configurable

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -340,6 +340,14 @@ in {
           '';
         };
 
+        pagerOpts = mkOption {
+          type = types.listOf types.str;
+          default = [ "--tabs=4" "-RFX" ];
+          description = ''
+            Arguments to be passed to <command>less</command>.
+          '';
+        };
+
         markEmptyLines = mkOption {
           type = types.bool;
           default = true;
@@ -547,7 +555,9 @@ in {
       programs.git.iniContent =
         let dsfCommand = "${pkgs.diff-so-fancy}/bin/diff-so-fancy";
         in {
-          core.pager = "${dsfCommand} | ${pkgs.less}/bin/less --tabs=4 -RFX";
+          core.pager = "${dsfCommand} | ${pkgs.less}/bin/less ${
+              escapeShellArgs cfg.diff-so-fancy.pagerOpts
+            }";
           interactive.diffFilter = "${dsfCommand} --patch";
           diff-so-fancy = {
             markEmptyLines = cfg.diff-so-fancy.markEmptyLines;


### PR DESCRIPTION
### Description
The `-X` prevents that screen is cleared when showing a diff that's
larger than my screen.
    
I.e. when running `git diff` and press `q`, the last thing I want to see
is the prompt with `git diff` and *not* the part of the diff I browsed,
to be clear
    
    $ git diff
    $ <cursor>
    
Considering that this is somewhat opinionated, I decided to build an
option which allows you to pass arbitrary commands to the less
invocation.

cc @rycee 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`. (It's a one-liner)

- [x] Code tested through `nix-shell --pure tests -A run.all`. (`broot` failed, but that doesn't seem related).

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
