### PR TITLE
home-manager: error out when showing news in flake

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -687,6 +687,12 @@ function newsReadIdsFile() {
 # put the output in the work directory to avoid the risk of an
 # unfortunately timed GC removing it.
 function buildNews() {
+    setFlakeAttribute
+    if [[ -v FLAKE_CONFIG_URI ]]; then
+        _iError "Sorry, this command is not yet supported in flake setup" >&2
+        exit 1
+    fi
+
     local output
     output="$WORK_DIR/news-info.sh"
 


### PR DESCRIPTION
### Description

Showing news is not yet supported in flake setups.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```