### PR TITLE
Misc qt fixes

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -16,10 +16,10 @@ let
     cde = libsForQt5.qtstyleplugins;
     plastique = libsForQt5.qtstyleplugins;
 
-    adwaita = adwaita-qt;
-    adwaita-dark = adwaita-qt;
-    adwaita-highcontrast = adwaita-qt;
-    adwaita-highcontrastinverse = adwaita-qt;
+    adwaita = [ adwaita-qt adwaita-qt6 ];
+    adwaita-dark = [ adwaita-qt adwaita-qt6 ];
+    adwaita-highcontrast = [ adwaita-qt adwaita-qt6 ];
+    adwaita-highcontrastinverse = [ adwaita-qt adwaita-qt6 ];
 
     breeze = libsForQt5.breeze-qt5;
 

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -128,7 +128,7 @@ in {
     };
   };
 
-  config = mkIf (cfg.enable && cfg.platformTheme != null) {
+  config = mkIf cfg.enable {
     assertions = [{
       assertion = cfg.platformTheme == "gnome" -> cfg.style.name != null
         && cfg.style.package != null;
@@ -160,12 +160,14 @@ in {
     ] else if cfg.platformTheme == "kde" then [
       pkgs.libsForQt5.plasma-integration
       pkgs.libsForQt5.systemsettings
-    ] else
-      [ pkgs.libsForQt5.qtstyleplugins ])
-      ++ lib.optionals (cfg.style.package != null)
+    ] else if cfg.platformTheme == "gtk2" then
+      [ pkgs.libsForQt5.qtstyleplugins ]
+    else
+      [ ]) ++ lib.optionals (cfg.style.package != null)
       (lib.toList cfg.style.package);
 
-    xsession.importedVariables = [ "QT_QPA_PLATFORMTHEME" ]
+    xsession.importedVariables =
+      lib.optionals (cfg.platformTheme != null) [ "QT_QPA_PLATFORMTHEME" ]
       ++ lib.optionals (cfg.style.name != null) [ "QT_STYLE_OVERRIDE" ];
 
     # Enable GTK+ style for Qt4 in Gtk/GNOME.

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -44,7 +44,7 @@ in {
       enable = mkEnableOption "Qt 4, 5 and 6 configuration";
 
       platformTheme = mkOption {
-        type = types.nullOr (types.enum [ "gtk" "gnome" "qtct" "kde" ]);
+        type = types.nullOr (types.enum [ "gtk" "gtk3" "gnome" "qtct" "kde" ]);
         default = null;
         example = "gnome";
         relatedPackages = [
@@ -63,6 +63,10 @@ in {
           `gtk`
           : Use GTK theme with
             [`qtstyleplugins`](https://github.com/qt/qtstyleplugins)
+
+          `gtk3`
+          : Use [GTK3 integration](https://github.com/qt/qtbase/tree/dev/src/plugins/platformthemes/gtk3)
+            for file picker dialogs, font and theme configuration
 
           `gnome`
           : Use GNOME theme with


### PR DESCRIPTION
### Description

Completely untested for now.

This PR does the following:
- fix a bug with configuration gating
- add the gtk3 platform theme, part of qtbase (I'm not 100% sure whether it needs more stuff to actually work, inside of `nix-shell --pure`, applications start, but attempting to open a file picker results in the usual complaint about gsettings schemas)
- add the qt6 package for adwaita-qt (ineffective without #4306, updates #3590)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
