### PR TITLE
man: use cfg when possible

### DIFF
--- a/modules/programs/man.nix
+++ b/modules/programs/man.nix
@@ -46,12 +46,12 @@ in {
     };
   };
 
-  config = mkIf config.programs.man.enable {
+  config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
     home.extraOutputsToInstall = [ "man" ];
 
     # This is mostly copy/pasted/adapted from NixOS' documentation.nix.
-    home.file = mkIf config.programs.man.generateCaches {
+    home.file = mkIf cfg.generateCaches {
       ".manpath".text = let
         # Generate a directory containing installed packages' manpages.
         manualPages = pkgs.buildEnv {


### PR DESCRIPTION
### Description

Minor simplification.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```