### PR TITLE
home-manager: slightly expand option description

### DIFF
--- a/modules/programs/home-manager.nix
+++ b/modules/programs/home-manager.nix
@@ -18,11 +18,10 @@ in {
         default = null;
         example = "$HOME/devel/home-manager";
         description = ''
-          The default path to use for Home Manager. If this path does
-          not exist then
-          <filename>$HOME/.config/nixpkgs/home-manager</filename> and
-          <filename>$HOME/.nixpkgs/home-manager</filename> will be
-          attempted.
+          The default path to use for Home Manager. When
+          <literal>null</literal>, then the <filename>home-manager</filename>
+          channel, <filename>$HOME/.config/nixpkgs/home-manager</filename>, and
+          <filename>$HOME/.nixpkgs/home-manager</filename> will be attempted.
         '';
       };
     };


### PR DESCRIPTION
### Description

Just make a note that the home-manager channel will be attempted when trying to find a Home Manager repo.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```