### PR TITLE
recoll: fix generation of string lists

### DIFF
--- a/modules/services/recoll.nix
+++ b/modules/services/recoll.nix
@@ -10,15 +10,16 @@ let
   # see the example configuration from the package (i.e.,
   # `$out/share/recoll/examples/recoll.conf`).
   mkRecollConfKeyValue = generators.mkKeyValueDefault {
-    mkValueString = v:
-      if v == true then
-        "1"
-      else if v == false then
-        "0"
-      else if isList v then
-        concatStringsSep " " v
-      else
-        generators.mkValueStringDefault { } v;
+    mkValueString = let mkQuoted = v: ''"${escape [ ''"'' ] v}"'';
+    in v:
+    if v == true then
+      "1"
+    else if v == false then
+      "0"
+    else if isList v then
+      concatMapStringsSep " " mkQuoted v
+    else
+      generators.mkValueStringDefault { } v;
   } " = ";
 
   # A modified version of 'lib.generators.toINI' that also accepts top-level

--- a/tests/modules/services/recoll/basic-configuration.conf
+++ b/tests/modules/services/recoll/basic-configuration.conf
@@ -1,16 +1,18 @@
+dbdir = ~/.cache/recoll/xapiandb
+
 nocjk = 0
 
-skippedNames+ = node_modules
+skippedNames+ = "node_modules"
 
-topdirs = ~/Downloads ~/Documents ~/library
+topdirs = "~/Downloads" "~/Documents" "~/library" "~/\"cool\" files"
 
 underscoresasletter = 1
 
 [~/library/projects]
-skippedNames+ = .editorconfig .gitignore result flake.lock go.sum
+skippedNames+ = ".editorconfig" ".gitignore" "result" "flake.lock" "go.sum"
 
 [~/library/projects/software]
-skippedNames+ = target result
+skippedNames+ = "target" "result"
 
 [~/what-is-this-project]
-skippedNames+ = whoa-there
+skippedNames+ = "whoa-there"

--- a/tests/modules/services/recoll/basic-configuration.nix
+++ b/tests/modules/services/recoll/basic-configuration.nix
@@ -6,7 +6,8 @@
     package = config.lib.test.mkStubPackage { };
     configDir = "${config.xdg.configHome}/recoll";
     settings = {
-      topdirs = [ "~/Downloads" "~/Documents" "~/library" ];
+      dbdir = "~/.cache/recoll/xapiandb";
+      topdirs = [ "~/Downloads" "~/Documents" "~/library" ''~/"cool" files'' ];
       "skippedNames+" = [ "node_modules" ];
       underscoresasletter = true;
       nocjk = false;

--- a/tests/modules/services/recoll/config-format-order.conf
+++ b/tests/modules/services/recoll/config-format-order.conf
@@ -4,7 +4,7 @@ d = 0
 
 e = This should be the second to the last non-attrset value in the config.
 
-g = This is coming from a list
+g = "This" "is" "coming" "from" "a" "list"
 
 [a]
 foo = bar
@@ -18,7 +18,7 @@ b = 53
 a = This should be second to the last for the attribute names with an attrset.
 b = 3193
 c = 0
-d = Hello there
+d = "Hello" "there"
 
 [foo]
 bar = This should be the last attribute with an attrset.


### PR DESCRIPTION
### Description

The updated implementation will quote string lists as per the description at

  https://www.lesbonscomptes.com/recoll/usermanual/#RCL.INSTALL.CONFIG

Fixes #3732

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```