### PR TITLE
dconf: Improve docs

### DIFF
--- a/docs/writing-modules.adoc
+++ b/docs/writing-modules.adoc
@@ -177,10 +177,10 @@ Builds a GVariant array containing the given list of elements, where each elemen
 where `type` and `types` are themselves a type and list of types, respectively.
 +
 [[sec-option-types-gvariant-mkEmptyArray]]`hm.gvariant.mkEmptyArray type`:::
-An alias of `hm.gvariant.mkArray type []`.
+An alias of <<sec-option-types-gvariant-mkArray,`hm.gvariant.mkArray type []`>>.
 +
 [[sec-option-types-gvariant-mkNothing]]`hm.gvariant.mkNothing type`:::
-Builds a GVariant maybe value (GVariant format string `m${type}`) whose (non-existent) element is of the given type. The `type` value is constructed as described for the `mkArray` function above.
+Builds a GVariant maybe value (GVariant format string `m${type}`) whose (non-existent) element is of the given type. The `type` value is constructed as described for the <<sec-option-types-gvariant-mkArray,`mkArray`>> function above.
 +
 [[sec-option-types-gvariant-mkJust]]`hm.gvariant.mkJust element`:::
 Builds a GVariant maybe value (GVariant format string `m${element.type}`) containing the given GVariant element.

--- a/docs/writing-modules.adoc
+++ b/docs/writing-modules.adoc
@@ -7,7 +7,7 @@ The module system in Home Manager is based entirely on the NixOS module system s
 [[sec-option-types]]
 === Option Types
 :wikipedia-dag: https://en.wikipedia.org/w/index.php?title=Directed_acyclic_graph&oldid=939656095
-:gvariant-description: https://developer.gnome.org/glib/stable/glib-GVariant.html#glib-GVariant.description
+:gvariant-description: https://docs.gtk.org/glib/struct.Variant.html#description
 
 Overall the basic option types are the same in Home Manager as NixOS. A few Home Manager options, however, make use of custom types that are worth describing in more detail. These are the option types `dagOf` and `gvariant` that are used, for example, by <<opt-programs.ssh.matchBlocks>> and <<opt-dconf.settings>>.
 

--- a/docs/writing-modules.adoc
+++ b/docs/writing-modules.adoc
@@ -83,7 +83,7 @@ This type is useful for options representing {gvariant-description}[GVariant] va
 Some Nix values are automatically coerced to matching GVariant value but the GVariant model is richer so you may need to use one of the provided constructor functions. Examples assume an option `foo.bar`  of type `hm.types.gvariant`.
 +
 [[sec-option-types-gvariant-mkBoolean]]`hm.gvariant.mkBoolean (v: bool)`:::
-Takes a Nix value `v` to a GVariant `boolean` value. Note, Nix booleans are automatically coerced using this function. That is,
+Takes a Nix value `v` to a GVariant `boolean` value (GVariant format string `b`). Note, Nix booleans are automatically coerced using this function. That is,
 +
 [source,nix]
 ----
@@ -97,7 +97,7 @@ is equivalent to
 foo.bar = true;
 ----
 [[sec-option-types-gvariant-mkString]]`hm.gvariant.mkString (v: string)`:::
-Takes a Nix value `v` to a GVariant `string` value. Note, Nix strings are automatically coerced using this function. That is,
+Takes a Nix value `v` to a GVariant `string` value (GVariant format string `s`). Note, Nix strings are automatically coerced using this function. That is,
 +
 [source,nix]
 ----
@@ -111,15 +111,15 @@ is equivalent to
 foo.bar = "a string";
 ----
 [[sec-option-types-gvariant-mkObjectpath]]`hm.gvariant.mkObjectpath (v: string)`:::
-Takes a Nix value `v` to a GVariant `objectpath` value.
+Takes a Nix value `v` to a GVariant `objectpath` value (GVariant format string `o`).
 [[sec-option-types-gvariant-mkUchar]]`hm.gvariant.mkUchar (v: string)`:::
