### PR TITLE
tmpfiles: use only `xdg.configFile`

### DIFF
--- a/modules/misc/tmpfiles.nix
+++ b/modules/misc/tmpfiles.nix
@@ -27,8 +27,8 @@ in {
         platforms.linux)
     ];
 
-    xdg = {
-      dataFile."user-tmpfiles.d/home-manager.conf" = {
+    xdg.configFile = {
+      "user-tmpfiles.d/home-manager.conf" = {
         text = ''
           # This file is created automatically and should not be modified.
           # Please change the option ‘systemd.user.tmpfiles.rules’ instead.
@@ -36,16 +36,14 @@ in {
         '';
         onChange = "${pkgs.systemd}/bin/systemd-tmpfiles --user --create";
       };
-      configFile = {
-        "systemd/user/basic.target.wants/systemd-tmpfiles-setup.service".source =
-          "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-setup.service";
-        "systemd/user/systemd-tmpfiles-setup.service".source =
-          "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-setup.service";
-        "systemd/user/timers.target.wants/systemd-tmpfiles-clean.timer".source =
-          "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-clean.timer";
-        "systemd/user/systemd-tmpfiles-clean.service".source =
-          "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-clean.service";
-      };
+      "systemd/user/basic.target.wants/systemd-tmpfiles-setup.service".source =
+        "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-setup.service";
+      "systemd/user/systemd-tmpfiles-setup.service".source =
+        "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-setup.service";
+      "systemd/user/timers.target.wants/systemd-tmpfiles-clean.timer".source =
+        "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-clean.timer";
+      "systemd/user/systemd-tmpfiles-clean.service".source =
+        "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-clean.service";
     };
   };
 }


### PR DESCRIPTION
### Description

In `modules/misc/tmpfiles.nix`, replace the single use of `xdg.dataFile` with `xdg.configFile`, which was used anyways.

Not only is this a small (positive) refactor, but it minimises the impact of #4397, as setting `xdg.dataHome` outside the homedir will not break `tmpfiles` anymore.


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted as per [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@dawidsowa
