### PR TITLE
rofi: skip override if there are no plugins

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -264,8 +264,8 @@ in {
 
     programs.rofi.finalPackage = let
       rofiWithPlugins = cfg.package.override
-        (old: rec { plugins = (old.plugins or [ ]) ++ cfg.plugins; });
-    in if builtins.hasAttr "override" cfg.package then
+        (old: { plugins = (old.plugins or [ ]) ++ cfg.plugins; });
+    in if builtins.hasAttr "override" cfg.package && cfg.plugins != [ ] then
       rofiWithPlugins
     else
       cfg.package;


### PR DESCRIPTION
### Description

Avoid needless calls to `override` (also allows using `pkgs.rofi-unwrapped` with no plugins).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.