### PR TITLE
hyprland: remove xwayland.hidpi

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -11,11 +11,15 @@ in {
   imports = [
     (lib.mkRemovedOptionModule # \
       [ "wayland" "windowManager" "hyprland" "disableAutoreload" ]
-      "Autoreloading now always happen")
+      "Autoreloading now always happens")
 
     (lib.mkRemovedOptionModule # \
       [ "wayland" "windowManager" "hyprland" "recommendedEnvironment" ]
       "Recommended environment variables are now always set")
+
+    (lib.mkRemovedOptionModule # \
+      [ "wayland" "windowManager" "hyprland" "xwayland" "hidpi" ]
+      "HiDPI patches are deprecated. Refer to https://wiki.hyprland.org/Configuring/XWayland")
 
     (lib.mkRenamedOptionModule # \
       [ "wayland" "windowManager" "hyprland" "nvidiaPatches" ] # \
@@ -32,8 +36,7 @@ in {
       readOnly = true;
       default = cfg.package.override {
         enableXWayland = cfg.xwayland.enable;
-        hidpiXWayland = cfg.xwayland.hidpi;
-        nvidiaPatches = cfg.enableNvidiaPatches;
+        enableNvidiaPatches = cfg.enableNvidiaPatches;
       };
       defaultText = lib.literalMD
         "`wayland.windowManager.hyprland.package` with applied configuration";
@@ -66,15 +69,7 @@ in {
       '';
     };
 
-    xwayland = {
-      enable = lib.mkEnableOption "XWayland" // { default = true; };
-      hidpi = lib.mkEnableOption null // {
-        description = ''
-          Enable HiDPI XWayland, based on [XWayland MR 733](https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/733).
-          See <https://wiki.hyprland.org/Nix/Options-Overrides/#xwayland-hidpi> for more info.
-        '';
-      };
-    };
+    xwayland.enable = lib.mkEnableOption "XWayland" // { default = true; };
 
     enableNvidiaPatches =
       lib.mkEnableOption "patching wlroots for better Nvidia support";


### PR DESCRIPTION
### Description

Remove `xwayland.hidpi` option, since we're dropping HiDPI XWayland patches support, opting to use the builtin xwayland:force_zero_scaling option instead. It is described in more detail in https://wiki.hyprland.org/Configuring/XWayland.

This change needs to be merged right after https://github.com/NixOS/nixpkgs/pull/247008 hits unstable, so that people don't get a broken module.

Reference PRs for this change:
- hyprwm/Hyprland#2870
- hyprwm/hyprland-wiki#282

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
