### PR TITLE
cliphist: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -242,6 +242,7 @@ let
     ./services/cachix-agent.nix
     ./services/caffeine.nix
     ./services/cbatticon.nix
+    ./services/cliphist.nix
     ./services/clipman.nix
     ./services/clipmenu.nix
     ./services/comodoro.nix

--- a/modules/services/cliphist.nix
+++ b/modules/services/cliphist.nix
@@ -1,0 +1,50 @@
+{ config, lib, pkgs, ... }:
+let cfg = config.services.cliphist;
+in {
+  meta.maintainers = [ lib.maintainers.janik ];
+
+  options.services.cliphist = {
+    enable =
+      lib.mkEnableOption "cliphist, a clipboard history “manager” for wayland";
+
+    package = lib.mkPackageOption pkgs "cliphist" { };
+
+    systemdTarget = lib.mkOption {
+      type = lib.types.str;
+      default = "graphical-session.target";
+      example = "sway-session.target";
+      description = ''
+        The systemd target that will automatically start the cliphist service.
+
+        When setting this value to `"sway-session.target"`,
+        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+        otherwise the service may never be started.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.cliphist" pkgs
+        lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    systemd.user.services.cliphist = {
+      Unit = {
+        Description = "Clipboard management daemon";
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        Type = "simple";
+        ExecStart =
+          "${pkgs.wl-clipboard}/bin/wl-paste --watch ${cfg.package}/bin/cliphist store";
+        Restart = "on-failure";
+      };
+
+      Install = { WantedBy = [ cfg.systemdTarget ]; };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -198,6 +198,7 @@ import nmt {
     ./modules/services/barrier
     ./modules/services/borgmatic
     ./modules/services/cachix-agent
+    ./modules/services/cliphist
     ./modules/services/clipman
     ./modules/services/comodoro
     ./modules/services/devilspie2

--- a/tests/modules/services/cliphist/cliphist-sway-session-target.nix
+++ b/tests/modules/services/cliphist/cliphist-sway-session-target.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  services.cliphist = {
+    enable = true;
+    systemdTarget = "sway-session.target";
+  };
+
+  test.stubs = {
+    cliphist = { };
+    wl-clipboard = { };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/systemd/user/cliphist.service
+  '';
+}

--- a/tests/modules/services/cliphist/default.nix
+++ b/tests/modules/services/cliphist/default.nix
@@ -1,0 +1,1 @@
+{ cliphist-sway-session-target = ./cliphist-sway-session-target.nix; }


### PR DESCRIPTION
### Description

This adds a module for https://github.com/sentriz/cliphist and is strongly inspired by the clipman module but still has some differences.  

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
