### PR TITLE
nushell: set home.sessionVariables in login.nu

### DIFF
--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -182,9 +182,13 @@ in {
           envVarsStr
         ];
       })
-      (mkIf (cfg.loginFile != null || cfg.extraLogin != "") {
+      (let
+        sessionVariables = concatStringsSep "\n"
+          (mapAttrsToList (k: v: "$env.${k} = ${v}") config.home.sessionVariables);
+      in mkIf (cfg.loginFile != null || cfg.extraLogin != "" || sessionVariables != "") {
         "${configDir}/login.nu".text = mkMerge [
           (mkIf (cfg.loginFile != null) cfg.loginFile.text)
+          sessionVariables
           cfg.extraLogin
         ];
       })


### PR DESCRIPTION
### Description
In other shells, we can source `~/.nix-profile/etc/profile.d/hm-session-vars.sh` to set these variables in login shells. For nushell I have directly mapped `home.sessionVariables` to nushell env declarations. If this isn't ok, I am happy to implement any feedback.

Resolves #4313
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
