### PR TITLE
bat: generate cache file in XDG cache home

### DIFF
--- a/modules/programs/bat.nix
+++ b/modules/programs/bat.nix
@@ -72,8 +72,11 @@ in {
       (name: body: { "bat/themes/${name}.tmTheme" = { text = body; }; }));
 
     home.activation.batCache = hm.dag.entryAfter [ "linkGeneration" ] ''
-      $VERBOSE_ECHO "Rebuilding bat theme cache"
-      $DRY_RUN_CMD ${lib.getExe package} cache --build
+      (
+        export XDG_CACHE_HOME=${escapeShellArg config.xdg.cacheHome}
+        $VERBOSE_ECHO "Rebuilding bat theme cache"
+        $DRY_RUN_CMD ${lib.getExe package} cache --build
+      )
     '';
   };
 }


### PR DESCRIPTION
### Description

Fixes #4345

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```