### PR TITLE
[backport 22.11] starship: condition nushell integration on nushell 0.73+

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -80,6 +80,14 @@ in {
   };
 
   config = mkIf cfg.enable {
+    assertions = [{
+      assertion = cfg.enableNushellIntegration
+        -> versionAtLeast config.programs.nushell.package.version "0.73";
+      message = ''
+        Nushell integration for starship requires nushell 0.73 or later.
+      '';
+    }];
+
     home.packages = [ cfg.package ];
 
     xdg.configFile."starship.toml" = mkIf (cfg.settings != { }) {


### PR DESCRIPTION
Backporting https://github.com/nix-community/home-manager/pull/3776

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
