### PR TITLE
Espanso: Fix broken module to be compatible with Espanso version 2.x

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -400,4 +400,10 @@
     github = "pedorich-n";
     githubId = 15573098;
   };
+  liyangau = {
+    name = "Li Yang";
+    email = "d@aufomm.com";
+    github = "liyangau";
+    githubId = 71299093;
+  };
 }

--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -32,7 +32,7 @@ in {
         type = yaml.type;
         default = { default = { }; };
         example = literalExpression ''
-          configs = {
+          {
             default = {
               show_notifications = false;
             };
@@ -53,7 +53,7 @@ in {
         type = yaml.type;
         default = { default.matches = [ ]; };
         example = literalExpression ''
-          matches = {
+          {
             base = {
               matches = [
                 {

--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -35,6 +35,11 @@ in {
             };
           };
         '';
+        description = ''
+          The Espanso configuration to use. See
+          <link xlink:href="https://espanso.org/docs/configuration/basics/"/>
+          for a description of available options.
+        '';
       };
 
       matches = mkOption {
@@ -73,6 +78,11 @@ in {
               ];
             };
           };
+        '';
+        description = ''
+          The Espanso matches to use. See
+          <link xlink:href="https://espanso.org/docs/matches/basics/"/>
+          for a description of available options.
         '';
       };
     };

--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -15,8 +15,11 @@ in {
     (mkRemovedOptionModule [ "services" "espanso" "settings" ]
       "Use services.espanso.configs and services.espanso.matches instead.")
   ];
-  meta.maintainers =
-    [ lib.hm.maintainers.liyangau maintainers.bobvanderlinden ];
+  meta.maintainers = [
+    maintainers.lucasew
+    maintainers.bobvanderlinden
+    lib.hm.maintainers.liyangau
+  ];
   options = {
     services.espanso = {
       enable = mkEnableOption "Espanso: cross platform text expander in Rust";

--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -15,7 +15,8 @@ in {
     (mkRemovedOptionModule [ "services" "espanso" "settings" ]
       "Use services.espanso.configs and services.espanso.matches instead.")
   ];
-  meta.maintainers = with maintainers; [ lucasew ];
+  meta.maintainers =
+    [ lib.hm.maintainers.liyangau maintainers.bobvanderlinden ];
   options = {
     services.espanso = {
       enable = mkEnableOption "Espanso: cross platform text expander in Rust";

--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -101,7 +101,7 @@ in {
       {
         assertion = versionAtLeast espansoVersion "2";
         message = ''
-          Only support version Espanso version 2
+          The services.espanso module only supports Espanso version 2 or later.
         '';
       }
     ];

--- a/tests/modules/services/espanso/basic-configuration.nix
+++ b/tests/modules/services/espanso/basic-configuration.nix
@@ -3,31 +3,40 @@
 {
   services.espanso = {
     enable = true;
-    settings = {
-      matches = [
-        { # Simple text replacement
-          trigger = ":espanso";
-          replace = "Hi there!";
-        }
-        { # Dates
-          trigger = ":date";
-          replace = "{{mydate}}";
-          vars = [{
-            name = "mydate";
+    configs = {
+      default = { show_notifications = false; };
+    };
+    matches = {
+      base = {
+        matches = [
+          {
+            trigger = ":now";
+            replace = "It's {{currentdate}} {{currenttime}}";
+          }
+          {
+            trigger = ":hello";
+            replace = ''
+              line1
+              line2'';
+          }
+          {
+            regex = ":hi(?P<person>.*)\\.";
+            replace = "Hi {{person}}!";
+          }
+        ];
+        global_vars = [
+          {
+            name = "currentdate";
             type = "date";
-            params = { format = "%m/%d/%Y"; };
-          }];
-        }
-        { # Shell commands
-          trigger = ":shell";
-          replace = "{{output}}";
-          vars = [{
-            name = "output";
-            type = "shell";
-            params = { cmd = "echo Hello from your shell"; };
-          }];
-        }
-      ];
+            params = { format = "%d/%m/%Y"; };
+          }
+          {
+            name = "currenttime";
+            type = "date";
+            params = { format = "%R"; };
+          }
+        ];
+      };
     };
   };
 
@@ -38,8 +47,12 @@
     assertFileExists "$serviceFile"
     assertFileContent "$serviceFile" ${./basic-configuration.service}
 
-    configFile=home-files/.config/espanso/default.yml
+    configFile=home-files/.config/espanso/config/default.yml
     assertFileExists "$configFile"
     assertFileContent "$configFile" ${./basic-configuration.yaml}
+
+    matchFile=home-files/.config/espanso/match/base.yml
+    assertFileExists "$matchFile"
+    assertFileContent "$matchFile" ${./basic-matches.yaml}
   '';
 }

--- a/tests/modules/services/espanso/basic-configuration.nix
+++ b/tests/modules/services/espanso/basic-configuration.nix
@@ -3,9 +3,7 @@
 {
   services.espanso = {
     enable = true;
-    configs = {
-      default = { show_notifications = false; };
-    };
+    configs = { default = { show_notifications = false; }; };
     matches = {
       base = {
         matches = [

--- a/tests/modules/services/espanso/basic-configuration.yaml
+++ b/tests/modules/services/espanso/basic-configuration.yaml
@@ -1,17 +1,1 @@
-matches:
-- replace: Hi there!
-  trigger: :espanso
-- replace: '{{mydate}}'
-  trigger: :date
-  vars:
-  - name: mydate
-    params:
-      format: '%m/%d/%Y'
-    type: date
-- replace: '{{output}}'
-  trigger: :shell
-  vars:
-  - name: output
-    params:
-      cmd: echo Hello from your shell
-    type: shell
+show_notifications: false

--- a/tests/modules/services/espanso/basic-matches.yaml
+++ b/tests/modules/services/espanso/basic-matches.yaml
@@ -1,0 +1,18 @@
+global_vars:
+- name: currentdate
+  params:
+    format: '%d/%m/%Y'
+  type: date
+- name: currenttime
+  params:
+    format: '%R'
+  type: date
+matches:
+- replace: It's {{currentdate}} {{currenttime}}
+  trigger: :now
+- replace: 'line1
+
+    line2'
+  trigger: :hello
+- regex: :hi(?P<person>.*)\.
+  replace: Hi {{person}}!


### PR DESCRIPTION
### Description

Espanso module does not work with 2.x version.  In the new version configuration and matches are put into different folders as below.
```
config/
  default.yml
match/
  base.yml
```
The updated module supports creating multiple files for both config and matches. Users have the full flexibility to create multiple files for different apps.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
