### PR TITLE
atuin: add disable key options

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -50,6 +50,15 @@ in {
       '';
     };
 
+    flags = mkOption {
+      default = [ ];
+      type = types.listOf types.str;
+      example = [ "--disable-up-arrow" "--disable-ctrl-r" ];
+      description = ''
+        Flags to append to the shell hook.
+      '';
+    };
+
     settings = mkOption {
       type = with types;
         let
@@ -78,7 +87,8 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = let flagsStr = escapeShellArgs cfg.flags;
+  in mkIf cfg.enable {
 
     # Always add the configured `atuin` package.
     home.packages = [ cfg.package ];
@@ -91,18 +101,18 @@ in {
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
         source "${pkgs.bash-preexec}/share/bash/bash-preexec.sh"
-        eval "$(${cfg.package}/bin/atuin init bash)"
+        eval "$(${cfg.package}/bin/atuin init bash ${flagsStr})"
       fi
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
       if [[ $options[zle] = on ]]; then
-        eval "$(${cfg.package}/bin/atuin init zsh)"
+        eval "$(${cfg.package}/bin/atuin init zsh ${flagsStr})"
       fi
     '';
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-      ${cfg.package}/bin/atuin init fish | source
+      ${cfg.package}/bin/atuin init fish ${flagsStr} | source
     '';
   };
 }

--- a/tests/modules/programs/atuin/bash.nix
+++ b/tests/modules/programs/atuin/bash.nix
@@ -18,6 +18,6 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
-      'eval "$(@atuin@/bin/atuin init bash)"'
+      'eval "$(@atuin@/bin/atuin init bash )"'
   '';
 }

--- a/tests/modules/programs/atuin/default.nix
+++ b/tests/modules/programs/atuin/default.nix
@@ -5,4 +5,5 @@
   atuin-fish = ./fish.nix;
   atuin-no-shell = ./no-shell.nix;
   atuin-zsh = ./zsh.nix;
+  atuin-set-flags = ./set-flags.nix;
 }

--- a/tests/modules/programs/atuin/fish.nix
+++ b/tests/modules/programs/atuin/fish.nix
@@ -19,6 +19,6 @@
     assertFileExists home-files/.config/fish/config.fish
     assertFileContains \
       home-files/.config/fish/config.fish \
-      'atuin init fish | source'
+      '@atuin@/bin/atuin init fish | source'
   '';
 }

--- a/tests/modules/programs/atuin/set-flags.nix
+++ b/tests/modules/programs/atuin/set-flags.nix
@@ -1,0 +1,39 @@
+{ lib, ... }:
+
+{
+  programs = {
+    atuin.enable = true;
+    atuin.flags = [ "--disable-ctrl-r" "--disable-up-arrow" ];
+    bash = {
+      enable = true;
+      enableCompletion = false;
+    };
+    zsh.enable = true;
+    fish.enable = true;
+  };
+
+  # Needed to avoid error with dummy fish package.
+  xdg.dataFile."fish/home-manager_generated_completions".source =
+    lib.mkForce (builtins.toFile "empty" "");
+
+  test.stubs = {
+    atuin = { };
+    bash-preexec = { };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileContains \
+      home-files/.bashrc \
+      "eval \"\$(@atuin@/bin/atuin init bash '--disable-ctrl-r' '--disable-up-arrow')\""
+
+    assertFileExists home-files/.zshrc
+    assertFileContains \
+      home-files/.zshrc \
+      "eval \"\$(@atuin@/bin/atuin init zsh '--disable-ctrl-r' '--disable-up-arrow')\""
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      "@atuin@/bin/atuin init fish --disable-ctrl-r --disable-up-arrow | source"
+  '';
+}

--- a/tests/modules/programs/atuin/zsh.nix
+++ b/tests/modules/programs/atuin/zsh.nix
@@ -15,6 +15,6 @@
     assertFileExists home-files/.zshrc
     assertFileContains \
       home-files/.zshrc \
-      'eval "$(@atuin@/bin/atuin init zsh)"'
+      'eval "$(@atuin@/bin/atuin init zsh )"'
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.
Adding Atuin options to disable ctrl+r and up-arrow as described in the [docs](https://atuin.sh/docs/config/key-binding)
-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.