### PR TITLE
copyq: Add QT_QPA_PLATFORM=xcb to service environment (#3530)

### DIFF
--- a/modules/services/copyq.nix
+++ b/modules/services/copyq.nix
@@ -46,6 +46,7 @@ in {
       Service = {
         ExecStart = "${cfg.package}/bin/copyq";
         Restart = "on-failure";
+        Environment = [ "QT_QPA_PLATFORM=xcb" ];
       };
 
       Install = { WantedBy = [ cfg.systemdTarget ]; };


### PR DESCRIPTION
-------

### Description

Fixes #3530.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.