### PR TITLE
flake: set source path in home-manager tool

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,8 @@
           in throwForRemovedArgs (import ./modules {
             inherit pkgs lib check extraSpecialArgs;
             configuration = { ... }: {
-              imports = modules;
+              imports = modules
+                ++ [{ programs.home-manager.path = toString ./.; }];
               nixpkgs = { inherit (pkgs) config overlays; };
             };
           });
@@ -96,7 +97,7 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           docs = import ./docs { inherit pkgs; };
-          hmPkg = pkgs.callPackage ./home-manager { };
+          hmPkg = pkgs.callPackage ./home-manager { path = toString ./.; };
         in {
           default = hmPkg;
           home-manager = hmPkg;


### PR DESCRIPTION
### Description

This makes sure that a NIX_PATH entry is added for use by non-flake commands, for example `home-manager uninstall`.

Fixes #3948
Replaces #3949

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```