### PR TITLE
git-sync: darwin support

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -147,6 +147,7 @@ import nmt {
     ./modules/xresources
   ] ++ lib.optionals isDarwin [
     ./modules/launchd
+    ./modules/services/git-sync-darwin
     ./modules/services/imapnotify-darwin
     ./modules/targets-darwin
   ] ++ lib.optionals isLinux [

--- a/tests/modules/services/git-sync-darwin/basic.nix
+++ b/tests/modules/services/git-sync-darwin/basic.nix
@@ -1,0 +1,18 @@
+{ config, ... }:
+
+{
+  services.git-sync = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@git-sync@"; };
+    repositories.test = {
+      path = "/a/path";
+      uri = "git+ssh://user@example.com:/~user/path/to/repo.git";
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=LaunchAgents/org.nix-community.home.git-sync-test.plist
+    assertFileExists "$serviceFile"
+    assertFileContent "$serviceFile" ${./expected-agent.plist}
+  '';
+}

--- a/tests/modules/services/git-sync-darwin/default.nix
+++ b/tests/modules/services/git-sync-darwin/default.nix
@@ -1,0 +1,1 @@
+{ git-sync = ./basic.nix; }

--- a/tests/modules/services/git-sync-darwin/expected-agent.plist
+++ b/tests/modules/services/git-sync-darwin/expected-agent.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.nix-community.home.git-sync-test</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>@git-sync@/bin/git-sync</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>500</integer>
+	<key>WatchPaths</key>
+	<array>
+		<string>/a/path</string>
+	</array>
+	<key>WorkingDirectory</key>
+	<string>/a/path</string>
+</dict>
+</plist>


### PR DESCRIPTION
### Description

`services.git-sync` support on darwin

- On darwin, creates a launch agent to run git-sync on an interval and when the `path` changes.
- The `uri` option is not used on Darwin. The auto-creation of the local git directory from the `uri` is a feature of the
[git-sync-on-inotify](https://github.com/simonthum/git-sync/blob/master/contrib/git-sync-on-inotify) wrapper (which won't work on Darwin afaik) and not `git-sync` itself.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@imalison  @cab404

_Disclaimer: new-ish to nix, first attempted home-manager contribution_
