### PR TITLE
zellij: generate completions with shell integration options

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -69,15 +69,18 @@ in {
       };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkOrder 200 ''
+      eval "$(zellij setup --generate-completion bash)"
       eval "$(zellij setup --generate-auto-start bash)"
     '');
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration (mkOrder 200 ''
+      eval "$(zellij setup --generate-completion zsh)"
       eval "$(zellij setup --generate-auto-start zsh)"
     '');
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration
       (mkOrder 200 ''
+        eval (zellij setup --generate-completion fish | string collect)
         eval (zellij setup --generate-auto-start fish | string collect)
       '');
   };

--- a/tests/modules/programs/zellij/enable-shells.nix
+++ b/tests/modules/programs/zellij/enable-shells.nix
@@ -26,14 +26,23 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
+      'eval "$(zellij setup --generate-completion bash)"'
+    assertFileContains \
+      home-files/.bashrc \
       'eval "$(zellij setup --generate-auto-start bash)"'
 
     assertFileExists home-files/.zshrc
     assertFileContains \
       home-files/.zshrc \
+      'eval "$(zellij setup --generate-completion zsh)"'
+    assertFileContains \
+      home-files/.zshrc \
       'eval "$(zellij setup --generate-auto-start zsh)"'
 
     assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      'eval (zellij setup --generate-completion fish | string collect)'
     assertFileContains \
       home-files/.config/fish/config.fish \
       'eval (zellij setup --generate-auto-start fish | string collect)'


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.
-->

Generate completions (and some aliases) for `zellij` with the available shell integration options (e.g. `enableZshIntegration` etc). [Link to documentation](https://zellij.dev/documentation/controlling-zellij-through-cli.html#completions).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@mainrs 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
