### PR TITLE
treewide: remove marsam as maintainer

### DIFF
--- a/modules/programs/bat.nix
+++ b/modules/programs/bat.nix
@@ -14,7 +14,7 @@ let
   };
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.bat = {
     enable = mkEnableOption "bat, a cat clone with wings";

--- a/modules/programs/gallery-dl.nix
+++ b/modules/programs/gallery-dl.nix
@@ -9,7 +9,7 @@ let
   jsonFormat = pkgs.formats.json { };
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.gallery-dl = {
     enable = mkEnableOption "gallery-dl";

--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -16,7 +16,7 @@ let
     }";
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.keychain = {
     enable = mkEnableOption "keychain";

--- a/modules/programs/ledger.nix
+++ b/modules/programs/ledger.nix
@@ -16,7 +16,7 @@ let
   } cfg.settings;
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.ledger = {
     enable = mkEnableOption "ledger, a double-entry accounting system";

--- a/modules/programs/lsd.nix
+++ b/modules/programs/lsd.nix
@@ -17,7 +17,7 @@ let
   };
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.lsd = {
     enable = mkEnableOption "lsd";

--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -6,7 +6,7 @@ let
   cfg = config.programs.mcfly;
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   imports = [
     (mkChangedOptionModule # \

--- a/modules/programs/navi.nix
+++ b/modules/programs/navi.nix
@@ -13,7 +13,7 @@ let
     config.xdg.configHome;
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.navi = {
     enable = mkEnableOption "Navi";

--- a/modules/programs/ncspot.nix
+++ b/modules/programs/ncspot.nix
@@ -9,7 +9,7 @@ let
   tomlFormat = pkgs.formats.toml { };
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.ncspot = {
     enable = mkEnableOption "ncspot";

--- a/modules/programs/noti.nix
+++ b/modules/programs/noti.nix
@@ -7,7 +7,7 @@ let
   cfg = config.programs.noti;
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.noti = {
     enable = mkEnableOption "Noti";

--- a/modules/programs/opam.nix
+++ b/modules/programs/opam.nix
@@ -7,7 +7,7 @@ let
   cfg = config.programs.opam;
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.opam = {
     enable = mkEnableOption "Opam";

--- a/modules/programs/papis.nix
+++ b/modules/programs/papis.nix
@@ -14,7 +14,7 @@ let
   };
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.papis = {
     enable = mkEnableOption "papis";

--- a/modules/programs/pazi.nix
+++ b/modules/programs/pazi.nix
@@ -7,7 +7,7 @@ let
   cfg = config.programs.pazi;
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.pazi = {
     enable = mkEnableOption "pazi";

--- a/modules/programs/rbenv.nix
+++ b/modules/programs/rbenv.nix
@@ -24,7 +24,7 @@ let
   };
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.rbenv = {
     enable = mkEnableOption "rbenv";

--- a/modules/programs/rtorrent.nix
+++ b/modules/programs/rtorrent.nix
@@ -7,7 +7,7 @@ let
   cfg = config.programs.rtorrent;
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   imports = [
     (mkRenamedOptionModule # \

--- a/modules/programs/sqls.nix
+++ b/modules/programs/sqls.nix
@@ -9,7 +9,7 @@ let
   yamlFormat = pkgs.formats.yaml { };
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.sqls = {
     enable = mkEnableOption "sqls, a SQL language server written in Go";

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -11,7 +11,7 @@ let
   starshipCmd = "${config.home.profileDirectory}/bin/starship";
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.starship = {
     enable = mkEnableOption "starship";

--- a/modules/programs/tealdeer.nix
+++ b/modules/programs/tealdeer.nix
@@ -12,7 +12,7 @@ let
     config.xdg.configHome;
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.tealdeer = {
     enable = mkEnableOption "Tealdeer";

--- a/modules/programs/translate-shell.nix
+++ b/modules/programs/translate-shell.nix
@@ -22,7 +22,7 @@ let
   toKeyValue = generators.toKeyValue { inherit mkKeyValue; };
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.translate-shell = {
     enable = mkEnableOption "translate-shell";

--- a/modules/programs/yt-dlp.nix
+++ b/modules/programs/yt-dlp.nix
@@ -13,7 +13,7 @@ let
       "--${name} ${toString value}");
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.yt-dlp = {
     enable = mkEnableOption "yt-dlp";

--- a/modules/programs/z-lua.nix
+++ b/modules/programs/z-lua.nix
@@ -15,7 +15,7 @@ let
   };
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.z-lua = {
     enable = mkEnableOption "z.lua";

--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -9,7 +9,7 @@ let
   cfgOptions = concatStringsSep " " cfg.options;
 
 in {
-  meta.maintainers = [ maintainers.marsam ];
+  meta.maintainers = [ ];
 
   options.programs.zoxide = {
     enable = mkEnableOption "zoxide";


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
