### PR TITLE
Allow starship inside emacs if STARSHIP_INSIDE_EMACS is set to yes

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -87,25 +87,25 @@ in {
     };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then
+      if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm" || $STARSHIP_INSIDE_EMACS == "yes") ]]; then
         eval "$(${starshipCmd} init bash --print-full-init)"
       fi
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then
+      if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm" || $STARSHIP_INSIDE_EMACS == "yes") ]]; then
         eval "$(${starshipCmd} init zsh)"
       fi
     '';
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-      if test "$TERM" != "dumb"  -a \( -z "$INSIDE_EMACS"  -o "$INSIDE_EMACS" = "vterm" \)
+      if test "$TERM" != "dumb"  -a \( -z "$INSIDE_EMACS"  -o "$INSIDE_EMACS" = "vterm" -o "$STARSHIP_INSIDE_EMACS" = "yes" \)
         eval (${starshipCmd} init fish)
       end
     '';
 
     programs.ion.initExtra = mkIf cfg.enableIonIntegration ''
-      if test $TERM != "dumb" && not exists -s INSIDE_EMACS || test $INSIDE_EMACS = "vterm"
+      if test $TERM != "dumb" && not exists -s INSIDE_EMACS || test $INSIDE_EMACS = "vterm" || test $STARSHIP_INSIDE_EMACS = "yes"
         eval $(${starshipCmd} init ion)
       end
     '';


### PR DESCRIPTION
### Description

I'm not sure why someone thought it was a good idea to say that starship should never be allowed inside emacs unless its vterm. It works just fine in ansi-term as well, and it should REALLY be left up to the user to decide to disable/enable something like this, but in any case, in the interest of keeping things a bit more the same, I've simply added a STARSHIP_INSIDE_EMACS environment variable that can override this behavior.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

