### PR TITLE
i3-sway: separate trayOutput values for sway

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -290,7 +290,8 @@ let
 
       trayOutput = mkNullableOption {
         type = types.str;
-        default = "primary";
+        # Sway/Wayland doesn't have the concept of a primary output. The default for sway is to show it on all outputs
+        default = if isI3 then "primary" else "*";
         description = "Where to output tray.";
       };
 

--- a/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
+++ b/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
@@ -90,7 +90,7 @@ bar {
   swaybar_command @sway@/bin/swaybar
   workspace_buttons yes
   strip_workspace_numbers no
-  tray_output primary
+  tray_output *
   colors {
     background #000000
     statusline #ffffff

--- a/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.conf
+++ b/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.conf
@@ -92,7 +92,7 @@ bar {
   swaybar_command @sway@/bin/swaybar
   workspace_buttons yes
   strip_workspace_numbers no
-  tray_output primary
+  tray_output *
   colors {
     background #000000
     statusline #ffffff

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -90,7 +90,7 @@ bar {
   swaybar_command @sway@/bin/swaybar
   workspace_buttons yes
   strip_workspace_numbers no
-  tray_output primary
+  tray_output *
   colors {
     background #000000
     statusline #ffffff

--- a/tests/modules/services/window-managers/sway/sway-modules.conf
+++ b/tests/modules/services/window-managers/sway/sway-modules.conf
@@ -102,7 +102,7 @@ bar {
   swaybar_command @sway@/bin/swaybar
   workspace_buttons yes
   strip_workspace_numbers no
-  tray_output primary
+  tray_output *
   colors {
     background #000000
     statusline #ffffff

--- a/tests/modules/services/window-managers/sway/sway-post-2003.conf
+++ b/tests/modules/services/window-managers/sway/sway-post-2003.conf
@@ -90,7 +90,7 @@ bar {
   swaybar_command @sway@/bin/swaybar
   workspace_buttons yes
   strip_workspace_numbers no
-  tray_output *
+  tray_output primary
   colors {
     background #000000
     statusline #ffffff
@@ -103,9 +103,4 @@ bar {
   }
 }
 
-workspace "1" output "eDP"
-workspace "ABC" output "DP"
-workspace "3: Test" output "HDMI"
-workspace "!"§$%&/(){}[]=?\*#<>-_.:,;²³" output "DVI"
-workspace "Multiple" output "DVI" "HDMI" "DP"
 exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE NIXOS_OZONE_WL; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-post-2003.nix
+++ b/tests/modules/services/window-managers/sway/sway-post-2003.nix
@@ -15,6 +15,6 @@
   nmt.script = ''
     assertFileExists home-files/.config/sway/config
     assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
-      ${./sway-default.conf}
+      ${./sway-post-2003.conf}
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
@@ -89,7 +89,7 @@ bar {
   swaybar_command @sway@/bin/swaybar
   workspace_buttons yes
   strip_workspace_numbers no
-  tray_output primary
+  tray_output *
   colors {
     background #000000
     statusline #ffffff


### PR DESCRIPTION

### Description

Fixes nix-community/home-manager#4488

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Scrumplex, @alexarice, @sumnerevans, @SebTM, and @oxalica

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
