### PR TITLE
home-manager: fix unbound variable check

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -93,7 +93,7 @@ function setConfigFile() {
                    'home.nix' "$HOME/.nixpkgs" "$hmConfigHome" >&2
         fi
 
-        if [[ $configFile ]]; then
+        if [[ -v configFile ]]; then
             HOME_MANAGER_CONFIG="$(realpath "$configFile")"
         else
             _i 'No configuration file found. Please create one at %s' \


### PR DESCRIPTION
Due to `set -u`, the check would abort the program when `configFile` is unset.

Fixes https://github.com/nix-community/home-manager/issues/3900

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
