### PR TITLE
atuin: Use flags option with nushell integration

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -129,7 +129,9 @@ in {
         if not ($atuin_cache | path exists) {
           mkdir $atuin_cache
         }
-        ${cfg.package}/bin/atuin init nu ${flagsStr} | save --force ${config.xdg.cacheHome}/atuin/init.nu
+        ${cfg.package}/bin/atuin init nu ${
+          builtins.concatStringsSep " " cfg.flags
+        } | save --force ${config.xdg.cacheHome}/atuin/init.nu
       '';
       extraConfig = ''
         source ${config.xdg.cacheHome}/atuin/init.nu

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -129,9 +129,7 @@ in {
         if not ($atuin_cache | path exists) {
           mkdir $atuin_cache
         }
-        ${cfg.package}/bin/atuin init nu ${
-          builtins.concatStringsSep " " cfg.flags
-        } | save --force ${config.xdg.cacheHome}/atuin/init.nu
+        ${cfg.package}/bin/atuin init nu ${flagsStr} | save --force ${config.xdg.cacheHome}/atuin/init.nu
       '';
       extraConfig = ''
         source ${config.xdg.cacheHome}/atuin/init.nu

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -129,7 +129,7 @@ in {
         if not ($atuin_cache | path exists) {
           mkdir $atuin_cache
         }
-        ${cfg.package}/bin/atuin init nu | save --force ${config.xdg.cacheHome}/atuin/init.nu
+        ${cfg.package}/bin/atuin init nu ${flagsStr} | save --force ${config.xdg.cacheHome}/atuin/init.nu
       '';
       extraConfig = ''
         source ${config.xdg.cacheHome}/atuin/init.nu


### PR DESCRIPTION
### Description

The nushell integration for atuin was not using the `flags` option. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
