### PR TITLE
direnv: add package options

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -24,6 +24,8 @@ in {
   options.programs.direnv = {
     enable = mkEnableOption "direnv, the environment switcher";
 
+    package = mkPackageOption pkgs "direnv" { };
+
     config = mkOption {
       type = tomlFormat.type;
       default = { };
@@ -89,12 +91,14 @@ in {
       enable = mkEnableOption ''
         [nix-direnv](https://github.com/nix-community/nix-direnv),
         a fast, persistent use_nix implementation for direnv'';
+
+      package = mkPackageOption pkgs "nix-direnv" { };
     };
 
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.direnv ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."direnv/direnv.toml" = mkIf (cfg.config != { }) {
       source = tomlFormat.generate "direnv-config" cfg.config;
@@ -103,25 +107,25 @@ in {
     xdg.configFile."direnv/direnvrc" = let
       text = concatStringsSep "\n" (optional (cfg.stdlib != "") cfg.stdlib
         ++ optional cfg.nix-direnv.enable
-        "source ${pkgs.nix-direnv}/share/nix-direnv/direnvrc");
+        "source ${cfg.nix-direnv.package}/share/nix-direnv/direnvrc");
     in mkIf (text != "") { inherit text; };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (
       # Using mkAfter to make it more likely to appear after other
       # manipulations of the prompt.
       mkAfter ''
-        eval "$(${pkgs.direnv}/bin/direnv hook bash)"
+        eval "$(${cfg.package}/bin/direnv hook bash)"
       '');
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      eval "$(${pkgs.direnv}/bin/direnv hook zsh)"
+      eval "$(${cfg.package}/bin/direnv hook zsh)"
     '';
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration (
       # Using mkAfter to make it more likely to appear after other
       # manipulations of the prompt.
       mkAfter ''
-        ${pkgs.direnv}/bin/direnv hook fish | source
+        ${cfg.package}/bin/direnv hook fish | source
       '');
 
     programs.nushell.extraConfig = mkIf cfg.enableNushellIntegration (
@@ -133,7 +137,7 @@ in {
         $env.config = ($env.config | update hooks ($env.config.hooks | default [] pre_prompt))
         $env.config = ($env.config | update hooks.pre_prompt ($env.config.hooks.pre_prompt | append {
           code: "
-            let direnv = (${pkgs.direnv}/bin/direnv export json | from json)
+            let direnv = (${cfg.package}/bin/direnv export json | from json)
             let direnv = if not ($direnv | is-empty) { $direnv } else { {} }
             $direnv | load-env
             "


### PR DESCRIPTION
### Description

Add package options for direnv and nix-direnv so that we can more easily override the packages used.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
