### PR TITLE
Improve firefox tests

### DIFF
--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -2,4 +2,5 @@
   firefox-profile-settings = ./profile-settings.nix;
   firefox-state-version-19_09 = ./state-version-19_09.nix;
   firefox-deprecated-native-messenger = ./deprecated-native-messenger.nix;
+  firefox-duplicate-profile-ids = ./duplicate-profile-ids.nix;
 }

--- a/tests/modules/programs/firefox/deprecated-native-messenger.nix
+++ b/tests/modules/programs/firefox/deprecated-native-messenger.nix
@@ -2,35 +2,20 @@
 
 with lib;
 
-lib.mkIf config.test.enableBig {
-  programs.firefox = {
-    enable = true;
-    enableGnomeExtensions = true;
+{
+  imports = [ ./setup-firefox-mock-overlay.nix ];
+
+  config = lib.mkIf config.test.enableBig {
+    programs.firefox = {
+      enable = true;
+      enableGnomeExtensions = true;
+    };
+
+    test.asserts.warnings.expected = [''
+      Using 'programs.firefox.enableGnomeExtensions' has been deprecated and
+      will be removed in the future. Please change to overriding the package
+      configuration using 'programs.firefox.package' instead. You can refer to
+      its example for how to do this.
+    ''];
   };
-
-  nixpkgs.overlays = [
-    (self: super: {
-      firefox-unwrapped = pkgs.runCommandLocal "firefox-0" {
-        meta.description = "I pretend to be Firefox";
-        passthru.gtk3 = null;
-      } ''
-        mkdir -p "$out"/{bin,lib}
-        touch "$out/bin/firefox"
-        chmod 755 "$out/bin/firefox"
-      '';
-
-      chrome-gnome-shell =
-        pkgs.runCommandLocal "dummy-chrome-gnome-shell" { } ''
-          mkdir -p $out/lib/mozilla/native-messaging-hosts
-          touch $out/lib/mozilla/native-messaging-hosts/dummy
-        '';
-    })
-  ];
-
-  test.asserts.warnings.expected = [''
-    Using 'programs.firefox.enableGnomeExtensions' has been deprecated and
-    will be removed in the future. Please change to overriding the package
-    configuration using 'programs.firefox.package' instead. You can refer to
-    its example for how to do this.
-  ''];
 }

--- a/tests/modules/programs/firefox/duplicate-profile-ids.nix
+++ b/tests/modules/programs/firefox/duplicate-profile-ids.nix
@@ -1,0 +1,23 @@
+{ config, lib, ... }:
+
+{
+  imports = [ ./setup-firefox-mock-overlay.nix ];
+
+  config = lib.mkIf config.test.enableBig {
+    test.asserts.assertions.expected = [''
+      Must not have Firefox profiles with duplicate IDs but
+        - ID 1 is used by first, second''];
+
+    programs.firefox = {
+      enable = true;
+
+      profiles = {
+        first = {
+          isDefault = true;
+          id = 1;
+        };
+        second = { id = 1; };
+      };
+    };
+  };
+}

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -2,201 +2,192 @@
 
 with lib;
 
-lib.mkIf config.test.enableBig {
-  programs.firefox = {
-    enable = true;
-    profiles.basic.isDefault = true;
+{
+  imports = [ ./setup-firefox-mock-overlay.nix ];
 
-    profiles.test = {
-      id = 1;
-      settings = {
-        "general.smoothScroll" = false;
-        "browser.newtabpage.pinned" = [{
-          title = "NixOS";
-          url = "https://nixos.org";
-        }];
-      };
-    };
+  config = lib.mkIf config.test.enableBig {
+    programs.firefox = {
+      enable = true;
+      profiles.basic.isDefault = true;
 
-    profiles.bookmarks = {
-      id = 2;
-      settings = { "general.smoothScroll" = false; };
-      bookmarks = [
-        {
-          toolbar = true;
-          bookmarks = [{
-            name = "Home Manager";
-            url = "https://nixos.wiki/wiki/Home_Manager";
+      profiles.test = {
+        id = 1;
+        settings = {
+          "general.smoothScroll" = false;
+          "browser.newtabpage.pinned" = [{
+            title = "NixOS";
+            url = "https://nixos.org";
           }];
-        }
-        {
-          name = "wikipedia";
-          tags = [ "wiki" ];
-          keyword = "wiki";
-          url = "https://en.wikipedia.org/wiki/Special:Search?search=%s&go=Go";
-        }
-        {
-          name = "kernel.org";
-          url = "https://www.kernel.org";
-        }
-        {
-          name = "Nix sites";
-          bookmarks = [
-            {
-              name = "homepage";
-              url = "https://nixos.org/";
-            }
-            {
-              name = "wiki";
-              tags = [ "wiki" "nix" ];
-              url = "https://nixos.wiki/";
-            }
-            {
-              name = "Nix sites";
-              bookmarks = [
-                {
-                  name = "homepage";
-                  url = "https://nixos.org/";
-                }
-                {
-                  name = "wiki";
-                  url = "https://nixos.wiki/";
-                }
-              ];
-            }
-          ];
-        }
-      ];
-    };
+        };
+      };
 
-    profiles.search = {
-      id = 3;
-      search = {
-        force = true;
-        default = "DuckDuckGo";
-        order = [ "Nix Packages" "NixOS Wiki" ];
-        engines = {
-          "Nix Packages" = {
-            urls = [{
-              template = "https://search.nixos.org/packages";
-              params = [
-                {
-                  name = "type";
-                  value = "packages";
-                }
-                {
-                  name = "query";
-                  value = "{searchTerms}";
-                }
-              ];
+      profiles.bookmarks = {
+        id = 2;
+        settings = { "general.smoothScroll" = false; };
+        bookmarks = [
+          {
+            toolbar = true;
+            bookmarks = [{
+              name = "Home Manager";
+              url = "https://nixos.wiki/wiki/Home_Manager";
             }];
+          }
+          {
+            name = "wikipedia";
+            tags = [ "wiki" ];
+            keyword = "wiki";
+            url =
+              "https://en.wikipedia.org/wiki/Special:Search?search=%s&go=Go";
+          }
+          {
+            name = "kernel.org";
+            url = "https://www.kernel.org";
+          }
+          {
+            name = "Nix sites";
+            bookmarks = [
+              {
+                name = "homepage";
+                url = "https://nixos.org/";
+              }
+              {
+                name = "wiki";
+                tags = [ "wiki" "nix" ];
+                url = "https://nixos.wiki/";
+              }
+              {
+                name = "Nix sites";
+                bookmarks = [
+                  {
+                    name = "homepage";
+                    url = "https://nixos.org/";
+                  }
+                  {
+                    name = "wiki";
+                    url = "https://nixos.wiki/";
+                  }
+                ];
+              }
+            ];
+          }
+        ];
+      };
 
-            icon =
-              "/run/current-system/sw/share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+      profiles.search = {
+        id = 3;
+        search = {
+          force = true;
+          default = "DuckDuckGo";
+          order = [ "Nix Packages" "NixOS Wiki" ];
+          engines = {
+            "Nix Packages" = {
+              urls = [{
+                template = "https://search.nixos.org/packages";
+                params = [
+                  {
+                    name = "type";
+                    value = "packages";
+                  }
+                  {
+                    name = "query";
+                    value = "{searchTerms}";
+                  }
+                ];
+              }];
 
-            definedAliases = [ "@np" ];
+              icon =
+                "/run/current-system/sw/share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+
+              definedAliases = [ "@np" ];
+            };
+
+            "NixOS Wiki" = {
+              urls = [{
+                template = "https://nixos.wiki/index.php?search={searchTerms}";
+              }];
+              iconUpdateURL = "https://nixos.wiki/favicon.png";
+              updateInterval = 24 * 60 * 60 * 1000;
+              definedAliases = [ "@nw" ];
+            };
+
+            "Bing".metaData.hidden = true;
+            "Google".metaData.alias = "@g";
           };
+        };
+      };
 
-          "NixOS Wiki" = {
-            urls = [{
-              template = "https://nixos.wiki/index.php?search={searchTerms}";
-            }];
-            iconUpdateURL = "https://nixos.wiki/favicon.png";
-            updateInterval = 24 * 60 * 60 * 1000;
-            definedAliases = [ "@nw" ];
+      profiles.searchWithoutDefault = {
+        id = 4;
+        search = {
+          force = true;
+          order = [ "Google" "Nix Packages" ];
+          engines = {
+            "Nix Packages" = {
+              urls = [{
+                template = "https://search.nixos.org/packages";
+                params = [
+                  {
+                    name = "type";
+                    value = "packages";
+                  }
+                  {
+                    name = "query";
+                    value = "{searchTerms}";
+                  }
+                ];
+              }];
+
+              definedAliases = [ "@np" ];
+            };
           };
-
-          "Bing".metaData.hidden = true;
-          "Google".metaData.alias = "@g";
         };
       };
     };
 
-    profiles.searchWithoutDefault = {
-      id = 4;
-      search = {
-        force = true;
-        order = [ "Google" "Nix Packages" ];
-        engines = {
-          "Nix Packages" = {
-            urls = [{
-              template = "https://search.nixos.org/packages";
-              params = [
-                {
-                  name = "type";
-                  value = "packages";
-                }
-                {
-                  name = "query";
-                  value = "{searchTerms}";
-                }
-              ];
-            }];
+    nmt.script = ''
+      assertFileRegex \
+        home-path/bin/firefox \
+        MOZ_APP_LAUNCHER
 
-            definedAliases = [ "@np" ];
-          };
-        };
-      };
-    };
-  };
-
-  nixpkgs.overlays = [
-    (self: super: {
-      firefox-unwrapped = pkgs.runCommand "firefox-0" {
-        meta.description = "I pretend to be Firefox";
-        preferLocalBuild = true;
-        passthru.gtk3 = null;
-      } ''
-        mkdir -p "$out"/{bin,lib}
-        touch "$out/bin/firefox"
-        chmod 755 "$out/bin/firefox"
-      '';
-    })
-  ];
-
-  nmt.script = ''
-    assertFileRegex \
-      home-path/bin/firefox \
-      MOZ_APP_LAUNCHER
-
-    assertDirectoryExists home-files/.mozilla/firefox/basic
-
-    assertFileContent \
-      home-files/.mozilla/firefox/test/user.js \
-      ${./profile-settings-expected-user.js}
-
-    bookmarksUserJs=$(normalizeStorePaths \
-      home-files/.mozilla/firefox/bookmarks/user.js)
-
-    assertFileContent \
-      $bookmarksUserJs \
-      ${./profile-settings-expected-bookmarks-user.js}
-
-    bookmarksFile="$(sed -n \
-      '/browser.bookmarks.file/ {s|^.*\(/nix/store[^"]*\).*|\1|;p}' \
-      $TESTED/home-files/.mozilla/firefox/bookmarks/user.js)"
-
-    assertFileContent \
-      $bookmarksFile \
-      ${./profile-settings-expected-bookmarks.html}
-
-    function assertFirefoxSearchContent() {
-      compressedSearch=$(normalizeStorePaths "$1")
-
-      decompressedSearch=$(dirname $compressedSearch)/search.json
-      ${pkgs.mozlz4a}/bin/mozlz4a -d "$compressedSearch" >(${pkgs.jq}/bin/jq . > "$decompressedSearch")
+      assertDirectoryExists home-files/.mozilla/firefox/basic
 
       assertFileContent \
-        $decompressedSearch \
-        "$2"
-    }
+        home-files/.mozilla/firefox/test/user.js \
+        ${./profile-settings-expected-user.js}
 
-    assertFirefoxSearchContent \
-      home-files/.mozilla/firefox/search/search.json.mozlz4 \
-      ${./profile-settings-expected-search.json}
+      bookmarksUserJs=$(normalizeStorePaths \
+        home-files/.mozilla/firefox/bookmarks/user.js)
 
-    assertFirefoxSearchContent \
-      home-files/.mozilla/firefox/searchWithoutDefault/search.json.mozlz4 \
-      ${./profile-settings-expected-search-without-default.json}
-  '';
+      assertFileContent \
+        $bookmarksUserJs \
+        ${./profile-settings-expected-bookmarks-user.js}
+
+      bookmarksFile="$(sed -n \
+        '/browser.bookmarks.file/ {s|^.*\(/nix/store[^"]*\).*|\1|;p}' \
+        $TESTED/home-files/.mozilla/firefox/bookmarks/user.js)"
+
+      assertFileContent \
+        $bookmarksFile \
+        ${./profile-settings-expected-bookmarks.html}
+
+      function assertFirefoxSearchContent() {
+        compressedSearch=$(normalizeStorePaths "$1")
+
+        decompressedSearch=$(dirname $compressedSearch)/search.json
+        ${pkgs.mozlz4a}/bin/mozlz4a -d "$compressedSearch" >(${pkgs.jq}/bin/jq . > "$decompressedSearch")
+
+        assertFileContent \
+          $decompressedSearch \
+          "$2"
+      }
+
+      assertFirefoxSearchContent \
+        home-files/.mozilla/firefox/search/search.json.mozlz4 \
+        ${./profile-settings-expected-search.json}
+
+      assertFirefoxSearchContent \
+        home-files/.mozilla/firefox/searchWithoutDefault/search.json.mozlz4 \
+        ${./profile-settings-expected-search-without-default.json}
+    '';
+  };
 }

--- a/tests/modules/programs/firefox/setup-firefox-mock-overlay.nix
+++ b/tests/modules/programs/firefox/setup-firefox-mock-overlay.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+
+{
+  nixpkgs.overlays = [
+    (self: super: {
+      firefox-unwrapped = pkgs.runCommandLocal "firefox-0" {
+        meta.description = "I pretend to be Firefox";
+        passthru.gtk3 = null;
+      } ''
+        mkdir -p "$out"/{bin,lib}
+        touch "$out/bin/firefox"
+        chmod 755 "$out/bin/firefox"
+      '';
+
+      chrome-gnome-shell =
+        pkgs.runCommandLocal "dummy-chrome-gnome-shell" { } ''
+          mkdir -p $out/lib/mozilla/native-messaging-hosts
+          touch $out/lib/mozilla/native-messaging-hosts/dummy
+        '';
+    })
+  ];
+}

--- a/tests/modules/programs/firefox/state-version-19_09.nix
+++ b/tests/modules/programs/firefox/state-version-19_09.nix
@@ -2,28 +2,18 @@
 
 with lib;
 
-lib.mkIf config.test.enableBig {
-  home.stateVersion = "19.09";
+{
+  imports = [ ./setup-firefox-mock-overlay.nix ];
 
-  programs.firefox.enable = true;
+  config = lib.mkIf config.test.enableBig {
+    home.stateVersion = "19.09";
 
-  nixpkgs.overlays = [
-    (self: super: {
-      firefox-unwrapped = pkgs.runCommand "firefox-0" {
-        meta.description = "I pretend to be Firefox";
-        preferLocalBuild = true;
-        passthru.gtk3 = null;
-      } ''
-        mkdir -p "$out"/{bin,lib}
-        touch "$out/bin/firefox"
-        chmod 755 "$out/bin/firefox"
-      '';
-    })
-  ];
+    programs.firefox.enable = true;
 
-  nmt.script = ''
-    assertFileRegex \
-      home-path/bin/firefox \
-      MOZ_APP_LAUNCHER
-  '';
+    nmt.script = ''
+      assertFileRegex \
+        home-path/bin/firefox \
+        MOZ_APP_LAUNCHER
+    '';
+  };
 }


### PR DESCRIPTION
### Description

- Make firefox test run in all cases
- Refactor firefox tests to avoid duplication of overlay definition
- Add test for duplicate profile id assertion

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->