### PR TITLE
xfconf: fix type order

### DIFF
--- a/modules/misc/xfconf.nix
+++ b/modules/misc/xfconf.nix
@@ -75,14 +75,9 @@ in {
 
     settings = mkOption {
       type = with types;
-        attrsOf (attrsOf (oneOf [
-          bool
-          int
-          xfIntVariant
-          float
-          str
-          (listOf (oneOf [ bool int xfIntVariant float str ]))
-        ])) // {
+      # xfIntVariant must come AFTER str; otherwise strings are treated as submodule imports...
+        let value = oneOf [ bool int float str xfIntVariant ];
+        in attrsOf (attrsOf (either value (listOf value))) // {
           description = "xfconf settings";
         };
       default = { };


### PR DESCRIPTION
Submodules must come after strings, otherwise strings are treated as paths and implicitly imported.

Fixes https://github.com/nix-community/home-manager/issues/3960

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
