### PR TITLE
fish: support simple key bindings

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -145,6 +145,9 @@ let
   aliasesStr = concatStringsSep "\n"
     (mapAttrsToList (k: v: "alias ${k} ${escapeShellArg v}") cfg.shellAliases);
 
+  bindsStr = concatStringsSep "\n"
+    (mapAttrsToList (k: v: "bind ${k} '${v}'") cfg.shellBinds);
+
   fishIndent = name: text:
     pkgs.runCommand name {
       nativeBuildInputs = [ cfg.package ];
@@ -209,6 +212,20 @@ in {
           An attribute set that maps aliases (the top level attribute names
           in this option) to abbreviations. Abbreviations are expanded with
           the longer phrase after they are entered.
+        '';
+      };
+
+      shellBinds = mkOption {
+        type = with types; attrsOf str;
+        default = { };
+        example = literalExpression ''
+          {
+            "\cg" = "git diff; commandline -f repaint";
+          }
+        '';
+        description = ''
+          An attribute set that maps a key bindings (the top level attribute names
+          in this option) to command strings or directly to build outputs.
         '';
       };
 
@@ -388,6 +405,9 @@ in {
 
           # Aliases
           ${aliasesStr}
+
+          # Binds
+          ${bindsStr}
 
           # Interactive shell initialisation
           ${cfg.interactiveShellInit}

--- a/tests/modules/programs/fish/bindings.nix
+++ b/tests/modules/programs/fish/bindings.nix
@@ -1,0 +1,29 @@
+{ config, ... }: {
+  config = {
+    programs.fish = {
+      enable = true;
+
+      shellBinds = {
+        "\\cd" = "exit";
+        "." = "rationalise-dot";
+        "\\cg" = "git diff; commandline -f repaint";
+        "\\cz" = "foo && bar";
+      };
+    };
+
+    nmt = {
+      description =
+        "if fish.shellBinds is set, check fish.config contains bindings";
+      script = ''
+        assertFileContains home-files/.config/fish/config.fish \
+          "bind \cd exit"
+        assertFileContains home-files/.config/fish/config.fish \
+          "bind . rationalise-dot"
+        assertFileContains home-files/.config/fish/config.fish \
+          "bind \cg 'git diff; commandline -f repaint'"
+        assertFileContains home-files/.config/fish/config.fish \
+          "bind \cz 'foo && bar'"
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -3,4 +3,5 @@
   fish-functions = ./functions.nix;
   fish-no-functions = ./no-functions.nix;
   fish-plugins = ./plugins.nix;
+  fish-bindings = ./bindings.nix;
 }


### PR DESCRIPTION
In fish shell, support simple keybinds of the form "SEQUENCE" -> COMMAND, as described in the fish docs: https://fishshell.com/docs/current/cmds/bind.html

### Description
Support generating simple keybinds for fish shell. The implementation is the same as that for the aliases which existed already, however I am unsure of the `escapeShellArg` function. It's presence would break the 3rd test case (I included this specifically because it is listed as an example in the [docs](https://fishshell.com/docs/current/cmds/bind.html)), but maybe there is a better way to handle this? 

This is my first time contributing to nix stuff so any pointers are appreciated.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
