### PR TITLE
taffybar: Avoid restarting too quickly

### DIFF
--- a/modules/services/taffybar.nix
+++ b/modules/services/taffybar.nix
@@ -32,6 +32,8 @@ in {
       Unit = {
         Description = "Taffybar desktop bar";
         PartOf = [ "tray.target" ];
+        StartLimitBurst = 5;
+        StartLimitIntervalSec = 10;
       };
 
       Service = {
@@ -39,6 +41,7 @@ in {
         BusName = "org.taffybar.Bar";
         ExecStart = "${cfg.package}/bin/taffybar";
         Restart = "on-failure";
+        RestartSec = "2s";
       };
 
       Install = { WantedBy = [ "tray.target" ]; };


### PR DESCRIPTION
### Description

taffybar restarts very quickly right now which can lead to a very quick failure in cases where the display is not ready in time

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

