### PR TITLE
activation-init.sh: create the Nix profiles path before accessing it

### DIFF
--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -105,6 +105,9 @@ _i "Starting Home Manager activation"
 $VERBOSE_RUN _i "Sanity checking Nix"
 nix-build --expr '{}' --no-out-link
 
+# Also make sure that the Nix profiles path is created.
+nix-env -q > /dev/null 2>&1
+
 migrateProfile
 setupVars
 


### PR DESCRIPTION
### Description

The Nix profiles path may not exist right after installing Nix. In that case, it is created on demand by the Nix CLI tools. But after #3861, Home Manager assumes it exists and fails if it doesn't. This caused problems when testing Home Manager configurations on GitHub Actions and cachix/install-nix-action was used to install Nix.

This change makes sure to trigger the creation of the Nix profiles path before attempting to access it.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
