### PR TITLE
nix: add a declarative alternative to Nix channels

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1656,6 +1656,17 @@ in {
           See https://codeberg.org/dnkl/yambar for more.
         '';
       }
+
+      {
+        time = "2024-05-25T14:36:03+00:00";
+        message = ''
+          Multiple new options are available:
+
+          - 'nix.nixPath'
+          - 'nix.keepOldNixPath'
+          - 'nix.channels'
+        '';
+      }
     ];
   };
 }

--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -10,6 +10,20 @@ let
 
   isNixAtLeast = versionAtLeast (getVersion nixPackage);
 
+  nixPath = lib.concatStringsSep ":" cfg.nixPath;
+
+  # The deploy path for declarative channels. The directory name is prefixed
+  # with a number to make it easier for files in ~/.nix-defexpr to control the
+  # order they'll be read relative to each other.
+  channelPath = ".nix-defexpr/50-home-manager";
+
+  channelsDrv = let
+    mkEntry = name: drv: {
+      inherit name;
+      path = toString drv;
+    };
+  in pkgs.linkFarm "channels" (lib.mapAttrsToList mkEntry cfg.channels);
+
   nixConf = assert isNixAtLeast "2.2";
     let
 
@@ -127,6 +141,22 @@ in {
       '';
     };
 
