### PR TITLE
antidote: fix  missing `$home` for static files

### DIFF
--- a/modules/programs/antidote.nix
+++ b/modules/programs/antidote.nix
@@ -42,9 +42,9 @@ in {
       source ${cfg.package}/share/antidote/antidote.zsh
       ${optionalString cfg.useFriendlyNames
       "zstyle ':antidote:bundle' use-friendly-names 'yes'"}
-      bundlefile=${relToDotDir ".zsh_plugins.txt"}
+      bundlefile=$HOME/${relToDotDir ".zsh_plugins.txt"}
       zstyle ':antidote:bundle' file $bundlefile
-      staticfile=${relToDotDir ".zsh_plugins.zsh"}
+      staticfile=$HOME/${relToDotDir ".zsh_plugins.zsh"}
       zstyle ':antidote:static' file $staticfile
       antidote load $bundlefile $staticfile
       ## home-manager/antidote end


### PR DESCRIPTION
add $HOME to pin .zsh_plugin path in zshrc , keeping antidote from creating empty .zsh_plugins.txt in pwd while new zsh process starting

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
