### PR TITLE
helix: Support `[[grammar]]` in languages.toml

### DIFF
--- a/tests/modules/programs/helix/default.nix
+++ b/tests/modules/programs/helix/default.nix
@@ -1,1 +1,4 @@
-{ helix-example-settings = ./example-settings.nix; }
+{
+  helix-example-settings = ./example-settings.nix;
+  helix-settings-with-use-grammars = ./settings-with-use-grammars.nix;
+}

--- a/tests/modules/programs/helix/example-settings.nix
+++ b/tests/modules/programs/helix/example-settings.nix
@@ -22,6 +22,14 @@ with lib;
         auto-format = false;
       }];
 
+      grammars = [{
+        name = "lalrpop";
+        source = {
+          git = "https://github.com/traxys/tree-sitter-lalrpop";
+          rev = "7744b56f03ac1e5643fad23c9dd90837fe97291e";
+        };
+      }];
+
       themes = {
         base16 = let
           transparent = "none";

--- a/tests/modules/programs/helix/languages-expected-use-grammars.toml
+++ b/tests/modules/programs/helix/languages-expected-use-grammars.toml
@@ -1,3 +1,5 @@
+[use-grammars]
+except = ["yaml", "json"]
 [[grammar]]
 name = "lalrpop"
 

--- a/tests/modules/programs/helix/settings-with-use-grammars.nix
+++ b/tests/modules/programs/helix/settings-with-use-grammars.nix
@@ -1,0 +1,34 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.helix = {
+      enable = true;
+
+      languages = [{
+        name = "rust";
+        auto-format = false;
+      }];
+
+      grammars = [{
+        name = "lalrpop";
+        source = {
+          git = "https://github.com/traxys/tree-sitter-lalrpop";
+          rev = "7744b56f03ac1e5643fad23c9dd90837fe97291e";
+        };
+      }];
+
+      use-grammars = { except = [ "yaml" "json" ]; };
+    };
+
+    test.stubs.helix = { };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/helix/languages.toml \
+        ${./languages-expected-use-grammars.toml}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add support for the `[[grammar]]` key of `languages.toml`: https://docs.helix-editor.com/languages.html#tree-sitter-grammar-configuration

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.


edit: Should fix #2871 