### PR TITLE
lf: simplify option validation

### DIFF
--- a/modules/programs/lf.nix
+++ b/modules/programs/lf.nix
@@ -2,55 +2,7 @@
 
 with lib;
 
-let
-  cfg = config.programs.lf;
-
-  knownSettings = {
-    anchorfind = types.bool;
-    color256 = types.bool;
-    dircounts = types.bool;
-    dirfirst = types.bool;
-    drawbox = types.bool;
-    globsearch = types.bool;
-    icons = types.bool;
-    hidden = types.bool;
-    ignorecase = types.bool;
-    ignoredia = types.bool;
-    incsearch = types.bool;
-    preview = types.bool;
-    reverse = types.bool;
-    smartcase = types.bool;
-    smartdia = types.bool;
-    wrapscan = types.bool;
-    wrapscroll = types.bool;
-    number = types.bool;
-    relativenumber = types.bool;
-    findlen = types.int;
-    period = types.int;
-    scrolloff = types.int;
-    tabstop = types.int;
-    errorfmt = types.str;
-    filesep = types.str;
-    ifs = types.str;
-    promptfmt = types.str;
-    shell = types.str;
-    sortby = types.str;
-    timefmt = types.str;
-    ratios = types.str;
-    info = types.str;
-    shellopts = types.str;
-  };
-
-  lfSettingsType = types.submodule {
-    options = let
-      opt = name: type:
-        mkOption {
-          type = types.nullOr type;
-          default = null;
-          visible = false;
-        };
-    in mapAttrs opt knownSettings;
-  };
+let cfg = config.programs.lf;
 in {
   meta.maintainers = [ hm.maintainers.owm111 ];
 
@@ -68,27 +20,19 @@ in {
       };
 
       settings = mkOption {
-        type = lfSettingsType;
+        type = with types;
+          attrsOf (oneOf [ str int (listOf (either str int)) bool ]);
         default = { };
         example = {
           tabstop = 4;
           number = true;
-          ratios = "1:1:2";
+          ratios = [ 1 1 2 ];
         };
         description = ''
-          An attribute set of lf settings. The attribute names and corresponding
-          values must be among the following supported options.
-
-          ${concatStringsSep "\n" (mapAttrsToList (n: v: ''
-            {var}`${n}`
-            : ${v.description}
-          '') knownSettings)}
-
-          See the lf documentation for detailed descriptions of these options.
-          Use {option}`programs.lf.previewer.*` to set lf's
-          {var}`previewer` option, and
-          [](#opt-programs.lf.extraConfig) for any other option not listed above.
-          All string options are quoted with double quotes.
+          An attribute set of lf settings. See the lf documentation for
+          detailed descriptions of these options. Prefer
+          {option}`programs.lf.previewer.*` for setting lf's {var}`previewer`
+          option. All string options are quoted with double quotes.
         '';
       };
 
@@ -181,12 +125,14 @@ in {
         optionalString (v != null) "set ${
           if isBool v then
             "${optionalString (!v) "no"}${k}"
+          else if isList v then
+            ''${k} "${concatStringsSep ":" (map (w: toString w) v)}"''
           else
             "${k} ${if isInt v then toString v else ''"${v}"''}"
         }";
 
-      settingsStr = concatStringsSep "\n" (remove "" (mapAttrsToList fmtSetting
-        (builtins.intersectAttrs knownSettings cfg.settings)));
+      settingsStr = concatStringsSep "\n"
+        (remove "" (mapAttrsToList fmtSetting cfg.settings));
 
       fmtCmdMap = before: k: v:
         "${before} ${k}${optionalString (v != null && v != "") " ${v}"}";

--- a/tests/modules/programs/lf/all-options.nix
+++ b/tests/modules/programs/lf/all-options.nix
@@ -71,7 +71,7 @@ in {
         ignorecase = false;
         icons = true;
         tabstop = 4;
-        ratios = "2:2:3";
+        ratios = [ 2 2 3 ];
       };
     };
 


### PR DESCRIPTION
### Description

Don't try to validate a limited set of hardcoded options, instead just convert them as-is. Now, users can keep all their options in a single attribute set, including arbitrary `user_{option}`s which was impossible to express with a hard-coded submodule. As a plus, there is also less maintainence burden.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@owm111