### PR TITLE
[backport 22.11] modules/git: make options passed to `less(1)` for `diff-so-fancy` configurable

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -340,6 +340,14 @@ in {
           '';
         };
 
+        pagerOpts = mkOption {
+          type = types.listOf types.str;
+          default = [ "--tabs=4" "-RFX" ];
+          description = ''
+            Arguments to be passed to <command>less</command>.
+          '';
+        };
+
         markEmptyLines = mkOption {
           type = types.bool;
           default = true;
@@ -550,7 +558,9 @@ in {
       programs.git.iniContent =
         let dsfCommand = "${pkgs.diff-so-fancy}/bin/diff-so-fancy";
         in {
-          core.pager = "${dsfCommand} | ${pkgs.less}/bin/less --tabs=4 -RFX";
+          core.pager = "${dsfCommand} | ${pkgs.less}/bin/less ${
+              escapeShellArgs cfg.diff-so-fancy.pagerOpts
+            }";
           interactive.diffFilter = "${dsfCommand} --patch";
           diff-so-fancy = {
             markEmptyLines = cfg.diff-so-fancy.markEmptyLines;


### PR DESCRIPTION
Backport https://github.com/nix-community/home-manager/pull/3704

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.