### PR TITLE
gh: option to enable helper for additional hosts

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -128,8 +128,8 @@ in {
     xdg.configFile."gh/config.yml".source =
       yamlFormat.generate "gh-config.yml" cfg.settings;
 
-    programs.git.extraConfig.credential =
-      lib.mkIf cfg.gitCredentialHelper.enable (builtins.listToAttrs (map (host:
+    programs.git.extraConfig.credential = mkIf cfg.gitCredentialHelper.enable
+      (builtins.listToAttrs (map (host:
         lib.nameValuePair host {
           helper = "${cfg.package}/bin/gh auth git-credential";
         }) cfg.gitCredentialHelper.hosts));

--- a/tests/modules/programs/gh/credential-helper.git.conf
+++ b/tests/modules/programs/gh/credential-helper.git.conf
@@ -1,2 +1,5 @@
 [credential "https://github.com"]
 	helper = "@gh@/bin/gh auth git-credential"
+
+[credential "https://github.example.com"]
+	helper = "@gh@/bin/gh auth git-credential"

--- a/tests/modules/programs/gh/credential-helper.nix
+++ b/tests/modules/programs/gh/credential-helper.nix
@@ -4,6 +4,7 @@
   programs.gh = {
     enable = true;
     enableGitCredentialHelper = true;
+    extraGitCredentialHelperHosts = [ "https://github.example.com" ];
   };
 
   programs.git.enable = true;

--- a/tests/modules/programs/gh/credential-helper.nix
+++ b/tests/modules/programs/gh/credential-helper.nix
@@ -3,8 +3,10 @@
 {
   programs.gh = {
     enable = true;
-    enableGitCredentialHelper = true;
-    extraGitCredentialHelperHosts = [ "https://github.example.com" ];
+    gitCredentialHelper = {
+      enable = true;
+      hosts = [ "https://github.com" "https://github.example.com" ];
+    };
   };
 
   programs.git.enable = true;


### PR DESCRIPTION
### Description

`gh` can also be used with github enterprise hosts, for which there exists no easy option to enable the credential helper except for directly working with `programs.git.extraConfig`.

Therefore I've added the option `programs.gh.extraGitCredentialHelperHosts`. The name is up for debate since it's maybe a bit verbose.

Not sure if this is a needed addition since it's somewhat niche, at the same time it's not very complex and makes the life of github enterprise users a little easier.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@Gerschtli @berbiche 
