### PR TITLE
Fix type of programs.helix.languages

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -47,7 +47,7 @@ in {
 
     languages = mkOption {
       type = with types;
-        coercedTo (listOf tomlFormat.type) (language:
+        coercedTo tomlFormat.type (language:
           lib.warn ''
             The syntax of programs.helix.languages has changed.
             It now generates the whole languages.toml file instead of just the language array in that file.


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Since it now generates the whole TOML, the type should be `tomlFormat.type` instead of `listOf tomlFormat.type`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
