### PR TITLE
home-manager-auto-expire: init

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2201,6 +2201,16 @@ in {
           services into a video player.
         '';
       }
+
+      {
+        time = "2025-04-02T00:00:00+00:00";
+        message = ''
+          A new service is available: 'services.home-manager.autoExpire'.
+
+          A service that allow to automatically expire (and optionally clean-up
+          Nix's store) old Home-Manager generations.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -340,6 +340,7 @@ let
     ./services/gpg-agent.nix
     ./services/grobi.nix
     ./services/gromit-mpx.nix
+    ./services/home-manager-auto-expire.nix
     ./services/home-manager-auto-upgrade.nix
     ./services/hound.nix
     ./services/hypridle.nix

--- a/modules/services/home-manager-auto-expire.nix
+++ b/modules/services/home-manager-auto-expire.nix
@@ -1,0 +1,100 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  cfg = config.services.home-manager.autoExpire;
+
+  homeManagerPackage = pkgs.callPackage ../../home-manager {
+    path = config.programs.home-manager.path;
+  };
+
+in {
+  meta.maintainers = [ lib.maintainers.thiagokokada ];
+
+  options = {
+    services.home-manager.autoExpire = {
+      enable = lib.mkEnableOption ''
+        the Home Manager expire service that periodically expire your
+        old Home Manager generations'';
+
+      timestamp = lib.mkOption {
+        type = lib.types.str;
+        default = "-30 days";
+        example = "-7 days";
+        description = ''
+          Remove generations older than `TIMESTAMP` where `TIMESTAMP` is
+          interpreted as in the -d argument of the date tool.
+        '';
+      };
+
+      frequency = lib.mkOption {
+        type = lib.types.str;
+        default = "monthly";
+        example = "weekly";
+        description = ''
+          The interval at which the Home Manager auto expire is run.
+
+          This value is passed to the systemd timer configuration
+          as the `OnCalendar` option.
+
+          The format is described in {manpage}`systemd.time(7)`.
+        '';
+      };
+
+      store = {
+        cleanup = lib.mkEnableOption ''
+          to cleanup Nix store when the Home Manager expire service runs.
+
+          It will use `nix-collect-garbage` to cleanup the store,
+          removing all unreachable store objects from the current user
+          (i.e.: not only the expired Home Manager generations).
+
+          This may not be what you want, this is why this option is disabled
+          by default'';
+
+        options = lib.mkOption {
+          type = lib.types.str;
+          description = ''
+            Options given to `nix-collection-garbage` when the service runs.
+          '';
+          default = "";
+          example = "--delete-older-than 30d";
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.home-manager.autoExpire" pkgs
+        lib.platforms.linux)
+    ];
+
+    systemd.user = {
+      timers.home-manager-auto-expire = {
+        Unit.Description = "Home Manager expire generations timer";
+
+        Install.WantedBy = [ "timers.target" ];
+
+        Timer = {
+          OnCalendar = cfg.frequency;
+          Unit = "home-manager-auto-expire.service";
+          Persistent = true;
+        };
+      };
+
+      services.home-manager-auto-expire = {
+        Unit.Description = "Home Manager expire generations";
+
+        Service.ExecStart = toString
+          (pkgs.writeShellScript "home-manager-auto-expire" (''
+            echo "Expire old Home Manager generations"
+            ${homeManagerPackage}/bin/home-manager expire-generations '${cfg.timestamp}'
+          '' + lib.optionalString cfg.store.cleanup ''
+            echo "Clean-up Nix store"
+            ${pkgs.nix}/bin/nix-collect-garbage ${cfg.store.options}
+          ''));
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -514,6 +514,7 @@ in import nmtSrc {
     ./modules/services/git-sync
     ./modules/services/glance
     ./modules/services/gromit-mpx
+    ./modules/services/home-manager-auto-expire
     ./modules/services/home-manager-auto-upgrade
     ./modules/services/hypridle
     ./modules/services/hyprpaper

--- a/tests/modules/services/home-manager-auto-expire/basic-configuration.nix
+++ b/tests/modules/services/home-manager-auto-expire/basic-configuration.nix
@@ -1,0 +1,18 @@
+{
+  config = {
+    services.home-manager.autoExpire = {
+      enable = true;
+      timestamp = "-7 days";
+      frequency = "00:00";
+      cleanup.store = true;
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/home-manager-auto-expire.service
+      assertFileExists $serviceFile
+
+      timerFile=home-files/.config/systemd/user/home-manager-auto-expire.timer
+      assertFileExists $timerFile
+    '';
+  };
+}

--- a/tests/modules/services/home-manager-auto-expire/default.nix
+++ b/tests/modules/services/home-manager-auto-expire/default.nix
@@ -1,0 +1,1 @@
+{ home-manager-auto-expire-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This commit introduces a new service that expires old Home-Manager generations.

It is inspired in the `home-manager-auto-upgrade` service that already exists: https://github.com/nix-community/home-manager/blob/master/modules/services/home-manager-auto-upgrade.nix

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
