### PR TITLE
qt: multiple fixes

### DIFF
--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -28,8 +28,9 @@ in {
       GTK_IM_MODULE = "fcitx";
       QT_IM_MODULE = "fcitx";
       XMODIFIERS = "@im=fcitx";
-      QT_PLUGIN_PATH =
-        "${fcitx5Package}/${pkgs.qt6.qtbase.qtPluginPrefix}:\${QT_PLUGIN_PATH}";
+      # Using mkDefault here since we override this value in qt module if enabled
+      QT_PLUGIN_PATH = lib.mkDefault
+        "$QT_PLUGIN_PATH\${QT_PLUGIN_PATH:+:}${fcitx5Package}/${pkgs.qt6.qtbase.qtPluginPrefix}";
     };
 
     systemd.user.services.fcitx5-daemon = {

--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -28,8 +28,7 @@ in {
       GTK_IM_MODULE = "fcitx";
       QT_IM_MODULE = "fcitx";
       XMODIFIERS = "@im=fcitx";
-      # Using mkDefault here since we override this value in qt module if enabled
-      QT_PLUGIN_PATH = lib.mkDefault
+      QT_PLUGIN_PATH =
         "$QT_PLUGIN_PATH\${QT_PLUGIN_PATH:+:}${fcitx5Package}/${pkgs.qt6.qtbase.qtPluginPrefix}";
     };
 

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -3,12 +3,19 @@
 let
   cfg = config.qt;
 
+  # Map platform names to their packages.
   platformPackages = with pkgs; {
     gnome = [ qgnomeplatform qgnomeplatform-qt6 ];
     gtk = [ libsForQt5.qtstyleplugins qt6Packages.qt6gtk2 ];
     kde = [ libsForQt5.plasma-integration libsForQt5.systemsettings ];
     lxqt = [ lxqt.lxqt-qtplugin lxqt.lxqt-config ];
     qtct = [ libsForQt5.qt5ct qt6Packages.qt6ct ];
+  };
+
+  # Maps style names to their QT_QPA_PLATFORMTHEME, if necessary.
+  styleNames = {
+    gtk = "gtk2";
+    qtct = "qt5ct";
   };
 
   # Maps known lowercase style names to style packages. Non-exhaustive.
@@ -152,12 +159,8 @@ in {
       qtVersions = with pkgs; [ qt5 qt6 ];
       makeQtPath = prefix: basePath: qt: "${basePath}/${qt.qtbase.${prefix}}";
     in lib.filterAttrs (n: v: v != null) {
-      QT_QPA_PLATFORMTHEME = if cfg.platformTheme == "gtk" then
-        "gtk2"
-      else if cfg.platformTheme == "qtct" then
-        "qt5ct"
-      else
-        cfg.platformTheme;
+      QT_QPA_PLATFORMTHEME =
+        styleNames.${cfg.platformTheme} or cfg.platformTheme;
       QT_STYLE_OVERRIDE = cfg.style.name;
       QT_PLUGIN_PATH = "$QT_PLUGIN_PATH\${QT_PLUGIN_PATH:+:}"
         + (lib.concatStringsSep ":"

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -57,7 +57,7 @@ in {
 
       platformTheme = lib.mkOption {
         type = with lib.types;
-          nullOr (enum [ "gtk" "gnome" "lxqt" "qtct" "kde" ]);
+          nullOr (enum [ "gtk" "gtk3" "gnome" "lxqt" "qtct" "kde" ]);
         default = null;
         example = "gnome";
         relatedPackages = [
@@ -80,6 +80,10 @@ in {
           `gtk`
           : Use GTK theme with
             [`qtstyleplugins`](https://github.com/qt/qtstyleplugins)
+
+          `gtk3`
+          : Use [GTK3 integration](https://github.com/qt/qtbase/tree/dev/src/plugins/platformthemes/gtk3)
+            for file picker dialogs, font and theme configuration
 
           `gnome`
           : Use GNOME theme with

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -38,7 +38,7 @@ in {
 
   options = {
     qt = {
-      enable = mkEnableOption "Qt 4, 5 and 6 configuration";
+      enable = mkEnableOption "Qt 5 and 6 configuration";
 
       platformTheme = mkOption {
         type = types.nullOr (types.enum [ "gtk" "gnome" "qtct" "kde" ]);
@@ -170,14 +170,5 @@ in {
 
     xsession.importedVariables = [ "QT_QPA_PLATFORMTHEME" ]
       ++ lib.optionals (cfg.style.name != null) [ "QT_STYLE_OVERRIDE" ];
-
-    # Enable GTK+ style for Qt4 in Gtk/GNOME.
-    # It doesn’t support the platform theme packages.
-    home.activation.useGtkThemeInQt4 =
-      mkIf (cfg.platformTheme == "gtk" || cfg.platformTheme == "gnome")
-      (hm.dag.entryAfter [ "writeBoundary" ] ''
-        $DRY_RUN_CMD ${pkgs.crudini}/bin/crudini $VERBOSE_ARG \
-          --set "${config.xdg.configHome}/Trolltech.conf" Qt style GTK+
-      '');
   };
 }

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -4,7 +4,7 @@ let
   cfg = config.qt;
 
   platformPackages = with pkgs; {
-    gnome = [ qgnomeplatform ];
+    gnome = [ qgnomeplatform qgnomeplatform-qt6 ];
     gtk = [ libsForQt5.qtstyleplugins qt6Packages.qt6gtk2 ];
     kde = [ libsForQt5.plasma-integration libsForQt5.systemsettings ];
     lxqt = [ lxqt.lxqt-qtplugin lxqt.lxqt-config ];
@@ -55,6 +55,7 @@ in {
         example = "gnome";
         relatedPackages = [
           "qgnomeplatform"
+          "qgnomeplatform-qt6"
           [ "libsForQt5" "plasma-integration" ]
           [ "libsForQt5" "qt5ct" ]
           [ "libsForQt5" "qtstyleplugins" ]

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -173,7 +173,7 @@ in {
         + (makeQtPath "qtQmlPrefix");
     };
 
-  in lib.mkIf (cfg.enable && cfg.platformTheme != null) {
+  in lib.mkIf cfg.enable {
     assertions = [{
       assertion = cfg.platformTheme == "gnome" -> cfg.style.name != null
         && cfg.style.package != null;
@@ -206,8 +206,8 @@ in {
       ++ lib.optionals (cfg.style.package != null)
       (lib.toList cfg.style.package);
 
-    xsession.importedVariables =
-      [ "QT_QPA_PLATFORMTHEME" "QT_PLUGIN_PATH" "QML2_IMPORT_PATH" ]
+    xsession.importedVariables = [ "QT_PLUGIN_PATH" "QML2_IMPORT_PATH" ]
+      ++ lib.optionals (cfg.platformTheme != null) [ "QT_QPA_PLATFORMTHEME" ]
       ++ lib.optionals (cfg.style.name != null) [ "QT_STYLE_OVERRIDE" ];
   };
 }

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -8,15 +8,15 @@ let
     bb10bright = libsForQt5.qtstyleplugins;
     bb10dark = libsForQt5.qtstyleplugins;
     cleanlooks = libsForQt5.qtstyleplugins;
-    gtk2 = libsForQt5.qtstyleplugins;
+    gtk2 = [ libsForQt5.qtstyleplugins qt6Packages.qt6gtk2 ];
     motif = libsForQt5.qtstyleplugins;
     cde = libsForQt5.qtstyleplugins;
     plastique = libsForQt5.qtstyleplugins;
 
-    adwaita = adwaita-qt;
-    adwaita-dark = adwaita-qt;
-    adwaita-highcontrast = adwaita-qt;
-    adwaita-highcontrastinverse = adwaita-qt;
+    adwaita = [ adwaita-qt adwaita-qt6 ];
+    adwaita-dark = [ adwaita-qt adwaita-qt6 ];
+    adwaita-highcontrast = [ adwaita-qt adwaita-qt6 ];
+    adwaita-highcontrastinverse = [ adwaita-qt adwaita-qt6 ];
 
     breeze = libsForQt5.breeze-qt5;
 
@@ -83,9 +83,11 @@ in {
           example = "adwaita-dark";
           relatedPackages = [
             "adwaita-qt"
+            "adwaita-qt6"
             [ "libsForQt5" "breeze-qt5" ]
-            [ "libsForQt5" "qtstyleplugins" ]
             [ "libsForQt5" "qtstyleplugin-kvantum" ]
+            [ "libsForQt5" "qtstyleplugins" ]
+            [ "qt6Packages" "qt6gtk2" ]
             [ "qt6Packages" "qtstyleplugin-kvantum" ]
           ];
           description = ''

--- a/tests/modules/misc/qt/qt-platform-theme-gnome.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gnome.nix
@@ -15,6 +15,10 @@
         'QT_QPA_PLATFORMTHEME="gnome"'
       assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
         'QT_STYLE_OVERRIDE="adwaita"'
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QT_PLUGIN_PATH'
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QML2_IMPORT_PATH'
     '';
   };
 }

--- a/tests/modules/misc/qt/qt-platform-theme-gtk.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gtk.nix
@@ -10,6 +10,10 @@
     nmt.script = ''
       assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
         'QT_QPA_PLATFORMTHEME="gtk2"'
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QT_PLUGIN_PATH'
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QML2_IMPORT_PATH'
     '';
   };
 }

--- a/tests/modules/misc/qt/qt-platform-theme-gtk.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gtk.nix
@@ -6,6 +6,7 @@
       enable = true;
       platformTheme = "gtk";
     };
+    i18n.inputMethod.enabled = "fcitx5";
 
     nmt.script = ''
       assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \


### PR DESCRIPTION
### Description

Remove remaining Qt 4 support from `qt` module since `nixpkgs` does not support Qt 4 anymore.

Export `QT_PLUGIN_PATH` and `QML2_IMPORT_PATH`, necessary for some plugins to work (e.g. `qt6ct`).

Remove top-level `with lib`.

Add missing style mappings.

Add `lxqt` support.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.
  + Removal of Qt 4 technically is not backwards compatible, but I don't think nobody cares.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
