### PR TITLE
pass-secret-service: Add dbus file, assert

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -489,7 +489,8 @@ Makefile                                              @thiagokokada
 
 /modules/services/parcellite.nix                      @gleber
 
-/modules/services/pass-secret-service.nix             @cab404
+/modules/services/pass-secret-service.nix             @cab404 @cyntheticfox
+/tests/modules/services/pass-secret-service.nix       @cyntheticfox
 
 /modules/services/password-store-sync.nix             @pacien
 

--- a/modules/services/gnome-keyring.nix
+++ b/modules/services/gnome-keyring.nix
@@ -30,7 +30,11 @@ in {
         lib.platforms.linux)
       {
         assertion = !config.services.pass-secret-store.enable;
-        message = "Only one libsecret service can be enabled at a time.";
+        message = ''
+          Only one secrets service per user can be enabled at a time.
+          Other services enabled:
+          - pass-secret-store
+        '';
       }
     ];
 

--- a/modules/services/gnome-keyring.nix
+++ b/modules/services/gnome-keyring.nix
@@ -28,6 +28,10 @@ in {
     assertions = [
       (lib.hm.assertions.assertPlatform "services.gnome-keyring" pkgs
         lib.platforms.linux)
+      {
+        assertion = !config.services.pass-secret-store.enable;
+        message = "Only one libsecret service can be enabled at a time.";
+      }
     ];
 
     systemd.user.services.gnome-keyring = {

--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -15,8 +15,8 @@ in {
     package = mkPackageOption pkgs "pass-secret-service" { };
 
     storePath = mkOption {
-      type = types.str;
-      default = "";
+      type = with types; nullOr str;
+      default = null;
       defaultText = "$HOME/.password-store";
       example = "/home/user/.local/share/password-store";
       description = ''
@@ -52,7 +52,7 @@ in {
         Service = {
           Type = "dbus";
           ExecStart = "${binPath} ${
-              optionalString (cfg.storePath != "") "--path ${cfg.storePath}"
+              optionalString (cfg.storePath != null) "--path ${cfg.storePath}"
             }";
           BusName = busName;
         };

--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -20,7 +20,10 @@ in {
       defaultText = "$HOME/.password-store";
       example = "/home/user/.local/share/password-store";
       description = ''
-        Absolute path to password store.
+      Absolute path to password store. Defaults to
+      <filename>$HOME/.password-store</filename> if the
+      <option>programs.password-store</option> module is not enabled, and
+      <option>programs.password-store.PASSWORD_STORE_DIR</option> if it is.
       '';
     };
   };

--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -5,8 +5,7 @@ with lib;
 let
   cfg = config.services.pass-secret-service;
 
-  serviceArgs =
-    optionalString (cfg.storePath != null) "--path ${cfg.storePath}";
+  busName = "org.freedesktop.secrets";
 in {
   meta.maintainers = with maintainers; [ cab404 cyntheticfox ];
 
@@ -16,11 +15,13 @@ in {
     package = mkPackageOption pkgs "pass-secret-service" { };
 
     storePath = mkOption {
-      type = with types; nullOr str;
-      default = null;
-      defaultText = "~/.password-store";
+      type = types.str;
+      default = "";
+      defaultText = "$HOME/.password-store";
       example = "/home/user/.local/share/password-store";
-      description = "Absolute path to password store.";
+      description = ''
+        Absolute path to password store.
+      '';
     };
   };
 
@@ -28,21 +29,34 @@ in {
     assertions = [
       (hm.assertions.assertPlatform "services.pass-secret-service" pkgs
         platforms.linux)
+      {
+        assertion = !config.services.gnome-keyring.enable;
+        message = "Only one secrets service per user can be enabled at a time";
+      }
     ];
 
-    systemd.user.services.pass-secret-service = {
-      Unit = {
-        AssertFileIsExecutable = "${cfg.package}/bin/pass_secret_service";
-        Description = "Pass libsecret service";
-        Documentation = "https://github.com/mdellweg/pass_secret_service";
-        PartOf = [ "default.target" ];
+    systemd.user.services.pass-secret-service =
+      let binPath = "${cfg.package}/bin/pass_secret_service";
+      in {
+        Unit = {
+          AssertFileIsExecutable = "${binPath}";
+          Description = "Pass libsecret service";
+          Documentation = "https://github.com/mdellweg/pass_secret_service";
+          PartOf = [ "default.target" ];
+        };
+
+        Service = {
+          Type = "dbus";
+          ExecStart = "${binPath} ${
+              optionalString (cfg.storePath != "") "--path ${cfg.storePath}"
+            }";
+          BusName = busName;
+        };
+
+        Install.WantedBy = [ "default.target" ];
       };
 
-      Service = {
-        ExecStart = "${cfg.package}/bin/pass_secret_service ${serviceArgs}";
-      };
-
-      Install = { WantedBy = [ "default.target" ]; };
-    };
+    xdg.dataFile."dbus-1/services/${busName}.service".source =
+      "${cfg.package}/share/dbus-1/services/${busName}.service";
   };
 }

--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -5,12 +5,6 @@ with lib;
 let
   cfg = config.services.pass-secret-service;
 
-  conflictingModules = [ "services.gnome-keyring" ];
-
-  moduleIsEnabled = v: config.${v}.enable or false;
-  hasConflicts = modulePathName: !(any moduleIsEnabled modulePathName);
-  getConflicts = filter moduleIsEnabled;
-
   busName = "org.freedesktop.secrets";
 in {
   meta.maintainers = with maintainers; [ cab404 cyntheticfox ];
@@ -26,10 +20,10 @@ in {
       defaultText = "$HOME/.password-store";
       example = "/home/user/.local/share/password-store";
       description = ''
-        Absolute path to password store. Defaults to
-        <filename>$HOME/.password-store</filename> if the
-        <option>programs.password-store</option> module is not enabled, and
-        <option>programs.password-store.settings.PASSWORD_STORE_DIR</option> else.
+      Absolute path to password store. Defaults to
+      <filename>$HOME/.password-store</filename> if the
+      <option>programs.password-store</option> module is not enabled, and
+      <option>programs.password-store.PASSWORD_STORE_DIR</option> if it is.
       '';
     };
   };
@@ -39,15 +33,11 @@ in {
       (hm.assertions.assertPlatform "services.pass-secret-service" pkgs
         platforms.linux)
       {
-        assertion = hasConflicts conflictingModules;
+        assertion = !config.services.gnome-keyring.enable;
         message = ''
           Only one secrets service per user can be enabled at a time.
           Other services enabled:
-          <ul>
-          ${map (v: ''
-            <li><option>${v}</option></li>
-          '') (getConflicts conflictingModules)}
-          </ul>
+          - gnome-keyring
         '';
       }
     ];

--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -20,10 +20,10 @@ in {
       defaultText = "$HOME/.password-store";
       example = "/home/user/.local/share/password-store";
       description = ''
-      Absolute path to password store. Defaults to
-      <filename>$HOME/.password-store</filename> if the
-      <option>programs.password-store</option> module is not enabled, and
-      <option>programs.password-store.settings.PASSWORD_STORE_DIR</option> if it is.
+        Absolute path to password store. Defaults to
+        <filename>$HOME/.password-store</filename> if the
+        <option>programs.password-store</option> module is not enabled, and
+        <option>programs.password-store.settings.PASSWORD_STORE_DIR</option> if it is.
       '';
     };
   };

--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -23,7 +23,7 @@ in {
       Absolute path to password store. Defaults to
       <filename>$HOME/.password-store</filename> if the
       <option>programs.password-store</option> module is not enabled, and
-      <option>programs.password-store.PASSWORD_STORE_DIR</option> if it is.
+      <option>programs.password-store.settings.PASSWORD_STORE_DIR</option> if it is.
       '';
     };
   };

--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -31,7 +31,11 @@ in {
         platforms.linux)
       {
         assertion = !config.services.gnome-keyring.enable;
-        message = "Only one secrets service per user can be enabled at a time";
+        message = ''
+          Only one secrets service per user can be enabled at a time.
+          Other services enabled:
+          - gnome-keyring
+        '';
       }
     ];
 


### PR DESCRIPTION
### Description

Add the dbus service file in the package folder to XDG_DATA_HOME, as well as adding an assertion to ensure both it and `gnome-keyring` aren't enabled at the same time.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
