### PR TITLE
ripgrep: remove configDir

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1033,10 +1033,18 @@ in
           defaults to 'null'.
         '';
       }
+
       {
         time = "2023-05-18T21:03:30+00:00";
         message = ''
           A new module is available: 'programs.script-directory'.
+        '';
+      }
+
+      {
+        time = "2023-06-03T22:19:32+00:00";
+        message = ''
+          A new module is available: 'programs.ripgrep'.
         '';
       }
     ];

--- a/modules/programs/ripgrep.nix
+++ b/modules/programs/ripgrep.nix
@@ -2,7 +2,9 @@
 
 with lib;
 
-let cfg = config.programs.ripgrep;
+let
+  cfg = config.programs.ripgrep;
+  configPath = "${config.xdg.configHome}/ripgrep/ripgreprc";
 in {
   meta.maintainers = [ hm.maintainers.pedorich-n ];
 
@@ -12,23 +14,14 @@ in {
 
       package = mkPackageOption pkgs "ripgrep" { };
 
-      configDir = mkOption {
-        type = types.str;
-        default = "${config.xdg.configHome}/ripgrep";
-        defaultText =
-          literalExpression ''"''${config.xdg.configHome}/ripgrep"'';
-        description = ''
-          Directory where the <filename>ripgreprc</filename> file will be stored.
-        '';
-      };
-
       arguments = mkOption {
         type = with types; listOf str;
         default = [ ];
         example = [ "--max-columns-preview" "--colors=line:style:bold" ];
         description = ''
-          List of arguments to pass to ripgrep. Each item is given to ripgrep as a single command line argument verbatim.
-
+          List of arguments to pass to ripgrep. Each item is given to ripgrep as
+          a single command line argument verbatim.
+          </para><para>
           See <link xlink:href="https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file"/>
           for an example configuration.
         '';
@@ -40,12 +33,10 @@ in {
     home = {
       packages = [ cfg.package ];
 
-      file."${cfg.configDir}/ripgreprc" =
+      file."${configPath}" =
         mkIf (cfg.arguments != [ ]) { text = lib.concatLines cfg.arguments; };
 
-      sessionVariables = {
-        "RIPGREP_CONFIG_PATH" = "${cfg.configDir}/ripgreprc";
-      };
+      sessionVariables = { "RIPGREP_CONFIG_PATH" = configPath; };
     };
   };
 }


### PR DESCRIPTION
### Description

Following the [conversation](https://github.com/nix-community/home-manager/pull/4017#discussion_r1215501801), I am removing the `configDir` argument and hard-coding the configuration location to `$XDG_CONFIG_HOME/ripgrep/ripgreprc`.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
