### PR TITLE
swappy: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -59,6 +59,12 @@
     githubId = 32838899;
     name = "Daniel Wagenknecht";
   };
+  eclairevoyant = {
+    name = "éclairevoyant";
+    email = "848000+eclairevoyant@users.noreply.github.com";
+    github = "eclairevoyant";
+    githubId = 848000;
+  };
   jkarlson = {
     email = "jekarlson@gmail.com";
     github = "jkarlson";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1143,6 +1143,13 @@ in
           A new module is available: 'services.ssh-agent'
         '';
       }
+
+      {
+        time = "2023-07-07T06:00:00+00:00";
+        message = ''
+          A new module is available: 'programs.swappy'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -188,6 +188,7 @@ let
     ./programs/sqls.nix
     ./programs/ssh.nix
     ./programs/starship.nix
+    ./programs/swappy.nix
     ./programs/swaylock.nix
     ./programs/taskwarrior.nix
     ./programs/tealdeer.nix

--- a/modules/programs/swappy.nix
+++ b/modules/programs/swappy.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.swappy;
+
+  iniFormat = pkgs.formats.ini { };
+
+  iniFile = iniFormat.generate "config" cfg.settings;
+
+in {
+  meta.maintainers = [ hm.maintainers.eclairevoyant ];
+
+  options.programs.swappy = {
+    enable = mkEnableOption "Swappy, a GTK-based screenshot editor for Wayland";
+
+    package = mkPackageOption pkgs "swappy" { };
+
+    settings = mkOption {
+      type = iniFormat.type;
+      default = { };
+      example = ''
+        {
+          Default = {
+            show_panel = true;
+          };
+        }'';
+      description = ''
+        Configuration to use for Swappy. See
+        <citerefentry>
+          <refentrytitle>swappy</refentrytitle>
+          <manvolnum>1</manvolnum>
+        </citerefentry>
+        for available options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile =
+      mkIf (cfg.settings != { }) { "swappy/config".source = iniFile; };
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds HM module for swappy, a simple GTK-based screenshot editor for Wayland.

See [project homepage](https://github.com/jtheoof/swappy) and [nixpkgs derivation](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/swappy/default.nix).

Empty config is used by default to allow the application to use its internal defaults.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).