### PR TITLE
uget: add programs.uget to manage uget/uget-integrator

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -213,6 +213,7 @@ let
     ./programs/tmux.nix
     ./programs/topgrade.nix
     ./programs/translate-shell.nix
+    ./programs/uget.nix
     ./programs/urxvt.nix
     ./programs/vdirsyncer.nix
     ./programs/vim.nix

--- a/modules/programs/uget.nix
+++ b/modules/programs/uget.nix
@@ -1,0 +1,127 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.uget;
+  browsers = [ "brave" "chrome" "chromium" "firefox" "librewolf" "vivaldi" ];
+
+in {
+  meta.maintainers = [ maintainers.poelzi ];
+
+  options.programs.uget = {
+    enable = mkEnableOption "uget download manager";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.uget;
+      defaultText = literalExpression "pkgs.uget";
+      description = "uget package to install.";
+    };
+
+    integrator = {
+      package = mkOption {
+        type = types.package;
+        default = pkgs.uget-integrator;
+        defaultText = literalExpression "pkgs.uget-integrator";
+        description = "uget-integrator package to install.";
+      };
+
+      enable = mkEnableOption "the uget-integrator extension host application";
+
+      browsers = mkOption {
+        type = types.listOf (types.enum browsers);
+        default = browsers;
+        example = [ "firefox" ];
+        description = "Which browsers to install browserpass for";
+      };
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ]
+      ++ (lib.lists.optional cfg.integrator.enable cfg.integrator.package);
+
+    # home.file = browser-extension.nativeHostFiles cfg.integrator.browsers (
+    #     fold (x: y: x // {"${y}" = "${cfg.integrator.package}/lib/mozilla/native-messaging-hosts/com.ugetdm.firefox.json";}));
+    home.file = foldl' (a: b: a // b) { } (concatMap (x:
+      with pkgs.stdenv;
+      if x == "brave" then
+        let
+          dir = if isDarwin then
+            "Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+          else
+            ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts";
+        in [{
+          # Policies are read from `/etc/brave/policies` only
+          # https://github.com/brave/brave-browser/issues/19052
+          "${dir}/com.ugetdm.firefox.json".source =
+            "${pkgs.uget-integrator}/lib/mozilla/native-messaging-hosts/com.ugetdm.firefox.json";
+        }]
+      else if x == "chrome" then
+        let
+          dir = if isDarwin then
+            "Library/Application Support/Google/Chrome/NativeMessagingHosts"
+          else
+            ".config/google-chrome/NativeMessagingHosts";
+        in [{
+          "${dir}/com.ugetdm.firefox.json".source =
+            "${pkgs.uget-integrator}/lib/mozilla/native-messaging-hosts/com.ugetdm.firefox.json";
+          "${dir}/../policies/managed/com.ugetdm.firefox.json".source =
+            "${pkgs.uget-integrator}/lib/mozilla/native-messaging-hosts/com.ugetdm.firefox.json";
+        }]
+      else if x == "chromium" then
+        let
+          dir = if isDarwin then
+            "Library/Application Support/Chromium/NativeMessagingHosts"
+          else
+            ".config/chromium/NativeMessagingHosts";
+        in [
+          {
+            "${dir}/com.ugetdm.firefox.json".source =
+              "${pkgs.uget-integrator}/lib/mozilla/native-messaging-hosts/com.ugetdm.firefox.json";
+          }
+          {
+            "${dir}/../policies/managed/com.ugetdm.firefox.json".source =
+              "${pkgs.uget-integrator}/lib/mozilla/native-messaging-hosts/com.ugetdm.firefox.json";
+          }
+        ]
+      else if x == "firefox" then
+        let
+          dir = if isDarwin then
+            "Library/Application Support/Mozilla/NativeMessagingHosts"
+          else
+            ".mozilla/native-messaging-hosts";
+        in [{
+          "${dir}/com.ugetdm.firefox.json".source =
+            "${pkgs.uget-integrator}/lib/mozilla/native-messaging-hosts/com.ugetdm.firefox.json";
+        }]
+      else if x == "librewolf" then
+        let
+          dir = if isDarwin then
+            "Library/Application Support/LibreWolf/NativeMessagingHosts"
+          else
+            ".librewolf/native-messaging-hosts";
+        in [{
+          "${dir}/com.ugetdm.firefox.json".source =
+            "${pkgs.uget-integrator}/lib/mozilla/native-messaging-hosts/com.ugetdm.firefox.json";
+        }]
+
+      else if x == "vivaldi" then
+        let
+          dir = if isDarwin then
+            "Library/Application Support/Vivaldi/NativeMessagingHosts"
+          else
+            ".config/vivaldi/NativeMessagingHosts";
+        in [{
+          "${dir}/com.ugetdm.firefox.json".source =
+            "${pkgs.uget-integrator}/lib/mozilla/native-messaging-hosts/com.ugetdm.firefox.json";
+          "${dir}/../policies/managed/com.ugetdm.firefox.json".source =
+            "${pkgs.uget-integrator}/lib/mozilla/native-messaging-hosts/com.ugetdm.firefox.json";
+        }]
+      else
+        throw "unknown browser ${x}") cfg.integrator.browsers);
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -144,6 +144,7 @@ import nmt {
     ./modules/programs/tmux
     ./modules/programs/topgrade
     ./modules/programs/translate-shell
+    ./modules/programs/uget
     ./modules/programs/vim-vint
     ./modules/programs/vscode
     ./modules/programs/watson

--- a/tests/modules/programs/uget/default.nix
+++ b/tests/modules/programs/uget/default.nix
@@ -1,0 +1,1 @@
+{ uget = ./uget.nix; }

--- a/tests/modules/programs/uget/uget.nix
+++ b/tests/modules/programs/uget/uget.nix
@@ -1,0 +1,38 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.uget = {
+      enable = true;
+      integrator = {
+        enable = true;
+        browsers =
+          [ "brave" "chrome" "chromium" "firefox" "librewolf" "vivaldi" ];
+      };
+    };
+
+    nmt.script = if pkgs.stdenv.hostPlatform.isDarwin then ''
+      for dir in "BraveSoftware/Brave-Browser" "Google/Chrome" "Chromium" "Mozilla" "LibreWolf" "Vivaldi"; do
+        assertFileExists "home-files/Library/Application Support/$dir/NativeMessagingHosts/com.ugetdm.firefox.json"
+      done
+
+      for dir in "Google/Chrome" "Chromium" "Vivaldi"; do
+        assertFileExists "home-files/Library/Application Support/$dir/policies/managed/com.ugetdm.firefox.json"
+      done
+    '' else ''
+      for dir in "BraveSoftware/Brave-Browser" "google-chrome" "chromium" "vivaldi"; do
+        assertFileExists "home-files/.config/$dir/NativeMessagingHosts/com.ugetdm.firefox.json"
+      done
+
+      for dir in "google-chrome" "chromium" "vivaldi"; do
+        assertFileExists "home-files/.config/$dir/policies/managed/com.ugetdm.firefox.json"
+      done
+
+      for dir in ".mozilla" ".librewolf"; do
+        assertFileExists "home-files/$dir/native-messaging-hosts/com.ugetdm.firefox.json"
+      done
+    '';
+  };
+}


### PR DESCRIPTION
### Description

add uget/uget-integrator support. Installing uget-integrator does not result in a working browser plugin, as a native host file is required.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
