### PR TITLE
Fix fusuma service (grep)

### DIFF
--- a/modules/services/fusuma.nix
+++ b/modules/services/fusuma.nix
@@ -96,10 +96,10 @@ in {
 
     extraPackages = mkOption {
       type = types.listOf types.package;
-      default = with pkgs; [ coreutils ];
-      defaultText = literalExpression "pkgs.coreutils";
+      default = with pkgs; [ coreutils gnugrep ];
+      defaultText = literalExpression "pkgs.coreutils pkgs.gnugrep";
       example = literalExpression ''
-        with pkgs; [ coreutils xdotool ];
+        with pkgs; [ coreutils gnugrep xdotool ];
       '';
       description = ''
         Extra packages needs to bring to the scope of fusuma service.

--- a/tests/modules/services/fusuma/expected-service.service
+++ b/tests/modules/services/fusuma/expected-service.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-Environment=PATH=@coreutils@/bin:@xdotool@/bin
+Environment=PATH=@coreutils@/bin:@gnugrep@/bin:@xdotool@/bin
 ExecStart=@fusuma@/bin/fusuma -c /home/hm-user/.config/fusuma/config.yaml
 
 [Unit]

--- a/tests/modules/services/fusuma/service.nix
+++ b/tests/modules/services/fusuma/service.nix
@@ -6,6 +6,7 @@
     package = config.lib.test.mkStubPackage { outPath = "@fusuma@"; };
     extraPackages = [
       (config.lib.test.mkStubPackage { outPath = "@coreutils@"; })
+      (config.lib.test.mkStubPackage { outPath = "@gnugrep@"; })
       (config.lib.test.mkStubPackage { outPath = "@xdotool@"; })
     ];
     settings = { };


### PR DESCRIPTION
The version of fusuma in nixpkgs as of two weeks ago requires grep.

https://github.com/iberianpig/fusuma/blob/ea76c7cf547c8ee5222121293bcfc2b23555f989/lib/fusuma/libinput_command.rb#L43

The default service should therefore include a provider of grep — I've selected gnugrep as that is what is on my system.
I did confirm that a service file with gnugrep works.
However, I did _not_ run the default service file — any meaningful file will have something like `xdotool`; I confirmed that my generated service file (with gnugrep and xdotool) works, whereas the version without gnugrep does not.
