### PR TITLE
i3-sway: quote output names

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/functions.nix
+++ b/modules/services/window-managers/i3-sway/lib/functions.nix
@@ -150,7 +150,7 @@ rec {
   windowCommandsStr = { command, criteria, ... }:
     "for_window ${criteriaStr criteria} ${command}";
   workspaceOutputStr = item:
-    ''workspace "${item.workspace}" output ${item.output}'';
+    ''workspace "${item.workspace}" output "${item.output}"'';
 
   indent = list:
     { includesWrapper ? true, level ? 1 }:

--- a/tests/modules/services/window-managers/i3/i3-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-workspace-output-expected.conf
@@ -94,7 +94,7 @@ bar {
   }
 }
 
-workspace "1" output eDP
-workspace "ABC" output DP
-workspace "3: Test" output HDMI
-workspace "!"§$%&/(){}[]=?\*#<>-_.:,;²³" output DVI
+workspace "1" output "eDP"
+workspace "ABC" output "DP"
+workspace "3: Test" output "HDMI"
+workspace "!"§$%&/(){}[]=?\*#<>-_.:,;²³" output "DVI"

--- a/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
@@ -103,8 +103,8 @@ bar {
   }
 }
 
-workspace "1" output eDP
-workspace "ABC" output DP
-workspace "3: Test" output HDMI
-workspace "!"§$%&/(){}[]=?\*#<>-_.:,;²³" output DVI
+workspace "1" output "eDP"
+workspace "ABC" output "DP"
+workspace "3: Test" output "HDMI"
+workspace "!"§$%&/(){}[]=?\*#<>-_.:,;²³" output "DVI"
 exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE NIXOS_OZONE_WL; systemctl --user start sway-session.target"


### PR DESCRIPTION
They can contain spaces.

Fixes https://github.com/nix-community/home-manager/issues/4058

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
