### PR TITLE
zsh prezto: fix path in example for 'prezto.pmoduleDirs'

### DIFF
--- a/modules/programs/zsh/prezto.nix
+++ b/modules/programs/zsh/prezto.nix
@@ -34,7 +34,8 @@ let
       pmoduleDirs = mkOption {
         type = types.listOf types.path;
         default = [ ];
-        example = [ "$HOME/.zprezto-contrib" ];
+        example = literalExpression
+          ''[ "''${config.home.homeDirectory}/.zprezto-contrib" ]'';
         description = "Add additional directories to load prezto modules from.";
       };
 


### PR DESCRIPTION
fixes #4452 

### Description

The example path in `programs.zsh.prezto.pmoduleDirs` is not compatible with shell environment variables like `$HOME`.

Thus it must be replaced with nix compatible variables eg: `home.homeDirectory`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
