### PR TITLE
New default configuration home

### DIFF
--- a/docs/faq.adoc
+++ b/docs/faq.adoc
@@ -72,7 +72,10 @@ For example, if you have two machines, called "kronos" and "rhea" on which you w
 - `rhea-jane.nix`, and
 - `common.nix`
 
-in your repository. On the kronos and rhea machines you can then make `~jane/.config/nixpkgs/home.nix` be a symbolic link to the corresponding file in your configuration repository.
+in your repository.
+On the kronos and rhea machines you can then make
+`~jane/.config/home-manager/home.nix`
+be a symbolic link to the corresponding file in your configuration repository.
 
 The `kronos-jane.nix` and `rhea-jane.nix` files follow the format
 

--- a/docs/man-configuration.xml
+++ b/docs/man-configuration.xml
@@ -13,12 +13,12 @@
  </refnamediv>
  <refsection>
   <title>Description</title>
-  <para>
-   The file <filename>~/.config/nixpkgs/home.nix</filename> contains the
+  <simpara>
+   The file <filename>~/.config/home-manager/home.nix</filename> contains the
    declarative specification of your Home Manager configuration. The command
    <command>home-manager</command> takes this file and realises the user
    environment configuration specified therein.
-  </para>
+  </simpara>
  </refsection>
  <refsection>
   <title>Options</title>

--- a/docs/man-home-manager.xml
+++ b/docs/man-home-manager.xml
@@ -200,7 +200,9 @@
   <title>Description</title>
   <para>
    This command updates the user environment so that it corresponds to the
-      configuration specified in <filename>~/.config/nixpkgs/home.nix</filename> or <filename>~/.config/nixpkgs/flake.nix</filename>.
+   configuration specified in
+   <filename>$XDG_CONFIG_HOME/home-manager/home.nix</filename> or
+   <filename>$XDG_CONFIG_HOME/home-manager/flake.nix</filename>.
   </para>
   <para>
    All operations using this tool expects a sub-command that indicates the
@@ -434,7 +436,7 @@
     <listitem>
      <para>
       Indicates the path to the Home Manager configuration file. If not given,
-      <filename>$XDG_CONFIG_HOME/nixpkgs/home.nix</filename> is used.
+      <filename>$XDG_CONFIG_HOME/home-manager/home.nix</filename> is used.
      </para>
     </listitem>
    </varlistentry>

--- a/docs/man-home-manager.xml
+++ b/docs/man-home-manager.xml
@@ -346,8 +346,8 @@
         </listitem>
         <listitem>
          <para>
-          optionally remove all Home Manager generations and make them
-          available for immediate garbage collection.
+          remove all Home Manager generations and make them available
+          for immediate garbage collection.
          </para>
         </listitem>
        </itemizedlist>

--- a/docs/nix-flakes.adoc
+++ b/docs/nix-flakes.adoc
@@ -118,9 +118,9 @@ and `nixpkgs` url to `github:NixOS/nixpkgs/nixos-22.11`.
 * The Home Manager library is exported by the flake under
 `lib.hm`.
 
-* You can use the above `flake.nix` as a template in `~/.config/nixpkgs` by
+* You can use the above `flake.nix` as a template in `~/.config/home-manager` by
 [source,console]
-$ nix flake new ~/.config/nixpkgs -t github:nix-community/home-manager
+$ nix flake new ~/.config/home-manager -t github:nix-community/home-manager
 ====
 
 2. Install Home Manager and apply the configuration by
@@ -129,9 +129,9 @@ $ nix flake new ~/.config/nixpkgs -t github:nix-community/home-manager
 $ nix run <flake-uri>#homeConfigurations.jdoe.activationPackage
 +
 Substitute `<flake-uri>` with the flake URI of the configuration flake.
-If `flake.nix` resides in `~/.config/nixpkgs`,
-`<flake-uri>` may be `~/.config/nixpkgs`
-as a Git tree or `path:~/.config/nixpkgs` if not.
+If `flake.nix` resides in `~/.config/home-manager`,
+`<flake-uri>` may be `~/.config/home-manager`
+as a Git tree or `path:~/.config/home-manager` if not.
 
 3. Since the release `21.05`,
 building a flake-based configuration is as simple as

--- a/docs/release-notes/rl-2305.adoc
+++ b/docs/release-notes/rl-2305.adoc
@@ -19,6 +19,17 @@ in your configuration then you must change it to
 [source,nix]
 programs.firefox.profiles.myprofile.extensions = [ foo bar ];
 
