### PR TITLE
tests: add mainProgram to stub packages

### DIFF
--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -33,7 +33,8 @@ let
 
   defaultBuildScript = "mkdir $out";
 
-  dummyPackage = pkgs.runCommandLocal "dummy" { } defaultBuildScript;
+  dummyPackage = pkgs.runCommandLocal "dummy" { meta.mainProgram = "dummy"; }
+    defaultBuildScript;
 
   mkStubPackage = { name ? "dummy", outPath ? null, version ? null
     , buildScript ? defaultBuildScript }:
@@ -41,7 +42,10 @@ let
       pkg = if name == "dummy" && buildScript == defaultBuildScript then
         dummyPackage
       else
-        pkgs.runCommandLocal name { pname = name; } buildScript;
+        pkgs.runCommandLocal name {
+          pname = name;
+          meta.mainProgram = name;
+        } buildScript;
     in pkg // optionalAttrs (outPath != null) {
       inherit outPath;
 


### PR DESCRIPTION
### Description

This is to avoid warnings being printed while tests are run.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```