### PR TITLE
xsession: add option xsession.initBeforeSystemd

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -139,7 +139,7 @@ in {
     }
 
     (mkIf cfg.x11.enable {
-      xsession.initExtra = ''
+      xsession.initBeforeSystemd = ''
         ${pkgs.xorg.xsetroot}/bin/xsetroot -xcf ${cursorPath} ${
           toString cfg.size
         }

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -99,6 +99,6 @@ in {
         '';
       };
 
-      xsession.initExtra = xrdbMerge;
+      xsession.initBeforeSystemd = xrdbMerge;
     };
 }

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -70,6 +70,13 @@ in {
         description = "Extra shell commands to run before session start.";
       };
 
+      initBeforeSystemd = mkOption {
+        type = types.lines;
+        default = "";
+        description =
+          "Shell commands to run before starting hm-graphical-session.target. For example, configuring x11 cursor and dpi.";
+      };
+
       initExtra = mkOption {
         type = types.lines;
         default = "";
@@ -199,6 +206,8 @@ in {
           . "${config.home.homeDirectory}/${cfg.profilePath}"
         fi
         unset HM_XPROFILE_SOURCED
+
+        ${cfg.initBeforeSystemd}
 
         systemctl --user start hm-graphical-session.target
 

--- a/tests/modules/misc/xsession/basic-xsession-expected.txt
+++ b/tests/modules/misc/xsession/basic-xsession-expected.txt
@@ -3,6 +3,8 @@ if [ -z "$HM_XPROFILE_SOURCED" ]; then
 fi
 unset HM_XPROFILE_SOURCED
 
+
+
 systemctl --user start hm-graphical-session.target
 
 init extra commands


### PR DESCRIPTION
### Description

This commit add an option called `xsession.initBeforeSystemd` to setup xsession related options such as merging xresources and doing other x11 related setup before `hm-graphical-session.target` is started.

For example, before this commit, if we set dpi using xresources, it won't work for user graphical systemd services since xresources is merged after `hm-graphical-session.target` is started.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
