### PR TITLE
i3-sway: add option trayPadding (tray_padding) for bars

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -69,8 +69,8 @@ rec {
     };
 
   barStr = { id, fonts, mode, hiddenState, position, workspaceButtons
-    , workspaceNumbers, command, statusCommand, colors, trayOutput, extraConfig
-    , ... }:
+    , workspaceNumbers, command, statusCommand, colors, trayOutput, trayPadding
+    , extraConfig, ... }:
     let colorsNotNull = lib.filterAttrs (n: v: v != null) colors != { };
     in ''
       bar {
@@ -93,6 +93,8 @@ rec {
                   lib.hm.booleans.yesNo (!workspaceNumbers)
                 }")
               (optionalString (trayOutput != null) "tray_output ${trayOutput}")
+              (optionalString (trayPadding != null)
+                "tray_padding ${toString trayPadding}")
               (optionals colorsNotNull (indent
                 (lists.subtractLists [ "" null ] [
                   "colors {"

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -293,6 +293,15 @@ let
         default = "primary";
         description = "Where to output tray.";
       };
+
+      trayPadding = mkNullableOption {
+        type = types.int;
+        default = null;
+        description = ''
+          Sets the pixel padding of the system tray.
+          This padding will surround the tray on all sides and between each item.
+        '';
+      };
     };
   };
 


### PR DESCRIPTION
### Description

Add option trayPadding (tray_padding) for bars.

Didn't find an example if I should create a test-case if there is no change in default behavior as we don't test them currently from what I found?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
