### PR TITLE
Add QT_PLUGIN_PATH and QML2_IMPORT_PATH to make Qt6 themes and plugins work properly

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -128,7 +128,7 @@ in {
     };
   };
 
-  config = mkIf (cfg.enable && cfg.platformTheme != null) {
+  config = mkIf cfg.enable {
     assertions = [{
       assertion = cfg.platformTheme == "gnome" -> cfg.style.name != null
         && cfg.style.package != null;
@@ -160,9 +160,10 @@ in {
     ] else if cfg.platformTheme == "kde" then [
       pkgs.libsForQt5.plasma-integration
       pkgs.libsForQt5.systemsettings
-    ] else
-      [ pkgs.libsForQt5.qtstyleplugins ])
-      ++ lib.optionals (cfg.style.package != null)
+    ] else if cfg.platformTheme == "gtk2" then
+      [ pkgs.libsForQt5.qtstyleplugins ]
+    else
+      [ ]) ++ lib.optionals (cfg.style.package != null)
       (lib.toList cfg.style.package);
 
     xsession.importedVariables = [ "QT_QPA_PLATFORMTHEME" ]


### PR DESCRIPTION
### Description

Add QT_PLUGIN_PATH and QML2_IMPORT_PATH environment variables to let Qt6 load plugins and qmls installed in home.packages, for example, fcitx5. There are also new options in case not convenient to add a path to home.packages.

#### Original

Fcitx5 needs QT_PLUGIN_PATH to grab input in Qt apps in wayland. Nixpkgs/NixOS module [does set this environment variable](https://github.com/NixOS/nixpkgs/blob/66aedfd010204949cb225cf749be08cb13ce1813/nixos/modules/i18n/input-method/fcitx5.nix#L65-L70), so it's long advised to enable this option together with Home Manager one, but it doesn't make sense to enable both of course.

In order to keep the possibility to reuse this environment variable for others, I've added a new option in Qt module. I'm new to Home Manager modules so I'm not 100% sure this is correct.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@Kranzes @ncfavier @rycee 
