### PR TITLE
man: fix caches generation in cross-compiled system

### DIFF
--- a/modules/programs/man.nix
+++ b/modules/programs/man.nix
@@ -57,13 +57,15 @@ in {
         };
 
         # Generate a database of all manpages in ${manualPages}.
-        manualCache = pkgs.runCommandLocal "man-cache" { } ''
+        manualCache = pkgs.runCommandLocal "man-cache" {
+          nativeBuildInputs = [ cfg.package ];
+        } ''
           # Generate a temporary man.conf so mandb knows where to
           # write cache files.
           echo "MANDB_MAP ${manualPages}/share/man $out" > man.conf
 
           # Run mandb to generate cache files:
-          ${cfg.package}/bin/mandb -C man.conf --no-straycats --create \
+          mandb -C man.conf --no-straycats --create \
             ${manualPages}/share/man
         '';
       in ''


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
