### PR TITLE
doc: replace invalid link

### DIFF
--- a/docs/contributing.adoc
+++ b/docs/contributing.adoc
@@ -50,8 +50,8 @@ The first option is good if you only temporarily want to use your clone.
 [[sec-guidelines]]
 === Guidelines
 :irc-home-manager: https://webchat.oftc.net/?channels=home-manager
-:valuable-options: https://github.com/Infinisil/rfcs/blob/config-option/rfcs/0042-config-option.md#valuable-options
-:rfc-42: https://github.com/Infinisil/rfcs/blob/config-option/rfcs/0042-config-option.md
+:valuable-options: https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md#valuable-options
+:rfc-42: https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md
 :assertions: https://nixos.org/manual/nixos/stable/index.html#sec-assertions
 
 If your contribution satisfy the following rules then there is a good chance it will be merged without too much trouble. The rules are enforced by the Home Manager maintainers and to a lesser extent the Home Manager CI system.


### PR DESCRIPTION
The link to the Nix RFC 42 is invalid. Replace this with a valid link to the upstream NixOS/rfcs repo, pinning it to the commit that introduced the RFC.

### Description

The link to the Nix RFC 42 is invalid and yields a 404. This fixes that issue.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`. (doesn't apply)

- [ ] Code tested through `nix-shell --pure tests -A run.all`. (doesn't apply)

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef). (doesn't apply)

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
