### PR TITLE
unison: add package option

### DIFF
--- a/modules/services/unison.nix
+++ b/modules/services/unison.nix
@@ -76,6 +76,10 @@ in {
   options.services.unison = {
     enable = mkEnableOption "Unison synchronisation";
 
+    package = mkPackageOption pkgs "unison" {
+      example = "pkgs.unison.override { enableX11 = false; }";
+    };
+
     pairs = mkOption {
       type = with types; attrsOf (submodule pairOptions);
       default = { };
@@ -117,7 +121,7 @@ in {
 
         Environment = [ "UNISON='${toString pairCfg.stateDirectory}'" ];
         ExecStart = ''
-          ${pkgs.unison}/bin/unison \
+          ${cfg.package}/bin/unison \
             ${serialiseArgs pairCfg.commandOptions} \
             ${strings.concatMapStringsSep " " escapeShellArg pairCfg.roots}
         '';


### PR DESCRIPTION
### Description

So that one can use the lighter headless version of Unison.


### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted
    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
- If this PR adds a new module
  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

