### PR TITLE
docs: add `toolbar` to firefox bookmarks example

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -309,6 +309,7 @@ in {
                   }
                   {
                     name = "Nix sites";
+                    toolbar = true;
                     bookmarks = [
                       {
                         name = "homepage";


### PR DESCRIPTION
### Description

This commit adds a clear example of how to get bookmarks into the bookmarks toolbar.
