### PR TITLE
yt-dlp: generate config if settings or extraConfig are defined

### DIFF
--- a/modules/programs/yt-dlp.nix
+++ b/modules/programs/yt-dlp.nix
@@ -66,9 +66,11 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."yt-dlp/config" = mkIf (cfg.settings != { }) {
-      text = concatStringsSep "\n"
-        (remove "" (renderSettings cfg.settings ++ [ cfg.extraConfig ])) + "\n";
-    };
+    xdg.configFile."yt-dlp/config" =
+      mkIf (cfg.settings != { } || cfg.extraConfig != "") {
+        text = concatStringsSep "\n"
+          (remove "" (renderSettings cfg.settings ++ [ cfg.extraConfig ]))
+          + "\n";
+      };
   };
 }

--- a/tests/modules/programs/yt-dlp/default.nix
+++ b/tests/modules/programs/yt-dlp/default.nix
@@ -1,1 +1,4 @@
-{ yt-dlp-simple-config = ./yt-dlp-simple-config.nix; }
+{
+  yt-dlp-simple-config = ./yt-dlp-simple-config.nix;
+  yt-dlp-extraConfig = ./yt-dlp-extraConfig.nix;
+}

--- a/tests/modules/programs/yt-dlp/yt-dlp-extraConfig-expected
+++ b/tests/modules/programs/yt-dlp/yt-dlp-extraConfig-expected
@@ -1,0 +1,2 @@
+--config-locations /home/user/.yt-dlp.conf
+

--- a/tests/modules/programs/yt-dlp/yt-dlp-extraConfig.nix
+++ b/tests/modules/programs/yt-dlp/yt-dlp-extraConfig.nix
@@ -1,0 +1,19 @@
+{ ... }:
+
+{
+  programs.yt-dlp = {
+    enable = true;
+    extraConfig = ''
+      --config-locations /home/user/.yt-dlp.conf
+    '';
+  };
+
+  test.stubs.yt-dlp = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/yt-dlp/config
+    assertFileContent home-files/.config/yt-dlp/config ${
+      ./yt-dlp-extraConfig-expected
+    }
+  '';
+}


### PR DESCRIPTION
### Description

Previously, the config was generated only if settings were defined. In a case where settings weren't defined, extraConfig was ignored. This happened to me while I moved my yt-dlp config to Nix. I simply put everything in extraConfig, without defining settings.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.