### PR TITLE
thefuck: add instant mode option

### DIFF
--- a/modules/programs/thefuck.nix
+++ b/modules/programs/thefuck.nix
@@ -1,7 +1,8 @@
 { config, lib, pkgs, ... }:
+
 with lib;
-let cfg = config.programs.thefuck;
-in {
+
+{
   meta.maintainers = [ hm.maintainers.ilaumjd ];
 
   options.programs.thefuck = {
@@ -9,6 +10,8 @@ in {
       "thefuck - magnificent app that corrects your previous console command";
 
     package = mkPackageOption pkgs "thefuck" { };
+
+    enableInstantMode = mkEnableOption "thefuck's experimental instant mode";
 
     enableBashIntegration = mkOption {
       default = true;
@@ -27,15 +30,22 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = let
+    cfg = config.programs.thefuck;
+
+    cliArgs = cli.toGNUCommandLineShell { } {
+      alias = true;
+      enable-experimental-instant-mode = cfg.enableInstantMode;
+    };
+
+    shEvalCmd = ''
+      eval "$(${cfg.package}/bin/thefuck ${cliArgs})"
+    '';
+  in mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      eval "$(${cfg.package}/bin/thefuck --alias)"
-    '';
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration shEvalCmd;
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      eval "$(${cfg.package}/bin/thefuck --alias)"
-    '';
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration shEvalCmd;
   };
 }

--- a/tests/modules/programs/thefuck/default.nix
+++ b/tests/modules/programs/thefuck/default.nix
@@ -1,4 +1,5 @@
 {
   thefuck-integration-enabled = ./integration-enabled.nix;
+  thefuck-integration-enabled-instant = ./integration-enabled-instant.nix;
   thefuck-integration-disabled = ./integration-disabled.nix;
 }

--- a/tests/modules/programs/thefuck/integration-enabled-instant.nix
+++ b/tests/modules/programs/thefuck/integration-enabled-instant.nix
@@ -2,7 +2,10 @@
 
 {
   programs = {
-    thefuck.enable = true;
+    thefuck = {
+      enable = true;
+      enableInstantMode = true;
+    };
     bash.enable = true;
     zsh.enable = true;
   };
@@ -13,11 +16,11 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
-      'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"')"'
+      'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"' '"'"'--enable-experimental-instant-mode'"'"')"'
 
     assertFileExists home-files/.zshrc
     assertFileContains \
       home-files/.zshrc \
-      'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"')"'
+      'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"' '"'"'--enable-experimental-instant-mode'"'"')"'
   '';
 }


### PR DESCRIPTION
### Description

This adds the option to add `--enable-experimental-instant-mode` to the initiation of `thefuck`.

I also moved the init command to a variable to be more DRY.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC
@ilaumjd 