### PR TITLE
himalaya: Fix notmuch backend

### DIFF
--- a/tests/modules/programs/himalaya/notmuch-sendmail-expected.toml
+++ b/tests/modules/programs/himalaya/notmuch-sendmail-expected.toml
@@ -5,7 +5,7 @@ backend = "notmuch"
 default = true
 display-name = "H. M. Test"
 email = "hm@example.com"
-notmuch-db-path = "/home/hm-user/Maildir/hm@example.com"
+notmuch-db-path = "/home/hm-user/Maildir"
 sender = "sendmail"
 sendmail-cmd = "msmtp"
 


### PR DESCRIPTION
### Description

Previously, IMAP was preferred over `notmuch`, even if `notmuch` was configured, causing problems with setting account flavor (which automatically sets IMAP settings). The new backend order is:

`notmuch` > IMAP > maildir

This also fixes the `notmuch` DB path being set to the wrong location. The `notmuch` DB is located at the maildir base path, not in each account's maildir.

https://github.com/nix-community/home-manager/blob/c24deeca64538dcbc589ed8da9146e4ca9eb85b7/modules/programs/notmuch.nix#L23

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
