### PR TITLE
grobi: Fix configuration file to emit YAML as expected by the tool

### DIFF
--- a/modules/services/grobi.nix
+++ b/modules/services/grobi.nix
@@ -94,9 +94,10 @@ in {
       Install = { WantedBy = [ "graphical-session.target" ]; };
     };
 
-    xdg.configFile."grobi.conf".text = builtins.toJSON {
-      execute_after = cfg.executeAfter;
-      rules = cfg.rules;
-    };
+    xdg.configFile."grobi.conf".source =
+      (pkgs.formats.yaml { }).generate "grobi-config" {
+        execute_after = cfg.executeAfter;
+        rules = cfg.rules;
+      };
   };
 }


### PR DESCRIPTION
### Description

When trying to work with 'grobi' i noted the service just fail and die,
when looking into it i've found out that the service expects YAML configuration but home manager converts it into JSON instead.

Looking at the project repo (https://github.com/fd0/grobi) shows there is only YAML support

Note regarding tests:
this is trying to drive by fix a problem found locally,
i looked into it and saw grobi today doesn't have any test case :\
looking at examples i see i can make a simple test, ok, but it doens't really trigger a verification on the tool just that "nix to yaml" conversion works,
is there a way to actually validate the emitted config?
Also, if im adding a new test for grobi, how do i trigger just it and not the whole test suite?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@mbrgm