### PR TITLE
Add `systemdTarget` options

### DIFF
--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -196,6 +196,14 @@ in {
         '';
         example = "polybar bar &";
       };
+
+      systemdTarget = mkOption {
+        type = types.str;
+        default = "tray.target";
+        description = ''
+          Systemd target to bind to.
+        '';
+      };
     };
   };
 
@@ -214,7 +222,7 @@ in {
     systemd.user.services.polybar = {
       Unit = {
         Description = "Polybar status bar";
-        PartOf = [ "tray.target" ];
+        PartOf = [ cfg.systemdTarget ];
         X-Restart-Triggers = mkIf (configFile != null) "${configFile}";
       };
 
@@ -227,7 +235,7 @@ in {
         Restart = "on-failure";
       };
 
-      Install = { WantedBy = [ "tray.target" ]; };
+      Install = { WantedBy = [ cfg.systemdTarget ]; };
     };
   };
 

--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -44,6 +44,14 @@ in {
       '';
     };
 
+    systemdTarget = mkOption {
+      type = types.str;
+      default = "graphical-session.target";
+      description = ''
+        Systemd target to bind to.
+      '';
+    };
+
     xautolock = {
       enable = mkOption {
         type = types.bool;
@@ -118,10 +126,10 @@ in {
         Unit = {
           Description = "xss-lock, session locker service";
           After = [ "graphical-session-pre.target" ];
-          PartOf = [ "graphical-session.target" ];
+          PartOf = [ cfg.systemdTarget ];
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = { WantedBy = [ cfg.systemdTarget ]; };
 
         Service = {
           ExecStart = concatStringsSep " "
@@ -141,10 +149,10 @@ in {
         Unit = {
           Description = "xautolock, session locker service";
           After = [ "graphical-session-pre.target" ];
-          PartOf = [ "graphical-session.target" ];
+          PartOf = [ cfg.systemdTarget ];
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = { WantedBy = [ cfg.systemdTarget ]; };
 
         Service = {
           ExecStart = concatStringsSep " " ([


### PR DESCRIPTION
### Description

Makes it easier to have multiple sessions from the same `home-manager` configuration

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.