### PR TITLE
home-environment: allow skipping sanity checks

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -711,8 +711,10 @@ in
 
           ${builtins.readFile ./lib-bash/activation-init.sh}
 
-          checkUsername ${escapeShellArg config.home.username}
-          checkHomeDirectory ${escapeShellArg config.home.homeDirectory}
+          if [[ ! -v SKIP_SANITY_CHECKS ]]; then
+            checkUsername ${escapeShellArg config.home.username}
+            checkHomeDirectory ${escapeShellArg config.home.homeDirectory}
+          fi
 
           ${activationCmds}
         '';


### PR DESCRIPTION
### Description

See https://github.com/nix-community/home-manager/issues/4019#issuecomment-1568659267

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```