### PR TITLE
myrepos: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -208,6 +208,8 @@ Makefile                                              @thiagokokada
 /modules/programs/mpv.nix                             @tadeokondrak @thiagokokada @chuangzhu
 /tests/modules/programs/mpv                           @thiagokokada @chuangzhu
 
+/modules/programs/mr.nix                              @nilp0inter
+
 /modules/programs/mu.nix                              @KarlJoad
 
 /modules/programs/mujmap.nix                          @elizagamedev

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -159,6 +159,12 @@
     github = "mifom";
     githubId = 23462908;
   };
+  nilp0inter = {
+    name = "Roberto Abdelkader Martínez Pérez";
+    email = "robertomartinezp@gmail.com";
+    github = "nilp0inter";
+    githubId = 1224006;
+  };
   seylerius = {
     email = "sable@seyleri.us";
     name = "Sable Seyler";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -987,6 +987,13 @@ in
           A new module is available: 'services.batsignal'.
         '';
       }
+
+      {
+        time = "2023-04-19T15:33:07+00:00";
+        message = ''
+          A new module is available: 'programs.mr'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -123,6 +123,7 @@ let
     ./programs/mercurial.nix
     ./programs/micro.nix
     ./programs/mpv.nix
+    ./programs/mr.nix
     ./programs/msmtp.nix
     ./programs/mu.nix
     ./programs/mujmap.nix

--- a/modules/programs/mr.nix
+++ b/modules/programs/mr.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.mr;
+
+  listToValue = concatMapStringsSep ", " (generators.mkValueStringDefault { });
+
+  iniFormat = pkgs.formats.ini { inherit listToValue; };
+
+in {
+  meta.maintainers = [ hm.maintainers.nilp0inter ];
+
+  options.programs.mr = {
+    enable = mkEnableOption
+      "mr, a tool to manage all your version control repositories";
+
+    package = mkPackageOption pkgs "mr" { };
+
+    settings = mkOption {
+      type = iniFormat.type;
+      default = { };
+      description = ''
+        Configuration written to <filename>$HOME/.mrconfig</filename>
+        See <link xlink:href="https://myrepos.branchable.com/"/>
+        for an example configuration.
+      '';
+      example = literalExpression ''
+        {
+          foo = {
+            checkout = "git clone git@github.com:joeyh/foo.git";
+            update = "git pull --rebase";
+          };
+          ".local/share/password-store" = {
+            checkout = "git clone git@github.com:myuser/password-store.git";
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    home.file.".mrconfig".source = iniFormat.generate ".mrconfig" cfg.settings;
+  };
+}
+


### PR DESCRIPTION
### Description

This adds options to configure `mr` (aka myrepos), a tool to manage all your version control repos.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.

NOTE: sorry I screwed up last pr #3518