### PR TITLE
copyq: fix typo in documentation

### DIFF
--- a/modules/services/copyq.nix
+++ b/modules/services/copyq.nix
@@ -18,7 +18,7 @@ in {
       default = "graphical-session.target";
       example = "sway-session.target";
       description = ''
-        The systemd target that will automatically start the Waybar service.
+        The systemd target that will automatically start the CopyQ service.
         </para>
         <para>
         When setting this value to <literal>"sway-session.target"</literal>,


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Fix typo in documentation for `services.copyq.systemdTarget`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
