### PR TITLE
shikane: init module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -419,6 +419,7 @@ let
       ./services/safeeyes.nix
       ./services/screen-locker.nix
       ./services/sctd.nix
+      ./services/shikane.nix
       ./services/signaturepdf.nix
       ./services/skhd.nix
       ./services/snixembed.nix

--- a/modules/services/shikane.nix
+++ b/modules/services/shikane.nix
@@ -1,0 +1,91 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.shikane;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = [ lib.maintainers.therealr5 ];
+
+  options.services.shikane = {
+
+    enable = lib.mkEnableOption "shikane, A dynamic output configuration tool that automatically detects and configures connected outputs based on a set of profiles.";
+
+    package = lib.mkPackageOption pkgs "shikane" { };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          profile = [
+            {
+              name = "external-monitor-default";
+              output = [
+                {
+                  match = "eDP-1";
+                  enable = true;
+                }
+                {
+                  match = "HDMI-A-1";
+                  enable = true;
+                  position = {
+                    x = 1920;
+                    y = 0;
+                  };
+                }
+              ];
+            }
+            {
+              name = "builtin-monitor-only";
+              output = [
+                {
+                  match = "eDP-1";
+                  enable = true;
+                }
+              ];
+            }
+          ];
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>$XDG_CONFIG_HOME/shikane/config.toml</filename>.
+        </para><para>
+        See <link xlink:href="https://gitlab.com/w0lff/shikane/-/blob/master/docs/shikane.5.man.md" />
+        for more information.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.shikane" pkgs lib.platforms.linux)
+    ];
+
+    xdg.configFile."shikane/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "shikane-config" cfg.settings;
+    };
+
+    systemd.user.services.shikane = {
+      Unit = {
+        Description = "Dynamic output configuration tool";
+        Documentation = "man:shikane(1)";
+        After = [ config.wayland.systemd.target ];
+        PartOf = [ config.wayland.systemd.target ];
+      };
+
+      Service = {
+        ExecStart = lib.getExe cfg.package;
+      };
+
+      Install = {
+        WantedBy = [ config.wayland.systemd.target ];
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -617,6 +617,7 @@ import nmtSrc {
       ./modules/services/remmina
       ./modules/services/restic
       ./modules/services/screen-locker
+      ./modules/services/shikane
       ./modules/services/signaturepdf
       ./modules/services/snixembed
       ./modules/services/swayidle

--- a/tests/modules/services/shikane/basic-configuration.nix
+++ b/tests/modules/services/shikane/basic-configuration.nix
@@ -1,0 +1,47 @@
+{ config, ... }:
+{
+  config = {
+    services.shikane = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { };
+      settings = {
+        profile = [
+          {
+            name = "external-monitor-default";
+            output = [
+              {
+                match = "eDP-1";
+                enable = true;
+              }
+              {
+                match = "HDMI-A-1";
+                enable = true;
+                position = {
+                  x = 1920;
+                  y = 0;
+                };
+              }
+            ];
+          }
+          {
+            name = "builtin";
+            output = [
+              {
+                match = "eDP-1";
+                enable = true;
+              }
+            ];
+          }
+        ];
+      };
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/shikane.service
+      assertFileExists $serviceFile
+
+      assertFileExists home-files/.config/shikane/config.toml
+      assertFileContent home-files/.config/shikane/config.toml ${./expected.toml}
+    '';
+  };
+}

--- a/tests/modules/services/shikane/default.nix
+++ b/tests/modules/services/shikane/default.nix
@@ -1,0 +1,1 @@
+{ shikane-basic-configuration = ./basic-configuration.nix; }

--- a/tests/modules/services/shikane/expected.toml
+++ b/tests/modules/services/shikane/expected.toml
@@ -1,0 +1,21 @@
+[[profile]]
+name = "external-monitor-default"
+
+[[profile.output]]
+enable = true
+match = "eDP-1"
+
+[[profile.output]]
+enable = true
+match = "HDMI-A-1"
+
+[profile.output.position]
+x = 1920
+y = 0
+
+[[profile]]
+name = "builtin"
+
+[[profile.output]]
+enable = true
+match = "eDP-1"


### PR DESCRIPTION
### Description
This adds shikane, another dynamic output configuration tool that automatically detects and configures connected outputs on wayland compositors.
Gitlab repo: https://gitlab.com/w0lff/shikane

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