-Takes a Nix value `v` to a GVariant `uchar` value.
+Takes a Nix value `v` to a GVariant `uchar` value (GVariant format string `y`).
 [[sec-option-types-gvariant-mkInt16]]`hm.gvariant.mkInt16 (v: int)`:::
-Takes a Nix value `v` to a GVariant `int16` value.
+Takes a Nix value `v` to a GVariant `int16` value (GVariant format string `n`).
 [[sec-option-types-gvariant-mkUint16]]`hm.gvariant.mkUint16 (v: int)`:::
-Takes a Nix value `v` to a GVariant `uint16` value.
+Takes a Nix value `v` to a GVariant `uint16` value (GVariant format string `q`).
 [[sec-option-types-gvariant-mkInt32]]`hm.gvariant.mkInt32 (v: int)`:::
-Takes a Nix value `v` to a GVariant `int32` value. Note, Nix integers are automatically coerced using this function. That is,
+Takes a Nix value `v` to a GVariant `int32` value (GVariant format string `i`). Note, Nix integers are automatically coerced using this function. That is,
 +
 [source,nix]
 ----
@@ -133,13 +133,13 @@ is equivalent to
 foo.bar = 7;
 ----
 [[sec-option-types-gvariant-mkUint32]]`hm.gvariant.mkUint32 (v: int)`:::
-Takes a Nix value `v` to a GVariant `uint32` value.
+Takes a Nix value `v` to a GVariant `uint32` value (GVariant format string `u`).
 [[sec-option-types-gvariant-mkInt64]]`hm.gvariant.mkInt64 (v: int)`:::
-Takes a Nix value `v` to a GVariant `int64` value.
+Takes a Nix value `v` to a GVariant `int64` value (GVariant format string `x`).
 [[sec-option-types-gvariant-mkUint64]]`hm.gvariant.mkUint64 (v: int)`:::
-Takes a Nix value `v` to a GVariant `uint64` value.
+Takes a Nix value `v` to a GVariant `uint64` value (GVariant format string `t`).
 [[sec-option-types-gvariant-mkDouble]]`hm.gvariant.mkDouble (v: double)`:::
-Takes a Nix value `v` to a GVariant `double` value. Note, Nix floats are automatically coerced using this function. That is,
+Takes a Nix value `v` to a GVariant `double` value (GVariant format string `d`). Note, Nix floats are automatically coerced using this function. That is,
 +
 [source,nix]
 ----
@@ -154,24 +154,24 @@ foo.bar = 3.14;
 ----
 +
 [[sec-option-types-gvariant-mkArray]]`hm.gvariant.mkArray type elements`:::
-Builds a GVariant array containing the given list of elements, where each element is a GVariant value of the given type. The `type` value can be constructed using
+Builds a GVariant array containing the given list of elements, where each element is a GVariant value of the given type (GVariant format string `a${type}`). The `type` value can be constructed using
 +
 --
