### PR TITLE
wpaperd: add wpaperd configuration

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -19,6 +19,12 @@
     githubId = 56743515;
     name = "Morgane Austreelis";
   };
+  Avimitin = {
+    name = "Avimitin";
+    email = "dev@avimit.in";
+    github = "Avimitin";
+    githubId = 30021675;
+  };
   blmhemu = {
     name = "blmhemu";
     email = "19410501+blmhemu@users.noreply.github.com";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1244,6 +1244,13 @@ in
           A new module is available: 'programs.awscli'.
         '';
       }
+
+      {
+        time = "2023-10-01T07:23:26+00:00";
+        message = ''
+          A new module is available: 'programs.wpaperd'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -224,6 +224,7 @@ let
     ./programs/wezterm.nix
     ./programs/wlogout.nix
     ./programs/wofi.nix
+    ./programs/wpaperd.nix
     ./programs/xmobar.nix
     ./programs/xplr.nix
     ./programs/yazi.nix

--- a/modules/programs/wpaperd.nix
+++ b/modules/programs/wpaperd.nix
@@ -1,0 +1,49 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.wpaperd;
+  tomlFormat = pkgs.formats.toml { };
+in {
+  meta.maintainers = [ hm.maintainers.Avimitin ];
+
+  options.programs.wpaperd = {
+    enable = mkEnableOption "wpaperd";
+
+    package = mkPackageOption pkgs "wpaperd" { };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          eDP-1 = {
+            path = "/home/foo/Pictures/Wallpaper";
+            apply-shadow = true;
+          };
+          DP-2 = {
+            path = "/home/foo/Pictures/Anime";
+            sorting = "descending";
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/wpaperd/wallpaper.toml`.
+        See <https://github.com/danyspin97/wpaperd#wallpaper-configuration>
+        for the full list of options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = {
+      "wpaperd/wallpaper.toml" = mkIf (cfg.settings != { }) {
+        source = tomlFormat.generate "wpaperd-wallpaper" cfg.settings;
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -196,6 +196,7 @@ import nmt {
     ./modules/programs/waybar
     ./modules/programs/wlogout
     ./modules/programs/wofi
+    ./modules/programs/wpaperd
     ./modules/programs/xmobar
     ./modules/programs/yt-dlp
     ./modules/services/avizo

--- a/tests/modules/programs/wpaperd/default.nix
+++ b/tests/modules/programs/wpaperd/default.nix
@@ -1,0 +1,1 @@
+{ wpaperd-example-settings = ./wpaperd-example-settings.nix; }

--- a/tests/modules/programs/wpaperd/wpaperd-example-settings.nix
+++ b/tests/modules/programs/wpaperd/wpaperd-example-settings.nix
@@ -1,0 +1,26 @@
+{ ... }:
+
+{
+  config = {
+    programs.wpaperd = {
+      enable = true;
+      settings = {
+        eDP-1 = {
+          path = "/home/foo/Pictures/Wallpaper";
+          apply-shadow = true;
+        };
+        DP-2 = {
+          path = "/home/foo/Pictures/Anime";
+          sorting = "descending";
+        };
+      };
+    };
+
+    test.stubs.wpaperd = { };
+
+    nmt.script = ''
+      assertFileContent home-files/.config/wpaperd/wallpaper.toml \
+        ${./wpaperd-expected-settings.toml}
+    '';
+  };
+}

--- a/tests/modules/programs/wpaperd/wpaperd-expected-settings.toml
+++ b/tests/modules/programs/wpaperd/wpaperd-expected-settings.toml
@@ -1,0 +1,7 @@
+[DP-2]
+path = "/home/foo/Pictures/Anime"
+sorting = "descending"
+
+[eDP-1]
+apply-shadow = true
+path = "/home/foo/Pictures/Wallpaper"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds home-manager module for program wpaperd.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
