### PR TITLE
vdirsyncer: add urlCommand and userNameCommand options

### DIFF
--- a/modules/accounts/calendar.nix
+++ b/modules/accounts/calendar.nix
@@ -58,15 +58,6 @@ let
         description = "User name for authentication.";
       };
 
-      # userNameCommand = mkOption {
-      #   type = types.nullOr (types.listOf types.str);
-      #   default = null;
-      #   example = [ "~/get-username.sh" ];
-      #   description = ''
-      #     A command that prints the user name to standard output.
-      #   '';
-      # };
-
       passwordCommand = mkOption {
         type = types.nullOr (types.listOf types.str);
         default = null;

--- a/modules/programs/vdirsyncer-accounts.nix
+++ b/modules/programs/vdirsyncer-accounts.nix
@@ -10,6 +10,20 @@ in {
   options.vdirsyncer = {
     enable = mkEnableOption "synchronization using vdirsyncer";
 
+    urlCommand = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      example = [ "~/get-url.sh" ];
+      description = "A command that prints the URL of the storage.";
+    };
+
+    userNameCommand = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      example = [ "~/get-username.sh" ];
+      description = "A command that prints the user name to standard output.";
+    };
+
     collections = mkOption {
       type = types.nullOr (types.listOf collection);
       default = null;


### PR DESCRIPTION
### Description

Fixes #4399 

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@pjones @teto 