### PR TITLE
fzf: fix fish integration

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -190,8 +190,9 @@ in {
       fi
     '');
 
-    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-      source ${cfg.package}/share/fzf/key-bindings.fish && fzf_key_bindings
-    '';
+    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration
+      (mkOrder 200 ''
+        source ${cfg.package}/share/fzf/key-bindings.fish && fzf_key_bindings
+      '');
   };
 }

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -190,7 +190,7 @@ in {
       fi
     '');
 
-    programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
+    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
       source ${cfg.package}/share/fzf/key-bindings.fish && fzf_key_bindings
     '';
   };


### PR DESCRIPTION
### Description

Since fzf 0.43.0, the `fzf_key_bindings` function is only defined when fish is running interactively, see [1].
This caused errors when entering non-interactive fish shells since we called `fzf_key_bindings` during startup.

[1]: https://github.com/junegunn/fzf/commit/7e89458a3b58c047c10494a5cb53d921fb08b4f3

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
