### PR TITLE
firefox: Support paths for userChrome & userContent

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -401,7 +401,7 @@ in {
           };
 
           userChrome = mkOption {
-            type = types.lines;
+            type = types.oneOf [ types.lines types.path ];
             default = "";
             description = "Custom ${appName} user chrome CSS.";
             example = ''
@@ -420,7 +420,7 @@ in {
           };
 
           userContent = mkOption {
-            type = types.lines;
+            type = types.oneOf [ types.lines types.path ];
             default = "";
             description = "Custom ${appName} user content CSS.";
             example = ''
@@ -868,10 +868,18 @@ in {
         "${profilesPath}/${profile.path}/.keep".text = "";
 
         "${profilesPath}/${profile.path}/chrome/userChrome.css" =
-          mkIf (profile.userChrome != "") { text = profile.userChrome; };
+          mkIf (profile.userChrome != "") (let
+            key =
+              if builtins.isString profile.userChrome then "text" else "source";
+          in { "${key}" = profile.userChrome; });
 
         "${profilesPath}/${profile.path}/chrome/userContent.css" =
-          mkIf (profile.userContent != "") { text = profile.userContent; };
+          mkIf (profile.userContent != "") (let
+            key = if builtins.isString profile.userContent then
+              "text"
+            else
+              "source";
+          in { "${key}" = profile.userContent; });
 
         "${profilesPath}/${profile.path}/user.js" = mkIf (profile.preConfig
           != "" || profile.settings != { } || profile.extraConfig != ""


### PR DESCRIPTION
### Description

A path may be preferred for some uses, and allowing it avoids the user needing to `builtins.readFile`, thus creating duplicates and making it more difficult to determine the actual store path.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
