### PR TITLE
 unison: Allow using same option multiple times

### DIFF
--- a/modules/services/unison.nix
+++ b/modules/services/unison.nix
@@ -22,7 +22,7 @@ let
       };
 
       commandOptions = mkOption rec {
-        type = with types; attrsOf str;
+        type = with types; attrsOf (either str (listOf str));
         apply = mergeAttrs default;
         default = {
           repeat = "watch";
@@ -35,6 +35,8 @@ let
         description = ''
           Additional command line options as a dictionary to pass to the
           <literal>unison</literal> program.
+          </para><para>
+          Use a list of strings to declare the same option multiple times.
           </para><para>
           See
           <citerefentry>
@@ -60,7 +62,9 @@ let
     };
   };
 
-  serialiseArg = key: val: escapeShellArg "-${key}=${escape [ "=" ] val}";
+  serialiseArg = key: val:
+    concatStringsSep " "
+    (forEach (toList val) (x: escapeShellArg "-${key}=${escape [ "=" ] x}"));
 
   serialiseArgs = args: concatStringsSep " " (mapAttrsToList serialiseArg args);
 


### PR DESCRIPTION
### Description

 Unison supports the same option to be given several times as a command
 line argument (e.g. unison -path xxx -path yyy).

 This commit adds Home Manager support for this by allowing a list of
 strings to be given to services.unison.pairs.<name>.commandOptions values.


### Checklist

(new to Nix and first PR, did not manage to fill all the checklist yet)

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@pacien 
