### PR TITLE
jujutsu: update for Jujutsu 0.8.0

### DIFF
--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -61,16 +61,16 @@ in {
     };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      source <(${pkgs.jujutsu}/bin/jj debug completion)
+      source <(${pkgs.jujutsu}/bin/jj util completion)
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      source <(${pkgs.jujutsu}/bin/jj debug completion --zsh | sed '$d')
+      source <(${pkgs.jujutsu}/bin/jj util completion --zsh | sed '$d')
       compdef _jj ${pkgs.jujutsu}/bin/jj
     '';
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-      ${pkgs.jujutsu}/bin/jj debug completion --fish | source
+      ${pkgs.jujutsu}/bin/jj util completion --fish | source
     '';
   };
 }


### PR DESCRIPTION
### Description

This change updates the `programs.jujutsu` module to align with a breaking change in the version 0.8.0 landed to nixpkgs unstable recently.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@shikanime 