### PR TITLE
xplr: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1179,6 +1179,13 @@ in
           A new module is available: 'services.git-sync'.
         '';
       }
+
+      {
+        time = "2023-08-15T15:45:45+00:00";
+        message = ''
+          A new module is available: 'programs.xplr'.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/xplr.nix
+++ b/modules/programs/xplr.nix
@@ -1,0 +1,72 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib)
+    concatStringsSep types mkIf mkOption mkEnableOption mkPackageOption
+    literalExpression;
+
+  cfg = config.programs.xplr;
+
+  initialConfig = ''
+    version = '${cfg.package.version}'
+  '';
+
+  # We provide a default version line within the configuration file, which is
+  # obtained from the package's attributes. Merge the initial configFile, a
+  # mapped list of plugins and then the user defined configuration to obtain the
+  # final configuration.
+  pluginPath = if cfg.plugins != [ ] then
+    (''
+      package.path=
+    '' + (concatStringsSep " ..\n"
+      (map (p: ''"${p}/init.lua;${p}/?.lua;"'') cfg.plugins)) + ''
+         ..
+        package.path
+      '')
+  else
+    "\n";
+
+  configFile = initialConfig + pluginPath + cfg.extraConfig;
+in {
+  meta.maintainers = [ lib.maintainers.NotAShelf ];
+
+  options.programs.xplr = {
+    enable = mkEnableOption "xplr, terminal UI based file explorer";
+
+    package = mkPackageOption pkgs "xplr" { };
+
+    plugins = mkOption {
+      type = with types; nullOr (listOf (either package str));
+      default = [ ];
+      defaultText = literalExpression "[]";
+      description = ''
+        Plugins to be added to your configuration file.
+
+        Must be a package, an absolute plugin path, or string to be recognized
+        by xplr. Paths will be relative to
+        {file}`$XDG_CONFIG_HOME/xplr/init.lua` unless they are absolute.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = literalExpression ''
+        require("wl-clipboard").setup {
+          copy_command = "wl-copy -t text/uri-list",
+          paste_command = "wl-paste",
+          keep_selection = true,
+        }
+      '';
+      description = ''
+        Extra xplr configuration.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."xplr/init.lua".source =
+      pkgs.writeText "init.lua" configFile;
+  };
+}


### PR DESCRIPTION
### Description

Adds a home-manager module for [xplr](https://github.com/sayanarijit/xplr)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
