### PR TITLE
nushell: adds login.nu configuration option

### DIFF
--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -96,6 +96,23 @@ in {
       '';
     };
 
+    loginFile = mkOption {
+      type = types.nullOr (linesOrSource "login.nu");
+      default = null;
+      example = ''
+        # Prints "Hello, World" upon logging into tty1
+        if (tty) == "/dev/tty1" {
+          echo "Hello, World"
+        }
+      '';
+      description = ''
+        The login file to be used for nushell upon logging in.
+        </para>
+        <para>
+        See <link xlink:href="https://www.nushell.sh/book/configuration.html#configuring-nu-as-a-login-shell" /> for more information.
+      '';
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";
@@ -109,6 +126,14 @@ in {
       default = "";
       description = ''
         Additional configuration to add to the nushell environment variables file.
+      '';
+    };
+
+    extraLogin = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Additional configuration to add to the nushell login file.
       '';
     };
 
@@ -159,6 +184,12 @@ in {
           (mkIf (cfg.envFile != null) cfg.envFile.text)
           cfg.extraEnv
           envVarsStr
+        ];
+      })
+      (mkIf (cfg.loginFile != null || cfg.extraLogin != "") {
+        "${configDir}/login.nu".text = mkMerge [
+          (mkIf (cfg.loginFile != null) cfg.loginFile.text)
+          cfg.extraLogin
         ];
       })
     ];

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -16,6 +16,13 @@
       let-env FOO = 'BAR'
     '';
 
+    loginFile.text = ''
+      # Prints "Hello, World" upon logging into tty1
+      if (tty) == "/dev/tty1" {
+        echo "Hello, World"
+      }
+    '';
+
     shellAliases = {
       "lsname" = "(ls | get name)";
       "ll" = "ls -a";
@@ -38,5 +45,8 @@
     assertFileContent \
       "${configDir}/env.nu" \
       ${./env-expected.nu}
+    assertFileContent \
+      "${configDir}/login.nu" \
+      ${./login-expected.nu}
   '';
 }

--- a/tests/modules/programs/nushell/login-expected.nu
+++ b/tests/modules/programs/nushell/login-expected.nu
@@ -1,0 +1,5 @@
+# Prints "Hello, World" upon logging into tty1
+if (tty) == "/dev/tty1" {
+  echo "Hello, World"
+}
+


### PR DESCRIPTION
### Description
Nushell has the option to source from the login.nu file upon logging in, in the case that nushell is used as a login shell.
See https://www.nushell.sh/book/configuration.html#configuring-nu-as-a-login-shell for more information.

This change adds the login file alongside the existing config and env files as another configuration option.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.
       (tested with `nix develop --ignore-environment .#tests.nushell-example-settings`)

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.