### PR TITLE
ssh: add setEnv option

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -15,6 +15,12 @@ let
 
   unwords = builtins.concatStringsSep " ";
 
+  mkSetEnvStr = envStr: unwords
+    (mapAttrsToList
+      (name: value: ''${name}="${escape [ "\"" "\\" ] (toString value)}"'')
+      envStr
+    );
+
   bindOptions = {
     address = mkOption {
       type = types.str;
@@ -189,6 +195,14 @@ let
         '';
       };
 
+      setEnv = mkOption {
+        type = with types; attrsOf (oneOf [ str path int float ]);
+        default = {};
+        description = ''
+          Environment variables and their value to send to the server.
+        '';
+      };
+
       compression = mkOption {
         type = types.nullOr types.bool;
         default = null;
@@ -322,6 +336,7 @@ let
     ++ optional (cf.hostname != null)        "  HostName ${cf.hostname}"
     ++ optional (cf.addressFamily != null)   "  AddressFamily ${cf.addressFamily}"
     ++ optional (cf.sendEnv != [])           "  SendEnv ${unwords cf.sendEnv}"
+    ++ optional (cf.setEnv != {})            "  SetEnv ${mkSetEnvStr cf.setEnv}"
     ++ optional (cf.serverAliveInterval != 0)
       "  ServerAliveInterval ${toString cf.serverAliveInterval}"
     ++ optional (cf.serverAliveCountMax != 3)

--- a/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
+++ b/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
@@ -5,6 +5,7 @@ Host * !github.com
 Host abc
   ProxyJump jump-host
 Host xyz
+  SetEnv BAR="_bar_ 42" FOO="foo12"
   ServerAliveInterval 60
   ServerAliveCountMax 10
   IdentityFile file

--- a/tests/modules/programs/ssh/match-blocks-attrs.nix
+++ b/tests/modules/programs/ssh/match-blocks-attrs.nix
@@ -35,6 +35,10 @@ with lib;
             }
           ];
           dynamicForwards = [{ port = 2839; }];
+          setEnv = {
+            FOO = "foo12";
+            BAR = "_bar_ 42";
+          };
         };
 
         "* !github.com" = {


### PR DESCRIPTION
### Description

Add support for the `SetEnv` option in the `programs.ssh` module.
It allows to set environment variables and send them to the server.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
