### PR TITLE
i3-sway: fix indentation

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -85,7 +85,7 @@ rec {
               (optionalString (position != null) "position ${position}")
               (optionalString (statusCommand != null)
                 "status_command ${statusCommand}")
-              "${moduleName}bar_command ${command}"
+              "  ${moduleName}bar_command ${command}"
               (optionalString (workspaceButtons != null)
                 "workspace_buttons ${lib.hm.booleans.yesNo workspaceButtons}")
               (optionalString (workspaceNumbers != null)


### PR DESCRIPTION
### Description

Currently the generated config file will be:
```
bar {
  position top
  status_command i3status
i3bar_command /nix/store/dyxib7xhhplkbvz07vw6mhc6islhgz2s-i3-4.21.1/bin/i3bar
}
```

What we need:
```
bar {
  position top
  status_command i3status
  i3bar_command /nix/store/dyxib7xhhplkbvz07vw6mhc6islhgz2s-i3-4.21.1/bin/i3bar
}
```