### PR TITLE
emacs: add version for default.el package

### DIFF
--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -19,6 +19,7 @@ let
       userConfig = epkgs.trivialBuild {
         pname = "default";
         src = pkgs.writeText "default.el" cfg.extraConfig;
+        version = "0.1.0";
         packageRequires = packages;
       };
     in packages ++ optional (cfg.extraConfig != "") userConfig;


### PR DESCRIPTION
A recent change[1] in Nixpkgs makes version attribute non-optional.

This change fixes evaluation of user configurations where `programs.emacs.extraConfig` is used.

[1]: https://github.com/NixOS/nixpkgs/pull/253448

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
