### PR TITLE
hyprland: add option for recommended environment variables

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -21,10 +21,6 @@ in {
       "Autoreloading now always happens")
 
     (lib.mkRemovedOptionModule # \
-      [ "wayland" "windowManager" "hyprland" "recommendedEnvironment" ]
-      "Recommended environment variables are now always set")
-
-    (lib.mkRemovedOptionModule # \
       [ "wayland" "windowManager" "hyprland" "xwayland" "hidpi" ]
       "HiDPI patches are deprecated. Refer to https://wiki.hyprland.org/Configuring/XWayland")
 
@@ -110,6 +106,12 @@ in {
     enableNvidiaPatches =
       lib.mkEnableOption "patching wlroots for better Nvidia support";
 
+    recommendedEnvironment = lib.mkEnableOption null // {
+      description = lib.mdDoc ''
+        Whether to set the recommended environment variables, namely `NIXOS_OZONE_WL`.
+      '';
+    };
+
     settings = lib.mkOption {
       type = with lib.types;
         let
@@ -191,6 +193,9 @@ in {
     in lib.optional inconsistent warning;
 
     home.packages = lib.optional (cfg.package != null) cfg.finalPackage;
+
+    home.sessionVariables =
+      lib.mkIf cfg.recommendedEnvironment { NIXOS_OZONE_WL = "1"; };
 
     xdg.configFile."hypr/hyprland.conf" = let
       combinedSettings = cfg.settings // {


### PR DESCRIPTION
### Description

Adds an option to enable recommended environment variables for wayland session, right now just `NIXOS_OZONE_WL`.

Fixes #4486.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@fufexan 