### PR TITLE
home-manager: set the correct NIX_PATH when running from flakes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,7 @@
         pkgs = nixpkgs.legacyPackages.${system};
         docs = import ./docs { inherit pkgs; };
         tests = import ./tests { inherit pkgs; };
-        hmPkg = pkgs.callPackage ./home-manager { };
+        hmPkg = pkgs.callPackage ./home-manager { path = ./.; };
       in {
         devShells.tests = tests.run;
         packages = {


### PR DESCRIPTION
### Description

`nix run home-manager` failed to work properly because it attempts to find the Home Manager source from `NIX_PATH`. The problem is, Home Manager wouldn't be in `NIX_PATH` in most cases if flakes are being used.

Before:

```console
❯ nix run home-manager -- -f home.nix news | head
error: file 'home-manager/home-manager/home-manager.nix' was not found in the Nix search path (add it using $NIX_PATH or -I)
/nix/store/pxmr8qxkhlc5r9ny9iz4i14saih39l4p-home-manager/bin/home-manager: line 712: /tmp/home-manager-build.fS7mCjQ1Tw/news-info.sh: No such file or directory
```

After:

```console
❯ nix run '.#' -- -f home.nix news | head
* 2023-01-31 22:08:41 [read]

  A new module is available: 'programs.rbenv'.



* 2023-01-30 10:39:11 [read]

  A new module is available: 'programs.wlogout'.

```

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
