### PR TITLE
zsh: allow setting custom syntax highlighting styles

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -212,6 +212,8 @@ let
     options = {
       enable = mkEnableOption "zsh syntax highlighting";
 
+      package = mkPackageOption pkgs "zsh-syntax-highlighting" { };
+
       styles = mkOption {
         type = types.attrsOf types.str;
         default = {};
@@ -608,7 +610,7 @@ in
           # Load zsh-syntax-highlighting after all custom widgets have been created
           # https://github.com/zsh-users/zsh-syntax-highlighting#faq
         ''
-          source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+          source ${cfg.syntaxHighlighting.package}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
           ${lib.concatStringsSep "\n" (
               lib.mapAttrsToList
                 (name: value: "ZSH_HIGHLIGHT_STYLES[${lib.escapeShellArg name}]=${lib.escapeShellArg value}")

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -208,9 +208,28 @@ let
     };
   };
 
+  syntaxHighlightingModule = types.submodule {
+    options = {
+      enable = mkEnableOption "zsh syntax highlighting";
+
+      styles = mkOption {
+        type = types.attrsOf types.str;
+        default = {};
+        description = ''
+          Custom styles for syntax highlighting.
+          See each highlighter's options: <link xlink:href="https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters.md"/>
+        '';
+      };
+    };
+  };
+
 in
 
 {
+  imports = [
+    (mkRenamedOptionModule [ "programs" "zsh" "enableSyntaxHighlighting" ] [ "programs" "zsh" "syntaxHighlighting" "enable" ])
+  ];
+
   options = {
     programs.zsh = {
       enable = mkEnableOption "Z shell (Zsh)";
@@ -312,9 +331,10 @@ in
         description = "Enable zsh autosuggestions";
       };
 
-      enableSyntaxHighlighting = mkOption {
-        default = false;
-        description = "Enable zsh syntax highlighting";
+      syntaxHighlighting = mkOption {
+        type = syntaxHighlightingModule;
+        default = {};
+        description = "Options related to zsh-syntax-highlighting.";
       };
 
       historySubstringSearch = mkOption {
@@ -584,11 +604,17 @@ in
         ${dirHashesStr}
         '')
 
-        (optionalString cfg.enableSyntaxHighlighting
+        (optionalString cfg.syntaxHighlighting.enable
           # Load zsh-syntax-highlighting after all custom widgets have been created
           # https://github.com/zsh-users/zsh-syntax-highlighting#faq
-          "source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-        )
+        ''
+          source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+          ${lib.concatStringsSep "\n" (
+              lib.mapAttrsToList
+                (name: value: "ZSH_HIGHLIGHT_STYLES[${lib.escapeShellArg name}]=${lib.escapeShellArg value}")
+                cfg.syntaxHighlighting.styles
+          )}
+        '')
 
         (optionalString (cfg.historySubstringSearch.enable or false)
           # Load zsh-history-substring-search after zsh-syntax-highlighting

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -7,4 +7,5 @@
   zsh-history-ignore-pattern = ./history-ignore-pattern.nix;
   zsh-history-substring-search = ./history-substring-search.nix;
   zsh-prezto = ./prezto.nix;
+  zsh-syntax-highlighting = ./syntax-highlighting.nix;
 }

--- a/tests/modules/programs/zsh/syntax-highlighting.nix
+++ b/tests/modules/programs/zsh/syntax-highlighting.nix
@@ -8,6 +8,7 @@ with lib;
       enable = true;
       syntaxHighlighting = {
         enable = true;
+        package = pkgs.hello;
         styles.comment = "fg=#6c6c6c";
       };
     };
@@ -15,7 +16,7 @@ with lib;
     test.stubs.zsh = { };
 
     nmt.script = ''
-      assertFileContains home-files/.zshrc "source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+      assertFileContains home-files/.zshrc "source ${pkgs.hello}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
       assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_STYLES['comment']='fg=#6c6c6c'"
     '';
   };

--- a/tests/modules/programs/zsh/syntax-highlighting.nix
+++ b/tests/modules/programs/zsh/syntax-highlighting.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.zsh = {
+      enable = true;
+      syntaxHighlighting = {
+        enable = true;
+        styles.comment = "fg=#6c6c6c";
+      };
+    };
+
+    test.stubs.zsh = { };
+
+    nmt.script = ''
+      assertFileContains home-files/.zshrc "source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+      assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_STYLES['comment']='fg=#6c6c6c'"
+    '';
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Commit message:

> Custom styles allow overriding the default colors.
> Example:
> ```nix
> {
>   zsh.syntaxHighlighting.styles.comment = "fg=#6c6c6c";
> }
> ```
> 
> See https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters.md

The motivation for adding this is to workaround https://github.com/zsh-users/zsh-syntax-highlighting/issues/510

I also made the package configurable since we have a module now.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
