### PR TITLE
sapling: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1334,6 +1334,13 @@ in
           to keep the previous behaviour.
         '';
       }
+
+      {
+        time = "2023-12-19T22:57:52+00:00";
+        message = ''
+          A new module is available: 'programs.sapling'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -192,6 +192,7 @@ let
     ./programs/rtx.nix
     ./programs/ruff.nix
     ./programs/sagemath.nix
+    ./programs/sapling.nix
     ./programs/sbt.nix
     ./programs/scmpuff.nix
     ./programs/script-directory.nix

--- a/modules/programs/sapling.nix
+++ b/modules/programs/sapling.nix
@@ -1,0 +1,83 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.sapling;
+
+  iniFormat = pkgs.formats.ini { };
+
+in {
+  meta.maintainers = [ maintainers.pbar ];
+
+  options = {
+    programs.sapling = {
+      enable = mkEnableOption "Sapling";
+
+      package = mkPackageOption pkgs "sapling" { };
+
+      userName = mkOption {
+        type = types.str;
+        description = "Default user name to use.";
+      };
+
+      userEmail = mkOption {
+        type = types.str;
+        description = "Default user email to use.";
+      };
+
+      aliases = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        description = "Sapling aliases to define.";
+      };
+
+      extraConfig = mkOption {
+        type = types.attrsOf types.anything;
+        default = { };
+        description = "Additional configuration to add.";
+      };
+
+      iniContent = mkOption {
+        type = iniFormat.type;
+        internal = true;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      home.packages = [ cfg.package ];
+
+      programs.sapling.iniContent.ui = {
+        username = cfg.userName + " <" + cfg.userEmail + ">";
+      };
+    }
+
+    (mkIf (!pkgs.stdenv.isDarwin) {
+      xdg.configFile."sapling/sapling.conf".source =
+        iniFormat.generate "sapling.conf" cfg.iniContent;
+    })
+    (mkIf (pkgs.stdenv.isDarwin) {
+      home.file."Library/Preferences/sapling/sapling.conf".source =
+        iniFormat.generate "sapling.conf" cfg.iniContent;
+    })
+
+    (mkIf (cfg.aliases != { }) {
+      programs.sapling.iniContent.alias = cfg.aliases;
+    })
+
+    (mkIf (lib.isAttrs cfg.extraConfig) {
+      programs.sapling.iniContent = cfg.extraConfig;
+    })
+
+    (mkIf (lib.isString cfg.extraConfig && !pkgs.stdenv.isDarwin) {
+      xdg.configFile."sapling/sapling.conf".text = cfg.extraConfig;
+    })
+    (mkIf (lib.isString cfg.extraConfig && pkgs.stdenv.isDarwin) {
+      home.file."Library/Preferences/sapling/sapling.conf".text =
+        cfg.extraConfig;
+    })
+  ]);
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -135,6 +135,7 @@ import nmt {
     ./modules/programs/rtx
     ./modules/programs/ruff
     ./modules/programs/sagemath
+    ./modules/programs/sapling
     ./modules/programs/sbt
     ./modules/programs/scmpuff
     ./modules/programs/sioyek

--- a/tests/modules/programs/sapling/default.nix
+++ b/tests/modules/programs/sapling/default.nix
@@ -1,0 +1,4 @@
+{
+  sapling-basic = ./sapling-basic.nix;
+  sapling-most = ./sapling-most.nix;
+}

--- a/tests/modules/programs/sapling/sapling-basic.nix
+++ b/tests/modules/programs/sapling/sapling-basic.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+
+{
+  programs.sapling = {
+    enable = true;
+    userName = "John Doe";
+    userEmail = "johndoe@example.com";
+  };
+
+  test.stubs.sapling = { };
+
+  nmt.script = let
+    configfile = if pkgs.stdenv.isDarwin then
+      "Library/Preferences/sapling/sapling.conf"
+    else
+      ".config/sapling/sapling.conf";
+
+    expected = builtins.toFile "sapling.conf" ''
+      [ui]
+      username=John Doe <johndoe@example.com>
+    '';
+  in ''
+    assertFileExists home-files/${configfile}
+    assertFileContent home-files/${configfile} ${expected}
+  '';
+}

--- a/tests/modules/programs/sapling/sapling-most.nix
+++ b/tests/modules/programs/sapling/sapling-most.nix
@@ -1,0 +1,48 @@
+{ pkgs, ... }:
+
+{
+  programs.sapling = {
+    enable = true;
+    userName = "John Doe";
+    userEmail = "johndoe@example.com";
+    aliases = {
+      cm = "commit";
+      d = "diff --exclude=*.lock";
+      s = "status";
+      view = "!$HG config paths.default | xargs open";
+    };
+    extraConfig = {
+      pager.pager = "delta";
+      gpg.key = "not-an-actual-key";
+    };
+  };
+
+  test.stubs.sapling = { };
+
+  nmt.script = let
+    configfile = if pkgs.stdenv.isDarwin then
+      "Library/Preferences/sapling/sapling.conf"
+    else
+      ".config/sapling/sapling.conf";
+
+    expected = builtins.toFile "sapling.conf" ''
+      [alias]
+      cm=commit
+      d=diff --exclude=*.lock
+      s=status
+      view=!$HG config paths.default | xargs open
+
+      [gpg]
+      key=not-an-actual-key
+
+      [pager]
+      pager=delta
+
+      [ui]
+      username=John Doe <johndoe@example.com>
+    '';
+  in ''
+    assertFileExists home-files/${configfile}
+    assertFileContent home-files/${configfile} ${expected}
+  '';
+}


### PR DESCRIPTION
sapling: add module
Adds a program module for [Sapling](https://sapling-scm.com/).

Since Sapling itself is very similar in nature to Mercurial,
`modules/programs/mercurial.nix` was copied to make this module with the
ignore pieces removed (Sapling respects gitignore).
