### PR TITLE
qt: fix breeze-qt5 path

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -94,7 +94,7 @@ in {
           example = "adwaita-dark";
           relatedPackages = [
             "adwaita-qt"
-            "breeze-qt5"
+            [ "libsForQt5" "breeze-qt5" ]
             [ "libsForQt5" "qtstyleplugins" ]
             "qtstyleplugin-kvantum-qt4"
             [ "libsForQt5" "qtstyleplugin-kvantum" ]


### PR DESCRIPTION
Don't use aliases as those may be disabled.

https://github.com/nix-community/home-manager/commit/4e09c83255c5b23d58714d56672d3946faf1bcef#commitcomment-118365867

It would be good to build the manual with `allowAliases = false` in CI so we can detect these errors, but currently I don't think we even build the manual in CI?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
