### PR TITLE
khal: add options for default and view sections

### DIFF
--- a/tests/modules/programs/khal/config.nix
+++ b/tests/modules/programs/khal/config.nix
@@ -1,7 +1,15 @@
 { ... }:
 
 {
-  programs.khal.enable = true;
+  programs.khal = {
+    enable = true;
+    settings = {
+      default.timedelta = "5d";
+      view.agenda_event_format =
+        "{calendar-color}{cancelled}{start-end-time-style} {title}{repeat-symbol}{reset}";
+    };
+
+  };
   accounts.calendar = {
     basePath = "$XDG_CONFIG_HOME/cal";
     accounts = {
@@ -27,6 +35,8 @@
   test.stubs = { khal = { }; };
 
   nmt.script = ''
-    assertFileExists home-files/.config/khal/config
+    configFile=home-files/.config/khal/config
+    assertFileExists $configFile
+    assertFileContent $configFile ${./khal-config-expected}
   '';
 }

--- a/tests/modules/programs/khal/khal-config-expected
+++ b/tests/modules/programs/khal/khal-config-expected
@@ -1,0 +1,26 @@
+[calendars]
+[[test]]
+path = /home/hm-user/$XDG_CONFIG_HOME/cal/test/
+readonly = True
+priority=10
+type=calendar
+
+
+
+[default]
+default_calendar=test
+highlight_event_days=true
+timedelta=5d
+
+[locale]
+dateformat=%x
+datetimeformat=%c
+firstweekday=0
+longdateformat=%x
+longdatetimeformat=%c
+timeformat=%X
+unicode_symbols=true
+weeknumbers=off
+
+[view]
+agenda_event_format={calendar-color}{cancelled}{start-end-time-style} {title}{repeat-symbol}{reset}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
The current khal module doesn't provide options to add settings in the [default] and [view] sections of the configuration file. This PR adds optional settings for both. I chose a generic option instead of separately defining all possible settings, due to the amount of them and the future maintenance required for keeping the list up to date.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
