### PR TITLE
yazi: add fish and nushell integration

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -6,7 +6,7 @@ let
   cfg = config.programs.yazi;
   tomlFormat = pkgs.formats.toml { };
 
-  shellIntegration = ''
+  bashIntegration = ''
     function ya() {
       tmp="$(mktemp -t "yazi-cwd.XXXXX")"
       yazi --cwd-file="$tmp"
@@ -14,6 +14,27 @@ let
         cd -- "$cwd"
       fi
       rm -f -- "$tmp"
+    }
+  '';
+  fishIntegration = ''
+    function ya
+      set tmp (mktemp -t "yazi-cwd.XXXXX")
+      yazi --cwd-file="$tmp"
+      if set cwd (cat -- "$tmp") && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]
+        cd -- "$cwd"
+      end
+      rm -f -- "$tmp"
+    end
+  '';
+  nushellIntegration = ''
+    def-env ya [] {
+      let tmp = (mktemp -t "yazi-cwd.XXXXX")
+      yazi --cwd-file $tmp
+      let cwd = (cat -- $tmp)
+      if $cwd != "" and $cwd != $env.PWD {
+        cd $cwd
+      }
+      rm -f $tmp
     }
   '';
 in {
@@ -30,8 +51,9 @@ in {
     };
 
     enableBashIntegration = mkEnableOption "Bash integration";
-
     enableZshIntegration = mkEnableOption "Zsh integration";
+    enableFishIntegration = mkEnableOption "Fish integration";
+    enableNushellIntegration = mkEnableOption "Nushell integration";
 
     keymap = mkOption {
       type = tomlFormat.type;
@@ -113,9 +135,12 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    programs.bash.initExtra = mkIf cfg.enableBashIntegration shellIntegration;
-
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration shellIntegration;
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration bashIntegration;
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration bashIntegration;
+    programs.fish.interactiveShellInit =
+      mkIf cfg.enableFishIntegration fishIntegration;
+    programs.nushell.extraConfig =
+      mkIf cfg.enableNushellIntegration nushellIntegration;
 
     xdg.configFile = {
       "yazi/keymap.toml" = mkIf (cfg.keymap != { }) {

--- a/tests/modules/programs/yazi/default.nix
+++ b/tests/modules/programs/yazi/default.nix
@@ -2,4 +2,6 @@
   yazi-settings = ./settings.nix;
   yazi-bash-integration-enabled = ./bash-integration-enabled.nix;
   yazi-zsh-integration-enabled = ./zsh-integration-enabled.nix;
+  yazi-fish-integration-enabled = ./fish-integration-enabled.nix;
+  yazi-nushell-integration-enabled = ./nushell-integration-enabled.nix;
 }

--- a/tests/modules/programs/yazi/fish-integration-enabled.nix
+++ b/tests/modules/programs/yazi/fish-integration-enabled.nix
@@ -1,0 +1,27 @@
+{ ... }:
+
+let
+  shellIntegration = ''
+    function ya
+      set tmp (mktemp -t "yazi-cwd.XXXXX")
+      yazi --cwd-file="$tmp"
+      if set cwd (cat -- "$tmp") && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]
+        cd -- "$cwd"
+      end
+      rm -f -- "$tmp"
+    end
+  '';
+in {
+  programs.fish.enable = true;
+
+  programs.yazi = {
+    enable = true;
+    enableFishIntegration = true;
+  };
+
+  test.stubs.yazi = { };
+
+  nmt.script = ''
+    assertFileContains home-files/.config/fish/config.fish '${shellIntegration}'
+  '';
+}

--- a/tests/modules/programs/yazi/nushell-integration-enabled.nix
+++ b/tests/modules/programs/yazi/nushell-integration-enabled.nix
@@ -1,0 +1,33 @@
+{ pkgs, ... }:
+
+let
+  shellIntegration = ''
+    def-env ya [] {
+      let tmp = (mktemp -t "yazi-cwd.XXXXX")
+      yazi --cwd-file $tmp
+      let cwd = (cat -- $tmp)
+      if $cwd != "" and $cwd != $env.PWD {
+        cd $cwd
+      }
+      rm -f $tmp
+    }
+  '';
+in {
+  programs.nushell.enable = true;
+
+  programs.yazi = {
+    enable = true;
+    enableNushellIntegration = true;
+  };
+
+  test.stubs.yazi = { };
+
+  nmt.script = let
+    configPath = if pkgs.stdenv.isDarwin then
+      "home-files/Library/Application Support/nushell/config.nu"
+    else
+      "home-files/.config/nushell/config.nu";
+  in ''
+    assertFileContains '${configPath}' '${shellIntegration}'
+  '';
+}


### PR DESCRIPTION
### Description

Add fish and nushell integration for yazi. Close #4480.

CC @Nyabinary @PhotonQuantum.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
