### PR TITLE
modules: types.string throws error now

### DIFF
--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -107,7 +107,7 @@ let
       };
 
       settings = mkOption {
-        type = types.attrsOf types.string;
+        type = types.attrsOf types.str;
         description = ''
           Extra key-value pairs to add to the `[Desktop Entry]` section.
           This may override other values.

--- a/modules/programs/tmate.nix
+++ b/modules/programs/tmate.nix
@@ -36,7 +36,7 @@ in {
       };
 
       dsaFingerprint = mkOption {
-        type = with types; nullOr string;
+        type = with types; nullOr str;
         default = null;
         example = literalExpression
           "SHA256:1111111111111111111111111111111111111111111";
@@ -44,7 +44,7 @@ in {
       };
 
       rsaFingerprint = mkOption {
-        type = with types; nullOr string;
+        type = with types; nullOr str;
         default = null;
         example = literalExpression
           "SHA256:1111111111111111111111111111111111111111111";


### PR DESCRIPTION
Since the merge of https://github.com/NixOS/nixpkgs/pull/247848

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
