### PR TITLE
fuzzel: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,6 +117,9 @@ Makefile                                              @thiagokokada
 /modules/services/fusuma.nix                          @iosmanthus
 /tests/modules/services/fusuma                        @iosmanthus
 
+/modules/programs/fuzzel.nix                          @Scrumplex
+/tests/modules/programs/fuzzel                        @Scrumplex
+
 /modules/programs/gallery-dl.nix                      @marsam
 /tests/modules/programs/gallery-dl                    @marsam
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1015,6 +1015,14 @@ in
           A new module is available: 'programs.translate-shell'.
         '';
       }
+
+      {
+        time = "2023-05-13T13:51:18+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'programs.fuzzel'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -76,6 +76,7 @@ let
     ./programs/firefox.nix
     ./programs/fish.nix
     ./programs/foot.nix
+    ./programs/fuzzel.nix
     ./programs/fzf.nix
     ./programs/gallery-dl.nix
     ./programs/getmail.nix

--- a/modules/programs/fuzzel.nix
+++ b/modules/programs/fuzzel.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  inherit (lib) literalExpression mkEnableOption mkPackageOption mkOption mkIf;
+
+  cfg = config.programs.fuzzel;
+
+  iniFormat = pkgs.formats.ini { };
+
+in {
+  meta.maintainers = [ lib.maintainers.Scrumplex ];
+
+  options.programs.fuzzel = {
+    enable = mkEnableOption "fuzzel";
+
+    package = mkPackageOption pkgs "fuzzel" { };
+
+    settings = mkOption {
+      type = iniFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          main = {
+            terminal = "''${pkgs.foot}/bin/foot";
+            layer = "overlay";
+          };
+          colors.background = "ffffffff";
+        }
+      '';
+      description = ''
+        Configuration for fuzzel written to
+        <filename>$XDG_CONFIG_HOME/fuzzel/fuzzel.ini</filename>. See
+        <citerefentry><refentrytitle>fuzzel.ini</refentrytitle>
+        <manvolnum>5</manvolnum></citerefentry> for a list of available options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.fuzzel" pkgs
+        lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."fuzzel/fuzzel.ini" = mkIf (cfg.settings != { }) {
+      source = iniFormat.generate "fuzzel.ini" cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -157,6 +157,7 @@ import nmt {
     ./modules/programs/borgmatic
     ./modules/programs/firefox
     ./modules/programs/foot
+    ./modules/programs/fuzzel
     ./modules/programs/getmail
     ./modules/programs/gnome-terminal
     ./modules/programs/hexchat

--- a/tests/modules/programs/fuzzel/default.nix
+++ b/tests/modules/programs/fuzzel/default.nix
@@ -1,0 +1,4 @@
+{
+  fuzzel-example-settings = ./example-settings.nix;
+  fuzzel-empty-settings = ./empty-settings.nix;
+}

--- a/tests/modules/programs/fuzzel/empty-settings.nix
+++ b/tests/modules/programs/fuzzel/empty-settings.nix
@@ -1,0 +1,11 @@
+{ ... }:
+
+{
+  programs.fuzzel.enable = true;
+
+  test.stubs.fuzzel = { };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/fuzzel
+  '';
+}

--- a/tests/modules/programs/fuzzel/example-settings-expected.ini
+++ b/tests/modules/programs/fuzzel/example-settings-expected.ini
@@ -1,0 +1,6 @@
+[border]
+width=6
+
+[main]
+dpi-aware=yes
+font=Fira Code:size=11

--- a/tests/modules/programs/fuzzel/example-settings.nix
+++ b/tests/modules/programs/fuzzel/example-settings.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+
+{
+  programs.fuzzel = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    settings = {
+      main = {
+        font = "Fira Code:size=11";
+        dpi-aware = "yes";
+      };
+
+      border = { width = 6; };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/fuzzel/fuzzel.ini \
+      ${./example-settings-expected.ini}
+  '';
+}


### PR DESCRIPTION
### Description

[fuzzel](https://codeberg.org/dnkl/fuzzel) is a lightweight app launcher for Wayland.
This module adds a simple way to configure it using HM.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
