### PR TITLE
aerc: fix config paths on darwin

### DIFF
--- a/modules/programs/aerc.nix
+++ b/modules/programs/aerc.nix
@@ -24,6 +24,11 @@ let
   aerc-accounts =
     attrsets.filterAttrs (_: v: v.aerc.enable) config.accounts.email.accounts;
 
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Preferences/aerc"
+  else
+    "${config.xdg.configHome}/aerc";
+
 in {
   meta.maintainers = with lib.hm.maintainers; [ lukasngl ];
 
@@ -121,12 +126,12 @@ in {
     mkStyleset = attrsets.mapAttrs' (k: v:
       let value = if isString v then v else toINI { global = v; };
       in {
-        name = "aerc/stylesets/${k}";
+        name = "${configDir}/stylesets/${k}";
         value.text = joinCfg [ header value ];
       });
 
     mkTemplates = attrsets.mapAttrs' (k: v: {
-      name = "aerc/templates/${k}";
+      name = "${configDir}/templates/${k}";
       value.text = v;
     });
 
@@ -190,8 +195,8 @@ in {
 
     home.packages = [ cfg.package ];
 
-    xdg.configFile = {
-      "aerc/accounts.conf" = mkIf genAccountsConf {
+    home.file = {
+      "${configDir}/accounts.conf" = mkIf genAccountsConf {
         text = joinCfg [
           header
           (mkINI cfg.extraAccounts)
@@ -200,7 +205,7 @@ in {
         ];
       };
 
-      "aerc/aerc.conf" = mkIf genAercConf {
+      "${configDir}/aerc.conf" = mkIf genAercConf {
         text = joinCfg [
           header
           (mkINI cfg.extraConfig)
@@ -208,7 +213,7 @@ in {
         ];
       };
 
-      "aerc/binds.conf" = mkIf genBindsConf {
+      "${configDir}/binds.conf" = mkIf genBindsConf {
         text = joinCfg [
           header
           (mkINI cfg.extraBinds)

--- a/tests/modules/programs/aerc/settings.nix
+++ b/tests/modules/programs/aerc/settings.nix
@@ -4,7 +4,11 @@ with lib;
 
 {
   config = {
-    nmt.script = let dir = "home-files/.config/aerc";
+    nmt.script = let
+      dir = if pkgs.stdenv.isDarwin then
+        "home-files/Library/Preferences/aerc"
+      else
+        "home-files/.config/aerc";
     in ''
       assertFileContent   ${dir}/accounts.conf     ${./extraAccounts.expected}
       assertFileContent   ${dir}/binds.conf        ${./extraBinds.expected}


### PR DESCRIPTION
### Description

Fix the config paths in the `programs.aerc` module so that they work on darwin.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
  - [x] on x86_64-linux
  - [x] on aarch64-darwin

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@lukasngl 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
