### PR TITLE
taskwarrior: add package option

### DIFF
--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -84,11 +84,13 @@ in {
           <filename>$XDG_CONFIG_HOME/task/taskrc</filename>.
         '';
       };
+
+      package = mkPackageOption pkgs "taskwarrior" { };
     };
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.taskwarrior ];
+    home.packages = [ cfg.package ];
 
     home.file."${homeConf}".text = ''
       data.location=${cfg.dataLocation}


### PR DESCRIPTION
### Description

Adds a `package` option to `taskwarrior` module.

This allows wrapping taskwarrior to have custom path for plugins.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
