### PR TITLE
ssh: don't install a client by default

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1028,9 +1028,9 @@ in
         time = "2023-05-13T14:34:21+00:00";
         condition = config.programs.ssh.enable;
         message = ''
-          The module 'programs.ssh' now installs an SSH client. The installed
+          The module 'programs.ssh' can now install an SSH client. The installed
           client is controlled by the 'programs.ssh.package` option, which
-          defaults to 'pkgs.openssh'.
+          defaults to 'null'.
         '';
       }
       {

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -361,7 +361,11 @@ in
   options.programs.ssh = {
     enable = mkEnableOption "SSH client configuration";
 
-    package = mkPackageOption pkgs "openssh" { };
+    package = mkPackageOption pkgs "openssh" {
+      nullable = true;
+      default = null;
+      extraDescription = "By default, the client provided by your system is used.";
+    };
 
     forwardAgent = mkOption {
       default = false;
@@ -527,7 +531,7 @@ in
       }
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = optional (cfg.package != null) cfg.package;
 
     home.file.".ssh/config".text =
       let

--- a/tests/modules/programs/ssh/default-config.nix
+++ b/tests/modules/programs/ssh/default-config.nix
@@ -6,8 +6,6 @@ with lib;
   config = {
     programs.ssh = { enable = true; };
 
-    test.stubs.openssh = { };
-
     home.file.assertions.text = builtins.toJSON
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 

--- a/tests/modules/programs/ssh/forwards-dynamic-bind-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-dynamic-bind-path-with-port-asserts.nix
@@ -17,8 +17,6 @@ with lib;
       };
     };
 
-    test.stubs.openssh = { };
-
     test.asserts.assertions.expected = [ "Forwarded paths cannot have ports." ];
   };
 }

--- a/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts.nix
@@ -27,8 +27,6 @@ with lib;
     home.file.result.text = builtins.toJSON
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
-    test.stubs.openssh = { };
-
     nmt.script = ''
       assertFileExists home-files/.ssh/config
       assertFileContent \

--- a/tests/modules/programs/ssh/forwards-local-bind-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-local-bind-path-with-port-asserts.nix
@@ -21,8 +21,6 @@ with lib;
       };
     };
 
-    test.stubs.openssh = { };
-
     test.asserts.assertions.expected = [ "Forwarded paths cannot have ports." ];
   };
 }

--- a/tests/modules/programs/ssh/forwards-local-host-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-local-host-path-with-port-asserts.nix
@@ -21,8 +21,6 @@ with lib;
       };
     };
 
-    test.stubs.openssh = { };
-
     test.asserts.assertions.expected = [ "Forwarded paths cannot have ports." ];
   };
 }

--- a/tests/modules/programs/ssh/forwards-remote-bind-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-remote-bind-path-with-port-asserts.nix
@@ -21,8 +21,6 @@ with lib;
       };
     };
 
-    test.stubs.openssh = { };
-
     test.asserts.assertions.expected = [ "Forwarded paths cannot have ports." ];
   };
 }

--- a/tests/modules/programs/ssh/forwards-remote-host-path-with-port-asserts.nix
+++ b/tests/modules/programs/ssh/forwards-remote-host-path-with-port-asserts.nix
@@ -21,8 +21,6 @@ with lib;
       };
     };
 
-    test.stubs.openssh = { };
-
     test.asserts.assertions.expected = [ "Forwarded paths cannot have ports." ];
   };
 }

--- a/tests/modules/programs/ssh/includes.nix
+++ b/tests/modules/programs/ssh/includes.nix
@@ -7,8 +7,6 @@
       includes = [ "config.d/*" "other/dir" ];
     };
 
-    test.stubs.openssh = { };
-
     nmt.script = ''
       assertFileExists home-files/.ssh/config
       assertFileContains home-files/.ssh/config "Include config.d/* other/dir"

--- a/tests/modules/programs/ssh/match-blocks-attrs.nix
+++ b/tests/modules/programs/ssh/match-blocks-attrs.nix
@@ -51,8 +51,6 @@ with lib;
     home.file.assertions.text = builtins.toJSON
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
-    test.stubs.openssh = { };
-
     nmt.script = ''
       assertFileExists home-files/.ssh/config
       assertFileContent \

--- a/tests/modules/programs/ssh/match-blocks-match-and-hosts.nix
+++ b/tests/modules/programs/ssh/match-blocks-match-and-hosts.nix
@@ -21,8 +21,6 @@ with lib;
     home.file.assertions.text = builtins.toJSON
       (map (a: a.message) (filter (a: !a.assertion) config.assertions));
 
-    test.stubs.openssh = { };
-
     nmt.script = ''
       assertFileExists home-files/.ssh/config
       assertFileContent \


### PR DESCRIPTION
Make use of the [recently added](https://github.com/NixOS/nixpkgs/pull/232808) nullable `mkPackageOption` feature to disable installing an SSH client by default: most people should use the client provided by their system (see https://github.com/nix-community/home-manager/pull/3668#issuecomment-1560496213).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
