### PR TITLE
home-manager: fix spurious error message in flake check

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -53,7 +53,7 @@ function setWorkDir() {
 # Checks whether the 'flakes' and 'nix-command' Nix options are enabled.
 function hasFlakeSupport() {
     type -p nix > /dev/null \
-        && nix show-config \
+        && nix show-config 2> /dev/null \
             | grep experimental-features \
             | grep flakes \
             | grep -q nix-command


### PR DESCRIPTION
### Description

Before this commit, running the hasFlakeSupport function causes an error message

    error: experimental Nix feature 'nix-command' is disabled; use
    '--extra-experimental-features nix-command' to override

when the Nix installation does not support the nix tool.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```