### PR TITLE
exa: removed stale comment

### DIFF
--- a/modules/programs/exa.nix
+++ b/modules/programs/exa.nix
@@ -46,8 +46,6 @@ with lib;
       ++ optional cfg.git "--git" ++ cfg.extraOptions);
 
     aliases = {
-      # Use `command` instead of hardcoding the path to exa so that aliases don't
-      # go stale after a system update.
       exa = "exa ${args}";
     } // optionalAttrs cfg.enableAliases {
       ls = "exa";


### PR DESCRIPTION
### Description

Removed a stale comment in the  exa module.

Looks like the comment about using command wasn't updated as part of [this accepted suggestion](https://github.com/nix-community/home-manager/pull/3505#pullrequestreview-1317412306) (you'll have to click "Show resolved" in the github UI to see the suggestion).

This line

```
exa = "command ${cmd}";
```

was changed to

```
exa = "exa ${exaArgs}";
```

so the comment doesn't make sense anymore.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
