### PR TITLE
atuin: Replace dead link in documentation

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -81,7 +81,7 @@ in {
         Configuration written to
         <filename>$XDG_CONFIG_HOME/atuin/config.toml</filename>.
         </para><para>
-        See <link xlink:href="https://github.com/ellie/atuin/blob/main/docs/config.md" /> for the full list
+        See <link xlink:href="https://atuin.sh/docs/config/" /> for the full list
         of options.
       '';
     };


### PR DESCRIPTION
### Description

This PR simply replaces a dead link, which was to a documentation markdown file, which is now hosted properly elsewhere.
It would also be possible to link to the new md file, which would be in a different directory. https://github.com/ellie/atuin/blob/main/docs/docs/config/config.md would be the link for that

### Checklist

<!--



  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
