### PR TITLE
borgmatic: Add missing support for output and hooks

### DIFF
--- a/modules/programs/borgmatic.nix
+++ b/modules/programs/borgmatic.nix
@@ -134,6 +134,10 @@ let
 
         extraConfig = extraConfigOption;
       };
+
+      output = { extraConfig = extraConfigOption; };
+
+      hooks = { extraConfig = extraConfigOption; };
     };
   });
 
@@ -168,6 +172,8 @@ let
       } // config.retention.extraConfig;
       consistency = removeNullValues { checks = config.consistency.checks; }
         // config.consistency.extraConfig;
+      output = config.output.extraConfig;
+      hooks = config.hooks.extraConfig;
     };
 in {
   meta.maintainers = [ maintainers.DamienCassou ];

--- a/tests/modules/programs/borgmatic/basic-configuration.nix
+++ b/tests/modules/programs/borgmatic/basic-configuration.nix
@@ -44,6 +44,12 @@ in {
 
           extraConfig = { prefix = "hostname"; };
         };
+
+        output = { extraConfig = { color = false; }; };
+
+        hooks = {
+          extraConfig = { before_actions = [ "echo Starting actions." ]; };
+        };
       };
     };
   };
@@ -96,6 +102,12 @@ in {
       (builtins.elemAt backups.main.consistency.checks 1).frequency
     }"
     expectations[consistency.prefix]="${backups.main.consistency.extraConfig.prefix}"
+    expectations[output.color]="${
+      boolToString backups.main.output.extraConfig.color
+    }"
+    expectations[hooks.before_actions[0]]="${
+      builtins.elemAt backups.main.hooks.extraConfig.before_actions 0
+    }"
 
     yq=${pkgs.yq-go}/bin/yq
 


### PR DESCRIPTION
### Description

Fix #3760 by adding output and hooks top-level configuration groups.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).