### PR TITLE
kime: fix configuration

### DIFF
--- a/modules/i18n/input-method/kime.nix
+++ b/modules/i18n/input-method/kime.nix
@@ -1,34 +1,33 @@
-{ config, pkgs, lib, generators, ... }:
-with lib;
+{ config, pkgs, lib, ... }:
+
 let
+  inherit (lib) literalExpression mkIf mkOption mkRemovedOptionModule types;
+
   cfg = config.i18n.inputMethod.kime;
-  yamlFormat = pkgs.formats.yaml { };
 in {
+  imports = [
+    (mkRemovedOptionModule [ "i18n" "inputMethod" "kime" "config" ] ''
+      Please use 'i18n.inputMethod.kime.extraConfig' instead.
+    '')
+  ];
+
   options = {
     i18n.inputMethod.kime = {
-      config = mkOption {
-        type = yamlFormat.type;
-        default = { };
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
         example = literalExpression ''
-          {
-            daemon = {
-              modules = ["Xim" "Indicator"];
-            };
-
-            indicator = {
-              icon_color = "White";
-            };
-
-            engine = {
-              hangul = {
-                layout = "dubeolsik";
-              };
-            };
-          }
+          daemon:
+            modules: [Xim,Indicator]
+          indicator:
+            icon_color: White
+          engine:
+            hangul:
+              layout: dubeolsik
         '';
         description = ''
           kime configuration. Refer to
-          <https://github.com/Riey/kime/blob/develop/docs/CONFIGURATION.md>
+          <https://github.com/Riey/kime/blob/v${pkgs.kime.version}/docs/CONFIGURATION.md>
           for details on supported values.
         '';
       };
@@ -44,8 +43,7 @@ in {
       XMODIFIERS = "@im=kime";
     };
 
-    xdg.configFile."kime/config.yaml".text =
-      replaceStrings [ "\\\\" ] [ "\\" ] (builtins.toJSON cfg.config);
+    xdg.configFile."kime/config.yaml".text = cfg.extraConfig;
 
     systemd.user.services.kime-daemon = {
       Unit = {

--- a/modules/i18n/input-method/kime.nix
+++ b/modules/i18n/input-method/kime.nix
@@ -27,7 +27,7 @@ in {
         '';
         description = ''
           kime configuration. Refer to
-          <https://github.com/Riey/kime/blob/v${pkgs.kime.version}/docs/CONFIGURATION.md>
+          <https://github.com/Riey/kime/blob/develop/docs/CONFIGURATION.md>
           for details on supported values.
         '';
       };

--- a/tests/modules/i18n/input-method/kime-configuration.nix
+++ b/tests/modules/i18n/input-method/kime-configuration.nix
@@ -1,14 +1,45 @@
 { config, pkgs, ... }:
 
-{
+let
+
+  kimeConfig = ''
+    daemon:
+      modules: [Xim,Indicator]
+    indicator:
+      icon_color: White
+    engine:
+      hangul:
+        layout: dubeolsik
+  '';
+
+in {
   i18n.inputMethod = {
     enabled = "kime";
-    kime.config = { engine = { hangul = { layout = "dubeolsik"; }; }; };
+    kime.extraConfig = kimeConfig;
   };
 
-  test.stubs.kime = { outPath = null; };
+  test.stubs = {
+    kime = { outPath = null; };
+    gtk2 = {
+      buildScript = ''
+        mkdir -p $out/bin
+        echo '#/usr/bin/env bash' > $out/bin/gtk-query-immodules-2.0
+        chmod +x $out/bin/*
+      '';
+    };
+    gtk3 = {
+      buildScript = ''
+        mkdir -p $out/bin
+        echo '#/usr/bin/env bash' > $out/bin/gtk-query-immodules-3.0
+        chmod +x $out/bin/*
+      '';
+    };
+  };
 
   nmt.script = ''
     assertFileExists home-files/.config/systemd/user/kime-daemon.service
+    assertFileExists home-files/.config/kime/config.yaml
+    assertFileContent home-files/.config/kime/config.yaml \
+      ${builtins.toFile "kime-expected.yaml" kimeConfig}
   '';
 }


### PR DESCRIPTION
Switches the kime configuration format to use unstructured text. This is necessary since version 3 and upwards use yaml tags. Closes #4261. Something like this was already done in nixpkgs, cf. https://github.com/NixOS/nixpkgs/pull/211937.

### Description

Kime has updated its configuration format following version 3 to use the yaml tag functionality. This is not supported by the yaml tooling in nixpkgs, leaving kime essentially unusable in home-manager (or at least unconfigurable). This PR switches the configuration setting to an unstructured text format, which is unfortunate but at least usable.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
There are no maintainers listed, but here's a couple of people who seem like they might be interested:
@Kranzes @rycee  @sudosubin