### PR TITLE
xdg-desktop-entries: make `exec` default to null

### DIFF
--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -34,6 +34,7 @@ let
       exec = mkOption {
         description = "Program to execute, possibly with arguments.";
         type = types.nullOr types.str;
+        default = null;
       };
 
       icon = mkOption {
@@ -131,6 +132,7 @@ let
           options.exec = mkOption {
             type = types.nullOr types.str;
             description = "Program to execute, possibly with arguments.";
+            default = null;
           };
           options.icon = mkOption {
             type = with types; nullOr (either str path);
@@ -161,10 +163,6 @@ let
       };
     };
   };
-
-  #formatting helpers
-  semicolonList = list:
-    (concatStringsSep ";" list) + ";"; # requires trailing semicolon
 
   #passes config options to makeDesktopItem in expected format
   makeFile = name: config:

--- a/tests/modules/misc/xdg/desktop-entries.nix
+++ b/tests/modules/misc/xdg/desktop-entries.nix
@@ -32,7 +32,6 @@ with lib;
         };
       };
       min = { # minimal definition
-        exec = "test --option";
         name = "Test";
       };
       deprecated = {

--- a/tests/modules/misc/xdg/desktop-min-expected.desktop
+++ b/tests/modules/misc/xdg/desktop-min-expected.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Exec=test --option
 Name=Test
 Terminal=false
 Type=Application


### PR DESCRIPTION
The [specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) does not require those keys to be set, and the type reflects that, so they should default to null.

Remove a dead binding.

Fixes https://github.com/nix-community/home-manager/issues/3825

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
