### PR TITLE
[Backport 23.05] home-manager-tool: prioritize `-I` parameters

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -883,7 +883,6 @@ COMMAND=""
 COMMAND_ARGS=()
 FLAKE_ARG=""
 
-setHomeManagerNixPath
 setHomeManagerPathVariables
 
 while [[ $# -gt 0 ]]; do
@@ -978,6 +977,8 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+setHomeManagerNixPath
 
 if [[ -z $COMMAND ]]; then
     doHelp >&2


### PR DESCRIPTION
In 176e455 the order between the action of `-I` parameters getting added to `EXTRA_NIX_PATH` and the action of a static path getting added to `EXTRA_NIX_PATH` was reversed, also reversing the order of `-I` parameters and the static `-I home-manager=...` leading to the static `-I home-manager=...` to always come before any of the `-I` parameters to later calls to nix commands.

This made it imposible to override the static home-manager path when calling the home-manager tool with `-I home-manager=...`. This was previously posible.

Backport of https://github.com/nix-community/home-manager/pull/4101
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
