### PR TITLE
[backport 22.11] gpg: allow unsigned tags

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -458,8 +458,8 @@ in {
     (mkIf (cfg.signing != null) {
       programs.git.iniContent = {
         user.signingKey = mkIf (cfg.signing.key != null) cfg.signing.key;
-        commit.gpgSign = cfg.signing.signByDefault;
-        tag.gpgSign = cfg.signing.signByDefault;
+        commit.gpgSign = mkDefault cfg.signing.signByDefault;
+        tag.gpgSign = mkDefault cfg.signing.signByDefault;
         gpg.program = cfg.signing.gpgPath;
       };
     })


### PR DESCRIPTION
(cherry picked from commit d331cceec7cc05061a3c6073eee06c4dba9cf5d3)

### Description

Backport https://github.com/nix-community/home-manager/pull/3479

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
