### PR TITLE
qt: add "kde" to qt.platformTheme

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -38,7 +38,7 @@ in {
       enable = mkEnableOption "Qt 4 and 5 configuration";
 
       platformTheme = mkOption {
-        type = types.nullOr (types.enum [ "gtk" "gnome" ]);
+        type = types.nullOr (types.enum [ "gtk" "gnome" "kde" ]);
         default = null;
         example = "gnome";
         relatedPackages =
@@ -58,6 +58,10 @@ in {
               <listitem><para>Use GNOME theme with
                 <link xlink:href="https://github.com/FedoraQt/QGnomePlatform">qgnomeplatform</link>
               </para></listitem>
+            </varlistentry>
+            <varlistentry>
+              <term><literal>kde</literal></term>
+              <listitem><para>Use Qt settings from Plasma</para></listitem>
             </varlistentry>
           </variablelist>
         '';
@@ -134,14 +138,17 @@ in {
     # Necessary because home.sessionVariables doesn't support mkIf
     home.sessionVariables = filterAttrs (n: v: v != null) {
       QT_QPA_PLATFORMTHEME =
-        if cfg.platformTheme == "gnome" then "gnome" else "gtk2";
+        if cfg.platformTheme == "gtk" then "gtk2" else cfg.platformTheme;
       QT_STYLE_OVERRIDE = cfg.style.name;
     };
 
     home.packages = if cfg.platformTheme == "gnome" then
       [ pkgs.qgnomeplatform ]
       ++ lib.optionals (cfg.style.package != null) [ cfg.style.package ]
-    else
+    else if cfg.platformTheme == "kde" then [
+      pkgs.libsForQt5.plasma-integration
+      pkgs.libsForQt5.systemsettings
+    ] else
       [ pkgs.libsForQt5.qtstyleplugins ];
 
     xsession.importedVariables = [ "QT_QPA_PLATFORMTHEME" ]


### PR DESCRIPTION
### Description
This allow you to configure Qt integration using KDE instead of `qgnomeplatform` or `qtstyleplugins`. Useful if your theme supports both GTK and KDE, for example Nordic.

To use this properly you will need to do some manual configuration for now. You can set the theme settings using `~/.config/kdeglobals`.

Example:

```nix
{ ... }:
{
  qt = {
    enable = true;
    platformTheme = "kde";
  };

  xdg = {
    configFile.kdeglobals.text = lib.generators.toINI { } {
      General = {
        ColorScheme = "nordicbluish";
        Name = "nordic-bluish";
        shadeSortColumn = true;
      };
      Icons = {
        Theme = "Nordic-bluish";
      };
      KDE = {
        LookAndFeelPackage = "Nordic-bluish";
        contrast = 4;
      };
    };

    dataFile = {
      # For General.ColorScheme
      color-schemes = {
        source = "${pkgs.nordic}/share/color-schemes";
        recursive = true;
      };
      # For KDE.LookAndFeelPackage
      plasma = {
        source = "${pkgs.nordic}/share/plasma";
        recursive = true;
      };
    };
  };
}
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
