### PR TITLE
vim: Allow plugins to specify a config

### DIFF
--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -85,7 +85,6 @@ in {
             package
             pluginWithConfigType
             str
-            (listOf (oneOf [ package pluginWithConfigType str ]))
           ]);
         default = [ ];
         example = literalExpression ''


### PR DESCRIPTION
### Description

Currently, in order to specify config options for plugins, you have to add the configuration to extraConfig. If you break up your vim definitions across multiple files, the ordering of the extraConfig options are not guaranteed.

Example:
default.nix:
```
{...}: {
  import = [./other-options.nix];
  programs.vim = {
    enable = true;
    extraConfig = ''
    let mapleader = ' '
    '';
  }
}
```

other-options.nix:
```
{...}: {
  programs.vim = {
    plugins = with pkgs.vimPlugins [pluginThatNeedsKeymap];

    extraConfig = ''
      nmap <leader>k <Plug>doPluginThing<CR>
    '';
  };
}
```

If other-option's extraConfig comes first, then, it will be using the wrong mapleader.

After this change (using the same default.nix from above):
other-options.nix:
```
{...}: {
  programs.vim = {
    plugins = with pkgs.vimPlugins [
    {
      plugin = pluginThatNeedsKeymap;
      config = ''
	nmap <leader>k <Plug>doPluginThing<CR>
      '';
    ];
  };
}
```

Now, all of the plugin specific configuration options are guaranteed to come after all of the extraConfig options and you don't have to worry about extraConfig's getting rearranged or refactoring your vim config.

The neovim module allows tacking configuration on to the plugin definition, this PR mostly lifts that portion out and tacks it on to the existing vim module without breaking backwards compatibility.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [NA] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [NA] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [NA] Added myself and the module files to `.github/CODEOWNERS`.
