### PR TITLE
borgmatic: fix configuration generation for version 1.8.0

### DIFF
--- a/modules/programs/borgmatic.nix
+++ b/modules/programs/borgmatic.nix
@@ -152,29 +152,22 @@ let
   hmExcludeFile = pkgs.writeText "hm-symlinks.txt" hmExcludePatterns;
 
   writeConfig = config:
-    generators.toYAML { } {
-      location = removeNullValues {
-        source_directories = config.location.sourceDirectories;
-        repositories = config.location.repositories;
-      } // config.location.extraConfig;
-      storage = removeNullValues {
-        encryption_passcommand = config.storage.encryptionPasscommand;
-      } // config.storage.extraConfig;
-      retention = removeNullValues {
-        keep_within = config.retention.keepWithin;
-        keep_secondly = config.retention.keepSecondly;
-        keep_minutely = config.retention.keepMinutely;
-        keep_hourly = config.retention.keepHourly;
-        keep_daily = config.retention.keepDaily;
-        keep_weekly = config.retention.keepWeekly;
-        keep_monthly = config.retention.keepMonthly;
-        keep_yearly = config.retention.keepYearly;
-      } // config.retention.extraConfig;
-      consistency = removeNullValues { checks = config.consistency.checks; }
-        // config.consistency.extraConfig;
-      output = config.output.extraConfig;
-      hooks = config.hooks.extraConfig;
-    };
+    generators.toYAML { } (removeNullValues ({
+      source_directories = config.location.sourceDirectories;
+      repositories = config.location.repositories;
+      encryption_passcommand = config.storage.encryptionPasscommand;
+      keep_within = config.retention.keepWithin;
+      keep_secondly = config.retention.keepSecondly;
+      keep_minutely = config.retention.keepMinutely;
+      keep_hourly = config.retention.keepHourly;
+      keep_daily = config.retention.keepDaily;
+      keep_weekly = config.retention.keepWeekly;
+      keep_monthly = config.retention.keepMonthly;
+      keep_yearly = config.retention.keepYearly;
+      checks = config.consistency.checks;
+    } // config.location.extraConfig // config.storage.extraConfig
+      // config.retention.extraConfig // config.consistency.extraConfig
+      // config.output.extraConfig // config.hooks.extraConfig));
 in {
   meta.maintainers = [ maintainers.DamienCassou ];
 

--- a/tests/modules/programs/borgmatic/basic-configuration.nix
+++ b/tests/modules/programs/borgmatic/basic-configuration.nix
@@ -62,50 +62,48 @@ in {
 
     declare -A expectations
 
-    expectations[location.source_directories[0]]="${
+    expectations[source_directories[0]]="${
       builtins.elemAt backups.main.location.sourceDirectories 0
     }"
-    expectations[location.repositories[0]]="${
+    expectations[repositories[0]]="${
       builtins.elemAt backups.main.location.repositories 0
     }"
-    expectations[location.repositories[1]]="${
+    expectations[repositories[1]]="${
       builtins.elemAt backups.main.location.repositories 1
     }"
-    expectations[location.one_file_system]="${
+    expectations[one_file_system]="${
       boolToString backups.main.location.extraConfig.one_file_system
     }"
-    expectations[location.exclude_patterns[0]]="${
+    expectations[exclude_patterns[0]]="${
       builtins.elemAt backups.main.location.extraConfig.exclude_patterns 0
     }"
 
-    expectations[storage.encryption_passcommand]="${backups.main.storage.encryptionPasscommand}"
-    expectations[storage.checkpoint_interval]="${
+    expectations[encryption_passcommand]="${backups.main.storage.encryptionPasscommand}"
+    expectations[checkpoint_interval]="${
       toString backups.main.storage.extraConfig.checkpoint_interval
     }"
 
-    expectations[retention.keep_within]="${backups.main.retention.keepWithin}"
-    expectations[retention.keep_secondly]="${
+    expectations[keep_within]="${backups.main.retention.keepWithin}"
+    expectations[keep_secondly]="${
       toString backups.main.retention.keepSecondly
     }"
-    expectations[retention.prefix]="${backups.main.retention.extraConfig.prefix}"
+    expectations[prefix]="${backups.main.retention.extraConfig.prefix}"
 
