### PR TITLE
imapnotify: Use JSON type for extraConfig

### DIFF
--- a/modules/services/imapnotify-accounts.nix
+++ b/modules/services/imapnotify-accounts.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ pkgs, lib, ... }:
 
 with lib;
 
@@ -31,7 +31,7 @@ with lib;
     };
 
     extraConfig = mkOption {
-      type = with types; attrsOf (oneOf [ bool int str ]);
+      type = let jsonFormat = pkgs.formats.json { }; in jsonFormat.type;
       default = { };
       example = { wait = 10; };
       description = "Additional configuration to add for this account.";

--- a/modules/services/imapnotify.nix
+++ b/modules/services/imapnotify.nix
@@ -65,7 +65,9 @@ in {
     services.imapnotify = { enable = mkEnableOption "imapnotify"; };
 
     accounts.email.accounts = mkOption {
-      type = with types; attrsOf (submodule (import ./imapnotify-accounts.nix));
+      type = with types;
+        attrsOf
+        (submodule (import ./imapnotify-accounts.nix { inherit pkgs lib; }));
     };
   };
 


### PR DESCRIPTION
### Description

goimapnotify's configuration is JSON-based, and the recommended configuration has:
```
  "tlsOptions": {
    "rejectUnauthorized": true
  },
```
However, since HM only allows an attrset of str/int/bool in `accounts.email.accounts.<name>.imapnotify.extraConfig`, it's impossible to configure such options.
This change changes the type to the JSON type provided by nixpkg's `formats.json`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted correctly

#### Maintainer CC

@NickHu 
