### PR TITLE
antidote:  add module  , a zsh plug manager

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1125,6 +1125,14 @@ in
           can control it by using the `qt5ct` and `qt6ct` applications;
           - `qt.style.name = "kvantum"`: override the style by using themes
           written in SVG. Supports many popular themes.
+          '';
+      }
+
+      {
+        time = "2023-06-17T22:18:22+00:00";
+        condition = config.programs.zsh.enable;
+        message = ''
+          A new modules is available: 'programs.zsh.antidote'
         '';
       }
     ];

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -51,6 +51,7 @@ let
     ./programs/afew.nix
     ./programs/alacritty.nix
     ./programs/alot.nix
+    ./programs/antidote.nix
     ./programs/aria2.nix
     ./programs/astroid.nix
     ./programs/atuin.nix

--- a/modules/programs/antidote.nix
+++ b/modules/programs/antidote.nix
@@ -1,0 +1,53 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.programs.zsh.antidote;
+
+  relToDotDir = file:
+    (optionalString (config.programs.zsh.dotDir != null)
+      (config.programs.zsh.dotDir + "/")) + file;
+
+  zPluginStr = with lib;
+    (pluginNames:
+      optionalString (pluginNames != [ ]) "${concatStrings (map (name: ''
+        ${name}
+      '') pluginNames)}");
+in {
+  meta.maintainers = [ maintainers.hitsmaxft ];
+
+  options.programs.zsh.antidote = {
+    enable = mkEnableOption "antidote - a zsh plugin manager";
+
+    plugins = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "zsh-users/zsh-autosuggestions" ];
+      description = "List of antidote plugins.";
+    };
+
+    useFriendlyNames = mkEnableOption "friendly names";
+
+    package = mkPackageOption pkgs "antidote" { };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.file."${relToDotDir ".zsh_plugins.txt"}".text = zPluginStr cfg.plugins;
+
+    ### move zsh_plugins.txt
+    programs.zsh.initExtraBeforeCompInit = ''
+      ## home-manager/antidote begin :
+      source ${cfg.package}/antidote.zsh
+      ${optionalString cfg.useFriendlyNames
+      "zstyle ':antidote:bundle' use-friendly-names 'yes'"}
+      bundlefile=${relToDotDir ".zsh_plugins.txt"}
+      zstyle ':antidote:bundle' file $bundlefile
+      staticfile=${relToDotDir ".zsh_plugins.zsh"}
+      zstyle ':antidote:static' file $staticfile
+      antidote load $bundlefile $staticfile
+      ## home-manager/antidote end
+    '';
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -57,6 +57,7 @@ import nmt {
     ./modules/programs/aerc
     ./modules/programs/alacritty
     ./modules/programs/alot
+    ./modules/programs/antidote
     ./modules/programs/aria2
     ./modules/programs/atuin
     ./modules/programs/autojump

--- a/tests/modules/programs/antidote/antidote.nix
+++ b/tests/modules/programs/antidote/antidote.nix
@@ -1,0 +1,31 @@
+{ ... }:
+
+let relToDotDirCustom = ".zshplugins";
+
+in {
+  programs.zsh = {
+    enable = true;
+    dotDir = relToDotDirCustom;
+    antidote = {
+      enable = true;
+      useFriendlyNames = true;
+      plugins = [ "zsh-users/zsh-autosuggestions" ];
+    };
+  };
+
+  test.stubs = {
+    antidote = { };
+    zsh = { };
+  };
+
+  nmt.script = ''
+    assertFileContains home-files/${relToDotDirCustom}/.zshrc \
+      'source @antidote@/antidote.zsh'
+    assertFileContains home-files/${relToDotDirCustom}/.zshrc \
+      'antidote load'
+    assertFileContains home-files/${relToDotDirCustom}/.zshrc \
+      "zstyle ':antidote:bundle' use-friendly-names 'yes'"
+    assertFileContains home-files/${relToDotDirCustom}/.zsh_plugins.txt \
+      'zsh-users/zsh-autosuggestions'
+  '';
+}

--- a/tests/modules/programs/antidote/default.nix
+++ b/tests/modules/programs/antidote/default.nix
@@ -1,0 +1,1 @@
+{ antidote-program = ./antidote.nix; }


### PR DESCRIPTION
### Description

<!--

add new zsh plugin manager antidote

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

