### PR TITLE
home-manager: handle profile list in Nix >2.17

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -1,4 +1,4 @@
-{ runCommand, lib, bash, callPackage, coreutils, findutils, gettext, gnused
+{ runCommand, lib, bash, callPackage, coreutils, findutils, gettext, gnused, jq
 , less, ncurses, unixtools
 # used for pkgs.path for nixos-option
 , pkgs
@@ -34,6 +34,7 @@ in runCommand "home-manager" {
         findutils
         gettext
         gnused
+        jq
         less
         ncurses
         nixos-option

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -11,11 +11,21 @@ export TEXTDOMAINDIR=@OUT@/share/locale
 # shellcheck disable=1091
 source @HOME_MANAGER_LIB@
 
+function nixProfileList() {
+    # We attempt to use `--json` first (added in Nix 2.17). Otherwise attempt to
+    # parse the legacy output format.
+    {
+        nix profile list --json 2>/dev/null \
+            | jq -r --arg name "$1" '.elements[].storePaths[] | select(endswith($name))'
+    } || {
+        nix profile list \
+            | { grep "$1\$" || test $? = 1; } \
+            | cut -d ' ' -f 4
+    }
+}
+
 function removeByName() {
-  nix profile list \
-      | { grep "$1" || test $? = 1; } \
-      | cut -d ' ' -f 4 \
-      | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
+    nixProfileList "$1" | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
 }
 
 function setNixProfileCommands() {


### PR DESCRIPTION
### Description

Nix 2.17 changed the format of the `nix profile list` output. This commit adds support for parsing the new JSON profile list format.

Fixes #4298

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```