### PR TITLE
nushell: deprecation of let-env

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -128,10 +128,10 @@ in {
       # Using mkAfter to make it more likely to appear after other
       # manipulations of the prompt.
       mkAfter ''
-        let-env config = ($env | default {} config).config
-        let-env config = ($env.config | default {} hooks)
-        let-env config = ($env.config | update hooks ($env.config.hooks | default [] pre_prompt))
-        let-env config = ($env.config | update hooks.pre_prompt ($env.config.hooks.pre_prompt | append {
+        $env.config = ($env | default {} config).config
+        $env.config = ($env.config | default {} hooks)
+        $env.config = ($env.config | update hooks ($env.config.hooks | default [] pre_prompt))
+        $env.config = ($env.config | update hooks.pre_prompt ($env.config.hooks.pre_prompt | append {
           code: "
             let direnv = (${pkgs.direnv}/bin/direnv export json | from json)
             let direnv = if ($direnv | length) == 1 { $direnv } else { {} }

--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -85,7 +85,7 @@ in {
       type = types.nullOr (linesOrSource "env.nu");
       default = null;
       example = ''
-        let-env FOO = 'BAR'
+        $env.FOO = 'BAR'
       '';
       description = ''
         The environment variables file to be used for nushell.
@@ -174,8 +174,7 @@ in {
 
       (let
         envVarsStr = concatStringsSep "\n"
-          (mapAttrsToList (k: v: "let-env ${k} = ${v}")
-            cfg.environmentVariables);
+          (mapAttrsToList (k: v: "$env.${k} = ${v}") cfg.environmentVariables);
       in mkIf (cfg.envFile != null || cfg.extraEnv != "" || envVarsStr != "") {
         "${configDir}/env.nu".text = mkMerge [
           (mkIf (cfg.envFile != null) cfg.envFile.text)

--- a/tests/modules/programs/nushell/env-expected.nu
+++ b/tests/modules/programs/nushell/env-expected.nu
@@ -1,4 +1,4 @@
-let-env FOO = 'BAR'
+$env.FOO = 'BAR'
 
 
-let-env BAR = $'(echo BAZ)'
+$env.BAR = $'(echo BAZ)'

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -13,7 +13,7 @@
     '';
 
     envFile.text = ''
-      let-env FOO = 'BAR'
+      $env.FOO = 'BAR'
     '';
 
     loginFile.text = ''


### PR DESCRIPTION
### Description

let-env has been deprecated in nushell's latest release.
This PR aims to fix the errors that this causes.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
