### PR TITLE
zellij: Add extraConfig option 

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -51,6 +51,39 @@ in {
     enableFishIntegration = mkEnableOption "Fish integration" // {
       default = false;
     };
+
+    extraConfig = mkOption {
+      type = lib.types.lines;
+      default = "";
+      example = ''
+        keybinds {
+            // keybinds are divided into modes
+            normal {
+                // bind instructions can include one or more keys (both keys will be bound separately)
+                // bind keys can include one or more actions (all actions will be performed with no sequential guarantees)
+                bind "Ctrl g" { SwitchToMode "locked"; }
+                bind "Ctrl p" { SwitchToMode "pane"; }
+                bind "Alt n" { NewPane; }
+                bind "Alt h" "Alt Left" { MoveFocusOrTab "Left"; }
+            }
+            pane {
+                bind "h" "Left" { MoveFocus "Left"; }
+                bind "l" "Right" { MoveFocus "Right"; }
+                bind "j" "Down" { MoveFocus "Down"; }
+                bind "k" "Up" { MoveFocus "Up"; }
+                bind "p" { SwitchFocus; }
+            }
+            locked {
+                bind "Ctrl g" { SwitchToMode "normal"; }
+            }
+        }
+      '';
+      description = ''
+        Extra configuration lines
+        Versions prior to 0.32.0 use Yaml
+        Versions after 0.32.0 use KDL
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -59,14 +92,28 @@ in {
     # Zellij switched from yaml to KDL in version 0.32.0:
     # https://github.com/zellij-org/zellij/releases/tag/v0.32.0
     xdg.configFile."zellij/config.yaml" = mkIf
-      (cfg.settings != { } && (versionOlder cfg.package.version "0.32.0")) {
-        source = yamlFormat.generate "zellij.yaml" cfg.settings;
-      };
+      ((cfg.settings != { } || cfg.extraConfig != "")
+        && (versionOlder cfg.package.version "0.32.0")) {
+          source =
+            let settings = yamlFormat.generate "zellij.yaml" cfg.settings;
+            in ''
+              ${settings}
+
+              ${cfg.extraConfig}
+            '';
+        };
 
     xdg.configFile."zellij/config.kdl" = mkIf
-      (cfg.settings != { } && (versionAtLeast cfg.package.version "0.32.0")) {
-        text = lib.hm.generators.toKDL { } cfg.settings;
-      };
+      ((cfg.settings != { } || cfg.extraConfig != "")
+        && (versionAtLeast cfg.package.version "0.32.0")) {
+          text = let settings = lib.hm.generators.toKDL { } cfg.settings;
+          in ''
+            ${settings}
+
+            ${cfg.extraConfig}
+          '';
+
+        };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkOrder 200 ''
       eval "$(zellij setup --generate-auto-start bash)"

--- a/tests/modules/programs/zellij/default.nix
+++ b/tests/modules/programs/zellij/default.nix
@@ -1,1 +1,4 @@
-{ zellij-enable-shells = ./enable-shells.nix; }
+{
+  zellij-enable-shells = ./enable-shells.nix;
+  zellij-extra-config = ./extra-config.nix;
+}

--- a/tests/modules/programs/zellij/extra-config.nix
+++ b/tests/modules/programs/zellij/extra-config.nix
@@ -32,6 +32,10 @@ in {
     };
   };
 
+  test.stubs = {
+    zellij = { };
+  };
+
   nmt.script = ''
     assertFileExists home-files/.config/zellij/config.kdl
     assertFileContains \

--- a/tests/modules/programs/zellij/extra-config.nix
+++ b/tests/modules/programs/zellij/extra-config.nix
@@ -1,0 +1,41 @@
+{ lib, ... }:
+
+let
+  testInput = ''
+    keybinds {
+        // keybinds are divided into modes
+        normal {
+            // bind instructions can include one or more keys (both keys will be bound separately)
+            // bind keys can include one or more actions (all actions will be performed with no sequential guarantees)
+            bind "Ctrl g" { SwitchToMode "locked"; }
+            bind "Ctrl p" { SwitchToMode "pane"; }
+            bind "Alt n" { NewPane; }
+            bind "Alt h" "Alt Left" { MoveFocusOrTab "Left"; }
+        }
+        pane {
+            bind "h" "Left" { MoveFocus "Left"; }
+            bind "l" "Right" { MoveFocus "Right"; }
+            bind "j" "Down" { MoveFocus "Down"; }
+            bind "k" "Up" { MoveFocus "Up"; }
+            bind "p" { SwitchFocus; }
+        }
+        locked {
+            bind "Ctrl g" { SwitchToMode "normal"; }
+        }
+    }
+  '';
+in {
+  programs = {
+    zellij = {
+      enable = true;
+      extraConfig = testInput;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/zellij/config.kdl
+    assertFileContains \
+      home-files/.config/zellij/config.kdl \
+      "${testInput}"
+  '';
+}


### PR DESCRIPTION

### Description

This just implements an extraConfig option for zellij
With the current module its hard to set keybinds (at least i couldnt find a way) and this acts as a bridge until a more idiomatic way has been implemented

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@mainrs 