### PR TITLE
khard: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -118,6 +118,7 @@ let
     ./programs/kakoune.nix
     ./programs/keychain.nix
     ./programs/khal.nix
+    ./programs/khard.nix
     ./programs/kitty.nix
     ./programs/kodi.nix
     ./programs/lazygit.nix

--- a/modules/programs/khard.nix
+++ b/modules/programs/khard.nix
@@ -1,0 +1,101 @@
+{ lib, config, pkgs, ... }:
+let
+  cfg = config.programs.khard;
+
+  khardAccounts = (lib.filterAttrs (_: a: a.khard.enable == true)
+    config.accounts.contact.accounts);
+
+  genStr = _: entry:
+    lib.concatStringsSep "\n" [
+      "[[${entry.name}]]"
+      "path=${entry.local.path}"
+    ];
+
+  mkKeyValue = lib.generators.mkKeyValueDefault {
+    mkValueString = (v:
+      with builtins;
+      if lib.isDerivation v then
+        toString v
+        # we default to not quoting strings
+      else if isString v then
+        v
+        # isString returns "1", which is not a good default
+      else if true == v then
+        "yes"
+        # here it returns to "", which is even less of a good default
+      else if false == v then
+        "no"
+      else if null == v then
+        "null"
+      else if isList v then
+        lib.concatStringsSep ", " v
+      else
+        "");
+  } "=";
+in {
+  meta.maintainers = with lib.maintainers; [ antonmosich ];
+
+  options = {
+    programs.khard = {
+      enable = lib.mkEnableOption "khard, a CLI vcard client";
+
+      defaultAction = lib.mkOption {
+        type = lib.types.enum [
+          "add-email"
+          "addressbooks"
+          "birthdays"
+          "copy"
+          "edit"
+          "email"
+          "filename"
+          "list"
+          "merge"
+          "move"
+          "new"
+          "phone"
+          "postaddress"
+          "remove"
+          "show"
+          "template"
+        ];
+        default = "list";
+        description = "The default action to execute";
+      };
+
+      settings = lib.mkOption {
+        type = with lib.types;
+          attrsOf (attrsOf (oneOf [ bool str (listOf str) ]));
+        default = { };
+        example = {
+          general.editor = [ "vim" "-i" "NONE" ];
+          "contact table" = {
+            display = "first_name";
+            show_nicknames = true;
+            show_uids = false;
+          };
+        };
+        description =
+          "Additional settings for khard. Other options take precedence.";
+      };
+    };
+
+    accounts.contact.accounts = lib.mkOption {
+      type = with lib.types;
+        attrsOf (submodule {
+          options.khard.enable = lib.mkEnableOption "khard access";
+        });
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ pkgs.khard ];
+
+    xdg.configFile."khard/khard.conf".text = lib.concatStringsSep "\n"
+      ([ "[addressbooks]" ] ++ (lib.mapAttrsToList genStr khardAccounts) ++ [
+        (lib.generators.toINI { inherit mkKeyValue; }
+          (lib.recursiveUpdate cfg.settings {
+            general = { default_action = cfg.defaultAction; };
+          }))
+      ]);
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -92,6 +92,7 @@ import nmt {
     ./modules/programs/kakoune
     ./modules/programs/kitty
     ./modules/programs/khal
+    ./modules/programs/khard
     ./modules/programs/ledger
     ./modules/programs/less
     ./modules/programs/lf

--- a/tests/modules/programs/khard/default.nix
+++ b/tests/modules/programs/khard/default.nix
@@ -1,0 +1,1 @@
+{ khard-example = ./example-config.nix; }

--- a/tests/modules/programs/khard/example-config.expected
+++ b/tests/modules/programs/khard/example-config.expected
@@ -1,0 +1,28 @@
+[addressbooks]
+[[family]]
+path=~/.contacts/family/
+[[friends]]
+path=~/.contacts/friends/
+[contact table]
+display=first_name
+group_by_addressbook=no
+localize_dates=yes
+preferred_email_address_type=pref, work, home
+preferred_phone_number_type=pref, cell, home
+reverse=no
+show_kinds=no
+show_nicknames=no
+show_uids=yes
+sort=last_name
+
+[general]
+debug=no
+default_action=list
+editor=vim, -i, NONE
+merge_editor=vimdiff
+
+[vcard]
+preferred_version=3.0
+private_objects=Jabber, Skype, Twitter
+search_in_source_files=no
+skip_unparsable=no

--- a/tests/modules/programs/khard/example-config.nix
+++ b/tests/modules/programs/khard/example-config.nix
@@ -1,0 +1,52 @@
+{ lib, pkgs, ... }:
+
+{
+  programs.khard = {
+    enable = true;
+    defaultAction = "list";
+    settings = {
+      general = {
+        debug = false;
+        editor = [ "vim" "-i" "NONE" ];
+        merge_editor = "vimdiff";
+      };
+      "contact table" = {
+        display = "first_name";
+        group_by_addressbook = false;
+        reverse = false;
+        show_nicknames = false;
+        show_uids = true;
+        show_kinds = false;
+        sort = "last_name";
+        localize_dates = true;
+        preferred_phone_number_type = [ "pref" "cell" "home" ];
+        preferred_email_address_type = [ "pref" "work" "home" ];
+      };
+      vcard = {
+        private_objects = [ "Jabber" "Skype" "Twitter" ];
+        preferred_version = "3.0";
+        search_in_source_files = false;
+        skip_unparsable = false;
+      };
+    };
+  };
+  accounts.contact.accounts = {
+    family = {
+      khard.enable = true;
+      local.path = "~/.contacts/family/";
+    };
+    friends = {
+      khard.enable = true;
+      local.path = "~/.contacts/friends/";
+    };
+  };
+
+  test.stubs = { khard = { }; };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/khard/khard.conf
+    assertFileContent home-files/.config/khard/khard.conf ${
+      ./example-config.expected
+    }
+  '';
+}


### PR DESCRIPTION
### Description
Adds a [khard](https://github.com/lucc/khard) module. Khard is an application somewhat similar, though not directly related to khal. Khard is used for managing, viewing etc. contacts that e.g. have been synced with vdirsyncer or similar applications.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

emacs-extra-config fails on my machine, but the tests for this PR pass.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
