### PR TITLE
i3status-rust: satisfy new 0.31 TOML output requirements

### DIFF
--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -6,7 +6,18 @@ let
 
   cfg = config.programs.i3status-rust;
 
-  settingsFormat = pkgs.formats.toml { };
+  settingsFormat = pkgs.formats.toml { } // {
+    # Since 0.31, the "block" key has to be first in the TOML output.
+    generate = name: value:
+      pkgs.runCommand name {
+        nativeBuildInputs = [ pkgs.jq pkgs.remarshal ];
+        value = builtins.toJSON value;
+        passAsFile = [ "value" ];
+      } ''
+        jq '.block |= map({block: .block} + del(.block))' "$valuePath" \
+          | json2toml --preserve-key-order > "$out"
+      '';
+  };
 
 in {
   meta.maintainers = with lib.maintainers; [ farlion thiagokokada ];

--- a/tests/modules/programs/i3status-rust/with-custom.nix
+++ b/tests/modules/programs/i3status-rust/with-custom.nix
@@ -105,12 +105,12 @@
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
             [[block]]
-            alert = 10.0
             block = "disk_space"
+            alert = 10
             info_type = "available"
             interval = 60
             path = "/"
-            warning = 20.0
+            warning = 20
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-default.nix
+++ b/tests/modules/programs/i3status-rust/with-default.nix
@@ -12,12 +12,12 @@
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
             [[block]]
-            alert = 10.0
             block = "disk_space"
+            alert = 10
             info_type = "available"
             interval = 60
             path = "/"
-            warning = 20.0
+            warning = 20
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-extra-settings.nix
+++ b/tests/modules/programs/i3status-rust/with-extra-settings.nix
@@ -115,12 +115,12 @@
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
             [[block]]
-            alert = 10.0
             block = "disk_space"
+            alert = 10
             info_type = "available"
             interval = 60
             path = "/"
-            warning = 20.0
+            warning = 20
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-multiple-bars.nix
+++ b/tests/modules/programs/i3status-rust/with-multiple-bars.nix
@@ -54,11 +54,11 @@
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
             [[block]]
-            alert = 10.0
             block = "disk_space"
+            alert = 10
             info_type = "available"
             interval = 60
-            warning = 20.0
+            warning = 20
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-version-02xx.nix
+++ b/tests/modules/programs/i3status-rust/with-version-02xx.nix
@@ -14,12 +14,12 @@
             icons = "none"
             theme = "plain"
             [[block]]
-            alert = 10.0
             block = "disk_space"
+            alert = 10
             info_type = "available"
             interval = 60
             path = "/"
-            warning = 20.0
+            warning = 20
 
             [[block]]
             block = "memory"


### PR DESCRIPTION
### Description

From the [0.31.0 news](https://github.com/greshake/i3status-rust/blob/49499c1ca624228c4b9e88b62b36cd0fa5e2dce5/NEWS.md#i3status-rust-0310):

> `block = "..."` is now required to be the first field of block configs.

The approach taken here normalizes numbers like `10.0` to `10`, but I think this should be inconsequential.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

