### PR TITLE
zellij: use xdg.configHome on darwin too

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -7,11 +7,6 @@ let
   cfg = config.programs.zellij;
   yamlFormat = pkgs.formats.yaml { };
 
-  configDir = if pkgs.stdenv.isDarwin then
-    "Library/Application Support/org.Zellij-Contributors.Zellij"
-  else
-    "${config.xdg.configHome}/zellij";
-
 in {
   meta.maintainers = [ hm.maintainers.mainrs ];
 
@@ -51,12 +46,12 @@ in {
 
     # Zellij switched from yaml to KDL in version 0.32.0:
     # https://github.com/zellij-org/zellij/releases/tag/v0.32.0
-    home.file."${configDir}/config.yaml" = mkIf
+    xdg.configFile."zellij/config.yaml" = mkIf
       (cfg.settings != { } && (versionOlder cfg.package.version "0.32.0")) {
         source = yamlFormat.generate "zellij.yaml" cfg.settings;
       };
 
-    home.file."${configDir}/config.kdl" = mkIf
+    xdg.configFile."zellij/config.kdl" = mkIf
       (cfg.settings != { } && (versionAtLeast cfg.package.version "0.32.0")) {
         text = lib.hm.generators.toKDL { } cfg.settings;
       };


### PR DESCRIPTION
### Description

Use `xdg.configHome` like most other tools on darwin.
Zellij supports both config locations: https://zellij.dev/documentation/configuration.html#where-does-zellij-look-for-the-config-file

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.