### PR TITLE
wezterm: add integrations for Bash and Zsh

### DIFF
--- a/modules/programs/wezterm.nix
+++ b/modules/programs/wezterm.nix
@@ -79,6 +79,9 @@ in {
       '';
     };
 
+    enableBashIntegration = mkEnableOption "WezTerm's Bash integration." // {
+      default = true;
+    };
   };
 
   config = mkIf cfg.enable {
@@ -99,5 +102,9 @@ in {
       nameValuePair "wezterm/colors/${name}.toml" {
         source = tomlFormat.generate "${name}.toml" { colors = value; };
       }) cfg.colorSchemes;
+
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
+      source "${cfg.package}/etc/profile.d/wezterm.sh"
+    '';
   };
 }

--- a/modules/programs/wezterm.nix
+++ b/modules/programs/wezterm.nix
@@ -7,6 +7,10 @@ let
   cfg = config.programs.wezterm;
   tomlFormat = pkgs.formats.toml { };
 
+  shellIntegrationStr = ''
+    source "${cfg.package}/etc/profile.d/wezterm.sh"
+  '';
+
 in {
   meta.maintainers = [ hm.maintainers.blmhemu ];
 
@@ -82,6 +86,10 @@ in {
     enableBashIntegration = mkEnableOption "WezTerm's Bash integration." // {
       default = true;
     };
+
+    enableZshIntegration = mkEnableOption "WezTerm's Zsh integration." // {
+      default = true;
+    };
   };
 
   config = mkIf cfg.enable {
@@ -103,8 +111,8 @@ in {
         source = tomlFormat.generate "${name}.toml" { colors = value; };
       }) cfg.colorSchemes;
 
-    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      source "${cfg.package}/etc/profile.d/wezterm.sh"
-    '';
+    programs.bash.initExtra =
+      mkIf cfg.enableBashIntegration shellIntegrationStr;
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration shellIntegrationStr;
   };
 }

--- a/tests/modules/programs/wezterm/bash-integration-default.nix
+++ b/tests/modules/programs/wezterm/bash-integration-default.nix
@@ -1,0 +1,14 @@
+{ ... }:
+
+{
+  programs.bash.enable = true;
+
+  # Bash integration is enabled by default.
+  programs.wezterm.enable = true;
+
+  test.stubs.wezterm = { };
+
+  nmt.script = ''
+    assertFileContains home-files/.bashrc 'source "@wezterm@/etc/profile.d/wezterm.sh"'
+  '';
+}

--- a/tests/modules/programs/wezterm/bash-integration-disabled.nix
+++ b/tests/modules/programs/wezterm/bash-integration-disabled.nix
@@ -1,0 +1,16 @@
+{ ... }:
+
+{
+  programs.bash.enable = true;
+
+  programs.wezterm = {
+    enable = true;
+    enableBashIntegration = false;
+  };
+
+  test.stubs.wezterm = { };
+
+  nmt.script = ''
+    assertFileNotRegex home-files/.bashrc 'source "@wezterm@/etc/profile.d/wezterm.sh"'
+  '';
+}

--- a/tests/modules/programs/wezterm/bash-integration-enabled.nix
+++ b/tests/modules/programs/wezterm/bash-integration-enabled.nix
@@ -1,0 +1,16 @@
+{ ... }:
+
+{
+  programs.bash.enable = true;
+
+  programs.wezterm = {
+    enable = true;
+    enableBashIntegration = true;
+  };
+
+  test.stubs.wezterm = { };
+
+  nmt.script = ''
+    assertFileContains home-files/.bashrc 'source "@wezterm@/etc/profile.d/wezterm.sh"'
+  '';
+}

--- a/tests/modules/programs/wezterm/default.nix
+++ b/tests/modules/programs/wezterm/default.nix
@@ -1,4 +1,8 @@
 {
   wezterm-example-setting = ./example-setting.nix;
   wezterm-empty-setting = ./empty-setting.nix;
+
+  wezterm-bash-integration-default = ./bash-integration-default.nix;
+  wezterm-bash-integration-disabled = ./bash-integration-disabled.nix;
+  wezterm-bash-integration-enabled = ./bash-integration-enabled.nix;
 }

--- a/tests/modules/programs/wezterm/default.nix
+++ b/tests/modules/programs/wezterm/default.nix
@@ -5,4 +5,8 @@
   wezterm-bash-integration-default = ./bash-integration-default.nix;
   wezterm-bash-integration-disabled = ./bash-integration-disabled.nix;
   wezterm-bash-integration-enabled = ./bash-integration-enabled.nix;
+
+  wezterm-zsh-integration-default = ./zsh-integration-default.nix;
+  wezterm-zsh-integration-disabled = ./zsh-integration-disabled.nix;
+  wezterm-zsh-integration-enabled = ./zsh-integration-enabled.nix;
 }

--- a/tests/modules/programs/wezterm/zsh-integration-default.nix
+++ b/tests/modules/programs/wezterm/zsh-integration-default.nix
@@ -1,0 +1,15 @@
+{ ... }:
+
+{
+  programs.zsh.enable = true;
+
+  # Zsh integration is enabled by default.
+  programs.wezterm.enable = true;
+
+  test.stubs.wezterm = { };
+  test.stubs.zsh = { };
+
+  nmt.script = ''
+    assertFileContains home-files/.zshrc 'source "@wezterm@/etc/profile.d/wezterm.sh"'
+  '';
+}

--- a/tests/modules/programs/wezterm/zsh-integration-disabled.nix
+++ b/tests/modules/programs/wezterm/zsh-integration-disabled.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs.zsh.enable = true;
+
+  programs.wezterm = {
+    enable = true;
+    enableZshIntegration = false;
+  };
+
+  test.stubs.wezterm = { };
+  test.stubs.zsh = { };
+
+  nmt.script = ''
+    assertFileNotRegex home-files/.zshrc 'source "@wezterm@/etc/profile.d/wezterm.sh"'
+  '';
+}

--- a/tests/modules/programs/wezterm/zsh-integration-enabled.nix
+++ b/tests/modules/programs/wezterm/zsh-integration-enabled.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs.zsh.enable = true;
+
+  programs.wezterm = {
+    enable = true;
+    enableZshIntegration = true;
+  };
+
+  test.stubs.wezterm = { };
+  test.stubs.zsh = { };
+
+  nmt.script = ''
+    assertFileContains home-files/.zshrc 'source "@wezterm@/etc/profile.d/wezterm.sh"'
+  '';
+}


### PR DESCRIPTION
### Description

Adds a new option `programs.wezterm.enableBashIntegration` that
sources WezTerm's Bash integration script in `.bashrc`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
