### PR TITLE
dunst: add systemd target option

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -64,6 +64,15 @@ in {
         description = "Package providing {command}`dunst`.";
       };
 
+      systemdTarget = mkOption {
+        type = types.str;
+        default = "graphical-session.target";
+        example = "sway-session.target";
+        description = ''
+          Systemd target to bind to.
+        '';
+      };
+
       configFile = mkOption {
         type = with types; either str path;
         default = "${config.xdg.configHome}/dunst/dunstrc";
@@ -192,6 +201,8 @@ in {
           Environment = optionalString (cfg.waylandDisplay != "")
             "WAYLAND_DISPLAY=${cfg.waylandDisplay}";
         };
+
+        Install.WantedBy = [ cfg.systemdTarget ];
       };
     }
 


### PR DESCRIPTION
### Description

Needed so it starts in sway environments.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
