### PR TITLE
fish: improve performance by generating alias functions instead of calling `alias`

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -143,7 +143,7 @@ let
       cfg.shellAbbrs);
 
   aliasesStr = concatStringsSep "\n"
-    (mapAttrsToList (k: v: "alias ${k} ${escapeShellArg v}") cfg.shellAliases);
+    (mapAttrsToList (k: v: "function ${k} -w ${escapeShellArg v}; ${v} $argv; end") cfg.shellAliases);
 
   fishIndent = name: text:
     pkgs.runCommand name {


### PR DESCRIPTION
### Description

Defining aliases with the `alias` command causes a performance hit, which may become very noticeable on lower end hardware and/or as the amount of aliases grow.

This is because `alias` is not a builtin command, but rather causes an eval to take place. More background information can be found here: https://github.com/fish-shell/fish-shell/issues/828

As a much more performant alternative, directly generate functions (which is what `alias` would do anyway). Thanks to the `-w` / `--wraps` option, we can keep the inherited completion.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
