### PR TITLE
dunst: add extraConfig option

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -125,6 +125,19 @@ in {
           };
         '';
       };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          [global]
+          frame_color = "#3b4252"
+          separator_color = "#404859"
+        '';
+        description = ''
+          Extra configuration lines to add to the end of the dunstrc file.
+        '';
+      };
     };
   };
 
@@ -197,7 +210,7 @@ in {
 
     (mkIf (cfg.settings != { }) {
       xdg.configFile."dunst/dunstrc" = {
-        text = toDunstIni cfg.settings;
+        text = toDunstIni cfg.settings + cfg.extraConfig;
         onChange = ''
           ${pkgs.procps}/bin/pkill -u "$USER" ''${VERBOSE+-e} dunst || true
         '';


### PR DESCRIPTION
### Description

Add a `extraConfig` option to the dunst module. The reason behind this change is, that I want to use the [base16.nix](https://github.com/SenchoPens/base16.nix) and [base16-dunst](https://github.com/tinted-theming/base16-dunst) to configure dunst's colorscheme. With `extraConfig` one would be able to simply do:

```nix
services.dunst.extraConfig =
    builtins.readFile (config.scheme inputs.base16-dunst);
```

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
