### PR TITLE
swaylock: Document the need for host PAM configuration

### DIFF
--- a/modules/programs/swaylock.nix
+++ b/modules/programs/swaylock.nix
@@ -16,7 +16,21 @@ in {
         false otherwise
       '';
       example = true;
-      description = "Whether to enable swaylock.";
+      description = ''
+        Whether to enable swaylock.
+
+        Note that PAM must be configured to enable swaylock to perform
+        authentication. The package installed through home-manager
+        will *not* be able to unlock the session without this
+        configuration.
+
+        On NixOS, this is by default enabled with the sway module, but
+        for other compositors it can currently be enabled using:
+
+        ```nix
+        security.pam.services.swaylock = {};
+        ```
+      '';
     };
 
     package = mkPackageOption pkgs "swaylock" { };


### PR DESCRIPTION
### Description

This adds a note about how swaylock can actually be made to unlock sessions when swaylock-specific PAM configuration is not yet set up.

The note on how to do it on NixOS seems like a useful hint, it's probably the most common use case where this will fail, but shout if NixOS-specific notes are not right here.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
  - [x] This is a documentation change; tested with `nix build .#html-docs` instead

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  - N/A

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
    - N/A

#### Maintainer CC

@rcerc 