-- `hm.gvariant.type.string`
-- `hm.gvariant.type.boolean`
-- `hm.gvariant.type.uchar`
-- `hm.gvariant.type.int16`
-- `hm.gvariant.type.uint16`
-- `hm.gvariant.type.int32`
-- `hm.gvariant.type.uint32`
-- `hm.gvariant.type.int64`
-- `hm.gvariant.type.uint64`
-- `hm.gvariant.type.double`
-- `hm.gvariant.type.variant`
-- `hm.gvariant.type.arrayOf type`
-- `hm.gvariant.type.maybeOf type`
-- `hm.gvariant.type.tupleOf types`
-- `hm.gvariant.type.dictionaryEntryOf types`
+- `hm.gvariant.type.string` (GVariant format string `s`)
+- `hm.gvariant.type.boolean` (GVariant format string `b`)
+- `hm.gvariant.type.uchar` (GVariant format string `y`)
+- `hm.gvariant.type.int16` (GVariant format string `n`)
+- `hm.gvariant.type.uint16` (GVariant format string `q`)
+- `hm.gvariant.type.int32` (GVariant format string `i`)
+- `hm.gvariant.type.uint32` (GVariant format string `u`)
+- `hm.gvariant.type.int64` (GVariant format string `x`)
+- `hm.gvariant.type.uint64` (GVariant format string `t`)
+- `hm.gvariant.type.double` (GVariant format string `d`)
+- `hm.gvariant.type.variant` (GVariant format string `v`)
+- `hm.gvariant.type.arrayOf type` (GVariant format string `a${type}`)
+- `hm.gvariant.type.maybeOf type` (GVariant format string `m${type}`)
+- `hm.gvariant.type.tupleOf types` (GVariant format string `(${lib.concatStrings types})`)
+- `hm.gvariant.type.dictionaryEntryOf [keyType valueType]` (GVariant format string `{${keyType}${valueType}}`)
 --
 +
 where `type` and `types` are themselves a type and list of types, respectively.
@@ -180,16 +180,16 @@ where `type` and `types` are themselves a type and list of types, respectively.
 An alias of `hm.gvariant.mkArray type []`.
 +
 [[sec-option-types-gvariant-mkNothing]]`hm.gvariant.mkNothing type`:::
-Builds a GVariant maybe value whose (non-existent) element is of the given type. The `type` value is constructed as described for the `mkArray` function above.
+Builds a GVariant maybe value (GVariant format string `m${type}`) whose (non-existent) element is of the given type. The `type` value is constructed as described for the `mkArray` function above.
 +
 [[sec-option-types-gvariant-mkJust]]`hm.gvariant.mkJust element`:::
-Builds a GVariant maybe value containing the given GVariant element.
+Builds a GVariant maybe value (GVariant format string `m${element.type}`) containing the given GVariant element.
 +
 [[sec-option-types-gvariant-mkTuple]]`hm.gvariant.mkTuple elements`:::
 Builds a GVariant tuple containing the given list of elements, where each element is a GVariant value.
 +
 [[sec-option-types-gvariant-mkVariant]]`hm.gvariant.mkVariant element`:::
-Builds a GVariant variant which contains the value of a GVariant element.
+Builds a GVariant variant (GVariant format string `v`) which contains the value of a GVariant element.
 +
-[[sec-option-types-gvariant-mkDictionaryEntry]]`hm.gvariant.mkDictionaryEntry elements`:::
-Builds a GVariant dictionary entry containing the given list of elements, where each element is a GVariant value.
+[[sec-option-types-gvariant-mkDictionaryEntry]]`hm.gvariant.mkDictionaryEntry [key value]`:::
+Builds a GVariant dictionary entry containing the given list of elements (GVariant format string `{${key.type}${value.type}}`), where each element is a GVariant value.

