### PR TITLE
gpg: fix URL of key in test case

### DIFF
--- a/tests/modules/programs/gpg/immutable-keyfiles.nix
+++ b/tests/modules/programs/gpg/immutable-keyfiles.nix
@@ -11,8 +11,8 @@
       {
         source = pkgs.fetchurl {
           url =
-            "https://keybase.io/rycee/pgp_keys.asc?fingerprint=36cacf52d098cc0e78fb0cb13573356c25c424d4";
-          hash = "sha256-5z2kTUXQp0f7kyP0Id6NS3rCdzGGrrkIYzGK42Qy9Sw=";
+            "https://keys.openpgp.org/pks/lookup?op=get&options=mr&search=0x36cacf52d098cc0e78fb0cb13573356c25c424d4";
+          hash = "sha256-9Zjsb/TtOyiPzMO/Jg3CtJwSxuw7QmX0pcfZT2/1w5E=";
         };
         trust = 1; # "unknown"
       }


### PR DESCRIPTION
### Description

Fixes #3803

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```