### PR TITLE
firefox: set ADD_DATE and LAST_MODIFIED of bookmarks to 1

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -68,7 +68,7 @@ let
         ''
           ${indent indentLevel}<DT><A HREF="${
             escapeXML bookmark.url
-          }" ADD_DATE="0" LAST_MODIFIED="0"${
+          }" ADD_DATE="1" LAST_MODIFIED="1"${
             lib.optionalString (bookmark.keyword != null)
             " SHORTCUTURL=\"${escapeXML bookmark.keyword}\""
           }${

--- a/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
+++ b/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
@@ -8,18 +8,18 @@
 <DL><p>
   <DT><H3 PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
   <DL><p>
-    <DT><A HREF="https://nixos.wiki/wiki/Home_Manager" ADD_DATE="0" LAST_MODIFIED="0">Home Manager</A>
+    <DT><A HREF="https://nixos.wiki/wiki/Home_Manager" ADD_DATE="1" LAST_MODIFIED="1">Home Manager</A>
   </p></DL>
-  <DT><A HREF="https://en.wikipedia.org/wiki/Special:Search?search=%s&amp;go=Go" ADD_DATE="0" LAST_MODIFIED="0" SHORTCUTURL="wiki" TAGS="wiki">wikipedia</A>
-  <DT><A HREF="https://www.kernel.org" ADD_DATE="0" LAST_MODIFIED="0">kernel.org</A>
+  <DT><A HREF="https://en.wikipedia.org/wiki/Special:Search?search=%s&amp;go=Go" ADD_DATE="1" LAST_MODIFIED="1" SHORTCUTURL="wiki" TAGS="wiki">wikipedia</A>
+  <DT><A HREF="https://www.kernel.org" ADD_DATE="1" LAST_MODIFIED="1">kernel.org</A>
   <DT><H3>Nix sites</H3>
   <DL><p>
-    <DT><A HREF="https://nixos.org/" ADD_DATE="0" LAST_MODIFIED="0">homepage</A>
-    <DT><A HREF="https://nixos.wiki/" ADD_DATE="0" LAST_MODIFIED="0" TAGS="wiki,nix">wiki</A>
+    <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>
+    <DT><A HREF="https://nixos.wiki/" ADD_DATE="1" LAST_MODIFIED="1" TAGS="wiki,nix">wiki</A>
     <DT><H3>Nix sites</H3>
     <DL><p>
-      <DT><A HREF="https://nixos.org/" ADD_DATE="0" LAST_MODIFIED="0">homepage</A>
-      <DT><A HREF="https://nixos.wiki/" ADD_DATE="0" LAST_MODIFIED="0">wiki</A>
+      <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>
+      <DT><A HREF="https://nixos.wiki/" ADD_DATE="1" LAST_MODIFIED="1">wiki</A>
     </p></DL>
   </p></DL>
 </p></DL>


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

For some reason, Firefox completely discards the ADD_DATE and LAST_MODIFIED attributes if they are set to 0. This has been confirmed by exporting a sample set of bookmarks generated by Nix using home-manager and comparing it to the same sample of bookmarks set manually and then exported.

Missing these attributes can cause problems for extensions and other tools that try to read bookmarks. A known example is the Tridactyl extension.

#### HTML exports of the sample set of bookmarks

##### Using bookmarks generated by Nix using home-manager

```html
<!DOCTYPE NETSCAPE-Bookmark-file-1>
<!-- This is an automatically generated file.
     It will be read and overwritten.
     DO NOT EDIT! -->
<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
<meta http-equiv="Content-Security-Policy"
      content="default-src 'self'; script-src 'none'; img-src data: *; object-src 'none'"></meta>
<TITLE>Bookmarks</TITLE>
<H1>Bookmarks Menu</H1>

<DL><p>
    <DT><A HREF="https://example.com/">MenuMark1</A>
    <DT><H3 ADD_DATE="1696095176" LAST_MODIFIED="1696095176">MenuFolder1</H3>
    <DL><p>
        <DT><A HREF="https://example.com/">InnerMark2</A>
    </DL><p>
    <DT><H3 ADD_DATE="1696092017" LAST_MODIFIED="1696095176" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
    <DL><p>
        <DT><A HREF="https://example.com/">ToolMark1</A>
        <DT><H3 ADD_DATE="1696095176" LAST_MODIFIED="1696095176">ToolFolder1</H3>
        <DL><p>
            <DT><A HREF="https://example.com/">InnerMark1</A>
        </DL><p>
    </DL><p>
</DL>
```

##### Using bookmarks manually set

```html
<!DOCTYPE NETSCAPE-Bookmark-file-1>
<!-- This is an automatically generated file.
     It will be read and overwritten.
     DO NOT EDIT! -->
<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
<meta http-equiv="Content-Security-Policy"
      content="default-src 'self'; script-src 'none'; img-src data: *; object-src 'none'"></meta>
<TITLE>Bookmarks</TITLE>
<H1>Bookmarks Menu</H1>

<DL><p>
    <DT><A HREF="https://example.com/" ADD_DATE="1696094909" LAST_MODIFIED="1696094909">MenuMark1</A>
    <DT><H3 ADD_DATE="1696094930" LAST_MODIFIED="1696094948">MenuFolder1</H3>
    <DL><p>
        <DT><A HREF="https://example.com/" ADD_DATE="1696094948" LAST_MODIFIED="1696094948">InnerMark2</A>
    </DL><p>
    <DT><H3 ADD_DATE="1696092017" LAST_MODIFIED="1696094882" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
    <DL><p>
        <DT><A HREF="https://example.com/" ADD_DATE="1696094839" LAST_MODIFIED="1696094861">ToolMark1</A>
        <DT><H3 ADD_DATE="1696094867" LAST_MODIFIED="1696094882">ToolFolder1</H3>
        <DL><p>
            <DT><A HREF="https://example.com/" ADD_DATE="1696094882" LAST_MODIFIED="1696094882">InnerMark1</A>
        </DL><p>
    </DL><p>
</DL>
```

##### Using bookmarks generated by Nix using home-manager after this PR

```html
<!DOCTYPE NETSCAPE-Bookmark-file-1>
<!-- This is an automatically generated file.
     It will be read and overwritten.
     DO NOT EDIT! -->
<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
<meta http-equiv="Content-Security-Policy"
      content="default-src 'self'; script-src 'none'; img-src data: *; object-src 'none'"></meta>
<TITLE>Bookmarks</TITLE>
<H1>Bookmarks Menu</H1>

<DL><p>
    <DT><A HREF="https://example.com/" ADD_DATE="1" LAST_MODIFIED="1">MenuMark1</A>
    <DT><H3 ADD_DATE="1696095853" LAST_MODIFIED="1696095853">MenuFolder1</H3>
    <DL><p>
        <DT><A HREF="https://example.com/" ADD_DATE="1" LAST_MODIFIED="1">InnerMark2</A>
    </DL><p>
    <DT><H3 ADD_DATE="1696092017" LAST_MODIFIED="1696095853" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
    <DL><p>
        <DT><A HREF="https://example.com/" ADD_DATE="1" LAST_MODIFIED="1">ToolMark1</A>
        <DT><H3 ADD_DATE="1696095853" LAST_MODIFIED="1696095853">ToolFolder1</H3>
        <DL><p>
            <DT><A HREF="https://example.com/" ADD_DATE="1" LAST_MODIFIED="1">InnerMark1</A>
        </DL><p>
    </DL><p>
</DL>
```

#### Screenshots of Tridactyl

##### Showing errors when using bookmarks generated by Nix using home-manager (prior to this PR)

![firefox-bookmarks-tridactyl](https://github.com/nix-community/home-manager/assets/26801023/32d93807-d881-4036-96c9-62e9b688c2d3)

##### Working correctly when using bookmarks generated by Nix using home-manager after this PR

![firefox-bookmarks-tridactyl-after](https://github.com/nix-community/home-manager/assets/26801023/21a5b957-b382-4917-8dd4-e7757596570f)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee @kira-bruneau 