### PR TITLE
hyprland: prioritize variables and beziers

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -178,7 +178,7 @@ in {
       toHyprconf = with lib;
         attrs: indentLevel:
         let
-          indent = concatStringsSep "" (replicate indentLevel "  ");
+          indent = concatStrings (replicate indentLevel "  ");
 
           mkSection = n: attrs: ''
             ${indent}${n} {

--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -175,22 +175,34 @@ in {
       shouldGenerate = cfg.systemdIntegration || cfg.extraConfig != ""
         || combinedSettings != { };
 
-      toHyprconf = attrs:
+      toHyprconf = with lib;
+        attrs: indentLevel:
         let
+          indent = concatStringsSep "" (replicate indentLevel "  ");
+
           mkSection = n: attrs: ''
-            ${n} {
-              ${toHyprconf attrs}}
+            ${indent}${n} {
+            ${toHyprconf attrs (indentLevel + 1)}${indent}}
           '';
-          mkFields = lib.generators.toKeyValue { listsAsDuplicateKeys = true; };
-          sections = lib.filterAttrs (n: v: lib.isAttrs v) attrs;
-          fields = lib.filterAttrs (n: v: !(lib.isAttrs v)) attrs;
-        in lib.concatStringsSep "\n" (lib.mapAttrsToList mkSection sections)
-        + mkFields fields;
+          sections = filterAttrs (n: v: isAttrs v) attrs;
+
+          mkFields = generators.toKeyValue { listsAsDuplicateKeys = true; };
+          allFields = filterAttrs (n: v: !(isAttrs v)) attrs;
+          importantFields =
+            filterAttrs (n: _: (hasPrefix "$" n) || (hasPrefix "bezier" n))
+            allFields;
+          fields = builtins.removeAttrs allFields
+            (mapAttrsToList (n: _: n) importantFields);
+        in mkFields importantFields
+        + concatStringsSep "\n" (mapAttrsToList mkSection sections)
+        + removeSuffix indent (indent + (concatStringsSep ''
+
+          ${indent}'' (splitString "\n" (mkFields fields))));
     in lib.mkIf shouldGenerate {
       text = lib.optionalString cfg.systemdIntegration ''
         exec-once = ${pkgs.dbus}/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP && systemctl --user start hyprland-session.target
       '' + lib.optionalString (combinedSettings != { })
-        (toHyprconf combinedSettings)
+        (toHyprconf combinedSettings 0)
         + lib.optionalString (cfg.extraConfig != "") cfg.extraConfig;
       onChange = lib.mkIf (cfg.package != null) ''
         (  # execute in subshell so that `shopt` won't affect other scripts

--- a/tests/modules/services/window-managers/hyprland/simple-config.conf
+++ b/tests/modules/services/window-managers/hyprland/simple-config.conf
@@ -1,5 +1,15 @@
 exec-once = /nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP && systemctl --user start hyprland-session.target
 $mod=SUPER
+bezier=smoothOut, 0.36, 0, 0.66, -0.56
+bezier=smoothIn, 0.25, 1, 0.5, 1
+bezier=overshot, 0.4,0.8,0.2,1.2
+animations {
+  animation=border, 1, 2, smoothIn
+  animation=fade, 1, 4, smoothOut
+  animation=windows, 1, 3, overshot, popin 80%
+  enabled=true
+}
+
 decoration {
   col.shadow=rgba(00000099)
   shadow_offset=0 5

--- a/tests/modules/services/window-managers/hyprland/simple-config.conf
+++ b/tests/modules/services/window-managers/hyprland/simple-config.conf
@@ -1,18 +1,18 @@
 exec-once = /nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP && systemctl --user start hyprland-session.target
+$mod=SUPER
 decoration {
   col.shadow=rgba(00000099)
-shadow_offset=0 5
+  shadow_offset=0 5
 }
 
 input {
   touchpad {
-  scroll_factor=0.300000
+    scroll_factor=0.300000
+  }
+  accel_profile=flat
+  follow_mouse=1
+  kb_layout=ro
 }
-accel_profile=flat
-follow_mouse=1
-kb_layout=ro
-}
-$mod=SUPER
 bindm=$mod, mouse:272, movewindow
 bindm=$mod, mouse:273, resizewindow
 bindm=$mod ALT, mouse:272, resizewindow

--- a/tests/modules/services/window-managers/hyprland/simple-config.nix
+++ b/tests/modules/services/window-managers/hyprland/simple-config.nix
@@ -15,6 +15,21 @@
 
       "$mod" = "SUPER";
 
+      animations = {
+        enabled = true;
+        animation = [
+          "border, 1, 2, smoothIn"
+          "fade, 1, 4, smoothOut"
+          "windows, 1, 3, overshot, popin 80%"
+        ];
+      };
+
+      bezier = [
+        "smoothOut, 0.36, 0, 0.66, -0.56"
+        "smoothIn, 0.25, 1, 0.5, 1"
+        "overshot, 0.4,0.8,0.2,1.2"
+      ];
+
       input = {
         kb_layout = "ro";
         follow_mouse = 1;


### PR DESCRIPTION
### Description

The `settings` attribute now handles `$variables` and `bezier`s differently,
putting them at the top of the file.
Also, proper indentation has been implemented.

EDIT(@ncfavier): fixes https://github.com/nix-community/home-manager/issues/4262

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
