### PR TITLE
xplr: fix cfg.plugins implementation for more than one plugin

### DIFF
--- a/modules/programs/xplr.nix
+++ b/modules/programs/xplr.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 let
   inherit (lib)
-    concatStringsSep types mkIf mkOption mkEnableOption mkPackageOption
-    literalExpression;
+    types mkIf mkOption mkEnableOption mkPackageOption literalExpression;
 
   cfg = config.programs.xplr;
 
@@ -10,21 +9,39 @@ let
     version = '${cfg.package.version}'
   '';
 
-  # We provide a default version line within the configuration file, which is
-  # obtained from the package's attributes. Merge the initial configFile, a
-  # mapped list of plugins and then the user defined configuration to obtain the
-  # final configuration.
-  pluginPath = if cfg.plugins != [ ] then
-    (''
-      package.path=
-    '' + (concatStringsSep " ..\n"
-      (map (p: ''"${p}/init.lua;${p}/?.lua;"'') cfg.plugins)) + ''
-         ..
-        package.path
-      '')
+  # If `value` is a Nix store path, create the symlink `/nix/store/newhash/${name}/*` 
+  # to `/nix/store/oldhash/*` and returns `/nix/store/newhash`.
+  wrapPlugin = name: value:
+    if lib.isStorePath value then
+      pkgs.symlinkJoin {
+        name = name;
+        paths = [ value ];
+        postBuild = ''
+          mkdir '${name}'
+          mv $out/* '${name}/'
+          mv '${name}' $out/
+        '';
+      }
+    else
+      builtins.dirOf value;
+
+  makePluginSearchPath = p: "${p}/?/init.lua;${p}/?.lua";
+
+  pluginPath = if cfg.plugins != { } then
+    let
+      wrappedPlugins = lib.mapAttrsToList wrapPlugin cfg.plugins;
+      searchPaths = map makePluginSearchPath wrappedPlugins;
+      pluginSearchPath = lib.concatStringsSep ";" searchPaths;
+    in (''
+      package.path = "${pluginSearchPath};" .. package.path
+    '')
   else
     "\n";
 
+  # We provide a default version line within the configuration file, which is
+  # obtained from the package's attributes. Merge the initial configFile, a
+  # mapped list of plugins and then the user defined configuration to obtain
+  # the final configuration.
   configFile = initialConfig + pluginPath + cfg.extraConfig;
 in {
   meta.maintainers = [ lib.maintainers.NotAShelf ];
@@ -35,15 +52,25 @@ in {
     package = mkPackageOption pkgs "xplr" { };
 
     plugins = mkOption {
-      type = with types; nullOr (listOf (either package str));
-      default = [ ];
-      defaultText = literalExpression "[]";
+      type = with types; nullOr (attrsOf (either package str));
+      default = { };
+      defaultText = literalExpression "{ }";
       description = ''
-        Plugins to be added to your configuration file.
+        An attribute set of plugin paths to be added to the [package.path]<https://www.lua.org/manual/5.4/manual.html#pdf-package.path> of the {file}`~/config/xplr/init.lua` configuration file.
 
-        Must be a package, an absolute plugin path, or string to be recognized
-        by xplr. Paths will be relative to
-        {file}`$XDG_CONFIG_HOME/xplr/init.lua` unless they are absolute.
+        Must be a package or string representing the plugin directory's path. 
+        If the path string is not absolute, it will be relative to {file}`$XDG_CONFIG_HOME/xplr/init.lua`.
+      '';
+      example = literalExpression ''
+        {
+          wl-clipboard = fetchFromGitHub {
+            owner = "sayanarijit";
+            repo = "wl-clipboard.xplr";
+            rev = "a3ffc87460c5c7f560bffea689487ae14b36d9c3";
+            hash = "sha256-I4rh5Zks9hiXozBiPDuRdHwW5I7ppzEpQNtirY0Lcks=";
+          }
+          local-plugin = "/home/user/.config/plugins/local-plugin";
+        };
       '';
     };
 


### PR DESCRIPTION
### Description

Would close https://github.com/nix-community/home-manager/issues/4520. Please see that issue (and the upstream discussion linked within) for more information.

Change the implementation of the `programs.xplr.plugins` option to correctly set the `package.path` in the written Lua config file.

Specifically, each component path of the `package.path` must have appropriate wildcard/template characters (what Lua calls "interrogation marks" or `?` characters).

Furthermore, due to the need (in the current implementation) to use `programs.xplr.extraConfig` to call `require(<plugin-name>).setup`, this implementation ensures that plugins in the Nix store are inside a predictably-named directory.

### Checklist

- [ ] Change is backwards compatible.

Unfortunately not. The `cfg.plugins` option currently takes a list for while it is proposed that it takes an attribute set.

While a change could be made that maintains complete backwards compatibility, one could argue that the usability improvements that accompany the change (of an already broken option) outweigh the cost of breaking back-compat.

- [x] Code formatted with ~~`./format`~~ `nixfmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted appropriately

#### Maintainer CC

@NotAShelf