### PR TITLE
rofi-pass: allow the user to set the package

### DIFF
--- a/modules/programs/rofi-pass.nix
+++ b/modules/programs/rofi-pass.nix
@@ -7,10 +7,13 @@ let
   cfg = config.programs.rofi.pass;
 
 in {
-  meta.maintainers = [ maintainers.seylerius ];
+  meta.maintainers = with maintainers; [ seylerius robwalt ];
 
   options.programs.rofi.pass = {
     enable = mkEnableOption "rofi integration with password-store";
+
+    package =
+      mkPackageOption pkgs "rofi-pass" { example = "pkgs.rofi-pass-wayland"; };
 
     stores = mkOption {
       type = types.listOf types.str;
@@ -37,7 +40,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.rofi-pass ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."rofi-pass/config".text = optionalString (cfg.stores != [ ])
       ("root=" + (concatStringsSep ":" cfg.stores) + "\n") + cfg.extraConfig


### PR DESCRIPTION


### Description

This is useful for swapping out the default package for the still unstable but soon normally available rofi-pass-wayland package

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
