### PR TITLE
zathura: add documentation for mode-specific mappings

### DIFF
--- a/modules/programs/zathura.nix
+++ b/modules/programs/zathura.nix
@@ -58,10 +58,14 @@ in {
           <manvolnum>5</manvolnum>
         </citerefentry>
         for the full list of possible mappings.
+
+        You can create a mode-specific mapping by specifying the mode before the key:
+        <literal>"[normal] &lt;C-b&gt;" = "scroll left";</literal>
       '';
       example = {
         D = "toggle_page_mode";
         "<Right>" = "navigate next";
+        "[fullscreen] <C-i>" = "zoom in";
       };
     };
 


### PR DESCRIPTION
### Description

As [this comment](https://github.com/nix-community/home-manager/pull/3134#issuecomment-1475944069) points out, the current zathura module does not support mode-specific mappings.
This PR allows the user to provide for a mapping an attrs that contains both the action and the mode.
Of course, the user can still provide a simple string which ensures backward compatibility.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
