### PR TITLE
Various minor improvements

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -2,6 +2,7 @@
 == Installing Home Manager
 
 :nix-darwin: https://github.com/LnL7/nix-darwin/
+:nixos-wiki-flakes: https://nixos.wiki/wiki/Flakes
 
 Home Manager can be used in three primary ways:
 
@@ -21,6 +22,12 @@ this setup.
 This allows the user profiles to be built together with the system
 when running `darwin-rebuild`. See <<sec-install-nix-darwin-module>>
 for a description of this setup.
+
+[NOTE]
+In this chapter we describe how to install Home Manager in the
+standard way using channels. If you prefer to use
+{nixos-wiki-flakes}[Nix Flakes] then please see the instructions in
+<<ch-nix-flakes>>.
 
 [[sec-install-standalone]]
 === Standalone installation

--- a/docs/nix-flakes.adoc
+++ b/docs/nix-flakes.adoc
@@ -3,8 +3,29 @@
 
 :nixos-wiki-flakes: https://nixos.wiki/wiki/Flakes
 
-Home Manager includes a `flake.nix` file for compatibility with {nixos-wiki-flakes}[Nix Flakes].
-The support is still experimental and may change in backwards incompatible ways.
+Home Manager is compatible with {nixos-wiki-flakes}[Nix Flakes]. But
+please be aware that the support it is still experimental and may
+change in backwards incompatible ways.
+
+Just like in the standard installation you can use the Home Manager
+flake in three ways:
+
+1. Using the standalone `home-manager` tool. For platforms other than
+NixOS and Darwin, this is the only available choice. It is also
+recommended for people on NixOS or Darwin that want to manage their
+home directory independently of the system as a whole. See
+<<sec-flakes-standalone>> for instructions on how to perform this
+installation.
+
+2. As a module within a NixOS system configuration. This allows the
+user profiles to be built together with the system when running
+`nixos-rebuild`. See <<sec-flakes-nixos-module>> for a description of
+this setup.
+
+3. As a module within a {nix-darwin}[nix-darwin] system configuration.
+This allows the user profiles to be built together with the system
+when running `darwin-rebuild`. See <<sec-flakes-nix-darwin-module>>
+for a description of this setup.
 
 [[sec-flakes-prerequisites]]
 === Prerequisites

--- a/flake.nix
+++ b/flake.nix
@@ -89,14 +89,16 @@
         pkgs = nixpkgs.legacyPackages.${system};
         docs = import ./docs { inherit pkgs; };
         tests = import ./tests { inherit pkgs; };
+        hmPkg = pkgs.callPackage ./home-manager { };
       in {
         devShells.tests = tests.run;
-        packages = rec {
-          home-manager = pkgs.callPackage ./home-manager { };
+        packages = {
+          default = hmPkg;
+          home-manager = hmPkg;
+
           docs-html = docs.manual.html;
-          docs-manpages = docs.manPages;
           docs-json = docs.options.json;
-          default = home-manager;
+          docs-manpages = docs.manPages;
         };
         # deprecated in Nix 2.7
         defaultPackage = self.packages.${system}.default;

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -677,7 +677,7 @@ while [[ $# -gt 0 ]]; do
             export VERBOSE=1
             ;;
         --version)
-            echo 22.11
+            echo 23.05-pre
             exit 0
             ;;
         *)


### PR DESCRIPTION
### Description

A collection of quick (individually unrelated changes):

- docs: slight improvement of Flake documentation
- flake: avoid recursive set
- home-manager: make `--version` report 23.05-pre. It is a bit misleading to report 22.11 when running from the master branch.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```