+* The default configuration location has been changed from
+`~/.config/nixpkgs/home.nix` to `~/.config/home-manager/home.nix`.
++
+Similarly, if you are using a Nix flake based setup
+then the default flake file location has changed from
+`~/.config/nixpkgs/flake.nix` to `~/.config/home-manager/flake.nix`.
++
+The old location will continue to work but using it will trigger a warning message.
+We changed the default configuration location to avoid confusion about
+which files belong to Home Manager and which belong to Nixpkgs.
+
 [[sec-release-23.05-state-version-changes]]
 === State Version Changes
 

--- a/docs/release-notes/rl-2305.adoc
+++ b/docs/release-notes/rl-2305.adoc
@@ -25,8 +25,14 @@ programs.firefox.profiles.myprofile.extensions = [ foo bar ];
 The state version in this release includes the changes below.
 These changes are only active if the `home.stateVersion` option is set to "23.05" or later.
 
-* The <<opt-xsession.windowManager.i3.config.window.titlebar>>,
-<<opt-xsession.windowManager.i3.config.floating.titlebar>>,
-<<opt-wayland.windowManager.sway.config.window.titlebar>>,
-<<opt-wayland.windowManager.sway.config.floating.titlebar>>, options now default to `true` which
-is consistent with the default values for those options used by `i3` and `sway`.
+* The options
++
+--
+- <<opt-xsession.windowManager.i3.config.window.titlebar>>
+- <<opt-xsession.windowManager.i3.config.floating.titlebar>>
+- <<opt-wayland.windowManager.sway.config.window.titlebar>>
+- <<opt-wayland.windowManager.sway.config.floating.titlebar>>
+--
++
+now default to `true` which is consistent with the default values
+for those options used by `i3` and `sway`.

--- a/docs/usage.adoc
+++ b/docs/usage.adoc
@@ -1,7 +1,14 @@
 [[ch-usage]]
 == Using Home Manager
 
-Your use of Home Manager is centered around the configuration file, which is typically found at `~/.config/nixpkgs/home.nix`.
+Your use of Home Manager is centered around the configuration file,
+which is typically found at `~/.config/home-manager/home.nix` in the standard installation
+or `~/.config/home-manager/flake.nix` in a Nix flake based installation.
+
+[NOTE]
+The default configuration used to be placed in `~/.config/nixpkgs`¸
+so you may see references to that elsewhere.
+The old directory still works but Home Manager will print a warning message when used.
 
 This configuration file can be _built_ and _activated_.
 
@@ -18,7 +25,7 @@ then building it, for example using `home-manager build`, will result in an erro
 ----
 $ home-manager build
 error: A definition for option `programs.emacs.enable' is not of type `boolean'. Definition values:
-- In `/home/jdoe/.config/nixpkgs/home.nix': "yes"
+- In `/home/jdoe/.config/home-manager/home.nix': "yes"
 (use '--show-trace' to show detailed location information)
 ----
 
@@ -32,7 +39,7 @@ Once a configuration is successfully built, it can be activated. The activation 
 [[sec-usage-configuration]]
 === Configuration Example
 
