### PR TITLE
sway: fix workspace 10 missing from default config

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -91,6 +91,7 @@ let
           "${cfg.config.modifier}+7" = "workspace number 7";
           "${cfg.config.modifier}+8" = "workspace number 8";
           "${cfg.config.modifier}+9" = "workspace number 9";
+          "${cfg.config.modifier}+0" = "workspace number 10";
 
           "${cfg.config.modifier}+Shift+1" =
             "move container to workspace number 1";
@@ -110,6 +111,8 @@ let
             "move container to workspace number 8";
           "${cfg.config.modifier}+Shift+9" =
             "move container to workspace number 9";
+          "${cfg.config.modifier}+Shift+0" =
+            "move container to workspace number 10";
 
           "${cfg.config.modifier}+Shift+minus" = "move scratchpad";
           "${cfg.config.modifier}+minus" = "scratchpad show";

--- a/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
+++ b/tests/modules/services/window-managers/sway/sway-bar-focused-colors.conf
@@ -16,6 +16,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -29,6 +30,7 @@ bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
 bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.conf
+++ b/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.conf
@@ -18,6 +18,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+bindsym --to-code Mod1+0 workspace number 10
 bindsym --to-code Mod1+1 workspace number 1
 bindsym --to-code Mod1+2 workspace number 2
 bindsym --to-code Mod1+3 workspace number 3
@@ -31,6 +32,7 @@ bindsym --to-code Mod1+Down focus down
 bindsym --to-code Mod1+Left focus left
 bindsym --to-code Mod1+Return exec @foot@/bin/foot
 bindsym --to-code Mod1+Right focus right
+bindsym --to-code Mod1+Shift+0 move container to workspace number 10
 bindsym --to-code Mod1+Shift+1 move container to workspace number 1
 bindsym --to-code Mod1+Shift+2 move container to workspace number 2
 bindsym --to-code Mod1+Shift+3 move container to workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-default.conf
+++ b/tests/modules/services/window-managers/sway/sway-default.conf
@@ -16,6 +16,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -29,6 +30,7 @@ bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
 bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-expected.conf
@@ -16,6 +16,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -29,6 +30,7 @@ bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
 bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy-expected.conf
@@ -16,6 +16,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -29,6 +30,7 @@ bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
 bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-modules.conf
+++ b/tests/modules/services/window-managers/sway/sway-modules.conf
@@ -16,6 +16,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -29,6 +30,7 @@ bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
 bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-null-package.conf
+++ b/tests/modules/services/window-managers/sway/sway-null-package.conf
@@ -16,6 +16,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -29,6 +30,7 @@ bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
 bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-post-2003.conf
+++ b/tests/modules/services/window-managers/sway/sway-post-2003.conf
@@ -16,6 +16,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -29,6 +30,7 @@ bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
 bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-default-expected.conf
@@ -16,6 +16,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 bindsym Mod1+9 workspace number 9
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -28,6 +29,7 @@ bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
 bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3

--- a/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/sway/sway-workspace-output-expected.conf
@@ -16,6 +16,7 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -29,6 +30,7 @@ bindsym Mod1+Down focus down
 bindsym Mod1+Left focus left
 bindsym Mod1+Return exec @foot@/bin/foot
 bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3


### PR DESCRIPTION
### Description

workspace 10 is part of upstream's default config, but was missing in home-manager.

The initial "sway: add module" PR (#829, 02d60400035028d4c8affab24557344ca371b9fd) went through multiple iterations and had workspace 10 included for a brief moment. Until the author removed it in a force-push commenting

> Have removed the last change which added bound ${modifer}+0 to workspace number 10 as this messed up workspace numbering in sway.

https://github.com/nix-community/home-manager/pull/829#issuecomment-575087553

The reason might have been, that sway used to sort the workspaces in the order they appeared in the config.

Attribute sets in nix are sorted, but not "naturally sorted", meaning `bindsym Mod1+0 workspace number 10` comes before `bindsym Mod1+0 workspace number 1`.

It's unclear if that's what really happened. A workaround would have been to use `lib.lists.naturalSort` in `keybindingsStr`.

But I cannot reproduce this anymore in any way.
I assume this has been fixed many years ago by now.

upstream config: https://github.com/swaywm/sway/blob/020a572ed615b8fe272c7566a27ee0abe73a58d7/config.in#L113-L134

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Scrumplex @alexarice @sumnerevans @SebTM @oxalica
