### PR TITLE
sxhkd: set scope OOMPolicy to continue

### DIFF
--- a/modules/services/sxhkd.nix
+++ b/modules/services/sxhkd.nix
@@ -75,7 +75,7 @@ in {
       sxhkdCommand = "${cfg.package}/bin/sxhkd ${toString cfg.extraOptions}";
     in ''
       systemctl --user stop sxhkd.scope 2> /dev/null || true
-      systemd-cat -t sxhkd systemd-run --user --scope -u sxhkd ${sxhkdCommand} &
+      systemd-cat -t sxhkd systemd-run --user --scope --property=OOMPolicy=continue -u sxhkd ${sxhkdCommand} &
     '';
   };
 }

--- a/tests/modules/services/sxhkd/service.nix
+++ b/tests/modules/services/sxhkd/service.nix
@@ -21,6 +21,6 @@
       'systemctl --user stop sxhkd.scope 2> /dev/null || true'
 
     assertFileContains $xsessionFile \
-      'systemd-cat -t sxhkd systemd-run --user --scope -u sxhkd @sxhkd@/bin/sxhkd -m 1 &'
+      'systemd-cat -t sxhkd systemd-run --user --scope --property=OOMPolicy=continue -u sxhkd @sxhkd@/bin/sxhkd -m 1 &'
   '';
 }


### PR DESCRIPTION
When a process inside the sxhkd scope is OOM killed, if the OOM policy is set to `stop` then the sxhkd scope itself will exit, terminating every process launched from the keyboard.

This is undesirable, set it to `continue` instead to keep other processes running.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@0qq 
