### PR TITLE
starship: Remove INSIDE_EMACS checks when enabling shell integration

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -100,26 +100,26 @@ in {
     };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then
+      if [[ $TERM != "dumb" ]]; then
         eval "$(${starshipCmd} init bash --print-full-init)"
       fi
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      if [[ $TERM != "dumb" && (-z $INSIDE_EMACS || $INSIDE_EMACS == "vterm") ]]; then
+      if [[ $TERM != "dumb" ]]; then
         eval "$(${starshipCmd} init zsh)"
       fi
     '';
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-      if test "$TERM" != "dumb"  -a \( -z "$INSIDE_EMACS"  -o "$INSIDE_EMACS" = "vterm" \)
+      if test "$TERM" != "dumb"
         eval (${starshipCmd} init fish)
         ${lib.optionalString cfg.enableTransience "enable_transience"}
       end
     '';
 
     programs.ion.initExtra = mkIf cfg.enableIonIntegration ''
-      if test $TERM != "dumb" && not exists -s INSIDE_EMACS || test $INSIDE_EMACS = "vterm"
+      if test $TERM != "dumb"
         eval $(${starshipCmd} init ion)
       end
     '';


### PR DESCRIPTION
### Description

Many of the terminals supported inside emacs work perfectly fine with STARSHIP.
The TERM=dumb case already handles the tramp and eterm cases, so as far as I can
tell, this is basically just a check for the benefit of OLD versions of
term-mode (see
https://www.emacswiki.org/emacs/AnsiTerm#:~:text=Historically%2C%20'M%2Dx%20ansi%2Dterm,the%20older%20'C%2Dc'%20binding.,
which indicates that it also now handles colors).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
