### PR TITLE
zsh: fix custom syntax highlighting styles

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -613,7 +613,7 @@ in
           source ${cfg.syntaxHighlighting.package}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
           ${lib.concatStringsSep "\n" (
               lib.mapAttrsToList
-                (name: value: "ZSH_HIGHLIGHT_STYLES[${lib.escapeShellArg name}]=${lib.escapeShellArg value}")
+                (name: value: "ZSH_HIGHLIGHT_STYLES+=(${lib.escapeShellArg name} ${lib.escapeShellArg value})")
                 cfg.syntaxHighlighting.styles
           )}
         '')

--- a/tests/modules/programs/zsh/syntax-highlighting.nix
+++ b/tests/modules/programs/zsh/syntax-highlighting.nix
@@ -17,7 +17,7 @@ with lib;
 
     nmt.script = ''
       assertFileContains home-files/.zshrc "source ${pkgs.hello}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-      assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_STYLES['comment']='fg=#6c6c6c'"
+      assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_STYLES+=('comment' 'fg=#6c6c6c')"
     '';
   };
 }


### PR DESCRIPTION
### Description

Previously, customizing a highlighting style with `programs.zsh.syntaxHighlighting.styles.comment = "fg=#6c6c6c"` did not work because in `.zshrc` it added `ZSH_HIGHLIGHT_STYLES['comment']='fg=#6c6c6c'` which changes the key `'comment'` instead of `comment`.

This pull request changes the syntax to `ZSH_HIGHLIGHT_STYLES+=('comment' 'fg=#6c6c6c')` which does not add the quotes to the key.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@ThinkChaos 