### PR TITLE
Jetbrains remote dev

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -223,6 +223,11 @@
     githubId = 33058747;
     name = "Gaetan Lepage";
   };
+  genericnerdyusername = {
+    email = "genericnerdyusername@proton.me";
+    github = "genericnerdyusername";
+    githubId = 111183546;
+  };
   maximsmol = {
     email = "maximsmol@gmail.com";
     github = "maximsmol";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1407,6 +1407,13 @@ in {
           A new module is available: 'services.arrpc'
         '';
       }
+
+      {
+        time = "2024-02-05T22:45:37+00:00";
+        message = ''
+          A new module is available: 'programs.jetbrains-remote'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -120,6 +120,7 @@ let
     ./programs/ion.nix
     ./programs/irssi.nix
     ./programs/java.nix
+    ./programs/jetbrains-remote.nix
     ./programs/jq.nix
     ./programs/jujutsu.nix
     ./programs/joshuto.nix

--- a/modules/programs/jetbrains-remote.nix
+++ b/modules/programs/jetbrains-remote.nix
@@ -1,0 +1,38 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.jetbrains-remote;
+
+in {
+  meta.maintainers = with lib.maintainers; [ genericnerdyusername ];
+
+  options.programs.jetbrains-remote = {
+    enable = mkEnableOption "JetBrains remote development system";
+
+    ides = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      example = literalExpression ''
+        with pkgs.jetbrains; [ clion pycharm-professional ];
+      '';
+      description = ''
+        IDEs accessible to the JetBrains remote development system.
+      '';
+    };
+  };
+
+  config = mkIf (cfg.enable && cfg.ides != [ ]) {
+    home.activation.jetBrainsRemote = let
+      mkLine = ide:
+        # Errors out if the symlink already exists
+        "${ide}/bin/${ide.meta.mainProgram}-remote-dev-server registerBackendLocationForGateway || true";
+      lines = map mkLine cfg.ides;
+      linesStr = ''
+        rm $HOME/.cache/JetBrains/RemoteDev/userProvidedDist/_nix_store*
+      '' + concatStringsSep "\n" lines;
+    in hm.dag.entryAfter [ "writeBoundary" ] linesStr;
+  };
+}


### PR DESCRIPTION
### Description

This adds a module that allows you to select the IDEs accessible using gateway and a ssh connection

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).