### PR TITLE
clipmenu: set Environment to a list

### DIFF
--- a/modules/services/clipmenu.nix
+++ b/modules/services/clipmenu.nix
@@ -49,10 +49,12 @@ in {
 
       Service = {
         ExecStart = "${cfg.package}/bin/clipmenud";
-        Environment = "PATH=${
+        Environment = [
+          "PATH=${
             makeBinPath
             (with pkgs; [ coreutils findutils gnugrep gnused systemd ])
-          }";
+          }"
+        ];
       };
 
       Install = { WantedBy = [ "graphical-session.target" ]; };


### PR DESCRIPTION
### Description

The clipmenud service uses environment variables for configuration (such as `CM_MAX_CLIPS` to set a history size limit and `CM_SELECTIONS` to pick whether to use clipboard/primary/secondary selection).

With `Environment` as a string there was no way for me to set those additional env vars, but using a list allows me to write:

```nix
systemd.user.services.clipmenu.Service.Environment = ["CM_SELECTIONS=clipboard"];
```

There should probably be an option on the module to allow specifying those vars along with the service, but in the mean time this allows users to append options separately.

I noticed a similar change (#3083) in the git history. I wonder if _all_ services should use lists for `Environment` so that they're more easily modifiable.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@DamienCassou 