### PR TITLE
Prepare borgmatic change

### DIFF
--- a/tests/modules/programs/borgmatic/basic-configuration.nix
+++ b/tests/modules/programs/borgmatic/basic-configuration.nix
@@ -12,7 +12,14 @@ in {
       main = {
         location = {
           sourceDirectories = [ "/my-stuff-to-backup" ];
-          repositories = [ "/mnt/disk1" "/mnt/disk2" ];
+          repositories = [
+            "/mnt/disk1"
+            { path = "/mnt/disk2"; }
+            {
+              path = "/mnt/disk3";
+              label = "disk3";
+            }
+          ];
           extraConfig = {
             one_file_system = true;
             exclude_patterns = [ "*.swp" ];
@@ -65,11 +72,17 @@ in {
     expectations[source_directories[0]]="${
       builtins.elemAt backups.main.location.sourceDirectories 0
     }"
-    expectations[repositories[0]]="${
-      builtins.elemAt backups.main.location.repositories 0
+    expectations[repositories[0].path]="${
+      (builtins.elemAt backups.main.location.repositories 0).path
     }"
-    expectations[repositories[1]]="${
-      builtins.elemAt backups.main.location.repositories 1
+    expectations[repositories[1].path]="${
+      (builtins.elemAt backups.main.location.repositories 1).path
+    }"
+    expectations[repositories[2].path]="${
+      (builtins.elemAt backups.main.location.repositories 2).path
+    }"
+    expectations[repositories[2].label]="${
+      (builtins.elemAt backups.main.location.repositories 2).label
     }"
     expectations[one_file_system]="${
       boolToString backups.main.location.extraConfig.one_file_system


### PR DESCRIPTION
### Description

This is preparing an upcoming change in borgmatic to make repositories consisting of paths only unusable. This addresses issue #4580 .

This PR:

1. Is backwards compatible. Paths only in the config will be translated to the required `{ path = "path/to/repo"; }`
2. Paths can be given as
```
    {
      path = "path";
      label = "label";
    }
```
3. Paths can be given as just `{ path = "path/to/repo"; }`, however, this resolves to a config file, which contains `null` as label, which is forbidden by `borgmatic`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

```
borgmatic-program-basic-configuration: OK
borgmatic-program-exclude-hm-symlinks: OK
borgmatic-program-exclude-hm-symlinks-nothing-else: OK
borgmatic-program-include-hm-symlinks: OK
borgmatic-service-basic-configuration: OK
```


- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
