### PR TITLE
ci: use the right channel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: cachix/install-nix-action@v19
       with:
         install_url: https://releases.nixos.org/nix/nix-2.13.3/install
-        nix_path: nixpkgs=channel:nixos-unstable
+        nix_path: nixpkgs=channel:nixos-22.11
     - uses: cachix/cachix-action@v12
       with:
         name: nix-community

--- a/tests/modules/programs/broot/broot.nix
+++ b/tests/modules/programs/broot/broot.nix
@@ -10,16 +10,12 @@
     assertFileExists home-files/.config/broot/conf.toml
     assertFileContent home-files/.config/broot/conf.toml ${
       builtins.toFile "broot.expected" ''
-        content_search_max_file_size = "10MB"
         imports = ["verbs.hjson", {file = "dark-blue-skin.hjson", luma = ["dark", "unknown"]}, {file = "white-skin.hjson", luma = "light"}]
         modal = true
         show_selection_mark = true
         verbs = []
 
         [skin]
-
-        [special_paths]
-        "/media" = "no-enter"
       ''
     }
   '';


### PR DESCRIPTION
### Description

The workflow used the wrong channel before.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```