### PR TITLE
.github: pin nix 2.13 in workflows

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v19
       with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v12
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v19
       with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v12
       with:

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: cachix/install-nix-action@v19
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v16
         with:


### PR DESCRIPTION
2.14 has a bug related to profile locations that breaks nix-env, which in turn breaks cachix. Pin to 2.13 for now.

More info at https://github.com/NixOS/nixpkgs/pull/218858#issuecomment-1448758169