### PR TITLE
home-manager: ignore errors from notify-send

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -527,7 +527,7 @@ function presentNews() {
         echo $'\n'"$msg"$'\n' >&2
 
         if [[ -v DISPLAY ]] && type -P notify-send > /dev/null; then
-            notify-send "Home Manager" "$msg"
+            notify-send "Home Manager" "$msg" > /dev/null 2>&1 || true
         fi
     elif [[ "$newsDisplay" == "show" ]]; then
         doShowNews --unread


### PR DESCRIPTION
### Description

Fixes #3878


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```