### PR TITLE
vdirsyncer: Fix service by moving the options before the command

### DIFF
--- a/modules/services/vdirsyncer.nix
+++ b/modules/services/vdirsyncer.nix
@@ -67,9 +67,9 @@ in {
       Service = {
         Type = "oneshot";
         # TODO `vdirsyncer discover`
-        ExecStart = "${cfg.package}/bin/vdirsyncer sync ${
+        ExecStart = "${cfg.package}/bin/vdirsyncer ${
             concatStringsSep " " vdirsyncerOptions
-          }";
+          } sync";
       };
     };
 


### PR DESCRIPTION
-------

### Description

vdirsyncer requires the global options to arrive before the command:

``` shellsession
$ vdirsyncer sync --verbosity INFO
Usage: vdirsyncer sync [OPTIONS] [COLLECTIONS]...
Try 'vdirsyncer sync --help' for help.

Error: No such option: --verbosity
$ vdirsyncer --verbosity INFO sync
Syncing …
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).