### PR TITLE
eza: init

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1214,6 +1214,13 @@ in
           A new module is available: 'programs.carapace'.
         '';
       }
+
+      {
+        time = "2023-09-07T14:52:19+00:00";
+        message = ''
+          A new module is available: 'programs.eza'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -78,6 +78,7 @@ let
     ./programs/eclipse.nix
     ./programs/emacs.nix
     ./programs/eww.nix
+    ./programs/eza.nix
     ./programs/exa.nix
     ./programs/feh.nix
     ./programs/firefox.nix

--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  meta.maintainers = [ maintainers.cafkafk ];
+
+  options.programs.eza = {
+    enable = mkEnableOption "eza, a modern replacement for {command}`ls`";
+
+    enableAliases = mkEnableOption "recommended eza aliases (ls, ll…)";
+
+    extraOptions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "--group-directories-first" "--header" ];
+      description = ''
+        Extra command line options passed to eza.
+      '';
+    };
+
+    icons = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Display icons next to file names ({option}`--icons` argument).
+      '';
+    };
+
+    git = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        List each file's Git status if tracked or ignored ({option}`--git` argument).
+      '';
+    };
+
+    package = mkPackageOption pkgs "eza" { };
+  };
+
+  config = let
+    cfg = config.programs.eza;
+
+    args = escapeShellArgs (optional cfg.icons "--icons"
+      ++ optional cfg.git "--git" ++ cfg.extraOptions);
+
+    aliases = {
+      eza = "eza ${args}";
+    } // optionalAttrs cfg.enableAliases {
+      ls = "eza";
+      ll = "eza -l";
+      la = "eza -a";
+      lt = "eza --tree";
+      lla = "eza -la";
+    };
+  in mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.bash.shellAliases = aliases;
+
+    programs.zsh.shellAliases = aliases;
+
+    programs.fish.shellAliases = aliases;
+
+    programs.ion.shellAliases = aliases;
+  };
+}


### PR DESCRIPTION
This copies the exa configuration for eza, the official fork of the
program.

Signed-off-by: Christina Sørensen <christina@cafkafk.com>

Refs: https://github.com/eza-community/eza/issues/207, https://github.com/ogham/exa/issues/1243

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
