### PR TITLE
bottom: use xdg.configHome on darwin too

### DIFF
--- a/modules/programs/bottom.nix
+++ b/modules/programs/bottom.nix
@@ -8,11 +8,6 @@ let
 
   tomlFormat = pkgs.formats.toml { };
 
-  configDir = if pkgs.stdenv.isDarwin then
-    "Library/Application Support"
-  else
-    config.xdg.configHome;
-
 in {
   options = {
     programs.bottom = {
@@ -32,8 +27,7 @@ in {
         default = { };
         description = ''
           Configuration written to
-          <filename>$XDG_CONFIG_HOME/bottom/bottom.toml</filename> on Linux or
-          <filename>$HOME/Library/Application Support/bottom/bottom.toml</filename> on Darwin.
+          <filename>$XDG_CONFIG_HOME/bottom/bottom.toml</filename>.
           </para><para>
           See <link xlink:href="https://github.com/ClementTsang/bottom/blob/master/sample_configs/default_config.toml"/>
           for the default configuration.
@@ -57,7 +51,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    home.file."${configDir}/bottom/bottom.toml" = mkIf (cfg.settings != { }) {
+    xdg.configFile."bottom/bottom.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "bottom.toml" cfg.settings;
     };
   };

--- a/tests/modules/programs/bottom/empty-settings.nix
+++ b/tests/modules/programs/bottom/empty-settings.nix
@@ -9,13 +9,8 @@ with lib;
       package = config.lib.test.mkStubPackage { };
     };
 
-    nmt.script = let
-      configDir = if pkgs.stdenv.isDarwin then
-        "home-files/Library/Application Support"
-      else
-        "home-files/.config";
-    in ''
-      assertPathNotExists ${configDir}/bottom
+    nmt.script = ''
+      assertPathNotExists home-files/.config/bottom
     '';
   };
 }

--- a/tests/modules/programs/bottom/example-settings.nix
+++ b/tests/modules/programs/bottom/example-settings.nix
@@ -18,14 +18,9 @@ with lib;
       };
     };
 
-    nmt.script = let
-      configDir = if pkgs.stdenv.isDarwin then
-        "home-files/Library/Application Support"
-      else
-        "home-files/.config";
-    in ''
+    nmt.script = ''
       assertFileContent \
-        "${configDir}/bottom/bottom.toml" \
+        "home-files/.config/bottom/bottom.toml" \
         ${./example-settings-expected.toml}
     '';
   };


### PR DESCRIPTION
### Description

Use `xdg.configHome` like most other tools on darwin.
Bottom supports both config locations: https://clementtsang.github.io/bottom/nightly/configuration/config-file/default-config/

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
