### PR TITLE
Fix path to Kitty theme files

### DIFF
--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -134,9 +134,10 @@ in {
         '')
 
         (optionalString (cfg.theme != null) ''
-          include ${pkgs.kitty-themes}/${
+          include ${pkgs.kitty-themes}/share/kitty-themes/${
             (head (filter (x: x.name == cfg.theme) (builtins.fromJSON
-              (builtins.readFile "${pkgs.kitty-themes}/themes.json")))).file
+              (builtins.readFile
+                "${pkgs.kitty-themes}/share/kitty-themes/themes.json")))).file
           }
         '')
         (toKittyConfig cfg.settings)


### PR DESCRIPTION
### Description

The theme files were moved to `share/kitty-themes` in nixos/nixpkgs#220872.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
