### PR TITLE
nixos: increase TimeoutStartSec from 1m30s to 5m

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -49,7 +49,7 @@ in {
             User = usercfg.home.username;
             Type = "oneshot";
             RemainAfterExit = "yes";
-            TimeoutStartSec = 90;
+            TimeoutStartSec = "5m";
             SyslogIdentifier = "hm-activate-${username}";
 
             ExecStart = let


### PR DESCRIPTION
### Description

I'm experiencing timeouts for home-manager-$USER.service in my NixOS VM tests. The NixOS testing framework increases the default timeout from 1m30 to 5m, but since home-manager specifies a timeout, that value wins.

There's no point in having a tight timeout value, so increase it to 5m.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes. I got a ton of different failing tests; it looks like `home-files/asserts/warnings.actual` is an empty file? I cannot imagine how these failures are related to this trivial change.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
