### PR TITLE
kitty: improve error message when theme not found

### DIFF
--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -135,9 +135,13 @@ in {
 
         (optionalString (cfg.theme != null) ''
           include ${pkgs.kitty-themes}/share/kitty-themes/${
-            (head (filter (x: x.name == cfg.theme) (builtins.fromJSON
-              (builtins.readFile
-                "${pkgs.kitty-themes}/share/kitty-themes/themes.json")))).file
+            let
+              matching = filter (x: x.name == cfg.theme) (builtins.fromJSON
+                (builtins.readFile
+                  "${pkgs.kitty-themes}/share/kitty-themes/themes.json"));
+            in throwIf (length matching == 0)
+            "kitty-themes does not contain a theme named ${cfg.theme}"
+            (head matching).file
           }
         '')
         (toKittyConfig cfg.settings)


### PR DESCRIPTION
### Description

Improve the error message in https://github.com/nix-community/home-manager/issues/3988

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
