### PR TITLE
home-manager.pot: fix typo

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -132,7 +132,7 @@ function setHomeManagerNixPath() {
             _iWarn $'The fallback Home Manager path %s has been deprecated and a file/directory was found there.' \
                    "$p"
             # translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
-            _i $'To remove this warning, do one of the fallowing.
+            _i $'To remove this warning, do one of the following.
 
 1. Explicitly tell Home Manager to use the path, for example by adding
 

--- a/home-manager/po/ca.po
+++ b/home-manager/po/ca.po
@@ -52,7 +52,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/cs.po
+++ b/home-manager/po/cs.po
@@ -54,7 +54,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/da.po
+++ b/home-manager/po/da.po
@@ -54,7 +54,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/de.po
+++ b/home-manager/po/de.po
@@ -54,7 +54,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/es.po
+++ b/home-manager/po/es.po
@@ -54,7 +54,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/fa.po
+++ b/home-manager/po/fa.po
@@ -50,7 +50,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/fi.po
+++ b/home-manager/po/fi.po
@@ -48,7 +48,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/fr.po
+++ b/home-manager/po/fr.po
@@ -54,7 +54,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/home-manager.pot
+++ b/home-manager/po/home-manager.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2023-07-30 09:08+0200\n"
+"POT-Creation-Date: 2023-09-13 23:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,36 +18,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: home-manager/home-manager:71
+#: home-manager/home-manager:81
 msgid "No configuration file found at %s"
 msgstr ""
 
 #. translators: The first '%s' specifier will be replaced by either
 #. 'home.nix' or 'flake.nix'.
-#: home-manager/home-manager:88 home-manager/home-manager:92
-#: home-manager/home-manager:182
+#: home-manager/home-manager:98 home-manager/home-manager:102
+#: home-manager/home-manager:192
 msgid ""
 "Keeping your Home Manager %s in %s is deprecated,\n"
 "please move it to %s"
 msgstr ""
 
-#: home-manager/home-manager:99
+#: home-manager/home-manager:109
 msgid "No configuration file found. Please create one at %s"
 msgstr ""
 
-#: home-manager/home-manager:114
+#: home-manager/home-manager:124
 msgid "Home Manager not found at %s."
 msgstr ""
 
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
-#: home-manager/home-manager:122
+#: home-manager/home-manager:132
 msgid ""
 "The fallback Home Manager path %s has been deprecated and a file/directory "
 "was found there."
 msgstr ""
 
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
-#: home-manager/home-manager:125
+#: home-manager/home-manager:135
 msgid ""
 "To remove this warning, do one of the following.\n"
 "\n"
@@ -68,38 +68,38 @@ msgid ""
 "     $ rm -r \"%s\""
 msgstr ""
 
-#: home-manager/home-manager:164
+#: home-manager/home-manager:174
 msgid "Could not find suitable profile directory, tried %s and %s"
 msgstr ""
 
 #. translators: Here "flake" is a noun that refers to the Nix Flakes feature.
-#: home-manager/home-manager:219
+#: home-manager/home-manager:229
 msgid "Can't inspect options of a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:281 home-manager/home-manager:304
-#: home-manager/home-manager:1023
+#: home-manager/home-manager:291 home-manager/home-manager:314
+#: home-manager/home-manager:1034
 msgid "%s: unknown option '%s'"
 msgstr ""
 
-#: home-manager/home-manager:286 home-manager/home-manager:1024
+#: home-manager/home-manager:296 home-manager/home-manager:1035
 msgid "Run '%s --help' for usage help"
 msgstr ""
 
-#: home-manager/home-manager:312 home-manager/home-manager:411
+#: home-manager/home-manager:322 home-manager/home-manager:421
 msgid "The file %s already exists, leaving it unchanged..."
 msgstr ""
 
-#: home-manager/home-manager:314 home-manager/home-manager:413
+#: home-manager/home-manager:324 home-manager/home-manager:423
 msgid "Creating %s..."
 msgstr ""
 
-#: home-manager/home-manager:455
+#: home-manager/home-manager:465
 msgid "Creating initial Home Manager generation..."
 msgstr ""
 
 #. translators: The "%s" specifier will be replaced by a file path.
-#: home-manager/home-manager:460
+#: home-manager/home-manager:470
 msgid ""
 "All done! The home-manager tool should now be installed and you can edit\n"
 "\n"
@@ -110,7 +110,7 @@ msgid ""
 msgstr ""
 
 #. translators: The "%s" specifier will be replaced by a URL.
-#: home-manager/home-manager:465
+#: home-manager/home-manager:475
 msgid ""
 "Uh oh, the installation failed! Please create an issue at\n"
 "\n"
@@ -120,11 +120,11 @@ msgid ""
 msgstr ""
 
 #. translators: Here "flake" is a noun that refers to the Nix Flakes feature.
-#: home-manager/home-manager:476
+#: home-manager/home-manager:486
 msgid "Can't instantiate a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:552
+#: home-manager/home-manager:562
 msgid ""
 "There is %d unread and relevant news item.\n"
 "Read it by running the command \"%s news\"."
@@ -134,72 +134,72 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: home-manager/home-manager:566
+#: home-manager/home-manager:576
 msgid "Unknown \"news.display\" setting \"%s\"."
 msgstr ""
 
-#: home-manager/home-manager:573
+#: home-manager/home-manager:583
 #, sh-format
 msgid "Please set the $EDITOR environment variable"
 msgstr ""
 
-#: home-manager/home-manager:588
+#: home-manager/home-manager:598
 msgid "Cannot run build in read-only directory"
 msgstr ""
 
-#: home-manager/home-manager:666
+#: home-manager/home-manager:676
 msgid "No generation with ID %s"
 msgstr ""
 
-#: home-manager/home-manager:668
+#: home-manager/home-manager:678
 msgid "Cannot remove the current generation %s"
 msgstr ""
 
-#: home-manager/home-manager:670
+#: home-manager/home-manager:680
 msgid "Removing generation %s"
 msgstr ""
 
-#: home-manager/home-manager:689
+#: home-manager/home-manager:699
 msgid "No generations to expire"
 msgstr ""
 
-#: home-manager/home-manager:700
+#: home-manager/home-manager:710
 msgid "No home-manager packages seem to be installed."
 msgstr ""
 
-#: home-manager/home-manager:781
+#: home-manager/home-manager:792
 msgid "Unknown argument %s"
 msgstr ""
 
-#: home-manager/home-manager:805
+#: home-manager/home-manager:816
 msgid "This will remove Home Manager from your system."
 msgstr ""
 
-#: home-manager/home-manager:808
+#: home-manager/home-manager:819
 msgid "This is a dry run, nothing will actually be uninstalled."
 msgstr ""
 
-#: home-manager/home-manager:812
+#: home-manager/home-manager:823
 msgid "Really uninstall Home Manager?"
 msgstr ""
 
-#: home-manager/home-manager:818
+#: home-manager/home-manager:829
 msgid "Switching to empty Home Manager configuration..."
 msgstr ""
 
-#: home-manager/home-manager:846
+#: home-manager/home-manager:857
 msgid "Yay!"
 msgstr ""
 
-#: home-manager/home-manager:851
+#: home-manager/home-manager:862
 msgid "Home Manager is uninstalled but your home.nix is left untouched."
 msgstr ""
 
-#: home-manager/home-manager:1063
+#: home-manager/home-manager:1074
 msgid "expire-generations expects one argument, got %d."
 msgstr ""
 
-#: home-manager/home-manager:1085
+#: home-manager/home-manager:1096
 msgid "Unknown command: %s"
 msgstr ""
 

--- a/home-manager/po/home-manager.pot
+++ b/home-manager/po/home-manager.pot
@@ -49,7 +49,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/id.po
+++ b/home-manager/po/id.po
@@ -54,7 +54,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/it.po
+++ b/home-manager/po/it.po
@@ -50,7 +50,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/ja.po
+++ b/home-manager/po/ja.po
@@ -52,7 +52,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/ko.po
+++ b/home-manager/po/ko.po
@@ -53,7 +53,7 @@ msgstr "대체 홈 매니저 경로 %s는 더 이상 사용되지 않게 되었�
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/lt.po
+++ b/home-manager/po/lt.po
@@ -52,7 +52,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/nb_NO.po
+++ b/home-manager/po/nb_NO.po
@@ -50,7 +50,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/nl.po
+++ b/home-manager/po/nl.po
@@ -52,7 +52,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/pl.po
+++ b/home-manager/po/pl.po
@@ -55,7 +55,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/pt.po
+++ b/home-manager/po/pt.po
@@ -50,7 +50,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/pt_BR.po
+++ b/home-manager/po/pt_BR.po
@@ -52,7 +52,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/ro.po
+++ b/home-manager/po/ro.po
@@ -56,7 +56,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/ru.po
+++ b/home-manager/po/ru.po
@@ -51,7 +51,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/sv.po
+++ b/home-manager/po/sv.po
@@ -54,7 +54,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/tr.po
+++ b/home-manager/po/tr.po
@@ -51,7 +51,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/uk.po
+++ b/home-manager/po/uk.po
@@ -54,7 +54,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/zh_Hans.po
+++ b/home-manager/po/zh_Hans.po
@@ -52,7 +52,7 @@ msgstr "后备 Home Manager 路径 %s 已被弃用，但在这里找到了一个
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/home-manager/po/zh_Hant.po
+++ b/home-manager/po/zh_Hant.po
@@ -50,7 +50,7 @@ msgstr ""
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
 #: home-manager/home-manager:125
 msgid ""
-"To remove this warning, do one of the fallowing.\n"
+"To remove this warning, do one of the following.\n"
 "\n"
 "1. Explicitly tell Home Manager to use the path, for example by adding\n"
 "\n"

--- a/modules/po/hm-modules.pot
+++ b/modules/po/hm-modules.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager Modules\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2023-07-30 09:08+0200\n"
+"POT-Creation-Date: 2023-09-13 23:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,7 @@ msgstr ""
 msgid "No change so reusing latest profile generation %s"
 msgstr ""
 
-#: modules/home-environment.nix:626
+#: modules/home-environment.nix:640
 msgid ""
 "Oops, Nix failed to install your new Home Manager profile!\n"
 "\n"
@@ -49,7 +49,7 @@ msgid ""
 "Then try activating your Home Manager configuration again."
 msgstr ""
 
-#: modules/home-environment.nix:659
+#: modules/home-environment.nix:673
 msgid "Activating %s"
 msgstr ""
 

--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -50,12 +50,14 @@ in {
       '';
 
       nushell = mkIf cfg.enableNushellIntegration {
+        # Note, the ${"$"} below is a work-around because xgettext otherwise
+        # interpret it as a Bash i18n string.
         extraEnv = ''
           let carapace_cache = "${config.xdg.cacheHome}/carapace"
           if not ($carapace_cache | path exists) {
             mkdir $carapace_cache
           }
-          ${bin} _carapace nushell | save -f $"($carapace_cache)/init.nu"
+          ${bin} _carapace nushell | save -f ${"$"}"($carapace_cache)/init.nu"
         '';
         extraConfig = ''
           source ${config.xdg.cacheHome}/carapace/init.nu


### PR DESCRIPTION
### Description

Fixes a typo

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
