### PR TITLE
bat: allow setting themes/syntaxes without IFD

### DIFF
--- a/modules/programs/bat.nix
+++ b/modules/programs/bat.nix
@@ -43,16 +43,33 @@ in {
     };
 
     themes = mkOption {
-      type = types.attrsOf types.lines;
+      type = types.attrsOf (types.either types.lines (types.submodule {
+        options = {
+          src = mkOption {
+            type = types.path;
+            description = "Path to the theme folder.";
+          };
+
+          file = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description =
+              "Subpath of the theme file within the source, if needed.";
+          };
+        };
+      }));
       default = { };
       example = literalExpression ''
         {
-          dracula = builtins.readFile (pkgs.fetchFromGitHub {
-            owner = "dracula";
-            repo = "sublime"; # Bat uses sublime syntax for its themes
-            rev = "26c57ec282abcaa76e57e055f38432bd827ac34e";
-            sha256 = "019hfl4zbn4vm4154hh3bwk6hm7bdxbr1hdww83nabxwjn99ndhv";
-          } + "/Dracula.tmTheme");
+          dracula = {
+            src = pkgs.fetchFromGitHub {
+              owner = "dracula";
+              repo = "sublime"; # Bat uses sublime syntax for its themes
+              rev = "26c57ec282abcaa76e57e055f38432bd827ac34e";
+              sha256 = "019hfl4zbn4vm4154hh3bwk6hm7bdxbr1hdww83nabxwjn99ndhv";
+            };
+            file = "Dracula.tmTheme";
+          };
         }
       '';
       description = ''
@@ -61,43 +78,84 @@ in {
     };
 
     syntaxes = mkOption {
-      type = types.attrsOf types.lines;
+      type = types.attrsOf (types.either types.lines (types.submodule {
+        options = {
+          src = mkOption {
+            type = types.path;
+            description = "Path to the syntax folder.";
+          };
+          file = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description =
+              "Subpath of the syntax file within the source, if needed.";
+          };
+        };
+      }));
       default = { };
       example = literalExpression ''
         {
-          syntaxes.gleam = builtins.readFile (pkgs.fetchFromGitHub {
-            owner = "molnarmark";
-            repo = "sublime-gleam";
-            rev = "2e761cdb1a87539d827987f997a20a35efd68aa9";
-            hash = "sha256-Zj2DKTcO1t9g18qsNKtpHKElbRSc9nBRE2QBzRn9+qs=";
-          } + "/syntax/gleam.sublime-syntax");
+          gleam = {
+            src = pkgs.fetchFromGitHub {
+              owner = "molnarmark";
+              repo = "sublime-gleam";
+              rev = "2e761cdb1a87539d827987f997a20a35efd68aa9";
+              hash = "sha256-Zj2DKTcO1t9g18qsNKtpHKElbRSc9nBRE2QBzRn9+qs=";
+            };
+            file = "syntax/gleam.sublime-syntax";
+          };
         }
       '';
       description = ''
         Additional syntaxes to provide.
       '';
     };
-
   };
 
-  config = mkIf cfg.enable {
-    home.packages = [ package ] ++ cfg.extraPackages;
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf (any isString (attrValues cfg.themes)) {
+      warnings = [''
+        Using programs.bat.themes as a string option is deprecated and will be
+        removed in the future. Please change to using it as an attribute set
+        instead.
+      ''];
+    })
+    (mkIf (any isString (attrValues cfg.syntaxes)) {
+      warnings = [''
+        Using programs.bat.syntaxes as a string option is deprecated and will be
+        removed in the future. Please change to using it as an attribute set
+        instead.
+      ''];
+    })
+    {
+      home.packages = [ package ] ++ cfg.extraPackages;
 
-    xdg.configFile = mkMerge ([{
-      "bat/config" =
-        mkIf (cfg.config != { }) { text = toConfigFile cfg.config; };
-    }] ++ flip mapAttrsToList cfg.themes
-      (name: body: { "bat/themes/${name}.tmTheme" = { text = body; }; })
-      ++ flip mapAttrsToList cfg.syntaxes (name: body: {
-        "bat/syntaxes/${name}.sublime-syntax" = { text = body; };
-      }));
+      xdg.configFile = mkMerge ([({
+        "bat/config" =
+          mkIf (cfg.config != { }) { text = toConfigFile cfg.config; };
+      })] ++ (flip mapAttrsToList cfg.themes (name: val: {
+        "bat/themes/${name}.tmTheme" = if isString val then {
+          text = val;
+        } else {
+          source =
+            if isNull val.file then "${val.src}" else "${val.src}/${val.file}";
+        };
+      })) ++ (flip mapAttrsToList cfg.syntaxes (name: val: {
+        "bat/syntaxes/${name}.sublime-syntax" = if isString val then {
+          text = val;
+        } else {
+          source =
+            if isNull val.file then "${val.src}" else "${val.src}/${val.file}";
+        };
+      })));
 
-    home.activation.batCache = hm.dag.entryAfter [ "linkGeneration" ] ''
-      (
-        export XDG_CACHE_HOME=${escapeShellArg config.xdg.cacheHome}
-        $VERBOSE_ECHO "Rebuilding bat theme cache"
-        $DRY_RUN_CMD ${lib.getExe package} cache --build
-      )
-    '';
-  };
+      home.activation.batCache = hm.dag.entryAfter [ "linkGeneration" ] ''
+        (
+          export XDG_CACHE_HOME=${escapeShellArg config.xdg.cacheHome}
+          $VERBOSE_ECHO "Rebuilding bat theme cache"
+          $DRY_RUN_CMD ${lib.getExe package} cache --build
+        )
+      '';
+    }
+  ]);
 }

--- a/tests/modules/programs/bat/default.nix
+++ b/tests/modules/programs/bat/default.nix
@@ -1,1 +1,4 @@
-{ bat = ./bat.nix; }
+{
+  bat = ./bat.nix;
+  bat-deprecated-options = ./deprecated-options.nix;
+}

--- a/tests/modules/programs/bat/deprecated-options.nix
+++ b/tests/modules/programs/bat/deprecated-options.nix
@@ -13,16 +13,30 @@ with lib;
         map-syntax = [ "*.jenkinsfile:Groovy" "*.props:Java Properties" ];
       };
 
-      themes.testtheme.src = pkgs.writeText "testtheme.tmTheme" ''
+      themes.testtheme = ''
         This is a test theme.
       '';
 
-      syntaxes.testsyntax.src = pkgs.writeText "testsyntax.sublime-syntax" ''
+      syntaxes.testsyntax = ''
         This is a test syntax.
       '';
     };
 
     test.stubs.bat = { };
+
+    test.asserts.warnings.enable = true;
+    test.asserts.warnings.expected = [
+      ''
+        Using programs.bat.themes as a string option is deprecated and will be
+        removed in the future. Please change to using it as an attribute set
+        instead.
+      ''
+      ''
+        Using programs.bat.syntaxes as a string option is deprecated and will be
+        removed in the future. Please change to using it as an attribute set
+        instead.
+      ''
+    ];
 
     nmt.script = ''
       assertFileExists home-files/.config/bat/config


### PR DESCRIPTION
### Description

The way the `bat` module is currently written makes it essentially impossible to
use themes and syntaxes without IFD, since you must provide the contents as
string, instead of just giving a path to be linked.

With this change, setting themes/syntaxes by-string will start issuing warnings,
and a new attribute model is added, lightly inspired by how
`programs.zsh.plugins` avoided this issue.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
cc. @stuebinm, @rycee, @lugray
