### PR TITLE
home-manager: allow the tool to be installed in submodule setups

### DIFF
--- a/modules/programs/home-manager.nix
+++ b/modules/programs/home-manager.nix
@@ -27,7 +27,7 @@ in {
     };
   };
 
-  config = mkIf (cfg.enable && !config.submoduleSupport.enable) {
+  config = mkIf cfg.enable {
     home.packages =
       [ (pkgs.callPackage ../../home-manager { inherit (cfg) path; }) ];
   };


### PR DESCRIPTION
### Description

Is there a reason why the standalone tool is not allowed to be installed when you are using home-manager as a submodule? I guess it's not necessary since you can just use `nixos-rebuild` instead. But if the user chooses to enable it anyways, IMO it should be properly installed.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee
