### PR TITLE
qcal: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1193,6 +1193,13 @@ in
           A new module is available: 'programs.pqiv'.
         '';
       }
+
+      {
+        time = "2023-08-22T16:06:52+00:00";
+        message = ''
+          A new module is available: 'programs.qcal'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -173,6 +173,7 @@ let
     ./programs/pubs.nix
     ./programs/pyenv.nix
     ./programs/pylint.nix
+    ./programs/qcal.nix
     ./programs/qutebrowser.nix
     ./programs/rbw.nix
     ./programs/readline.nix

--- a/modules/programs/qcal.nix
+++ b/modules/programs/qcal.nix
@@ -1,0 +1,66 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  cfg = config.programs.qcal;
+
+  qcalAccounts = lib.attrValues
+    (lib.filterAttrs (_: a: a.qcal.enable) config.accounts.calendar.accounts);
+
+  rename = oldname:
+    builtins.getAttr oldname {
+      url = "Url";
+      userName = "Username";
+      passwordCommand = "PasswordCmd";
+    };
+
+  filteredAccounts = let
+    mkAccount = account:
+      lib.filterAttrs (_: v: v != null) (with account.remote; {
+        Url = url;
+        Username = if userName == null then null else userName;
+        PasswordCmd =
+          if passwordCommand == null then null else toString passwordCommand;
+      });
+  in map mkAccount qcalAccounts;
+
+in {
+  meta.maintainers = with lib.maintainers; [ antonmosich ];
+
+  options = {
+    programs.qcal = {
+      enable = lib.mkEnableOption "qcal, a CLI calendar application";
+
+      timezone = lib.mkOption {
+        type = lib.types.singleLineStr;
+        default = "Local";
+        example = "Europe/Vienna";
+        description = "Timezone to display calendar entries in";
+      };
+
+      defaultNumDays = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 30;
+        description = "Default number of days to show calendar entries for";
+      };
+    };
+
+    accounts.calendar.accounts = lib.mkOption {
+      type = with lib.types;
+        attrsOf
+        (submodule { options.qcal.enable = lib.mkEnableOption "qcal access"; });
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ pkgs.qcal ];
+
+    xdg.configFile."qcal/config.json".source =
+      let jsonFormat = pkgs.formats.json { };
+      in jsonFormat.generate "qcal.json" {
+        DefaultNumDays = cfg.defaultNumDays;
+        Timezone = cfg.timezone;
+        Calendars = filteredAccounts;
+      };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -120,6 +120,7 @@ import nmt {
     ./modules/programs/powerline-go
     ./modules/programs/pubs
     ./modules/programs/pyenv
+    ./modules/programs/qcal
     ./modules/programs/qutebrowser
     ./modules/programs/readline
     ./modules/programs/ripgrep

--- a/tests/modules/programs/qcal/default.nix
+++ b/tests/modules/programs/qcal/default.nix
@@ -1,0 +1,5 @@
+{
+  qcal-http = ./http-calendar.nix;
+  qcal-webdav = ./webdav-calendar.nix;
+  qcal-mixed = ./mixed.nix;
+}

--- a/tests/modules/programs/qcal/http-calendar.json-expected
+++ b/tests/modules/programs/qcal/http-calendar.json-expected
@@ -1,0 +1,9 @@
+{
+  "Calendars": [
+    {
+      "Url": "https://example.com/events.ical"
+    }
+  ],
+  "DefaultNumDays": 30,
+  "Timezone": "Local"
+}

--- a/tests/modules/programs/qcal/http-calendar.nix
+++ b/tests/modules/programs/qcal/http-calendar.nix
@@ -1,0 +1,18 @@
+{ pkgs, lib, ... }:
+
+{
+  programs.qcal.enable = true;
+  accounts.calendar.accounts.test = {
+    qcal.enable = true;
+    remote = { url = "https://example.com/events.ical"; };
+  };
+
+  test.stubs = { qcal = { }; };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/qcal/config.json
+    assertFileContent home-files/.config/qcal/config.json ${
+      ./http-calendar.json-expected
+    }
+  '';
+}

--- a/tests/modules/programs/qcal/mixed.json-expected
+++ b/tests/modules/programs/qcal/mixed.json-expected
@@ -1,0 +1,14 @@
+{
+  "Calendars": [
+    {
+      "Url": "https://example.com/events.ical"
+    },
+    {
+      "PasswordCmd": "pass show calendar",
+      "Url": "https://cal.example.com/anton/work",
+      "Username": "anton"
+    }
+  ],
+  "DefaultNumDays": 30,
+  "Timezone": "Local"
+}

--- a/tests/modules/programs/qcal/mixed.nix
+++ b/tests/modules/programs/qcal/mixed.nix
@@ -1,0 +1,28 @@
+{ pkgs, lib, ... }:
+
+{
+  programs.qcal.enable = true;
+  accounts.calendar.accounts = {
+    http-test = {
+      remote = { url = "https://example.com/events.ical"; };
+      qcal.enable = true;
+    };
+    webdav-test = {
+      remote = {
+        url = "https://cal.example.com/anton/work";
+        userName = "anton";
+        passwordCommand = [ "pass" "show" "calendar" ];
+      };
+      qcal.enable = true;
+    };
+  };
+
+  test.stubs = { qcal = { }; };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/qcal/config.json
+    assertFileContent home-files/.config/qcal/config.json ${
+      ./mixed.json-expected
+    }
+  '';
+}

--- a/tests/modules/programs/qcal/webdav-calendar.json-expected
+++ b/tests/modules/programs/qcal/webdav-calendar.json-expected
@@ -1,0 +1,11 @@
+{
+  "Calendars": [
+    {
+      "PasswordCmd": "pass show calendar",
+      "Url": "https://cal.example.com/anton/work",
+      "Username": "anton"
+    }
+  ],
+  "DefaultNumDays": 23,
+  "Timezone": "Europe/Berlin"
+}

--- a/tests/modules/programs/qcal/webdav-calendar.nix
+++ b/tests/modules/programs/qcal/webdav-calendar.nix
@@ -1,0 +1,26 @@
+{ pkgs, lib, ... }:
+
+{
+  programs.qcal = {
+    enable = true;
+    defaultNumDays = 23;
+    timezone = "Europe/Berlin";
+  };
+  accounts.calendar.accounts.test = {
+    qcal.enable = true;
+    remote = {
+      url = "https://cal.example.com/anton/work";
+      userName = "anton";
+      passwordCommand = [ "pass" "show" "calendar" ];
+    };
+  };
+
+  test.stubs = { qcal = { }; };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/qcal/config.json
+    assertFileContent home-files/.config/qcal/config.json ${
+      ./webdav-calendar.json-expected
+    }
+  '';
+}


### PR DESCRIPTION
### Description
@teto suggested I write a home-manager module for qcal. qcal is a CLI calendar application, which does not cache anything, unlike most other similar applications.
While I played around in the recent months, I still feel rather new to nix, please review my code carefully.
My module and tests are heavily inspired by the existing khal module. I tried to make the tests such that config files can be semantically compared, not just diffed. The only problem I have there is that for qcal the "order" of calendars doesn't matter and as such the order in the list in the json file doesn't matter, but that is not included in the "semantic" comparison. If you have an idea on how to implement that, please tell me.

qcal has been very recently added to nixpkgs, ~qcal hasn't even made it to nixpkgs-unstable yet,~ so consider that when reviewing this PR.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
