### PR TITLE
sway: allow --i3 flag in `config.window.hideEdgeBorders`

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -420,7 +420,10 @@ in {
         };
 
         hideEdgeBorders = mkOption {
-          type = types.enum [ "none" "vertical" "horizontal" "both" "smart" ];
+          type = let
+            opts = [ "none" "vertical" "horizontal" "both" "smart" ];
+            swayOpts = opts ++ (builtins.map (x: "--i3 " + x) opts);
+          in types.enum (if isSway then swayOpts else opts);
           default = "none";
           description = "Hide window borders adjacent to the screen edges.";
         };


### PR DESCRIPTION


### Description

Before this commit, it was impossible to include the "--i3" flag in the wayland.windowManager.sway.config.window.hideEdgeBorders option value. Now the enum is expanded to include all possible "--i3 <option>" values while leaving the equivalent i3 option unchanged.

Not sure if this warrants an extra test case, but I'm happy to add one.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.

Fixes #3589 
