### PR TITLE
i18n.inputMethod.fcitx5: Add fcitx5-qt paths to QT_PLUGIN_PATH

### DIFF
--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -6,6 +6,8 @@ let
   im = config.i18n.inputMethod;
   cfg = im.fcitx5;
   fcitx5Package = pkgs.fcitx5-with-addons.override { inherit (cfg) addons; };
+  inherit (pkgs.libsForQt5) qtbase;
+  inherit (pkgs) qt6;
 in {
   options = {
     i18n.inputMethod.fcitx5 = {
@@ -27,6 +29,8 @@ in {
       GLFW_IM_MODULE = "ibus"; # IME support in kitty
       GTK_IM_MODULE = "fcitx";
       QT_IM_MODULE = "fcitx";
+      QT_PLUGIN_PATH =
+        "$QT_PLUGIN_PATH:${fcitx5Package}/${qtbase.qtPluginPrefix}:${fcitx5Package}/${qt6.qtbase.qtPluginPrefix}";
       XMODIFIERS = "@im=fcitx";
     };
 


### PR DESCRIPTION
### Description

Some applications, like Telegram Desktop, are unable to invoke fcitx because the Qt plugins provided by `fcitx5-qt` aren't visible to Qt.

There are four ways that a Qt application can load plugins[^1]. Of these four, two appear to be good candidates for distribution maintainers:

1. build Qt Core specifying a global path where plugins can be installed to which applications will be able to discover by querying `QLibraryInfo`[^2]; or,

2. add the path to your plugin to the environment variable `QT_PLUGIN_PATH`.

The first method mentioned here is not feasible for NixOS so relying on an environment variable is the best path forward. Using `QT_PLUGIN_PATH` to solve these issues is also prior art in nixpkgs.

Ironically, the Qt documentation recommends against using `QT_PLUGIN_PATH` as a system-wide environment variable but I don't see any other option.

[^1]: https://doc.qt.io/qt-6/deployment-plugins.html
[^2]: https://doc.qt.io/qt-6/qlibraryinfo.html#LibraryPath-enum

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
