### PR TITLE
programs/alot: make Sent and Drafts folder optional

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -321,7 +321,7 @@ let
             };
 
             drafts = mkOption {
-              type = types.str;
+              type = types.nullOr types.str;
               default = "Drafts";
               description = ''
                 Relative path of the drafts mail folder.

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -68,7 +68,9 @@ let
         realname = realName;
         sendmail_command =
           optionalString (alot.sendMailCommand != null) alot.sendMailCommand;
+      } // optionalAttrs (folders.sent != null) {
         sent_box = "maildir" + "://" + maildir.absPath + "/" + folders.sent;
+      } // optionalAttrs (folders.drafts != null) {
         draft_box = "maildir" + "://" + maildir.absPath + "/" + folders.drafts;
       } // optionalAttrs (aliases != [ ]) {
         aliases = concatStringsSep "," aliases;


### PR DESCRIPTION
Some of the email providers (like GMail and Fastmail) save Sent messages
automatically, so make the folders optional in the configuration.

Make Drafts folder optional as well, to allow it to be configured
manually in the extraConf with location outside of the maildir.
