### PR TITLE
nushell: introduce settings option

### DIFF
--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -179,6 +179,10 @@ in {
   };
 
   config = mkIf cfg.enable {
+    assertions = [{
+      assertion = (cfg.settings != { }) -> (builtins.compareVersions cfg.package.version "0.72" >= 0);
+      message = "programs.nushell.settings requires nushell >= 0.72, but was ${cfg.package.version}";
+    }];
     home.packages = [ cfg.package ];
     home.file = mkMerge [
       (mkIf (cfg.configFile != null || cfg.extraConfig != "") {

--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -80,7 +80,7 @@ let
     merge = mergeEqualOption;
   };
 in {
-  meta.maintainers = [ maintainers.Philipp-M ];
+  meta.maintainers = with maintainers; [ Philipp-M bobvanderlinden ];
 
   options.programs.nushell = {
     enable = mkEnableOption "nushell";

--- a/tests/modules/programs/nushell/config-expected.nu
+++ b/tests/modules/programs/nushell/config-expected.nu
@@ -1,6 +1,25 @@
-let $config = {
-  filesize_metric: false
-  table_mode: rounded
-  use_ls_colors: true
+let-env config = {
+  completions: {
+    external: {
+      completer: {|spans|
+        carapace $spans.0 nushell $spans | from json
+      }
+      
+      enable: true
+      max_results: 100
+    }
+  }
+  filesize: {
+    metric: false
+  }
+  ls: {
+    colors: true
+  }
+  table: {
+    mode: "rounded"
+  }
 }
 
+source $HOME/file_a.nu
+
+source $HOME/file_b.nu

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -1,15 +1,30 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 {
   programs.nushell = {
     enable = true;
 
+    settings = {
+      filesize.metric = false;
+      table.mode = "rounded";
+      ls.colors = true;
+      completions.external = {
+        enable = true;
+        max_results = 100;
+        completer.__nu = ''
+          {|spans|
+            carapace $spans.0 nushell $spans | from json
+          }
+        '';
+      };
+    };
+
     configFile.text = ''
-      let $config = {
-        filesize_metric: false
-        table_mode: rounded
-        use_ls_colors: true
-      }
+      source $HOME/file_a.nu
+    '';
+
+    extraConfig = ''
+      source $HOME/file_b.nu
     '';
 
     envFile.text = ''

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -32,7 +32,9 @@
     '';
   };
 
-  test.stubs.nushell = { };
+  test.stubs.nushell = {
+    version = "0.73.0";
+  };
 
   nmt.script = let
     configDir = if pkgs.stdenv.isDarwin then


### PR DESCRIPTION
Currently it is convoluted to set basic configuration options for Nushell. It always requires "let-env config =". Because multiple sources need to set these options from home-maanger, the config needs to be updated as well, resulting in multiple "let-env config" statements that update potentially existing config values.

When combined with other home-manager options that add to the Nushell configuration it is error-prone to set options yourself. New users will want to set "show_banner = false", but it is non-trivial when direnv integration is enabled.

This change makes sure all settings can be set at once. The settings are serialized to Nu code.

In addition, the settings also support Nu expressions, which allows referring to variables set in env.nu as well as using more complex expressions.

Lastly, the test examples have been updated with new (nested) configuration options. See
https://www.nushell.sh/blog/2022-11-29-nushell-0.72.html#config-options-have-been-grouped-together

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
