### PR TITLE
git-credential-oauth: init

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1094,6 +1094,13 @@ in
           may be necessary as new modules are added.
         '';
       }
+
+      {
+        time = "2023-06-14T21:25:34+00:00";
+        message = ''
+          A new module is available: 'programs.git-credential-oauth'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -85,6 +85,7 @@ let
     ./programs/getmail.nix
     ./programs/gh.nix
     ./programs/git-cliff.nix
+    ./programs/git-credential-oauth.nix
     ./programs/git.nix
     ./programs/gitui.nix
     ./programs/gnome-terminal.nix

--- a/modules/programs/git-credential-oauth.nix
+++ b/modules/programs/git-credential-oauth.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  cfg = config.programs.git-credential-oauth;
+
+in {
+  meta.maintainers = [ lib.maintainers.tomodachi94 ];
+
+  options = {
+    programs.git-credential-oauth = {
+      enable = lib.mkEnableOption "Git authentication handler for OAuth";
+
+      package = lib.mkPackageOption pkgs "git-credential-oauth" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.git.extraConfig.credential.helper =
+      [ "${cfg.package}/bin/git-credential-oauth" ];
+  };
+}


### PR DESCRIPTION
### Description

Adds a module to enable the Git OAuth credential helper, which is a much more secure alternative to the `store` method that is common practice.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
