### PR TITLE
Fix flake install template to account for usernames with "."

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -406,7 +406,7 @@ EOF
       system = "$nixSystem";
       pkgs = nixpkgs.legacyPackages.\${system};
     in {
-      homeConfigurations.$USER = home-manager.lib.homeManagerConfiguration {
+      homeConfigurations."$USER" = home-manager.lib.homeManagerConfiguration {
         inherit pkgs;
 
         # Specify your home configuration modules here, for example,


### PR DESCRIPTION
During a recent installation I was receiving the error:

```
error: flake 'git+file:///home/paulo.casaretto/.config/home-manager' does not provide attribute 'packages.x86_64-linux.homeConfigurations."paulo.casaretto".activationPackage', 'legacyPackages.x86_64-linux.homeConfigurations."paulo.casaretto".activationPackage' or 'homeConfigurations."paulo.casaretto".activationPackage'
```

Upon inspection it became clear that this line was the culprit:

```
homeConfigurations.paulo.casaretto = home-manager.lib.homeManagerConfiguration {
```

Changing to 
```
homeConfigurations."paulo.casaretto" = home-manager.lib.homeManagerConfiguration {
```

Fixed the problem.