### PR TITLE
flake: Move tests back to devShells.*.tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           tests = import ./tests { inherit pkgs; };
-        in tests.run);
+        in { tests = tests.run; });
 
       packages = forAllSystems (system:
         let


### PR DESCRIPTION
### Description

I assume it was erroneously lost during flake-utils removal in https://github.com/nix-community/home-manager/pull/3860

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] ~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~ N/A

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
