### PR TITLE
[23.05] backport #4066

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           echo "Error: literalExample should be replaced by literalExpression" > /dev/stderr
           exit 1
         fi
-    - run: nix-build -A docs.jsonModuleMaintainers
+    - run: nix-build --show-trace -A docs.jsonModuleMaintainers
     - run: ./format -c
-    - run: nix-shell . -A install
-    - run: nix-shell --arg enableBig false --pure tests -A run.all
+    - run: nix-shell --show-trace . -A install
+    - run: nix-shell --show-trace --arg enableBig false --pure tests -A run.all

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -394,4 +394,10 @@
     github = "natecox";
     githubId = 2782695;
   };
+  liyangau = {
+    name = "Li Yang";
+    email = "d@aufomm.com";
+    github = "liyangau";
+    githubId = 71299093;
+  };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -64,7 +64,6 @@ import nmt {
     ./modules/programs/bat
     ./modules/programs/bottom
     ./modules/programs/broot
-    ./modules/programs/browserpass
     ./modules/programs/btop
     ./modules/programs/dircolors
     ./modules/programs/direnv
@@ -155,6 +154,7 @@ import nmt {
     ./modules/programs/autorandr
     ./modules/programs/beets  # One test relies on services.mpd
     ./modules/programs/borgmatic
+    ./modules/programs/browserpass # TODO re-enable on Darwin when https://github.com/NixOS/nixpkgs/pull/236258#issuecomment-1583450593 is fixed
     ./modules/programs/firefox
     ./modules/programs/foot
     ./modules/programs/fuzzel

--- a/tests/modules/services/espanso/basic-configuration.nix
+++ b/tests/modules/services/espanso/basic-configuration.nix
@@ -3,31 +3,38 @@
 {
   services.espanso = {
     enable = true;
-    settings = {
-      matches = [
-        { # Simple text replacement
-          trigger = ":espanso";
-          replace = "Hi there!";
-        }
-        { # Dates
-          trigger = ":date";
-          replace = "{{mydate}}";
-          vars = [{
-            name = "mydate";
+    configs = { default = { show_notifications = false; }; };
+    matches = {
+      base = {
+        matches = [
+          {
+            trigger = ":now";
+            replace = "It's {{currentdate}} {{currenttime}}";
+          }
+          {
+            trigger = ":hello";
+            replace = ''
+              line1
+              line2'';
+          }
+          {
+            regex = ":hi(?P<person>.*)\\.";
+            replace = "Hi {{person}}!";
+          }
+        ];
+        global_vars = [
+          {
+            name = "currentdate";
             type = "date";
-            params = { format = "%m/%d/%Y"; };
-          }];
-        }
-        { # Shell commands
-          trigger = ":shell";
-          replace = "{{output}}";
-          vars = [{
-            name = "output";
-            type = "shell";
-            params = { cmd = "echo Hello from your shell"; };
-          }];
-        }
-      ];
+            params = { format = "%d/%m/%Y"; };
+          }
+          {
+            name = "currenttime";
+            type = "date";
+            params = { format = "%R"; };
+          }
+        ];
+      };
     };
   };
 
@@ -38,8 +45,12 @@
     assertFileExists "$serviceFile"
     assertFileContent "$serviceFile" ${./basic-configuration.service}
 
-    configFile=home-files/.config/espanso/default.yml
+    configFile=home-files/.config/espanso/config/default.yml
     assertFileExists "$configFile"
     assertFileContent "$configFile" ${./basic-configuration.yaml}
+
+    matchFile=home-files/.config/espanso/match/base.yml
+    assertFileExists "$matchFile"
+    assertFileContent "$matchFile" ${./basic-matches.yaml}
   '';
 }

--- a/tests/modules/services/espanso/basic-configuration.yaml
+++ b/tests/modules/services/espanso/basic-configuration.yaml
@@ -1,17 +1,1 @@
-matches:
-- replace: Hi there!
-  trigger: :espanso
-- replace: '{{mydate}}'
-  trigger: :date
-  vars:
-  - name: mydate
-    params:
-      format: '%m/%d/%Y'
-    type: date
-- replace: '{{output}}'
-  trigger: :shell
-  vars:
-  - name: output
-    params:
-      cmd: echo Hello from your shell
-    type: shell
+show_notifications: false

--- a/tests/modules/services/espanso/basic-matches.yaml
+++ b/tests/modules/services/espanso/basic-matches.yaml
@@ -1,0 +1,18 @@
+global_vars:
+- name: currentdate
+  params:
+    format: '%d/%m/%Y'
+  type: date
+- name: currenttime
+  params:
+    format: '%R'
+  type: date
+matches:
+- replace: It's {{currentdate}} {{currenttime}}
+  trigger: :now
+- replace: 'line1
+
+    line2'
+  trigger: :hello
+- regex: :hi(?P<person>.*)\.
+  replace: Hi {{person}}!


### PR DESCRIPTION
Backport #4066 to 23.05 since that has espanso 2.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
