### PR TITLE
ssh: made the ssh config file path modular

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -392,6 +392,21 @@ in
       '';
     };
 
+    userConfigFile = mkOption {
+      type = types.str;
+      default = ".ssh/config";
+      description = ''
+      tells Home-Manager where in your home you want your ssh config to be.
+      Example: <filename>.ssh/config<filename> will put it into 
+      <filename>~/.ssh/config<filename>
+      while <filename>.config/ssh/config<filename> will put it into 
+      <filename>~/.config/ssh/config<filename>
+      file is put into <filename>~/.ssh/config</filename> by default.
+      can be paired with a alias 'ssh = "ssh -F"' to declutter your 
+      home folder.
+      '';
+    };
+
     userKnownHostsFile = mkOption {
       type = types.str;
       default = "~/.ssh/known_hosts";
@@ -510,7 +525,7 @@ in
       }
     ];
 
-    home.file.".ssh/config".text =
+    home.file.${cfg.userConfigFile}.text =
       let
         sortedMatchBlocks = hm.dag.topoSort cfg.matchBlocks;
         sortedMatchBlocksStr = builtins.toJSON sortedMatchBlocks;


### PR DESCRIPTION
made a new option programs.ssh.userConfigFile with default ".ssh/config" and replaced home.file.".ssh/config".text with home.file.${cfg.userConfigFile}.text

### Description

<!--

Please provide a brief description of your change.

-->

adds an Option programs.ssh.userConfigFile which expects a String returned (default .ssh/config).
replaces home.file.".ssh/config".txt with home.file.${cfg.userConfigFile}.txt
can be used together with an Alias (ssh = ssh -F /path/to/file) to declutter the home directory
default option for userConfigFile is still ".ssh/config"

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

this PR doesn't add a new Module.
