### PR TITLE
Clean up deprecated lib functions

### DIFF
--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -30,7 +30,7 @@ let
           toString v
         else if isString v then
           v
-        else if isCoercibleToString v then
+        else if isConvertibleWithToString v then
           toString v
         else
           abort "The nix conf value: ${toPretty { } v} can not be encoded";

--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -129,7 +129,9 @@ in {
 
   config = {
     _module.args = {
-      pkgs = mkOverride modules.defaultPriority _pkgs;
+      # We use a no-op override to make sure that the option can be merged without evaluating
+      # `_pkgs`, see https://github.com/nix-community/home-manager/pull/993
+      pkgs = mkOverride modules.defaultOverridePriority _pkgs;
       pkgs_i686 =
         if _pkgs.stdenv.isLinux && _pkgs.stdenv.hostPlatform.isx86 then
           _pkgs.pkgsi686Linux


### PR DESCRIPTION
`isCoercibleToString` and `defaultPriority` will start raising warnings when 22.11 goes EOL.

~~Note that `mkOverride defaultOverridePriority` is a no-op, so we can just remove it.~~

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible (**if using the correct branch of nixpkgs**).

- [X] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
