### PR TITLE
fish: 2 fixes

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -221,9 +221,11 @@ let
 
   translatedSessionVariables =
     pkgs.runCommandLocal "hm-session-vars.fish" { } ''
+      (echo "function setup_hm_session_vars;"
       ${pkgs.buildPackages.babelfish}/bin/babelfish \
-        <${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh \
-        >$out
+      <${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh
+      echo "end"
+      echo "setup_hm_session_vars") > $out
     '';
 
 in {


### PR DESCRIPTION
### Description

Wrap babelfish version of `hm-session-vars.sh` into a function to ensure this can be safely evaluated at session startup. The current session vars shell script uses a `return` statement and this breaks the generated script.

Ensure that the fzf key bindings function is not called in non-interactive scenarios when fzf does not declare the function.

- This PR wraps the hm-session-vars into a immediately called function.
- This PR does not evaluate fzf_key_bindings in interactive mode

 ### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted correctly

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

- @yu-re-ka 
- @emilazy
