### PR TITLE
zsh: allow variable expansion for `zsh-history-substring-search` key codes

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -204,7 +204,8 @@ let
         default = [ "^[[A" ];
         description = ''
           The key codes to be used when searching up.
-          The default of `^[[A` corresponds to the UP key.
+          The default of `^[[A` may correspond to the UP key -- if not, try
+          `$terminfo[kcuu1]`.
         '';
       };
       searchDownKey = mkOption {
@@ -212,7 +213,8 @@ let
         default = [ "^[[B" ];
         description = ''
           The key codes to be used when searching down.
-          The default of `^[[B` corresponds to the DOWN key.
+          The default of `^[[B` may correspond to the DOWN key -- if not, try
+          `$terminfo[kcud1]`.
         '';
       };
     };
@@ -635,11 +637,11 @@ in
         ''
           source ${pkgs.zsh-history-substring-search}/share/zsh-history-substring-search/zsh-history-substring-search.zsh
           ${lib.concatMapStringsSep "\n"
-            (upKey: "bindkey '${upKey}' history-substring-search-up")
+            (upKey: "bindkey \"${upKey}\" history-substring-search-up")
             (lib.toList cfg.historySubstringSearch.searchUpKey)
           }
           ${lib.concatMapStringsSep "\n"
-            (downKey: "bindkey '${downKey}' history-substring-search-down")
+            (downKey: "bindkey \"${downKey}\" history-substring-search-down")
             (lib.toList cfg.historySubstringSearch.searchDownKey)
           }
         '')

--- a/tests/modules/programs/zsh/history-substring-search.nix
+++ b/tests/modules/programs/zsh/history-substring-search.nix
@@ -17,9 +17,9 @@ with lib;
 
     # Written with regex to ensure we don't end up missing newlines in the future
     nmt.script = ''
-      assertFileRegex home-files/.zshrc "^bindkey '\^\[\[B' history-substring-search-down$"
-      assertFileRegex home-files/.zshrc "^bindkey '\^\[\[A' history-substring-search-up$"
-      assertFileRegex home-files/.zshrc "^bindkey '\\\\eOA' history-substring-search-up$"
+      assertFileRegex home-files/.zshrc "^bindkey \"\^\[\[B\" history-substring-search-down$"
+      assertFileRegex home-files/.zshrc "^bindkey \"\^\[\[A\" history-substring-search-up$"
+      assertFileRegex home-files/.zshrc "^bindkey \"\\\\eOA\" history-substring-search-up$"
     '';
   };
 }


### PR DESCRIPTION
Switch from single to double quotes.

Also adds suggestion that I found helpful to descriptions (taken from
the project's [README](https://github.com/zsh-users/zsh-history-substring-search/blob/4abed97b6e67eb5590b39bcd59080aa23192f25d/README.md?plain=1#L71-L74)).

### Description

See above.

There may be an argument for adding `$terminfo[kcuu1]` and `$terminfo[kcud1]` to the defaults although I don't know enough about `terminfo` to know if the variable will be defined for everyone's environments.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
