### PR TITLE
xfconf: support uint

### DIFF
--- a/modules/misc/xfconf.nix
+++ b/modules/misc/xfconf.nix
@@ -6,8 +6,31 @@ let
 
   cfg = config.xfconf;
 
+  xfIntVariant = types.submodule {
+    options = {
+      type = mkOption {
+        type = types.enum [ "int" "uint" "uint64" ];
+        description = ''
+          To distinguish between int, uint and uint64 in xfconf,
+          you can specify the type in xfconf with this submodule.
+          For other types, you don't need to use this submodule,
+          just specify the value is enough.
+        '';
+      };
+      value = mkOption {
+        type = types.int;
+        description = "The value in xfconf.";
+      };
+    };
+  };
+
   withType = v:
-    if builtins.isBool v then [
+    if builtins.isAttrs v then [
+      "-t"
+      v.type
+      "-s"
+      (toString v.value)
+    ] else if builtins.isBool v then [
       "-t"
       "bool"
       "-s"
@@ -55,9 +78,10 @@ in {
         attrsOf (attrsOf (oneOf [
           bool
           int
+          xfIntVariant
           float
           str
-          (listOf (oneOf [ bool int float str ]))
+          (listOf (oneOf [ bool int xfIntVariant float str ]))
         ])) // {
           description = "xfconf settings";
         };


### PR DESCRIPTION
### Description

#### The Problem
The xfconf module of home-manager can't distinguish between `int` and `uint`, all exported integer types in xml are `int`, e.g. the result of this module is `<property name="dpms-on-ac-sleep" type="int" value="15"/>`, while the correct config in xml should be `<property name="dpms-on-ac-sleep" type="uint" value="15"/>`.
Some xfconf consumers use `xfconf_channel_get_uint()` to get config, and this function discards values with wrong types, e.g. it will discard `15` from `<property name="dpms-on-ac-sleep" type="int" value="15"/>`.

#### The Solution
change from
```
"xfce4-power-manager/dpms-on-ac-sleep" = 15;
```
to
```
"xfce4-power-manager/dpms-on-ac-sleep" = { type = "uint"; value = 15; };
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
