### PR TITLE
granted: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -448,4 +448,10 @@
     github = "liyangau";
     githubId = 71299093;
   };
+  wcarlsen = {
+    name = "Willi Carlsen";
+    email = "carlsenwilli+nix@gmail.com";
+    github = "wcarlsen";
+    githubId = 17003032;
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1288,6 +1288,13 @@ in
           A new module is available: 'programs.cava'.
         '';
       }
+
+      {
+        time = "2023-11-01T21:18:20+00:00";
+        message = ''
+          A new module is available: 'programs.granted'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -99,6 +99,7 @@ let
     ./programs/gnome-terminal.nix
     ./programs/go.nix
     ./programs/gpg.nix
+    ./programs/granted.nix
     ./programs/havoc.nix
     ./programs/helix.nix
     ./programs/hexchat.nix

--- a/modules/programs/granted.nix
+++ b/modules/programs/granted.nix
@@ -1,0 +1,36 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.granted;
+  package = pkgs.granted;
+
+in {
+  meta.maintainers = [ hm.maintainers.wcarlsen ];
+
+  options.programs.granted = {
+    enable = mkEnableOption "granted";
+
+    enableZshIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Zsh integration.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ package ];
+
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      function assume() {
+        export GRANTED_ALIAS_CONFIGURED="true"
+        source ${package}/bin/.assume-wrapped "$@"
+        unset GRANTED_ALIAS_CONFIGURED
+      }
+    '';
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -84,6 +84,7 @@ import nmt {
     ./modules/programs/git
     ./modules/programs/git-cliff
     ./modules/programs/gpg
+    ./modules/programs/granted
     ./modules/programs/helix
     ./modules/programs/himalaya
     ./modules/programs/htop

--- a/tests/modules/programs/granted/default.nix
+++ b/tests/modules/programs/granted/default.nix
@@ -1,0 +1,4 @@
+{
+  granted-integration-enabled = ./integration-enabled.nix;
+  granted-integration-disabled = ./integration-disabled.nix;
+}

--- a/tests/modules/programs/granted/integration-disabled.nix
+++ b/tests/modules/programs/granted/integration-disabled.nix
@@ -1,0 +1,27 @@
+{ pkgs, ... }:
+
+{
+  programs = {
+    granted.enable = true;
+    granted.enableZshIntegration = false;
+    zsh.enable = true;
+  };
+
+  test.stubs.granted = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+    assertFileNotRegex \
+      home-files/.zshrc \
+      'function assume()'
+    assertFileNotRegex \
+      home-files/.zshrc \
+      'export GRANTED_ALIAS_CONFIGURED="true"'
+    assertFileNotRegex \
+      home-files/.zshrc \
+      'source @granted@/bin/.assume-wrapped "$@"'
+    assertFileNotRegex \
+      home-files/.zshrc \
+      'unset GRANTED_ALIAS_CONFIGURED'
+  '';
+}

--- a/tests/modules/programs/granted/integration-enabled.nix
+++ b/tests/modules/programs/granted/integration-enabled.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+
+{
+  programs = {
+    granted.enable = true;
+    zsh.enable = true;
+  };
+
+  test.stubs.granted = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+    assertFileContains \
+      home-files/.zshrc \
+      'function assume()'
+    assertFileContains \
+      home-files/.zshrc \
+      'export GRANTED_ALIAS_CONFIGURED="true"'
+    assertFileContains \
+      home-files/.zshrc \
+      'source @granted@/bin/.assume-wrapped "$@"'
+    assertFileContains \
+      home-files/.zshrc \
+      'unset GRANTED_ALIAS_CONFIGURED'
+  '';
+}


### PR DESCRIPTION
### Description

Add granted module https://github.com/common-fate/granted in order to simplify setup, so that others don't encounter the issue referenced in this issue https://github.com/NixOS/nixpkgs/issues/258867.

Granted require an alias set to work correct and they don't take nix into account, hence this module solves the basic setup issue.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
