### PR TITLE
nnn: Add extraSessionVariables and extraArgs

### DIFF
--- a/tests/modules/programs/nnn/nnn.nix
+++ b/tests/modules/programs/nnn/nnn.nix
@@ -19,6 +19,11 @@
         v = "imgview";
       };
     };
+    extraArgs = [ "-b d" "-P c" ];
+    extraSessionVariables = {
+      NNN_OPTS = "cEnrx";
+      NNN_COLORS = "#0a1b2c3d";
+    };
   };
 
   test.stubs = {
@@ -48,6 +53,15 @@
       for plugin in 'export NNN_PLUG' 'fzcd' 'finder' 'imgview'; do
         assertFileRegex home-path/bin/nnn "$plugin"
       done
+
+      for argument in '\-b d' '\-P c'; do
+        assertFileRegex home-path/bin/nnn "$argument"
+      done
+
+      for variable in 'export NNN_OPTS' 'cEnrx' 'export NNN_COLORS' '#0a1b2c3d'; do
+        assertFileRegex home-path/bin/nnn "$variable"
+      done
+
     '';
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

I have added two options to the nnn module, `extraSessionVariables` and `extraArgs`. They add environment variables and arguments, respectively, to nnn's wrapper.

My rationale for this change is that it simplifies calling nnn in contexts where environment variables and aliases set in one's shell may not necessarily be available, such as by executing it through keybindings set in window managers such as `hyprland`.

Currently, one would have to run nnn indirectly using `bash -c`, `zsh -c`, etc. in order to give it access to arguments set through aliases and environment variables not already set by Home Manager.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@thiagokokada 