### PR TITLE
calendars: add missing modules

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -15,6 +15,8 @@ let
 
   modules = [
     ./accounts/email.nix
+    ./accounts/calendar.nix
+    ./accounts/contacts.nix
     ./config/home-cursor.nix
     ./config/i18n.nix
     ./files.nix


### PR DESCRIPTION
### Description

seems like I missed some code when rebasing  https://github.com/nix-community/home-manager/pull/4078 . Will try to do some more cleanup + prepare automatic labeling

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
