### PR TITLE
xfconf: fix dbus may not be started in the startup of NixOS.

### DIFF
--- a/modules/misc/xfconf.nix
+++ b/modules/misc/xfconf.nix
@@ -97,6 +97,19 @@ in {
         commands = mapAttrsToList
           (channel: properties: mapAttrsToList (mkCommand channel) properties)
           cfg.settings;
-      in concatMapStrings concatStrings commands);
+
+        load = pkgs.writeShellScript "load-xfconf"
+          (concatMapStrings concatStrings commands);
+      in ''
+        if [[ -v DBUS_SESSION_BUS_ADDRESS ]]; then
+          export DBUS_RUN_SESSION_CMD=""
+        else
+          export DBUS_RUN_SESSION_CMD="${pkgs.dbus}/bin/dbus-run-session --dbus-daemon=${pkgs.dbus}/bin/dbus-daemon"
+        fi
+
+        $DRY_RUN_CMD $DBUS_RUN_SESSION_CMD ${load}
+
+        unset DBUS_RUN_SESSION_CMD
+      '');
   };
 }


### PR DESCRIPTION
### Description

fix https://github.com/nix-community/home-manager/pull/3378#issuecomment-1368015573
ref: https://github.com/nix-community/home-manager/blob/693d76eeb84124cc3110793ff127aeab3832f95c/modules/misc/dconf.nix#L102-L106
output:
```
Feb 26 23:58:53 laptop hm-activate-cgq[1076]: Activating xfconfSettings
Feb 26 23:58:53 laptop hm-activate-cgq[1455]: dbus-daemon[1455]: [session uid=1000 pid=1455] Activating service name='org.xfce.Xfconf' requested by ':1.0' (uid=1000 pid=1458 com>
Feb 26 23:58:53 laptop hm-activate-cgq[1455]: dbus-daemon[1455]: [session uid=1000 pid=1455] Successfully activated service 'org.xfce.Xfconf'
Feb 26 23:58:53 laptop xfconfd[1465]: Name org.xfce.Xfconf lost on the message dbus, exiting.
Feb 26 23:58:53 laptop systemd[1]: Finished Home Manager environment for cgq.
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
