### PR TITLE
k9s: add aliases, plugins, views

### DIFF
--- a/modules/programs/k9s.nix
+++ b/modules/programs/k9s.nix
@@ -50,11 +50,28 @@ in {
       '';
     };
 
+    aliases = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      description = ''
+        Aliases written to
+        {file}`$XDG_CONFIG_HOME/k9s/aliases.yml`. See
+        <https://k9scli.io/topics/aliases/>
+        for supported values.
+      '';
+      example = literalExpression ''
+        alias = {
+          # Use pp as an alias for Pod
+          pp = "v1/pods";
+        };
+      '';
+    };
+
     hotkey = mkOption {
       type = yamlFormat.type;
       default = { };
       description = ''
-        hotkeys written to
+        Hotkeys written to
         {file}`$XDG_CONFIG_HOME/k9s/hotkey.yml`. See
         <https://k9scli.io/topics/hotkeys/>
         for supported values.
@@ -67,6 +84,66 @@ in {
               shortCut = "Shift-0";
               description = "Viewing pods";
               command = "pods";
+            };
+          };
+        };
+      '';
+    };
+
+    plugin = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      description = ''
+        Plugins written to
+        {file}`$XDG_CONFIG_HOME/k9s/plugin.yml`. See
+        <https://k9scli.io/topics/plugins/>
+        for supported values.
+      '';
+      example = literalExpression ''
+        plugin = {
+          # Defines a plugin to provide a `ctrl-l` shortcut to tail the logs while in pod view.
+          fred = {
+            shortCut = "Ctrl-L";
+            description = "Pod logs";
+            scopes = [ "po" ];
+            command = "kubectl";
+            background = false;
+            args = [
+              "logs"
+              "-f"
+              "$NAME"
+              "-n"
+              "$NAMESPACE"
+              "--context"
+              "$CLUSTER"
+            ];
+          };
+        };
+      '';
+    };
+
+    views = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      description = ''
+        Resource column views written to
+        {file}`$XDG_CONFIG_HOME/k9s/views.yml`. See
+        <https://k9scli.io/topics/columns/>
+        for supported values.
+      '';
+      example = literalExpression ''
+        k9s = {
+          views = {
+            "v1/pods" = {
+              columns = [
+                "AGE"
+                "NAMESPACE"
+                "NAME"
+                "IP"
+                "NODE"
+                "STATUS"
+                "READY"
+              ];
             };
           };
         };
@@ -85,8 +162,20 @@ in {
       source = yamlFormat.generate "k9s-skin" cfg.skin;
     };
 
+    xdg.configFile."k9s/aliases.yml" = mkIf (cfg.aliases != { }) {
+      source = yamlFormat.generate "k9s-aliases" cfg.aliases;
+    };
+
     xdg.configFile."k9s/hotkey.yml" = mkIf (cfg.hotkey != { }) {
       source = yamlFormat.generate "k9s-hotkey" cfg.hotkey;
+    };
+
+    xdg.configFile."k9s/plugin.yml" = mkIf (cfg.plugin != { }) {
+      source = yamlFormat.generate "k9s-plugin" cfg.plugin;
+    };
+
+    xdg.configFile."k9s/views.yml" = mkIf (cfg.views != { }) {
+      source = yamlFormat.generate "k9s-views" cfg.views;
     };
   };
 }

--- a/tests/modules/programs/k9s/example-aliases-expected.yml
+++ b/tests/modules/programs/k9s/example-aliases-expected.yml
@@ -1,0 +1,2 @@
+alias:
+  pp: v1/pods

--- a/tests/modules/programs/k9s/example-plugin-expected.yml
+++ b/tests/modules/programs/k9s/example-plugin-expected.yml
@@ -1,0 +1,16 @@
+plugin:
+  fred:
+    args:
+    - logs
+    - -f
+    - $NAME
+    - -n
+    - $NAMESPACE
+    - --context
+    - $CLUSTER
+    background: false
+    command: kubectl
+    description: Pod logs
+    scopes:
+    - po
+    shortCut: Ctrl-L

--- a/tests/modules/programs/k9s/example-settings.nix
+++ b/tests/modules/programs/k9s/example-settings.nix
@@ -35,6 +35,29 @@
         };
       };
     };
+    aliases = { alias = { pp = "v1/pods"; }; };
+    plugin = {
+      plugin = {
+        fred = {
+          shortCut = "Ctrl-L";
+          description = "Pod logs";
+          scopes = [ "po" ];
+          command = "kubectl";
+          background = false;
+          args =
+            [ "logs" "-f" "$NAME" "-n" "$NAMESPACE" "--context" "$CLUSTER" ];
+        };
+      };
+    };
+    views = {
+      k9s = {
+        views = {
+          "v1/pods" = {
+            columns = [ "AGE" "NAMESPACE" "NAME" "IP" "NODE" "STATUS" "READY" ];
+          };
+        };
+      };
+    };
   };
 
   nmt.script = ''
@@ -43,12 +66,24 @@
       home-files/.config/k9s/config.yml \
       ${./example-config-expected.yml}
     assertFileExists home-files/.config/k9s/skin.yml
-    assertFileExists home-files/.config/k9s/hotkey.yml
     assertFileContent \
       home-files/.config/k9s/skin.yml \
       ${./example-skin-expected.yml}
+    assertFileExists home-files/.config/k9s/hotkey.yml
     assertFileContent \
       home-files/.config/k9s/hotkey.yml \
       ${./example-hotkey-expected.yml}
+    assertFileExists home-files/.config/k9s/aliases.yml
+    assertFileContent \
+      home-files/.config/k9s/aliases.yml \
+      ${./example-aliases-expected.yml}
+    assertFileExists home-files/.config/k9s/plugin.yml
+    assertFileContent \
+      home-files/.config/k9s/plugin.yml \
+      ${./example-plugin-expected.yml}
+    assertFileExists home-files/.config/k9s/views.yml
+    assertFileContent \
+      home-files/.config/k9s/views.yml \
+      ${./example-views-expected.yml}
   '';
 }

--- a/tests/modules/programs/k9s/example-views-expected.yml
+++ b/tests/modules/programs/k9s/example-views-expected.yml
@@ -1,0 +1,11 @@
+k9s:
+  views:
+    v1/pods:
+      columns:
+      - AGE
+      - NAMESPACE
+      - NAME
+      - IP
+      - NODE
+      - STATUS
+      - READY


### PR DESCRIPTION
### Description

Adding the remaining config files for k9s. Documented at https://k9scli.io/

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@liyangau

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
