### PR TITLE
mpd: add `extraArgs`

### DIFF
--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -92,6 +92,15 @@ in {
         '';
       };
 
+      extraArgs = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "--verbose" ];
+        description = ''
+          Extra command-line arguments to pass to MPD.
+        '';
+      };
+
       dataDir = mkOption {
         type = types.path;
         default = "${config.xdg.dataHome}/${name}";
@@ -176,7 +185,9 @@ in {
 
       Service = {
         Environment = "PATH=${config.home.profileDirectory}/bin";
-        ExecStart = "${cfg.package}/bin/mpd --no-daemon ${mpdConf}";
+        ExecStart = "${cfg.package}/bin/mpd --no-daemon ${mpdConf} ${
+            escapeShellArgs cfg.extraArgs
+          }";
         Type = "notify";
         ExecStartPre = ''
           ${pkgs.bash}/bin/bash -c "${pkgs.coreutils}/bin/mkdir -p '${cfg.dataDir}' '${cfg.playlistDirectory}'"'';

--- a/tests/modules/services/mpd/basic-configuration.nix
+++ b/tests/modules/services/mpd/basic-configuration.nix
@@ -6,6 +6,7 @@ with lib;
   services.mpd = {
     enable = true;
     musicDirectory = "/my/music/dir";
+    extraArgs = [ "--verbose" ];
   };
 
   home.stateVersion = "22.11";

--- a/tests/modules/services/mpd/basic-configuration.service
+++ b/tests/modules/services/mpd/basic-configuration.service
@@ -3,7 +3,7 @@ WantedBy=default.target
 
 [Service]
 Environment=PATH=/home/hm-user/.nix-profile/bin
-ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf
+ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf '--verbose'
 ExecStartPre=/nix/store/00000000000000000000000000000000-bash/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
 Type=notify
 

--- a/tests/modules/services/mpd/before-state-version-22_11.nix
+++ b/tests/modules/services/mpd/before-state-version-22_11.nix
@@ -3,7 +3,10 @@
 with lib;
 
 {
-  services.mpd.enable = true;
+  services.mpd = {
+    enable = true;
+    extraArgs = [ "--verbose" ];
+  };
 
   home.stateVersion = "18.09";
 

--- a/tests/modules/services/mpd/xdg-music-dir.nix
+++ b/tests/modules/services/mpd/xdg-music-dir.nix
@@ -3,7 +3,11 @@
 with lib;
 
 {
-  services.mpd.enable = true;
+  services.mpd = {
+    enable = true;
+    extraArgs = [ "--verbose" ];
+  };
+
   xdg.userDirs.enable = true;
 
   home.stateVersion = "22.11";


### PR DESCRIPTION
Allow passing arguments to the MPD command line. Currently the only interesting one is `--verbose`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
