### PR TITLE
exa: always configure `exa` alias

### DIFF
--- a/modules/programs/exa.nix
+++ b/modules/programs/exa.nix
@@ -9,7 +9,7 @@ with lib;
     enable =
       mkEnableOption "exa, a modern replacement for <command>ls</command>";
 
-    enableAliases = mkEnableOption "recommended exa aliases";
+    enableAliases = mkEnableOption "recommended exa aliases (ls, ll…)";
 
     extraOptions = mkOption {
       type = types.listOf types.str;
@@ -49,6 +49,7 @@ with lib;
       # Use `command` instead of hardcoding the path to exa so that aliases don't
       # go stale after a system update.
       exa = "exa ${args}";
+    } // optionalAttrs cfg.enableAliases {
       ls = "exa";
       ll = "exa -l";
       la = "exa -a";
@@ -58,12 +59,12 @@ with lib;
   in mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    programs.bash.shellAliases = mkIf cfg.enableAliases aliases;
+    programs.bash.shellAliases = aliases;
 
-    programs.zsh.shellAliases = mkIf cfg.enableAliases aliases;
+    programs.zsh.shellAliases = aliases;
 
-    programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
+    programs.fish.shellAliases = aliases;
 
-    programs.ion.shellAliases = mkIf cfg.enableAliases aliases;
+    programs.ion.shellAliases = aliases;
   };
 }


### PR DESCRIPTION
Otherwise the `icons`, `git` and `extraOptions` options have no effect unless `enableAliases` is true.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.