### PR TITLE
i3status-rust: revert #3938

### DIFF
--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -237,6 +237,12 @@ in {
     assertions = [
       (hm.assertions.assertPlatform "programs.i3status-rust" pkgs
         platforms.linux)
+      {
+        assertion = lib.versionOlder cfg.package.version "0.31.0"
+          || lib.versionAtLeast cfg.package.version "0.31.2";
+        message =
+          "Only i3status-rust <0.31.0 or ≥0.31.2 is supported due to a config format incompatibility.";
+      }
     ];
 
     home.packages = [ cfg.package ];

--- a/modules/programs/i3status-rust.nix
+++ b/modules/programs/i3status-rust.nix
@@ -6,18 +6,7 @@ let
 
   cfg = config.programs.i3status-rust;
 
-  settingsFormat = pkgs.formats.toml { } // {
-    # Since 0.31, the "block" key has to be first in the TOML output.
-    generate = name: value:
-      pkgs.runCommand name {
-        nativeBuildInputs = [ pkgs.jq pkgs.remarshal ];
-        value = builtins.toJSON value;
-        passAsFile = [ "value" ];
-      } ''
-        jq '.block |= map({block: .block} + del(.block))' "$valuePath" \
-          | json2toml --preserve-key-order > "$out"
-      '';
-  };
+  settingsFormat = pkgs.formats.toml { };
 
 in {
   meta.maintainers = with lib.maintainers; [ farlion thiagokokada ];

--- a/tests/modules/programs/i3status-rust/default.nix
+++ b/tests/modules/programs/i3status-rust/default.nix
@@ -4,4 +4,5 @@
   i3status-rust-with-extra-settings = ./with-extra-settings.nix;
   i3status-rust-with-multiple-bars = ./with-multiple-bars.nix;
   i3status-rust-with-version-02xx = ./with-version-02xx.nix;
+  i3status-rust-with-version-0311 = ./with-version-0311.nix;
 }

--- a/tests/modules/programs/i3status-rust/with-custom.nix
+++ b/tests/modules/programs/i3status-rust/with-custom.nix
@@ -105,12 +105,12 @@
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
             [[block]]
+            alert = 10.0
             block = "disk_space"
-            alert = 10
             info_type = "available"
             interval = 60
             path = "/"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-default.nix
+++ b/tests/modules/programs/i3status-rust/with-default.nix
@@ -4,7 +4,7 @@
   config = {
     programs.i3status-rust = { enable = true; };
 
-    test.stubs.i3status-rust = { version = "0.30.0"; };
+    test.stubs.i3status-rust = { version = "0.31.2"; };
 
     nmt.script = ''
       assertFileExists home-files/.config/i3status-rust/config-default.toml

--- a/tests/modules/programs/i3status-rust/with-default.nix
+++ b/tests/modules/programs/i3status-rust/with-default.nix
@@ -12,12 +12,12 @@
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
             [[block]]
+            alert = 10.0
             block = "disk_space"
-            alert = 10
             info_type = "available"
             interval = 60
             path = "/"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-extra-settings.nix
+++ b/tests/modules/programs/i3status-rust/with-extra-settings.nix
@@ -115,12 +115,12 @@
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
             [[block]]
+            alert = 10.0
             block = "disk_space"
-            alert = 10
             info_type = "available"
             interval = 60
             path = "/"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-multiple-bars.nix
+++ b/tests/modules/programs/i3status-rust/with-multiple-bars.nix
@@ -54,11 +54,11 @@
         ${
           pkgs.writeText "i3status-rust-expected-config" ''
             [[block]]
+            alert = 10.0
             block = "disk_space"
-            alert = 10
             info_type = "available"
             interval = 60
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-version-02xx.nix
+++ b/tests/modules/programs/i3status-rust/with-version-02xx.nix
@@ -14,12 +14,12 @@
             icons = "none"
             theme = "plain"
             [[block]]
+            alert = 10.0
             block = "disk_space"
-            alert = 10
             info_type = "available"
             interval = 60
             path = "/"
-            warning = 20
+            warning = 20.0
 
             [[block]]
             block = "memory"

--- a/tests/modules/programs/i3status-rust/with-version-0311.nix
+++ b/tests/modules/programs/i3status-rust/with-version-0311.nix
@@ -1,0 +1,13 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    programs.i3status-rust = { enable = true; };
+
+    test.stubs.i3status-rust = { version = "0.31.1"; };
+
+    test.asserts.assertions.expected = [
+      "Only i3status-rust <0.31.0 or ≥0.31.2 is supported due to a config format incompatibility."
+    ];
+  };
+}


### PR DESCRIPTION
### Description

See https://github.com/nix-community/home-manager/pull/3938#issuecomment-1532862992

https://github.com/NixOS/nixpkgs/pull/230355 has been merged, but it will still take a few days until it reaches the relevant channels.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