-A fresh install of Home Manager will generate a minimal `~/.config/nixpkgs/home.nix` file containing something like
+A fresh install of Home Manager will generate a minimal `~/.config/home-manager/home.nix` file containing something like
 
 [source,nix]
 ----

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -56,29 +56,42 @@ function setWorkDir() {
 # an error message and exit with an error code.
 function setConfigFile() {
     if [[ -v HOME_MANAGER_CONFIG ]] ; then
-        if [[ ! -e "$HOME_MANAGER_CONFIG" ]] ; then
-            _i "No configuration file found at %s" \
+        if [[ -e "$HOME_MANAGER_CONFIG" ]] ; then
+            HOME_MANAGER_CONFIG="$(realpath "$HOME_MANAGER_CONFIG")"
+        else
+            _i 'No configuration file found at %s' \
                "$HOME_MANAGER_CONFIG" >&2
             exit 1
         fi
+    elif [[ ! -v HOME_MANAGER_CONFIG ]]; then
+        local configHome="${XDG_CONFIG_HOME:-$HOME/.config}"
+        local hmConfigHome="$configHome/home-manager"
+        local nixpkgsConfigHome="$configHome/nixpkgs"
+        local defaultConfFile="$hmConfigHome/home.nix"
+        local configFlake
 
-        HOME_MANAGER_CONFIG="$(realpath "$HOME_MANAGER_CONFIG")"
-        return
-    fi
-
-    local defaultConfFile="${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home.nix"
-    local confFile
-    for confFile in "$defaultConfFile" \
-                    "$HOME/.nixpkgs/home.nix" ; do
-        if [[ -e "$confFile" ]] ; then
-            HOME_MANAGER_CONFIG="$(realpath "$confFile")"
-            return
+        if [[ -e "$defaultConfFile" ]]; then
+            configFile="$defaultConfFile"
+        elif [[ -e "$nixpkgsConfigHome/home.nix" ]]; then
+            configFile="$nixpkgsConfigHome/home.nix"
+            # translators: The first '%s' specifier will be replaced by either
+            # 'home.nix' or 'flake.nix'.
+            _iWarn $'Keeping your Home Manager %s in %s is deprecated,\nplease move it to %s' \
+                   'home.nix' "$nixpkgsConfigHome" "$hmConfigHome" >&2
+        elif [[ -e "$HOME/.nixpkgs/home.nix" ]]; then
+            configFile="$HOME/.nixpkgs/home.nix"
+            _iWarn $'Keeping your Home Manager %s in %s is deprecated,\nplease move it to %s' \
+                   'home.nix' "$HOME/.nixpkgs" "$hmConfigHome" >&2
         fi
-    done
 
-    _i "No configuration file found. Please create one at %s" \
-       "$defaultConfFile" >&2
-    exit 1
+        if [[ $configFile ]]; then
+            HOME_MANAGER_CONFIG="$(realpath "$configFile")"
+        else
+            _i 'No configuration file found. Please create one at %s' \
+               "$defaultConfFile" >&2
+            exit 1
+        fi
+    fi
 }
 
 function setHomeManagerNixPath() {
@@ -111,9 +124,24 @@ function setHomeManagerPathVariables() {
 }
 
 function setFlakeAttribute() {
-    local configFlake="${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/flake.nix"
-    if [[ -z $FLAKE_ARG && ! -v HOME_MANAGER_CONFIG && -e "$configFlake" ]]; then
-        FLAKE_ARG="$(dirname "$(readlink -f "$configFlake")")"
+    if [[ -z $FLAKE_ARG && ! -v HOME_MANAGER_CONFIG ]]; then
+        local configHome="${XDG_CONFIG_HOME:-$HOME/.config}"
+        local hmConfigHome="$configHome/home-manager"
+        local nixpkgsConfigHome="$configHome/nixpkgs"
+
+        local configFlake
+
+        if [[ -e "$hmConfigHome/flake.nix" ]]; then
+            configFlake="$hmConfigHome/flake.nix"
+        elif [[ -e "$nixpkgsConfigHome/flake.nix" ]]; then
+            configFlake="$nixpkgsConfigHome/flake.nix"
+            _iWarn $'Keeping your Home Manager %s in %s is deprecated,\nplease move it to %s' \
+                   'flake.nix' "$nixpkgsConfigHome" "$hmConfigHome" >&2
+        fi
+
+        if [[ -v configFlake ]]; then
+            FLAKE_ARG="$(dirname "$(readlink -f "$configFlake")")"
+        fi
     fi
 
     if [[ -n "$FLAKE_ARG" ]]; then
@@ -121,7 +149,7 @@ function setFlakeAttribute() {
         case $FLAKE_ARG in
             *#*)
                 local name="${FLAKE_ARG#*#}"
-            ;;
+                ;;
             *)
                 local name="$USER"
                 # Check both long and short hostnames; long first to preserve
@@ -134,7 +162,7 @@ function setFlakeAttribute() {
                         fi
                     fi
                 done
-            ;;
+                ;;
         esac
         export FLAKE_CONFIG_URI="$flake#homeConfigurations.\"$name\""
     fi

--- a/home-manager/install.nix
+++ b/home-manager/install.nix
@@ -15,7 +15,7 @@ in runCommand "home-manager-install" {
   shellHook = ''
     ${hmBashLibInit}
 
-    confFile="''${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home.nix"
+    confFile="''${XDG_CONFIG_HOME:-$HOME/.config}/home-manager/home.nix"
 
     if [[ ! -e $confFile ]]; then
       echo

--- a/home-manager/po/home-manager.pot
+++ b/home-manager/po/home-manager.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2023-03-07 23:36+0100\n"
+"POT-Creation-Date: 2023-03-14 23:10+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,23 +18,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: home-manager/home-manager:60
+#: home-manager/home-manager:62
 msgid "No configuration file found at %s"
 msgstr ""
 
-#: home-manager/home-manager:79
+#. translators: The first '%s' specifier will be replaced by either
+#. 'home.nix' or 'flake.nix'.
+#: home-manager/home-manager:79 home-manager/home-manager:83
+#: home-manager/home-manager:138
+msgid ""
+"Keeping your Home Manager %s in %s is deprecated,\n"
+"please move it to %s"
+msgstr ""
+
+#: home-manager/home-manager:90
 msgid "No configuration file found. Please create one at %s"
 msgstr ""
 
-#: home-manager/home-manager:146
+#: home-manager/home-manager:174
 msgid "Can't inspect options of a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:185
+#: home-manager/home-manager:213
 msgid "Can't instantiate a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:258
+#: home-manager/home-manager:286
 msgid ""
 "There is %d unread and relevant news item.\n"
 "Read it by running the command \"%s news\"."
@@ -44,80 +53,80 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: home-manager/home-manager:272
+#: home-manager/home-manager:300
 msgid "Unknown \"news.display\" setting \"%s\"."
 msgstr ""
 
-#: home-manager/home-manager:279
+#: home-manager/home-manager:307
 #, sh-format
 msgid "Please set the $EDITOR environment variable"
 msgstr ""
 
-#: home-manager/home-manager:294
+#: home-manager/home-manager:322
 msgid "Cannot run build in read-only directory"
 msgstr ""
 
-#: home-manager/home-manager:378
+#: home-manager/home-manager:406
 msgid "No generation with ID %s"
 msgstr ""
 
-#: home-manager/home-manager:380
+#: home-manager/home-manager:408
 msgid "Cannot remove the current generation %s"
 msgstr ""
 
-#: home-manager/home-manager:382
+#: home-manager/home-manager:410
 msgid "Removing generation %s"
 msgstr ""
 
-#: home-manager/home-manager:401
+#: home-manager/home-manager:429
 msgid "No generations to expire"
 msgstr ""
 
-#: home-manager/home-manager:412
+#: home-manager/home-manager:440
 msgid "No home-manager packages seem to be installed."
 msgstr ""
 
-#: home-manager/home-manager:469
+#: home-manager/home-manager:497
 msgid "Unknown argument %s"
 msgstr ""
 
-#: home-manager/home-manager:485
+#: home-manager/home-manager:513
 msgid "This will remove Home Manager from your system."
 msgstr ""
 
-#: home-manager/home-manager:488
+#: home-manager/home-manager:516
 msgid "This is a dry run, nothing will actually be uninstalled."
 msgstr ""
 
-#: home-manager/home-manager:492
+#: home-manager/home-manager:520
 msgid "Really uninstall Home Manager?"
 msgstr ""
 
-#: home-manager/home-manager:498
+#: home-manager/home-manager:526
 msgid "Switching to empty Home Manager configuration..."
 msgstr ""
 
-#: home-manager/home-manager:525
+#: home-manager/home-manager:553
 msgid "Yay!"
 msgstr ""
 
-#: home-manager/home-manager:530
+#: home-manager/home-manager:558
 msgid "Home Manager is uninstalled but your home.nix is left untouched."
 msgstr ""
 
-#: home-manager/home-manager:695
+#: home-manager/home-manager:723
 msgid "%s: unknown option '%s'"
 msgstr ""
 
-#: home-manager/home-manager:696
+#: home-manager/home-manager:724
 msgid "Run '%s --help' for usage help"
 msgstr ""
 
-#: home-manager/home-manager:730
+#: home-manager/home-manager:758
 msgid "expire-generations expects one argument, got %d."
 msgstr ""
 
-#: home-manager/home-manager:752
+#: home-manager/home-manager:780
 msgid "Unknown command: %s"
 msgstr ""
 

--- a/modules/po/hm-modules.pot
+++ b/modules/po/hm-modules.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager Modules\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2023-03-07 23:36+0100\n"
+"POT-Creation-Date: 2023-03-14 23:10+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,15 +53,15 @@ msgstr ""
 msgid "Activating %s"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:18
+#: modules/lib-bash/activation-init.sh:16
 msgid "Migrating profiles from %s to %s"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:77
+#: modules/lib-bash/activation-init.sh:75
 msgid "Sanity checking oldGenNum and oldGenPath"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:80
+#: modules/lib-bash/activation-init.sh:78
 msgid ""
 "The previous generation number and path are in conflict! These\n"
 "must be either both empty or both set but are now set to\n"
@@ -77,26 +77,26 @@ msgid ""
 "and trying home-manager switch again. Good luck!"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:97
+#: modules/lib-bash/activation-init.sh:95
 msgid "Starting Home Manager activation"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:101
+#: modules/lib-bash/activation-init.sh:99
 msgid "Sanity checking Nix"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:107
+#: modules/lib-bash/activation-init.sh:105
 msgid "This is a dry run"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:111
+#: modules/lib-bash/activation-init.sh:109
 msgid "This is a live run"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:118
+#: modules/lib-bash/activation-init.sh:116
 msgid "Using Nix version: %s"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:121
+#: modules/lib-bash/activation-init.sh:119
 msgid "Activation variables:"
 msgstr ""


### PR DESCRIPTION
### Description

This changes the default configuration location for Home Manager configurations from

    $XDG_CONFIG_HOME/nixpkgs

to

    $XDG_CONFIG_HOME/home-manager

The old location is still supported but using it will trigger a warning message.

I also included a few minor unrelated changes.

Fixes #3640

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```