### PR TITLE
README: Remove the pills

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,9 @@ Words of warning
 ----------------
 
 Unfortunately, it is quite possible to get difficult to understand
-errors when working with Home Manager, such as infinite loops with no
-clear source reference. You should therefore be comfortable using the
-Nix language and the various tools in the Nix ecosystem. Reading
-through the [Nix Pills][] document is a good way to familiarize
-yourself with them.
+errors when working with Home Manager. You should therefore be
+comfortable using the Nix language and the various tools in the Nix
+ecosystem.
 
 If you are not very familiar with Nix but still want to use Home
 Manager then you are strongly encouraged to start with a small and
@@ -125,7 +123,6 @@ This project is licensed under the terms of the [MIT license](LICENSE).
 [configuration options]: https://nix-community.github.io/home-manager/options.html
 [#home-manager]: https://webchat.oftc.net/?channels=home-manager
 [OFTC]: https://oftc.net/
-[Nix Pills]: https://nixos.org/guides/nix-pills/
 [Nix Flakes]: https://nixos.wiki/wiki/Flakes
 [nix-darwin]: https://github.com/LnL7/nix-darwin
 [manual standalone install]: https://nix-community.github.io/home-manager/index.html#sec-install-standalone


### PR DESCRIPTION
This removes the Nix Pills reference, because they are not a good introduction to the Nix ecosystem, but rather a thorough explanation of many disparate things. Reading through them might give some light bulb moments for an intermediate reader, but that does not mean that they're good for a beginner.

I've also removed the mention of infinite recursion without source location. That's an old meme for a problem that has been mostly solved. Mentioning it here has two effects
 - Propagate the outdated meme
 - Make users insensitive to bad errors. Learned helplessness. That kind of thing. What we really want is for them to report bad error messages, so that they can be fixed. And they can be fixed; just report them at `NixOS/nix`

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
