### PR TITLE
beets: add mpdIntegration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,7 +81,8 @@ Makefile                                              @thiagokokada
 
 /modules/programs/bat.nix                             @marsam
 
-/modules/programs/beets.nix                           @rycee
+/modules/programs/beets.nix                           @rycee @Scrumplex
+/tests/modules/programs/beets                         @Scrumplex
 
 /modules/programs/bottom.nix                          @polykernel
 /tests/modules/programs/bottom                        @polykernel

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -145,6 +145,7 @@ import nmt {
     ./modules/misc/xsession
     ./modules/programs/abook
     ./modules/programs/autorandr
+    ./modules/programs/beets  # One test relies on services.mpd
     ./modules/programs/borgmatic
     ./modules/programs/firefox
     ./modules/programs/foot

--- a/tests/modules/programs/beets/default.nix
+++ b/tests/modules/programs/beets/default.nix
@@ -1,0 +1,5 @@
+{
+  beets-mpdstats = ./mpdstats.nix;
+  beets-mpdstats-external = ./mpdstats-external.nix;
+  beets-mpdupdate = ./mpdupdate.nix;
+}

--- a/tests/modules/programs/beets/mpdstats-expected.service
+++ b/tests/modules/programs/beets/mpdstats-expected.service
@@ -1,0 +1,10 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=@beets@/bin/beet mpdstats
+
+[Unit]
+After=mpd.service
+Description=Beets MPDStats daemon
+Requires=mpd.service

--- a/tests/modules/programs/beets/mpdstats-expected.yaml
+++ b/tests/modules/programs/beets/mpdstats-expected.yaml
@@ -1,0 +1,5 @@
+mpd:
+  host: localhost
+  port: 4242
+plugins:
+- mpdstats

--- a/tests/modules/programs/beets/mpdstats-external-expected.service
+++ b/tests/modules/programs/beets/mpdstats-external-expected.service
@@ -1,0 +1,8 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=@beets@/bin/beet mpdstats
+
+[Unit]
+Description=Beets MPDStats daemon

--- a/tests/modules/programs/beets/mpdstats-external-expected.yaml
+++ b/tests/modules/programs/beets/mpdstats-external-expected.yaml
@@ -1,0 +1,5 @@
+mpd:
+  host: 10.0.0.42
+  port: 6601
+plugins:
+- mpdstats

--- a/tests/modules/programs/beets/mpdstats-external.nix
+++ b/tests/modules/programs/beets/mpdstats-external.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    home.stateVersion = "23.05";
+
+    programs.beets = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { outPath = "@beets@"; };
+      mpdIntegration = {
+        enableStats = true;
+        host = "10.0.0.42";
+        port = 6601;
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/beets/config.yaml
+      assertFileContent \
+        home-files/.config/beets/config.yaml \
+        ${./mpdstats-external-expected.yaml}
+
+      assertFileExists home-files/.config/systemd/user/beets-mpdstats.service
+      assertFileContent \
+        home-files/.config/systemd/user/beets-mpdstats.service \
+        ${./mpdstats-external-expected.service}
+    '';
+  };
+}

--- a/tests/modules/programs/beets/mpdstats.nix
+++ b/tests/modules/programs/beets/mpdstats.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    home.stateVersion = "23.05";
+
+    services.mpd = {
+      enable = true;
+      musicDirectory = "/my/music/dir";
+      network.port = 4242;
+    };
+
+    programs.beets = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { outPath = "@beets@"; };
+      mpdIntegration.enableStats = true;
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/beets/config.yaml
+      assertFileContent \
+        home-files/.config/beets/config.yaml \
+        ${./mpdstats-expected.yaml}
+
+      assertFileExists home-files/.config/systemd/user/beets-mpdstats.service
+      assertFileContent \
+        home-files/.config/systemd/user/beets-mpdstats.service \
+        ${./mpdstats-expected.service}
+    '';
+  };
+}

--- a/tests/modules/programs/beets/mpdupdate-expected.yaml
+++ b/tests/modules/programs/beets/mpdupdate-expected.yaml
@@ -1,0 +1,5 @@
+mpd:
+  host: localhost
+  port: 6600
+plugins:
+- mpdupdate

--- a/tests/modules/programs/beets/mpdupdate.nix
+++ b/tests/modules/programs/beets/mpdupdate.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    home.stateVersion = "23.05";
+
+    programs.beets = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { outPath = "@beets@"; };
+      mpdIntegration.enableUpdate = true;
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/beets/config.yaml
+      assertFileContent \
+        home-files/.config/beets/config.yaml \
+        ${./mpdupdate-expected.yaml}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Allow configuration of mpdstats and mpdupdate plugins for Beets using Home Manager.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
