### PR TITLE
aerc: do not use smtp-starttls

### DIFF
--- a/modules/programs/aerc-accounts.nix
+++ b/modules/programs/aerc-accounts.nix
@@ -177,21 +177,20 @@ in {
               params = cfg.aerc.smtpOauth2Params;
             };
 
-            protocol = if smtp.tls.enable && !smtp.tls.useStartTls then
-              "smtps${loginMethod'}"
+            protocol = if smtp.tls.enable then
+              if smtp.tls.useStartTls then
+                "smtp${loginMethod'}"
+              else
+                "smtps${loginMethod'}"
             else
-              "smtp${loginMethod'}";
+              "smtp+insecure${loginMethod'}";
 
             port' = optPort smtp.port;
-
-            smtp-starttls =
-              if smtp.tls.enable && smtp.tls.useStartTls then "yes" else null;
 
           in {
             outgoing =
               "${protocol}://${userName}@${smtp.host}${port'}${oauthParams'}";
-          } // optPwCmd "outgoing" passwordCommand
-          // optAttr "smtp-starttls" smtp-starttls;
+          } // optPwCmd "outgoing" passwordCommand;
 
         msmtp = cfg: {
           outgoing = "msmtpq --read-envelope-from --read-recipients";

--- a/tests/modules/programs/aerc/extraAccounts.expected
+++ b/tests/modules/programs/aerc/extraAccounts.expected
@@ -38,7 +38,6 @@ source-cred-cmd = echo PaSsWorD!
 [e_smtp-nopasscmd-tls-starttls]
 from = Foo Bar <addr@mail.invalid>
 outgoing = smtp+plain://foobar@smtp.host.invalid:42
-smtp-starttls = yes
 
 [f_smtp-passcmd-tls-nostarttls]
 from = Foo Bar <addr@mail.invalid>
@@ -47,12 +46,12 @@ outgoing-cred-cmd = echo PaSsWorD!
 
 [g_smtp-passcmd-notls-nostarttls]
 from = Foo Bar <addr@mail.invalid>
-outgoing = smtp+plain://foobar@smtp.host.invalid:42
+outgoing = smtp+insecure+plain://foobar@smtp.host.invalid:42
 outgoing-cred-cmd = echo PaSsWorD!
 
 [h_smtp-passcmd-notls-starttls]
 from = Foo Bar <addr@mail.invalid>
-outgoing = smtp+plain://foobar@smtp.host.invalid:42
+outgoing = smtp+insecure+plain://foobar@smtp.host.invalid:42
 outgoing-cred-cmd = echo PaSsWorD!
 
 [i_maildir-mbsync]


### PR DESCRIPTION
### Description

This option was deprecated in 0.15.0, +insecure schema is suggested instead.
Thus, we can just copy imap logic, which already uses +insecure.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@lukasngl 