### PR TITLE
neovim: Add missing newlines to init.lua

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -392,26 +392,25 @@ in {
 
     home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };
 
-    xdg.configFile =
-      let hasLuaConfig = hasAttr "lua" config.programs.neovim.generatedConfigs;
-      in mkMerge (
-        # writes runtime
-        (map (x: x.runtime) pluginsNormalized) ++ [{
-          "nvim/init.lua" = let
-            luaRcContent =
-              lib.optionalString (neovimConfig.neovimRcContent != "")
-              "vim.cmd [[source ${
-                pkgs.writeText "nvim-init-home-manager.vim"
-                neovimConfig.neovimRcContent
-              }]]" + config.programs.neovim.extraLuaConfig
-              + lib.optionalString hasLuaConfig
-              config.programs.neovim.generatedConfigs.lua;
-          in mkIf (luaRcContent != "") { text = luaRcContent; };
-
-          "nvim/coc-settings.json" = mkIf cfg.coc.enable {
-            source = jsonFormat.generate "coc-settings.json" cfg.coc.settings;
-          };
-        }]);
+    xdg.configFile = let
+      hasLuaConfig = hasAttr "lua" config.programs.neovim.generatedConfigs;
+      vimRcContent = lib.optionalString (neovimConfig != "") pkgs.writeText
+        "nvim-init-home-manager.vim" neovimConfig.neovimRcContent;
+      luaRcContent = lib.concatStringsSep "\n" (lib.remove "" [
+        (lib.optionalString (vimRcContent != "")
+          "vim.cmd [[source ${vimRcContent}]]")
+        (config.programs.neovim.extraLuaConfig)
+        (lib.optionalString hasLuaConfig
+          config.programs.neovim.generatedConfigs.lua)
+      ]);
+    in mkMerge (
+      # writes runtime
+      (map (x: x.runtime) pluginsNormalized) ++ [{
+        "nvim/init.lua" = mkIf (luaRcContent != "") { text = luaRcContent; };
+        "nvim/coc-settings.json" = mkIf cfg.coc.enable {
+          source = jsonFormat.generate "coc-settings.json" cfg.coc.settings;
+        };
+      }]);
 
     programs.neovim.finalPackage = pkgs.wrapNeovimUnstable cfg.package
       (neovimConfig // {

--- a/tests/modules/programs/neovim/default.nix
+++ b/tests/modules/programs/neovim/default.nix
@@ -6,4 +6,5 @@
   # waiting for a nixpkgs patch
   neovim-no-init = ./no-init.nix;
   neovim-extra-lua-init = ./extra-lua-init.nix;
+  neovim-init-newline = ./init-newline.nix;
 }

--- a/tests/modules/programs/neovim/init-newline.nix
+++ b/tests/modules/programs/neovim/init-newline.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  extraConfig = ''
+    echo extraConfigVim
+  '';
+in {
+  config = {
+    programs.neovim = {
+      enable = true;
+      inherit extraConfig;
+      extraLuaConfig = ''
+        -- extraLuaConfig
+      '';
+    };
+    nmt.script = ''
+      nvimFolder="home-files/.config/nvim"
+      assertFileContent "$nvimFolder/init.lua" ${
+        pkgs.writeText "init.lua-expected" ''
+          vim.cmd [[source ${
+            pkgs.writeText "nvim-init-home-manager.vim" extraConfig
+          }]]
+          -- extraLuaConfig
+        ''
+      }
+    '';
+  };
+}


### PR DESCRIPTION
### Description

When generating `init.lua` the Lua config would be placed immediately
after the nvim config without a new line.

```
vim.cmd [[source /nix/store/cs3al9x1ml5ds3n6n433wcdxp89awac4-nvim-init-home-manager.vim]]--first line of Lua config
```

This change places a newline after each config portion.

```
vim.cmd [[source /nix/store/cs3al9x1ml5ds3n6n433wcdxp89awac4-nvim-init-home-manager.vim]]
--first line of Lua config
```
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
