### PR TITLE
Update documentation to mention renamed option name.

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -206,7 +206,7 @@ in {
         </para>
         <para>
         When setting this value to <literal>"sway-session.target"</literal>,
-        make sure to also enable <option>wayland.windowManager.sway.systemdIntegration</option>,
+        make sure to also enable <option>wayland.windowManager.sway.systemd.enable</option>,
         otherwise the service may never be started.
       '';
     };

--- a/modules/services/clipman.nix
+++ b/modules/services/clipman.nix
@@ -18,7 +18,7 @@ in {
         </para>
         <para>
         When setting this value to <literal>"sway-session.target"</literal>,
-        make sure to also enable <option>wayland.windowManager.sway.systemdIntegration</option>,
+        make sure to also enable <option>wayland.windowManager.sway.systemd.enable</option>,
         otherwise the service may never be started.
       '';
     };

--- a/modules/services/copyq.nix
+++ b/modules/services/copyq.nix
@@ -22,7 +22,7 @@ in {
         </para>
         <para>
         When setting this value to <literal>"sway-session.target"</literal>,
-        make sure to also enable <option>wayland.windowManager.sway.systemdIntegration</option>,
+        make sure to also enable <option>wayland.windowManager.sway.systemd.enable</option>,
         otherwise the service may never be started.
       '';
     };


### PR DESCRIPTION
### Description

#3747 renamed the option `wayland.windowManager.sway.systemdIntegration` to `wayland.windowManager.sway.systemd.enable`.

 This PR simply updates documentation to reference the new option instead. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
