### PR TITLE
gtk: Add gtk4.extraCss option

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -204,6 +204,15 @@ in {
             <filename>$XDG_CONFIG_HOME/gtk-4.0/settings.ini</filename>.
           '';
         };
+
+        extraCss = mkOption {
+          type = types.lines;
+          default = "";
+          description = ''
+            Extra configuration lines to add verbatim to
+            <filename>$XDG_CONFIG_HOME/gtk-4.0/gtk.css</filename>.
+          '';
+        };
       };
     };
   };
@@ -267,6 +276,9 @@ in {
 
     xdg.configFile."gtk-4.0/settings.ini".text =
       toGtk3Ini { Settings = gtkIni // cfg4.extraConfig; };
+
+    xdg.configFile."gtk-4.0/gtk.css" =
+      mkIf (cfg4.extraCss != "") { text = cfg4.extraCss; };
 
     dconf.settings."org/gnome/desktop/interface" = dconfIni;
   });


### PR DESCRIPTION
### Description

Add gtk4.extraCss option that works like gtk3.extraCss.
I use it to remove shadows and rounded corners from popover menus since they show an ugly black rectangle if compositing is disabled.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
