### PR TITLE
aerc: add assertion to limit per-account extraConfig to UI config

### DIFF
--- a/modules/programs/aerc-accounts.nix
+++ b/modules/programs/aerc-accounts.nix
@@ -53,9 +53,9 @@ in {
           example =
             literalExpression ''{ source = "maildir://~/Maildir/example"; }'';
           description = ''
-            Extra config added to the configuration of this account in
+            Extra config added to the configuration section for this account in
             <filename>$HOME/.config/aerc/accounts.conf</filename>.
-            See aerc-config(5).
+            See <citerefentry><refentrytitle>aerc-accounts</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
           '';
         };
 
@@ -66,18 +66,20 @@ in {
             ''{ messages = { d = ":move ''${folder.trash}<Enter>"; }; }'';
           description = ''
             Extra bindings specific to this account, added to
-            <filename>$HOME/.config/aerc/accounts.conf</filename>.
-            See <citerefentry><refentrytitle>aerc-config</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+            <filename>$HOME/.config/aerc/binds.conf</filename>.
+            See <citerefentry><refentrytitle>aerc-binds</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
           '';
         };
 
         extraConfig = mkOption {
           type = confSections;
           default = { };
-          example = literalExpression "{ ui = { sidebar-width = 42; }; }";
+          example = literalExpression "{ ui = { sidebar-width = 25; }; }";
           description = ''
-            Extra config specific to this account, added to
-            <filename>$HOME/.config/aerc/aerc.conf</filename>.
+            Config specific to this account, added to <filename>$HOME/.config/aerc/aerc.conf</filename>.
+            Aerc only supports per-account UI configuration.
+            For other sections of <filename>$HOME/.config/aerc/aerc.conf</filename>,
+            use <literal>.programs.aerc.extraConfig</literal>.
             See <citerefentry><refentrytitle>aerc-config</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
           '';
         };

--- a/modules/programs/aerc-accounts.nix
+++ b/modules/programs/aerc-accounts.nix
@@ -79,7 +79,7 @@ in {
             Config specific to this account, added to <filename>$HOME/.config/aerc/aerc.conf</filename>.
             Aerc only supports per-account UI configuration.
             For other sections of <filename>$HOME/.config/aerc/aerc.conf</filename>,
-            use <literal>.programs.aerc.extraConfig</literal>.
+            use <literal>programs.aerc.extraConfig</literal>.
             See <citerefentry><refentrytitle>aerc-config</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
           '';
         };

--- a/modules/programs/aerc.nix
+++ b/modules/programs/aerc.nix
@@ -8,7 +8,7 @@ let
     ((type: either type (listOf type)) (nullOr (oneOf [ str int bool float ])))
     // {
       description =
-        "values (null, bool, int, string of float) or a list of values, that will be joined with a comma";
+        "values (null, bool, int, string, or float) or a list of values, that will be joined with a comma";
     };
 
   confSection = types.attrsOf primitive;
