### PR TITLE
home-cursor: follow xdg spec for icons folder

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -119,7 +119,7 @@ in {
       # Set name in icons theme, for compatibility with AwesomeWM etc. See:
       # https://github.com/nix-community/home-manager/issues/2081
       # https://wiki.archlinux.org/title/Cursor_themes#XDG_specification
-      home.file.".icons/default/index.theme".text = ''
+      xdg.dataFile."icons/default/index.theme".text = ''
         [icon theme]
         Name=Default
         Comment=Default Cursor Theme


### PR DESCRIPTION
### Description

Currently, the `home.pointerCursor` module creates a file in the `~/.icons/` folder.
~~According to the [XDG spec for _Icon Theme Specification_](https://www.freedesktop.org/wiki/Specifications/icon-theme-spec/), it seems that [this folder can be located in one of the `$XDG_DATA_DIRS` folders](https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s03.html).~~
This PR moves the `icons/` folder to this location.

EDIT:  According to [the Arch wiki](https://wiki.archlinux.org/title/Cursor_themes#Manually) and my testing, it seems to work better when using `$XDG_DATA_HOME/icons/`.
Maybe it is better to put it in both places.
For information, the implementation of `$XDG_DATA_DIRS` is the following:
```nix
xdg.systemDirs.data = [
  (toString (pkgs.writeTextDir "icons/default/index.theme" ''
    [icon theme]
    Name=Default
    Comment=Default Cursor Theme
    Inherits=${cfg.name}
  ''))
];
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
