### PR TITLE
ci: build manual and push to home-manager.dev

### DIFF
--- a/.builds/manual.yml
+++ b/.builds/manual.yml
@@ -1,0 +1,34 @@
+image: nixos/unstable
+sources:
+  - https://git.sr.ht/~rycee/home-manager
+secrets:
+  - 01ad357c-3214-4f73-bb7e-2441e440cc51
+  - 7d16ccc0-1c4f-4fd6-91c1-c54fc0f5807f
+  - bd5f26ee-78b8-4a6f-9d68-8d8f53a068f1
+environment:
+  NIX_CONFIG: "experimental-features = nix-command flakes"
+packages:
+  - nixos.cachix
+tasks:
+  - setup: |
+      cachix use rycee
+  - build: |
+      cd ./home-manager
+      gitBranch="$(git show -s --pretty=%D HEAD | sed '{ s/.*, //; s!origin/!!; }')"
+      [[ $gitBranch == master || $gitBranch == release-??.?? ]] || exit 0
+      nix build -L .#docs-html
+      cachix push rycee ./result
+  - deploy: |
+      cd ./home-manager
+      gitBranch="$(git show -s --pretty=%D HEAD | sed '{ s/.*, //; s!origin/!!; }')"
+      [[ $gitBranch == master || $gitBranch == release-??.?? ]] || exit 0
+
+      if [[ $gitBranch == master ]]; then
+        dirName="unstable"
+      else
+        dirName="$(cat .release)"
+      fi
+
+      rsync --delete -r --info=stats \
+        "result/share/doc/home-manager/" \
+        "hm-web:/srv/www/home-manager.dev/manual/$dirName"


### PR DESCRIPTION
### Description

This builds the manual on builds.sr.ht and pushes it for availability on

  https://home-manager.dev/manual/unstable or
  https://home-manager.dev/manual/{version}

depending on which release branch is built.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```