### PR TITLE
docs: update link to allowed users setting

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -33,7 +33,7 @@ standard way using channels. If you prefer to use
 === Standalone installation
 
 :nix-allowed-users: https://nixos.org/nix/manual/#conf-allowed-users
-:nixos-allowed-users: https://nixos.org/nixos/manual/options.html#opt-nix.allowedUsers
+:nixos-allowed-users: https://nixos.org/manual/nixos/stable/options.html#opt-nix.settings.allowed-users
 :bash: https://www.gnu.org/software/bash/
 :zsh: http://zsh.sourceforge.net/
 :fish: https://fishshell.com
@@ -47,7 +47,7 @@ example, you should be able to successfully run a command like
 root user. For a multi-user install of Nix this means that your user
 must be covered by the {nix-allowed-users}[`allowed-users`] Nix
 option. On NixOS you can control this option using the
-{nixos-allowed-users}[`nix.allowedUsers`] system option.
+{nixos-allowed-users}[`nix.settings.allowed-users`] system option.
 
 2. Add the appropriate Home Manager channel. If you are following
 Nixpkgs master or an unstable channel you can run


### PR DESCRIPTION
### Description

Update a "dead" link in the installation instructions, also use correct option name. The option has been changed somewhene during 2022.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
