### PR TITLE
home-manager: fix some completions commands

### DIFF
--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -301,7 +301,7 @@ _home-manager_completions ()
               "--verbose" "--cores" "--debug" "--impure" "--keep-failed" \
               "--keep-going" "-j" "--max-jobs" "--no-substitute" "--no-out-link" \
               "-L" "--print-build-logs" \
-              "--show-trace" "--substitute" "--builders" "--version" \
+              "--show-trace" "--flake" "--substitute" "--builders" "--version" \
               "--update-input" "--override-input" "--experimental-features" \
               "--extra-experimental-features" "--refresh")
 

--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -6,6 +6,7 @@ _arguments \
   '-A[attribute]:ATTRIBUTE:()' \
   '-I[search path]:PATH:_files -/' \
   '-b[backup files]:EXT:()' \
+  '--flake[flake-uri]:PATH:_files -/' \
   '--cores[cores]:NUM:()' \
   '--debug[debug]' \
   '--impure[impure]' \
@@ -53,6 +54,7 @@ case "$state" in
       build|switch)
         _arguments \
           '--cores[cores]:NUM:()' \
+          '--flake[flake-uri]:PATH:_files -/' \
           '--debug[debug]' \
           '--impure[impure]' \
           '--keep-failed[keep failed]' \


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
