### PR TITLE
kitty: always export `KITTY_SHELL_INTEGRATION`

### DIFF
--- a/tests/modules/programs/kitty/example-settings-expected.conf
+++ b/tests/modules/programs/kitty/example-settings-expected.conf
@@ -5,7 +5,7 @@ font_size 8
 
 
 # Shell integration is sourced and configured manually
-shell_integration no-rc enabled
+shell_integration no-rc
 
 enable_audio_bell no
 scrollback_lines 10000


### PR DESCRIPTION
### Description

This ensures that `KITTY_SHELL_INTEGRATION` is manually set to the user's `shellIntegration.mode`. This is necessary because the variable is not automatically set in subshells, `kitty @ launch`, etc. `shellIntegration.mode` is also now ensured to always contain `no-rc`.

Note that this is intended behavior, `KITTY_SHELL_INTEGRATION` is not always guaranteed to be set in all cases: https://github.com/kovidgoyal/kitty/issues/6783

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
