### PR TITLE
Fixed home-manager path for flake installs

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -301,7 +301,7 @@ function doInit() {
 
         mkdir -p "$confDir"
         cat > "$confFile" <<EOF
-{ config, pkgs, ... }:
+{ config, pkgs, home-manager, ... }:
 
 {
   # Home Manager needs a bit of information about you and the paths it should
@@ -369,7 +369,11 @@ $xdgVars
   };
 
   # Let Home Manager install and manage itself.
-  programs.home-manager.enable = true;
+  programs.home-manager = {
+    enable = true;
+    path = "\${home-manager}";
+  };
+
 }
 EOF
     fi
@@ -415,6 +419,7 @@ EOF
 
         # Optionally use extraSpecialArgs
         # to pass through arguments to home.nix
+	extraSpecialArgs = { inherit home-manager; };
       };
     };
 }


### PR DESCRIPTION
### Description

This fixes #3948. There may be better ways to do this but this seems to work :) 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
