### PR TITLE
dconf: disable on darwin

### DIFF
--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -25,7 +25,13 @@ in {
     dconf = {
       enable = mkOption {
         type = types.bool;
-        default = true;
+        # While technically dconf on darwin could work, our activation step
+        # requires dbus, which only *lightly* supports Darwin in general, and
+        # not at all in the way it's packaged in nixpkgs. Because of this, we
+        # just disable dconf for darwin hosts by default.
+        # In the future, if someone gets dbus working, this _could_ be
+        # re-enabled, unclear whether there's actual value in it though.
+        default = !pkgs.stdenv.hostPlatform.isDarwin;
         visible = false;
         description = ''
           Whether to enable dconf settings.


### PR DESCRIPTION
### Description

This disables the dconf module on darwin, since it always fails to activate as
dbus is unavailable there.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
