### PR TITLE
tests: fix `getOutput` on stubs

### DIFF
--- a/tests/modules/programs/autojump/default-settings.nix
+++ b/tests/modules/programs/autojump/default-settings.nix
@@ -8,6 +8,7 @@ with lib;
 
     test.stubs.autojump = {
       buildScript = "mkdir -p $out/bin; touch $out/bin/autojump";
+      outPath = null;
     };
 
     nmt.script = ''

--- a/tests/modules/services/git-sync/basic.nix
+++ b/tests/modules/services/git-sync/basic.nix
@@ -24,7 +24,7 @@
         WantedBy=default.target
 
         [Service]
-        Environment=PATH=/nix/store/00000000000000000000000000000000-openssh/bin:/nix/store/00000000000000000000000000000000-git/bin
+        Environment=PATH=@openssh@/bin:/nix/store/00000000000000000000000000000000-git/bin
         Environment=GIT_SYNC_DIRECTORY=/a/path
         Environment=GIT_SYNC_COMMAND=@git-sync@/bin/git-sync
         Environment=GIT_SYNC_REPOSITORY=git+ssh://user@example.com:/~user/path/to/repo.git

--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -41,8 +41,18 @@ let
         dummyPackage
       else
         pkgs.runCommandLocal name { pname = name; } buildScript;
-    in pkg // optionalAttrs (outPath != null) { inherit outPath; }
-    // optionalAttrs (version != null) { inherit version; };
+    in pkg // optionalAttrs (outPath != null) {
+      inherit outPath;
+
+      # Prevent getOutput from descending into outputs
+      outputSpecified = true;
+
+      # Allow the original package to be used in derivation inputs
+      __spliced = {
+        buildHost = pkg;
+        hostTarget = pkg;
+      };
+    } // optionalAttrs (version != null) { inherit version; };
 
 in {
   options.test.stubs = mkOption {


### PR DESCRIPTION
Currently, stub packages can't be used with `getExe`, see https://github.com/nix-community/home-manager/pull/3291#issuecomment-1572756632.

Setting `outputSpecified` prevents `getOutput` from descending into outputs, which don't have an overridden `outPath`.

Alternatives:
- removing all outputs makes things fail
- also overriding `outPath` in outputs is more code

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
