### PR TITLE
network-manager-applet: removed `--sm-disable` flag

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -37,6 +37,12 @@
     github = "CarlosLoboxyz";
     githubId = 86011416;
   };
+  cvoges12 = {
+    name = "Clayton Voges";
+    email = "38054771+cvoges12@users.noreply.github.com";
+    github = "cvoges12";
+    githubId = 38054771;
+  };
   d-dervishi = {
     email = "david.dervishi@epfl.ch";
     github = "d-dervishi";

--- a/modules/services/network-manager-applet.nix
+++ b/modules/services/network-manager-applet.nix
@@ -7,7 +7,7 @@ let
   cfg = config.services.network-manager-applet;
 
 in {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = [ maintainers.rycee maintainers.cvoges12 ];
 
   options = {
     services.network-manager-applet = {
@@ -32,10 +32,8 @@ in {
       Install = { WantedBy = [ "graphical-session.target" ]; };
 
       Service = {
-        ExecStart = toString
-          ([ "${pkgs.networkmanagerapplet}/bin/nm-applet" "--sm-disable" ]
-            ++ optional config.xsession.preferStatusNotifierItems
-            "--indicator");
+        ExecStart = toString ([ "${pkgs.networkmanagerapplet}/bin/nm-applet" ]
+          ++ optional config.xsession.preferStatusNotifierItems "--indicator");
       };
     };
   };


### PR DESCRIPTION
### Description

`--sm-disable` flag is deprecated. It doesn't show in the manpages, any documentation, and others have seemed to notice as well:

> The `--sm-disable` flag isn't used anymore due to the applet no longer being session-managed.

From: <https://askubuntu.com/a/525273>

Which cites: <https://mail.gnome.org/archives/networkmanager-list/2011-May/msg00141.html>

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 
