### PR TITLE
k9s: add hotkey option

### DIFF
--- a/modules/programs/k9s.nix
+++ b/modules/programs/k9s.nix
@@ -8,7 +8,7 @@ let
   yamlFormat = pkgs.formats.yaml { };
 
 in {
-  meta.maintainers = [ hm.maintainers.katexochen ];
+  meta.maintainers = [ hm.maintainers.katexochen maintainers.liyangau ];
 
   options.programs.k9s = {
     enable =
@@ -49,6 +49,29 @@ in {
         };
       '';
     };
+
+    hotkey = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      description = ''
+        hotkeys written to
+        {file}`$XDG_CONFIG_HOME/k9s/hotkey.yml`. See
+        <https://k9scli.io/topics/hotkeys/>
+        for supported values.
+      '';
+      example = literalExpression ''
+        hotkey = {
+          # Make sure this is camel case
+          hotKey = {
+            shift-0 = {
+              shortCut = "Shift-0";
+              description = "Viewing pods";
+              command = "pods";
+            };
+          };
+        };
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -60,6 +83,10 @@ in {
 
     xdg.configFile."k9s/skin.yml" = mkIf (cfg.skin != { }) {
       source = yamlFormat.generate "k9s-skin" cfg.skin;
+    };
+
+    xdg.configFile."k9s/hotkey.yml" = mkIf (cfg.hotkey != { }) {
+      source = yamlFormat.generate "k9s-hotkey" cfg.hotkey;
     };
   };
 }

--- a/modules/programs/k9s.nix
+++ b/modules/programs/k9s.nix
@@ -8,7 +8,7 @@ let
   yamlFormat = pkgs.formats.yaml { };
 
 in {
-  meta.maintainers = [ hm.maintainers.katexochen maintainers.liyangau ];
+  meta.maintainers = with maintainers;  [ katexochen liyangau ];
 
   options.programs.k9s = {
     enable =

--- a/modules/programs/k9s.nix
+++ b/modules/programs/k9s.nix
@@ -8,7 +8,7 @@ let
   yamlFormat = pkgs.formats.yaml { };
 
 in {
-  meta.maintainers = with maintainers;  [ katexochen liyangau ];
+  meta.maintainers = with maintainers; [ katexochen liyangau ];
 
   options.programs.k9s = {
     enable =

--- a/tests/modules/programs/k9s/example-hotkey-expected.yml
+++ b/tests/modules/programs/k9s/example-hotkey-expected.yml
@@ -1,0 +1,5 @@
+hotKey:
+  shift-0:
+    command: pods
+    description: Viewing pods
+    shortCut: Shift-0

--- a/tests/modules/programs/k9s/example-settings.nix
+++ b/tests/modules/programs/k9s/example-settings.nix
@@ -13,7 +13,15 @@
         headless = false;
       };
     };
-
+    hotkey = {
+      hotKey = {
+        shift-0 = {
+          shortCut = "Shift-0";
+          description = "Viewing pods";
+          command = "pods";
+        };
+      };
+    };
     skin = {
       k9s = {
         body = {
@@ -35,8 +43,12 @@
       home-files/.config/k9s/config.yml \
       ${./example-config-expected.yml}
     assertFileExists home-files/.config/k9s/skin.yml
+    assertFileExists home-files/.config/k9s/hotkey.yml
     assertFileContent \
       home-files/.config/k9s/skin.yml \
       ${./example-skin-expected.yml}
+    assertFileContent \
+      home-files/.config/k9s/hotkey.yml \
+      ${./example-hotkey-expected.yml}
   '';
 }


### PR DESCRIPTION
### Description

This PR adds an option to customise k9s hotkeys.

The keyword `hotKey` must be in camel case on the user config and it store the file at `k9s/hotkey.yml`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@katexochen
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
