### PR TITLE
pasystray: add extraOptions

### DIFF
--- a/modules/services/pasystray.nix
+++ b/modules/services/pasystray.nix
@@ -2,14 +2,26 @@
 
 with lib;
 
-{
+let cfg = config.services.pasystray;
+
+in {
   meta.maintainers = [ hm.maintainers.pltanton ];
 
   options = {
-    services.pasystray = { enable = mkEnableOption "PulseAudio system tray"; };
+    services.pasystray = {
+      enable = mkEnableOption "PulseAudio system tray";
+
+      extraOptions = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Extra command-line arguments to pass to {command}`pasystray`.
+        '';
+      };
+    };
   };
 
-  config = mkIf config.services.pasystray.enable {
+  config = mkIf cfg.enable {
     assertions = [
       (hm.assertions.assertPlatform "services.pasystray" pkgs platforms.linux)
     ];
@@ -28,7 +40,8 @@ with lib;
         Environment =
           let toolPaths = makeBinPath [ pkgs.paprefs pkgs.pavucontrol ];
           in [ "PATH=${toolPaths}" ];
-        ExecStart = "${pkgs.pasystray}/bin/pasystray";
+        ExecStart = escapeShellArgs
+          ([ "${pkgs.pasystray}/bin/pasystray" ] ++ cfg.extraOptions);
       };
     };
   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -79,8 +79,8 @@ import nmt {
     ./modules/programs/gallery-dl
     ./modules/programs/gh
     ./modules/programs/gh-dash
-    ./modules/programs/git-cliff
     ./modules/programs/git
+    ./modules/programs/git-cliff
     ./modules/programs/gpg
     ./modules/programs/helix
     ./modules/programs/himalaya
@@ -91,8 +91,8 @@ import nmt {
     ./modules/programs/jujutsu
     ./modules/programs/k9s
     ./modules/programs/kakoune
-    ./modules/programs/kitty
     ./modules/programs/khal
+    ./modules/programs/kitty
     ./modules/programs/ledger
     ./modules/programs/less
     ./modules/programs/lf
@@ -134,7 +134,6 @@ import nmt {
     ./modules/programs/sm64ex
     ./modules/programs/ssh
     ./modules/programs/starship
-    ./modules/services/syncthing/common
     ./modules/programs/taskwarrior
     ./modules/programs/texlive
     ./modules/programs/tmate
@@ -149,6 +148,7 @@ import nmt {
     ./modules/programs/zellij
     ./modules/programs/zplug
     ./modules/programs/zsh
+    ./modules/services/syncthing/common
     ./modules/xresources
   ] ++ lib.optionals isDarwin [
     ./modules/launchd
@@ -218,8 +218,8 @@ import nmt {
     ./modules/services/lieer
     ./modules/services/mopidy
     ./modules/services/mpd
-    ./modules/services/mpdris2
     ./modules/services/mpd-mpris
+    ./modules/services/mpdris2
     ./modules/services/pantalaimon
     ./modules/services/parcellite
     ./modules/services/pass-secret-service

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -223,6 +223,7 @@ import nmt {
     ./modules/services/pantalaimon
     ./modules/services/parcellite
     ./modules/services/pass-secret-service
+    ./modules/services/pasystray
     ./modules/services/pbgopy
     ./modules/services/picom
     ./modules/services/playerctld

--- a/tests/modules/services/pasystray/default.nix
+++ b/tests/modules/services/pasystray/default.nix
@@ -1,0 +1,1 @@
+{ pasystray-service = ./service.nix; }

--- a/tests/modules/services/pasystray/expected.service
+++ b/tests/modules/services/pasystray/expected.service
@@ -1,0 +1,13 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+Environment=PATH=@paprefs@/bin:@pavucontrol@/bin
+ExecStart='@pasystray@/bin/pasystray' '-g'
+
+[Unit]
+After=graphical-session-pre.target
+After=tray.target
+Description=PulseAudio system tray
+PartOf=graphical-session.target
+Requires=tray.target

--- a/tests/modules/services/pasystray/service.nix
+++ b/tests/modules/services/pasystray/service.nix
@@ -1,0 +1,19 @@
+{ ... }:
+
+{
+  services.pasystray = {
+    enable = true;
+    extraOptions = [ "-g" ];
+  };
+
+  test.stubs = {
+    pasystray = { };
+    paprefs = { };
+    pavucontrol = { };
+  };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/pasystray.service)
+    assertFileContent "$serviceFile" ${./expected.service}
+  '';
+}


### PR DESCRIPTION
e.g. for `-g`.

### Description

Adds support for extra arguments to `pasystray`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@pltanton 