### PR TITLE
home-manager: fix for missing profile directory in nix v2.17.0

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -648,6 +648,8 @@ function doSwitch() {
 }
 
 function doListGens() {
+    setHomeManagerPathVariables
+
     # Whether to colorize the generations output.
     local color="never"
     if [[ ! -v NO_COLOR && -t 1 ]]; then
@@ -665,6 +667,7 @@ function doListGens() {
 # Removes linked generations. Takes as arguments identifiers of
 # generations to remove.
 function doRmGenerations() {
+    setHomeManagerPathVariables
     setVerboseAndDryRun
 
     pushd "$HM_PROFILE_DIR" > /dev/null
@@ -686,6 +689,8 @@ function doRmGenerations() {
 }
 
 function doExpireGenerations() {
+    setHomeManagerPathVariables
+
     local generations
     generations="$( \
         find "$HM_PROFILE_DIR" -name 'home-manager-*-link' -not -newermt "$1" \
@@ -810,6 +815,7 @@ function doShowNews() {
 }
 
 function doUninstall() {
+    setHomeManagerPathVariables
     setVerboseAndDryRun
     setNixProfileCommands
 
@@ -944,8 +950,6 @@ PASSTHROUGH_OPTS=()
 COMMAND=""
 COMMAND_ARGS=()
 FLAKE_ARG=""
-
-setHomeManagerPathVariables
 
 while [[ $# -gt 0 ]]; do
     opt="$1"


### PR DESCRIPTION
### Description

Fixes #4403.

Due to a possible bug in nix v2.15.0 - v2.17.0, `nix run` no longer creates the default profile, which makes the flake installation of home-manager fail on new nix installations. This PR makes sure that `nix-env -q` is executed in order to create the profile.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
