### PR TITLE
chromium: add support for dictionaries

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -123,6 +123,20 @@ let
           documentation](https://developer.chrome.com/docs/extensions/mv2/external_extensions).
         '';
       };
+
+      dictionaries = mkOption {
+        inherit visible;
+        type = types.listOf types.package;
+        default = [ ];
+        example = literalExpression ''
+          [
+            pkgs.hunspellDictsChromium.en_US
+          ]
+        '';
+        description = ''
+          List of ${name} dictionaries to install.
+        '';
+      };
     };
 
   browserConfig = cfg:
@@ -159,6 +173,11 @@ let
           });
         };
 
+      dictionary = pkg: {
+        name = "${configDir}/Dictionaries/${pkg.passthru.dictFileName}";
+        value.source = pkg;
+      };
+
       package = if cfg.commandLineArgs != [ ] then
         cfg.package.override {
           commandLineArgs = concatStringsSep " " cfg.commandLineArgs;
@@ -168,8 +187,9 @@ let
 
     in mkIf cfg.enable {
       home.packages = [ package ];
-      home.file = optionalAttrs (!isProprietaryChrome)
-        (listToAttrs (map extensionJson cfg.extensions));
+      home.file = optionalAttrs (!isProprietaryChrome) (listToAttrs
+        ((map extensionJson cfg.extensions)
+          ++ (map dictionary cfg.dictionaries)));
     };
 
 in {


### PR DESCRIPTION
### Description

This patch adds support for installing hunspell dictionaries in chromium.

Follow up to https://github.com/NixOS/nixpkgs/pull/238805

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
