### PR TITLE
unison: better retry/restart reporting failures

### DIFF
--- a/modules/services/unison.nix
+++ b/modules/services/unison.nix
@@ -65,9 +65,10 @@ let
 
   serialiseArgs = args: concatStringsSep " " (mapAttrsToList serialiseArg args);
 
+  unitName = name: "unison-pair-${name}";
+
   makeDefs = gen:
-    mapAttrs'
-    (name: pairCfg: nameValuePair "unison-pair-${name}" (gen name pairCfg))
+    mapAttrs' (name: pairCfg: nameValuePair (unitName name) (gen name pairCfg))
     cfg.pairs;
 
 in {
@@ -102,19 +103,10 @@ in {
     ];
 
     systemd.user.services = makeDefs (name: pairCfg: {
-      Unit = {
-        Description = "Unison pair sync (${name})";
-        # Retry forever, useful in case of network disruption.
-        StartLimitIntervalSec = 0;
-      };
-
+      Unit.Description = "Unison pair sync (${name})";
       Service = {
-        Restart = "always";
-        RestartSec = 60;
-
         CPUSchedulingPolicy = "idle";
         IOSchedulingClass = "idle";
-
         Environment = [ "UNISON='${toString pairCfg.stateDirectory}'" ];
         ExecStart = ''
           ${pkgs.unison}/bin/unison \
@@ -122,8 +114,16 @@ in {
             ${strings.concatMapStringsSep " " escapeShellArg pairCfg.roots}
         '';
       };
+    });
 
-      Install = { WantedBy = [ "default.target" ]; };
+    systemd.user.timers = makeDefs (name: pairCfg: {
+      Unit.Description = "Unison pair sync auto-restart (${name})";
+      Install.WantedBy = [ "timers.target" ];
+      Timer = {
+        Unit = "${unitName name}.service";
+        OnActiveSec = 1;
+        OnUnitInactiveSec = 60;
+      };
     });
   };
 }


### PR DESCRIPTION
### Description

The service was never marked with a failed state with the previous
approach, which could lead broken synchronisation pair states to go
undetected.

The module now uses a timer instead of unlimited restarts, which does
not have this issue.


### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted
    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
- If this PR adds a new module
  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
