### PR TITLE
home-cursor.nix: enable gtk module when enabling gtk config generation

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -42,7 +42,8 @@ let
 
       gtk = {
         enable = mkEnableOption ''
-          gtk config generation for <option>home.pointerCursor</option>
+          gtk config generation for <option>home.pointerCursor</option>.
+	  Note that <option>gtk</option> has to be enabled for the configs to take effect
         '';
       };
     };
@@ -152,7 +153,6 @@ in {
     })
 
     (mkIf cfg.gtk.enable {
-      gtk.enable = true;
       gtk.cursorTheme = mkDefault { inherit (cfg) package name size; };
     })
   ]);

--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -42,8 +42,7 @@ let
 
       gtk = {
         enable = mkEnableOption ''
-          gtk config generation for <option>home.pointerCursor</option>.
-	  Note that <option>gtk</option> has to be enabled for the configs to take effect
+          gtk config generation for <option>home.pointerCursor</option>
         '';
       };
     };
@@ -105,6 +104,12 @@ in {
         backends, you can toggle them via the enable option. For example,
         <xref linkend="opt-home.pointerCursor.x11.enable"/>
         will enable x11 cursor configurations.
+	</para><para>
+        Note that this will merely generate the cursor configurations.
+	To apply the configurations, the relevant subsytems must also be configured.
+	For example, <xref linkend="opt-home.pointerCursor.gtk.enable"/> will generate
+        the gtk cursor configuration, but <xref linkend="opt-gtk.enable"/> needs
+        to be set for it to be applied.
       '';
     };
   };

--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -152,6 +152,7 @@ in {
     })
 
     (mkIf cfg.gtk.enable {
+      gtk.enable = true;
       gtk.cursorTheme = mkDefault { inherit (cfg) package name size; };
     })
   ]);

--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -104,10 +104,10 @@ in {
         backends, you can toggle them via the enable option. For example,
         <xref linkend="opt-home.pointerCursor.x11.enable"/>
         will enable x11 cursor configurations.
-	</para><para>
+        </para><para>
         Note that this will merely generate the cursor configurations.
-	To apply the configurations, the relevant subsytems must also be configured.
-	For example, <xref linkend="opt-home.pointerCursor.gtk.enable"/> will generate
+        To apply the configurations, the relevant subsytems must also be configured.
+        For example, <xref linkend="opt-home.pointerCursor.gtk.enable"/> will generate
         the gtk cursor configuration, but <xref linkend="opt-gtk.enable"/> needs
         to be set for it to be applied.
       '';


### PR DESCRIPTION
The gtk configurations are not generated unless config.gtk is enabled. This is a point of confusion because config.home.pointerCursor.gtk can essentially be disabled, despite having it enabled.

### Description

I changed the home.pointerCursor.gtk option such that it also enables the gtk module. The pointerCursor.gtk option essentially does nothing when the gtk module is disabled, so I think it is safe to assume that you would want to enable gtk when using this option. My cursor size was not consistent between applications, and it admittedly took me way too long to figure out that this was the problem..

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
