### PR TITLE
sway: add support for XDG autostart using systemd

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -328,7 +328,13 @@ let
   };
 
 in {
-  meta.maintainers = with maintainers; [ alexarice sumnerevans sebtm oxalica ];
+  meta.maintainers = with maintainers; [
+    Scrumplex
+    alexarice
+    sumnerevans
+    sebtm
+    oxalica
+  ];
 
   imports = let modulePath = [ "wayland" "windowManager" "sway" ];
   in [

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -316,7 +316,7 @@ let
           ++ map workspaceOutputStr workspaceOutputAssign # custom mapping
         )
       else
-        [ ]) ++ (optional cfg.systemdIntegration ''
+        [ ]) ++ (optional cfg.systemd.enable ''
           exec "${pkgs.dbus}/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE NIXOS_OZONE_WL; systemctl --user start sway-session.target"'')
       ++ (optional (!cfg.xwayland) "xwayland disable") ++ [ cfg.extraConfig ]));
 
@@ -329,6 +329,12 @@ let
 
 in {
   meta.maintainers = with maintainers; [ alexarice sumnerevans sebtm oxalica ];
+
+  imports = let modulePath = [ "wayland" "windowManager" "sway" ];
+  in [
+    (mkRenamedOptionModule (modulePath ++ [ "systemdIntegration" ])
+      (modulePath ++ [ "systemd" "enable" ]))
+  ];
 
   options.wayland.windowManager.sway = {
     enable = mkEnableOption "sway wayland compositor";
@@ -346,22 +352,32 @@ in {
       '';
     };
 
-    systemdIntegration = mkOption {
-      type = types.bool;
-      default = pkgs.stdenv.isLinux;
-      example = false;
-      description = ''
-        Whether to enable <filename>sway-session.target</filename> on
-        sway startup. This links to
-        <filename>graphical-session.target</filename>.
-        Some important environment variables will be imported to systemd
-        and dbus user environment before reaching the target, including
-        <itemizedlist>
-          <listitem><para><literal>DISPLAY</literal></para></listitem>
-          <listitem><para><literal>WAYLAND_DISPLAY</literal></para></listitem>
-          <listitem><para><literal>SWAYSOCK</literal></para></listitem>
-          <listitem><para><literal>XDG_CURRENT_DESKTOP</literal></para></listitem>
-        </itemizedlist>
+    systemd = {
+      enable = mkOption {
+        type = types.bool;
+        default = pkgs.stdenv.isLinux;
+        example = false;
+        description = ''
+          Whether to enable <filename>sway-session.target</filename> on
+          sway startup. This links to
+          <filename>graphical-session.target</filename>.
+          Some important environment variables will be imported to systemd
+          and dbus user environment before reaching the target, including
+          <itemizedlist>
+            <listitem><para><literal>DISPLAY</literal></para></listitem>
+            <listitem><para><literal>WAYLAND_DISPLAY</literal></para></listitem>
+            <listitem><para><literal>SWAYSOCK</literal></para></listitem>
+            <listitem><para><literal>XDG_CURRENT_DESKTOP</literal></para></listitem>
+          </itemizedlist>
+        '';
+      };
+
+      xdgAutostart = mkEnableOption ''
+        autostart of applications using
+        <citerefentry>
+          <refentrytitle>systemd-xdg-autostart-generator</refentrytitle>
+          <manvolnum>8</manvolnum>
+        </citerefentry>
       '';
     };
 
@@ -469,13 +485,16 @@ in {
         '';
       };
 
-      systemd.user.targets.sway-session = mkIf cfg.systemdIntegration {
+      systemd.user.targets.sway-session = mkIf cfg.systemd.enable {
         Unit = {
           Description = "sway compositor session";
           Documentation = [ "man:systemd.special(7)" ];
           BindsTo = [ "graphical-session.target" ];
-          Wants = [ "graphical-session-pre.target" ];
+          Wants = [ "graphical-session-pre.target" ]
+            ++ optional cfg.systemd.xdgAutostart "xdg-desktop-autostart.target";
           After = [ "graphical-session-pre.target" ];
+          Before =
+            optional cfg.systemd.xdgAutostart "xdg-desktop-autostart.target";
         };
       };
 

--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -10,6 +10,7 @@
   sway-null-config = ./sway-null-config.nix;
   sway-null-package = ./sway-null-package.nix;
   sway-post-2003 = ./sway-post-2003.nix;
+  sway-systemd-autostart = ./sway-systemd-autostart.nix;
   sway-workspace-default = ./sway-workspace-default.nix;
   sway-workspace-output = ./sway-workspace-output.nix;
   swaynag-example-settings = ./swaynag-example-settings.nix;

--- a/tests/modules/services/window-managers/sway/sway-default.target
+++ b/tests/modules/services/window-managers/sway/sway-default.target
@@ -1,0 +1,6 @@
+[Unit]
+After=graphical-session-pre.target
+BindsTo=graphical-session.target
+Description=sway compositor session
+Documentation=man:systemd.special(7)
+Wants=graphical-session-pre.target

--- a/tests/modules/services/window-managers/sway/sway-no-xwayland.nix
+++ b/tests/modules/services/window-managers/sway/sway-no-xwayland.nix
@@ -7,7 +7,7 @@
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
     config = null;
-    systemdIntegration = false;
+    systemd.enable = false;
     xwayland = false;
   };
 

--- a/tests/modules/services/window-managers/sway/sway-null-config.nix
+++ b/tests/modules/services/window-managers/sway/sway-null-config.nix
@@ -7,7 +7,7 @@
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
     config = null;
-    systemdIntegration = false;
+    systemd.enable = false;
   };
 
   nmt.script = ''

--- a/tests/modules/services/window-managers/sway/sway-systemd-autostart.nix
+++ b/tests/modules/services/window-managers/sway/sway-systemd-autostart.nix
@@ -8,15 +8,13 @@
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
     # overriding findutils causes issues
     config.menu = "${pkgs.dmenu}/bin/dmenu_run";
+
+    systemd.xdgAutostart = true;
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/sway/config
-    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
-      ${./sway-default.conf}
-
     assertFileExists home-files/.config/systemd/user/sway-session.target
     assertFileContent home-files/.config/systemd/user/sway-session.target \
-      ${./sway-default.target}
+      ${./sway-systemd-autostart.target}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-systemd-autostart.target
+++ b/tests/modules/services/window-managers/sway/sway-systemd-autostart.target
@@ -1,0 +1,8 @@
+[Unit]
+After=graphical-session-pre.target
+Before=xdg-desktop-autostart.target
+BindsTo=graphical-session.target
+Description=sway compositor session
+Documentation=man:systemd.special(7)
+Wants=graphical-session-pre.target
+Wants=xdg-desktop-autostart.target


### PR DESCRIPTION
### Description

Using the option `wayland.windowManager.sway.systemd.xdgAutostart`, users can now choose to start applications present in `$XDG_CONFIG_HOME/autostart` when starting their sway session.

This change also renames `wayland.windowManager.sway.systemdIntegration` to `wayland.windowManager.sway.systemd.enable`;

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
