### PR TITLE
rbw: enable shell completion

### DIFF
--- a/modules/programs/rbw.nix
+++ b/modules/programs/rbw.nix
@@ -95,11 +95,47 @@ in {
         managed by Home Manager.
       '';
     };
+
+    enableBashIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Bash integration.
+      '';
+    };
+
+    enableZshIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Zsh integration.
+      '';
+    };
+
+    enableFishIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Fish integration.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
     {
       home.packages = [ cfg.package ];
+
+      programs.bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
+        source ${cfg.package}/share/bash-completion/completions/rbw.bash
+      '';
+
+      programs.zsh.initExtra = lib.mkIf cfg.enableZshIntegration ''
+        source ${cfg.package}/share/zsh/site-functions/_rbw
+      '';
+
+      programs.fish.shellInit = lib.mkIf cfg.enableFishIntegration ''
+        source ${cfg.package}/share/fish/vendor_completions.d/rbw.fish
+      '';
     }
 
     # Only manage configuration if not empty


### PR DESCRIPTION
### Description

rbw module autocompletion was not enabled. So I copy/pasted this feature from other modules.

NB: I only checked this on fish.

### Checklist

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@ambroisie 