### PR TITLE
lsd: allow user to configure colors

### DIFF
--- a/modules/programs/lsd.nix
+++ b/modules/programs/lsd.nix
@@ -45,6 +45,26 @@ in {
         for supported values.
       '';
     };
+
+    colors = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = {
+        size = {
+          none = "grey";
+          small = "yellow";
+          large = "dark_yellow";
+        };
+      };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/lsd/colors.yaml`. See
+        <https://github.com/lsd-rs/lsd/tree/v1.0.0#color-theme-file-content> for
+        supported colors.
+
+        If this option is non-empty then the `color.theme` option is
+        automatically set to `"custom"`.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -55,6 +75,13 @@ in {
     programs.zsh.shellAliases = mkIf cfg.enableAliases aliases;
 
     programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
+
+    programs.lsd =
+      mkIf (cfg.colors != { }) { settings.color.theme = "custom"; };
+
+    xdg.configFile."lsd/colors.yaml" = mkIf (cfg.colors != { }) {
+      source = yamlFormat.generate "lsd-colors" cfg.colors;
+    };
 
     xdg.configFile."lsd/config.yaml" = mkIf (cfg.settings != { }) {
       source = yamlFormat.generate "lsd-config" cfg.settings;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -96,6 +96,7 @@ import nmt {
     ./modules/programs/ledger
     ./modules/programs/less
     ./modules/programs/lf
+    ./modules/programs/lsd
     ./modules/programs/lieer
     ./modules/programs/man
     ./modules/programs/mbsync

--- a/tests/modules/programs/lsd/default.nix
+++ b/tests/modules/programs/lsd/default.nix
@@ -1,0 +1,1 @@
+{ lsd-example-settings = ./example-settings.nix; }

--- a/tests/modules/programs/lsd/example-colors-expected.yaml
+++ b/tests/modules/programs/lsd/example-colors-expected.yaml
@@ -1,0 +1,8 @@
+date:
+  day-old: green
+  older: dark_green
+size:
+  large: dark_yellow
+  medium: yellow
+  none: grey
+  small: grey

--- a/tests/modules/programs/lsd/example-settings-expected.yaml
+++ b/tests/modules/programs/lsd/example-settings-expected.yaml
@@ -1,0 +1,14 @@
+blocks:
+- date
+- size
+- name
+color:
+  theme: custom
+date: relative
+ignore-globs:
+- .git
+- .hg
+- .bsp
+layout: oneline
+sorting:
+  dir-grouping: first

--- a/tests/modules/programs/lsd/example-settings.nix
+++ b/tests/modules/programs/lsd/example-settings.nix
@@ -1,0 +1,44 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.lsd = {
+      enable = true;
+      enableAliases = false;
+      settings = {
+        date = "relative";
+        blocks = [ "date" "size" "name" ];
+        layout = "oneline";
+        sorting.dir-grouping = "first";
+        ignore-globs = [ ".git" ".hg" ".bsp" ];
+      };
+      colors = {
+        date = {
+          day-old = "green";
+          older = "dark_green";
+        };
+        size = {
+          none = "grey";
+          small = "grey";
+          medium = "yellow";
+          large = "dark_yellow";
+        };
+      };
+    };
+
+    test.stubs.lsd = { };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/lsd/config.yaml
+      assertFileExists home-files/.config/lsd/colors.yaml
+      assertFileContent \
+        home-files/.config/lsd/config.yaml \
+        ${./example-settings-expected.yaml}
+      assertFileContent \
+        home-files/.config/lsd/colors.yaml \
+        ${./example-colors-expected.yaml}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR add new `colors` option for user to configure lsd colors.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

I have tested the related option on my machines, and they should work as expected.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
