### PR TITLE
neomutt: add missing stub in test

### DIFF
--- a/tests/modules/programs/neomutt/neomutt-with-binds-invalid-settings.nix
+++ b/tests/modules/programs/neomutt/neomutt-with-binds-invalid-settings.nix
@@ -20,6 +20,8 @@ with lib;
       }];
     };
 
+    test.stubs.neomutt = { };
+
     test.asserts.assertions.expected = [
       "The 'programs.neomutt.(binds|macros).map' list must contain at least one element."
     ];


### PR DESCRIPTION
Fixes tests on Darwin where neomutt currently fails to build https://github.com/NixOS/nixpkgs/issues/232074