### PR TITLE
zplug: Update the path of init.zsh

### DIFF
--- a/modules/programs/zplug.nix
+++ b/modules/programs/zplug.nix
@@ -47,7 +47,7 @@ in {
     programs.zsh.initExtraBeforeCompInit = ''
       export ZPLUG_HOME=${cfg.zplugHome}
 
-      source ${pkgs.zplug}/init.zsh
+      source ${pkgs.zplug}/share/zplug/init.zsh
 
       ${optionalString (cfg.plugins != [ ]) ''
         ${concatStrings (map (plugin: ''

--- a/tests/modules/programs/zplug/modules.nix
+++ b/tests/modules/programs/zplug/modules.nix
@@ -29,7 +29,7 @@ with lib;
 
     nmt.script = ''
       assertFileContains home-files/.zshrc \
-        'source @zplug@/init.zsh'
+        'source @zplug@/share/zplug/init.zsh'
 
       assertFileContains home-files/.zshrc \
         'zplug "plugins/git", from:oh-my-zsh'


### PR DESCRIPTION
### Description

The current zplug nixpkgs puts everything under `$out/`. It pollutes the nix
profile dir.

This is a breaking change. It depends on an change of the output path in the
nixpkgs zplug package.

Please see https://github.com/nix-community/home-manager/pull/3916 for the reason that we decided to go with a breaking change, and the alternative we considered there. @ncfavier FYI I create a new PR here as I failed to get Github branch rename work for the old PR.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] ~~Change is backwards compatible.~~

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```