### PR TITLE
Add support for firefox containers

### DIFF
--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -3,4 +3,5 @@
   firefox-state-version-19_09 = ./state-version-19_09.nix;
   firefox-deprecated-native-messenger = ./deprecated-native-messenger.nix;
   firefox-duplicate-profile-ids = ./duplicate-profile-ids.nix;
+  firefox-duplicate-container-ids = ./duplicate-container-ids.nix;
 }

--- a/tests/modules/programs/firefox/duplicate-container-ids.nix
+++ b/tests/modules/programs/firefox/duplicate-container-ids.nix
@@ -1,0 +1,35 @@
+{ config, lib, ... }:
+
+{
+  imports = [ ./setup-firefox-mock-overlay.nix ];
+
+  config = lib.mkIf config.test.enableBig {
+    test.asserts.assertions.expected = [''
+      Must not have a Firefox container with an existing ID but
+        - ID 9 is used by dangerous, shopping''];
+
+    programs.firefox = {
+      enable = true;
+
+      profiles = {
+        my-profile = {
+          isDefault = true;
+          id = 1;
+
+          containers = {
+            "shopping" = {
+              id = 9;
+              color = "blue";
+              icon = "circle";
+            };
+            "dangerous" = {
+              id = 9;
+              color = "red";
+              icon = "circle";
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/tests/modules/programs/firefox/duplicate-profile-ids.nix
+++ b/tests/modules/programs/firefox/duplicate-profile-ids.nix
@@ -5,7 +5,7 @@
 
   config = lib.mkIf config.test.enableBig {
     test.asserts.assertions.expected = [''
-      Must not have Firefox profiles with duplicate IDs but
+      Must not have a Firefox profile with an existing ID but
         - ID 1 is used by first, second''];
 
     programs.firefox = {

--- a/tests/modules/programs/firefox/profile-settings-expected-containers.json
+++ b/tests/modules/programs/firefox/profile-settings-expected-containers.json
@@ -1,0 +1,1 @@
+{"identities":[{"color":"yellow","icon":"circle","name":"shopping","public":true,"userContextId":6}],"lastUserContextId":6,"version":4}

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 {
   imports = [ ./setup-firefox-mock-overlay.nix ];
 
@@ -142,6 +140,17 @@ with lib;
           };
         };
       };
+
+      profiles.containers = {
+        id = 5;
+        containers = {
+          "shopping" = {
+            id = 6;
+            icon = "circle";
+            color = "yellow";
+          };
+        };
+      };
     };
 
     nmt.script = ''
@@ -154,6 +163,10 @@ with lib;
       assertFileContent \
         home-files/.mozilla/firefox/test/user.js \
         ${./profile-settings-expected-user.js}
+
+      assertFileContent \
+        home-files/.mozilla/firefox/containers/containers.json \
+        ${./profile-settings-expected-containers.json}
 
       bookmarksUserJs=$(normalizeStorePaths \
         home-files/.mozilla/firefox/bookmarks/user.js)


### PR DESCRIPTION
### Description

Generate containers for https://support.mozilla.org/en-US/kb/containers.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->