### PR TITLE
home-manager: avoid stray error message

### DIFF
--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -42,7 +42,7 @@ function setupVars() {
     # In the future we may perform a one-shot migration to the new location.
     #
     # shellcheck disable=2174
-    if [[ -d "$globalProfilesDir" ]] || mkdir -m 0755 -p "$globalProfilesDir"; then
+    if [[ -d "$globalProfilesDir" ]] || mkdir -m 0755 -p "$globalProfilesDir" 2>/dev/null; then
         declare -r hmProfilesDir="$globalProfilesDir"
     else
         declare -r hmProfilesDir="$hmStateDir/profiles"


### PR DESCRIPTION
### Description

Failure to create the global profiles directory is not actually an error since we can recover. Therefore, avoid printing the mkdir error message.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```