### PR TITLE
docs: bump nmd

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -7,8 +7,8 @@ let
 
   nmdSrc = fetchTarball {
     url =
-      "https://git.sr.ht/~rycee/nmd/archive/590dd725f3b06fb3888311efaab7312e03f605d1.tar.gz";
-    sha256 = "0hzg802rnxpfiwwvk12kxhqxnfhg3snin6h7lrq5yk626hj6n6jj";
+      "https://git.sr.ht/~rycee/nmd/archive/f5a18594255866342ace46827c390c36875337e5.tar.gz";
+    sha256 = "0qvs72zd9rkj47a55fjin00f9lazhz4ivr0bkviykcydvy9ihdpq";
   };
 
   nmd = import nmdSrc { inherit lib pkgs; };


### PR DESCRIPTION
### Description

Fix build with older Nix.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```