### PR TITLE
aerc: add notmuch support

### DIFF
--- a/modules/programs/aerc-accounts.nix
+++ b/modules/programs/aerc-accounts.nix
@@ -133,6 +133,16 @@ in {
           source =
             "maildir://${config.accounts.email.maildirBasePath}/${cfg.maildir.path}";
         };
+        notmuch = cfg:
+          let
+            maildir-store =
+              if account.mbsync.enable || account.offlineimap.enable then
+                "${config.accounts.email.maildirBasePath}"
+              else
+                null;
+          in {
+            source = "notmuch://${config.accounts.email.maildirBasePath}";
+          } // optAttr "maildir-store" maildir-store;
         imap = { userName, imap, passwordCommand, aerc, ... }@cfg:
           let
             loginMethod' =
@@ -186,7 +196,9 @@ in {
         // (optAttr "postpone" account.folders.drafts)
         // (optAttr "aliases" account.aliases) // account.aerc.extraAccounts;
       sourceCfg = account:
-        if account.mbsync.enable || account.offlineimap.enable then
+        if account.notmuch.enable then
+          mkConfig.notmuch account
+        else if account.mbsync.enable || account.offlineimap.enable then
           mkConfig.maildir account
         else if account.imap != null then
           mkConfig.imap account

--- a/tests/modules/programs/aerc/extraAccounts.expected
+++ b/tests/modules/programs/aerc/extraAccounts.expected
@@ -55,9 +55,23 @@ outgoing-cred-cmd = echo PaSsWorD!
 from = Foo Bar <addr@mail.invalid>
 source = maildir:///home/hm-user/Maildir/i_maildir-mbsync
 
+[i_maildir-mbsync-notmuch]
+from = Foo Bar <addr@mail.invalid>
+maildir-store = /home/hm-user/Maildir
+source = notmuch:///home/hm-user/Maildir
+
+[j_maildir-notmuch]
+from = Foo Bar <addr@mail.invalid>
+source = notmuch:///home/hm-user/Maildir
+
 [j_maildir-offlineimap]
 from = Foo Bar <addr@mail.invalid>
 source = maildir:///home/hm-user/Maildir/j_maildir-offlineimap
+
+[j_maildir-offlineimap-notmuch]
+from = Foo Bar <addr@mail.invalid>
+maildir-store = /home/hm-user/Maildir
+source = notmuch:///home/hm-user/Maildir
 
 [l_smtp-auth-none]
 from = Foo Bar <addr@mail.invalid>

--- a/tests/modules/programs/aerc/settings.nix
+++ b/tests/modules/programs/aerc/settings.nix
@@ -191,7 +191,16 @@ with lib;
         };
       };
       i_maildir-mbsync = basics // { mbsync.enable = true; };
+      i_maildir-mbsync-notmuch = basics // {
+        mbsync.enable = true;
+        notmuch.enable = true;
+      };
+      j_maildir-notmuch = basics // { notmuch.enable = true; };
       j_maildir-offlineimap = basics // { offlineimap.enable = true; };
+      j_maildir-offlineimap-notmuch = basics // {
+        offlineimap.enable = true;
+        notmuch.enable = true;
+      };
       k_notEnabled = basics // { aerc.enable = false; };
       l_smtp-auth-none = basics // {
         smtp = {


### PR DESCRIPTION
This doesn't touch query-map option which could be used to create virtual mailboxes with imap. The maildir backend creates virtual mailboxes automatically.

### Checklist

- [ ] Change is backwards compatible. (It depends how you look at it, given that notmuch was ignored with aerc the generation will break for `notmuch.enable = true` and `mbsync.enable.true` setups, because it'll be notmuch now). Maybe the `aerc.notmuch` option should be added? 
 
- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted