### PR TITLE
accounts.email.<account>.maildir.absPath: allow overriding

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -209,9 +209,7 @@ let
       };
 
       absPath = mkOption {
-        type = types.path;
-        readOnly = true;
-        internal = true;
+        type = types.str;
         default = "${cfg.maildirBasePath}/${config.path}";
         description = ''
           A convenience option whose value is the absolute path of


### PR DESCRIPTION
### Description

I wanted to use an imaps:// url as a maildir, but the current accounts module makes this impossible. Exposing absPath for overriding allows me to do this. It works well.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
