### PR TITLE
zsh: allow multiple bindings to history-substring-search

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -190,18 +190,18 @@ let
     options = {
       enable = mkEnableOption "history substring search";
       searchUpKey = mkOption {
-        type = types.str;
-        default = "^[[A";
+        type = with types; either (listOf str) str ;
+        default = [ "^[[A" ];
         description = ''
-          The key code to be used when searching up.
+          The key codes to be used when searching up.
           The default of <literal>^[[A</literal> corresponds to the UP key.
         '';
       };
       searchDownKey = mkOption {
-        type = types.str;
-        default = "^[[B";
+        type = with types; either (listOf str) str ;
+        default = [ "^[[B" ];
         description = ''
-          The key code to be used when searching down.
+          The key codes to be used when searching down.
           The default of <literal>^[[B</literal> corresponds to the DOWN key.
         '';
       };
@@ -593,8 +593,14 @@ in
           # https://github.com/zsh-users/zsh-history-substring-search#usage
         ''
           source ${pkgs.zsh-history-substring-search}/share/zsh-history-substring-search/zsh-history-substring-search.zsh
-          bindkey '${cfg.historySubstringSearch.searchUpKey}' history-substring-search-up
-          bindkey '${cfg.historySubstringSearch.searchDownKey}' history-substring-search-down
+          ${lib.concatMapStringsSep "\n"
+            (upKey: "bindkey '${upKey}' history-substring-search-up")
+            (lib.toList cfg.historySubstringSearch.searchUpKey)
+          }
+          ${lib.concatMapStringsSep "\n"
+            (downKey: "bindkey '${downKey}' history-substring-search-down")
+            (lib.toList cfg.historySubstringSearch.searchDownKey)
+          }
         '')
       ]);
     }

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -5,5 +5,6 @@
   zsh-history-path-old-default = ./history-path-old-default.nix;
   zsh-history-path-old-custom = ./history-path-old-custom.nix;
   zsh-history-ignore-pattern = ./history-ignore-pattern.nix;
+  zsh-history-substring-search = ./history-substring-search.nix;
   zsh-prezto = ./prezto.nix;
 }

--- a/tests/modules/programs/zsh/history-substring-search.nix
+++ b/tests/modules/programs/zsh/history-substring-search.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.zsh = {
+      enable = true;
+      historySubstringSearch = {
+        enable = true;
+        searchDownKey = "^[[B";
+        searchUpKey = [ "^[[A" "\\eOA" ];
+      };
+    };
+
+    test.stubs.zsh = { };
+
+    # Written with regex to ensure we don't end up missing newlines in the future
+    nmt.script = ''
+      assertFileRegex home-files/.zshrc "^bindkey '\^\[\[B' history-substring-search-down$"
+      assertFileRegex home-files/.zshrc "^bindkey '\^\[\[A' history-substring-search-up$"
+      assertFileRegex home-files/.zshrc "^bindkey '\\\\eOA' history-substring-search-up$"
+    '';
+  };
+}


### PR DESCRIPTION
### Description

It's pretty common to need multiple bindings to
history-substring-search, since different terminals will send different
keys for up/down.

This does not break back-compatibility, and introduces a new test

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
