### PR TITLE
goimapnotify: remove test dependency on notmuch

### DIFF
--- a/tests/modules/programs/beets/mpdstats-external.nix
+++ b/tests/modules/programs/beets/mpdstats-external.nix
@@ -1,29 +1,27 @@
-{ config, lib, pkgs, ... }:
+{ config, ... }:
 
 {
-  config = {
-    home.stateVersion = "23.05";
+  home.stateVersion = "23.05";
 
-    programs.beets = {
-      enable = true;
-      package = config.lib.test.mkStubPackage { outPath = "@beets@"; };
-      mpdIntegration = {
-        enableStats = true;
-        host = "10.0.0.42";
-        port = 6601;
-      };
+  programs.beets = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@beets@"; };
+    mpdIntegration = {
+      enableStats = true;
+      host = "10.0.0.42";
+      port = 6601;
     };
-
-    nmt.script = ''
-      assertFileExists home-files/.config/beets/config.yaml
-      assertFileContent \
-        home-files/.config/beets/config.yaml \
-        ${./mpdstats-external-expected.yaml}
-
-      assertFileExists home-files/.config/systemd/user/beets-mpdstats.service
-      assertFileContent \
-        home-files/.config/systemd/user/beets-mpdstats.service \
-        ${./mpdstats-external-expected.service}
-    '';
   };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/beets/config.yaml
+    assertFileContent \
+      home-files/.config/beets/config.yaml \
+      ${./mpdstats-external-expected.yaml}
+
+    assertFileExists home-files/.config/systemd/user/beets-mpdstats.service
+    assertFileContent \
+      home-files/.config/systemd/user/beets-mpdstats.service \
+      ${./mpdstats-external-expected.service}
+  '';
 }

--- a/tests/modules/programs/beets/mpdstats.nix
+++ b/tests/modules/programs/beets/mpdstats.nix
@@ -1,31 +1,29 @@
-{ config, lib, pkgs, ... }:
+{ config, ... }:
 
 {
-  config = {
-    home.stateVersion = "23.05";
+  home.stateVersion = "23.05";
 
-    services.mpd = {
-      enable = true;
-      musicDirectory = "/my/music/dir";
-      network.port = 4242;
-    };
-
-    programs.beets = {
-      enable = true;
-      package = config.lib.test.mkStubPackage { outPath = "@beets@"; };
-      mpdIntegration.enableStats = true;
-    };
-
-    nmt.script = ''
-      assertFileExists home-files/.config/beets/config.yaml
-      assertFileContent \
-        home-files/.config/beets/config.yaml \
-        ${./mpdstats-expected.yaml}
-
-      assertFileExists home-files/.config/systemd/user/beets-mpdstats.service
-      assertFileContent \
-        home-files/.config/systemd/user/beets-mpdstats.service \
-        ${./mpdstats-expected.service}
-    '';
+  services.mpd = {
+    enable = true;
+    musicDirectory = "/my/music/dir";
+    network.port = 4242;
   };
+
+  programs.beets = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@beets@"; };
+    mpdIntegration.enableStats = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/beets/config.yaml
+    assertFileContent \
+      home-files/.config/beets/config.yaml \
+      ${./mpdstats-expected.yaml}
+
+    assertFileExists home-files/.config/systemd/user/beets-mpdstats.service
+    assertFileContent \
+      home-files/.config/systemd/user/beets-mpdstats.service \
+      ${./mpdstats-expected.service}
+  '';
 }

--- a/tests/modules/programs/beets/mpdupdate.nix
+++ b/tests/modules/programs/beets/mpdupdate.nix
@@ -1,20 +1,18 @@
-{ config, lib, pkgs, ... }:
+{ config, ... }:
 
 {
-  config = {
-    home.stateVersion = "23.05";
+  home.stateVersion = "23.05";
 
-    programs.beets = {
-      enable = true;
-      package = config.lib.test.mkStubPackage { outPath = "@beets@"; };
-      mpdIntegration.enableUpdate = true;
-    };
-
-    nmt.script = ''
-      assertFileExists home-files/.config/beets/config.yaml
-      assertFileContent \
-        home-files/.config/beets/config.yaml \
-        ${./mpdupdate-expected.yaml}
-    '';
+  programs.beets = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@beets@"; };
+    mpdIntegration.enableUpdate = true;
   };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/beets/config.yaml
+    assertFileContent \
+      home-files/.config/beets/config.yaml \
+      ${./mpdupdate-expected.yaml}
+  '';
 }

--- a/tests/modules/programs/goimapnotify/launchd.nix
+++ b/tests/modules/programs/goimapnotify/launchd.nix
@@ -5,37 +5,36 @@ with lib;
 {
   imports = [ ../../accounts/email-test-accounts.nix ];
 
-  config = {
-    accounts.email.accounts = {
-      "hm@example.com" = {
-        notmuch.enable = true;
-        imap.port = 993;
+  accounts.email.accounts = {
+    "hm@example.com" = {
+      notmuch.enable = true;
+      imap.port = 993;
 
-        imapnotify = {
-          enable = true;
-          boxes = [ "Inbox" ];
-          onNotify = ''
-            ${pkgs.notmuch}/bin/notmuch new
-          '';
-        };
+      imapnotify = {
+        enable = true;
+        boxes = [ "Inbox" ];
+        onNotify = ''
+          ${pkgs.notmuch}/bin/notmuch new
+        '';
       };
     };
-
-    services.imapnotify = {
-      enable = true;
-      package = (config.lib.test.mkStubPackage {
-        name = "goimapnotify";
-        outPath = "@goimapnotify@";
-      });
-    };
-
-    nmt.script = let
-      serviceFileName =
-        "org.nix-community.home.imapnotify-hm-example.com.plist";
-    in ''
-      serviceFile=LaunchAgents/${serviceFileName}
-      assertFileExists $serviceFile
-      assertFileContent $serviceFile ${./launchd.plist}
-    '';
   };
+
+  services.imapnotify = {
+    enable = true;
+    package = (config.lib.test.mkStubPackage {
+      name = "goimapnotify";
+      outPath = "@goimapnotify@";
+    });
+  };
+
+  test.stubs.notmuch = { };
+
+  nmt.script = let
+    serviceFileName = "org.nix-community.home.imapnotify-hm-example.com.plist";
+  in ''
+    serviceFile=LaunchAgents/${serviceFileName}
+    assertFileExists $serviceFile
+    assertFileContent $serviceFile ${./launchd.plist}
+  '';
 }

--- a/tests/modules/programs/nnn/nnn.nix
+++ b/tests/modules/programs/nnn/nnn.nix
@@ -1,55 +1,53 @@
-{ config, lib, pkgs, ... }:
+{ pkgs, ... }:
 
 {
-  config = {
-    programs.nnn = {
-      enable = true;
-      bookmarks = {
-        d = "~/Documents";
-        D = "~/Downloads";
-        p = "~/Pictures";
-        v = "~/Videos";
-      };
-      package = pkgs.nnnDummy;
-      extraPackages = with pkgs; [ foo bar ];
-      plugins = {
-        src = ./plugins;
-        mappings = {
-          c = "fzcd";
-          f = "finder";
-          v = "imgview";
-        };
+  programs.nnn = {
+    enable = true;
+    bookmarks = {
+      d = "~/Documents";
+      D = "~/Downloads";
+      p = "~/Pictures";
+      v = "~/Videos";
+    };
+    package = pkgs.nnnDummy;
+    extraPackages = with pkgs; [ foo bar ];
+    plugins = {
+      src = ./plugins;
+      mappings = {
+        c = "fzcd";
+        f = "finder";
+        v = "imgview";
       };
     };
+  };
 
-    test.stubs = {
-      nnnDummy.buildScript = ''
-        runHook preInstall
+  test.stubs = {
+    nnnDummy.buildScript = ''
+      runHook preInstall
 
-        mkdir -p "$out/bin"
-        touch "$out/bin/nnn"
-        chmod +x "$out/bin/nnn"
+      mkdir -p "$out/bin"
+      touch "$out/bin/nnn"
+      chmod +x "$out/bin/nnn"
 
-        runHook postInstall
-      '';
-      foo = { name = "foo"; };
-      bar = { name = "bar"; };
-    };
+      runHook postInstall
+    '';
+    foo = { name = "foo"; };
+    bar = { name = "bar"; };
+  };
 
-    nmt = {
-      description =
-        "Check if the binary is correctly wrapped and if the symlinks are made";
-      script = ''
-        assertDirectoryExists home-files/.config/nnn/plugins
+  nmt = {
+    description =
+      "Check if the binary is correctly wrapped and if the symlinks are made";
+    script = ''
+      assertDirectoryExists home-files/.config/nnn/plugins
 
-        for bookmark in 'export NNN_BMS' '~/Downloads' '~/Documents' '~/Pictures' '~/Videos'; do
-          assertFileRegex home-path/bin/nnn "$bookmark"
-        done
+      for bookmark in 'export NNN_BMS' '~/Downloads' '~/Documents' '~/Pictures' '~/Videos'; do
+        assertFileRegex home-path/bin/nnn "$bookmark"
+      done
 
-        for plugin in 'export NNN_PLUG' 'fzcd' 'finder' 'imgview'; do
-          assertFileRegex home-path/bin/nnn "$plugin"
-        done
-      '';
-    };
+      for plugin in 'export NNN_PLUG' 'fzcd' 'finder' 'imgview'; do
+        assertFileRegex home-path/bin/nnn "$plugin"
+      done
+    '';
   };
 }

--- a/tests/modules/programs/qutebrowser/keybindings.nix
+++ b/tests/modules/programs/qutebrowser/keybindings.nix
@@ -1,47 +1,43 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ lib, pkgs, ... }:
 
 {
-  config = {
-    programs.qutebrowser = {
-      enable = true;
+  programs.qutebrowser = {
+    enable = true;
 
-      enableDefaultBindings = false;
+    enableDefaultBindings = false;
 
-      keyBindings = {
-        normal = {
-          "<Ctrl-v>" = "spawn mpv {url}";
-          ",l" = ''config-cycle spellcheck.languages ["en-GB"] ["en-US"]'';
-          "<F1>" = mkMerge [
-            "config-cycle tabs.show never always"
-            "config-cycle statusbar.show in-mode always"
-            "config-cycle scrolling.bar never always"
-          ];
-        };
-        prompt = { "<Ctrl-y>" = "prompt-yes"; };
+    keyBindings = {
+      normal = {
+        "<Ctrl-v>" = "spawn mpv {url}";
+        ",l" = ''config-cycle spellcheck.languages ["en-GB"] ["en-US"]'';
+        "<F1>" = lib.mkMerge [
+          "config-cycle tabs.show never always"
+          "config-cycle statusbar.show in-mode always"
+          "config-cycle scrolling.bar never always"
+        ];
       };
+      prompt = { "<Ctrl-y>" = "prompt-yes"; };
     };
-
-    test.stubs.qutebrowser = { };
-
-    nmt.script = let
-      qutebrowserConfig = if pkgs.stdenv.hostPlatform.isDarwin then
-        ".qutebrowser/config.py"
-      else
-        ".config/qutebrowser/config.py";
-    in ''
-      assertFileContent \
-        home-files/${qutebrowserConfig} \
-        ${
-          pkgs.writeText "qutebrowser-expected-config.py" ''
-            config.load_autoconfig(False)
-            c.bindings.default = {}
-            config.bind(",l", "config-cycle spellcheck.languages [\"en-GB\"] [\"en-US\"]", mode="normal")
-            config.bind("<Ctrl-v>", "spawn mpv {url}", mode="normal")
-            config.bind("<F1>", "config-cycle tabs.show never always ;; config-cycle statusbar.show in-mode always ;; config-cycle scrolling.bar never always", mode="normal")
-            config.bind("<Ctrl-y>", "prompt-yes", mode="prompt")''
-        }
-    '';
   };
+
+  test.stubs.qutebrowser = { };
+
+  nmt.script = let
+    qutebrowserConfig = if pkgs.stdenv.hostPlatform.isDarwin then
+      ".qutebrowser/config.py"
+    else
+      ".config/qutebrowser/config.py";
+  in ''
+    assertFileContent \
+      home-files/${qutebrowserConfig} \
+      ${
+        pkgs.writeText "qutebrowser-expected-config.py" ''
+          config.load_autoconfig(False)
+          c.bindings.default = {}
+          config.bind(",l", "config-cycle spellcheck.languages [\"en-GB\"] [\"en-US\"]", mode="normal")
+          config.bind("<Ctrl-v>", "spawn mpv {url}", mode="normal")
+          config.bind("<F1>", "config-cycle tabs.show never always ;; config-cycle statusbar.show in-mode always ;; config-cycle scrolling.bar never always", mode="normal")
+          config.bind("<Ctrl-y>", "prompt-yes", mode="prompt")''
+      }
+  '';
 }

--- a/tests/modules/programs/qutebrowser/quickmarks.nix
+++ b/tests/modules/programs/qutebrowser/quickmarks.nix
@@ -1,33 +1,29 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ pkgs, ... }:
 
 {
-  config = {
-    programs.qutebrowser = {
-      enable = true;
+  programs.qutebrowser = {
+    enable = true;
 
-      quickmarks = {
-        nixpkgs = "https://github.com/NixOS/nixpkgs";
-        home-manager = "https://github.com/nix-community/home-manager";
-      };
+    quickmarks = {
+      nixpkgs = "https://github.com/NixOS/nixpkgs";
+      home-manager = "https://github.com/nix-community/home-manager";
     };
-
-    test.stubs.qutebrowser = { };
-
-    nmt.script = let
-      quickmarksFile = if pkgs.stdenv.hostPlatform.isDarwin then
-        ".qutebrowser/quickmarks"
-      else
-        ".config/qutebrowser/quickmarks";
-    in ''
-      assertFileContent \
-        home-files/${quickmarksFile} \
-        ${
-          pkgs.writeText "qutebrowser-expected-quickmarks" ''
-            home-manager https://github.com/nix-community/home-manager
-            nixpkgs https://github.com/NixOS/nixpkgs''
-        }
-    '';
   };
+
+  test.stubs.qutebrowser = { };
+
+  nmt.script = let
+    quickmarksFile = if pkgs.stdenv.hostPlatform.isDarwin then
+      ".qutebrowser/quickmarks"
+    else
+      ".config/qutebrowser/quickmarks";
+  in ''
+    assertFileContent \
+      home-files/${quickmarksFile} \
+      ${
+        pkgs.writeText "qutebrowser-expected-quickmarks" ''
+          home-manager https://github.com/nix-community/home-manager
+          nixpkgs https://github.com/NixOS/nixpkgs''
+      }
+  '';
 }

--- a/tests/modules/programs/qutebrowser/settings.nix
+++ b/tests/modules/programs/qutebrowser/settings.nix
@@ -1,50 +1,46 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ pkgs, ... }:
 
 {
-  config = {
-    programs.qutebrowser = {
-      enable = true;
+  programs.qutebrowser = {
+    enable = true;
 
-      settings = {
-        colors = {
-          hints = {
-            bg = "#000000";
-            fg = "#ffffff";
-          };
-          tabs.bar.bg = "#000000";
+    settings = {
+      colors = {
+        hints = {
+          bg = "#000000";
+          fg = "#ffffff";
         };
-        spellcheck.languages = [ "en-US" "sv-SE" ];
-        tabs.tabs_are_windows = true;
+        tabs.bar.bg = "#000000";
       };
-
-      extraConfig = ''
-        # Extra qutebrowser configuration.
-      '';
+      spellcheck.languages = [ "en-US" "sv-SE" ];
+      tabs.tabs_are_windows = true;
     };
 
-    test.stubs.qutebrowser = { };
-
-    nmt.script = let
-      qutebrowserConfig = if pkgs.stdenv.hostPlatform.isDarwin then
-        ".qutebrowser/config.py"
-      else
-        ".config/qutebrowser/config.py";
-    in ''
-      assertFileContent \
-        home-files/${qutebrowserConfig} \
-        ${
-          pkgs.writeText "qutebrowser-expected-config.py" ''
-            config.load_autoconfig(False)
-            c.colors.hints.bg = "#000000"
-            c.colors.hints.fg = "#ffffff"
-            c.colors.tabs.bar.bg = "#000000"
-            c.spellcheck.languages = ["en-US", "sv-SE"]
-            c.tabs.tabs_are_windows = True
-            # Extra qutebrowser configuration.
-          ''
-        }
+    extraConfig = ''
+      # Extra qutebrowser configuration.
     '';
   };
+
+  test.stubs.qutebrowser = { };
+
+  nmt.script = let
+    qutebrowserConfig = if pkgs.stdenv.hostPlatform.isDarwin then
+      ".qutebrowser/config.py"
+    else
+      ".config/qutebrowser/config.py";
+  in ''
+    assertFileContent \
+      home-files/${qutebrowserConfig} \
+      ${
+        pkgs.writeText "qutebrowser-expected-config.py" ''
+          config.load_autoconfig(False)
+          c.colors.hints.bg = "#000000"
+          c.colors.hints.fg = "#ffffff"
+          c.colors.tabs.bar.bg = "#000000"
+          c.spellcheck.languages = ["en-US", "sv-SE"]
+          c.tabs.tabs_are_windows = True
+          # Extra qutebrowser configuration.
+        ''
+      }
+  '';
 }

--- a/tests/modules/programs/terminator/config-file.nix
+++ b/tests/modules/programs/terminator/config-file.nix
@@ -1,24 +1,24 @@
-{ config, lib, pkgs, ... }: {
-  config = {
-    programs.terminator = {
-      enable = true;
-      config = {
-        global_config.borderless = true;
-        profiles.default.background_color = "#002b36";
-      };
+{ pkgs, ... }:
+
+{
+  programs.terminator = {
+    enable = true;
+    config = {
+      global_config.borderless = true;
+      profiles.default.background_color = "#002b36";
     };
-
-    test.stubs.terminator = { };
-
-    nmt.script = ''
-      assertFileContent home-files/.config/terminator/config ${
-        pkgs.writeText "expected" ''
-          [global_config]
-          borderless = True
-          [profiles]
-          [[default]]
-          background_color = "#002b36"''
-      }
-    '';
   };
+
+  test.stubs.terminator = { };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/terminator/config ${
+      pkgs.writeText "expected" ''
+        [global_config]
+        borderless = True
+        [profiles]
+        [[default]]
+        background_color = "#002b36"''
+    }
+  '';
 }

--- a/tests/modules/programs/topgrade/settings.nix
+++ b/tests/modules/programs/topgrade/settings.nix
@@ -1,36 +1,32 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ lib, ... }:
 
 {
-  config = {
-    programs.topgrade = {
-      enable = true;
+  programs.topgrade = {
+    enable = true;
 
-      settings = mkMerge [
-        {
-          disable = [ "sdkman" "flutter" "node" "nix" "home_manager" ];
+    settings = lib.mkMerge [
+      {
+        disable = [ "sdkman" "flutter" "node" "nix" "home_manager" ];
 
-          remote_topgrades = [ "backup" "ci" ];
+        remote_topgrades = [ "backup" "ci" ];
 
-          remote_topgrade_path = "bin/topgrade";
-        }
+        remote_topgrade_path = "bin/topgrade";
+      }
 
-        {
-          set_title = false;
-          cleanup = true;
+      {
+        set_title = false;
+        cleanup = true;
 
-          commands = { "Purge unused APT packages" = "sudo apt autoremove"; };
-        }
-      ];
-    };
-
-    test.stubs.topgrade = { };
-
-    nmt.script = ''
-      assertFileContent \
-        home-files/.config/topgrade.toml \
-        ${./settings-expected.toml}
-    '';
+        commands = { "Purge unused APT packages" = "sudo apt autoremove"; };
+      }
+    ];
   };
+
+  test.stubs.topgrade = { };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/topgrade.toml \
+      ${./settings-expected.toml}
+  '';
 }

--- a/tests/modules/programs/vscode/keybindings.nix
+++ b/tests/modules/programs/vscode/keybindings.nix
@@ -1,7 +1,5 @@
 # Test that keybindings.json is created correctly.
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ pkgs, ... }:
 
 let
   bindings = [
@@ -65,18 +63,16 @@ let
   '';
 
 in {
-  config = {
-    programs.vscode = {
-      enable = true;
-      keybindings = bindings;
-      package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
-    };
-
-    nmt.script = ''
-      assertFileExists "home-files/${keybindingsPath}"
-      assertFileContent "home-files/${keybindingsPath}" "${expectedKeybindings}"
-
-      assertPathNotExists "home-files/${settingsPath}"
-    '';
+  programs.vscode = {
+    enable = true;
+    keybindings = bindings;
+    package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
   };
+
+  nmt.script = ''
+    assertFileExists "home-files/${keybindingsPath}"
+    assertFileContent "home-files/${keybindingsPath}" "${expectedKeybindings}"
+
+    assertPathNotExists "home-files/${settingsPath}"
+  '';
 }

--- a/tests/modules/programs/vscode/tasks.nix
+++ b/tests/modules/programs/vscode/tasks.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, ... }:
+{ pkgs, ... }:
 
 let
 

--- a/tests/modules/programs/zplug/modules.nix
+++ b/tests/modules/programs/zplug/modules.nix
@@ -1,52 +1,48 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, pkgs, ... }:
 
 {
-  config = {
-    programs.zsh = {
+  programs.zsh = {
+    enable = true;
+    zplug = {
       enable = true;
-      zplug = {
-        enable = true;
-        zplugHome = pkgs.emptyDirectory;
-        plugins = [
-          {
-            name = "plugins/git";
-            tags = [ "from:oh-my-zsh" ];
-          }
-          {
-            name = "lib/clipboard";
-            tags = [ "from:oh-my-zsh" ''if:"[[ $OSTYPE == *darwin* ]]"'' ];
-          }
-        ];
-      };
+      zplugHome = pkgs.emptyDirectory;
+      plugins = [
+        {
+          name = "plugins/git";
+          tags = [ "from:oh-my-zsh" ];
+        }
+        {
+          name = "lib/clipboard";
+          tags = [ "from:oh-my-zsh" ''if:"[[ $OSTYPE == *darwin* ]]"'' ];
+        }
+      ];
     };
-
-    test.stubs = {
-      zplug = { };
-      zsh = { };
-    };
-
-    nmt.script = ''
-      assertFileContains home-files/.zshrc \
-        'source @zplug@/share/zplug/init.zsh'
-
-      assertFileContains home-files/.zshrc \
-        'zplug "plugins/git", from:oh-my-zsh'
-
-      assertFileContains home-files/.zshrc \
-        'zplug "lib/clipboard", from:oh-my-zsh, if:"[[ $OSTYPE == *darwin* ]]"'
-
-      assertFileContains home-files/.zshrc \
-        'if ! zplug check; then
-           zplug install
-         fi'
-
-      assertFileRegex home-files/.zshrc \
-        '^zplug load$'
-
-      assertFileContains home-files/.zshrc \
-        'export ZPLUG_HOME=${config.programs.zsh.zplug.zplugHome}'
-    '';
   };
+
+  test.stubs = {
+    zplug = { };
+    zsh = { };
+  };
+
+  nmt.script = ''
+    assertFileContains home-files/.zshrc \
+      'source @zplug@/share/zplug/init.zsh'
+
+    assertFileContains home-files/.zshrc \
+      'zplug "plugins/git", from:oh-my-zsh'
+
+    assertFileContains home-files/.zshrc \
+      'zplug "lib/clipboard", from:oh-my-zsh, if:"[[ $OSTYPE == *darwin* ]]"'
+
+    assertFileContains home-files/.zshrc \
+      'if ! zplug check; then
+         zplug install
+       fi'
+
+    assertFileRegex home-files/.zshrc \
+      '^zplug load$'
+
+    assertFileContains home-files/.zshrc \
+      'export ZPLUG_HOME=${config.programs.zsh.zplug.zplugHome}'
+  '';
 }


### PR DESCRIPTION


### Description

Also minor test cleanup.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```