### PR TITLE
Re-enable nixpkgs release check

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -455,12 +455,12 @@ in
 
     home.enableNixpkgsReleaseCheck = mkOption {
       type = types.bool;
-      default = false;          # Temporarily disabled until release stabilizes.
+      default = true;
       description = ''
         Determines whether to check for release version mismatch between Home
         Manager and Nixpkgs. Using mismatched versions is likely to cause errors
         and unexpected behavior. It is therefore highly recommended to use a
-        release of Home Manager than corresponds with your chosen release of
+        release of Home Manager that corresponds with your chosen release of
         Nixpkgs.
         </para><para>
         When this option is enabled and a mismatch is detected then a warning
@@ -497,7 +497,7 @@ in
 
           Using mismatched versions is likely to cause errors and unexpected
           behavior. It is therefore highly recommended to use a release of Home
-          Manager than corresponds with your chosen release of Nixpkgs.
+          Manager that corresponds with your chosen release of Nixpkgs.
 
           If you insist then you can disable this warning by adding
 


### PR DESCRIPTION
Was disabled in https://github.com/nix-community/home-manager/commit/dc2a4e4146d1626bc6a916cb57c9e12be2399ca3#diff-5c980e4c769c045b39cdf1cf9597e9cb2d45929f77e106ee8d9abbcdd7b501a0 and never re-enabled. No wonder we're getting so many bug reports caused by out of sync nixpkgs!

This should be backported to 23.05, and maybe even to 22.11.

It might make sense to have a short "grace period" around branch-off, so that you can keep using home-manager master and nixpkgs master together even if one of them has bumped its version. This should happen automatically, as turning the release check off and on is prone to forgetting and if we're ready to do that we might as well just bump `.version`. I'm not sure how to best implement this; I think one way would be to ensure that master always "knows" it's master and not a release branch.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
