### PR TITLE
Revert "flake: Move tests back to devShells.*.tests (#3905)"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           tests = import ./tests { inherit pkgs; };
-        in { tests = tests.run; });
+        in tests.run);
 
       packages = forAllSystems (system:
         let


### PR DESCRIPTION
### Description

This reverts commit 6f9781b1b0cf3fedbe9d2d0a785aeec4d6085c10 to fix errors of `nix flake check` and `nix flake show`. `devShells` expects an attrset of derivations, not nested attrsets.

This also breaks [nil](https://github.com/oxalica/nil)'s flake evaluation with `nix flake show`.

See also https://github.com/nix-community/home-manager/pull/3905#issuecomment-1521259152


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
