### PR TITLE
zplug: Add options to allow override the package and the root dir of …

### DIFF
--- a/modules/programs/zplug.nix
+++ b/modules/programs/zplug.nix
@@ -26,6 +26,21 @@ in {
   options.programs.zsh.zplug = {
     enable = mkEnableOption "zplug - a zsh plugin manager";
 
+    package = mkOption {
+      type = types.package;
+      default = pkgs.zplug;
+      defaultText = literalExpression "pkgs.zplug";
+      description = "The zplug package to install.";
+    };
+
+    zplugPackageRootDir = mkOption {
+      type = with types; either str path;
+      default = "${cfg.package}";
+      defaultText = literalExpression "cfg.package";
+      description =
+        "Path to the dir that contains the outputs (e.g. init.zsh) of the zplug package.";
+    };
+
     plugins = mkOption {
       default = [ ];
       type = types.listOf pluginModule;
@@ -47,7 +62,7 @@ in {
     programs.zsh.initExtraBeforeCompInit = ''
       export ZPLUG_HOME=${cfg.zplugHome}
 
-      source ${pkgs.zplug}/init.zsh
+      source ${cfg.zplugPackageRootDir}/init.zsh
 
       ${optionalString (cfg.plugins != [ ]) ''
         ${concatStrings (map (plugin: ''

--- a/tests/modules/programs/zplug/modules.nix
+++ b/tests/modules/programs/zplug/modules.nix
@@ -8,6 +8,8 @@ with lib;
       enable = true;
       zplug = {
         enable = true;
+        package = config.lib.test.mkStubPackage { outPath = "@test-zplug@"; };
+        zplugPackageRootDir = "${config.programs.zsh.zplug.package}/share";
         zplugHome = pkgs.emptyDirectory;
         plugins = [
           {
@@ -29,7 +31,7 @@ with lib;
 
     nmt.script = ''
       assertFileContains home-files/.zshrc \
-        'source @zplug@/init.zsh'
+        'source @test-zplug@/share/init.zsh'
 
       assertFileContains home-files/.zshrc \
         'zplug "plugins/git", from:oh-my-zsh'


### PR DESCRIPTION
…the package

The nixpkgs zplug package puts everything under `$out/` that pollutes the nix profile dir. Ideally the package output should be in a place like `$out/share/zplug`. Modifying the package itself will break backward compatibility, like here HM hardcodes the init script path to `${pkgs.zplug}/init.zsh`.

The zplugPackageRootDir option in this change allow using a zplug overlay that changes the output path, e.g.
```
zplug = super.zplug.overrideAttrs (old: {
  installPhase = ''
    outdir=$out/share/zplug
    mkdir -p $outdir
    cp -r $src/* $outdir/
  '';
});
```
and then in HM:
```
zplugPackageRootDir = "${cfg.package}/share/zplug"
```

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```