### PR TITLE
gnome-terminal: add assertion on profile names

### DIFF
--- a/tests/modules/programs/gnome-terminal/bad-profile-name.nix
+++ b/tests/modules/programs/gnome-terminal/bad-profile-name.nix
@@ -1,0 +1,25 @@
+{ config, ... }:
+
+{
+  programs.gnome-terminal = {
+    enable = true;
+    profile = {
+      bad-name = { visibleName = "a"; };
+      "e0b782ed-6aca-44eb-8c75-62b3706b6220" = {
+        default = true;
+        visibleName = "b";
+      };
+      another-bad-name = { visibleName = "c"; };
+    };
+  };
+
+  nixpkgs.overlays = [
+    (self: super: { gnome.gnome-terminal = config.lib.test.mkStubPackage { }; })
+  ];
+
+  test.stubs.dconf = { };
+
+  test.asserts.assertions.expected = [''
+    The attribute name of a Gnome Terminal profile must be a UUID.
+    Incorrect profile names: another-bad-name, bad-name''];
+}

--- a/tests/modules/programs/gnome-terminal/default.nix
+++ b/tests/modules/programs/gnome-terminal/default.nix
@@ -1,1 +1,4 @@
-{ gnome-terminal-1 = ./gnome-terminal-1.nix; }
+{
+  gnome-terminal-1 = ./gnome-terminal-1.nix;
+  gnome-terminal-bad-profile-name = ./bad-profile-name.nix;
+}


### PR DESCRIPTION
### Description

Without the assert the profile will just not show up in Gnome Terminal and it is a bit tricky to find out why.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```