### PR TITLE
xfconf: remove properties with null values

### DIFF
--- a/modules/misc/xfconf.nix
+++ b/modules/misc/xfconf.nix
@@ -76,7 +76,7 @@ in {
     settings = mkOption {
       type = with types;
       # xfIntVariant must come AFTER str; otherwise strings are treated as submodule imports...
-        let value = oneOf [ bool int float str xfIntVariant ];
+        let value = nullOr (oneOf [ bool int float str xfIntVariant ]);
         in attrsOf (attrsOf (either value (listOf value))) // {
           description = "xfconf settings";
         };
@@ -108,8 +108,11 @@ in {
         mkCommand = channel: property: value: ''
           $DRY_RUN_CMD ${pkgs.xfce.xfconf}/bin/xfconf-query \
             ${
-              escapeShellArgs
-              ([ "-n" "-c" channel "-p" "/${property}" ] ++ withType value)
+              if value != null then
+                escapeShellArgs
+                ([ "-n" "-c" channel "-p" "/${property}" ] ++ withType value)
+              else
+                escapeShellArgs ([ "-r" "-c" channel "-p" "/${property}" ])
             }
         '';
 


### PR DESCRIPTION
### Description

In some cases, I'd like to remove xfconf properties. For example, if you set a keyboard shortcut's value to an empty string:

```
xfconf.settings.xfce4-keyboard-shortcuts."commands/custom/<Alt><Super>s" = "";
```


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
