### PR TITLE
bat: allow adding custom syntaxes

### DIFF
--- a/modules/programs/bat.nix
+++ b/modules/programs/bat.nix
@@ -60,6 +60,24 @@ in {
       '';
     };
 
+    syntaxes = mkOption {
+      type = types.attrsOf types.lines;
+      default = { };
+      example = literalExpression ''
+        {
+          syntaxes.gleam = builtins.readFile (pkgs.fetchFromGitHub {
+            owner = "molnarmark";
+            repo = "sublime-gleam";
+            rev = "2e761cdb1a87539d827987f997a20a35efd68aa9";
+            hash = "sha256-Zj2DKTcO1t9g18qsNKtpHKElbRSc9nBRE2QBzRn9+qs=";
+          } + "/syntax/gleam.sublime-syntax");
+        }
+      '';
+      description = ''
+        Additional syntaxes to provide.
+      '';
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -69,7 +87,10 @@ in {
       "bat/config" =
         mkIf (cfg.config != { }) { text = toConfigFile cfg.config; };
     }] ++ flip mapAttrsToList cfg.themes
-      (name: body: { "bat/themes/${name}.tmTheme" = { text = body; }; }));
+      (name: body: { "bat/themes/${name}.tmTheme" = { text = body; }; })
+      ++ flip mapAttrsToList cfg.syntaxes (name: body: {
+        "bat/syntaxes/${name}.sublime-syntax" = { text = body; };
+      }));
 
     home.activation.batCache = hm.dag.entryAfter [ "linkGeneration" ] ''
       (

--- a/tests/modules/programs/bat/bat.nix
+++ b/tests/modules/programs/bat/bat.nix
@@ -16,6 +16,10 @@ with lib;
       themes.testtheme = ''
         This is a test theme.
       '';
+
+      syntaxes.testsyntax = ''
+        This is a test syntax.
+      '';
     };
 
     test.stubs.bat = { };
@@ -35,6 +39,13 @@ with lib;
       assertFileContent home-files/.config/bat/themes/testtheme.tmTheme ${
         pkgs.writeText "bat.expected" ''
           This is a test theme.
+        ''
+      }
+
+      assertFileExists home-files/.config/bat/syntaxes/testsyntax.sublime-syntax
+      assertFileContent home-files/.config/bat/syntaxes/testsyntax.sublime-syntax ${
+        pkgs.writeText "bat.expected" ''
+          This is a test syntax.
         ''
       }
     '';


### PR DESCRIPTION
adds an option to add custom syntax files to bat's cache, analogous to the existing programs.bat.themes option.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
  - [x] Code tested through `nix develop --ignore-environment .#bat`; I also tried the above, but it fails in some emacs test (which also fails on current master for me, i.e. 5171f5ef654425e09d9c2100f856d887da595437, so I've ignored it)
  - (also currently in use in my own home config)

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

maintainer list is empty; @rycee made the last commit touching the module