### PR TITLE
vscode: add options for global and user snippets

### DIFF
--- a/tests/modules/programs/vscode/default.nix
+++ b/tests/modules/programs/vscode/default.nix
@@ -2,4 +2,5 @@
   vscode-keybindings = ./keybindings.nix;
   vscode-tasks = ./tasks.nix;
   vscode-update-checks = ./update-checks.nix;
+  vscode-snippets = ./snippets.nix;
 }

--- a/tests/modules/programs/vscode/snippets.nix
+++ b/tests/modules/programs/vscode/snippets.nix
@@ -1,0 +1,71 @@
+{ pkgs, ... }:
+
+let
+
+  snippetsDir = if pkgs.stdenv.hostPlatform.isDarwin then
+    "Library/Application Support/Code/User/snippets"
+  else
+    ".config/Code/User/snippets";
+
+  globalSnippetsPath = "${snippetsDir}/global.code-snippets";
+
+  globalSnippetsExpectedContent = pkgs.writeText "global.code-snippet" ''
+    {
+      "fixme": {
+        "body": [
+          "fixme body in global user snippet"
+        ],
+        "description": "Insert a FIXME remark",
+        "prefix": [
+          "fixme"
+        ]
+      }
+    }
+  '';
+
+  haskellSnippetsPath = "${snippetsDir}/haskell.json";
+
+  haskellSnippetsExpectedContent = pkgs.writeText "haskell.json" ''
+    {
+      "impl": {
+        "body": [
+          "impl body in user haskell snippet"
+        ],
+        "description": "Insert an implementation stub",
+        "prefix": [
+          "impl"
+        ]
+      }
+    }
+  '';
+
+in {
+  programs.vscode = {
+    enable = true;
+    package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
+    globalSnippets = {
+      fixme = {
+        prefix = [ "fixme" ];
+        body = [ "fixme body in global user snippet" ];
+        description = "Insert a FIXME remark";
+      };
+    };
+    languageSnippets = {
+      haskell = {
+        impl = {
+          prefix = [ "impl" ];
+          body = [ "impl body in user haskell snippet" ];
+          description = "Insert an implementation stub";
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/${globalSnippetsPath}"
+    assertFileContent "home-files/${globalSnippetsPath}" "${globalSnippetsExpectedContent}"
+
+    assertFileExists "home-files/${haskellSnippetsPath}"
+    assertFileContent "home-files/${haskellSnippetsPath}" "${haskellSnippetsExpectedContent}"
+  '';
+}


### PR DESCRIPTION
### Description

Add options to vscode module for defining global and language specific user snippets.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
