### PR TITLE
git: Add delta.package option

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -994,13 +994,6 @@ in
           A new module is available: 'programs.mr'.
         '';
       }
-
-      {
-        time = "2023-04-20T04:55:07+00:00";
-        message = ''
-          Add `delta.package` option to `programs.git`.
-        '';
-      }
     ];
   };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -994,6 +994,13 @@ in
           A new module is available: 'programs.mr'.
         '';
       }
+
+      {
+        time = "2023-04-20T04:55:07+00:00";
+        message = ''
+          Add `delta.package` option to `programs.git`.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -310,12 +310,7 @@ in {
           '';
         };
 
-        package = mkOption {
-          type = types.package;
-          default = pkgs.delta;
-          defaultText = literalExpression "pkgs.delta";
-          description = "Package providing <command>delta</command>.";
-        };
+        package = mkPackageOption pkgs "delta" { };
 
         options = mkOption {
           type = with types;

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -310,6 +310,13 @@ in {
           '';
         };
 
+        package = mkOption {
+          type = types.package;
+          default = pkgs.delta;
+          defaultText = literalExpression "pkgs.delta";
+          description = "Package providing <command>delta</command>.";
+        };
+
         options = mkOption {
           type = with types;
             let
@@ -538,16 +545,17 @@ in {
       in { diff.external = difftCommand; };
     })
 
-    (mkIf cfg.delta.enable {
-      home.packages = [ pkgs.delta ];
+    (mkIf cfg.delta.enable (let deltaPackage = cfg.delta.package;
+    in {
+      home.packages = [ deltaPackage ];
 
-      programs.git.iniContent = let deltaCommand = "${pkgs.delta}/bin/delta";
+      programs.git.iniContent = let deltaCommand = "${deltaPackage}/bin/delta";
       in {
         core.pager = deltaCommand;
         interactive.diffFilter = "${deltaCommand} --color-only";
         delta = cfg.delta.options;
       };
-    })
+    }))
 
     (mkIf cfg.diff-so-fancy.enable {
       home.packages = [ pkgs.diff-so-fancy ];


### PR DESCRIPTION
### Description

Make it possible to customize the `delta` package

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
