### PR TITLE
helix: add defaultEditor

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -18,6 +18,15 @@ in {
       description = "The package to use for helix.";
     };
 
+    defaultEditor = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to configure <command>hx</command> as the default
+        editor using the <envar>EDITOR</envar> environment variable.
+      '';
+    };
+
     settings = mkOption {
       type = tomlFormat.type;
       default = { };
@@ -153,6 +162,8 @@ in {
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
+
+    home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "hx"; };
 
     xdg.configFile = let
       settings = {


### PR DESCRIPTION
### Description

Whether to configure Helix as the default editor.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.