### PR TITLE
kitty: add shellIntegration

### DIFF
--- a/tests/modules/programs/kitty/example-settings-expected.conf
+++ b/tests/modules/programs/kitty/example-settings-expected.conf
@@ -4,6 +4,9 @@ font_family DejaVu Sans
 font_size 8
 
 
+# Shell integration is sourced and configured manually
+shell_integration no-rc enabled
+
 enable_audio_bell no
 scrollback_lines 10000
 update_check_interval 0


### PR DESCRIPTION


### Description
Kitty provides integrations for bash, fish and zsh. The new programs.kitty.shellIntegration options allow the configuration of these integrations.

See https://sw.kovidgoyal.net/kitty/shell-integration for more details

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
