### PR TITLE
zoxide: enable nushell integration

### DIFF
--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -6,6 +6,8 @@ let
 
   cfg = config.programs.zoxide;
 
+  cfgOptions = concatStringsSep " " cfg.options;
+
 in {
   meta.maintainers = [ maintainers.marsam ];
 
@@ -53,27 +55,42 @@ in {
         Whether to enable Fish integration.
       '';
     };
+
+    enableNushellIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Nushell integration.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      eval "$(${cfg.package}/bin/zoxide init bash ${
-        concatStringsSep " " cfg.options
-      })"
+      eval "$(${cfg.package}/bin/zoxide init bash ${cfgOptions})"
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      eval "$(${cfg.package}/bin/zoxide init zsh ${
-        concatStringsSep " " cfg.options
-      })"
+      eval "$(${cfg.package}/bin/zoxide init zsh ${cfgOptions})"
     '';
 
     programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
-      ${cfg.package}/bin/zoxide init fish ${
-        concatStringsSep " " cfg.options
-      } | source
+      ${cfg.package}/bin/zoxide init fish ${cfgOptions} | source
     '';
+
+    programs.nushell = mkIf cfg.enableNushellIntegration {
+      extraEnv = ''
+        let zoxide_cache = "${config.xdg.cacheHome}/zoxide"
+        if not ($zoxide_cache | path exists) {
+          mkdir $zoxide_cache
+        }
+        ${cfg.package}/bin/zoxide init nushell ${cfgOptions} | save --force ${config.xdg.cacheHome}/zoxide/init.nu
+      '';
+      extraConfig = ''
+        source ${config.xdg.cacheHome}/zoxide/init.nu
+      '';
+    };
   };
 }


### PR DESCRIPTION
### Description

Add zoxide nushell integration.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
