### PR TITLE
fnott: add DBus service file

### DIFF
--- a/modules/services/fnott.nix
+++ b/modules/services/fnott.nix
@@ -107,6 +107,13 @@ in {
       };
     };
 
+    xdg.dataFile."dbus-1/services/fnott.service".text = ''
+      [D-BUS Service]
+      Name=org.freedesktop.Notifications
+      Exec=${cfg.package}/bin/fnott
+      SystemdService=fnott.service
+    '';
+
     xdg.configFile."fnott/fnott.ini".source =
       iniFormat.generate "fnott.ini" cfg.settings;
   };

--- a/tests/modules/services/fnott/systemd-user-dbus-service-expected.service
+++ b/tests/modules/services/fnott/systemd-user-dbus-service-expected.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.freedesktop.Notifications
+Exec=@fnott@/bin/fnott
+SystemdService=fnott.service

--- a/tests/modules/services/fnott/systemd-user-service.nix
+++ b/tests/modules/services/fnott/systemd-user-service.nix
@@ -11,6 +11,10 @@
       assertFileContent \
         home-files/.config/systemd/user/fnott.service \
         ${./systemd-user-service-expected.service}
+
+      assertFileContent \
+        home-files/.local/share/dbus-1/services/fnott.service \
+        ${./systemd-user-dbus-service-expected.service}
     '';
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This is needed to make fnott bus-activatable. Otherwise it won't be started when a bus request is made [0].
Done in the same way as e.g. dunst sets that up [1,2].

Fixes notifications through fnott on my machine.
Tested using a simple `nix-shell -p libnotify --run 'notify-send test'`.

[0] https://www.freedesktop.org/software/systemd/man/systemd.service.html#id-1.10.6
[1] https://github.com/nix-community/home-manager/blob/master/modules/services/dunst.nix#L139
[2] https://github.com/dunst-project/dunst/blob/master/org.knopwob.dunst.service.in

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
