### PR TITLE
browserpass: test on Darwin again

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -64,6 +64,7 @@ import nmt {
     ./modules/programs/bat
     ./modules/programs/bottom
     ./modules/programs/broot
+    ./modules/programs/browserpass
     ./modules/programs/btop
     ./modules/programs/dircolors
     ./modules/programs/direnv
@@ -157,7 +158,6 @@ import nmt {
     ./modules/programs/beets  # One test relies on services.mpd
     ./modules/programs/borgmatic
     ./modules/programs/boxxy
-    ./modules/programs/browserpass # TODO re-enable on Darwin when https://github.com/NixOS/nixpkgs/pull/236258#issuecomment-1583450593 is fixed
     ./modules/programs/firefox
     ./modules/programs/foot
     ./modules/programs/fuzzel


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/236749 is in all channels now.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
