### PR TITLE
fix: antidote zsh path changed

### DIFF
--- a/modules/programs/antidote.nix
+++ b/modules/programs/antidote.nix
@@ -39,7 +39,7 @@ in {
     ### move zsh_plugins.txt
     programs.zsh.initExtraBeforeCompInit = ''
       ## home-manager/antidote begin :
-      source ${cfg.package}/antidote.zsh
+      source ${cfg.package}/share/antidote/antidote.zsh
       ${optionalString cfg.useFriendlyNames
       "zstyle ':antidote:bundle' use-friendly-names 'yes'"}
       bundlefile=${relToDotDir ".zsh_plugins.txt"}

--- a/tests/modules/programs/antidote/antidote.nix
+++ b/tests/modules/programs/antidote/antidote.nix
@@ -1,7 +1,6 @@
-{ ... }:
+{ pkgs, ... }:
 
 let relToDotDirCustom = ".zshplugins";
-
 in {
   programs.zsh = {
     enable = true;
@@ -20,7 +19,7 @@ in {
 
   nmt.script = ''
     assertFileContains home-files/${relToDotDirCustom}/.zshrc \
-      'source @antidote@/antidote.zsh'
+      'source @antidote@/share/antidote/antidote.zsh'
     assertFileContains home-files/${relToDotDirCustom}/.zshrc \
       'antidote load'
     assertFileContains home-files/${relToDotDirCustom}/.zshrc \


### PR DESCRIPTION
### Description

fix bug in latest added module antidote.  

since the package submit into nixpkgs is different from my local overlays, relocating zsh path


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
