### PR TITLE
home-manager-tool: Depricate home-manager paths

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -3,9 +3,7 @@
 # used for pkgs.path for nixos-option
 , pkgs
 
-# Extra path to Home Manager. If set then this path will be tried
-# before `$HOME/.config/nixpkgs/home-manager` and
-# `$HOME/.nixpkgs/home-manager`.
+# Path to use as the Home Manager channel.
 , path ? null }:
 
 let

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -104,13 +104,41 @@ function setConfigFile() {
 }
 
 function setHomeManagerNixPath() {
-    local path
-    for path in "@HOME_MANAGER_PATH@" \
-                "${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home-manager" \
-                "$HOME/.nixpkgs/home-manager" ; do
+    local path="@HOME_MANAGER_PATH@"
+
+    if [[ -n "$path" ]] ; then
         if [[ -e "$path" || "$path" =~ ^https?:// ]] ; then
             EXTRA_NIX_PATH+=("home-manager=$path")
             return
+        else
+            _iWarn 'Home Manager not found at %s.' "$path"
+        fi
+    fi
+
+    for p in "${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home-manager" \
+             "$HOME/.nixpkgs/home-manager" ; do
+        if [[ -e "$p" ]] ; then
+            # translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
+            _iWarn $'The fallback Home Manager path %s has been deprecated and a file/directory was found there.' \
+                   "$p"
+            # translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
+            _i $'To remove this warning, do one of the fallowing.
+
+1. Explicitly tell Home Manager to use the path, for example by adding
+
+     { programs.home-manager.path = "%s"; }
+
+   to your configuration.
+
+   If you import Home Manager directly, you can use the `path` parameter
+
+     pkgs.callPackage /path/to/home-manager-package { path = "%s"; }
+
+   when calling the Home Manager package.
+
+2. Remove the deprecated path.
+
+     $ rm -r "%s"' "$p" "$p" "$p"
         fi
     done
 }

--- a/home-manager/po/home-manager.pot
+++ b/home-manager/po/home-manager.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2023-05-27 09:08+0200\n"
+"POT-Creation-Date: 2023-07-16 10:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,7 +25,7 @@ msgstr ""
 #. translators: The first '%s' specifier will be replaced by either
 #. 'home.nix' or 'flake.nix'.
 #: home-manager/home-manager:88 home-manager/home-manager:92
-#: home-manager/home-manager:154
+#: home-manager/home-manager:182
 msgid ""
 "Keeping your Home Manager %s in %s is deprecated,\n"
 "please move it to %s"
@@ -35,38 +35,71 @@ msgstr ""
 msgid "No configuration file found. Please create one at %s"
 msgstr ""
 
-#: home-manager/home-manager:136
+#: home-manager/home-manager:114
+msgid "Home Manager not found at %s."
+msgstr ""
+
+#. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
+#: home-manager/home-manager:122
+msgid ""
+"The fallback Home Manager path %s has been deprecated and a file/directory "
+"was found there."
+msgstr ""
+
+#. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
+#: home-manager/home-manager:125
+msgid ""
+"To remove this warning, do one of the fallowing.\n"
+"\n"
+"1. Explicitly tell Home Manager to use the path, for example by adding\n"
+"\n"
+"     { programs.home-manager.path = \"%s\"; }\n"
+"\n"
+"   to your configuration.\n"
+"\n"
+"   If you import Home Manager directly, you can use the `path` parameter\n"
+"\n"
+"     pkgs.callPackage /path/to/home-manager-package { path = \"%s\"; }\n"
+"\n"
+"   when calling the Home Manager package.\n"
+"\n"
+"2. Remove the deprecated path.\n"
+"\n"
+"     $ rm -r \"%s\""
+msgstr ""
+
+#: home-manager/home-manager:164
 msgid "Could not find suitable profile directory, tried %s and %s"
 msgstr ""
 
 #. translators: Here "flake" is a noun that refers to the Nix Flakes feature.
-#: home-manager/home-manager:191
+#: home-manager/home-manager:219
 msgid "Can't inspect options of a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:253 home-manager/home-manager:276
-#: home-manager/home-manager:973
+#: home-manager/home-manager:281 home-manager/home-manager:304
+#: home-manager/home-manager:1000
 msgid "%s: unknown option '%s'"
 msgstr ""
 
-#: home-manager/home-manager:258 home-manager/home-manager:974
+#: home-manager/home-manager:286 home-manager/home-manager:1001
 msgid "Run '%s --help' for usage help"
 msgstr ""
 
-#: home-manager/home-manager:284 home-manager/home-manager:383
+#: home-manager/home-manager:312 home-manager/home-manager:411
 msgid "The file %s already exists, leaving it unchanged..."
 msgstr ""
 
-#: home-manager/home-manager:286 home-manager/home-manager:385
+#: home-manager/home-manager:314 home-manager/home-manager:413
 msgid "Creating %s..."
 msgstr ""
 
-#: home-manager/home-manager:427
+#: home-manager/home-manager:455
 msgid "Creating initial Home Manager generation..."
 msgstr ""
 
 #. translators: The "%s" specifier will be replaced by a file path.
-#: home-manager/home-manager:432
+#: home-manager/home-manager:460
 msgid ""
 "All done! The home-manager tool should now be installed and you can edit\n"
 "\n"
@@ -77,7 +110,7 @@ msgid ""
 msgstr ""
 
 #. translators: The "%s" specifier will be replaced by a URL.
-#: home-manager/home-manager:437
+#: home-manager/home-manager:465
 msgid ""
 "Uh oh, the installation failed! Please create an issue at\n"
 "\n"
@@ -87,11 +120,11 @@ msgid ""
 msgstr ""
 
 #. translators: Here "flake" is a noun that refers to the Nix Flakes feature.
-#: home-manager/home-manager:448
+#: home-manager/home-manager:476
 msgid "Can't instantiate a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:521
+#: home-manager/home-manager:549
 msgid ""
 "There is %d unread and relevant news item.\n"
 "Read it by running the command \"%s news\"."
@@ -101,77 +134,77 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: home-manager/home-manager:535
+#: home-manager/home-manager:563
 msgid "Unknown \"news.display\" setting \"%s\"."
 msgstr ""
 
-#: home-manager/home-manager:542
+#: home-manager/home-manager:570
 #, sh-format
 msgid "Please set the $EDITOR environment variable"
 msgstr ""
 
-#: home-manager/home-manager:557
+#: home-manager/home-manager:585
 msgid "Cannot run build in read-only directory"
 msgstr ""
 
-#: home-manager/home-manager:641
+#: home-manager/home-manager:669
 msgid "No generation with ID %s"
 msgstr ""
 
-#: home-manager/home-manager:643
+#: home-manager/home-manager:671
 msgid "Cannot remove the current generation %s"
 msgstr ""
 
-#: home-manager/home-manager:645
+#: home-manager/home-manager:673
 msgid "Removing generation %s"
 msgstr ""
 
-#: home-manager/home-manager:664
+#: home-manager/home-manager:692
 msgid "No generations to expire"
 msgstr ""
 
-#: home-manager/home-manager:675
+#: home-manager/home-manager:703
 msgid "No home-manager packages seem to be installed."
 msgstr ""
 
 #. translators: Here "flake" is a noun that refers to the Nix Flakes feature.
-#: home-manager/home-manager:702
+#: home-manager/home-manager:730
 msgid "Sorry, this command is not yet supported in flake setup"
 msgstr ""
 
-#: home-manager/home-manager:739
+#: home-manager/home-manager:767
 msgid "Unknown argument %s"
 msgstr ""
 
-#: home-manager/home-manager:755
+#: home-manager/home-manager:783
 msgid "This will remove Home Manager from your system."
 msgstr ""
 
-#: home-manager/home-manager:758
+#: home-manager/home-manager:786
 msgid "This is a dry run, nothing will actually be uninstalled."
 msgstr ""
 
-#: home-manager/home-manager:762
+#: home-manager/home-manager:790
 msgid "Really uninstall Home Manager?"
 msgstr ""
 
-#: home-manager/home-manager:768
+#: home-manager/home-manager:796
 msgid "Switching to empty Home Manager configuration..."
 msgstr ""
 
-#: home-manager/home-manager:795
+#: home-manager/home-manager:823
 msgid "Yay!"
 msgstr ""
 
-#: home-manager/home-manager:800
+#: home-manager/home-manager:828
 msgid "Home Manager is uninstalled but your home.nix is left untouched."
 msgstr ""
 
-#: home-manager/home-manager:1011
+#: home-manager/home-manager:1040
 msgid "expire-generations expects one argument, got %d."
 msgstr ""
 
-#: home-manager/home-manager:1033
+#: home-manager/home-manager:1062
 msgid "Unknown command: %s"
 msgstr ""
 

--- a/modules/po/hm-modules.pot
+++ b/modules/po/hm-modules.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager Modules\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2023-05-27 09:08+0200\n"
+"POT-Creation-Date: 2023-07-16 10:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,7 @@ msgstr ""
 msgid "No change so reusing latest profile generation %s"
 msgstr ""
 
-#: modules/home-environment.nix:627
+#: modules/home-environment.nix:634
 msgid ""
 "Oops, Nix failed to install your new Home Manager profile!\n"
 "\n"
@@ -49,7 +49,7 @@ msgid ""
 "Then try activating your Home Manager configuration again."
 msgstr ""
 
-#: modules/home-environment.nix:660
+#: modules/home-environment.nix:667
 msgid "Activating %s"
 msgstr ""
 


### PR DESCRIPTION
### Description
Depricate hard-coded fallback home-manager paths. Specificly "${XDG_CONFIG_HOME:-$HOME/.config}/nixpkgs/home-manager" and "$HOME/.nixpkgs/home-manager".

Use @HOME_MANAGER_PATH@ if it has been provided and points to something that exisits. Warn the user if it does not point to something.

If we have not been provided with a @HOME_MANAGER_PATH@ that exisits, then for both hard-coded paths show a warning if something exisits where the paths are pointing.

This no longer attempts to use either of the hard-coded paths as fallbacks for the home-manager path.

Alternative to https://github.com/nix-community/home-manager/pull/4084
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
