### PR TITLE
nixpkgs-disabled: Allow modules to extend package set

### DIFF
--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -85,6 +85,18 @@ in
       '';
     };
 
+    readOnly = lib.mkOption {
+      default = false;
+      example = true;
+      type = lib.types.bool;
+      description = ''
+        Whether to prohibit specifying <option>nixpkgs.config</option>,
+        <option>nixpkgs.overlays</option> or, in the case
+        <option>nixpkgs.inheritGlobalPkgs</option> is
+        <literal>true</literal>, <option>nixpkgs.system</option>.
+      '';
+    };
+
     config = lib.mkOption {
       default = { };
       example = {
@@ -172,5 +184,14 @@ in
       pkgs_i686 =
         if _pkgs.stdenv.isLinux && _pkgs.stdenv.hostPlatform.isx86 then _pkgs.pkgsi686Linux else { };
     };
+
+    assertions = [{
+      assertion = !cfg.readOnly || cfg.config == { } && cfg.overlays == [ ]
+        && (!cfg.inheritGlobalPkgs || cfg.system == null);
+      message = ''
+        Nixpkgs cannot be reconfigured or extended because
+        <option>nixpkgs.readOnly</option> is <literal>true</literal>.
+      '';
+    }];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -520,23 +520,21 @@ let
     ++ lib.optional useNixpkgsModule ./misc/nixpkgs.nix
     ++ lib.optional (!useNixpkgsModule) ./misc/nixpkgs-disabled.nix;
 
-  pkgsModule =
-    { config, ... }:
-    {
-      config =
-        {
-          _module.args.baseModules = modules;
-          _module.args.pkgsPath = lib.mkDefault (
-            if lib.versionAtLeast config.home.stateVersion "20.09" then pkgs.path else <nixpkgs>
-          );
-          _module.args.pkgs = lib.mkDefault pkgs;
-          _module.check = check;
-          lib = lib.hm;
-        }
-        // lib.optionalAttrs useNixpkgsModule {
-          nixpkgs.system = lib.mkDefault pkgs.stdenv.hostPlatform.system;
-        };
+  pkgsModule = { config, ... }: {
+    config = {
+      _module.args.baseModules = modules;
+      _module.args.pkgsPath = lib.mkDefault
+        (if lib.versionAtLeast config.home.stateVersion "20.09" then
+          pkgs.path
+        else
+          <nixpkgs>);
+      _module.args.superPkgs = pkgs;
+      _module.check = check;
+      lib = lib.hm;
+    } // lib.optionalAttrs useNixpkgsModule {
+      nixpkgs.system = lib.mkDefault pkgs.stdenv.hostPlatform.system;
     };
+  };
 
 in
 modules ++ [ pkgsModule ]

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -39,7 +39,7 @@ let
           imports = import ../modules/modules.nix {
             inherit pkgs;
             lib = extendedLib;
-            useNixpkgsModule = !cfg.useGlobalPkgs;
+            inheritGlobalPkgs = cfg.useGlobalPkgs;
           };
 
           config = {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Allow Home Manager modules to extend the package set when using `modules/misc/nixpkgs-disabled.nix` by re-importing the original package set with the new configuration and overlays added. Since this is only done when `nixpkgs.{config,overlays}` is specified, the defaults incur no overhead.

This change has been working for me for a while when using the NixOS module with `useGlobalPkgs = true`. However, I have not tried cross-compilation, for example.

Please let me know if there is a better way to implement this than what I propose.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@thiagokokada
