### PR TITLE
jujutsu: fix zsh completion

### DIFF
--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -65,7 +65,7 @@ in {
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      source <(${pkgs.jujutsu}/bin/jj util completion --zsh | sed '$d')
+      source <(${pkgs.jujutsu}/bin/jj util completion --zsh)
       compdef _jj ${pkgs.jujutsu}/bin/jj
     '';
 


### PR DESCRIPTION
### Description

In jujutsu 0.8, the library that generates shell completions was upgraded, and the new version no longer requires truncating the last line in order to work, and in fact, outputs an error message if you do (because the completion code is now missing the `fi` to close an `if` statement). The guidance upstream for enabling completion [has been updated accordingly](https://github.com/martinvonz/jj/issues/1393), and this change updates the home-manager module to match.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
