### PR TITLE
clipman: wrong module name in description

### DIFF
--- a/modules/services/clipman.nix
+++ b/modules/services/clipman.nix
@@ -1,11 +1,6 @@
 { config, lib, pkgs, ... }:
-
 with lib;
-
-let
-
-  cfg = config.services.clipman;
-
+let cfg = config.services.clipman;
 in {
   meta.maintainers = [ maintainers.jwygoda ];
 
@@ -19,7 +14,7 @@ in {
       default = "graphical-session.target";
       example = "sway-session.target";
       description = ''
-        The systemd target that will automatically start the Waybar service.
+        The systemd target that will automatically start the clipman service.
         </para>
         <para>
         When setting this value to <literal>"sway-session.target"</literal>,


### PR DESCRIPTION
### Description

The clipman module was referencing "Waybar" in the systemd target option. This PR fixes that.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

