### PR TITLE
xsession: allow xplugd to restart on failure

### DIFF
--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -139,6 +139,7 @@ in {
 
           Service = {
             Type = "forking";
+            Restart = "on-failure";
             ExecStart = let
               script = pkgs.writeShellScript "xplugrc" ''
                 case "$1,$3" in


### PR DESCRIPTION

### Description

After years of my last change adding xplugd to this module, today it crashed and I had to relearn what was going on here in this subsystem.

It seems to have just been a transient error or something from updating my systems. This should let it recover a bit better.

Related: https://github.com/nix-community/home-manager/pull/2450

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@berbiche, merger of last PR.