### PR TITLE
home-manager: fix activate script for use-xdg-base-directories use case

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -29,7 +29,7 @@ function removeByName() {
 }
 
 function setNixProfileCommands() {
-    if [[ -e $HOME/.nix-profile/manifest.json ]] || [[ -e $HOME/.local/state/nix/profile/manifest.json ]] ; then
+    if [[ -e $HOME/.nix-profile/manifest.json || -e "${XDG_STATE_HOME:-$HOME/.local/state}/nix/profile/manifest.json" ]] ; then
         LIST_OUTPATH_CMD="nix profile list"
         REMOVE_CMD="removeByName"
     else

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -29,7 +29,7 @@ function removeByName() {
 }
 
 function setNixProfileCommands() {
-    if [[ -e $HOME/.nix-profile/manifest.json ]] ; then
+    if [[ -e $HOME/.nix-profile/manifest.json ]] || [[ -e $HOME/.local/state/nix/profile/manifest.json ]] ; then
         LIST_OUTPATH_CMD="nix profile list"
         REMOVE_CMD="removeByName"
     else

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -207,6 +207,7 @@ in
       type = types.path;
       defaultText = literalExpression ''
         "''${home.homeDirectory}/.nix-profile"  or
+        "''${home.homeDirectory}/.local/state/nix/profile"  or
         "/etc/profiles/per-user/''${home.username}"
       '';
       readOnly = true;
@@ -585,7 +586,7 @@ in
       if config.submoduleSupport.externalPackageInstall
       then
         ''
-          if [[ -e $HOME/.nix-profile/manifest.json ]] ; then
+          if [[ -e $HOME/.nix-profile/manifest.json ]] || [[ -e $HOME/.local/state/nix/profile/manifest.json ]] ; then
             nix profile list \
               | { grep 'home-manager-path$' || test $? = 1; } \
               | cut -d ' ' -f 4 \
@@ -623,7 +624,7 @@ in
             $DRY_RUN_CMD $oldNix profile install $1
           }
 
-          if [[ -e $HOME/.nix-profile/manifest.json ]] ; then
+          if [[ -e $HOME/.nix-profile/manifest.json ]] || [[ -e $HOME/.local/state/nix/profile/manifest.json ]] ; then
             INSTALL_CMD="nix profile install"
             INSTALL_CMD_ACTUAL="nixReplaceProfile"
             LIST_CMD="nix profile list"

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -207,7 +207,7 @@ in
       type = types.path;
       defaultText = literalExpression ''
         "''${home.homeDirectory}/.nix-profile"  or
-        "''${home.homeDirectory}/.local/state/nix/profile"  or
+        "''${config.xdg.stateHome}/nix/profile"  or
         "/etc/profiles/per-user/''${home.username}"
       '';
       readOnly = true;
@@ -624,7 +624,7 @@ in
             $DRY_RUN_CMD $oldNix profile install $1
           }
 
-          if [[ -e $HOME/.nix-profile/manifest.json ]] || [[ -e $HOME/.local/state/nix/profile/manifest.json ]] ; then
+          if [[ -e $HOME/.nix-profile/manifest.json || -e "${config.xdg.stateHome}/nix/profile/manifest.json" ]] ; then
             INSTALL_CMD="nix profile install"
             INSTALL_CMD_ACTUAL="nixReplaceProfile"
             LIST_CMD="nix profile list"

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -586,7 +586,7 @@ in
       if config.submoduleSupport.externalPackageInstall
       then
         ''
-          if [[ -e $HOME/.nix-profile/manifest.json ]] || [[ -e $HOME/.local/state/nix/profile/manifest.json ]] ; then
+          if [[ -e $HOME/.nix-profile/manifest.json || -e "${config.xdg.stateHome}/nix/profile/manifest.json" ]] ; then
             nix profile list \
               | { grep 'home-manager-path$' || test $? = 1; } \
               | cut -d ' ' -f 4 \

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -207,7 +207,7 @@ in
       type = types.path;
       defaultText = literalExpression ''
         "''${home.homeDirectory}/.nix-profile"  or
-        "''${config.xdg.stateHome}/nix/profile"  or
+        "''${home.homeDirectory}/.local/state/nix/profile"  or
         "/etc/profiles/per-user/''${home.username}"
       '';
       readOnly = true;
@@ -586,7 +586,7 @@ in
       if config.submoduleSupport.externalPackageInstall
       then
         ''
-          if [[ -e $HOME/.nix-profile/manifest.json || -e "${config.xdg.stateHome}/nix/profile/manifest.json" ]] ; then
+          if [[ -e $HOME/.nix-profile/manifest.json || -e "''${XDG_STATE_HOME:-$HOME/.local/state}/nix/profile/manifest.json" ]] ; then
             nix profile list \
               | { grep 'home-manager-path$' || test $? = 1; } \
               | cut -d ' ' -f 4 \
@@ -624,7 +624,7 @@ in
             $DRY_RUN_CMD $oldNix profile install $1
           }
 
-          if [[ -e $HOME/.nix-profile/manifest.json || -e "${config.xdg.stateHome}/nix/profile/manifest.json" ]] ; then
+          if [[ -e $HOME/.nix-profile/manifest.json || -e "''${XDG_STATE_HOME:-$HOME/.local/state}/nix/profile/manifest.json" ]] ; then
             INSTALL_CMD="nix profile install"
             INSTALL_CMD_ACTUAL="nixReplaceProfile"
             LIST_CMD="nix profile list"


### PR DESCRIPTION
### Description

This is illustrative PR for issue https://github.com/nix-community/home-manager/issues/4593

Cannot assure that this is fixing the issue, but for illustrative purpose.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
