### PR TITLE
home: Add buildEnvWithNoChroot to help avoid darwin sandbox failures

### DIFF
--- a/modules/targets/darwin/fonts.nix
+++ b/modules/targets/darwin/fonts.nix
@@ -7,11 +7,11 @@
 
 let
   homeDir = config.home.homeDirectory;
-  fontsEnv = pkgs.buildEnv {
+  fontsEnv = (pkgs.buildEnv {
     name = "home-manager-fonts";
     paths = config.home.packages;
     pathsToLink = "/share/fonts";
-  };
+  }).overrideAttrs (old: { __noChroot = config.home.buildEnvWithNoChroot; });
   fonts = "${fontsEnv}/share/fonts";
   installDir = "${homeDir}/Library/Fonts/HomeManager";
 in

--- a/modules/targets/darwin/linkapps.nix
+++ b/modules/targets/darwin/linkapps.nix
@@ -25,11 +25,11 @@ in
     # Install MacOS applications to the user environment.
     home.file.${cfg.linkApps.directory}.source =
       let
-        apps = pkgs.buildEnv {
+        apps = (pkgs.buildEnv {
           name = "home-manager-applications";
           paths = config.home.packages;
           pathsToLink = "/Applications";
-        };
+        }).overrideAttrs (old: { __noChroot = config.home.buildEnvWithNoChroot; });
       in
       "${apps}/Applications";
   };

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -19,13 +19,15 @@ in
       system.activationScripts.postActivation.text = lib.concatStringsSep "\n" (
         lib.mapAttrsToList (username: usercfg: ''
           echo Activating home-manager configuration for ${usercfg.home.username}
-          sudo -u ${usercfg.home.username} --set-home ${pkgs.writeShellScript "activation-${usercfg.home.username}" ''
+          sudo -u ${usercfg.home.username} --set-home ${(pkgs.writeShellScript "activation-${usercfg.home.username}" ''
             ${lib.optionalString (
               cfg.backupFileExtension != null
             ) "export HOME_MANAGER_BACKUP_EXT=${lib.escapeShellArg cfg.backupFileExtension}"}
             ${lib.optionalString cfg.verbose "export VERBOSE=1"}
             exec ${usercfg.home.activationPackage}/activate
-          ''}
+            '').overrideAttrs (old: {
+              __noChroot = pkgs.stdenv.hostPlatform.isDarwin;
+            })}
         '') cfg.users
       );
     })


### PR DESCRIPTION
### Description

Sets `__noChroot = true` on select `buildEnv` derivations that assemble
large numbers of paths. This may be used to avoid sandbox failures on
darwin, see https://github.com/NixOS/nix/issues/4119 and the `sandbox`
option in `man nix.conf`.

I wish there was a way to do something akin to overlays for config, alas
there is not afaik, so the only way is to add an option. Since this is
opt-in, anyone enabling it thus understands the “risks” of disabling the
sandbox, however the risk for these derivations should be fairly low,
and this allows enabling the sandbox more generally on Darwin, which is
beneficial.

I have only added to the derivations that started giving me problems,
others may suffer from others but these are definitely likely to have
huge dependency lists therefore exposing the problem.

I’m open to a different name for the option, hard to come up with something representative but concise. I have not added any tests since it’s a rather cumbersome scenario to test, and may also be flaky. The default path (option disabled) is I expect already well-covered.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
