### PR TITLE
nixpkgs: fix semicolon and list layout in docs

### DIFF
--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -79,14 +79,15 @@ in {
     overlays = mkOption {
       default = null;
       example = literalExpression ''
-        [ (self: super: {
-            openssh = super.openssh.override {
+        [
+          (final: prev: {
+            openssh = prev.openssh.override {
               hpnSupport = true;
               withKerberos = true;
-              kerberos = self.libkrb5;
+              kerberos = final.libkrb5;
             };
-          };
-        ) ]
+          })
+        ]
       '';
       type = types.nullOr (types.listOf overlayType);
       description = ''


### PR DESCRIPTION
### Description

tried to copy paste the example overlay from the docs, there seems to be an additional `;`. Also adapted function parameters to reflect new guidelines and layout to be more "list" like

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