+    channels = lib.mkOption {
+      type = with lib.types; attrsOf package;
+      default = { };
+      example = lib.literalExpression "{ inherit nixpkgs; }";
+      description = lib.mdDoc ''
+        A declarative alternative to Nix channels. Whereas with stock channels,
+        you would register URLs and fetch them into the Nix store with
+        {manpage}`nix-channel(1)`, this option allows you to register the store
+        path directly. One particularly useful example is registering flake
+        inputs as channels.
+
+        This option can coexist with stock Nix channels. If the same channel is
+        defined in both, this option takes precedence.
+      '';
+    };
+
     registry = mkOption {
       type = types.attrsOf (types.submodule (let
         inputAttrs = types.attrsOf
@@ -241,6 +271,11 @@ in {
 
     (mkIf (cfg.nixPath != [ ] && cfg.keepOldNixPath) {
       home.sessionVariables.NIX_PATH = "${nixPath}\${NIX_PATH:+:$NIX_PATH}";
+    })
+
+    (lib.mkIf (cfg.channels != { }) {
+      nix.nixPath = [ "${config.home.homeDirectory}/${channelPath}" ];
+      home.file."${channelPath}".source = channelsDrv;
     })
 
     (mkIf (cfg.registry != { }) {

--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -1,8 +1,12 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+
+  inherit (lib)
+    boolToString concatStringsSep escape floatToString getVersion isBool
+    isConvertibleWithToString isDerivation isFloat isInt isList isString
+    literalExpression maintainers mapAttrsToList mkDefault mkEnableOption mkIf
+    mkMerge mkOption optionalString toPretty types versionAtLeast;
 
   cfg = config.nix;
 
@@ -10,7 +14,7 @@ let
 
   isNixAtLeast = versionAtLeast (getVersion nixPackage);
 
-  nixPath = lib.concatStringsSep ":" cfg.nixPath;
+  nixPath = concatStringsSep ":" cfg.nixPath;
 
   useXdg = config.nix.enable
     && (config.nix.settings.use-xdg-base-directories or false);
@@ -130,7 +134,7 @@ in {
         "$HOME/.nix-defexpr/channels"
         "darwin-config=$HOME/.config/nixpkgs/darwin-configuration.nix"
       ];
-      description = lib.mdDoc ''
+      description = ''
         Adds new directories to the Nix expression search path.
 
         Used by Nix when looking up paths in angular brackets
@@ -142,7 +146,7 @@ in {
       type = types.bool;
       default = true;
       example = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether {option}`nix.nixPath` should keep the previously set values in
         {env}`NIX_PATH`.
       '';
@@ -152,7 +156,7 @@ in {
       type = with lib.types; attrsOf package;
       default = { };
       example = lib.literalExpression "{ inherit nixpkgs; }";
-      description = lib.mdDoc ''
+      description = ''
         A declarative alternative to Nix channels. Whereas with stock channels,
         you would register URLs and fetch them into the Nix store with
         {manpage}`nix-channel(1)`, this option allows you to register the store

--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -12,10 +12,17 @@ let
 
   nixPath = lib.concatStringsSep ":" cfg.nixPath;
 
+  useXdg = config.nix.enable
+    && (config.nix.settings.use-xdg-base-directories or false);
+  defexprDir = if useXdg then
+    "${config.xdg.stateHome}/nix/defexpr"
+  else
+    "${config.home.homeDirectory}/.nix-defexpr";
+
   # The deploy path for declarative channels. The directory name is prefixed
-  # with a number to make it easier for files in ~/.nix-defexpr to control the
-  # order they'll be read relative to each other.
-  channelPath = ".nix-defexpr/50-home-manager";
+  # with a number to make it easier for files in defexprDir to control the order
+  # they'll be read relative to each other.
+  channelPath = "${defexprDir}/50-home-manager";
 
   channelsDrv = let
     mkEntry = name: drv: {
@@ -274,7 +281,7 @@ in {
     })
 
     (lib.mkIf (cfg.channels != { }) {
-      nix.nixPath = [ "${config.home.homeDirectory}/${channelPath}" ];
+      nix.nixPath = [ channelPath ];
       home.file."${channelPath}".source = channelsDrv;
     })
 

--- a/tests/modules/misc/nix/default.nix
+++ b/tests/modules/misc/nix/default.nix
@@ -4,4 +4,5 @@
   nix-example-registry = ./example-registry.nix;
   nix-keep-old-nix-path = ./keep-old-nix-path.nix;
   nix-example-channels = ./example-channels.nix;
+  nix-example-channels-xdg = ./example-channels-xdg.nix;
 }

--- a/tests/modules/misc/nix/default.nix
+++ b/tests/modules/misc/nix/default.nix
@@ -3,4 +3,5 @@
   nix-example-settings = ./example-settings.nix;
   nix-example-registry = ./example-registry.nix;
   nix-keep-old-nix-path = ./keep-old-nix-path.nix;
+  nix-example-channels = ./example-channels.nix;
 }

--- a/tests/modules/misc/nix/default.nix
+++ b/tests/modules/misc/nix/default.nix
@@ -2,4 +2,5 @@
   nix-empty-settings = ./empty-settings.nix;
   nix-example-settings = ./example-settings.nix;
   nix-example-registry = ./example-registry.nix;
+  nix-keep-old-nix-path = ./keep-old-nix-path.nix;
 }

--- a/tests/modules/misc/nix/empty-settings.nix
+++ b/tests/modules/misc/nix/empty-settings.nix
@@ -8,6 +8,7 @@ with lib;
 
     nmt.script = ''
       assertPathNotExists home-files/.config/nix
+      assertPathNotExists home-files/.nix-defexpr/50-home-manager
     '';
   };
 }

--- a/tests/modules/misc/nix/example-channels-xdg.nix
+++ b/tests/modules/misc/nix/example-channels-xdg.nix
@@ -1,0 +1,29 @@
+{ lib, config, pkgs, ... }:
+
+let
+  exampleChannel = pkgs.writeTextDir "default.nix" ''
+    { pkgs ? import <nixpkgs> { } }:
+
+    {
+      example = pkgs.emptyDirectory;
+    }
+  '';
+in {
+  config = {
+    nix = {
+      package = config.lib.test.mkStubPackage {
+        version = lib.getVersion pkgs.nixVersions.stable;
+      };
+      channels.example = exampleChannel;
+      settings.use-xdg-base-directories = true;
+    };
+
+    nmt.script = ''
+      assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+        'export NIX_PATH="/home/hm-user/.local/state/nix/defexpr/50-home-manager''${NIX_PATH:+:$NIX_PATH}"'
+      assertFileContent \
+        home-files/.local/state/nix/defexpr/50-home-manager/example/default.nix \
+        ${exampleChannel}/default.nix
+    '';
+  };
+}

--- a/tests/modules/misc/nix/example-channels.nix
+++ b/tests/modules/misc/nix/example-channels.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, ... }:
+
+let
+  exampleChannel = pkgs.writeTextDir "default.nix" ''
+    { pkgs ? import <nixpkgs> { } }:
+
+    {
+      example = pkgs.emptyDirectory;
+    }
+  '';
+in {
+  config = {
+    nix = {
+      package = config.lib.test.mkStubPackage { };
+      channels.example = exampleChannel;
+    };
+
+    nmt.script = ''
+      assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+        'export NIX_PATH="/home/hm-user/.nix-defexpr/50-home-manager''${NIX_PATH:+:$NIX_PATH}"'
+      assertFileContent \
+        home-files/.nix-defexpr/50-home-manager/example/default.nix \
+        ${exampleChannel}/default.nix
+    '';
+  };
+}

--- a/tests/modules/misc/nix/example-settings.nix
+++ b/tests/modules/misc/nix/example-settings.nix
@@ -17,6 +17,8 @@ with lib;
         '';
       };
 
+      nixPath = [ "/a" "/b/c" ];
+
       settings = {
         use-sandbox = true;
         show-trace = true;
@@ -28,6 +30,9 @@ with lib;
       assertFileContent \
         home-files/.config/nix/nix.conf \
         ${./example-settings-expected.conf}
+
+      assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+        'export NIX_PATH="/a:/b/c''${NIX_PATH:+:$NIX_PATH}"'
     '';
   };
 }

--- a/tests/modules/misc/nix/keep-old-nix-path.nix
+++ b/tests/modules/misc/nix/keep-old-nix-path.nix
@@ -1,0 +1,16 @@
+{ config, ... }:
+
+{
+  config = {
+    nix = {
+      package = config.lib.test.mkStubPackage { };
+      nixPath = [ "/a" "/b/c" ];
+      keepOldNixPath = false;
+    };
+
+    nmt.script = ''
+      assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+        'export NIX_PATH="/a:/b/c"'
+    '';
+  };
+}


### PR DESCRIPTION
### Description
This adds a new option, `nix.channels`. It's the Nix channels equivalent of the `nix.registry` option, and compatible with pre-Flake Nix tooling including nix-env and nix-shell. Like `nix.registry`, this option is useful for pinning Nix channels.

Channels defined in the new option can coexist with channels introduced through the `nix-channel` command. If the same channel exists in both, the one from Home Manager will be prioritized.

This PR builds on #2677 with minor changes and additional tests.

Closes #2677.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.