### PR TITLE
kanshi: support adaptive sync

### DIFF
--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -80,15 +80,28 @@ let
           Sets the output transform.
         '';
       };
+
+      adaptiveSync = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        example = true;
+        description = ''
+          Enables or disables adaptive synchronization
+          (aka. Variable Refresh Rate).
+        '';
+      };
     };
   };
 
-  outputStr = { criteria, status, mode, position, scale, transform, ... }:
+  outputStr =
+    { criteria, status, mode, position, scale, transform, adaptiveSync, ... }:
     ''output "${criteria}"'' + optionalString (status != null) " ${status}"
     + optionalString (mode != null) " mode ${mode}"
     + optionalString (position != null) " position ${position}"
     + optionalString (scale != null) " scale ${toString scale}"
-    + optionalString (transform != null) " transform ${transform}";
+    + optionalString (transform != null) " transform ${transform}"
+    + optionalString (adaptiveSync != null)
+    " adaptive_sync ${if adaptiveSync then "on" else "off"}";
 
   profileModule = types.submodule {
     options = {


### PR DESCRIPTION
### Description

Adds a configuration option to turn the `adaptive_sync on/off` option in the config

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@nurelin 