### PR TITLE
rio: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -299,6 +299,12 @@
     github = "nurelin";
     githubId = 5276274;
   };
+  otavio = {
+    email = "otavio.salvador@ossystems.com.br";
+    github = "otavio";
+    githubId = 25278;
+    name = "Otavio Salvador";
+  };
   pltanton = {
     name = "pltanton";
     email = "plotnikovanton@gmail.com";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1221,6 +1221,15 @@ in
           A new module is available: 'programs.eza'.
         '';
       }
+
+      {
+        time = "2023-09-18T11:44:11+00:00";
+        message = ''
+          A new module is available: 'programs.rio'.
+
+          Rio is a hardware-accelerated GPU terminal emulator powered by WebGPU.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -178,6 +178,7 @@ let
     ./programs/qutebrowser.nix
     ./programs/rbw.nix
     ./programs/readline.nix
+    ./programs/rio.nix
     ./programs/ripgrep.nix
     ./programs/rofi-pass.nix
     ./programs/rofi.nix

--- a/modules/programs/rio.nix
+++ b/modules/programs/rio.nix
@@ -1,0 +1,52 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.programs.rio;
+
+  settingsFormat = pkgs.formats.toml { };
+
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+in {
+  options.programs.rio = {
+    enable = lib.mkEnableOption null // {
+      description = lib.mdDoc ''
+        Enable Rio, a terminal built to run everywhere, as a native desktop applications by
+        Rust/WebGPU or even in the browsers powered by WebAssembly/WebGPU.
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "rio" { };
+
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      description = ''
+        Configuration written to <filename>$XDG_CONFIG_HOME/rio/config.toml</filename> on Linux or
+        <filename>$HOME/Library/Application Support/rio/config.toml</filename> on Darwin. See
+        <link xlink:href="https://raphamorim.io/rio/docs/#configuration-file"/> for options.
+      '';
+    };
+  };
+  meta.maintainers = [ lib.maintainers.otavio ];
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      home.packages = [ cfg.package ];
+    }
+
+    # Only manage configuration if not empty
+    (lib.mkIf (cfg.settings != { } && !isDarwin) {
+      xdg.configFile."rio/config.toml".source = if lib.isPath cfg.settings then
+        cfg.settings
+      else
+        settingsFormat.generate "rio.toml" cfg.settings;
+    })
+
+    (lib.mkIf (cfg.settings != { } && isDarwin) {
+      home.file."Library/Application Support/rio/config.toml".source =
+        if lib.isPath cfg.settings then
+          cfg.settings
+        else
+          settingsFormat.generate "rio.toml" cfg.settings;
+    })
+  ]);
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -124,6 +124,7 @@ import nmt {
     ./modules/programs/qcal
     ./modules/programs/qutebrowser
     ./modules/programs/readline
+    ./modules/programs/rio
     ./modules/programs/ripgrep
     ./modules/programs/rtx
     ./modules/programs/sagemath

--- a/tests/modules/programs/rio/default.nix
+++ b/tests/modules/programs/rio/default.nix
@@ -1,0 +1,4 @@
+{
+  rio-example-settings = ./example-settings.nix;
+  rio-empty-settings = ./empty-settings.nix;
+}

--- a/tests/modules/programs/rio/empty-settings.nix
+++ b/tests/modules/programs/rio/empty-settings.nix
@@ -1,0 +1,11 @@
+_:
+
+{
+  programs.rio.enable = true;
+
+  test.stubs.rio = { };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/rio
+  '';
+}

--- a/tests/modules/programs/rio/example-settings.nix
+++ b/tests/modules/programs/rio/example-settings.nix
@@ -1,0 +1,32 @@
+{ config, pkgs, ... }:
+
+let
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+  path = if isDarwin then
+    "Library/Application Support/rio/config.toml"
+  else
+    ".config/rio/config.toml";
+
+  expected = pkgs.writeText "rio-expected.toml" ''
+    cursor = "_"
+    padding-x = 0
+    performance = "Low"
+  '';
+in {
+  programs.rio = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    settings = {
+      cursor = "_";
+      performance = "Low";
+      padding-x = 0;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/"${path}"
+    assertFileContent home-files/"${path}" '${expected}'
+  '';
+}


### PR DESCRIPTION
### Description

Adds a `programs.rio` module to control Rio installation and configuration.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
