### PR TITLE
home-manager: Enable completely controling home-manager path

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,8 @@ rec {
     jsonModuleMaintainers = jsonModuleMaintainers; # Unstable, mainly for CI.
   };
 
-  home-manager = pkgs.callPackage ./home-manager { path = toString ./.; };
+  home-manager =
+    pkgs.callPackage ./home-manager { paths = [ (toString ./.) ]; };
 
   install =
     pkgs.callPackage ./home-manager/install.nix { inherit home-manager; };

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -103,7 +103,7 @@ to your `~/.profile` file.
 
 If instead of using channels you want to run Home Manager from a Git
 checkout of the repository then you can use the
-<<opt-programs.home-manager.path>> option to specify the absolute path
+<<opt-programs.home-manager.paths>> option to specify the absolute path
 to the repository.
 
 Once installed you can see <<ch-usage>> for a more detailed

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -6,11 +6,11 @@
 # Extra path to Home Manager. If set then this path will be tried
 # before `$HOME/.config/nixpkgs/home-manager` and
 # `$HOME/.nixpkgs/home-manager`.
-, path ? null }:
+, paths ? [ ] }:
 
 let
 
-  pathStr = if path == null then "" else path;
+  pathsStr = lib.concatMapStringsSep " " (x: ''"'' + x + ''"'') paths;
 
   nixos-option = pkgs.nixos-option or (callPackage
     (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { });
@@ -43,7 +43,7 @@ in runCommand "home-manager" {
       ]
     }" \
     --subst-var-by HOME_MANAGER_LIB '${../lib/bash/home-manager.sh}' \
-    --subst-var-by HOME_MANAGER_PATH '${pathStr}' \
+    --subst-var-by HOME_MANAGER_PATHS '${pathsStr}' \
     --subst-var-by OUT "$out"
 
   install -D -m755 ${./completion.bash} \

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -105,9 +105,7 @@ function setConfigFile() {
 
 function setHomeManagerNixPath() {
     local path
-    for path in "@HOME_MANAGER_PATH@" \
-                "${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home-manager" \
-                "$HOME/.nixpkgs/home-manager" ; do
+    for path in @HOME_MANAGER_PATHS@; do
         if [[ -e "$path" || "$path" =~ ^https?:// ]] ; then
             EXTRA_NIX_PATH+=("home-manager=$path")
             return

--- a/modules/programs/home-manager.nix
+++ b/modules/programs/home-manager.nix
@@ -13,10 +13,13 @@ in {
     programs.home-manager = {
       enable = mkEnableOption "Home Manager";
 
-      path = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = "$HOME/devel/home-manager";
+      paths = mkOption {
+        type = types.listOf types.str;
+        default = [
+          "\${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home-manager"
+          "$HOME/.nixpkgs/home-manager"
+        ];
+        example = [ "$HOME/devel/home-manager" ];
         description = ''
           The default path to use for Home Manager. When
           <literal>null</literal>, then the <filename>home-manager</filename>
@@ -29,6 +32,6 @@ in {
 
   config = mkIf (cfg.enable && !config.submoduleSupport.enable) {
     home.packages =
-      [ (pkgs.callPackage ../../home-manager { inherit (cfg) path; }) ];
+      [ (pkgs.callPackage ../../home-manager { inherit (cfg) paths; }) ];
   };
 }

--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -5,7 +5,7 @@ let
   cfg = config.services.home-manager.autoUpgrade;
 
   homeManagerPackage = pkgs.callPackage ../../home-manager {
-    path = config.programs.home-manager.path;
+    paths = [ (toString config.programs.home-manager.paths) ];
   };
 
 in {

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,3 +1,4 @@
 final: prev: {
-  home-manager = prev.callPackage ./home-manager { path = toString ./.; };
+  home-manager =
+    prev.callPackage ./home-manager { paths = [ (toString ./.) ]; };
 }


### PR DESCRIPTION
### Description
Enables a users to completely control the entire list of paths that are checked for home-manager's nix code when using the `home-manager` script.

My personal motivation for me is that my use case for the `home-manager` script is that I always pass it a path to the home-manager repo with `-I` and I never want any other path to be tried. 

In hm 22.11 "-I" parameters to precedence over single configurable path `programs.home-manager.path` and the built-in paths in the script. This was because `-I` arguments have precedence over `NIX_PATH` and `programs.home-manager.path` (or one of the builtin paths) would be added to NIX_PATH. https://github.com/nix-community/home-manager/commit/176e455371a8371586e8a3ff0d56ee9f3ca2324e changed the behavior so that the path selected by `setHomeManagerNixPath` is added to the list of parameters passed to the build command before any other arguments to `home-manager` (`-I home-manager=...` in my case.

As I only really want to the `home-manager` script to not check any paths I dont give it at runtime. This change allows anyone to change those build-time paths to anything, including an empty list (what I need).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
