### PR TITLE
doc: show how to writeShellScriptBin from a file

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -337,6 +337,8 @@ $xdgVars
     # (pkgs.writeShellScriptBin "my-hello" ''
     #   echo "Hello, \${config.home.username}!"
     # '')
+    # # or you can load it from a local file: 
+    # (pkgs.writeShellScriptBin "my-hello" (builtins.readFile ./my-hello.sh))
   ];
 
   # Home Manager is pretty good at managing dotfiles. The primary way to manage


### PR DESCRIPTION
### Description

I added explicitly how to import a shell from a file. 
See https://discourse.nixos.org/t/cannot-run-basic-shell-using-writeshellscriptbin/28835

### Checklist

- [x] Change is backwards compatible.

This PR contains only comments so I guess there is no need for other checks. 