### PR TITLE
neovim: Enable tests on Darwin

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -96,6 +96,7 @@ import nmt {
     ./modules/programs/ncmpcpp
     ./modules/programs/ne
     ./modules/programs/neomutt
+    ./modules/programs/neovim
     ./modules/programs/newsboat
     ./modules/programs/nheko
     ./modules/programs/nix-index
@@ -158,7 +159,6 @@ import nmt {
     ./modules/programs/looking-glass-client
     ./modules/programs/mangohud
     ./modules/programs/ncmpcpp-linux
-    ./modules/programs/neovim   # Broken package dependency on Darwin.
     ./modules/programs/rbw
     ./modules/programs/rofi
     ./modules/programs/rofi-pass


### PR DESCRIPTION
### Description

Checked on Apple Silicon laptop with both `aarch64-darwin` and `x86-64-darwin`. All tests succeeded on both.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] ~Code formatted with `./format`.~ `tests/default.nix` is not formatted with `nixfmt`, but I didn't mess with formatting.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] ~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~ N/A

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.