### PR TITLE
lsd: use -A instead of -a in aliases

### DIFF
--- a/modules/programs/lsd.nix
+++ b/modules/programs/lsd.nix
@@ -11,9 +11,10 @@ let
   aliases = {
     ls = "${pkgs.lsd}/bin/lsd";
     ll = "${pkgs.lsd}/bin/lsd -l";
-    la = "${pkgs.lsd}/bin/lsd -a";
+    la = "${pkgs.lsd}/bin/lsd -A";
     lt = "${pkgs.lsd}/bin/lsd --tree";
-    lla = "${pkgs.lsd}/bin/lsd -la";
+    lla = "${pkgs.lsd}/bin/lsd -lA";
+    llt = "${pkgs.lsd}/bin/lsd -l --tree";
   };
 
 in {


### PR DESCRIPTION
Hi,

### Description

The current `lla` alias, together with the `total-size` option try to get the size of the `..` directory, and for this has to recursively open all sibling folders. This may be super slow if some of those siblings contain too many files, and raise a ton of useless errors if some of those siblings contains non-readable files.

I'm suggesting to use `-A` instead, which will skip the obvious `.` and `..` folders.

While here, I think we could also add `llt`.

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
