### PR TITLE
remmina: Init module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1498,6 +1498,14 @@ in {
           A new module is available: 'programs.spotify-player'.
         '';
       }
+
+      {
+        time = "2024-04-19T14:53:17+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.remmina'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -340,6 +340,7 @@ let
     ./services/recoll.nix
     ./services/redshift-gammastep/gammastep.nix
     ./services/redshift-gammastep/redshift.nix
+    ./services/remmina.nix
     ./services/rsibreak.nix
     ./services/safeeyes.nix
     ./services/screen-locker.nix

--- a/modules/services/remmina.nix
+++ b/modules/services/remmina.nix
@@ -1,0 +1,74 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  inherit (lib) mkIf mkMerge mkEnableOption mkPackageOption mkOption;
+
+  cfg = config.services.remmina;
+
+in {
+  meta.maintainers = with lib.maintainers; [ cyntheticfox ];
+
+  options.services.remmina = {
+    enable = mkEnableOption "Remmina";
+
+    package = mkPackageOption pkgs "remmina" { };
+
+    addRdpMimeTypeAssoc = mkEnableOption "Remmina RDP file open option" // {
+      default = true;
+    };
+
+    systemdService = {
+      enable = mkEnableOption "systemd Remmina service" // { default = true; };
+
+      startupFlags = mkOption {
+        type = with lib.types; listOf str;
+        default = [ "--icon" ];
+        description = ''
+          Startup flags documented in the manpage to run at service startup.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    { home.packages = [ cfg.package ]; }
+
+    (mkIf cfg.systemdService.enable {
+      systemd.user.services.remmina = {
+        Unit = {
+          Description = "Remmina remote desktop client";
+          Documentation = "man:remmina(1)";
+          Requires = [ "graphical-session-pre.target" ];
+        };
+
+        Service = {
+          Type = "simple";
+          ExecStart = "${lib.getExe cfg.package} ${
+              lib.escapeShellArgs cfg.systemdService.startupFlags
+            }";
+          Restart = "on-failure";
+        };
+
+        Install.WantedBy = [ "graphical-session.target" ];
+      };
+    })
+
+    (mkIf (config.xdg.mimeApps.enable && cfg.addRdpMimeTypeAssoc) {
+      xdg.mimeApps.associations.added."application/x-rdp" =
+        "org.remmina.Remmina.desktop";
+
+      xdg.dataFile."mime/packages/application-x-rdp.xml".text = ''
+        <?xml version="1.0" encoding="UTF-8"?>
+        <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+          <mime-type type="application/x-rdp">
+            <comment>rdp file</comment>
+            <icon name="application-x-rdp"/>
+            <glob-deleteall/>
+            <glob pattern="*.rdp"/>
+          </mime-type>
+        </mime-info>
+      '';
+    })
+  ]);
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -255,6 +255,7 @@ in import nmtSrc {
     ./modules/services/polybar
     ./modules/services/recoll
     ./modules/services/redshift-gammastep
+    ./modules/services/remmina
     ./modules/services/screen-locker
     ./modules/services/signaturepdf
     ./modules/services/swayidle

--- a/tests/modules/services/remmina/basic-config.nix
+++ b/tests/modules/services/remmina/basic-config.nix
@@ -1,0 +1,26 @@
+{ config, ... }: {
+  xdg.mimeApps.enable = true;
+
+  services.remmina = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    addRdpMimeTypeAssoc = false;
+    systemdService = {
+      enable = true;
+      startupFlags = [ "--icon" "--enable-extra-hardening" ];
+    };
+  };
+
+  nmt.script = ''
+    serviceFile='./home-files/.config/systemd/user/remmina.service'
+
+    assertFileExists $serviceFile
+    assertFileRegex $serviceFile 'ExecStart=.*/bin/dummy'
+    assertFileRegex $serviceFile "dummy '--icon' '--enable-extra-hardening'"
+
+    mimetypeFile='./home-files/.local/share/mime/packages/application-x-rdp.xml'
+
+    assertPathNotExists $mimetypeFile
+  '';
+}

--- a/tests/modules/services/remmina/default-config.nix
+++ b/tests/modules/services/remmina/default-config.nix
@@ -1,0 +1,20 @@
+{ config, ... }: {
+  xdg.mimeApps.enable = true;
+
+  services.remmina = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+  };
+
+  nmt.script = ''
+    serviceFile='./home-files/.config/systemd/user/remmina.service'
+
+    assertFileExists $serviceFile
+    assertFileRegex $serviceFile 'ExecStart=.*--icon'
+
+    mimetypeFile='./home-files/.local/share/mime/packages/application-x-rdp.xml'
+
+    assertFileExists $mimetypeFile
+    assertFileRegex $mimetypeFile '<mime-type type="application/x-rdp">'
+  '';
+}

--- a/tests/modules/services/remmina/default.nix
+++ b/tests/modules/services/remmina/default.nix
@@ -1,0 +1,4 @@
+{
+  remmina-default-config = ./default-config.nix;
+  remmina-basic-config = ./basic-config.nix;
+}


### PR DESCRIPTION
### Description

Create a module to enable managing Remmina, an RDP client, with a home-manager module, providing a systemd service and mimetype integration that can be disabled if so desired.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [x] Added myself and the module files to `.github/CODEOWNERS`.
