### PR TITLE
Fix indented string in tmux plugins example

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -313,10 +313,10 @@ in {
             }
             {
               plugin = tmuxPlugins.continuum;
-              extraConfig = '''
+              extraConfig = ''
                 set -g @continuum-restore 'on'
                 set -g @continuum-save-interval '60' # minutes
-              ''';
+              '';
             }
           ]
         '';


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Fixes incorrect documentation. The diff'd example is incorrect, as it uses triple `'''` delimiters instead of `''`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
