### PR TITLE
docs: Document osConfig module argument

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -219,6 +219,15 @@ the dependency on `NIX_PATH`, which is otherwise used for importing
 Nixpkgs.
 ====
 
+[NOTE]
+====
+Home Manager will pass `osConfig` as a module argument to any modules
+you create. This contains the system's NixOS configuration.
+
+[source,nix]
+{ lib, pkgs, osConfig, ... }:
+====
+
 Once installed you can see <<ch-usage>> for a more detailed
 description of Home Manager and how to use it.
 
@@ -323,6 +332,15 @@ home-manager.useGlobalPkgs = true;
 This saves an extra Nixpkgs evaluation, adds consistency, and removes
 the dependency on `NIX_PATH`, which is otherwise used for importing
 Nixpkgs.
+====
+
+[NOTE]
+====
+Home Manager will pass `osConfig` as a module argument to any modules
+you create. This contains the system's nix-darwin configuration.
+
+[source,nix]
+{ lib, pkgs, osConfig, ... }:
 ====
 
 Once installed you can see <<ch-usage>> for a more detailed


### PR DESCRIPTION
As mentioned https://github.com/nix-community/home-manager/issues/393#issuecomment-1259996423.

Otherwise only documented in source code, which isn't very findable.



### Description

Document `osConfig` as a module argument to get the system configuration.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
