### PR TITLE
systemd: accept derivations as values for systemd options

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -51,7 +51,7 @@ let
 
   unitType = unitKind:
     with types;
-    let primitive = either bool (either int str);
+    let primitive = oneOf [ bool int str path ];
     in attrsOf (attrsOf (attrsOf (either primitive (listOf primitive)))) // {
       description = "systemd ${unitKind} unit configuration";
     };


### PR DESCRIPTION
### Description

Allow for values of type derivation to be used as values for systemd options. This allows for instance to assign the result of `pkgs.writeShellScript` to `ExecStart` directly, without needing to call `toString` every time.
It is also closer to what people might be used to from NixOS.

~~Note: I don't really like the formatting of having one `attrsOf` on a separate line, but the auto-formatter seems to insist on doing it that way...~~

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
