### PR TITLE
maintainers: rename houstdav000 → cyntheticfox

### DIFF
--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -8,7 +8,7 @@ let
   serviceArgs =
     optionalString (cfg.storePath != null) "--path ${cfg.storePath}";
 in {
-  meta.maintainers = with maintainers; [ cab404 houstdav000 ];
+  meta.maintainers = with maintainers; [ cab404 cyntheticfox ];
 
   options.services.pass-secret-service = {
     enable = mkEnableOption "Pass libsecret service";


### PR DESCRIPTION
Renamed in nixpkgs https://github.com/NixOS/nixpkgs/pull/223976, so now our tests are [failing](https://github.com/nix-community/home-manager/actions/runs/4599709875/jobs/8125413653?pr=3837#step:6:7)... @rycee we need to find a way to avoid that, but I'm not sure how.

cc @cyntheticfox 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.