### PR TITLE
darkman: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1273,6 +1273,14 @@ in
           A new module is available: 'programs.thefuck'.
         '';
       }
+
+      {
+        time = "2023-10-17T06:33:24+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.darkman'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -254,6 +254,7 @@ let
     ./services/clipmenu.nix
     ./services/comodoro.nix
     ./services/copyq.nix
+    ./services/darkman.nix
     ./services/devilspie2.nix
     ./services/dropbox.nix
     ./services/dunst.nix

--- a/modules/services/darkman.nix
+++ b/modules/services/darkman.nix
@@ -1,0 +1,115 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.darkman;
+
+  yamlFormat = pkgs.formats.yaml { };
+
+  scriptsOptionType = kind:
+    mkOption {
+      type = types.attrsOf (types.oneOf [ types.path types.lines ]);
+      default = { };
+      example = literalExpression ''
+        {
+          gtk-theme = '''
+            ''${pkgs.dconf}/bin/dconf write \
+                /org/gnome/desktop/interface/color-scheme "'prefer-${kind}'"
+          ''';
+          my-python-script = pkgs.writers.writePython3 "my-python-script" { } '''
+            print('Do something!')
+          ''';
+        }
+      '';
+      description = ''
+        Scripts to run when switching to "${kind} mode".
+
+        Multiline strings are interpreted as Bash shell scripts and a shebang is
+        not required.
+      '';
+    };
+
+  generateScripts = folder:
+    mapAttrs' (k: v: {
+      name = "${folder}/${k}";
+      value = {
+        source = if builtins.isPath v || isDerivation v then
+          v
+        else
+          pkgs.writeShellScript (hm.strings.storeFileName k) v;
+      };
+    });
+in {
+  meta.maintainers = [ maintainers.xlambein ];
+
+  options.services.darkman = {
+    enable = mkEnableOption ''
+      darkman, a tool that automatically switches dark-mode on and off based on
+      the time of the day'';
+
+    package = mkPackageOption pkgs "darkman" { };
+
+    settings = mkOption {
+      type = types.submodule { freeformType = yamlFormat.type; };
+      example = literalExpression ''
+        {
+          lat = 52.3;
+          lng = 4.8;
+          usegeoclue = true;
+        }
+      '';
+      description = ''
+        Settings for the {command}`darkman` command. See
+        <https://darkman.whynothugo.nl/#CONFIGURATION> for details.
+      '';
+    };
+
+    darkModeScripts = scriptsOptionType "dark";
+
+    lightModeScripts = scriptsOptionType "light";
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.darkman" pkgs platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = {
+      "darkman/config.yaml" = mkIf (cfg.settings != { }) {
+        source = yamlFormat.generate "darkman-config.yaml" cfg.settings;
+      };
+    };
+
+    xdg.dataFile = mkMerge [
+      (mkIf (cfg.darkModeScripts != { })
+        (generateScripts "dark-mode.d" cfg.darkModeScripts))
+      (mkIf (cfg.lightModeScripts != { })
+        (generateScripts "light-mode.d" cfg.lightModeScripts))
+    ];
+
+    systemd.user.services.darkman = {
+      Unit = {
+        Description = "Darkman system service";
+        Documentation = "man:darkman(1)";
+        PartOf = [ "graphical-session.target" ];
+        BindsTo = [ "graphical-session.target" ];
+        X-Restart-Triggers =
+          [ "${config.xdg.configFile."darkman/config.yaml".source}" ];
+      };
+
+      Service = {
+        Type = "dbus";
+        BusName = "nl.whynothugo.darkman";
+        ExecStart = "${getExe cfg.package} run";
+        Restart = "on-failure";
+        TimeoutStopSec = 15;
+        Slice = "background.slice";
+      };
+
+      Install.WantedBy = mkDefault [ "graphical-session.target" ];
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -208,6 +208,7 @@ import nmt {
     ./modules/services/cliphist
     ./modules/services/clipman
     ./modules/services/comodoro
+    ./modules/services/darkman
     ./modules/services/devilspie2
     ./modules/services/dropbox
     ./modules/services/emacs

--- a/tests/modules/services/darkman/basic-configuration.nix
+++ b/tests/modules/services/darkman/basic-configuration.nix
@@ -1,0 +1,70 @@
+{ config, pkgs, ... }:
+
+{
+  services.darkman = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "darkman";
+      outPath = "@darkman@";
+    };
+
+    settings.lat = 50.8;
+    settings.lng = 4.4;
+    settings.usegeoclue = true;
+
+    darkModeScripts.color-scheme-dark = ''
+      dconf write /org/gnome/desktop/interface/color-scheme "'prefer-dark'"
+    '';
+
+    lightModeScripts.color-scheme-light = pkgs.writeScript "my-python-script" ''
+      #!${pkgs.python}/bin/python
+
+      print('Do something!')
+    '';
+  };
+
+  test.stubs.python = { };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/darkman.service)
+    darkModeScriptFile=$(normalizeStorePaths home-files/.local/share/dark-mode.d/color-scheme-dark)
+    lightModeScriptFile=$(normalizeStorePaths home-files/.local/share/light-mode.d/color-scheme-light)
+
+    assertFileExists $serviceFile
+    assertFileContent $serviceFile ${
+      builtins.toFile "expected" ''
+        [Install]
+        WantedBy=graphical-session.target
+
+        [Service]
+        BusName=nl.whynothugo.darkman
+        ExecStart=@darkman@/bin/darkman run
+        Restart=on-failure
+        Slice=background.slice
+        TimeoutStopSec=15
+        Type=dbus
+
+        [Unit]
+        BindsTo=graphical-session.target
+        Description=Darkman system service
+        Documentation=man:darkman(1)
+        PartOf=graphical-session.target
+        X-Restart-Triggers=/nix/store/00000000000000000000000000000000-darkman-config.yaml
+      ''
+    }
+    assertFileContent $darkModeScriptFile ${
+      builtins.toFile "expected" ''
+        #!/nix/store/00000000000000000000000000000000-bash/bin/bash
+        dconf write /org/gnome/desktop/interface/color-scheme "'prefer-dark'"
+
+      ''
+    }
+    assertFileContent $lightModeScriptFile ${
+      builtins.toFile "expected" ''
+        #!@python@/bin/python
+
+        print('Do something!')
+      ''
+    }
+  '';
+}

--- a/tests/modules/services/darkman/default.nix
+++ b/tests/modules/services/darkman/default.nix
@@ -1,0 +1,1 @@
+{ darkman-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

This adds a service module for the `darkman` utility.  The module starts a `darkman` service, and allows you to configure your location and other `darkman` settings.  It also offers the possibility to set scripts that are triggered when entering dark or light mode.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
