### PR TITLE
keychain: improve nushell integration

### DIFF
--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -117,7 +117,10 @@ in {
       eval "$(SHELL=zsh ${shellCommand})"
     '';
     programs.nushell.extraConfig = mkIf cfg.enableNushellIntegration ''
-      ${shellCommand} | parse -r '(\w+)=(.*); export \1' | transpose -ird | load-env
+      let keychain_shell_command = (SHELL=bash ${shellCommand}| parse -r '(\w+)=(.*); export \1' | transpose -ird)
+      if not ($keychain_shell_command|is-empty) {
+        $keychain_shell_command | load-env
+      }
     '';
     xsession.initExtra = mkIf cfg.enableXsessionIntegration ''
       eval "$(SHELL=bash ${shellCommand})"


### PR DESCRIPTION
### Description
When the pipeline results in an empty list, load-env throws an error. So I added a check.

- If the parse does not match/returns an empty list, `transpose -ird` does not transform it into a record and thus load-env fails. I added an empty check to catch this.
- The parsing assumes keychain to emit bash-style completions, so set SHELL=bash to ensure keychain output is in the expected format.


I think this should also fix #4255 .
### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC
@CardboardTurkey 
@Infinidoge 


<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
