### PR TITLE
sxhkd: allow usage of derivations as keybind commands

### DIFF
--- a/modules/services/sxhkd.nix
+++ b/modules/services/sxhkd.nix
@@ -38,13 +38,15 @@ in {
     };
 
     keybindings = mkOption {
-      type = types.attrsOf (types.nullOr types.str);
+      type =
+        types.attrsOf (types.nullOr (types.oneOf [ types.str types.path ]));
       default = { };
       description = "An attribute set that assigns hotkeys to commands.";
       example = literalExpression ''
         {
           "super + shift + {r,c}" = "i3-msg {restart,reload}";
           "super + {s,w}"         = "i3-msg {stacking,tabbed}";
+          "super + F1"            = pkgs.writeShellScript "script" "echo $USER";
         }
       '';
     };

--- a/tests/modules/services/sxhkd/configuration.nix
+++ b/tests/modules/services/sxhkd/configuration.nix
@@ -1,6 +1,10 @@
 { config, pkgs, ... }:
 
-{
+let
+  script = pkgs.writeShellScript "script.sh" ''
+    echo "test"
+  '';
+in {
   services.sxhkd = {
     enable = true;
 
@@ -10,6 +14,7 @@
       "super + a" = "run command a";
       "super + b" = null;
       "super + Shift + b" = "run command b";
+      "super + s" = script;
     };
 
     extraConfig = ''
@@ -27,6 +32,11 @@
 
     assertFileExists $sxhkdrc
 
-    assertFileContent $sxhkdrc ${./sxhkdrc}
+    assertFileContent $sxhkdrc ${
+      pkgs.substituteAll {
+        src = ./sxhkdrc;
+        inherit script;
+      }
+    }
   '';
 }

--- a/tests/modules/services/sxhkd/sxhkdrc
+++ b/tests/modules/services/sxhkd/sxhkdrc
@@ -5,6 +5,9 @@ super + a
   run command a
 
 
+super + s
+  @script@
+
 super + c
   call command c
 


### PR DESCRIPTION
### Description

This makes it consistent with some other options, like `systemd.user.services.Service.ExecStart`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
