### PR TITLE
launchd: update option definition

### DIFF
--- a/modules/launchd/launchd.nix
+++ b/modules/launchd/launchd.nix
@@ -28,6 +28,8 @@
 with lib;
 
 {
+  freeformType = with types; attrsOf anything; # added by Home Manager
+
   options = {
     Label = mkOption {
       type = types.str;

--- a/tests/modules/launchd/agents.nix
+++ b/tests/modules/launchd/agents.nix
@@ -13,6 +13,7 @@ with lib;
           SuccessfulExit = false;
         };
         ProcessType = "Background";
+        UnrecognizedByHomeManager = "should make it to the resulting plist";
       };
     };
 

--- a/tests/modules/launchd/expected-agent.plist
+++ b/tests/modules/launchd/expected-agent.plist
@@ -19,5 +19,7 @@
 		<string>--with-arguments</string>
 		<string>foo</string>
 	</array>
+	<key>UnrecognizedByHomeManager</key>
+	<string>should make it to the resulting plist</string>
 </dict>
 </plist>


### PR DESCRIPTION
### Description

This includes 2 changes:

1. Make Launch Agents config a freeform setting so that Home Manager can process options that aren't listed in the option definition
2. Sync the option definition for Launch Agents with nix-darwin

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
