### PR TITLE
khard: Add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1251,6 +1251,13 @@ in
           A new module is available: 'programs.wpaperd'.
         '';
       }
+
+      {
+        time = "2023-10-01T07:28:45+00:00";
+        message = ''
+          A new module is available: 'programs.khard'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -121,6 +121,7 @@ let
     ./programs/kakoune.nix
     ./programs/keychain.nix
     ./programs/khal.nix
+    ./programs/khard.nix
     ./programs/kitty.nix
     ./programs/kodi.nix
     ./programs/lazygit.nix

--- a/modules/programs/khard.nix
+++ b/modules/programs/khard.nix
@@ -1,0 +1,88 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.programs.khard;
+
+  accounts =
+    lib.filterAttrs (_: acc: acc.khard.enable) config.accounts.contact.accounts;
+
+  renderSettings = with lib.generators;
+    toINI {
+      mkKeyValue = mkKeyValueDefault rec {
+        mkValueString = v:
+          if lib.isList v then
+            lib.concatStringsSep ", " v
+          else if lib.isBool v then
+            if v then "yes" else "no"
+          else
+            v;
+      } "=";
+    };
+in {
+  meta.maintainers =
+    [ lib.hm.maintainers.olmokramer lib.maintainers.antonmosich ];
+
+  options = {
+    programs.khard = {
+      enable = lib.mkEnableOption "Khard: an address book for the Unix console";
+
+      settings = lib.mkOption {
+        type = with lib.types;
+          submodule {
+            freeformType = let primOrList = oneOf [ bool str (listOf str) ];
+            in attrsOf (attrsOf primOrList);
+
+            options.general.default_action = lib.mkOption {
+              type = str;
+              default = "list";
+              description = "The default action to execute.";
+            };
+          };
+        default = { };
+        description = ''
+          Khard settings. See
+          <https://khard.readthedocs.io/en/latest/#configuration>
+          for more information.
+        '';
+        example = lib.literalExpression ''
+          {
+            general = {
+              default_action = "list";
+              editor = ["vim" "-i" "NONE"];
+            };
+
+            "contact table" = {
+              display = "formatted_name";
+              preferred_phone_number_type = ["pref" "cell" "home"];
+              preferred_email_address_type = ["pref" "work" "home"];
+            };
+
+            vcard = {
+              private_objects = ["Jabber" "Skype" "Twitter"];
+            };
+          }
+        '';
+      };
+    };
+
+    accounts.contact.accounts = lib.mkOption {
+      type = with lib.types;
+        attrsOf (submodule {
+          options.khard.enable = lib.mkEnableOption "khard access";
+        });
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ pkgs.khard ];
+
+    xdg.configFile."khard/khard.conf".text = ''
+      [addressbooks]
+      ${lib.concatMapStringsSep "\n" (acc: ''
+        [[${acc.name}]]
+        path = ${acc.local.path}
+      '') (lib.attrValues accounts)}
+
+      ${renderSettings cfg.settings}
+    '';
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -93,6 +93,7 @@ import nmt {
     ./modules/programs/k9s
     ./modules/programs/kakoune
     ./modules/programs/khal
+    ./modules/programs/khard
     ./modules/programs/kitty
     ./modules/programs/ledger
     ./modules/programs/less

--- a/tests/modules/programs/khard/basic_config.nix
+++ b/tests/modules/programs/khard/basic_config.nix
@@ -1,0 +1,34 @@
+{
+  accounts.contact = {
+    basePath = ".contacts";
+    accounts.test = {
+      local.type = "filesystem";
+      khard.enable = true;
+    };
+  };
+
+  programs.khard = {
+    enable = true;
+    settings = {
+      general = {
+        default_action = "list";
+        editor = [ "vim" "-i" "NONE" ];
+      };
+
+      "contact table" = {
+        group_by_address_book = true;
+        reverse = false;
+        preferred_phone_number_type = [ "pref" "cell" "home" ];
+        preferred_email_address_type = [ "pref" "work" "home" ];
+      };
+    };
+  };
+
+  test.stubs.khard = { };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/khard/khard.conf \
+      ${./basic_config_expected}
+  '';
+}

--- a/tests/modules/programs/khard/basic_config_expected
+++ b/tests/modules/programs/khard/basic_config_expected
@@ -1,0 +1,15 @@
+[addressbooks]
+[[test]]
+path = /home/hm-user/.contacts/test
+
+
+[contact table]
+group_by_address_book=yes
+preferred_email_address_type=pref, work, home
+preferred_phone_number_type=pref, cell, home
+reverse=no
+
+[general]
+default_action=list
+editor=vim, -i, NONE
+

--- a/tests/modules/programs/khard/default.nix
+++ b/tests/modules/programs/khard/default.nix
@@ -1,0 +1,5 @@
+{
+  khard_empty_config = ./empty_config.nix;
+  khard_basic_config = ./basic_config.nix;
+  khard_multiple_accounts = ./multiple_accounts.nix;
+}

--- a/tests/modules/programs/khard/empty_config.nix
+++ b/tests/modules/programs/khard/empty_config.nix
@@ -1,0 +1,19 @@
+{
+  accounts.contact = {
+    basePath = ".contacts";
+    accounts.test = {
+      local.type = "filesystem";
+      khard.enable = true;
+    };
+  };
+
+  programs.khard.enable = true;
+
+  test.stubs.khard = { };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/khard/khard.conf \
+      ${./empty_config_expected}
+  '';
+}

--- a/tests/modules/programs/khard/empty_config_expected
+++ b/tests/modules/programs/khard/empty_config_expected
@@ -1,0 +1,8 @@
+[addressbooks]
+[[test]]
+path = /home/hm-user/.contacts/test
+
+
+[general]
+default_action=list
+

--- a/tests/modules/programs/khard/multiple_accounts.nix
+++ b/tests/modules/programs/khard/multiple_accounts.nix
@@ -1,0 +1,23 @@
+{
+  accounts.contact = {
+    basePath = ".contacts";
+    accounts.test1 = {
+      local.type = "filesystem";
+      khard.enable = true;
+    };
+    accounts.test2 = {
+      local.type = "filesystem";
+      khard.enable = true;
+    };
+  };
+
+  programs.khard.enable = true;
+
+  test.stubs.khard = { };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/khard/khard.conf \
+      ${./multiple_accounts_expected}
+  '';
+}

--- a/tests/modules/programs/khard/multiple_accounts_expected
+++ b/tests/modules/programs/khard/multiple_accounts_expected
@@ -1,0 +1,11 @@
+[addressbooks]
+[[test1]]
+path = /home/hm-user/.contacts/test1
+
+[[test2]]
+path = /home/hm-user/.contacts/test2
+
+
+[general]
+default_action=list
+


### PR DESCRIPTION
### Description

Add support for [khard](https://github.com/lucc/khard), integrating it with the recently merged contact infrastructure.

/cc @teto as author of the calendar and contacts infra PR.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
