### PR TITLE
docs: fix standalone (path-based) install instructions

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -70,7 +70,7 @@ $ nix-channel --update
 Manager generation:
 +
 [source,console]
-$ nix-shell '<home-manager>' -A install
+$ nix-shell ~/.nix-defexpr/channels/home-manager -A install
 +
 Once finished, Home Manager should be active and available in your
 user environment.


### PR DESCRIPTION
### Description

Don't depend on `NIX_PATH` being correctly set during the installation process.

Fixes #4071, fixes #3091, fixes #2564, fixes #1267, fixes #487. See NixOS/nix#2033.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
