### PR TITLE
thunderbird: add userChrome and userContent options

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -157,6 +157,28 @@ in {
                 example = true;
                 description = "Allow using external GPG keys with GPGME.";
               };
+
+              userChrome = mkOption {
+                type = types.lines;
+                default = "";
+                description = "Custom Thunderbird user chrome CSS.";
+                example = ''
+                  /* Hide tab bar in Thunderbird */
+                  #tabs-toolbar {
+                    visibility: collapse !important;
+                  }
+                '';
+              };
+
+              userContent = mkOption {
+                type = types.lines;
+                default = "";
+                description = "Custom Thunderbird user content CSS.";
+                example = ''
+                  /* Hide scrollbar on Thunderbird pages */
+                  *{scrollbar-width:none !important}
+                '';
+              };
             };
           }));
       };
@@ -276,6 +298,12 @@ in {
       "${thunderbirdConfigPath}/profiles.ini" =
         mkIf (cfg.profiles != { }) { text = generators.toINI { } profilesIni; };
     }] ++ flip mapAttrsToList cfg.profiles (name: profile: {
+      "${thunderbirdProfilesPath}/${name}/chrome/userChrome.css" =
+        mkIf (profile.userChrome != "") { text = profile.userChrome; };
+
+      "${thunderbirdProfilesPath}/${name}/chrome/userContent.css" =
+        mkIf (profile.userContent != "") { text = profile.userContent; };
+
       "${thunderbirdProfilesPath}/${name}/user.js" = let
         accounts = filter (a:
           a.thunderbird.profiles == [ ]

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -35,6 +35,12 @@
       first = {
         isDefault = true;
         withExternalGnupg = true;
+        userChrome = ''
+          * { color: blue !important; }
+        '';
+        userContent = ''
+          * { color: red !important; }
+        '';
       };
 
       second.settings = { "second.setting" = "some-test-setting"; };
@@ -60,5 +66,13 @@
     assertFileExists home-files/.thunderbird/second/user.js
     assertFileContent home-files/.thunderbird/second/user.js \
       ${./thunderbird-expected-second.js}
+
+    assertFileExists home-files/.thunderbird/first/chrome/userChrome.css
+    assertFileContent home-files/.thunderbird/first/chrome/userChrome.css \
+      <(echo "* { color: blue !important; }")
+
+    assertFileExists home-files/.thunderbird/first/chrome/userContent.css
+    assertFileContent home-files/.thunderbird/first/chrome/userContent.css \
+      <(echo "* { color: red !important; }")
   '';
 }


### PR DESCRIPTION
Adds options to the Thunderbird module for specifying userChrome and userContent CSS styling

### Description

Thunderbird allows creating files `chrome/userChrome.css` and `chrome/userContent.css` to style its UI. This adds an option for each of them, just like the Firefox module.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

Firefox's userChrome/userContent options didn't have any tests, but I added some basic ones anyway

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
