### PR TITLE
programs.vscode: add option to disable auto updates for extensions

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -48,6 +48,9 @@ let
     // optionalAttrs (!cfg.enableUpdateCheck) { "update.mode" = "none"; }
     // optionalAttrs (!cfg.enableExtensionUpdateCheck) {
       "extensions.autoCheckUpdates" = false;
+    } // optionalAttrs (!cfg.enableExtensionUpdate) {
+      "extensions.autoUpdate" = false;
+      "extensions.autoCheckUpdates" = false;
     };
 in {
   imports = [
@@ -77,6 +80,15 @@ in {
         default = true;
         description = ''
           Whether to enable update checks/notifications.
+        '';
+      };
+
+      enableExtensionUpdate = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable automatic extension updates.
+          Disabling this also disables update checks.
         '';
       };
 


### PR DESCRIPTION
### Description

The current `enableExtensionUpdateCheck` is confusing because it does not prevent VS Code from auto-updating extensions that were installed declaratively. The new `enableExtensionUpdate` option probably matches what most users would like better, by disabling both the update notifications and the auto-updates. Perhaps the `enableExtensionUpdateCheck` option should even be deprecated in favor of this new one.

cc @wamserma who initially contributed this option (#2965)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] ~~Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.~~ Only ran VS Code-specific tests.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
