### PR TITLE
chromium: fix `commandLineArgs` to use the user specified package

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -42,9 +42,6 @@ let
         description = ''
           List of command-line arguments to be passed to ${name}.
           </para><para>
-          Note this option does not have any effect when using a
-          custom package for <option>programs.${browser}.package</option>.
-          </para><para>
           For a list of common switches, see
           <link xlink:href="https://chromium.googlesource.com/chromium/src/+/refs/heads/main/chrome/common/chrome_switches.cc">Chrome switches</link>.
           </para><para>
@@ -162,20 +159,18 @@ let
           });
         };
 
+      package = if cfg.commandLineArgs != [ ] then
+        cfg.package.override {
+          commandLineArgs = concatStringsSep " " cfg.commandLineArgs;
+        }
+      else
+        cfg.package;
+
     in mkIf cfg.enable {
-      home.packages = [ cfg.package ];
+      home.packages = [ package ];
       home.file = optionalAttrs (!isProprietaryChrome)
         (listToAttrs (map extensionJson cfg.extensions));
     };
-
-  browserPkgs = genAttrs supportedBrowsers (browser:
-    let cfg = config.programs.${browser};
-    in if cfg.commandLineArgs != [ ] then
-      pkgs.${browser}.override {
-        commandLineArgs = concatStringsSep " " cfg.commandLineArgs;
-      }
-    else
-      pkgs.${browser});
 
 in {
   # Extensions do not work with the proprietary Google Chrome version
@@ -188,15 +183,14 @@ in {
     ];
 
   options.programs = {
-    chromium = browserModule browserPkgs.chromium "Chromium" true;
-    google-chrome =
-      browserModule browserPkgs.google-chrome "Google Chrome" false;
+    chromium = browserModule pkgs.chromium "Chromium" true;
+    google-chrome = browserModule pkgs.google-chrome "Google Chrome" false;
     google-chrome-beta =
-      browserModule browserPkgs.google-chrome-beta "Google Chrome Beta" false;
+      browserModule pkgs.google-chrome-beta "Google Chrome Beta" false;
     google-chrome-dev =
-      browserModule browserPkgs.google-chrome-dev "Google Chrome Dev" false;
-    brave = browserModule browserPkgs.brave "Brave Browser" false;
-    vivaldi = browserModule browserPkgs.vivaldi "Vivaldi Browser" false;
+      browserModule pkgs.google-chrome-dev "Google Chrome Dev" false;
+    brave = browserModule pkgs.brave "Brave Browser" false;
+    vivaldi = browserModule pkgs.vivaldi "Vivaldi Browser" false;
   };
 
   config = mkMerge


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

`commandLineArgs` were only being applied when the user didn't override the `package` option.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
