### PR TITLE
docs: bump nmd

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -7,8 +7,8 @@ let
 
   nmdSrc = fetchTarball {
     url =
-      "https://git.sr.ht/~rycee/nmd/archive/f5a18594255866342ace46827c390c36875337e5.tar.gz";
-    sha256 = "0qvs72zd9rkj47a55fjin00f9lazhz4ivr0bkviykcydvy9ihdpq";
+      "https://git.sr.ht/~rycee/nmd/archive/abb15317ebd17e5a0a7dd105e2ce52f2700185a8.tar.gz";
+    sha256 = "0zzrbjxf15hada279irif7s3sb8vs95jn4y4f8694as0j739gd1m";
   };
 
   nmd = import nmdSrc { inherit lib pkgs; };


### PR DESCRIPTION
### Description

Makes code callouts unselectable.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```