### PR TITLE
Qutebrowser userscripts

### DIFF
--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -239,6 +239,28 @@ in {
       '';
     };
 
+    greasemonkey = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      example = literalExpression ''
+        [
+          (pkgs.fetchurl {
+            url = "https://raw.githubusercontent.com/afreakk/greasemonkeyscripts/1d1be041a65c251692ee082eda64d2637edf6444/youtube_sponsorblock.js";
+            sha256 = "sha256-e3QgDPa3AOpPyzwvVjPQyEsSUC9goisjBUDMxLwg8ZE=";
+          })
+          (pkgs.writeText "some-script.js" '''
+            // ==UserScript==
+            // @name  Some Greasemonkey script
+            // ==/UserScript==
+          ''')
+        ]
+      '';
+      description = ''
+        Greasemonkey userscripts to add to qutebrowser's {file}`greasemonkey`
+        directory.
+      '';
+    };
+
     extraConfig = mkOption {
       type = types.lines;
       default = "";
@@ -265,6 +287,9 @@ in {
 
     quickmarksFile = optionals (cfg.quickmarks != { }) concatStringsSep "\n"
       ((mapAttrsToList formatQuickmarks cfg.quickmarks));
+
+    greasemonkeyDir = optionals (cfg.greasemonkey != [ ]) pkgs.linkFarmFromDrvs
+      "greasemonkey-userscripts" cfg.greasemonkey;
   in mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
@@ -299,6 +324,16 @@ in {
     xdg.configFile."qutebrowser/quickmarks" =
       mkIf (cfg.quickmarks != { } && pkgs.stdenv.hostPlatform.isLinux) {
         text = quickmarksFile;
+      };
+
+    home.file.".qutebrowser/greasemonkey" =
+      mkIf (cfg.greasemonkey != [ ] && pkgs.stdenv.hostPlatform.isDarwin) {
+        source = greasemonkeyDir;
+      };
+
+    xdg.configFile."qutebrowser/greasemonkey" =
+      mkIf (cfg.greasemonkey != [ ] && pkgs.stdenv.hostPlatform.isLinux) {
+        source = greasemonkeyDir;
       };
   };
 }

--- a/tests/modules/programs/qutebrowser/default.nix
+++ b/tests/modules/programs/qutebrowser/default.nix
@@ -1,5 +1,6 @@
 {
-  qutebrowser-settings = ./settings.nix;
+  qutebrowser-greasemonkey = ./greasemonkey.nix;
   qutebrowser-keybindings = ./keybindings.nix;
   qutebrowser-quickmarks = ./quickmarks.nix;
+  qutebrowser-settings = ./settings.nix;
 }

--- a/tests/modules/programs/qutebrowser/greasemonkey.nix
+++ b/tests/modules/programs/qutebrowser/greasemonkey.nix
@@ -1,0 +1,34 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  greasemonkeyScript = pkgs.writeText "qutebrowser-greasemonkey.js" ''
+    // ==UserScript==
+    // @name        foo
+    // @namespace   foo
+    // @match       https://example.com/*
+    // @grant       none
+    // ==/UserScript==
+  '';
+
+in {
+  programs.qutebrowser = {
+    enable = true;
+    greasemonkey = [ greasemonkeyScript ];
+  };
+
+  test.stubs.qutebrowser = { };
+
+  nmt.script = let
+    scriptDir = if pkgs.stdenv.hostPlatform.isDarwin then
+      ".qutebrowser/greasemonkey"
+    else
+      ".config/qutebrowser/greasemonkey";
+  in ''
+    assertFileContent \
+      home-files/${scriptDir}/qutebrowser-greasemonkey.js \
+      ${greasemonkeyScript}
+  '';
+}


### PR DESCRIPTION
### Description

This adds the `programs.qutebrowser.greasemonkey` option, a list of packages that represent greasemonkey userscripts.

This PR finalizes the changes in #3301 since it hasn't been touched in a while and had changes requested recently.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@somasis @sumnerevans 

