### PR TITLE
home-manager: take extraSpecialArgs.lib into consideration

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,6 +1,6 @@
 { configuration
 , pkgs
-, lib ? pkgs.lib
+, lib ? extraSpecialArgs.lib or pkgs.lib
 
   # Whether to check that each option has a matching declaration.
 , check ? true
@@ -21,7 +21,7 @@ let
     in
       fold f res res.config.warnings;
 
-  extendedLib = import ./lib/stdlib-extended.nix lib;
+  extendedLib = import ./lib/stdlib-extended.nix extraSpecialArgs.lib or lib;
 
   hmModules =
     import ./modules.nix {
@@ -33,7 +33,9 @@ let
     modules = [ configuration ] ++ hmModules;
     specialArgs = {
       modulesPath = builtins.toString ./.;
-    } // extraSpecialArgs;
+    } // extraSpecialArgs // optionalAttrs (extraSpecialArgs ? lib) {
+      lib = extendedLib;
+    };
   };
 
   module = showWarnings (


### PR DESCRIPTION
### Description

I have an extended lib that I pass through my configurations, including Home Manager configurations, via the special arguments. It being the only place to safely override the default lib, considering that you might use lib in defining imports. However, since Home Manager also extends lib, these extensions get lost due to my special argument lib overriding the default Home Manager extended lib. I made a few changes to make sure the special argument lib is favored and extended instead of the one passed as an argument, such that Home Manager extensions to lib don't get lost.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
