### PR TITLE
i3-sway: fix indentation of `bar` blocks

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -72,65 +72,54 @@ rec {
     , workspaceNumbers, command, statusCommand, colors, trayOutput, trayPadding
     , extraConfig, ... }:
     let colorsNotNull = lib.filterAttrs (n: v: v != null) colors != { };
-    in ''
-      bar {
-        ${
-          concatStringsSep "\n" (indent (lists.subtractLists [ "" null ]
-            (flatten [
-              (optionalString (id != null) "id ${id}")
-              (fontConfigStr fonts)
-              (optionalString (mode != null) "mode ${mode}")
-              (optionalString (hiddenState != null)
-                "hidden_state ${hiddenState}")
-              (optionalString (position != null) "position ${position}")
-              (optionalString (statusCommand != null)
-                "status_command ${statusCommand}")
-              "${moduleName}bar_command ${command}"
-              (optionalString (workspaceButtons != null)
-                "workspace_buttons ${lib.hm.booleans.yesNo workspaceButtons}")
-              (optionalString (workspaceNumbers != null)
-                "strip_workspace_numbers ${
-                  lib.hm.booleans.yesNo (!workspaceNumbers)
-                }")
-              (optionalString (trayOutput != null) "tray_output ${trayOutput}")
-              (optionalString (trayPadding != null)
-                "tray_padding ${toString trayPadding}")
-              (optionals colorsNotNull (indent
-                (lists.subtractLists [ "" null ] [
-                  "colors {"
-                  (optionalString (colors.background != null)
-                    "background ${colors.background}")
-                  (optionalString (colors.statusline != null)
-                    "statusline ${colors.statusline}")
-                  (optionalString (colors.separator != null)
-                    "separator ${colors.separator}")
-                  (optionalString (colors.focusedBackground != null)
-                    "focused_background ${colors.focusedBackground}")
-                  (optionalString (colors.focusedStatusline != null)
-                    "focused_statusline ${colors.focusedStatusline}")
-                  (optionalString (colors.focusedSeparator != null)
-                    "focused_separator ${colors.focusedSeparator}")
-                  (optionalString (colors.focusedWorkspace != null)
-                    "focused_workspace ${
-                      barColorSetStr colors.focusedWorkspace
-                    }")
-                  (optionalString (colors.activeWorkspace != null)
-                    "active_workspace ${barColorSetStr colors.activeWorkspace}")
-                  (optionalString (colors.inactiveWorkspace != null)
-                    "inactive_workspace ${
-                      barColorSetStr colors.inactiveWorkspace
-                    }")
-                  (optionalString (colors.urgentWorkspace != null)
-                    "urgent_workspace ${barColorSetStr colors.urgentWorkspace}")
-                  (optionalString (colors.bindingMode != null)
-                    "binding_mode ${barColorSetStr colors.bindingMode}")
-                  "}"
-                ]) { }))
-              extraConfig
-            ])) { })
-        }
-      }
-    '';
+    in concatMapStrings (x: x + "\n") (indent (lists.subtractLists [ "" null ]
+      (flatten [
+        "bar {"
+        (optionalString (id != null) "id ${id}")
+        (fontConfigStr fonts)
+        (optionalString (mode != null) "mode ${mode}")
+        (optionalString (hiddenState != null) "hidden_state ${hiddenState}")
+        (optionalString (position != null) "position ${position}")
+        (optionalString (statusCommand != null)
+          "status_command ${statusCommand}")
+        "${moduleName}bar_command ${command}"
+        (optionalString (workspaceButtons != null)
+          "workspace_buttons ${lib.hm.booleans.yesNo workspaceButtons}")
+        (optionalString (workspaceNumbers != null) "strip_workspace_numbers ${
+            lib.hm.booleans.yesNo (!workspaceNumbers)
+          }")
+        (optionalString (trayOutput != null) "tray_output ${trayOutput}")
+        (optionalString (trayPadding != null)
+          "tray_padding ${toString trayPadding}")
+        (optionals colorsNotNull (indent (lists.subtractLists [ "" null ] [
+          "colors {"
+          (optionalString (colors.background != null)
+            "background ${colors.background}")
+          (optionalString (colors.statusline != null)
+            "statusline ${colors.statusline}")
+          (optionalString (colors.separator != null)
+            "separator ${colors.separator}")
+          (optionalString (colors.focusedBackground != null)
+            "focused_background ${colors.focusedBackground}")
+          (optionalString (colors.focusedStatusline != null)
+            "focused_statusline ${colors.focusedStatusline}")
+          (optionalString (colors.focusedSeparator != null)
+            "focused_separator ${colors.focusedSeparator}")
+          (optionalString (colors.focusedWorkspace != null)
+            "focused_workspace ${barColorSetStr colors.focusedWorkspace}")
+          (optionalString (colors.activeWorkspace != null)
+            "active_workspace ${barColorSetStr colors.activeWorkspace}")
+          (optionalString (colors.inactiveWorkspace != null)
+            "inactive_workspace ${barColorSetStr colors.inactiveWorkspace}")
+          (optionalString (colors.urgentWorkspace != null)
+            "urgent_workspace ${barColorSetStr colors.urgentWorkspace}")
+          (optionalString (colors.bindingMode != null)
+            "binding_mode ${barColorSetStr colors.bindingMode}")
+          "}"
+        ]) { }))
+        extraConfig
+        "}"
+      ])) { });
 
   gapsStr = with cfg.config.gaps;
     concatStringsSep "\n" (lists.subtractLists [ "" null ] [

--- a/tests/modules/services/window-managers/i3/i3-bar-focused-colors-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-bar-focused-colors-expected.conf
@@ -94,6 +94,6 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 

--- a/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
@@ -91,6 +91,6 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 

--- a/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
@@ -91,6 +91,6 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 

--- a/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
@@ -92,6 +92,6 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 

--- a/tests/modules/services/window-managers/i3/i3-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-workspace-default-expected.conf
@@ -90,6 +90,6 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 

--- a/tests/modules/services/window-managers/i3/i3-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-workspace-output-expected.conf
@@ -91,7 +91,7 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 
 workspace "1" output eDP

--- a/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
+++ b/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
@@ -103,7 +103,7 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 
 exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE NIXOS_OZONE_WL; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.conf
+++ b/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.conf
@@ -102,7 +102,7 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 
 exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE NIXOS_OZONE_WL; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -100,7 +100,7 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 
 exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE NIXOS_OZONE_WL; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-modules.conf
+++ b/tests/modules/services/window-managers/sway/sway-modules.conf
@@ -112,7 +112,7 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 
 exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE NIXOS_OZONE_WL; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-null-package.conf
+++ b/tests/modules/services/window-managers/sway/sway-null-package.conf
@@ -100,7 +100,7 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 
 exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE NIXOS_OZONE_WL; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
@@ -99,7 +99,7 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 
 exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE NIXOS_OZONE_WL; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
@@ -100,7 +100,7 @@ bar {
     inactive_workspace #333333 #222222 #888888
     urgent_workspace #2f343a #900000 #ffffff
     binding_mode #2f343a #900000 #ffffff
-}
+  }
 }
 
 workspace "1" output eDP


### PR DESCRIPTION
The `indent` function unindents the first and last line by default, so the `"bar {"` `"}"` wrapper should go inside the list.

Replaces https://github.com/nix-community/home-manager/pull/3976

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.