### PR TITLE
zsh: allow enabling syntax highlighters

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -226,9 +226,20 @@ let
 
       package = mkPackageOption pkgs "zsh-syntax-highlighting" { };
 
+      highlighters = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "brackets" ];
+        description = ''
+          Highlighters to enable
+          See the list of highlighters: <https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters.md>
+        '';
+      };
+
       styles = mkOption {
         type = types.attrsOf types.str;
         default = {};
+        example = { comment = "fg=black,bold"; };
         description = ''
           Custom styles for syntax highlighting.
           See each highlighter's options: <https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters.md>
@@ -624,6 +635,7 @@ in
           # https://github.com/zsh-users/zsh-syntax-highlighting#faq
         ''
           source ${cfg.syntaxHighlighting.package}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+          ZSH_HIGHLIGHT_HIGHLIGHTERS+=(${lib.concatStringsSep " " (map lib.escapeShellArg cfg.syntaxHighlighting.highlighters)})
           ${lib.concatStringsSep "\n" (
               lib.mapAttrsToList
                 (name: value: "ZSH_HIGHLIGHT_STYLES+=(${lib.escapeShellArg name} ${lib.escapeShellArg value})")

--- a/tests/modules/programs/zsh/syntax-highlighting.nix
+++ b/tests/modules/programs/zsh/syntax-highlighting.nix
@@ -9,6 +9,7 @@ with lib;
       syntaxHighlighting = {
         enable = true;
         package = pkgs.hello;
+        highlighters = [ "brackets" "pattern" "cursor" ];
         styles.comment = "fg=#6c6c6c";
       };
     };
@@ -17,6 +18,7 @@ with lib;
 
     nmt.script = ''
       assertFileContains home-files/.zshrc "source ${pkgs.hello}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+      assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_HIGHLIGHTERS+=('brackets' 'pattern' 'cursor')"
       assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_STYLES+=('comment' 'fg=#6c6c6c')"
     '';
   };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
I added an option to enable individual highlighters (eg. bracket highlighting) for zsh.
Closes #4353.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@ThinkChaos 
