### PR TITLE
home-manager: fix config file variable check

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -93,7 +93,7 @@ function setConfigFile() {
                    'home.nix' "$HOME/.nixpkgs" "$hmConfigHome" >&2
         fi
 
-        if [[ $configFile ]]; then
+        if [[ -v configFile ]]; then
             HOME_MANAGER_CONFIG="$(realpath "$configFile")"
         else
             _i 'No configuration file found. Please create one at %s' \


### PR DESCRIPTION
### Description
Fixes #3900 

Since the `set -u` option turned on, the `home-manager` script errors and exits when trying to expand `$configFile` when no config file is found and the variable is unset. Instead, use `[[ -v configFile ]]` which tests if variable is unset without causing a fatal error in case it is not.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
