### PR TITLE
fluxbox: Try fix xsession cmdline

### DIFF
--- a/modules/services/window-managers/fluxbox.nix
+++ b/modules/services/window-managers/fluxbox.nix
@@ -107,8 +107,7 @@ in {
         mkIf (cfg.windowmenu != "") { text = cfg.windowmenu; };
     };
 
-    xsession.windowManager.command = concatStringsSep " "
-      ([ "${cfg.package}/bin/fluxbox" ]
-        ++ escapeShellArgs (remove "" cfg.extraCommandLineArgs));
+    xsession.windowManager.command = escapeShellArgs
+      ([ "${cfg.package}/bin/fluxbox" ] ++ remove "" cfg.extraCommandLineArgs);
   };
 }


### PR DESCRIPTION
### Description

Self-explanatory, fixes #4457 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] N/A ~Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.~

- [ ] N/A ~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] N/A ~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~

#### Maintainer CC

@AndersonTorres 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
