### PR TITLE
nixos: convert option documentation to Markdown

### DIFF
--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -43,22 +43,20 @@ let
 
 in {
   options.home-manager = {
-    useUserPackages = mkEnableOption ''
+    useUserPackages = mkEnableOption (mdDoc ''
       installation of user packages through the
-      <option>users.users.&lt;name&gt;.packages</option> option
-    '';
+      [](#opt-users.users._name_.packages) option'');
 
-    useGlobalPkgs = mkEnableOption ''
-      using the system configuration's <literal>pkgs</literal>
+    useGlobalPkgs = mkEnableOption (mdDoc ''
+      using the system configuration's `pkgs`
       argument in Home Manager. This disables the Home Manager
-      options <option>nixpkgs.*</option>
-    '';
+      options {option}`nixpkgs.*`'');
 
     backupFileExtension = mkOption {
       type = types.nullOr types.str;
       default = null;
       example = "backup";
-      description = ''
+      description = mdDoc ''
         On activation move existing files by appending the given
         file extension rather than exiting with an error.
       '';
@@ -68,8 +66,8 @@ in {
       type = types.attrs;
       default = { };
       example = literalExpression "{ inherit emacs-overlay; }";
-      description = ''
-        Extra <literal>specialArgs</literal> passed to Home Manager. This
+      description = mdDoc ''
+        Extra `specialArgs` passed to Home Manager. This
         option can be used to pass additional arguments to all modules.
       '';
     };
@@ -78,7 +76,7 @@ in {
       type = with types; listOf raw;
       default = [ ];
       example = literalExpression "[ { home.packages = [ nixpkgs-fmt ]; } ]";
-      description = ''
+      description = mdDoc ''
         Extra modules added to all users.
       '';
     };
@@ -90,7 +88,7 @@ in {
       default = { };
       # Prevent the entire submodule being included in the documentation.
       visible = "shallow";
-      description = ''
+      description = mdDoc ''
         Per-user Home Manager configuration.
       '';
     };


### PR DESCRIPTION
### Description

NixOS 23.11 has migrated fully to Markdown and no longer accepts DocBook documentation.

I was going to do this migration for the whole Home Manager tree per https://github.com/nix-community/home-manager/issues/4142#issuecomment-1604826414 but am holding off for now in light of https://github.com/LnL7/nix-darwin/pull/707#issuecomment-1605499202. Still happy to do it if it's desired, though; I think it makes sense to follow nixpkgs' choices and tooling given the inherent tight coupling, unavoidability of processing at least some Markdown (for module system options), and the code sharing benefits (both in terms of the documentation generation itself and adapting modules between the two).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).