### PR TITLE
nushell: add support for shellAliases

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -513,6 +513,7 @@ in
     programs.bash.shellAliases = cfg.shellAliases;
     programs.zsh.shellAliases = cfg.shellAliases;
     programs.fish.shellAliases = cfg.shellAliases;
+    programs.nushell.shellAliases = cfg.shellAliases;
 
     home.sessionVariables =
       let

--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -111,6 +111,20 @@ in {
         Additional configuration to add to the nushell environment variables file.
       '';
     };
+
+    shellAliases = mkOption {
+      type = with types; attrsOf str;
+      default = { };
+      example = literalExpression ''
+        {
+          g = "git";
+        }
+      '';
+      description = ''
+        An attribute set that maps aliases (the top level attribute names
+        in this option) to command strings or directly to build outputs.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -119,6 +133,7 @@ in {
       (mkIf (cfg.configFile != null || cfg.extraConfig != "") {
         "${configDir}/config.nu".text = mkMerge [
           (mkIf (cfg.configFile != null) cfg.configFile.text)
+          (concatStringsSep "\n" (mapAttrsToList (k: v: "alias ${k} = ${v}") cfg.shellAliases))
           cfg.extraConfig
         ];
       })

--- a/tests/modules/programs/nushell/config-expected.nu
+++ b/tests/modules/programs/nushell/config-expected.nu
@@ -4,3 +4,4 @@ let $config = {
   use_ls_colors: true
 }
 
+alias g = git

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -15,6 +15,10 @@
     envFile.text = ''
       let-env FOO = 'BAR'
     '';
+
+    shellAliases = {
+      g = "git";
+    };
   };
 
   test.stubs.nushell = { };


### PR DESCRIPTION
Currently extraConfig needs to be used for defining aliases for Nushell. Other shells inherit from home.shellAliases. It would be nice if home-manager did this for Nushell as well.

This change adds a shellAliases option that creates `alias k = v` entries in `config.nu`.

Nushell's `shellAliases` is set to `home.shellAlises` in the same way fish' shellAliases option does.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

I got an (seemingly) unrelated error:

```
error: The option `programs.borgmatic.backups.main.location.extraConfig.exclude_from' has conflicting definition values:
```


- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
