### PR TITLE
zsh: add `package` option to `oh-my-zsh`

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -142,6 +142,8 @@ let
     options = {
       enable = mkEnableOption "oh-my-zsh";
 
+      package = mkPackageOption pkgs "oh-my-zsh" { };
+
       plugins = mkOption {
         default = [];
         example = [ "git" "sudo" ];
@@ -447,7 +449,7 @@ in
 
     (mkIf cfg.oh-my-zsh.enable {
       home.file."${relToDotDir ".zshenv"}".text = ''
-        ZSH="${pkgs.oh-my-zsh}/share/oh-my-zsh";
+        ZSH="${cfg.oh-my-zsh.package}/share/oh-my-zsh";
         ZSH_CACHE_DIR="${config.xdg.cacheHome}/oh-my-zsh";
       '';
     })
@@ -482,7 +484,7 @@ in
     {
       home.packages = with pkgs; [ zsh ]
         ++ optional cfg.enableCompletion nix-zsh-completions
-        ++ optional cfg.oh-my-zsh.enable oh-my-zsh;
+        ++ optional cfg.oh-my-zsh.enable cfg.oh-my-zsh.package;
 
       home.file."${relToDotDir ".zshrc"}".text = concatStringsSep "\n" ([
         cfg.initExtraFirst


### PR DESCRIPTION
### Description

Adds a `package` option to `programs.zsh.oh-my-zsh`, which allows omz to be overridden with a custom package. My motivation was being able to use `pkgs.unstable.oh-my-zsh` with it, without doing so via another overlay.

This is my first small contribution to the nix ecosystem, and I'm unsure how I would add tests for this, since I couldn't find existing tests for `programs.zsh.oh-my-zsh`.

Maybe the same option should also be added to `programs.zsh.prezto`?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.