### PR TITLE
atuin: enable nushell integration

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -85,6 +85,14 @@ in {
         of options.
       '';
     };
+
+    enableNushellIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Nushell integration.
+      '';
+    };
   };
 
   config = let flagsStr = escapeShellArgs cfg.flags;
@@ -114,5 +122,18 @@ in {
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
       ${cfg.package}/bin/atuin init fish ${flagsStr} | source
     '';
+
+    programs.nushell = mkIf cfg.enableNushellIntegration {
+      extraEnv = ''
+        let atuin_cache = "${config.xdg.cacheHome}/atuin"
+        if not ($atuin_cache | path exists) {
+          mkdir $atuin_cache
+        }
+        ${cfg.package}/bin/atuin init nu | save --force ${config.xdg.cacheHome}/atuin/init.nu
+      '';
+      extraConfig = ''
+        source ${config.xdg.cacheHome}/atuin/init.nu
+      '';
+    };
   };
 }


### PR DESCRIPTION
### Description

The latest atuin supports nushell now, this just adds the option to handle it.
nixpkgs has just merged the latest atuin on master, so we might need to wait until the change gets reflected to nixpkgs-unstable. Happy to leave this open in the meanwhile for review.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
