### PR TITLE
tests: bump nmt to latest

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -6,8 +6,8 @@ let
 
   nmt = fetchTarball {
     url =
-      "https://gitlab.com/api/v4/projects/rycee%2Fnmt/repository/archive.tar.gz?sha=d83601002c99b78c89ea80e5e6ba21addcfe12ae";
-    sha256 = "1xzwwxygzs1cmysg97hzd285r7n1g1lwx5y1ar68gwq07a1rczmv";
+      "https://gitlab.com/api/v4/projects/rycee%2Fnmt/repository/archive.tar.gz?sha=4df00c569b1badfedffecd7ccd60f794550486db";
+    sha256 = "1cyly1zazgj8z6bazml4js7lqaqvpp8lw045aqchlpvp42bl1lp4";
   };
 
   modules = import ../modules/modules.nix {


### PR DESCRIPTION
### Description

Updates nmt to latest revision that includes @ncfavier's [space leak fix and improved error reporting](https://git.sr.ht/~rycee/nmt/commit/4df00c569b1badfedffecd7ccd60f794550486db).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```