### PR TITLE
antidote: make static file store in /tmp and use  antidote config hash id

### DIFF
--- a/tests/modules/programs/antidote/antidote.nix
+++ b/tests/modules/programs/antidote/antidote.nix
@@ -24,7 +24,5 @@ in {
       'antidote load'
     assertFileContains home-files/${relToDotDirCustom}/.zshrc \
       "zstyle ':antidote:bundle' use-friendly-names 'yes'"
-    assertFileContains home-files/${relToDotDirCustom}/.zsh_plugins.txt \
-      'zsh-users/zsh-autosuggestions'
   '';
 }


### PR DESCRIPTION
hotfix file update time problem for antidote load, trigger update after every generation

### Description

a bugfix for #4164 

> antidote load $bundlefile [$staticfile] will auto update $staticfile if bundlefile is newer than staticfile (mod_time)
> since nix store file never update mod_time , so this will never happend, will leads to .zsh never update
> this PR using stat to check symbolic link update time and update static file , after a home-manager switch , new zsh process will trigger update $HOME/.zsh_plugins.zsh


.zshrc cnotent example

```
## home-manager/antidote begin :
source /nix/store/0sz79m8m6m5wz63ak8rs7zdqxli2nzhc-antidote-1.8.7/share/antidote/antidote.zsh
zstyle ':antidote:bundle' use-friendly-names 'yes'

bundlefile=/nix/store/8gjm5qhy9ygwsjfqz8yxb8w66vgsh2gv-hm_antidote-files
zstyle ':antidote:bundle' file $bundlefile
staticfile=/tmp/tmp_hm_zsh_plugins.zsh-8gjm5qhy9ygwsjfqz8yxb8w66vgsh2gv
zstyle ':antidote:static' file $staticfile

antidote load $bundlefile $staticfile
```


```
 bundlefile=/nix/store/ig24sgxnrxwlz9dhi55x4ix7ydxszj94-hm_antidote-files/zsh_plugins.txt;
 zstyle ':antidote:bundle' file $bundlefile
staticfile="/tmp/tmp_hm_zsh_plugins.zsh$(cat /nix/store/ig24sgxnrxwlz9dhi55x4ix7ydxszj94-hm_antidote-files/uuid)"
zstyle ':antidote:static' file $staticfile
```

static load content store under /tmp now, static file generate so fast,  recreate after  reboot  is ok 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

