### PR TITLE
thunderbird: add auth methods

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -133,6 +133,21 @@ let
           Configuration for secure connections.
         '';
       };
+
+      authentication = mkOption {
+        type = types.enum [
+          "password"
+          "encrypted-password"
+          "gssapi"
+          "ntlm"
+          "tls"
+          "oauth2"
+        ];
+        default = "password";
+        description = ''
+          Authentication method for login.
+        '';
+      };
     };
   };
 
@@ -193,6 +208,21 @@ let
         default = { };
         description = ''
           Configuration for secure connections.
+        '';
+      };
+
+      authentication = mkOption {
+        type = types.enum [
+          "password"
+          "encrypted-password"
+          "gssapi"
+          "ntlm"
+          "tls"
+          "oauth2"
+        ];
+        default = "password";
+        description = ''
+          Authentication method for login.
         '';
       };
     };

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -7,6 +7,15 @@ let
 
   cfg = config.programs.thunderbird;
 
+  authMethods = {
+    password = 3;
+    encrypted-password = 4;
+    gssapi = 5;
+    ntlm = 6;
+    tls = 7;
+    oauth2 = 10;
+  };
+
   enabledAccounts = attrValues
     (filterAttrs (_: a: a.thunderbird.enable) config.accounts.email.accounts);
 
@@ -76,6 +85,8 @@ let
     } // optionalAttrs account.primary {
       "mail.accountmanager.defaultaccount" = "account_${id}";
     } // optionalAttrs (account.imap != null) {
+      "mail.server.server_${id}.authMethod" =
+        authMethods.${account.imap.authentication};
       "mail.server.server_${id}.directory" =
         "${thunderbirdProfilesPath}/${profile.name}/ImapMail/${id}";
       "mail.server.server_${id}.directory-rel" = "[ProfD]ImapMail/${id}";
@@ -94,7 +105,8 @@ let
       "mail.server.server_${id}.userName" = account.userName;
     } // optionalAttrs (account.smtp != null) {
       "mail.identity.id_${id}.smtpServer" = "smtp_${id}";
-      "mail.smtpserver.smtp_${id}.authMethod" = 3;
+      "mail.smtpserver.smtp_${id}.authMethod" =
+        authMethods.${account.smtp.authentication};
       "mail.smtpserver.smtp_${id}.hostname" = account.smtp.host;
       "mail.smtpserver.smtp_${id}.port" =
         if (account.smtp.port != null) then account.smtp.port else 587;

--- a/tests/modules/accounts/email-test-accounts.nix
+++ b/tests/modules/accounts/email-test-accounts.nix
@@ -21,6 +21,7 @@
         realName = "H. M. Test Jr.";
         passwordCommand = "password-command 2";
         imap.host = "imap.example.org";
+        imap.authentication = "oauth2";
         smtp.host = "smtp.example.org";
         smtp.tls.useStartTls = true;
       };

--- a/tests/modules/programs/thunderbird/thunderbird-expected-first.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-first.js
@@ -39,6 +39,7 @@ user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.useremail", "hm@example.com");
 user_pref("mail.identity.id_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.valid", true);
 user_pref("mail.openpgp.allow_external_gnupg", true);
+user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.authMethod", 10);
 user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.directory", ".thunderbird/first/ImapMail/bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.directory-rel", "[ProfD]ImapMail/bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.hostname", "imap.example.org");
@@ -48,6 +49,7 @@ user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da50
 user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.socketType", 3);
 user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.type", "imap");
 user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.userName", "home.manager.jr");
+user_pref("mail.server.server_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.authMethod", 3);
 user_pref("mail.server.server_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.directory", ".thunderbird/first/ImapMail/cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f");
 user_pref("mail.server.server_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.directory-rel", "[ProfD]ImapMail/cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f");
 user_pref("mail.server.server_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.hostname", "imap.example.com");

--- a/tests/modules/programs/thunderbird/thunderbird-expected-second.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-second.js
@@ -11,6 +11,7 @@ user_pref("mail.identity.id_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da5039
 user_pref("mail.identity.id_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.useremail", "hm@example.org");
 user_pref("mail.identity.id_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.valid", true);
 user_pref("mail.openpgp.allow_external_gnupg", false);
+user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.authMethod", 10);
 user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.directory", ".thunderbird/second/ImapMail/bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.directory-rel", "[ProfD]ImapMail/bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.server.server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.hostname", "imap.example.org");


### PR DESCRIPTION
### Description

Add configuration options for IMAP and SMTP authentication methods in `accounts.email.accounts`, and use them in the Thunderbird module. At this point, the available methods are those supported by Thunderbird.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
