### PR TITLE
scmpuff: enable or disable aliases

### DIFF
--- a/tests/modules/programs/scmpuff/bash.nix
+++ b/tests/modules/programs/scmpuff/bash.nix
@@ -12,6 +12,6 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
-      'eval "$(@scmpuff@/bin/scmpuff init -s)"'
+      'eval "$(@scmpuff@/bin/scmpuff init --shell=bash)"'
   '';
 }

--- a/tests/modules/programs/scmpuff/default.nix
+++ b/tests/modules/programs/scmpuff/default.nix
@@ -6,4 +6,5 @@
   scmpuff-zsh = ./zsh.nix;
   scmpuff-fish = ./fish.nix;
   scmpuff-no-fish = ./no-fish.nix;
+  scmpuff-no-aliases = ./no-aliases.nix;
 }

--- a/tests/modules/programs/scmpuff/fish.nix
+++ b/tests/modules/programs/scmpuff/fish.nix
@@ -16,6 +16,6 @@
     assertFileExists home-files/.config/fish/config.fish
     assertFileContains \
       home-files/.config/fish/config.fish \
-      '@scmpuff@/bin/scmpuff init -s --shell=fish | source'
+      '@scmpuff@/bin/scmpuff init --shell=fish | source'
   '';
 }

--- a/tests/modules/programs/scmpuff/no-aliases.nix
+++ b/tests/modules/programs/scmpuff/no-aliases.nix
@@ -1,0 +1,34 @@
+{ lib, ... }:
+
+{
+  programs = {
+    scmpuff.enable = true;
+    scmpuff.enableAliases = false;
+    bash.enable = true;
+    fish.enable = true;
+    zsh.enable = true;
+  };
+
+  # Needed to avoid error with dummy fish package.
+  xdg.dataFile."fish/home-manager_generated_completions".source =
+    lib.mkForce (builtins.toFile "empty" "");
+
+  test.stubs.scmpuff = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileContains \
+      home-files/.bashrc \
+      'eval "$(@scmpuff@/bin/scmpuff init --shell=bash --aliases=false)"'
+
+    assertFileExists home-files/.zshrc
+    assertFileContains \
+      home-files/.zshrc \
+      'eval "$(@scmpuff@/bin/scmpuff init --shell=zsh --aliases=false)"'
+
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      '@scmpuff@/bin/scmpuff init --shell=fish --aliases=false | source'
+  '';
+}

--- a/tests/modules/programs/scmpuff/no-bash.nix
+++ b/tests/modules/programs/scmpuff/no-bash.nix
@@ -12,6 +12,6 @@
   test.stubs.scmpuff = { };
 
   nmt.script = ''
-    assertFileNotRegex home-files/.bashrc '@scmpuff@/bin/scmpuff'
+    assertFileNotRegex home-files/.bashrc '@scmpuff@'
   '';
 }

--- a/tests/modules/programs/scmpuff/no-shell.nix
+++ b/tests/modules/programs/scmpuff/no-shell.nix
@@ -17,7 +17,7 @@
   };
 
   nmt.script = ''
-    assertFileNotRegex home-files/.zshrc '@scmpuff@ init -s'
-    assertFileNotRegex home-files/.bashrc '@scmpuff@ init -s'
+    assertFileNotRegex home-files/.zshrc '@scmpuff@'
+    assertFileNotRegex home-files/.bashrc '@scmpuff@'
   '';
 }

--- a/tests/modules/programs/scmpuff/zsh.nix
+++ b/tests/modules/programs/scmpuff/zsh.nix
@@ -15,6 +15,6 @@
     assertFileExists home-files/.zshrc
     assertFileContains \
       home-files/.zshrc \
-      'eval "$(@scmpuff@/bin/scmpuff init -s)"'
+      'eval "$(@scmpuff@/bin/scmpuff init --shell=zsh)"'
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Currently, `scmpuff` is giving their aliases  (e.g. `ga`, `gd`, `gco`) by default. I already have my own aliases for git and personally don't like theirs. I added `enableAliases` so we can enable or disable it.

Reference: https://github.com/mroth/scmpuff#can-i-disable-or-change-the-default-git-shortcut-aliases

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@cpcloud