### PR TITLE
fish: support flexible abbreviations

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -138,9 +138,76 @@ let
     };
   };
 
-  abbrsStr = concatStringsSep "\n"
-    (mapAttrsToList (k: v: "abbr --add --global -- ${k} ${escapeShellArg v}")
-      cfg.shellAbbrs);
+  abbrModule = types.submodule {
+    options = {
+      expansion = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          The command expanded by an abbreviation.
+        '';
+      };
+
+      position = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        example = "anywhere";
+        description = ''
+          If the position is "command", the abbreviation expands only if
+          the position is a command. If it is "anywhere", the abbreviation
+          expands anywhere.
+        '';
+      };
+
+      regex = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          The regular expression pattern matched instead of the literal name.
+        '';
+      };
+
+      setCursor = mkOption {
+        type = with types; (either bool str);
+        default = false;
+        description = ''
+          The marker indicates the position of the cursor when the abbreviation
+          is expanded. When setCursor is true, the marker is set with a default
+          value of "%".
+        '';
+      };
+
+      function = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          The fish function expanded instead of a literal string.
+        '';
+      };
+    };
+  };
+
+  abbrsStr = concatStringsSep "\n" (mapAttrsToList (name: def:
+    let
+      mods = with def;
+        cli.toGNUCommandLineShell {
+          mkOption = k: v:
+            if v == null then
+              [ ]
+            else if k == "set-cursor" then
+              [ "--${k}=${lib.generators.mkValueStringDefault { } v}" ]
+            else [
+              "--${k}"
+              (lib.generators.mkValueStringDefault { } v)
+            ];
+        } {
+          inherit position regex function;
+          set-cursor = setCursor;
+        };
+      modifiers = if isAttrs def then mods else "";
+      expansion = if isAttrs def then def.expansion else def;
+    in "abbr --add ${modifiers} -- ${name}"
+    + optionalString (expansion != null) " \"${expansion}\"") cfg.shellAbbrs);
 
   aliasesStr = concatStringsSep "\n"
     (mapAttrsToList (k: v: "alias ${k} ${escapeShellArg v}") cfg.shellAliases);
@@ -192,12 +259,18 @@ in {
       };
 
       shellAbbrs = mkOption {
-        type = with types; attrsOf str;
+        type = with types; attrsOf (either str abbrModule);
         default = { };
-        example = {
-          l = "less";
-          gco = "git checkout";
-        };
+        example = literalExpression ''
+          {
+            l = "less";
+            gco = "git checkout";
+            "-C" = {
+              position = "anywhere";
+              expansion = "--color";
+            };
+          }
+        '';
         description = ''
           An attribute set that maps aliases (the top level attribute names
           in this option) to abbreviations. Abbreviations are expanded with

--- a/tests/modules/programs/fish/abbrs.nix
+++ b/tests/modules/programs/fish/abbrs.nix
@@ -1,0 +1,62 @@
+{ config, ... }: {
+  config = {
+    programs.fish = {
+      enable = true;
+
+      shellAbbrs = {
+        l = "less";
+        gco = "git checkout";
+        "-C" = {
+          position = "anywhere";
+          expansion = "--color";
+        };
+        L = {
+          position = "anywhere";
+          setCursor = true;
+          expansion = "% | less";
+        };
+        "!!" = {
+          position = "anywhere";
+          function = "last_history_item";
+        };
+        vim_edit_texts = {
+          position = "command";
+          regex = ".+\\.txt";
+          function = "vim_edit";
+        };
+        "4DIRS" = {
+          setCursor = "!";
+          expansion =
+            "$(string join \\n -- 'for dir in */' 'cd $dir' '!' 'cd ..' 'end')";
+        };
+        dotdot = {
+          regex = "^\\.\\.+$";
+          function = "multicd";
+        };
+      };
+    };
+
+    nmt = {
+      description =
+        "if fish.shellAbbrs is set, check fish.config contains valid abbreviations";
+      script = ''
+        assertFileContains home-files/.config/fish/config.fish \
+          'abbr --add -- l less'
+        assertFileContains home-files/.config/fish/config.fish \
+          'abbr --add -- gco "git checkout"'
+        assertFileContains home-files/.config/fish/config.fish \
+          'abbr --add --position anywhere -- -C --color'
+        assertFileContains home-files/.config/fish/config.fish \
+          'abbr --add --position anywhere --set-cursor -- L "% | less"'
+        assertFileContains home-files/.config/fish/config.fish \
+          'abbr --add --function last_history_item --position anywhere -- !!'
+        assertFileContains home-files/.config/fish/config.fish \
+          "abbr --add --function vim_edit --position command --regex '.+\.txt' -- vim_edit_texts"
+        assertFileContains home-files/.config/fish/config.fish \
+          'abbr --add '"'"'--set-cursor=!'"'"' -- 4DIRS "$(string join \n -- '"'"'for dir in */'"'"' '"'"'cd $dir'"'"' '"'"'!'"'"' '"'"'cd ..'"'"' '"'"'end'"'"')'
+        assertFileContains home-files/.config/fish/config.fish \
+          "abbr --add --function multicd --regex '^\.\.+$' -- dotdot"
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -1,4 +1,5 @@
 {
+  fish-abbrs = ./abbrs.nix;
   fish-format-scripts = ./format-scripts.nix;
   fish-functions = ./functions.nix;
   fish-no-functions = ./no-functions.nix;


### PR DESCRIPTION
### Description

resolves #3706 
https://github.com/fish-shell/fish-shell/releases/tag/3.6.0

I added abbrModule with referring to the functionModule implementation. 
abbrModule follows the "add" subcommand. (https://fishshell.com/docs/current/cmds/abbr.html)

The backward compatibility is preserved by setting the type of fish.shellAbbrs to attrsOf (either str abbrModule). I have confirmed this in the tests added this time.
Also, the --global option is no longer needed. I have removed it from the abbrsStr configuration.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
