### PR TITLE
starship: add enable_transience for fish

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -77,6 +77,19 @@ in {
     enableNushellIntegration = mkEnableOption "Nushell integration" // {
       default = true;
     };
+
+    enableTransience = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        The TransientPrompt feature of Starship replaces previous prompts with a
+        custom string. This is only a valid option for the Fish shell.
+
+        For documentation on how to change the default replacement string and
+        for more information visit
+        https://starship.rs/advanced-config/#transientprompt-and-transientrightprompt-in-cmd
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -101,6 +114,7 @@ in {
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
       if test "$TERM" != "dumb"  -a \( -z "$INSIDE_EMACS"  -o "$INSIDE_EMACS" = "vterm" \)
         eval (${starshipCmd} init fish)
+        ${lib.optionalString cfg.enableTransience "enable_transience"}
       end
     '';
 

--- a/tests/modules/programs/starship/default.nix
+++ b/tests/modules/programs/starship/default.nix
@@ -1,1 +1,5 @@
-{ starship-settings = ./settings.nix; }
+{
+  starship-settings = ./settings.nix;
+  starship-fish-with-transience = ./fish_with_transience.nix;
+  starship-fish-without-transience = ./fish_without_transience.nix;
+}

--- a/tests/modules/programs/starship/fish_with_transience.nix
+++ b/tests/modules/programs/starship/fish_with_transience.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs = {
+      fish.enable = true;
+
+      starship = {
+        enable = true;
+        enableTransience = true;
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/fish/config.fish
+      assertFileRegex home-files/.config/fish/config.fish 'enable_transience'
+    '';
+  };
+}

--- a/tests/modules/programs/starship/fish_without_transience.nix
+++ b/tests/modules/programs/starship/fish_without_transience.nix
@@ -1,0 +1,17 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs = {
+      fish.enable = true;
+      starship.enable = true;
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/fish/config.fish
+      assertFileNotRegex home-files/.config/fish/config.fish 'enable_transience'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Starship has an advanced, experimental feature where fancy stuff in the prompt can be replaced with something more simple after the command is ran. This is very helpful for copy and pasting shell history somewhere else.

<img width="682" alt="image" src="https://github.com/nix-community/home-manager/assets/1973/a45c2949-7800-45e5-bf0d-6c98555641d8">

docs: https://starship.rs/advanced-config/#transientprompt-and-transientrightprompt-in-fish

Fish is currently the only shell as far as I can tell that both home-manager and starship support for this feature. Since the function has to be called after starship is loaded, this seems like the best place to put it. Without putting it inside home-manager itself, you would have to forego the provided `programs.fish.interactiveShellInit` entirely just so you can be sure to only call the new function after starship is loaded, which seems like a shame.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

I did run just the starship-settings test, but there weren't any tests for the shell init hooks.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

