### PR TITLE
ssh-agent: add assertion and fix news entry

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1138,7 +1138,7 @@ in
 
       {
         time = "2023-06-30T14:46:22+00:00";
-        condition = config.services.ssh-agent.enable;
+        condition = hostPlatform.isLinux;
         message = ''
           A new module is available: 'services.ssh-agent'
         '';

--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -14,6 +14,11 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.ssh-agent" pkgs
+        lib.platforms.linux)
+    ];
+
     home.sessionVariablesExtra = ''
       if [[ -z "$SSH_AUTH_SOCK" ]]; then
         export SSH_AUTH_SOCK=$XDG_RUNTIME_DIR/ssh-agent


### PR DESCRIPTION
### Description

See https://github.com/nix-community/home-manager/pull/4178#discussion_r1249460142

Signed-off-by: Sumner Evans <me@sumnerevans.com>

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
