### PR TITLE
tmate: don't generate empty config file

### DIFF
--- a/modules/programs/tmate.nix
+++ b/modules/programs/tmate.nix
@@ -65,7 +65,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    home.file.".tmate.conf".text = let
+    home.file.".tmate.conf" = let
       conf =
         optional (cfg.host != null) ''set -g tmate-server-host "${cfg.host}"''
         ++ optional (cfg.port != null)
@@ -75,6 +75,6 @@ in {
         ++ optional (cfg.rsaFingerprint != null)
         ''set -g tmate-server-rsa-fingerprint "${cfg.rsaFingerprint}"''
         ++ optional (cfg.extraConfig != "") cfg.extraConfig;
-    in concatStringsSep "\n" conf + "\n";
+    in mkIf (conf != [ ]) { text = concatLines conf; };
   };
 }


### PR DESCRIPTION
### Description

Fixes https://github.com/nix-community/home-manager/issues/4270

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
