### PR TITLE
Include hm-session-vars.sh in activation script

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -551,7 +551,7 @@ in
       destination = "/etc/profile.d/hm-session-vars.sh";
       text = ''
         # Only source this once.
-        if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
+        if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
         export __HM_SESS_VARS_SOURCED=1
 
         ${config.lib.shell.exportAll cfg.sessionVariables}
@@ -715,6 +715,7 @@ in
 
           export PATH="${activationBinPaths}"
           ${config.lib.bash.initHomeManagerLib}
+          source ${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh
 
           ${builtins.readFile ./lib-bash/activation-init.sh}
 

--- a/tests/modules/home-environment/session-variables-expected.txt
+++ b/tests/modules/home-environment/session-variables-expected.txt
@@ -1,5 +1,5 @@
 # Only source this once.
-if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
+if [ -n "${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
 export __HM_SESS_VARS_SOURCED=1
 @exportLocaleVar@
 export V1="v1"

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -6,7 +6,7 @@ let
 
   linuxExpected = ''
     # Only source this once.
-    if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
+    if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
     export LOCALE_ARCHIVE_2_27="${config.i18n.glibcLocales}/lib/locale/locale-archive"
@@ -20,7 +20,7 @@ let
 
   darwinExpected = ''
     # Only source this once.
-    if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
+    if [ -n "''${__HM_SESS_VARS_SOURCED-}" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
     export V1="v1"


### PR DESCRIPTION
### Description

Add the newly generated sessionVariablesPackage / hm-session-vars.sh file in the activation script.
This allows activation scripts to access the settings of the home.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
