### PR TITLE
docs: bump nmd

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -7,8 +7,8 @@ let
 
   nmdSrc = fetchTarball {
     url =
-      "https://git.sr.ht/~rycee/nmd/archive/89a4092ea397642ca1d5712d4af62f8a4daae184.tar.gz";
-    sha256 = "0p1c8lwz33myqpirk4bh9vhfkgg0h9zwks0kfaj4siaivc4wjgvs";
+      "https://git.sr.ht/~rycee/nmd/archive/824a380546b5d0d0eb701ff8cd5dbafb360750ff.tar.gz";
+    sha256 = "0vvj40k6bw8ssra8wil9rqbsznmfy1kwy7cihvm13rajwdg9ycgg";
   };
 
   nmd = import nmdSrc { inherit lib pkgs; };


### PR DESCRIPTION
### Description

Removes the need to apply `fix-man-options-duplication.patch`. See, e.g., https://github.com/NixOS/nixpkgs/pull/166509.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```