### PR TITLE
home-manager: migrate profiles to Nix state directory

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -117,18 +117,25 @@ function setHomeManagerNixPath() {
 
 # Sets some useful Home Manager related paths as global read-only variables.
 function setHomeManagerPathVariables() {
-    declare -r nixStateDir="${NIX_STATE_DIR:-/nix/var/nix}"
-    declare -r globalProfilesDir="$nixStateDir/profiles/per-user/$USER"
-    declare -r globalGcrootsDir="$nixStateDir/gcroots/per-user/$USER"
+    declare -r globalNixStateDir="${NIX_STATE_DIR:-/nix/var/nix}"
+    declare -r globalProfilesDir="$globalNixStateDir/profiles/per-user/$USER"
+    declare -r globalGcrootsDir="$globalNixStateDir/gcroots/per-user/$USER"
+
+    declare -r stateHome="${XDG_STATE_HOME:-$HOME/.local/state}"
+    declare -r userNixStateDir="$stateHome/nix"
 
     declare -gr HM_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/home-manager"
-    declare -gr HM_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/home-manager"
+    declare -gr HM_STATE_DIR="$stateHome/home-manager"
     declare -gr HM_GCROOT_LEGACY_PATH="$globalGcrootsDir/current-home"
 
-    if [[ -d "$globalProfilesDir" ]]; then
+    if [[ -d $userNixStateDir/profiles ]]; then
+        declare -gr HM_PROFILE_DIR="$userNixStateDir/profiles"
+    elif [[ -d $globalProfilesDir ]]; then
         declare -gr HM_PROFILE_DIR="$globalProfilesDir"
     else
-        declare -gr HM_PROFILE_DIR="$HM_STATE_DIR/profiles"
+        _iError 'Could not find suitable profile directory, tried %s and %s' \
+                "$HM_STATE_DIR/profiles" "$globalProfilesDir" >&2
+        exit 1
     fi
 }
 
@@ -769,16 +776,16 @@ function doUninstall() {
                 $DRY_RUN_CMD rm $VERBOSE_ARG -r "$HM_DATA_HOME"
             fi
 
+            if [[ -e $HM_STATE_DIR ]]; then
+                $DRY_RUN_CMD rm $VERBOSE_ARG -r "$HM_STATE_DIR"
+            fi
+
             if [[ -e $HM_PROFILE_DIR ]]; then
                 $DRY_RUN_CMD rm $VERBOSE_ARG "$HM_PROFILE_DIR/home-manager"*
             fi
 
             if [[ -e $HM_GCROOT_LEGACY_PATH ]]; then
                 $DRY_RUN_CMD rm $VERBOSE_ARG "$HM_GCROOT_LEGACY_PATH"
-            fi
-
-            if [[ -e $HM_STATE_DIR ]]; then
-                $DRY_RUN_CMD rm $VERBOSE_ARG -r "$HM_STATE_DIR"
             fi
             ;;
         *)

--- a/home-manager/po/home-manager.pot
+++ b/home-manager/po/home-manager.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2023-03-15 20:11+0100\n"
+"POT-Creation-Date: 2023-04-10 13:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,7 +25,7 @@ msgstr ""
 #. translators: The first '%s' specifier will be replaced by either
 #. 'home.nix' or 'flake.nix'.
 #: home-manager/home-manager:88 home-manager/home-manager:92
-#: home-manager/home-manager:147
+#: home-manager/home-manager:154
 msgid ""
 "Keeping your Home Manager %s in %s is deprecated,\n"
 "please move it to %s"
@@ -35,33 +35,37 @@ msgstr ""
 msgid "No configuration file found. Please create one at %s"
 msgstr ""
 
-#: home-manager/home-manager:183
+#: home-manager/home-manager:136
+msgid "Could not find suitable profile directory, tried %s and %s"
+msgstr ""
+
+#: home-manager/home-manager:190
 msgid "Can't inspect options of a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:245 home-manager/home-manager:268
-#: home-manager/home-manager:907
+#: home-manager/home-manager:252 home-manager/home-manager:275
+#: home-manager/home-manager:970
 msgid "%s: unknown option '%s'"
 msgstr ""
 
-#: home-manager/home-manager:250 home-manager/home-manager:908
+#: home-manager/home-manager:257 home-manager/home-manager:971
 msgid "Run '%s --help' for usage help"
 msgstr ""
 
-#: home-manager/home-manager:276 home-manager/home-manager:326
+#: home-manager/home-manager:283 home-manager/home-manager:382
 msgid "The file %s already exists, leaving it unchanged..."
 msgstr ""
 
-#: home-manager/home-manager:278 home-manager/home-manager:328
+#: home-manager/home-manager:285 home-manager/home-manager:384
 msgid "Creating %s..."
 msgstr ""
 
-#: home-manager/home-manager:370
+#: home-manager/home-manager:426
 msgid "Creating initial Home Manager generation..."
 msgstr ""
 
 #. translators: The "%s" specifier will be replaced by a file path.
-#: home-manager/home-manager:375
+#: home-manager/home-manager:431
 msgid ""
 "All done! The home-manager tool should now be installed and you can edit\n"
 "\n"
@@ -72,7 +76,7 @@ msgid ""
 msgstr ""
 
 #. translators: The "%s" specifier will be replaced by a URL.
-#: home-manager/home-manager:380
+#: home-manager/home-manager:436
 msgid ""
 "Uh oh, the installation failed! Please create an issue at\n"
 "\n"
@@ -81,11 +85,11 @@ msgid ""
 "if the error seems to be the fault of Home Manager."
 msgstr ""
 
-#: home-manager/home-manager:390
+#: home-manager/home-manager:446
 msgid "Can't instantiate a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:463
+#: home-manager/home-manager:519
 msgid ""
 "There is %d unread and relevant news item.\n"
 "Read it by running the command \"%s news\"."
@@ -95,72 +99,76 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: home-manager/home-manager:477
+#: home-manager/home-manager:533
 msgid "Unknown \"news.display\" setting \"%s\"."
 msgstr ""
 
-#: home-manager/home-manager:484
+#: home-manager/home-manager:540
 #, sh-format
 msgid "Please set the $EDITOR environment variable"
 msgstr ""
 
-#: home-manager/home-manager:499
+#: home-manager/home-manager:555
 msgid "Cannot run build in read-only directory"
 msgstr ""
 
-#: home-manager/home-manager:583
+#: home-manager/home-manager:639
 msgid "No generation with ID %s"
 msgstr ""
 
-#: home-manager/home-manager:585
+#: home-manager/home-manager:641
 msgid "Cannot remove the current generation %s"
 msgstr ""
 
-#: home-manager/home-manager:587
+#: home-manager/home-manager:643
 msgid "Removing generation %s"
 msgstr ""
 
-#: home-manager/home-manager:606
+#: home-manager/home-manager:662
 msgid "No generations to expire"
 msgstr ""
 
-#: home-manager/home-manager:617
+#: home-manager/home-manager:673
 msgid "No home-manager packages seem to be installed."
 msgstr ""
 
-#: home-manager/home-manager:674
+#: home-manager/home-manager:699
+msgid "Sorry, this command is not yet supported in flake setup"
+msgstr ""
+
+#: home-manager/home-manager:736
 msgid "Unknown argument %s"
 msgstr ""
 
-#: home-manager/home-manager:690
+#: home-manager/home-manager:752
 msgid "This will remove Home Manager from your system."
 msgstr ""
 
-#: home-manager/home-manager:693
+#: home-manager/home-manager:755
 msgid "This is a dry run, nothing will actually be uninstalled."
 msgstr ""
 
-#: home-manager/home-manager:697
+#: home-manager/home-manager:759
 msgid "Really uninstall Home Manager?"
 msgstr ""
 
-#: home-manager/home-manager:703
+#: home-manager/home-manager:765
 msgid "Switching to empty Home Manager configuration..."
 msgstr ""
 
-#: home-manager/home-manager:730
+#: home-manager/home-manager:792
 msgid "Yay!"
 msgstr ""
 
-#: home-manager/home-manager:735
+#: home-manager/home-manager:797
 msgid "Home Manager is uninstalled but your home.nix is left untouched."
 msgstr ""
 
-#: home-manager/home-manager:945
+#: home-manager/home-manager:1008
 msgid "expire-generations expects one argument, got %d."
 msgstr ""
 
-#: home-manager/home-manager:967
+#: home-manager/home-manager:1030
 msgid "Unknown command: %s"
 msgstr ""
 

--- a/modules/po/hm-modules.pot
+++ b/modules/po/hm-modules.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager Modules\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2023-03-15 20:11+0100\n"
+"POT-Creation-Date: 2023-04-10 13:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,15 +53,19 @@ msgstr ""
 msgid "Activating %s"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:16
-msgid "Migrating profiles from %s to %s"
+#: modules/lib-bash/activation-init.sh:22
+msgid "Migrating profile from %s to %s"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:75
+#: modules/lib-bash/activation-init.sh:53
+msgid "Could not find suitable profile directory, tried %s and %s"
+msgstr ""
+
+#: modules/lib-bash/activation-init.sh:81
 msgid "Sanity checking oldGenNum and oldGenPath"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:78
+#: modules/lib-bash/activation-init.sh:84
 msgid ""
 "The previous generation number and path are in conflict! These\n"
 "must be either both empty or both set but are now set to\n"
@@ -77,26 +81,26 @@ msgid ""
 "and trying home-manager switch again. Good luck!"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:95
+#: modules/lib-bash/activation-init.sh:101
 msgid "Starting Home Manager activation"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:99
+#: modules/lib-bash/activation-init.sh:105
 msgid "Sanity checking Nix"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:105
+#: modules/lib-bash/activation-init.sh:112
 msgid "This is a dry run"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:109
+#: modules/lib-bash/activation-init.sh:116
 msgid "This is a live run"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:116
+#: modules/lib-bash/activation-init.sh:122
 msgid "Using Nix version: %s"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:119
+#: modules/lib-bash/activation-init.sh:125
 msgid "Activation variables:"
 msgstr ""


### PR DESCRIPTION
### Description

If the user runs a recent Nix version that places per-user profiles in `$XDG_STATE_DIR/nix/profiles`, then migrate the home-manager profile there.

Also clean up `setupVars` a bit.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```