### PR TITLE
pyenv: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1150,6 +1150,13 @@ in
           A new modules is available: 'programs.darcs'
         '';
       }
+
+      {
+        time = "2023-07-08T09:21:06+00:00";
+        message = ''
+          A new module is available: 'programs.pyenv'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -169,6 +169,7 @@ let
     ./programs/pls.nix
     ./programs/powerline-go.nix
     ./programs/pubs.nix
+    ./programs/pyenv.nix
     ./programs/pylint.nix
     ./programs/qutebrowser.nix
     ./programs/rbw.nix

--- a/modules/programs/pyenv.nix
+++ b/modules/programs/pyenv.nix
@@ -1,0 +1,79 @@
+{ config, pkgs, lib, ... }:
+
+let
+
+  cfg = config.programs.pyenv;
+
+  tomlFormat = pkgs.formats.toml { };
+
+in {
+  meta.maintainers = with lib.maintainers; [ tmarkus ];
+
+  options.programs.pyenv = {
+    enable = lib.mkEnableOption "pyenv";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.pyenv;
+      defaultText = lib.literalExpression "pkgs.pyenv";
+      description = "The package to use for pyenv.";
+    };
+
+    enableBashIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to enable pyenv's Bash integration.
+      '';
+    };
+
+    enableZshIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to enable pyenv's Zsh integration.
+      '';
+    };
+
+    enableFishIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to enable pyenv's Fish integration.
+      '';
+    };
+
+    rootDirectory = lib.mkOption {
+      type = lib.types.path;
+      apply = toString;
+      default = "${config.xdg.dataHome}/pyenv";
+      defaultText = "\${config.xdg.dataHome}/pyenv";
+      description = ''
+        The pyenv root directory (PYENV_ROOT).
+        </para><para>
+        Note: Deviating from upstream which uses `$HOME/.pyenv`,
+        the default path is set according to the XDG base directory specification.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Always add the configured `pyenv` package.
+    home.packages = [ cfg.package ];
+
+    programs.bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
+      export PYENV_ROOT="${cfg.rootDirectory}"
+      eval "$(${lib.getExe cfg.package} init - bash)"
+    '';
+
+    programs.zsh.initExtra = lib.mkIf cfg.enableZshIntegration ''
+      export PYENV_ROOT="${cfg.rootDirectory}"
+      eval "$(${lib.getExe cfg.package} init - zsh)"
+    '';
+
+    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+      set -Ux PYENV_ROOT "${cfg.rootDirectory}"
+      ${lib.getExe cfg.package} init - fish | source
+    '';
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -117,6 +117,7 @@ import nmt {
     ./modules/programs/pls
     ./modules/programs/powerline-go
     ./modules/programs/pubs
+    ./modules/programs/pyenv
     ./modules/programs/qutebrowser
     ./modules/programs/readline
     ./modules/programs/ripgrep

--- a/tests/modules/programs/pyenv/bash.nix
+++ b/tests/modules/programs/pyenv/bash.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs = {
+    bash.enable = true;
+    pyenv.enable = true;
+  };
+
+  test.stubs.pyenv = { name = "pyenv"; };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileContains \
+      home-files/.bashrc \
+      'eval "$(@pyenv@/bin/pyenv init - bash)"'
+  '';
+}

--- a/tests/modules/programs/pyenv/default.nix
+++ b/tests/modules/programs/pyenv/default.nix
@@ -1,0 +1,5 @@
+{
+  pyenv-bash = ./bash.nix;
+  pyenv-zsh = ./zsh.nix;
+  pyenv-fish = ./fish.nix;
+}

--- a/tests/modules/programs/pyenv/fish.nix
+++ b/tests/modules/programs/pyenv/fish.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs = {
+    fish.enable = true;
+    pyenv.enable = true;
+  };
+
+  test.stubs.pyenv = { name = "pyenv"; };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      '@pyenv@/bin/pyenv init - fish | source'
+  '';
+}

--- a/tests/modules/programs/pyenv/zsh.nix
+++ b/tests/modules/programs/pyenv/zsh.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs = {
+    zsh.enable = true;
+    pyenv.enable = true;
+  };
+
+  test.stubs.pyenv = { name = "pyenv"; };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+    assertFileContains \
+      home-files/.zshrc \
+      'eval "$(@pyenv@/bin/pyenv init - zsh)"'
+  '';
+}


### PR DESCRIPTION
### Description

Add a module `programs.pyenv` for [pyenv](https://github.com/pyenv/pyenv).

Note for reviewers: pyenv was only [recently added to Nixpkgs](https://github.com/NixOS/nixpkgs/pull/239499). Make sure you're using a sufficiently recent Nixpkgs version when reviewing without flakes.

Since this is my first time messing with HM modules, I based the module off of `programs.atuin` which is (very) roughly similar in structure. Just in case I accidentally missed a remaining reference to Atuin somewhere - which I'm pretty sure I didn't, but you never know...

### Checklist

<!--
Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines
-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
