### PR TITLE
borgmatic: Optionally exclude home-manager symlinks from backup

### DIFF
--- a/modules/programs/borgmatic.nix
+++ b/modules/programs/borgmatic.nix
@@ -5,6 +5,8 @@ with lib;
 let
   cfg = config.programs.borgmatic;
 
+  yamlFormat = pkgs.formats.yaml { };
+
   mkNullableOption = args:
     lib.mkOption (args // {
       type = lib.types.nullOr args.type;
@@ -20,7 +22,7 @@ let
     };
 
   extraConfigOption = mkOption {
-    type = with types; attrsOf (oneOf [ str bool path int (listOf str) ]);
+    type = yamlFormat.type;
     default = { };
     description = "Extra settings.";
   };

--- a/tests/modules/programs/borgmatic/default.nix
+++ b/tests/modules/programs/borgmatic/default.nix
@@ -1,1 +1,7 @@
-{ borgmatic-program-basic-configuration = ./basic-configuration.nix; }
+{
+  borgmatic-program-basic-configuration = ./basic-configuration.nix;
+  borgmatic-program-include-hm-symlinks = ./include-hm-symlinks.nix;
+  borgmatic-program-exclude-hm-symlinks = ./exclude-hm-symlinks.nix;
+  borgmatic-program-exclude-hm-symlinks-nothing-else =
+    ./exclude-hm-symlinks-nothing-else.nix;
+}

--- a/tests/modules/programs/borgmatic/exclude-hm-symlinks-nothing-else.nix
+++ b/tests/modules/programs/borgmatic/exclude-hm-symlinks-nothing-else.nix
@@ -1,0 +1,40 @@
+{ config, pkgs, ... }:
+
+let
+  backups = config.programs.borgmatic.backups;
+  excludeFile = pkgs.writeText "excludeFile.txt" "/foo/bar";
+in {
+  config = {
+    programs.borgmatic = {
+      enable = true;
+      backups = {
+        main = {
+          location = {
+            sourceDirectories = [ "/my-stuff-to-backup" ];
+            repositories = [ "/mnt/disk1" ];
+            excludeHomeManagerSymlinks = true;
+          };
+        };
+      };
+    };
+
+    test.stubs.borgmatic = { };
+
+    nmt.script = ''
+      config_file=$TESTED/home-files/.config/borgmatic.d/main.yaml
+      assertFileExists $config_file
+
+      yq=${pkgs.yq-go}/bin/yq
+
+      hmExclusionsFile=$($yq '.location.exclude_from[0]' $config_file)
+      expected_content='/home/hm-user/.config/borgmatic.d/main.yaml'
+
+      grep --quiet "$expected_content" "$hmExclusionsFile"
+
+      if [[ $? -ne 0 ]]; then
+        echo "Expected to find $expected_content in file $hmExclusionsFile but didn't" >&2
+        exit 1
+      fi
+    '';
+  };
+}

--- a/tests/modules/programs/borgmatic/exclude-hm-symlinks.nix
+++ b/tests/modules/programs/borgmatic/exclude-hm-symlinks.nix
@@ -1,0 +1,54 @@
+{ config, pkgs, ... }:
+
+let
+  backups = config.programs.borgmatic.backups;
+  excludeFile = pkgs.writeText "excludeFile.txt" "/foo/bar";
+in {
+  config = {
+    programs.borgmatic = {
+      enable = true;
+      backups = {
+        main = {
+          location = {
+            sourceDirectories = [ "/my-stuff-to-backup" ];
+            repositories = [ "/mnt/disk1" ];
+            excludeHomeManagerSymlinks = true;
+            extraConfig = { exclude_from = [ (toString excludeFile) ]; };
+          };
+        };
+      };
+    };
+
+    test.stubs.borgmatic = { };
+
+    nmt.script = ''
+      config_file=$TESTED/home-files/.config/borgmatic.d/main.yaml
+      assertFileExists $config_file
+
+      declare -A expectations
+
+      expectations[location.exclude_from[0]]="${excludeFile}"
+
+      yq=${pkgs.yq-go}/bin/yq
+
+      for filter in "''${!expectations[@]}"; do
+        expected_value="''${expectations[$filter]}"
+        actual_value="$($yq ".$filter" $config_file)"
+
+        if [[ "$actual_value" != "$expected_value" ]]; then
+          fail "Expected '$filter' to be '$expected_value' but was '$actual_value'"
+        fi
+      done
+
+      hmExclusionsFile=$($yq '.location.exclude_from[1]' $config_file)
+      expected_content='/home/hm-user/.config/borgmatic.d/main.yaml'
+
+      grep --quiet "$expected_content" "$hmExclusionsFile"
+
+      if [[ $? -ne 0 ]]; then
+        echo "Expected to find $expected_content in file $hmExclusionsFile but didn't" >&2
+        exit 1
+      fi
+    '';
+  };
+}

--- a/tests/modules/programs/borgmatic/include-hm-symlinks.nix
+++ b/tests/modules/programs/borgmatic/include-hm-symlinks.nix
@@ -1,0 +1,45 @@
+{ config, pkgs, ... }:
+
+let
+  backups = config.programs.borgmatic.backups;
+  excludeFile = pkgs.writeText "excludeFile.txt" "/foo/bar";
+in {
+  config = {
+    programs.borgmatic = {
+      enable = true;
+      backups = {
+        main = {
+          location = {
+            sourceDirectories = [ "/my-stuff-to-backup" ];
+            repositories = [ "/mnt/disk1" ];
+            excludeHomeManagerSymlinks = false;
+            extraConfig = { exclude_from = [ (toString excludeFile) ]; };
+          };
+        };
+      };
+    };
+
+    test.stubs.borgmatic = { };
+
+    nmt.script = ''
+      config_file=$TESTED/home-files/.config/borgmatic.d/main.yaml
+      assertFileExists $config_file
+
+      declare -A expectations
+
+      expectations[location.exclude_from[0]]="${excludeFile}"
+
+      yq=${pkgs.yq-go}/bin/yq
+
+      for filter in "''${!expectations[@]}"; do
+        expected_value="''${expectations[$filter]}"
+        actual_value="$($yq ".$filter" $config_file)"
+
+        if [[ "$actual_value" != "$expected_value" ]]; then
+          fail "Expected '$filter' to be '$expected_value' but was '$actual_value'"
+        fi
+      done
+
+    '';
+  };
+}


### PR DESCRIPTION
-------

### Description

Make it easy to generate a borgmatic's exclusion list containing all
symlinks generated by home manager.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.