### PR TITLE
helix: provide more detailed settings description

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -24,11 +24,15 @@ in {
       example = literalExpression ''
         {
           theme = "base16";
-          lsp.display-messages = true;
+          editor = {
+            line-number = "relative";
+            lsp.display-messages = true;
+          };
           keys.normal = {
             space.space = "file_picker";
             space.w = ":w";
             space.q = ":q";
+            esc = [ "collapse_selection" "keep_primary_selection" ];
           };
         }
       '';

--- a/tests/modules/programs/helix/example-settings.nix
+++ b/tests/modules/programs/helix/example-settings.nix
@@ -9,11 +9,15 @@ with lib;
 
       settings = {
         theme = "base16";
-        lsp.display-messages = true;
+        editor = {
+          line-number = "relative";
+          lsp.display-messages = true;
+        };
         keys.normal = {
           space.space = "file_picker";
           space.w = ":w";
           space.q = ":q";
+          esc = [ "collapse_selection" "keep_primary_selection" ];
         };
       };
 

--- a/tests/modules/programs/helix/settings-expected.toml
+++ b/tests/modules/programs/helix/settings-expected.toml
@@ -1,9 +1,15 @@
 theme = "base16"
 
+[editor]
+line-number = "relative"
+
+[editor.lsp]
+display-messages = true
+
+[keys.normal]
+esc = ["collapse_selection", "keep_primary_selection"]
+
 [keys.normal.space]
 q = ":q"
 space = "file_picker"
 w = ":w"
-
-[lsp]
-display-messages = true


### PR DESCRIPTION
### Description
Helix changed the definition of options. E.g. editor specific options need to be prefixed with editor. This PR reflects this and also adds some more common settings. 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.
       Tests failed with unrelated borgmatic test
- [x] Code tested through `nix-shell --pure tests -A run.helix-example-settings`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
