### PR TITLE
aerc: update auth mechanisms

### DIFF
--- a/modules/programs/aerc-accounts.nix
+++ b/modules/programs/aerc-accounts.nix
@@ -48,7 +48,8 @@ in {
           '';
         };
         smtpAuth = mkOption {
-          type = with types; nullOr (enum [ "none" "plain" "login" ]);
+          type = with types;
+            nullOr (enum [ "none" "plain" "login" "oauthbearer" "xoauth2" ]);
           default = "plain";
           example = "auth";
           description = ''


### PR DESCRIPTION
Update aerc account auth mechanisms. Add oauthbearer and xoauth2 as supported auth mechanisms.
