### PR TITLE
listenbrainz-mpd: add module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -440,6 +440,8 @@ Makefile                                              @thiagokokada
 
 /modules/services/lieer.nix                           @tadfisher
 
+/modules/services/listenbrainz-mpd.nix                @Scrumplex
+
 /modules/services/lorri.nix                           @Gerschtli
 
 /modules/services/mako.nix                            @onny

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -948,6 +948,14 @@ in
           'programs.i3status-rust.package' to an older version.
         '';
       }
+
+      {
+        time = "2023-03-22T07:20:00+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.listenbrainz-mpd'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -243,6 +243,7 @@ let
     ./services/keybase.nix
     ./services/keynav.nix
     ./services/lieer.nix
+    ./services/listenbrainz-mpd.nix
     ./services/lorri.nix
     ./services/mako.nix
     ./services/mbsync.nix

--- a/modules/services/listenbrainz-mpd.nix
+++ b/modules/services/listenbrainz-mpd.nix
@@ -1,0 +1,51 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  inherit (lib.options) mkEnableOption mkPackageOption mkOption;
+  inherit (lib.modules) mkIf;
+
+  cfg = config.services.listenbrainz-mpd;
+
+  tomlFormat = pkgs.formats.toml { };
+
+in {
+  meta.maintainers = [ lib.maintainers.Scrumplex ];
+
+  options.services.listenbrainz-mpd = {
+    enable = mkEnableOption "listenbrainz-mpd";
+
+    package = mkPackageOption pkgs "listenbrainz-mpd" { };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      description = ''
+        Configuration for listenbrainz-mpd written to
+        <filename>$XDG_CONFIG_HOME/listenbrainz-mpd/config.toml</filename>.
+      '';
+      example = { submission.tokenFile = "/run/secrets/listenbrainz-mpd"; };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services."listenbrainz-mpd" = {
+      Unit = {
+        Description = "ListenBrainz submission client for MPD";
+        Documentation = "https://codeberg.org/elomatreb/listenbrainz-mpd";
+        After = [ "mpd.service" ];
+        Requires = [ "mpd.service" ];
+      };
+      Service = {
+        ExecStart = "${cfg.package}/bin/listenbrainz-mpd";
+        Restart = "always";
+        RestartSec = 5;
+      };
+      Install.WantedBy = [ "default.target" ];
+    };
+
+    xdg.configFile."listenbrainz-mpd/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "listenbrainz-mpd.toml" cfg.settings;
+    };
+  };
+}


### PR DESCRIPTION
### Description

Adds a simple service to configure [listenbrainz-mpd](https://codeberg.org/elomatreb/listenbrainz-mpd).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
