### PR TITLE
neovim: Add nvim-treesitter configuration

### DIFF
--- a/tests/modules/programs/neovim/default.nix
+++ b/tests/modules/programs/neovim/default.nix
@@ -2,6 +2,7 @@
   neovim-plugin-config = ./plugin-config.nix;
   neovim-coc-config = ./coc-config.nix;
   neovim-runtime = ./runtime.nix;
+  neovim-treesitter = ./treesitter.nix;
 
   # waiting for a nixpkgs patch
   neovim-no-init = ./no-init.nix;

--- a/tests/modules/programs/neovim/treesitter.nix
+++ b/tests/modules/programs/neovim/treesitter.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }: {
+  programs.neovim = {
+    enable = true;
+    treesitter.enable = true;
+  };
+  nmt.script = ''
+    assertFileContent "home-files/.config/nvim/init.lua" ${
+      pkgs.writeText "init.lua-expected" ''
+        require('nvim-treesitter.configs').setup {
+          -- auto_install is not reproducible
+          auto_install = false,
+          highlight = {
+            enable = true,
+            disable = {  },
+            -- docs claim that this slows down the editor and mostly not needed
+            additional_vim_regex_highlighting = false,
+          };
+        }
+      ''
+    };
+  '';
+}


### PR DESCRIPTION
### Description

Allows to use only necessary grammars and compose their list acrossmodules.

I had to implement this for my dotflies where I configure different languages in different modules, for example: 
https://github.com/YorikSar/dotfiles/commit/c591a5aa7d47ddce5616316298af1ff8b508bcf1

Hopefully this would save others this headache.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.