### PR TITLE
zsh-abbr: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -257,6 +257,12 @@
     githubId = 605641;
     name = "Bart Bakker";
   };
+  ilaumjd = {
+    name = "Ilham AM";
+    email = "ilaumjd@gmail.com";
+    github = "ilaumjd";
+    githubId = 16514431;
+  };
   jrobsonchase = {
     email = "josh@robsonchase.com";
     github = "jrobsonchase";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1258,6 +1258,14 @@ in
           A new module is available: 'programs.khard'.
         '';
       }
+
+      {
+        time = "2023-10-04T06:06:08+00:00";
+        condition = config.programs.zsh.enable;
+        message = ''
+          A new module is available: 'programs.zsh.zsh-abbr'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -237,6 +237,7 @@ let
     ./programs/zplug.nix
     ./programs/zsh.nix
     ./programs/zsh/prezto.nix
+    ./programs/zsh/zsh-abbr.nix
     ./services/autorandr.nix
     ./services/avizo.nix
     ./services/barrier.nix

--- a/modules/programs/zsh/zsh-abbr.nix
+++ b/modules/programs/zsh/zsh-abbr.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.programs.zsh.zsh-abbr;
+in {
+  meta.maintainers = [ hm.maintainers.ilaumjd ];
+
+  options.programs.zsh.zsh-abbr = {
+    enable =
+      mkEnableOption "zsh-abbr - zsh manager for auto-expanding abbreviations";
+
+    abbreviations = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        l = "less";
+        gco = "git checkout";
+      };
+      description = ''
+        An attribute set that maps aliases (the top level attribute names
+        in this option) to abbreviations. Abbreviations are expanded with
+        the longer phrase after they are entered.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.zsh.plugins = [{
+      name = "zsh-abbr";
+      src = pkgs.zsh-abbr;
+      file = "/share/zsh/zsh-abbr/abbr.plugin.zsh";
+    }];
+
+    xdg.configFile = {
+      "zsh-abbr/user-abbreviations".text = concatStringsSep "\n"
+        (mapAttrsToList (k: v: "abbr ${escapeShellArg k}=${escapeShellArg v}")
+          cfg.abbreviations) + "\n";
+    };
+  };
+}

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -8,4 +8,5 @@
   zsh-history-substring-search = ./history-substring-search.nix;
   zsh-prezto = ./prezto.nix;
   zsh-syntax-highlighting = ./syntax-highlighting.nix;
+  zsh-abbr = ./zsh-abbr.nix;
 }

--- a/tests/modules/programs/zsh/zsh-abbr.nix
+++ b/tests/modules/programs/zsh/zsh-abbr.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs.zsh.zsh-abbr = {
+    enable = true;
+    abbreviations = { ga = "git add"; };
+  };
+
+  test.stubs.zsh-abbr = { };
+
+  nmt.script = ''
+    abbreviations=home-files/.config/zsh-abbr/user-abbreviations
+
+    assertFileExists $abbreviations
+    assertFileContains $abbreviations "abbr 'ga'='git add'"
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add `zsh-abbr` module under `zsh`.
Add `zsh-abbr.abbrs` option so we can use fish-like abbreviations in zsh.

References: https://github.com/olets/zsh-abbr

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