@@ -162,15 +162,27 @@ in {
   in mkIf cfg.enable {
     warnings = if genAccountsConf
     && (cfg.extraConfig.general.unsafe-accounts-conf or false) == false then [''
-      aerc: An email account was configured, but `extraConfig.general.unsafe-accounts-conf` is set to false or unset.
-      This will prevent aerc from starting, see `unsafe-accounts-conf` in the man page aerc-config(5), which states:
+      aerc: `programs.aerc.enable` is set, but `...extraConfig.general.unsafe-accounts-conf` is set to false or unset.
+      This will prevent aerc from starting; see `unsafe-accounts-conf` in the man page aerc-config(5):
       > By default, the file permissions of accounts.conf must be restrictive and only allow reading by the file owner (0600).
       > Set this option to true to ignore this permission check. Use this with care as it may expose your credentials.
-      These file permissions are not possible with home-manger, since the generated file is stored in the nix-store with read-only access for all users (0444).
-      If `passwordCommand` is properly set, no credentials will be stored in the nix store.
-      Therefore, consider setting the option `extraConfig.general.unsafe-accounts-conf` to true.
+      These permissions are not possible with home-manger, since the generated file is in the nix-store (permissions 0444).
+      Therefore, please set `programs.aerc.extraConfig.general.unsafe-accounts-conf = true`.
+      This option is safe; if `passwordCommand` is properly set, no credentials will be written to the nix store.
     ''] else
       [ ];
+
+    assertions = [{
+      assertion = let
+        extraConfigSections = (unique (flatten
+          (mapAttrsToList (_: v: attrNames v.aerc.extraConfig) aerc-accounts)));
+      in extraConfigSections == [ ] || extraConfigSections == [ "ui" ];
+      message = ''
+        Only the UI section of <filename>$XDG_CONFIG_HOME/aerc/aerc.conf</filename>
+        supports contextual (per-account configuration. Please move any other
+        configuration to <literal>programs.aerc.extraConfig</literal>.
+      '';
+    }];
 
     home.packages = [ cfg.package ];
 

--- a/modules/programs/aerc.nix
+++ b/modules/programs/aerc.nix
@@ -166,7 +166,7 @@ in {
       This will prevent aerc from starting; see `unsafe-accounts-conf` in the man page aerc-config(5):
       > By default, the file permissions of accounts.conf must be restrictive and only allow reading by the file owner (0600).
       > Set this option to true to ignore this permission check. Use this with care as it may expose your credentials.
-      These permissions are not possible with home-manger, since the generated file is in the nix-store (permissions 0444).
+      These permissions are not possible with home-manager, since the generated file is in the nix-store (permissions 0444).
       Therefore, please set `programs.aerc.extraConfig.general.unsafe-accounts-conf = true`.
       This option is safe; if `passwordCommand` is properly set, no credentials will be written to the nix store.
     ''] else
@@ -178,9 +178,9 @@ in {
           (mapAttrsToList (_: v: attrNames v.aerc.extraConfig) aerc-accounts)));
       in extraConfigSections == [ ] || extraConfigSections == [ "ui" ];
       message = ''
-        Only the UI section of <filename>$XDG_CONFIG_HOME/aerc/aerc.conf</filename>
-        supports contextual (per-account configuration. Please move any other
-        configuration to <literal>programs.aerc.extraConfig</literal>.
+        Only the ui section of $XDG_CONFIG_HOME/aerc.conf supports contextual (per-account) configuration.
+        Please configure it with accounts.email.accounts._.aerc.extraConfig.ui and move any other
+        configuration to programs.aerc.extraConfig.
       '';
     }];
 

--- a/tests/modules/programs/aerc/assertion.nix
+++ b/tests/modules/programs/aerc/assertion.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    test.asserts.assertions.expected = [''
+      Only the ui section of $XDG_CONFIG_HOME/aerc.conf supports contextual (per-account) configuration.
+      Please configure it with accounts.email.accounts._.aerc.extraConfig.ui and move any other
+      configuration to programs.aerc.extraConfig.
+    ''];
+    test.asserts.warnings.expected = [''
+      aerc: `programs.aerc.enable` is set, but `...extraConfig.general.unsafe-accounts-conf` is set to false or unset.
+      This will prevent aerc from starting; see `unsafe-accounts-conf` in the man page aerc-config(5):
+      > By default, the file permissions of accounts.conf must be restrictive and only allow reading by the file owner (0600).
+      > Set this option to true to ignore this permission check. Use this with care as it may expose your credentials.
+      These permissions are not possible with home-manager, since the generated file is in the nix-store (permissions 0444).
+      Therefore, please set `programs.aerc.extraConfig.general.unsafe-accounts-conf = true`.
+      This option is safe; if `passwordCommand` is properly set, no credentials will be written to the nix store.
+    ''];
+
+    test.stubs.aerc = { };
+
+    programs.aerc = {
+      enable = true;
+      extraAccounts = {
+        Test1 = {
+          source = "maildir:///dev/null";
+          enable-folders-sort = true;
+          folders = [ "INBOX" "SENT" "JUNK" ];
+        };
+      };
+      extraConfig.general = {
+        # unsafe-accounts-conf = true;
+        pgp-provider = "gpg";
+      };
+    };
+
+    accounts.email.accounts.Test2 = {
+      address = "addr@mail.invalid";
+      userName = "addr@mail.invalid";
+      realName = "Foo Bar";
+      primary = true;
+      imap.host = "imap.host.invalid";
+      passwordCommand = "echo PaSsWorD!";
+      aerc = {
+        enable = true;
+        extraConfig.general.pgp-provider = "internal";
+      };
+    };
+  };
+}

--- a/tests/modules/programs/aerc/default.nix
+++ b/tests/modules/programs/aerc/default.nix
@@ -1,4 +1,5 @@
 {
   aerc-noSettings = ./noSettings.nix;
   aerc-settings = ./settings.nix;
+  aerc-assertion = ./assertion.nix;
 }


### PR DESCRIPTION
### Description

The aerc configuration file `aerc.conf` can contain 10 sections, but only the UI section supports what the aerc manual calls contextual configuration. This works by appending to the section heading either `:account=name` or `:folder=bar`. It's supported in `config.accounts.email.accounts.<name>.aerc.extraConfig.*.*`, as the aerc-accounts module applies a
function to add `<name>` to section headings.
However, this means home-manager will generate files like:
```
[general:account=default]
log-file=...
```
and the options will not be recognized by aerc.

This change only adds the account name to the UI section by adding a `attrsets.filterAttrs` check to `mkAccountConfig`. This could be confusing if a user only wants to apply their configuration to one account, and a possible alternative could be to change this option to something like `config.accounts.email.accounts.<name>.aerc.uiConfig.*`.
The error message about setting `unsafe-accounts-conf = true` has also been updated, to clarify it should be set
in the global `programs.aerc.extraConfig` section.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted