### PR TITLE
hyprland: use `toKeyValue`'s `indent` argument

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -186,7 +186,10 @@ in {
           '';
           sections = filterAttrs (n: v: isAttrs v) attrs;
 
-          mkFields = generators.toKeyValue { listsAsDuplicateKeys = true; };
+          mkFields = generators.toKeyValue {
+            listsAsDuplicateKeys = true;
+            inherit indent;
+          };
           allFields = filterAttrs (n: v: !(isAttrs v)) attrs;
           importantFields =
             filterAttrs (n: _: (hasPrefix "$" n) || (hasPrefix "bezier" n))
@@ -195,9 +198,7 @@ in {
             (mapAttrsToList (n: _: n) importantFields);
         in mkFields importantFields
         + concatStringsSep "\n" (mapAttrsToList mkSection sections)
-        + removeSuffix indent (indent + (concatStringsSep ''
-
-          ${indent}'' (splitString "\n" (mkFields fields))));
+        + mkFields fields;
     in lib.mkIf shouldGenerate {
       text = lib.optionalString cfg.systemdIntegration ''
         exec-once = ${pkgs.dbus}/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP && systemctl --user start hyprland-session.target


### PR DESCRIPTION
Freshly added in https://github.com/NixOS/nixpkgs/pull/244819

Tracking: https://nixpk.gs/pr-tracker.html?pr=244819

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
