### PR TITLE
awscli: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1237,6 +1237,13 @@ in
           A new module is available: 'programs.bacon'.
         '';
       }
+
+      {
+        time = "2023-09-30T07:47:23+00:00";
+        message = ''
+          A new module is available: 'programs.awscli'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -57,6 +57,7 @@ let
     ./programs/atuin.nix
     ./programs/autojump.nix
     ./programs/autorandr.nix
+    ./programs/awscli.nix
     ./programs/bash.nix
     ./programs/bashmount.nix
     ./programs/bat.nix

--- a/modules/programs/awscli.nix
+++ b/modules/programs/awscli.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.awscli;
+  iniFormat = pkgs.formats.ini { };
+
+in {
+  meta.maintainers = [ lib.maintainers.anthonyroussel ];
+
+  options.programs.awscli = {
+    enable = lib.mkEnableOption "AWS CLI tool";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.awscli2;
+      defaultText = lib.literalExpression "pkgs.awscli2";
+      description = "Package providing {command}`aws`.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule { freeformType = iniFormat.type; };
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "default" = {
+            region = "eu-west-3";
+            output = "json";
+          };
+        };
+      '';
+      description = "Configuration written to {file}`$HOME/.aws/config`.";
+    };
+
+    credentials = lib.mkOption {
+      type = lib.types.submodule { freeformType = iniFormat.type; };
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "default" = {
+            "credential_process" = "${pkgs.pass}/bin/pass show aws";
+          };
+        };
+      '';
+      description = ''
+        Configuration written to {file}`$HOME/.aws/credentials`.
+
+        For security reasons, never store cleartext passwords here.
+        We recommend that you use `credential_process` option to retrieve
+        the IAM credentials from your favorite password manager during runtime,
+        or use AWS IAM Identity Center to get short-term credentials.
+
+        See <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-authentication.html>.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.file."${config.home.homeDirectory}/.aws/config".source =
+      iniFormat.generate "aws-config-${config.home.username}" cfg.settings;
+
+    home.file."${config.home.homeDirectory}/.aws/credentials".source =
+      iniFormat.generate "aws-credentials-${config.home.username}"
+      cfg.credentials;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -170,6 +170,7 @@ import nmt {
     ./modules/misc/xsession
     ./modules/programs/abook
     ./modules/programs/autorandr
+    ./modules/programs/awscli
     ./modules/programs/beets  # One test relies on services.mpd
     ./modules/programs/borgmatic
     ./modules/programs/boxxy

--- a/tests/modules/programs/awscli/aws-config.conf
+++ b/tests/modules/programs/awscli/aws-config.conf
@@ -1,0 +1,3 @@
+[default]
+output=json
+region=eu-west-3

--- a/tests/modules/programs/awscli/aws-credentials.conf
+++ b/tests/modules/programs/awscli/aws-credentials.conf
@@ -1,0 +1,2 @@
+[iam]
+credential_process=pass show aws

--- a/tests/modules/programs/awscli/awscli.nix
+++ b/tests/modules/programs/awscli/awscli.nix
@@ -1,0 +1,28 @@
+{ ... }:
+
+{
+  programs = {
+    awscli = {
+      enable = true;
+      settings = {
+        default = {
+          output = "json";
+          region = "eu-west-3";
+        };
+      };
+      credentials = { iam = { credential_process = "pass show aws"; }; };
+    };
+  };
+
+  test.stubs.awscli2 = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.aws/config
+    assertFileContent home-files/.aws/config \
+      ${./aws-config.conf}
+
+    assertFileExists home-files/.aws/credentials
+    assertFileContent home-files/.aws/credentials \
+      ${./aws-credentials.conf}
+  '';
+}

--- a/tests/modules/programs/awscli/default.nix
+++ b/tests/modules/programs/awscli/default.nix
@@ -1,0 +1,1 @@
+{ awscli = ./awscli.nix; }


### PR DESCRIPTION
### Description

Add `programs.awscli` module to:

* Automatically install awscli2 in your home environment
* Configure your ~/.aws/config and ~/.aws/credentials files

Also added myself as maintainer of the `programs.awscli` module.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
