### PR TITLE
remove qtstyleplugin-kvantum-qt4

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -23,11 +23,8 @@ let
 
     breeze = libsForQt5.breeze-qt5;
 
-    kvantum = [
-      qtstyleplugin-kvantum-qt4
-      libsForQt5.qtstyleplugin-kvantum
-      qt6Packages.qtstyleplugin-kvantum
-    ];
+    kvantum =
+      [ libsForQt5.qtstyleplugin-kvantum qt6Packages.qtstyleplugin-kvantum ];
   };
 
 in {
@@ -88,7 +85,6 @@ in {
             "adwaita-qt"
             [ "libsForQt5" "breeze-qt5" ]
             [ "libsForQt5" "qtstyleplugins" ]
-            "qtstyleplugin-kvantum-qt4"
             [ "libsForQt5" "qtstyleplugin-kvantum" ]
             [ "qt6Packages" "qtstyleplugin-kvantum" ]
           ];


### PR DESCRIPTION
### Description

Removes references to qtstyleplugin-kvantum-qt4 which has been removed because it depended on qt4.

Throwing at rebuild:
```
       … while calling the 'head' builtin

         at /nix/store/av6ibf16025dfc1s0dwz9d27dcdwjckb-nixos/nixos/lib/attrsets.nix:820:11:

          819|         || pred here (elemAt values 1) (head values) then
          820|           head values
             |           ^
          821|         else

       … while evaluating the attribute 'value'

         at /nix/store/av6ibf16025dfc1s0dwz9d27dcdwjckb-nixos/nixos/lib/modules.nix:807:9:

          806|     in warnDeprecation opt //
          807|       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
             |         ^
          808|         inherit (res.defsFinal') highestPrio;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: qtstyleplugin-kvantum-qt4 has been removed, because it depended on qt4
```

Issue: https://github.com/nix-community/home-manager/issues/4446


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee @thiagokokada 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
