### PR TITLE
zellij: disables shell integrations by default

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -41,15 +41,15 @@ in {
     };
 
     enableBashIntegration = mkEnableOption "Enable Bash integration." // {
-      default = true;
+      default = false;
     };
 
     enableZshIntegration = mkEnableOption "Enable Zsh integration." // {
-      default = true;
+      default = false;
     };
 
     enableFishIntegration = mkEnableOption "Enable Fish integration." // {
-      default = true;
+      default = false;
     };
   };
 

--- a/tests/modules/programs/zellij/enable-shells.nix
+++ b/tests/modules/programs/zellij/enable-shells.nix
@@ -3,7 +3,12 @@
 {
   programs = {
     # All shell integratons are enabled by default.
-    zellij.enable = true;
+    zellij = {
+      enable = true;
+      enableBashIntegration = true;
+      enableZshIntegration = true;
+      enableFishIntegration = true;
+    };
     bash.enable = true;
     zsh.enable = true;
     fish.enable = true;

--- a/tests/modules/programs/zellij/enable-shells.nix
+++ b/tests/modules/programs/zellij/enable-shells.nix
@@ -2,7 +2,6 @@
 
 {
   programs = {
-    # All shell integratons are enabled by default.
     zellij = {
       enable = true;
       enableBashIntegration = true;


### PR DESCRIPTION
### Description

I added the shell integrations back in this PR: https://github.com/nix-community/home-manager/pull/3926

There was some early feedback suggesting that shell integrations shouldn't be enabled by default, so I'm opening this PR to make it more convenient for the maintainers to pivot to this options if desired.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
