### PR TITLE
zellij: switch to kdl configuration file format

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -5,12 +5,69 @@ with lib;
 let
 
   cfg = config.programs.zellij;
-  yamlFormat = pkgs.formats.yaml { };
 
   configDir = if pkgs.stdenv.isDarwin then
     "Library/Application Support/org.Zellij-Contributors.Zellij"
   else
     "${config.xdg.configHome}/zellij";
+
+  # Generate a KDL-style config file from an attrset of nodes
+  # To learn more about the KDL format, see
+  # https://github.com/kdl-org/kdl/blob/main/SPEC.md
+  toKdl = attrs:
+    let
+      mapAttrsToStringsSep = sep: mapFn: attrs:
+        concatStringsSep sep (mapAttrsToList mapFn attrs);
+
+      mapListToStringsSep = sep: mapFn: list:
+        concatStringsSep sep (map mapFn list);
+
+      processValue = value:
+        if (isInt value) then
+          toString value
+        else if (isFloat value) then
+          floatToString value
+        else if (isString value) then
+          ''"${value}"''
+        else if (value == true) then
+          "true"
+        else if (value == false) then
+          "false"
+        else if (value == null) then
+          "null"
+        else if (isList value) then
+          (mapListToStringsSep " " processValue value)
+        else
+          "";
+
+      processProps =
+        mapAttrsToStringsSep "" (key: value: "${key}=${processValue value}");
+
+      processNode = name: value:
+        if isAttrs value then
+          let
+            args = optionalString (hasAttr "__args" value)
+              (processValue value.__args);
+
+            props = optionalString (hasAttr "__props" value)
+              (processProps value.__props);
+
+            childrenAttrs = filterAttrs
+              (name: value: (name != "__args") || (name != "__props")) value;
+
+            children = optionalString (childrenAttrs != { }) ''
+              {
+              ${processAttrsOfNodes childrenAttrs}
+              }'';
+
+          in concatStringsSep " " [ name args props children ";" ]
+        else
+          "${name} ${processValue value};";
+
+      processAttrsOfNodes = mapAttrsToStringsSep "\n" processNode;
+
+      # map input to ini sections
+    in processAttrsOfNodes attrs;
 
 in {
   meta.maintainers = [ hm.maintainers.mainrs ];
@@ -28,7 +85,7 @@ in {
     };
 
     settings = mkOption {
-      type = yamlFormat.type;
+      type = types.attrs;
       default = { };
       example = literalExpression ''
         {
@@ -38,7 +95,7 @@ in {
       '';
       description = ''
         Configuration written to
-        <filename>$XDG_CONFIG_HOME/zellij/config.yaml</filename>.
+        <filename>$XDG_CONFIG_HOME/zellij/config.kdl</filename>.
         </para><para>
         See <link xlink:href="https://zellij.dev/documentation" /> for the full
         list of options.
@@ -49,8 +106,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    home.file."${configDir}/config.yaml" = mkIf (cfg.settings != { }) {
-      source = yamlFormat.generate "zellij.yaml" cfg.settings;
-    };
+    home.file."${configDir}/config.kdl" =
+      mkIf (cfg.settings != { }) { text = toKdl cfg.settings; };
   };
 }


### PR DESCRIPTION
### Description

The configuration file format for zellij has changed from YAML to [kdl](https://kdl.dev/).
Relevant PR: https://github.com/zellij-org/zellij/pull/1759

The home-manager module for zellij is still outputting the configuration to a yaml file.
This is still working as zellij converts it to a kdl file at first launch.
However, if a change is made from home-manager, the content of the `config.yaml` symlink will change but as `config.kdl` already exists, zellij will ignore the changes.

In this PR, I propose a basic function to generate the KDL file from a nix configuration.

@mainrs 
@rycee 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
