### PR TITLE
docs: simplify flake-specific instructions in the documentation

### DIFF
--- a/docs/nix-flakes.adoc
+++ b/docs/nix-flakes.adoc
@@ -126,10 +126,7 @@ $ nix flake new ~/.config/nixpkgs -t github:nix-community/home-manager
 2. Install Home Manager and apply the configuration by
 +
 [source,console]
-----
-$ nix build --no-link <flake-uri>#homeConfigurations.jdoe.activationPackage
-$ "$(nix path-info <flake-uri>#homeConfigurations.jdoe.activationPackage)"/activate
-----
+$ nix run <flake-uri>#homeConfigurations.jdoe.activationPackage
 +
 Substitute `<flake-uri>` with the flake URI of the configuration flake.
 If `flake.nix` resides in `~/.config/nixpkgs`,


### PR DESCRIPTION
- install home-manager via `nix run` rather than `nix-build` then running the activation script out of the store manually
- suggest simply using `home-manager switch` when the configuration lives in `~/.config/nixpkgs`

### Description

The flake setup was needlessly complicated and a bit overwhelming for beginners whom home-manager might be their entry point in the world of Nix.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`. (I don't use channels so this failed)

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like
