### PR TITLE
helix: improve warning message for languages option

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -53,7 +53,7 @@ in {
             It now generates the whole languages.toml file instead of just the language array in that file.
 
             Use
-            { language = <languages list>; }
+            programs.helix.languages = { language = <languages list>; }
             instead.
           '' { inherit language; }) (addCheck tomlFormat.type builtins.isAttrs);
       default = { };


### PR DESCRIPTION
### Description

https://github.com/nix-community/home-manager/pull/4003#issuecomment-1564355930

The warning message for programs.helix.languages was unclear and did not specify the full path of the option. This commit changes the warning message to include the full path and make it easier for users to understand how to update their configuration.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
