### PR TITLE
Added the joshuto file manager

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -329,6 +329,12 @@
     github = "sebtm";
     githubId = 17243347;
   };
+  rasmus-kirk = {
+    name = "Rasmus Kirk";
+    email = "mail@rasmuskirk.com";
+    github = "rasmus-kirk";
+    githubId = 57323869;
+  };
   rosuavio = {
     name = "Rosario Pulella";
     email = "RosarioPulella@gmail.com";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -103,6 +103,7 @@ let
     ./programs/java.nix
     ./programs/jq.nix
     ./programs/jujutsu.nix
+    ./programs/joshuto.nix
     ./programs/just.nix
     ./programs/k9s.nix
     ./programs/kakoune.nix

--- a/modules/programs/joshuto.nix
+++ b/modules/programs/joshuto.nix
@@ -1,0 +1,88 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.joshuto;
+  tomlFormat = pkgs.formats.toml { };
+in {
+  meta.maintainers = [ maintainers.rasmus-kirk ];
+
+  options.programs.joshuto = {
+    enable = mkEnableOption "joshuto file manager";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.joshuto;
+      defaultText = literalExpression "pkgs.joshuto";
+      description = "The package to use for joshuto.";
+    };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      description = ''
+        Configuration written to
+        <filename>$XDG_CONFIG_HOME/joshuto/joshuto.toml</filename>.
+        </para><para>
+        See <link xlink:href="https://github.com/kamiyaa/joshuto/blob/main/docs/configuration/joshuto.toml.md" />
+        for the full list of options.
+      '';
+    };
+
+    keymap = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      description = ''
+        Configuration written to
+        <filename>$XDG_CONFIG_HOME/joshuto/keymap.toml</filename>.
+        </para><para>
+        See <link xlink:href="https://github.com/kamiyaa/joshuto/blob/main/docs/configuration/keymap.toml.md" />
+        for the full list of options. Note that this option will overwrite any existing keybinds.
+      '';
+    };
+
+    mimetype = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      description = ''
+        Configuration written to
+        <filename>$XDG_CONFIG_HOME/joshuto/mimetype.toml</filename>.
+        </para><para>
+        See <link xlink:href="https://github.com/kamiyaa/joshuto/blob/main/docs/configuration/mimetype.toml.md" />
+        for the full list of options
+      '';
+    };
+
+    theme = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      description = ''
+        Configuration written to
+        <filename>$XDG_CONFIG_HOME/joshuto/theme.toml</filename>.
+        </para><para>
+        See <link xlink:href="https://github.com/kamiyaa/joshuto/blob/main/docs/configuration/theme.toml.md" />
+        for the full list of options
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = {
+      "joshuto/joshuto.toml" = mkIf (cfg.settings != { }) {
+        source = tomlFormat.generate "joshuto-settings" cfg.settings;
+      };
+      "joshuto/keymap.toml" = mkIf (cfg.keymap != { }) {
+        source = tomlFormat.generate "joshuto-keymap" cfg.keymap;
+      };
+      "joshuto/mimetype.toml" = mkIf (cfg.mimetype != { }) {
+        source = tomlFormat.generate "joshuto-mimetype" cfg.mimetype;
+      };
+      "joshuto/theme.toml" = mkIf (cfg.theme != { }) {
+        source = tomlFormat.generate "joshuto-theme" cfg.theme;
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Description

Added the [joshuto](https://github.com/kamiyaa/joshuto) file manager

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
