### PR TITLE
comodoro: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1101,6 +1101,16 @@ in
           A new module is available: 'programs.git-credential-oauth'.
         '';
       }
+
+      {
+        time = "2023-06-14T21:41:22+00:00";
+        message = ''
+          Two new modules are available:
+
+            - 'programs.comodoro' and
+            - 'services.comodoro'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -68,6 +68,7 @@ let
     ./programs/btop.nix
     ./programs/chromium.nix
     ./programs/command-not-found/command-not-found.nix
+    ./programs/comodoro.nix
     ./programs/dircolors.nix
     ./programs/direnv.nix
     ./programs/discocss.nix
@@ -234,6 +235,7 @@ let
     ./services/cbatticon.nix
     ./services/clipman.nix
     ./services/clipmenu.nix
+    ./services/comodoro.nix
     ./services/copyq.nix
     ./services/devilspie2.nix
     ./services/dropbox.nix

--- a/modules/programs/comodoro.nix
+++ b/modules/programs/comodoro.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.comodoro;
+  tomlFormat = pkgs.formats.toml { };
+
+in {
+  meta.maintainers = with lib.hm.maintainers; [ soywod ];
+
+  options.programs.comodoro = {
+    enable = lib.mkEnableOption "Comodoro, a CLI to manage your time";
+
+    package = lib.mkPackageOption pkgs "comodoro" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule { freeformType = tomlFormat.type; };
+      default = { };
+      description = ''
+        Comodoro configuration.
+        See <link xlink:href="https://pimalaya.org/comodoro/cli/configuration/"/> for supported values.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."comodoro/config.toml".source =
+      tomlFormat.generate "comodoro-config.toml" cfg.settings;
+  };
+}

--- a/modules/services/comodoro.nix
+++ b/modules/services/comodoro.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.comodoro;
+
+  args = with cfg; {
+    inherit preset;
+    protocols = if lib.isList protocols then
+      lib.concatStringsSep " " protocols
+    else
+      protocols;
+  };
+
+in {
+  meta.maintainers = with lib.hm.maintainers; [ soywod ];
+
+  options.services.comodoro = {
+    enable = lib.mkEnableOption "Comodoro server";
+
+    package = lib.mkPackageOption pkgs "comodoro" { };
+
+    environment = lib.mkOption {
+      type = with lib.types; attrsOf str;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "PASSWORD_STORE_DIR" = "~/.password-store";
+        }
+      '';
+      description = ''
+        Extra environment variables to be exported in the service.
+      '';
+    };
+
+    preset = lib.mkOption {
+      type = lib.types.nonEmptyStr;
+      description = ''
+        Use configuration from the given preset as defined in the configuration file.
+      '';
+    };
+
+    protocols = lib.mkOption {
+      type = with lib.types; nonEmptyListOf nonEmptyStr;
+      description = ''
+        Define protocols the server should use to accept requests.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    systemd.user.services.comodoro = {
+      Unit = {
+        Description = "Comodoro server";
+        After = [ "network.target" ];
+      };
+      Install = { WantedBy = [ "default.target" ]; };
+      Service = {
+        ExecStart = with args;
+          "${cfg.package}/bin/comodoro server start ${preset} ${protocols}";
+        ExecSearchPath = "/bin";
+        Restart = "always";
+        RestartSec = 10;
+        Environment =
+          lib.mapAttrsToList (key: val: "${key}=${val}") cfg.environment;
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -66,6 +66,7 @@ import nmt {
     ./modules/programs/broot
     ./modules/programs/browserpass
     ./modules/programs/btop
+    ./modules/programs/comodoro
     ./modules/programs/dircolors
     ./modules/programs/direnv
     ./modules/programs/emacs
@@ -186,6 +187,7 @@ import nmt {
     ./modules/services/borgmatic
     ./modules/services/cachix-agent
     ./modules/services/clipman
+    ./modules/services/comodoro
     ./modules/services/devilspie2
     ./modules/services/dropbox
     ./modules/services/emacs

--- a/tests/modules/programs/comodoro/comodoro.nix
+++ b/tests/modules/programs/comodoro/comodoro.nix
@@ -1,0 +1,35 @@
+{ ... }:
+
+{
+  programs.comodoro = {
+    enable = true;
+    settings = {
+      test-preset = {
+        cycles = [
+          {
+            name = "Work";
+            duration = 1500;
+          }
+          {
+            name = "Rest";
+            duration = 500;
+          }
+        ];
+
+        tcp-host = "localhost";
+        tcp-port = 8080;
+
+        on-server-start = "echo server started";
+        on-timer-stop = "echo timer stopped";
+        on-work-begin = "echo work cycle began";
+      };
+    };
+  };
+
+  test.stubs.comodoro = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/comodoro/config.toml
+    assertFileContent home-files/.config/comodoro/config.toml ${./expected.toml}
+  '';
+}

--- a/tests/modules/programs/comodoro/default.nix
+++ b/tests/modules/programs/comodoro/default.nix
@@ -1,0 +1,1 @@
+{ comodoro-program = ./comodoro.nix; }

--- a/tests/modules/programs/comodoro/expected.toml
+++ b/tests/modules/programs/comodoro/expected.toml
@@ -1,0 +1,13 @@
+[test-preset]
+on-server-start = "echo server started"
+on-timer-stop = "echo timer stopped"
+on-work-begin = "echo work cycle began"
+tcp-host = "localhost"
+tcp-port = 8080
+[[test-preset.cycles]]
+duration = 1500
+name = "Work"
+
+[[test-preset.cycles]]
+duration = 500
+name = "Rest"

--- a/tests/modules/services/comodoro/comodoro.nix
+++ b/tests/modules/services/comodoro/comodoro.nix
@@ -1,0 +1,16 @@
+{ ... }:
+
+{
+  services.comodoro = {
+    enable = true;
+    preset = "preset";
+    protocols = [ "tcp" ];
+  };
+
+  test.stubs.comodoro = { };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/comodoro.service)
+    assertFileContent "$serviceFile" ${./expected.service}
+  '';
+}

--- a/tests/modules/services/comodoro/default.nix
+++ b/tests/modules/services/comodoro/default.nix
@@ -1,0 +1,1 @@
+{ comodoro-service = ./comodoro.nix; }

--- a/tests/modules/services/comodoro/expected.service
+++ b/tests/modules/services/comodoro/expected.service
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecSearchPath=/bin
+ExecStart=@comodoro@/bin/comodoro server start preset tcp
+Restart=always
+RestartSec=10
+
+[Unit]
+After=network.target
+Description=Comodoro server


### PR DESCRIPTION
### Description

**Comodoro, a CLI to manage your time**. Key features:

- Centralized server timer controllable by multiple clients at the same time
- Multi protocols (only TCP for now, but you can build your own)
- Cycles customizable via config file (Pomodoro style, 52/17 style, custom)
- Server and timer hooks customizable via config file

Website & doc: https://pimalaya.org/comodoro/

Sources: https://github.com/soywod/comodoro

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

@toastal 