### PR TITLE
khal: uncomment locale config

### DIFF
--- a/modules/programs/khal.nix
+++ b/modules/programs/khal.nix
@@ -152,6 +152,7 @@ in {
       description = ''
         khal locale settings. 
       '';
+      default = { };
     };
   };
 
@@ -161,7 +162,7 @@ in {
     xdg.configFile."khal/config".text = concatStringsSep "\n" ([ "[calendars]" ]
       ++ mapAttrsToList genCalendarStr khalAccounts ++ [
         (generators.toINI { } {
-          # locale = definedAttrs (cfg.locale // { _module = null; });
+          locale = definedAttrs (cfg.locale // { _module = null; });
 
           default = optionalAttrs (!isNull primaryAccount) {
             highlight_event_days = true;


### PR DESCRIPTION
### Description
While the locale options were declared, the weren't used in the generation of the config file, because the locale submodule missed a default, which failed the tests. I added an empty attribute set as a default, which fixes the test, and works with the defaults in the submodule options as expected.
Closes #4283 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
Not really maintainer, but @teto 