### PR TITLE
aerc: symlink aerc directory on macos

### DIFF
--- a/modules/programs/aerc.nix
+++ b/modules/programs/aerc.nix
@@ -3,6 +3,7 @@
 with lib;
 let
   cfg = config.programs.aerc;
+  homeDir = config.home.homeDirectory;
 
   primitive = with types;
     ((type: either type (listOf type)) (nullOr (oneOf [ str int bool float ])))
@@ -216,5 +217,12 @@ in {
         ];
       };
     } // (mkStyleset cfg.stylesets) // (mkTemplates cfg.templates);
+
+    home.activation = if pkgs.stdenv.isDarwin then {
+      linkAerc = ''
+        ln -s ${homeDir}/.config/aerc ${homeDir}/Library/Preferences/aerc || true
+      '';
+    } else
+      { };
   };
 }


### PR DESCRIPTION
### Description

On MacOS, aerc uses the ~/Library/Preferences/aerc directory instead of ~/.config/aerc. This adds a symlink at ~/Library/Preferences/aerc pointing to ~/.config/aerc on MacOS.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@lukasngl 