### PR TITLE
i3status-rust: update it to handle 0.30.x releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -152,7 +152,8 @@ Makefile                                              @thiagokokada
 
 /modules/programs/i3status.nix                        @JustinLovinger
 
-/modules/programs/i3status-rust.nix                   @workflow
+/modules/programs/i3status-rust.nix                   @workflow @thiagokokada
+/tests/modules/programs/i3status-rust                 @thiagokokada
 
 /modules/programs/ion.nix                             @jo1gi
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -931,6 +931,23 @@ in
           A new module is available: 'services.avizo'.
         '';
       }
+
+      {
+        time = "2023-03-16:12:00+00:00";
+        condition = config.programs.i3status-rust.enable;
+        message = ''
+          Module 'i3status-rust' was updated to support the new configuration
+          format from 0.30.x releases, that introduces many breaking changes.
+          The documentation was updated with examples from 0.30.x to help
+          the transition.
+
+          See https://github.com/greshake/i3status-rust/blob/v0.30.0/NEWS.md
+          for instructions on how to migrate.
+
+          Users that don't want to migrate yet can set
+          'programs.i3status-rust.package' to an older version.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -21,36 +21,32 @@ in {
           blocks = mkOption {
             type = settingsFormat.type;
             default = [
+              { block = "cpu"; }
               {
                 block = "disk_space";
                 path = "/";
-                alias = "/";
                 info_type = "available";
-                unit = "GB";
-                interval = 60;
+                interval = 20;
                 warning = 20.0;
                 alert = 10.0;
+                format = " $icon root: $available.eng(w:2) ";
               }
               {
                 block = "memory";
-                display_type = "memory";
-                format_mem = "{mem_used_percents}";
-                format_swap = "{swap_used_percents}";
+                format = " $icon $mem_total_used_percents.eng(w:2) ";
+                format_alt = " $icon_swap $swap_used_percents.eng(w:2) ";
               }
               {
-                block = "cpu";
-                interval = 1;
+                block = "sound";
+                click = [{
+                  button = "left";
+                  cmd = "pavucontrol";
+                }];
               }
-              {
-                block = "load";
-                interval = 1;
-                format = "{1m}";
-              }
-              { block = "sound"; }
               {
                 block = "time";
-                interval = 60;
-                format = "%a %d/%m %R";
+                interval = 5;
+                format = " $timestamp.datetime(f:'%a %d/%m %R') ";
               }
             ];
             description = ''
@@ -64,20 +60,23 @@ in {
                 {
                   block = "disk_space";
                   path = "/";
-                  alias = "/";
                   info_type = "available";
-                  unit = "GB";
                   interval = 60;
                   warning = 20.0;
                   alert = 10.0;
                 }
                 {
                   block = "sound";
-                  format = "{output_name} {volume}%";
-                  on_click = "pavucontrol --tab=3";
+                  format = " $icon $output_name {$volume.eng(w:2) |}";
+                  click = [
+                    {
+                      button = "left";
+                      cmd = "pavucontrol --tab=3";
+                    }
+                  ];
                   mappings = {
-                   "alsa_output.pci-0000_00_1f.3.analog-stereo" = "";
-                   "bluez_sink.70_26_05_DA_27_A4.a2dp_sink" = "";
+                    "alsa_output.pci-0000_00_1f.3.analog-stereo" = "";
+                    "bluez_sink.70_26_05_DA_27_A4.a2dp_sink" = "";
                   };
                 }
               ];
@@ -94,7 +93,7 @@ in {
             example = literalExpression ''
               {
                 theme =  {
-                  name = "solarized-dark";
+                  theme = "solarized-dark";
                   overrides = {
                     idle_bg = "#123456";
                     idle_fg = "#abcdef";
@@ -109,10 +108,10 @@ in {
             default = "none";
             description = ''
               The icons set to use. See
-              <link xlink:href="https://github.com/greshake/i3status-rust/blob/master/themes.md"/>
+              <link xlink:href="https://github.com/greshake/i3status-rust/blob/master/doc/themes.md"/>
               for a list of available icon sets.
             '';
-            example = "awesome5";
+            example = "awesome6";
           };
 
           theme = mkOption {
@@ -120,7 +119,7 @@ in {
             default = "plain";
             description = ''
               The theme to use. See
-              <link xlink:href="https://github.com/greshake/i3status-rust/blob/master/themes.md"/>
+              <link xlink:href="https://github.com/greshake/i3status-rust/blob/master/doc/themes.md"/>
               for a list of available themes.
             '';
             example = "gruvbox-dark";
@@ -134,18 +133,15 @@ in {
             {
               block = "disk_space";
               path = "/";
-              alias = "/";
               info_type = "available";
-              unit = "GB";
               interval = 60;
               warning = 20.0;
               alert = 10.0;
             }
             {
               block = "memory";
-              display_type = "memory";
-              format_mem = "{mem_used_percents}";
-              format_swap = "{swap_used_percents}";
+              format = " $icon mem_used_percents ";
+              format_alt = " $icon $swap_used_percents ";
             }
             {
               block = "cpu";
@@ -154,13 +150,13 @@ in {
             {
               block = "load";
               interval = 1;
-              format = "{1m}";
+              format = " $icon $1m ";
             }
             { block = "sound"; }
             {
               block = "time";
               interval = 60;
-              format = "%a %d/%m %R";
+              format = " $timestamp.datetime(f:'%a %d/%m %R') ";
             }
           ];
         };
@@ -187,18 +183,15 @@ in {
             {
                block = "disk_space";
                path = "/";
-               alias = "/";
                info_type = "available";
-               unit = "GB";
                interval = 60;
                warning = 20.0;
                alert = 10.0;
              }
              {
                block = "memory";
-               display_type = "memory";
-               format_mem = "{mem_used_percents}";
-               format_swap = "{swap_used_percents}";
+               format_mem = " $icon $mem_used_percents ";
+               format_swap = " $icon $swap_used_percents ";
              }
              {
                block = "cpu";
@@ -207,18 +200,18 @@ in {
              {
                block = "load";
                interval = 1;
-               format = "{1m}";
+               format = " $icon $1m ";
              }
              { block = "sound"; }
              {
                block = "time";
                interval = 60;
-               format = "%a %d/%m %R";
+               format = " $timestamp.datetime(f:'%a %d/%m %R') ";
              }
           ];
           settings = {
             theme =  {
-              name = "solarized-dark";
+              theme = "solarized-dark";
               overrides = {
                 idle_bg = "#123456";
                 idle_fg = "#abcdef";
@@ -258,8 +251,8 @@ in {
         '';
 
         source = settingsFormat.generate ("config-${cfgFileSuffix}.toml") ({
-          theme = cfg.theme;
-          icons = cfg.icons;
+          theme = { theme = cfg.theme; };
+          icons = { icons = cfg.icons; };
           block = cfg.blocks;
         } // cfg.settings);
       })) cfg.bars;

--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -241,7 +241,7 @@ in {
 
     home.packages = [ cfg.package ];
 
-    xdg.configFile = mapAttrs' (cfgFileSuffix: cfg:
+    xdg.configFile = mapAttrs' (cfgFileSuffix: cfgBar:
       nameValuePair ("i3status-rust/config-${cfgFileSuffix}.toml") ({
         onChange = mkIf config.xsession.windowManager.i3.enable ''
           i3Socket="''${XDG_RUNTIME_DIR:-/run/user/$UID}/i3/ipc-socket.*"
@@ -251,10 +251,16 @@ in {
         '';
 
         source = settingsFormat.generate ("config-${cfgFileSuffix}.toml") ({
-          theme = { theme = cfg.theme; };
-          icons = { icons = cfg.icons; };
-          block = cfg.blocks;
-        } // cfg.settings);
+          theme = if lib.versionAtLeast cfg.package.version "0.30.0" then {
+            theme = cfgBar.theme;
+          } else
+            cfgBar.theme;
+          icons = if lib.versionAtLeast cfg.package.version "0.30.0" then {
+            icons = cfgBar.icons;
+          } else
+            cfgBar.icons;
+          block = cfgBar.blocks;
+        } // cfgBar.settings);
       })) cfg.bars;
   };
 }

--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -9,7 +9,7 @@ let
   settingsFormat = pkgs.formats.toml { };
 
 in {
-  meta.maintainers = [ maintainers.farlion ];
+  meta.maintainers = with lib.maintainers; [ farlion thiagokokada ];
 
   options.programs.i3status-rust = {
     enable = mkEnableOption "a replacement for i3-status written in Rust";

--- a/tests/modules/programs/i3status-rust/default.nix
+++ b/tests/modules/programs/i3status-rust/default.nix
@@ -3,4 +3,5 @@
   i3status-rust-with-custom = ./with-custom.nix;
   i3status-rust-with-extra-settings = ./with-extra-settings.nix;
   i3status-rust-with-multiple-bars = ./with-multiple-bars.nix;
+  i3status-rust-with-version-02xx = ./with-version-02xx.nix;
 }

--- a/tests/modules/programs/i3status-rust/with-custom.nix
+++ b/tests/modules/programs/i3status-rust/with-custom.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 {
   config = {
     programs.i3status-rust = {
@@ -99,7 +97,7 @@ with lib;
       };
     };
 
-    test.stubs.i3status-rust = { };
+    test.stubs.i3status-rust = { version = "0.30.0"; };
 
     nmt.script = ''
       assertFileExists home-files/.config/i3status-rust/config-custom.toml

--- a/tests/modules/programs/i3status-rust/with-custom.nix
+++ b/tests/modules/programs/i3status-rust/with-custom.nix
@@ -12,9 +12,7 @@ with lib;
             {
               block = "disk_space";
               path = "/";
-              alias = "/";
               info_type = "available";
-              unit = "GB";
               interval = 60;
               warning = 20.0;
               alert = 10.0;
@@ -28,34 +26,27 @@ with lib;
             {
               block = "cpu";
               interval = 1;
-              format = "{barchart}";
+              format = " $icon $barchart ";
             }
             {
               block = "load";
               interval = 1;
-              format = "{1m} {5m}";
+              format = " $icon $1m $5m ";
             }
             {
               block = "temperature";
-              collapsed = true;
               interval = 10;
-              format = "{min}° min, {max}° max, {average}° avg";
+              format = "$icon $min min, $max max, $average avg";
               chip = "*-isa-*";
-            }
-            {
-              block = "networkmanager";
-              ap_format = "{ssid} @ {strength}%";
-              on_click = "kcmshell5 kcm_networkmanagement";
             }
             {
               block = "net";
               device = "enp9s0u2u1u2c2";
-              speed_up = true;
               interval = 5;
             }
             {
               block = "speedtest";
-              bytes = true;
+              format = " ^icon_ping $ping ";
             }
             {
               block = "xrandr";
@@ -65,7 +56,10 @@ with lib;
             {
               block = "sound";
               format = "{output_name} {volume}%";
-              on_click = "pavucontrol --tab=3";
+              click = [{
+                button = "left";
+                cmd = "pavucontrol --tab=3";
+              }];
               mappings = {
                 "alsa_output.pci-0000_00_1f.3.analog-stereo" = "";
                 "bluez_sink.70_26_05_DA_27_A4.a2dp_sink" = "";
@@ -75,12 +69,25 @@ with lib;
               block = "music";
               player = "spotify";
               buttons = [ "play" "prev" "next" ];
-              on_collapsed_click = "i3-msg '[class=Spotify] focus'";
+              click = [
+                {
+                  button = "play";
+                  action = "music_play";
+                }
+                {
+                  button = "prev";
+                  action = "music_prev";
+                }
+                {
+                  button = "next";
+                  action = "music_next";
+                }
+              ];
             }
             {
               block = "time";
               interval = 60;
-              format = "%a %d.%m %R";
+              format = " $timestamp.datetime(f:'%a %d/%m %R') ";
             }
             { block = "battery"; }
           ];
@@ -99,16 +106,12 @@ with lib;
       assertFileContent home-files/.config/i3status-rust/config-custom.toml \
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
-            icons = "awesome5"
-            theme = "gruvbox-dark"
             [[block]]
             alert = 10.0
-            alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
             path = "/"
-            unit = "GB"
             warning = 20.0
 
             [[block]]
@@ -119,35 +122,28 @@ with lib;
 
             [[block]]
             block = "cpu"
-            format = "{barchart}"
+            format = " $icon $barchart "
             interval = 1
 
             [[block]]
             block = "load"
-            format = "{1m} {5m}"
+            format = " $icon $1m $5m "
             interval = 1
 
             [[block]]
             block = "temperature"
             chip = "*-isa-*"
-            collapsed = true
-            format = "{min}° min, {max}° max, {average}° avg"
+            format = "$icon $min min, $max max, $average avg"
             interval = 10
-
-            [[block]]
-            ap_format = "{ssid} @ {strength}%"
-            block = "networkmanager"
-            on_click = "kcmshell5 kcm_networkmanagement"
 
             [[block]]
             block = "net"
             device = "enp9s0u2u1u2c2"
             interval = 5
-            speed_up = true
 
             [[block]]
             block = "speedtest"
-            bytes = true
+            format = " ^icon_ping $ping "
 
             [[block]]
             block = "xrandr"
@@ -156,7 +152,10 @@ with lib;
             [[block]]
             block = "sound"
             format = "{output_name} {volume}%"
-            on_click = "pavucontrol --tab=3"
+
+            [[block.click]]
+            button = "left"
+            cmd = "pavucontrol --tab=3"
 
             [block.mappings]
             "alsa_output.pci-0000_00_1f.3.analog-stereo" = ""
@@ -165,16 +164,33 @@ with lib;
             [[block]]
             block = "music"
             buttons = ["play", "prev", "next"]
-            on_collapsed_click = "i3-msg '[class=Spotify] focus'"
             player = "spotify"
+
+            [[block.click]]
+            action = "music_play"
+            button = "play"
+
+            [[block.click]]
+            action = "music_prev"
+            button = "prev"
+
+            [[block.click]]
+            action = "music_next"
+            button = "next"
 
             [[block]]
             block = "time"
-            format = "%a %d.%m %R"
+            format = " $timestamp.datetime(f:'%a %d/%m %R') "
             interval = 60
 
             [[block]]
             block = "battery"
+
+            [icons]
+            icons = "awesome5"
+
+            [theme]
+            theme = "gruvbox-dark"
           ''
         }
     '';

--- a/tests/modules/programs/i3status-rust/with-default.nix
+++ b/tests/modules/programs/i3status-rust/with-default.nix
@@ -13,23 +13,18 @@ with lib;
       assertFileContent home-files/.config/i3status-rust/config-default.toml \
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
-            icons = "none"
-            theme = "plain"
             [[block]]
             alert = 10.0
-            alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
             path = "/"
-            unit = "GB"
             warning = 20.0
 
             [[block]]
             block = "memory"
-            display_type = "memory"
-            format_mem = "{mem_used_percents}"
-            format_swap = "{swap_used_percents}"
+            format = " $icon mem_used_percents "
+            format_alt = " $icon $swap_used_percents "
 
             [[block]]
             block = "cpu"
@@ -37,7 +32,7 @@ with lib;
 
             [[block]]
             block = "load"
-            format = "{1m}"
+            format = " $icon $1m "
             interval = 1
 
             [[block]]
@@ -45,8 +40,14 @@ with lib;
 
             [[block]]
             block = "time"
-            format = "%a %d/%m %R"
+            format = " $timestamp.datetime(f:'%a %d/%m %R') "
             interval = 60
+
+            [icons]
+            icons = "none"
+
+            [theme]
+            theme = "plain"
           ''
         }
     '';

--- a/tests/modules/programs/i3status-rust/with-extra-settings.nix
+++ b/tests/modules/programs/i3status-rust/with-extra-settings.nix
@@ -12,9 +12,7 @@ with lib;
             {
               block = "disk_space";
               path = "/";
-              alias = "/";
               info_type = "available";
-              unit = "GB";
               interval = 60;
               warning = 20.0;
               alert = 10.0;
@@ -28,34 +26,27 @@ with lib;
             {
               block = "cpu";
               interval = 1;
-              format = "{barchart}";
+              format = " $icon $barchart ";
             }
             {
               block = "load";
               interval = 1;
-              format = "{1m} {5m}";
+              format = " $icon $1m $5m ";
             }
             {
               block = "temperature";
-              collapsed = true;
               interval = 10;
-              format = "{min}° min, {max}° max, {average}° avg";
+              format = "$icon $min min, $max max, $average avg";
               chip = "*-isa-*";
-            }
-            {
-              block = "networkmanager";
-              ap_format = "{ssid} @ {strength}%";
-              on_click = "kcmshell5 kcm_networkmanagement";
             }
             {
               block = "net";
               device = "enp9s0u2u1u2c2";
-              speed_up = true;
               interval = 5;
             }
             {
               block = "speedtest";
-              bytes = true;
+              format = " ^icon_ping $ping ";
             }
             {
               block = "xrandr";
@@ -65,7 +56,10 @@ with lib;
             {
               block = "sound";
               format = "{output_name} {volume}%";
-              on_click = "pavucontrol --tab=3";
+              click = [{
+                button = "left";
+                cmd = "pavucontrol --tab=3";
+              }];
               mappings = {
                 "alsa_output.pci-0000_00_1f.3.analog-stereo" = "";
                 "bluez_sink.70_26_05_DA_27_A4.a2dp_sink" = "";
@@ -75,12 +69,25 @@ with lib;
               block = "music";
               player = "spotify";
               buttons = [ "play" "prev" "next" ];
-              on_collapsed_click = "i3-msg '[class=Spotify] focus'";
+              click = [
+                {
+                  button = "play";
+                  action = "music_play";
+                }
+                {
+                  button = "prev";
+                  action = "music_prev";
+                }
+                {
+                  button = "next";
+                  action = "music_next";
+                }
+              ];
             }
             {
               block = "time";
               interval = 60;
-              format = "%a %d.%m %R";
+              format = " $timestamp.datetime(f:'%a %d/%m %R') ";
             }
             { block = "battery"; }
           ];
@@ -89,7 +96,7 @@ with lib;
 
           settings = {
             theme = {
-              name = "solarized-dark";
+              theme = "solarized-dark";
               overrides = {
                 idle_bg = "#123456";
                 idle_fg = "#abcdef";
@@ -109,15 +116,12 @@ with lib;
       assertFileContent home-files/.config/i3status-rust/config-extra-settings.toml \
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
-            icons = "awesome5"
             [[block]]
             alert = 10.0
-            alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
             path = "/"
-            unit = "GB"
             warning = 20.0
 
             [[block]]
@@ -128,35 +132,28 @@ with lib;
 
             [[block]]
             block = "cpu"
-            format = "{barchart}"
+            format = " $icon $barchart "
             interval = 1
 
             [[block]]
             block = "load"
-            format = "{1m} {5m}"
+            format = " $icon $1m $5m "
             interval = 1
 
             [[block]]
             block = "temperature"
             chip = "*-isa-*"
-            collapsed = true
-            format = "{min}° min, {max}° max, {average}° avg"
+            format = "$icon $min min, $max max, $average avg"
             interval = 10
-
-            [[block]]
-            ap_format = "{ssid} @ {strength}%"
-            block = "networkmanager"
-            on_click = "kcmshell5 kcm_networkmanagement"
 
             [[block]]
             block = "net"
             device = "enp9s0u2u1u2c2"
             interval = 5
-            speed_up = true
 
             [[block]]
             block = "speedtest"
-            bytes = true
+            format = " ^icon_ping $ping "
 
             [[block]]
             block = "xrandr"
@@ -165,7 +162,10 @@ with lib;
             [[block]]
             block = "sound"
             format = "{output_name} {volume}%"
-            on_click = "pavucontrol --tab=3"
+
+            [[block.click]]
+            button = "left"
+            cmd = "pavucontrol --tab=3"
 
             [block.mappings]
             "alsa_output.pci-0000_00_1f.3.analog-stereo" = ""
@@ -174,19 +174,33 @@ with lib;
             [[block]]
             block = "music"
             buttons = ["play", "prev", "next"]
-            on_collapsed_click = "i3-msg '[class=Spotify] focus'"
             player = "spotify"
+
+            [[block.click]]
+            action = "music_play"
+            button = "play"
+
+            [[block.click]]
+            action = "music_prev"
+            button = "prev"
+
+            [[block.click]]
+            action = "music_next"
+            button = "next"
 
             [[block]]
             block = "time"
-            format = "%a %d.%m %R"
+            format = " $timestamp.datetime(f:'%a %d/%m %R') "
             interval = 60
 
             [[block]]
             block = "battery"
 
+            [icons]
+            icons = "awesome5"
+
             [theme]
-            name = "solarized-dark"
+            theme = "solarized-dark"
 
             [theme.overrides]
             idle_bg = "#123456"

--- a/tests/modules/programs/i3status-rust/with-extra-settings.nix
+++ b/tests/modules/programs/i3status-rust/with-extra-settings.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 {
   config = {
     programs.i3status-rust = {
@@ -109,7 +107,7 @@ with lib;
       };
     };
 
-    test.stubs.i3status-rust = { };
+    test.stubs.i3status-rust = { version = "0.30.0"; };
 
     nmt.script = ''
       assertFileExists home-files/.config/i3status-rust/config-extra-settings.toml

--- a/tests/modules/programs/i3status-rust/with-multiple-bars.nix
+++ b/tests/modules/programs/i3status-rust/with-multiple-bars.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 {
   config = {
     programs.i3status-rust = {
@@ -48,7 +46,7 @@ with lib;
 
     };
 
-    test.stubs.i3status-rust = { };
+    test.stubs.i3status-rust = { version = "0.30.0"; };
 
     nmt.script = ''
       assertFileExists home-files/.config/i3status-rust/config-top.toml

--- a/tests/modules/programs/i3status-rust/with-multiple-bars.nix
+++ b/tests/modules/programs/i3status-rust/with-multiple-bars.nix
@@ -13,19 +13,15 @@ with lib;
           blocks = [
             {
               block = "disk_space";
-              path = "/";
-              alias = "/";
               info_type = "available";
-              unit = "GB";
               interval = 60;
               warning = 20.0;
               alert = 10.0;
             }
             {
               block = "memory";
-              display_type = "memory";
-              format_mem = "{Mug}GB ({Mup}%)";
-              format_swap = "{SUp}%";
+              format_mem = " $icon $Mug ($Mup) ";
+              format_swap = " $icon $SUp ";
             }
           ];
         };
@@ -35,12 +31,12 @@ with lib;
             {
               block = "cpu";
               interval = 1;
-              format = "{barchart}";
+              format = " $icon $barchart ";
             }
             {
               block = "load";
               interval = 1;
-              format = "{1m} {5m}";
+              format = " $icon $1m $5m ";
             }
           ];
           icons = "awesome5";
@@ -59,23 +55,23 @@ with lib;
       assertFileContent home-files/.config/i3status-rust/config-top.toml \
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
-            icons = "none"
-            theme = "plain"
             [[block]]
             alert = 10.0
-            alias = "/"
             block = "disk_space"
             info_type = "available"
             interval = 60
-            path = "/"
-            unit = "GB"
             warning = 20.0
 
             [[block]]
             block = "memory"
-            display_type = "memory"
-            format_mem = "{Mug}GB ({Mup}%)"
-            format_swap = "{SUp}%"
+            format_mem = " $icon $Mug ($Mup) "
+            format_swap = " $icon $SUp "
+
+            [icons]
+            icons = "none"
+
+            [theme]
+            theme = "plain"
           ''
         }
 
@@ -84,17 +80,21 @@ with lib;
         home-files/.config/i3status-rust/config-bottom.toml \
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
-            icons = "awesome5"
-            theme = "gruvbox-dark"
             [[block]]
             block = "cpu"
-            format = "{barchart}"
+            format = " $icon $barchart "
             interval = 1
 
             [[block]]
             block = "load"
-            format = "{1m} {5m}"
+            format = " $icon $1m $5m "
             interval = 1
+
+            [icons]
+            icons = "awesome5"
+
+            [theme]
+            theme = "gruvbox-dark"
           ''
         }
     '';

--- a/tests/modules/programs/i3status-rust/with-version-02xx.nix
+++ b/tests/modules/programs/i3status-rust/with-version-02xx.nix
@@ -4,13 +4,15 @@
   config = {
     programs.i3status-rust = { enable = true; };
 
-    test.stubs.i3status-rust = { version = "0.30.0"; };
+    test.stubs.i3status-rust = { version = "0.29.9"; };
 
     nmt.script = ''
       assertFileExists home-files/.config/i3status-rust/config-default.toml
       assertFileContent home-files/.config/i3status-rust/config-default.toml \
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
+            icons = "none"
+            theme = "plain"
             [[block]]
             alert = 10.0
             block = "disk_space"
@@ -40,12 +42,6 @@
             block = "time"
             format = " $timestamp.datetime(f:'%a %d/%m %R') "
             interval = 60
-
-            [icons]
-            icons = "none"
-
-            [theme]
-            theme = "plain"
           ''
         }
     '';


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

0.30.0 is a major release that brings many breaking changes to the configuration file. See:
https://github.com/greshake/i3status-rust/blob/master/NEWS.md#i3status-rust-0300

The only one that actually affects the module though is the change in how the theme/icons are defined. Other changes are mostly on how to specify formatting/blocks, and since we just generate the TOML as-is, it needs changes in the user side.

So most changes in this commit are documentation updates, having up-to-date examples from things that changed, e.g.: the new `click` attribute that now can be applied to any block.

Fixes #3771.
Related nixpkgs PR: https://github.com/NixOS/nixpkgs/pull/217546

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible. *As long someone stays in `stateVersion = 22.05`*.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
