### PR TITLE
lazygit: use xdg.configHome on darwin too if xdg.enable

### DIFF
--- a/modules/programs/lazygit.nix
+++ b/modules/programs/lazygit.nix
@@ -34,8 +34,10 @@ in {
       '';
       description = ''
         Configuration written to
-        <filename>$XDG_CONFIG_HOME/lazygit/config.yml</filename> on Linux
-        or <filename>~/Library/Application Support/lazygit/config.yml</filename> on Darwin. See
+        <filename>$XDG_CONFIG_HOME/lazygit/config.yml</filename>
+        on Linux or on Darwin if <xref linkend="opt-xdg.enable"/> is set, otherwise
+        <filename>~/Library/Application Support/lazygit/config.yml</filename>.
+        See
         <link xlink:href="https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md"/>
         for supported values.
       '';
@@ -46,12 +48,12 @@ in {
     home.packages = [ cfg.package ];
 
     home.file."Library/Application Support/lazygit/config.yml" =
-      mkIf (cfg.settings != { } && isDarwin) {
+      mkIf (cfg.settings != { } && (isDarwin && !config.xdg.enable)) {
         source = yamlFormat.generate "lazygit-config" cfg.settings;
       };
 
     xdg.configFile."lazygit/config.yml" =
-      mkIf (cfg.settings != { } && !isDarwin) {
+      mkIf (cfg.settings != { } && !(isDarwin && !config.xdg.enable)) {
         source = yamlFormat.generate "lazygit-config" cfg.settings;
       };
   };


### PR DESCRIPTION
### Description

Use `xdg.configHome` if `xdg.enable` is true, like most other tools on darwin.
Lazygit supports XDG path if XDG_CONFIG_HOME is defined: https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md

Fixes #3634.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.