### PR TITLE
zsh: add `package` option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -215,6 +215,8 @@ in
     programs.zsh = {
       enable = mkEnableOption "Z shell (Zsh)";
 
+      package = mkPackageOption pkgs "zsh" { };
+
       autocd = mkOption {
         default = null;
         description = ''
@@ -482,8 +484,8 @@ in
     }
 
     {
-      home.packages = with pkgs; [ zsh ]
-        ++ optional cfg.enableCompletion nix-zsh-completions
+      home.packages = [ cfg.package ]
+        ++ optional cfg.enableCompletion pkgs.nix-zsh-completions
         ++ optional cfg.oh-my-zsh.enable cfg.oh-my-zsh.package;
 
       home.file."${relToDotDir ".zshrc"}".text = concatStringsSep "\n" ([
@@ -499,7 +501,7 @@ in
           fpath+=($profile/share/zsh/site-functions $profile/share/zsh/$ZSH_VERSION/functions $profile/share/zsh/vendor-completions)
         done
 
-        HELPDIR="${pkgs.zsh}/share/zsh/$ZSH_VERSION/help"
+        HELPDIR="${cfg.package}/share/zsh/$ZSH_VERSION/help"
         ''
 
         (optionalString (cfg.defaultKeymap != null) ''


### PR DESCRIPTION
### Description

Much like it is already available for many other modules, add it here too.

[ Also, I noticed there is no explicitly assigned maintainer/codeowner for the `zsh` module. I'd be willing to take over and actively maintain if that would be desired, as I'm using it since many years now and care about it. ] 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.

