### PR TITLE
eww: make `configDir` setting optional

### DIFF
--- a/modules/programs/eww.nix
+++ b/modules/programs/eww.nix
@@ -23,7 +23,8 @@ in {
     };
 
     configDir = mkOption {
-      type = types.path;
+      type = types.nullOr types.path;
+      default = null;
       example = literalExpression "./eww-config-dir";
       description = ''
         The directory that gets symlinked to
@@ -32,8 +33,11 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
-    xdg.configFile."eww".source = cfg.configDir;
-  };
+  config = mkIf cfg.enable (mkMerge [
+    { home.packages = [ cfg.package ]; }
+
+    (mkIf (cfg.configDir != null) {
+      xdg.configFile."eww".source = cfg.configDir;
+    })
+  ]);
 }


### PR DESCRIPTION
### Description

Manually configuring `eww` with `xdg.configFile."eww".text` in order to leverage Nix' capabilities, is inconvenient due to the required `xdg.configFile."eww".source` symlink.

This change makes the symlink optional.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@mainrs