### PR TITLE
helix: update languages.toml generation (support every option in languages.toml)

### DIFF
--- a/tests/modules/programs/helix/example-settings.nix
+++ b/tests/modules/programs/helix/example-settings.nix
@@ -21,10 +21,27 @@ with lib;
         };
       };
 
-      languages = [{
-        name = "rust";
-        auto-format = false;
-      }];
+      languages = {
+        language-server.typescript-language-server = let
+          typescript-language-server = config.lib.test.mkStubPackage {
+            outPath = "@typescript-language-server@";
+          };
+          typescript =
+            config.lib.test.mkStubPackage { outPath = "@typescript@"; };
+        in {
+          command =
+            "${typescript-language-server}/bin/typescript-language-server";
+          args = [
+            "--stdio"
+            "--tsserver-path=${typescript}/lib/node_modules/typescript/lib"
+          ];
+        };
+
+        language = [{
+          name = "rust";
+          auto-format = false;
+        }];
+      };
 
       themes = {
         base16 = let

--- a/tests/modules/programs/helix/languages-expected.toml
+++ b/tests/modules/programs/helix/languages-expected.toml
@@ -1,3 +1,7 @@
 [[language]]
 auto-format = false
 name = "rust"
+
+[language-server.typescript-language-server]
+args = ["--stdio", "--tsserver-path=@typescript@/lib/node_modules/typescript/lib"]
+command = "@typescript-language-server@/bin/typescript-language-server"


### PR DESCRIPTION
### Description

Updates the generation of `languages.toml` by supporting every option in it with `programs.helix.languages`. This is a breaking change (which IMHO is justified, as it should be more future-proof).

It closes #3911 as well, as it achieves basically the same (support serializing `grammar` and `use-grammars`) with less code (but a breaking change as mentioned above).

But #2871 is not fixed by this, as this seems to be a little bit more tricky (see discussion in this issue).

Motivation for this is support for multiple language servers (https://github.com/helix-editor/helix/pull/2507)
I've included a comment in the example of this option, which I will remove once a new stable helix version is out (but this will likely take some time, as just a new version came out).
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
