### PR TITLE
i18n: Use glibcLocales from NixOS if possible (#2333)

### DIFF
--- a/modules/config/i18n.nix
+++ b/modules/config/i18n.nix
@@ -15,15 +15,16 @@
 # below for changes:
 # https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/pkgs/development/libraries/glibc/nix-locale-archive.patch
 
-{ lib, pkgs, ... }:
+{ lib, pkgs, config, ... }:
 
 with lib;
 
 let
+  inherit (config.i18n) glibcLocales;
 
-  inherit (pkgs.glibcLocales) version;
+  inherit (glibcLocales) version;
 
-  archivePath = "${pkgs.glibcLocales}/lib/locale/locale-archive";
+  archivePath = "${glibcLocales}/lib/locale/locale-archive";
 
   # lookup the version of glibcLocales and set the appropriate environment vars
   localeVars = if versionAtLeast version "2.27" then {
@@ -35,6 +36,31 @@ let
 
 in {
   meta.maintainers = with maintainers; [ midchildan ];
+
+  options = {
+    i18n.glibcLocales = mkOption {
+      type = types.path;
+      description = ''
+        Customized <literal>glibcLocales</literal> package providing
+        the <literal>LOCALE_ARCHIVE_*</literal> environment variable.
+        </para><para>
+        This option only applies to the Linux platform.
+        </para><para>
+        When Home Manager is configured with NixOS, the default value
+        will be set to <varname>i18n.glibcLocales</varname> from the
+        system configuration.
+      '';
+      example = literalExpression ''
+        pkgs.glibcLocales.override {
+          allLocales = false;
+          locales = [ "en_US.UTF-8/UTF-8" ];
+        }
+      '';
+      # NB. See nixos/default.nix for NixOS default.
+      default = pkgs.glibcLocales;
+      defaultText = literalExpression "pkgs.glibcLocales";
+    };
+  };
 
   config = mkIf pkgs.stdenv.hostPlatform.isLinux {
     # For shell sessions.

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -23,6 +23,9 @@ in {
           # fontconfig by default.
           fonts.fontconfig.enable = lib.mkDefault
             (cfg.useUserPackages && config.fonts.fontconfig.enable);
+
+          # Inherit glibcLocales setting from NixOS.
+          i18n.glibcLocales = lib.mkDefault config.i18n.glibcLocales;
         }];
       };
     }

--- a/tests/modules/config/i18n/default.nix
+++ b/tests/modules/config/i18n/default.nix
@@ -14,4 +14,26 @@
       '';
     };
   };
+
+  i18n-custom-locales = { pkgs, ... }: {
+    config = let stub = pkgs.glibcLocalesCustom;
+    in {
+      test.stubs.glibcLocalesCustom = {
+        inherit (pkgs.glibcLocales) version;
+        outPath = null; # we need a real path for this stub
+      };
+
+      i18n.glibcLocales = stub;
+
+      nmt.script = ''
+        hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
+        assertFileExists $hmEnvFile
+        assertFileRegex $hmEnvFile 'LOCALE_ARCHIVE_.*${stub}'
+
+        envFile=home-files/.config/environment.d/10-home-manager.conf
+        assertFileExists $envFile
+        assertFileRegex $envFile 'LOCALE_ARCHIVE_.*${stub}'
+      '';
+    };
+  };
 }

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -9,7 +9,7 @@ let
     if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
-    export LOCALE_ARCHIVE_2_27="${pkgs.glibcLocales}/lib/locale/locale-archive"
+    export LOCALE_ARCHIVE_2_27="${config.i18n.glibcLocales}/lib/locale/locale-archive"
     export V1="v1"
     export V2="v2-v1"
     export XDG_CACHE_HOME="/home/hm-user/.cache"

--- a/tests/modules/misc/xdg/system-dirs.nix
+++ b/tests/modules/misc/xdg/system-dirs.nix
@@ -10,7 +10,7 @@
       assertFileExists $envFile
       assertFileContent $envFile ${
         pkgs.writeText "expected" ''
-          LOCALE_ARCHIVE_2_27=${pkgs.glibcLocales}/lib/locale/locale-archive
+          LOCALE_ARCHIVE_2_27=${config.i18n.glibcLocales}/lib/locale/locale-archive
           XDG_CACHE_HOME=/home/hm-user/.cache
           XDG_CONFIG_DIRS=/etc/xdg:/foo/bar''${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}
           XDG_CONFIG_HOME=/home/hm-user/.config

--- a/tests/modules/systemd/session-variables.nix
+++ b/tests/modules/systemd/session-variables.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 
 {
   systemd.user.sessionVariables = {
@@ -11,7 +11,7 @@
     assertFileExists $envFile
     assertFileContent $envFile ${
       pkgs.writeText "expected" ''
-        LOCALE_ARCHIVE_2_27=${pkgs.glibcLocales}/lib/locale/locale-archive
+        LOCALE_ARCHIVE_2_27=${config.i18n.glibcLocales}/lib/locale/locale-archive
         V_int=1
         V_str=2
         XDG_CACHE_HOME=/home/hm-user/.cache


### PR DESCRIPTION
### Description

This will reduce the system closure size by about 200MB under NixOS by sharing the `glibcLocales` package.

When home-manager is installed on Linux without the NixOS module, all glibc locales are installed, as before.

Resolves #2333

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix develop --ignore-environment .#all` ⇒ OK.

- [x] Test cases updated/added ⇒ added `i18n-custom-locales` and modified other tests referencing `pkgs.glibcLocales`.

- [x] Commit message is formatted as per docs.

- [x] Option docs built and inspected with `nix build .#docs-html` and `nix build .#docs-manpages`.
