### PR TITLE
xfconf: remove properties with null values

### DIFF
--- a/modules/misc/xfconf.nix
+++ b/modules/misc/xfconf.nix
@@ -76,7 +76,7 @@ in {
     settings = mkOption {
       type = with types;
       # xfIntVariant must come AFTER str; otherwise strings are treated as submodule imports...
-        let value = oneOf [ bool int float str xfIntVariant ];
+        let value = nullOr (oneOf [ bool int float str xfIntVariant ]);
         in attrsOf (attrsOf (either value (listOf value))) // {
           description = "xfconf settings";
         };
@@ -108,8 +108,11 @@ in {
         mkCommand = channel: property: value: ''
           $DRY_RUN_CMD ${pkgs.xfce.xfconf}/bin/xfconf-query \
             ${
-              escapeShellArgs
-              ([ "-n" "-c" channel "-p" "/${property}" ] ++ withType value)
+              escapeShellArgs ([ "-c" channel "-p" "/${property}" ]
+                ++ (if value == null then
+                  [ "-r" ]
+                else
+                  [ "-n" ] ++ withType value))
             }
         '';
 


### PR DESCRIPTION
### Description

In some cases, I'd like to remove xfconf properties. For example, if you set a keyboard shortcut's value to an empty string:

```
xfconf.settings.xfce4-keyboard-shortcuts."commands/custom/<Alt><Super>s" = "";
```

Rather than removing the property, this will cause an error. A property must be removed with `xfconf-query -r ...`.

I had considered adding a separate list of properties for removal:

```
xfconf.unsettings.xfce4-keyboard-shortcuts = [ "commands/custom/<Alt><Super>s" ]
```

but that would allow for both setting and unsetting the same property and doesn't allow for defaults vs. overrides, etc.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```