### PR TITLE
zsh: Add `historySubstringSearch.prefixed` config option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -205,6 +205,15 @@ let
           The default of `^[[B` corresponds to the DOWN key.
         '';
       };
+      prefixed = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Defines how the command history will be searched for your query.
+          If set to true, your query will be matched against the start of
+          each history entry.
+        '';
+      };
     };
   };
 
@@ -631,6 +640,9 @@ in
             (downKey: "bindkey '${downKey}' history-substring-search-down")
             (lib.toList cfg.historySubstringSearch.searchDownKey)
           }
+          ${optionalString cfg.historySubstringSearch.prefixed ''
+            HISTORY_SUBSTRING_SEARCH_PREFIXED=true
+          ''}
         '')
       ]);
     }

--- a/tests/modules/programs/zsh/history-substring-search.nix
+++ b/tests/modules/programs/zsh/history-substring-search.nix
@@ -10,6 +10,7 @@ with lib;
         enable = true;
         searchDownKey = "^[[B";
         searchUpKey = [ "^[[A" "\\eOA" ];
+        prefixed = true;
       };
     };
 
@@ -20,6 +21,7 @@ with lib;
       assertFileRegex home-files/.zshrc "^bindkey '\^\[\[B' history-substring-search-down$"
       assertFileRegex home-files/.zshrc "^bindkey '\^\[\[A' history-substring-search-up$"
       assertFileRegex home-files/.zshrc "^bindkey '\\\\eOA' history-substring-search-up$"
+      assertFileRegex home-files/.zshrc "^HISTORY_SUBSTRING_SEARCH_PREFIXED=true$"
     '';
   };
 }


### PR DESCRIPTION
### Description

Fixes https://github.com/nix-community/home-manager/issues/4162

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

### Maintainer CC

@ncfavier  
