### PR TITLE
email: fix runbox.com TLS setup

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -465,9 +465,15 @@ let
       })
 
       (mkIf (config.flavor == "runbox.com") {
-        imap = { host = "mail.runbox.com"; };
+        imap = {
+          host = "mail.runbox.com";
+          port = 993;
+        };
 
-        smtp = { host = "mail.runbox.com"; };
+        smtp = {
+          host = "mail.runbox.com";
+          port = if config.smtp.tls.useStartTls then 587 else 465;
+        };
       })
     ];
   };


### PR DESCRIPTION
### Description

This adds proper TLS port configuration for runbox.com IMAP and SMTP servers.

### Checklist

- [X] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee (not too sure, could not find meta.maintainers, sorry)