### PR TITLE
lib/file-type: convert `executable` to bool

### DIFF
--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -115,7 +115,8 @@ in
         target = mkDefault name;
         source = mkIf (config.text != null) (
           mkDefault (pkgs.writeTextFile {
-            inherit (config) executable text;
+            inherit (config) text;
+            executable = config.executable == true; # can be null
             name = hm.strings.storeFileName name;
           })
         );


### PR DESCRIPTION
It doesn't make sense to pass `executable = null` to `writeTextFile`.

Fixes https://github.com/nix-community/home-manager/issues/4035

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
