### PR TITLE
ranger: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -113,6 +113,12 @@
     github = "foo-dogsquared";
     githubId = 34962634;
   };
+  fpob = {
+    name = "Filip Pobořil";
+    email = "fpob@proton.me";
+    github = "fpob";
+    githubId = 6289078;
+  };
   olmokramer = {
     name = "Olmo Kramer";
     email = "olmokramer@users.noreply.github.com";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1429,6 +1429,13 @@ in {
           A new module is available: 'programs.zk'
         '';
       }
+
+      {
+        time = "2024-03-08T22:23:24+00:00";
+        message = ''
+          A new module is available: 'programs.ranger'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -189,6 +189,7 @@ let
     ./programs/pylint.nix
     ./programs/qcal.nix
     ./programs/qutebrowser.nix
+    ./programs/ranger.nix
     ./programs/rbw.nix
     ./programs/readline.nix
     ./programs/rio.nix

--- a/modules/programs/ranger.nix
+++ b/modules/programs/ranger.nix
@@ -1,0 +1,182 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let cfg = config.programs.ranger;
+
+in {
+  options.programs.ranger = {
+    enable = mkEnableOption "ranger file manager";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.ranger;
+      defaultText = literalExpression "pkgs.ranger";
+      description = "The ranger package to use.";
+    };
+
+    extraPackages = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      description = "Extra packages added to ranger.";
+    };
+
+    finalPackage = mkOption {
+      type = types.package;
+      readOnly = true;
+      visible = false;
+      description = "Resulting ranger package.";
+    };
+
+    settings = mkOption {
+      type = types.attrsOf
+        (types.oneOf [ types.bool types.float types.int types.str ]);
+      default = { };
+      description = ''
+        Settings written to {file}`$XDG_CONFIG_HOME/ranger/rc.conf`.
+      '';
+      example = {
+        column_ratios = "1,3,3";
+        confirm_on_delete = "never";
+        unicode_ellipsis = true;
+        scroll_offset = 8;
+      };
+    };
+
+    aliases = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = ''
+        Aliases written to {file}`$XDG_CONFIG_HOME/ranger/rc.conf`.
+      '';
+      example = {
+        e = "edit";
+        setl = "setlocal";
+        filter = "scout -prts";
+      };
+    };
+
+    mappings = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = ''
+        Mappings written to {file}`$XDG_CONFIG_HOME/ranger/rc.conf`.
+      '';
+      example = {
+        Q = "quitall";
+        q = "quit";
+      };
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra configuration lines to add to
+        {file}`$XDG_CONFIG_HOME/ranger/rc.conf`.
+      '';
+    };
+
+    plugins = mkOption {
+      type = types.listOf (types.submodule {
+        options = {
+          name = mkOption {
+            type = types.str;
+            description = ''
+              Name of the plugin linked to
+              {file}`$XDG_CONFIG_HOME/ranger/plugins/`. In the case of a
+              single-file plugin, it must also have `.py` suffix.
+            '';
+          };
+          src = mkOption {
+            type = types.path;
+            description = ''
+              The plugin file or directory.
+            '';
+          };
+        };
+      });
+      default = [ ];
+      description = ''
+        List of files to be added to {file}`$XDG_CONFIG_HOME/ranger/plugins/`.
+      '';
+      example = literalExpression ''
+        [
+          {
+            name = "zoxide";
+            src = builtins.fetchGit {
+              url = "https://github.com/jchook/ranger-zoxide.git";
+              rev = "363df97af34c96ea873c5b13b035413f56b12ead";
+            };
+          }
+        ]
+      '';
+    };
+
+    rifle = mkOption {
+      type = types.listOf (types.submodule {
+        options = {
+          condition = mkOption {
+            type = types.str;
+            description = ''
+              A condition to match a file.
+            '';
+            example = "mime ^text, label editor";
+          };
+          command = mkOption {
+            type = types.str;
+            description = ''
+              A command to run for the matching file.
+            '';
+            example = literalExpression ''"${pkgs.vim}/bin/vim -- \"$@\""'';
+          };
+        };
+      });
+      default = [ ];
+      description = ''
+        Settings written to {file}`$XDG_CONFIG_HOME/ranger/rifle.conf`.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      programs.ranger.finalPackage = cfg.package.overrideAttrs (oldAttrs: {
+        propagatedBuildInputs = oldAttrs.propagatedBuildInputs
+          ++ cfg.extraPackages;
+      });
+
+      home.packages = [ cfg.finalPackage ];
+
+      xdg.configFile."ranger/rc.conf".text = let
+        mkString = generators.mkValueStringDefault { };
+        mkConfig = cmd:
+          generators.toKeyValue {
+            mkKeyValue = k: v: "${cmd} ${k} ${mkString v}";
+          };
+      in ''
+        ${mkConfig "set" cfg.settings}
+        ${mkConfig "alias" cfg.aliases}
+        ${mkConfig "map" cfg.mappings}
+        ${cfg.extraConfig}
+      '';
+    }
+
+    (mkIf (cfg.plugins != [ ]) {
+      xdg.configFile = let
+        toAttrs = i: {
+          name = "ranger/plugins/${i.name}";
+          value.source = i.src;
+        };
+      in listToAttrs (map toAttrs cfg.plugins);
+    })
+
+    (mkIf (cfg.rifle != [ ]) {
+      xdg.configFile."ranger/rifle.conf".text =
+        let lines = map (i: "${i.condition} = ${i.command}") cfg.rifle;
+        in concatLines lines;
+    })
+  ]);
+
+  meta.maintainers = [ hm.maintainers.fpob ];
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -126,6 +126,7 @@ in import nmtSrc {
     ./modules/programs/pyenv
     ./modules/programs/qcal
     ./modules/programs/qutebrowser
+    ./modules/programs/ranger
     ./modules/programs/readline
     ./modules/programs/rio
     ./modules/programs/ripgrep

--- a/tests/modules/programs/ranger/configuration-rc.conf
+++ b/tests/modules/programs/ranger/configuration-rc.conf
@@ -1,0 +1,13 @@
+set column_ratios 1,3,3
+set confirm_on_delete never
+set scroll_offset 8
+set unicode_ellipsis true
+
+alias e edit
+alias filter scout -prts
+alias setl setlocal
+
+map Q quitall
+map q quit
+
+unmap gd

--- a/tests/modules/programs/ranger/configuration-rifle.conf
+++ b/tests/modules/programs/ranger/configuration-rifle.conf
@@ -1,0 +1,2 @@
+mime ^text, label editor = vim -- "$@"
+mime ^text, label pager = less -- "$@"

--- a/tests/modules/programs/ranger/configuration.nix
+++ b/tests/modules/programs/ranger/configuration.nix
@@ -1,0 +1,43 @@
+{ ... }:
+
+{
+  programs.ranger = {
+    enable = true;
+    settings = {
+      column_ratios = "1,3,3";
+      confirm_on_delete = "never";
+      unicode_ellipsis = true;
+      scroll_offset = 8;
+    };
+    aliases = {
+      e = "edit";
+      setl = "setlocal";
+      filter = "scout -prts";
+    };
+    mappings = {
+      Q = "quitall";
+      q = "quit";
+    };
+    extraConfig = "unmap gd";
+    rifle = [
+      {
+        condition = "mime ^text, label editor";
+        command = ''vim -- "$@"'';
+      }
+      {
+        condition = "mime ^text, label pager";
+        command = ''less -- "$@"'';
+      }
+    ];
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/ranger/rc.conf
+    assertFileContent home-files/.config/ranger/rc.conf \
+      ${./configuration-rc.conf}
+
+    assertFileExists home-files/.config/ranger/rifle.conf
+    assertFileContent home-files/.config/ranger/rifle.conf \
+      ${./configuration-rifle.conf}
+  '';
+}

--- a/tests/modules/programs/ranger/default.nix
+++ b/tests/modules/programs/ranger/default.nix
@@ -1,0 +1,1 @@
+{ ranger-configuration = ./configuration.nix; }


### PR DESCRIPTION
### Description

Add module `programs.ranger`

Supersedes #3264 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
