### PR TITLE
Darcs: new module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1143,6 +1143,13 @@ in
           A new module is available: 'services.ssh-agent'
         '';
       }
+
+      {
+        time = "2023-07-08T08:27:41+00:00";
+        message = ''
+          A new modules is available: 'programs.darcs'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -70,6 +70,7 @@ let
     ./programs/chromium.nix
     ./programs/command-not-found/command-not-found.nix
     ./programs/comodoro.nix
+    ./programs/darcs.nix
     ./programs/dircolors.nix
     ./programs/direnv.nix
     ./programs/discocss.nix

--- a/modules/programs/darcs.nix
+++ b/modules/programs/darcs.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.darcs;
+
+in {
+  meta.maintainers = with maintainers; [ chris-martin ];
+
+  options = {
+    programs.darcs = {
+      enable = mkEnableOption "darcs";
+
+      package = mkPackageOption pkgs "darcs" { };
+
+      author = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "Fred Bloggs <fred@example.net>" ];
+        description = ''
+          If this list has a single entry, it will be used as the author
+          when you record a patch. If there are multiple entries, Darcs
+          will prompt you to choose one of them.
+        '';
+      };
+
+      boring = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "^.idea$" ".iml$" "^.stack-work$" ];
+        description = "File patterns to ignore";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    { home.packages = [ cfg.package ]; }
+
+    (mkIf (cfg.author != [ ]) {
+      home.file.".darcs/author".text =
+        concatMapStrings (x: x + "\n") cfg.author;
+    })
+
+    (mkIf (cfg.boring != [ ]) {
+      home.file.".darcs/boring".text =
+        concatMapStrings (x: x + "\n") cfg.boring;
+    })
+
+  ]);
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -68,6 +68,7 @@ import nmt {
     ./modules/programs/browserpass
     ./modules/programs/btop
     ./modules/programs/comodoro
+    ./modules/programs/darcs
     ./modules/programs/dircolors
     ./modules/programs/direnv
     ./modules/programs/emacs

--- a/tests/modules/programs/darcs/author-expected.txt
+++ b/tests/modules/programs/darcs/author-expected.txt
@@ -1,0 +1,2 @@
+Real Person <personal@example.com>
+Real Person <corporate@example.com>

--- a/tests/modules/programs/darcs/author.nix
+++ b/tests/modules/programs/darcs/author.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    programs.darcs = {
+      enable = true;
+      author = [
+        "Real Person <personal@example.com>"
+        "Real Person <corporate@example.com>"
+      ];
+    };
+
+    nmt.script = ''
+      assertFileContent home-files/.darcs/author ${./author-expected.txt}
+    '';
+  };
+}

--- a/tests/modules/programs/darcs/boring-expected.txt
+++ b/tests/modules/programs/darcs/boring-expected.txt
@@ -1,0 +1,3 @@
+^.idea$
+.iml$
+^.stack-work$

--- a/tests/modules/programs/darcs/boring.nix
+++ b/tests/modules/programs/darcs/boring.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    programs.darcs = {
+      enable = true;
+      boring = [ "^.idea$" ".iml$" "^.stack-work$" ];
+    };
+
+    nmt.script = ''
+      assertFileContent home-files/.darcs/boring ${./boring-expected.txt}
+    '';
+  };
+}

--- a/tests/modules/programs/darcs/default.nix
+++ b/tests/modules/programs/darcs/default.nix
@@ -1,0 +1,4 @@
+{
+  darcs-author = ./author.nix;
+  darcs-boring = ./boring.nix;
+}


### PR DESCRIPTION
### Description

This adds a pretty simple module for the [Darcs](http://darcs.net) package manager, with support for two commonly-used configuration options: "author" (commiter name/email) and "boring" (akin to `.gitignore`).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
