### PR TITLE
command-not-found: make script portable

### DIFF
--- a/modules/programs/command-not-found/command-not-found.pl
+++ b/modules/programs/command-not-found/command-not-found.pl
@@ -1,4 +1,4 @@
-#! @perl@/bin/perl -w
+#!/usr/bin/env -S @perl@/bin/perl -w
 
 use strict;
 use DBI;


### PR DESCRIPTION
Without `/usr/bin/env -S`, this breaks with bash on Darwin

### Description

I discovered that shebang being a pure script (not binary) seems to be problematic with

[bashInteractive package](https://search.nixos.org/packages?channel=unstable&show=bashInteractive) on Darwin (I imagine the same for 
[bash](https://search.nixos.org/packages?channel=unstable&show=bash))

But works with [zsh](https://search.nixos.org/packages?channel=unstable&show=zsh)

So I found and tested the solution that works for both bash and zsh on Darwin as well as NixOS.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
	- not sure if any updates on test cases are required for this change
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
