### PR TITLE
home-cursor: remove IFD when linking icon directories

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -66,13 +66,6 @@ let
     '';
   };
 
-  iconMappings = let
-    knownFiles = filterAttrs (_: type: type != "unknown")
-      (builtins.readDir "${cfg.package}/share/icons");
-  in mapAttrs'
-  (n: _: nameValuePair ".icons/${n}" "${cfg.package}/share/icons/${n}")
-  knownFiles;
-
 in {
   meta.maintainers = [ maintainers.polykernel maintainers.league ];
 
@@ -154,20 +147,19 @@ in {
         XCURSOR_THEME = mkDefault cfg.name;
       };
 
-      # Add symlinks of cursor icons to subdirectories in $HOME/.icons, needed for
+      # Add symlink of cursor icon directory to $HOME/.icons, needed for
       # backwards compatibility with some applications. See:
       # https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s03.html
-      home.file = (mapAttrs (_: source: { inherit source; }) iconMappings) // {
-        ".icons/default/index.theme".source =
-          "${defaultIndexThemePackage}/share/icons/default/index.theme";
-      };
+      home.file.".icons/default/index.theme".source =
+        "${defaultIndexThemePackage}/share/icons/default/index.theme";
+      home.file.".icons/${cfg.name}".source =
+        "${cfg.package}/share/icons/${cfg.name}";
 
-      # Add cursor icon links to $XDG_DATA_HOME as well for redundancy.
-      xdg.dataFile = (mapAttrs (_: source: { inherit source; }) iconMappings)
-        // {
-          ".icons/default/index.theme".source =
-            "${defaultIndexThemePackage}/share/icons/default/index.theme";
-        };
+      # Add cursor icon link to $XDG_DATA_HOME as well for redundancy.
+      xdg.dataFile.".icons/default/index.theme".source =
+        "${defaultIndexThemePackage}/share/icons/default/index.theme";
+      xdg.dataFile.".icons/${cfg.name}".source =
+        "${cfg.package}/share/icons/${cfg.name}";
     }
 
     (mkIf cfg.x11.enable {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

An IFD was introduced in https://github.com/nix-community/home-manager/commit/bdb5bcad01ff7332fdcf4b128211e81905113f84, from reading the top-level directories of the
`home.pointerCursor.package` at instantiation time.

This commit removes the IFD introduced when linking icon directories by linking only the icon directory matching `home.pointerCursor.name` in `home.pointerCursor.package`. This should have the same effect as linking all top-level directories of the supplied icon package as the module generates cursor configurations pertaining to the cursor identified by `home.pointerCursor.name`. Since any additional icon directories present are not explicitly referenced by the module, any difference in behavior would be attributed to impurities and should be eliminated.

fixes https://github.com/nix-community/home-manager/issues/4367

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->