-    expectations[consistency.checks[0].name]="${
+    expectations[checks[0].name]="${
       (builtins.elemAt backups.main.consistency.checks 0).name
     }"
-    expectations[consistency.checks[0].frequency]="${
+    expectations[checks[0].frequency]="${
       (builtins.elemAt backups.main.consistency.checks 0).frequency
     }"
-    expectations[consistency.checks[1].name]="${
+    expectations[checks[1].name]="${
       (builtins.elemAt backups.main.consistency.checks 1).name
     }"
-    expectations[consistency.checks[1].frequency]="${
+    expectations[checks[1].frequency]="${
       (builtins.elemAt backups.main.consistency.checks 1).frequency
     }"
-    expectations[consistency.prefix]="${backups.main.consistency.extraConfig.prefix}"
-    expectations[output.color]="${
-      boolToString backups.main.output.extraConfig.color
-    }"
-    expectations[hooks.before_actions[0]]="${
+    expectations[prefix]="${backups.main.consistency.extraConfig.prefix}"
+    expectations[color]="${boolToString backups.main.output.extraConfig.color}"
+    expectations[before_actions[0]]="${
       builtins.elemAt backups.main.hooks.extraConfig.before_actions 0
     }"
 
@@ -120,7 +118,7 @@ in {
       fi
     done
 
-    one_file_system=$($yq ".location.one_file_system" $config_file)
+    one_file_system=$($yq ".one_file_system" $config_file)
     if [[ $one_file_system != "true" ]]; then
        fail "Expected one_file_system to be true but it was $one_file_system"
     fi

--- a/tests/modules/programs/borgmatic/exclude-hm-symlinks-nothing-else.nix
+++ b/tests/modules/programs/borgmatic/exclude-hm-symlinks-nothing-else.nix
@@ -27,7 +27,7 @@ in {
 
     yq=${pkgs.yq-go}/bin/yq
 
-    hmExclusionsFile=$($yq '.location.exclude_from[0]' $config_file)
+    hmExclusionsFile=$($yq '.exclude_from[0]' $config_file)
     expected_content='/home/hm-user/.config/borgmatic.d/main.yaml'
 
     grep --quiet "$expected_content" "$hmExclusionsFile"

--- a/tests/modules/programs/borgmatic/exclude-hm-symlinks.nix
+++ b/tests/modules/programs/borgmatic/exclude-hm-symlinks.nix
@@ -28,7 +28,7 @@ in {
 
     declare -A expectations
 
-    expectations[location.exclude_from[0]]="${excludeFile}"
+    expectations[exclude_from[0]]="${excludeFile}"
 
     yq=${pkgs.yq-go}/bin/yq
 
@@ -41,7 +41,7 @@ in {
       fi
     done
 
-    hmExclusionsFile=$($yq '.location.exclude_from[1]' $config_file)
+    hmExclusionsFile=$($yq '.exclude_from[1]' $config_file)
     expected_content='/home/hm-user/.config/borgmatic.d/main.yaml'
 
     grep --quiet "$expected_content" "$hmExclusionsFile"

--- a/tests/modules/programs/borgmatic/include-hm-symlinks.nix
+++ b/tests/modules/programs/borgmatic/include-hm-symlinks.nix
@@ -28,7 +28,7 @@ in {
 
     declare -A expectations
 
-    expectations[location.exclude_from[0]]="${excludeFile}"
+    expectations[exclude_from[0]]="${excludeFile}"
 
     yq=${pkgs.yq-go}/bin/yq
 


### PR DESCRIPTION
-------

### Description

The configuration file format of borgmatic has changed in version
1.8.0:
https://projects.torsion.org/borgmatic-collective/borgmatic/src/branch/main/NEWS

This commit makes home-manager generates borgmatic's configuration file
using the new format.

Even though the NEWS file indicates that old configuration files are
compatible, this is not 100% the case: empty sections work fine in old
borgmatic but stop working in new ones. I've reported the bug upstream
by email as I couldn't create an account on the forge.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] ~Change is backwards compatible.~ **Change is backwards INCOMPATIBLE**

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->