### PR TITLE
neovim: expose finalPackage

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -237,7 +237,6 @@ in {
 
       finalPackage = mkOption {
         type = types.package;
-        visible = false;
         readOnly = true;
         description = "Resulting customized neovim package.";
       };


### PR DESCRIPTION
### Description

Currently, there are 5 packages that can be managed with Home Manager that expose `finalPackage` option publicly: `pandoc`, `rofi`, `timidity`, `emacs`, `hyprland`. This commit adds the 6th one: `neovim`. While the final package that is being built after all of the modifications should be considered an implementation detail, in cases of complex software like `neovim` this could hide important details.

One particular case that comes to mind is using `lazy.nvim` package manager. It exposes a number of useful APIs that really help managing configuration, such as conditional keybindings, dependency tree building, merging configurations, and so on. Questions about using it on NixOS come up often, because manually recreating this functionality is hard, and it's a very popular method of managing plugins that has good UI/UX.

As it is now, it is impossible to use `lazy.nvim` with Nix efficiently. `lazy.nvim` monopolizes the plugin management, which means that installing plugins with Nix and managing them with `lazy.nvim` is not supported. Some of the pitfalls are already described: https://github.com/folke/lazy.nvim/issues/402
https://github.com/folke/lazy.nvim/issues/66

In short, to integrate `lazy.nvim` with Nix there are three things that must be done:
1. `lazy.nvim` resets packpath, which should be managed by Nix; it has to be turned off with `performance.reset_packpath = false` option in `lazy.nvim`
2. Same thing applies to rtp, the relevant option is `performance.rtp.reset = false`
3. `dev.path` must be specified as the folder that contains the plugins. This folder is the path to Nix store path with Neovim plugins, and the plugins that are managed by Nix must be marked as `dev = true` 
 
The third condition can not be fulfilled without this PR, as the final package that Home Manager produces is not exposed, therefore it is impossible to extract the Nix store path. This PR makes it possible to be extracted via `${pkgs.vimUtils.packDir
config.home-manager.users.<user>.programs.neovim.finalPackage.passthru.packpathDirs}/pack/myNeovimPackages/start}` expression.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@emilazy 