### PR TITLE
firefox: add support for specifying policies

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -169,7 +169,10 @@ let
     else if isDarwin then
       package
     else if versionAtLeast config.home.stateVersion "19.09" then
-      package.override (old: { cfg = old.cfg or { } // fcfg; })
+      package.override (old: {
+        cfg = old.cfg or { } // fcfg;
+        extraPolicies = cfg.policies;
+      })
     else
       (pkgs.wrapFirefox.override { config = bcfg; }) package { };
 
@@ -228,6 +231,17 @@ in {
         type = with types; nullOr package;
         readOnly = true;
         description = "Resulting Firefox package.";
+      };
+
+      policies = mkOption {
+        type = types.attrsOf jsonFormat.type;
+        default = { };
+        description =
+          "[See list of policies](https://mozilla.github.io/policy-templates/).";
+        example = {
+          DefaultDownloadDirectory = "\${home}/Downloads";
+          BlockAboutConfig = true;
+        };
       };
 
       profiles = mkOption {

--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -4,4 +4,5 @@
   firefox-deprecated-native-messenger = ./deprecated-native-messenger.nix;
   firefox-duplicate-profile-ids = ./duplicate-profile-ids.nix;
   firefox-duplicate-container-ids = ./duplicate-container-ids.nix;
+  firefox-policies = ./policies.nix;
 }

--- a/tests/modules/programs/firefox/policies.nix
+++ b/tests/modules/programs/firefox/policies.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [ ./setup-firefox-mock-overlay.nix ];
+
+  config = lib.mkIf config.test.enableBig {
+    home.stateVersion = "23.05";
+
+    programs.firefox = {
+      enable = true;
+      policies = { BlockAboutConfig = true; };
+    };
+
+    nmt.script = ''
+      jq=${lib.getExe pkgs.jq}
+      config_file="${config.programs.firefox.finalPackage}/lib/firefox/distribution/policies.json"
+
+      assertFileExists "$config_file"
+      blockAboutConfig_actual_value="$($jq ".policies.BlockAboutConfig" $config_file)"
+
+      if [[ $blockAboutConfig_actual_value != "true" ]]; then
+        fail "Expected '$config_file' to set 'policies.BlockAboutConfig' to true"
+      fi
+    '';
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

/cc @rycee @kira-bruneau