### PR TITLE
[backport #3639] programs.neovim: add extraLuaConfig

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -240,6 +240,17 @@ in {
         '';
       };
 
+      extraLuaConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          vim.opt.nobackup = true
+        '';
+        description = ''
+          Custom lua lines.
+        '';
+      };
+
       extraPackages = mkOption {
         type = with types; listOf package;
         default = [ ];
@@ -373,6 +384,7 @@ in {
             luaRcContent =
               lib.optionalString (neovimConfig.neovimRcContent != "")
               "vim.cmd [[source ${config.xdg.configHome}/nvim/init-home-manager.vim]]"
+              + config.programs.neovim.extraLuaConfig
               + lib.optionalString hasLuaConfig
               config.programs.neovim.generatedConfigs.lua;
           in mkIf (luaRcContent != "") { text = luaRcContent; };

--- a/tests/modules/programs/neovim/default.nix
+++ b/tests/modules/programs/neovim/default.nix
@@ -5,4 +5,5 @@
 
   # waiting for a nixpkgs patch
   neovim-no-init = ./no-init.nix;
+  neovim-extra-lua-init = ./extra-lua-init.nix;
 }

--- a/tests/modules/programs/neovim/extra-lua-init.nix
+++ b/tests/modules/programs/neovim/extra-lua-init.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.neovim = {
+      enable = true;
+
+      extraLuaConfig = ''
+        -- extraLuaConfig
+      '';
+    };
+    nmt.script = ''
+      nvimFolder="home-files/.config/nvim"
+      assertFileContent "$nvimFolder/init.lua" ${
+        pkgs.writeText "init.lua-expected" ''
+          -- extraLuaConfig
+        ''
+      }
+    '';
+  };
+}


### PR DESCRIPTION
cherry picked from commit 9621e9ab80a038cd11c7cfcae4df46a59d62b16a

### Description

See #3639.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.

cc @GuillaumeDesforges 