### PR TITLE
firefox: support bookmark tags

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -71,6 +71,9 @@ let
           }" ADD_DATE="0" LAST_MODIFIED="0"${
             lib.optionalString (bookmark.keyword != null)
             " SHORTCUTURL=\"${escapeXML bookmark.keyword}\""
+          }${
+            lib.optionalString (bookmark.tags != [ ])
+            " TAGS=\"${escapeXML (concatStringsSep "," bookmark.tags)}\""
           }>${escapeXML bookmark.name}</A>'';
 
       directoryToHTML = indentLevel: directory: ''
@@ -251,6 +254,12 @@ in {
                       description = "Bookmark name.";
                     };
 
+                    tags = mkOption {
+                      type = types.listOf types.str;
+                      default = [ ];
+                      description = "Bookmark tags.";
+                    };
+
                     keyword = mkOption {
                       type = types.nullOr types.str;
                       default = null;
@@ -300,6 +309,7 @@ in {
                 [
                   {
                     name = "wikipedia";
+                    tags = [ "wiki" ];
                     keyword = "wiki";
                     url = "https://en.wikipedia.org/wiki/Special:Search?search=%s&go=Go";
                   }
@@ -317,6 +327,7 @@ in {
                       }
                       {
                         name = "wiki";
+                        tags = [ "wiki" "nix" ];
                         url = "https://nixos.wiki/";
                       }
                     ];

--- a/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
+++ b/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
@@ -10,12 +10,12 @@
   <DL><p>
     <DT><A HREF="https://nixos.wiki/wiki/Home_Manager" ADD_DATE="0" LAST_MODIFIED="0">Home Manager</A>
   </p></DL>
-  <DT><A HREF="https://en.wikipedia.org/wiki/Special:Search?search=%s&amp;go=Go" ADD_DATE="0" LAST_MODIFIED="0" SHORTCUTURL="wiki">wikipedia</A>
+  <DT><A HREF="https://en.wikipedia.org/wiki/Special:Search?search=%s&amp;go=Go" ADD_DATE="0" LAST_MODIFIED="0" SHORTCUTURL="wiki" TAGS="wiki">wikipedia</A>
   <DT><A HREF="https://www.kernel.org" ADD_DATE="0" LAST_MODIFIED="0">kernel.org</A>
   <DT><H3>Nix sites</H3>
   <DL><p>
     <DT><A HREF="https://nixos.org/" ADD_DATE="0" LAST_MODIFIED="0">homepage</A>
-    <DT><A HREF="https://nixos.wiki/" ADD_DATE="0" LAST_MODIFIED="0">wiki</A>
+    <DT><A HREF="https://nixos.wiki/" ADD_DATE="0" LAST_MODIFIED="0" TAGS="wiki,nix">wiki</A>
     <DT><H3>Nix sites</H3>
     <DL><p>
       <DT><A HREF="https://nixos.org/" ADD_DATE="0" LAST_MODIFIED="0">homepage</A>

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -31,6 +31,7 @@ lib.mkIf config.test.enableBig {
         }
         {
           name = "wikipedia";
+          tags = [ "wiki" ];
           keyword = "wiki";
           url = "https://en.wikipedia.org/wiki/Special:Search?search=%s&go=Go";
         }
@@ -47,6 +48,7 @@ lib.mkIf config.test.enableBig {
             }
             {
               name = "wiki";
+              tags = [ "wiki" "nix" ];
               url = "https://nixos.wiki/";
             }
             {


### PR DESCRIPTION
Closes https://github.com/nix-community/home-manager/issues/3941

cc @kira-bruneau 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
