### PR TITLE
nushell: add envVars attribute

### DIFF
--- a/tests/modules/programs/nushell/env-expected.nu
+++ b/tests/modules/programs/nushell/env-expected.nu
@@ -1,2 +1,4 @@
 let-env FOO = 'BAR'
 
+
+let-env BAR = $'(echo BAZ)'

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -20,6 +20,8 @@
       "lsname" = "(ls | get name)";
       "ll" = "ls -a";
     };
+
+    environmentVariables = { BAR = "$'(echo BAZ)'"; };
   };
 
   test.stubs.nushell = { };


### PR DESCRIPTION
### Description

Much like what was done with shellAliases, I wanted a convenient way to set environment variables.
Admittedly that can be done in extraEnv. The one use case where this becomes very convenient is with the appearance of those CLI tools that require an API key in your env. That is env var should be a secret and ideally read from a path. This is just a more convenient way of having an env var be a string or read from a path.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