--- a/docs/writing-modules.adoc
+++ b/docs/writing-modules.adoc
@@ -77,12 +77,12 @@ foo.bar = {
 +
 would place `c` before `b` and after `a` in the graph.
 
-`hm.types.gvariant`::
+[[sec-option-types-gvariant]]`hm.types.gvariant`::
 This type is useful for options representing {gvariant-description}[GVariant] values. The type accepts all primitive GVariant types as well as arrays and tuples. Dictionaries are not currently supported.
 +
 To create a GVariant value you can use a number of provided functions. Examples assume an option `foo.bar`  of type `hm.types.gvariant`.
 +
-`hm.gvariant.mkBoolean (v: bool)`:::
+[[sec-option-types-gvariant-mkBoolean]]`hm.gvariant.mkBoolean (v: bool)`:::
 Takes a Nix value `v` to a GVariant `boolean` value. Note, Nix booleans are automatically coerced using this function. That is,
 +
 [source,nix]
@@ -96,7 +96,7 @@ is equivalent to
 ----
 foo.bar = true;
 ----
-`hm.gvariant.mkString (v: string)`:::
+[[sec-option-types-gvariant-mkString]]`hm.gvariant.mkString (v: string)`:::
 Takes a Nix value `v` to a GVariant `string` value. Note, Nix strings are automatically coerced using this function. That is,
 +
 [source,nix]
@@ -110,15 +110,15 @@ is equivalent to
 ----
 foo.bar = "a string";
 ----
-`hm.gvariant.mkObjectpath (v: string)`:::
+[[sec-option-types-gvariant-mkObjectpath]]`hm.gvariant.mkObjectpath (v: string)`:::
 Takes a Nix value `v` to a GVariant `objectpath` value.
-`hm.gvariant.mkUchar (v: string)`:::
+[[sec-option-types-gvariant-mkUchar]]`hm.gvariant.mkUchar (v: string)`:::
 Takes a Nix value `v` to a GVariant `uchar` value.
-`hm.gvariant.mkInt16 (v: int)`:::
+[[sec-option-types-gvariant-mkInt16]]`hm.gvariant.mkInt16 (v: int)`:::
 Takes a Nix value `v` to a GVariant `int16` value.
-`hm.gvariant.mkUint16 (v: int)`:::
+[[sec-option-types-gvariant-mkUint16]]`hm.gvariant.mkUint16 (v: int)`:::
 Takes a Nix value `v` to a GVariant `uint16` value.
-`hm.gvariant.mkInt32 (v: int)`:::
+[[sec-option-types-gvariant-mkInt32]]`hm.gvariant.mkInt32 (v: int)`:::
 Takes a Nix value `v` to a GVariant `int32` value. Note, Nix integers are automatically coerced using this function. That is,
 +
 [source,nix]
@@ -132,13 +132,13 @@ is equivalent to
 ----
 foo.bar = 7;
 ----
-`hm.gvariant.mkUint32 (v: int)`:::
+[[sec-option-types-gvariant-mkUint32]]`hm.gvariant.mkUint32 (v: int)`:::
 Takes a Nix value `v` to a GVariant `uint32` value.
-`hm.gvariant.mkInt64 (v: int)`:::
+[[sec-option-types-gvariant-mkInt64]]`hm.gvariant.mkInt64 (v: int)`:::
 Takes a Nix value `v` to a GVariant `int64` value.
-`hm.gvariant.mkUint64 (v: int)`:::
+[[sec-option-types-gvariant-mkUint64]]`hm.gvariant.mkUint64 (v: int)`:::
 Takes a Nix value `v` to a GVariant `uint64` value.
-`hm.gvariant.mkDouble (v: double)`:::
+[[sec-option-types-gvariant-mkDouble]]`hm.gvariant.mkDouble (v: double)`:::
 Takes a Nix value `v` to a GVariant `double` value. Note, Nix floats are automatically coerced using this function. That is,
 +
 [source,nix]
@@ -153,7 +153,7 @@ is equivalent to
 foo.bar = 3.14;
 ----
 +
-`hm.gvariant.mkArray type elements`:::
+[[sec-option-types-gvariant-mkArray]]`hm.gvariant.mkArray type elements`:::
 Builds a GVariant array containing the given list of elements, where each element is a GVariant value of the given type. The `type` value can be constructed using
 +
 --
@@ -176,20 +176,20 @@ Builds a GVariant array containing the given list of elements, where each elemen
 +
 where `type` and `types` are themselves a type and list of types, respectively.
 +
-`hm.gvariant.mkEmptyArray type`:::
+[[sec-option-types-gvariant-mkEmptyArray]]`hm.gvariant.mkEmptyArray type`:::
 An alias of `hm.gvariant.mkArray type []`.
 +
-`hm.gvariant.mkNothing type`:::
+[[sec-option-types-gvariant-mkNothing]]`hm.gvariant.mkNothing type`:::
 Builds a GVariant maybe value whose (non-existent) element is of the given type. The `type` value is constructed as described for the `mkArray` function above.
 +
-`hm.gvariant.mkJust element`:::
+[[sec-option-types-gvariant-mkJust]]`hm.gvariant.mkJust element`:::
 Builds a GVariant maybe value containing the given GVariant element.
 +
-`hm.gvariant.mkTuple elements`:::
+[[sec-option-types-gvariant-mkTuple]]`hm.gvariant.mkTuple elements`:::
 Builds a GVariant tuple containing the given list of elements, where each element is a GVariant value.
 +
-`hm.gvariant.mkVariant element`:::
+[[sec-option-types-gvariant-mkVariant]]`hm.gvariant.mkVariant element`:::
 Builds a GVariant variant which contains the value of a GVariant element.
 +
-`hm.gvariant.mkDictionaryEntry elements`:::
+[[sec-option-types-gvariant-mkDictionaryEntry]]`hm.gvariant.mkDictionaryEntry elements`:::
 Builds a GVariant dictionary entry containing the given list of elements, where each element is a GVariant value.

--- a/docs/writing-modules.adoc
+++ b/docs/writing-modules.adoc
@@ -80,7 +80,7 @@ would place `c` before `b` and after `a` in the graph.
 [[sec-option-types-gvariant]]`hm.types.gvariant`::
 This type is useful for options representing {gvariant-description}[GVariant] values. The type accepts all primitive GVariant types as well as arrays, tuples, ``maybe'' types, and dictionaries.
 +
-To create a GVariant value you can use a number of provided functions. Examples assume an option `foo.bar`  of type `hm.types.gvariant`.
+Some Nix values are automatically coerced to matching GVariant value but the GVariant model is richer so you may need to use one of the provided constructor functions. Examples assume an option `foo.bar`  of type `hm.types.gvariant`.
 +
 [[sec-option-types-gvariant-mkBoolean]]`hm.gvariant.mkBoolean (v: bool)`:::
 Takes a Nix value `v` to a GVariant `boolean` value. Note, Nix booleans are automatically coerced using this function. That is,

--- a/docs/writing-modules.adoc
+++ b/docs/writing-modules.adoc
@@ -78,7 +78,7 @@ foo.bar = {
 would place `c` before `b` and after `a` in the graph.
 
 [[sec-option-types-gvariant]]`hm.types.gvariant`::
-This type is useful for options representing {gvariant-description}[GVariant] values. The type accepts all primitive GVariant types as well as arrays and tuples. Dictionaries are not currently supported.
+This type is useful for options representing {gvariant-description}[GVariant] values. The type accepts all primitive GVariant types as well as arrays, tuples, ``maybe'' types, and dictionaries.
 +
 To create a GVariant value you can use a number of provided functions. Examples assume an option `foo.bar`  of type `hm.types.gvariant`.
 +

--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -59,6 +59,17 @@ in {
         '';
         description = ''
           Settings to write to the dconf configuration system.
+          </para><para>
+          Note that the database is strongly-typed so you need to use the same types
+          as described in the GSettings schema. For example, if an option is of type
+          <literal>uint32</literal> (<literal>u</literal>), you need to wrap the number
+          using the <literal>lib.hm.gvariant.mkUint32</literal> constructor.
+          Otherwise, since Nix integers are implicitly coerced to <literal>int32</literal>
+          (<literal>i</literal>), it would get stored in the database as such, and GSettings
+          might be confused when loading the setting.
+          </para><para>
+          You might want to use <link xlink:href="https://github.com/gvolpe/dconf2nix">dconf2nix</link>
+          to convert dconf database dumps into compatible Nix expression.
         '';
       };
     };


### PR DESCRIPTION
### Description

Try to preempt a frequent pain point, most recently in https://discourse.nixos.org/t/dash-to-dock-does-not-respect-max-icon-size-when-set-with-dconf-settings-in-configuration-nix/27904.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
