### PR TITLE
feat(fish): theme support

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -416,8 +416,17 @@ in {
     # in the paths and any initialization scripts.
     (mkIf (length cfg.plugins > 0) {
       xdg.configFile = mkMerge ((map (plugin: {
-        "fish/conf.d/plugin-${plugin.name}.fish".source =
-          fishIndent "${plugin.name}.fish" ''
+        "fish/conf.d/plugin-${plugin.name}.fish" = {
+          onChange = fishIndent ''
+            if test -d $plugin_dir/themes
+              # https://github.com/fish-shell/fish-shell/issues/9456
+              mkdir -p $__fish_config_dir/themes
+              for f in $plugin_dir/themes/*.theme
+                ln -sf $f $__fish_config_dir/themes/(basename $f)
+              end
+            end
+          '';
+          source = fishIndent "${plugin.name}.fish" ''
             # Plugin ${plugin.name}
             set -l plugin_dir ${plugin.src}
 
@@ -445,6 +454,7 @@ in {
               source $plugin_dir/init.fish
             end
           '';
+        };
       }) cfg.plugins));
     })
   ]);


### PR DESCRIPTION
### Description

Adds very rudimentary support for themes in fish.

Right now it is linking on every shell, which is not ideal... I'm new to nix, is there a way to do the linking just when "installing" the plugin? Once I figure that out (or if someone help me :)) I'll fix the remaining checklist items. :) 

refs #3724
refs https://github.com/fish-shell/fish-shell/issues/9456


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
