### PR TITLE
draft: tmux: add configBeforePlugin option

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -100,7 +100,7 @@ let
     set  -s escape-time       ${toString cfg.escapeTime}
     set  -g history-limit     ${toString cfg.historyLimit}
 
-    ${optionalString ((builtins.stringLength cfg.configBeforePlugin) > 0) ''
+    ${optionalString (cfg.configBeforePlugin != "") ''
     # ============================================= #
     # Extra configs before plugins                  #
     # --------------------------------------------- #

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -159,7 +159,7 @@ in {
           Additional configuration in <filename>tmux.conf</filename>
           before plugins run-shell session. This is useful to configure
           status-right or status-left that uses variables exposed by plugins.
-        ''
+        '';
       };
 
       clock24 = mkOption {

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -100,11 +100,11 @@ let
     set  -s escape-time       ${toString cfg.escapeTime}
     set  -g history-limit     ${toString cfg.historyLimit}
 
-    ${optionalString (cfg.configBeforePlugin != "") ''
+    ${optionalString (cfg.extraConfigBeforePlugin != "") ''
     # ============================================= #
     # Extra configs before plugins                  #
     # --------------------------------------------- #
-    ${cfg.configBeforePlugin}
+    ${cfg.extraConfigBeforePlugin}
     ''}
   '';
 
@@ -154,7 +154,7 @@ in {
         description = "Base index for windows and panes.";
       };
 
-      configBeforePlugin = mkOption { 
+      extraConfigBeforePlugin = mkOption { 
         type = types.lines; 
         default = "";
         description = ''

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -101,10 +101,10 @@ let
     set  -g history-limit     ${toString cfg.historyLimit}
 
     ${optionalString (cfg.extraConfigBeforePlugin != "") ''
-    # ============================================= #
-    # Extra configs before plugins                  #
-    # --------------------------------------------- #
-    ${cfg.extraConfigBeforePlugin}
+      # ============================================= #
+      # Extra configs before plugins                  #
+      # --------------------------------------------- #
+      ${cfg.extraConfigBeforePlugin}
     ''}
   '';
 
@@ -154,8 +154,8 @@ in {
         description = "Base index for windows and panes.";
       };
 
-      extraConfigBeforePlugin = mkOption { 
-        type = types.lines; 
+      extraConfigBeforePlugin = mkOption {
+        type = types.lines;
         default = "";
         description = ''
           Additional configuration in <filename>tmux.conf</filename>

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -99,6 +99,11 @@ let
     setw -g clock-mode-style  ${if cfg.clock24 then "24" else "12"}
     set  -s escape-time       ${toString cfg.escapeTime}
     set  -g history-limit     ${toString cfg.historyLimit}
+
+    # ============================================= #
+    # Extra configs before plugins                  #
+    # --------------------------------------------- #
+    ${cfg.configBeforePlugin}
   '';
 
   configPlugins = {
@@ -145,6 +150,16 @@ in {
         example = 1;
         type = types.ints.unsigned;
         description = "Base index for windows and panes.";
+      };
+
+      configBeforePlugin = mkOption { 
+        type = types.lines; 
+        default = "";
+        description = ''
+          Additional configuration in <filename>tmux.conf</filename>
+          before plugins run-shell session. This is useful to configure
+          status-right or status-left that uses variables exposed by plugins.
+        ''
       };
 
       clock24 = mkOption {

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -100,10 +100,12 @@ let
     set  -s escape-time       ${toString cfg.escapeTime}
     set  -g history-limit     ${toString cfg.historyLimit}
 
+    ${optionalString ((builtins.stringLength cfg.configBeforePlugin) > 0) ''
     # ============================================= #
     # Extra configs before plugins                  #
     # --------------------------------------------- #
     ${cfg.configBeforePlugin}
+    ''}
   '';
 
   configPlugins = {


### PR DESCRIPTION
### Description

- Adds `programs.tmux.configBeforePlugin` option. 
- This complements `programs.tmux.extraConfig`, but should allow `tmux` config for `status-right` and `status-left` to take in variables exposed by plugins
- Requested by https://github.com/nix-community/home-manager/issues/3555

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.
  - Unrelated tests failing: https://github.com/nix-community/home-manager/issues/3803

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
