### PR TITLE
home-cursor: fix typo in XDG data directory link

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -155,10 +155,10 @@ in {
       home.file.".icons/${cfg.name}".source =
         "${cfg.package}/share/icons/${cfg.name}";
 
-      # Add cursor icon link to $XDG_DATA_HOME as well for redundancy.
-      xdg.dataFile.".icons/default/index.theme".source =
+      # Add cursor icon link to $XDG_DATA_HOME/icons as well for redundancy.
+      xdg.dataFile."icons/default/index.theme".source =
         "${defaultIndexThemePackage}/share/icons/default/index.theme";
-      xdg.dataFile.".icons/${cfg.name}".source =
+      xdg.dataFile."icons/${cfg.name}".source =
         "${cfg.package}/share/icons/${cfg.name}";
     }
 


### PR DESCRIPTION
This commit fixes a typo in XDG data directory link location in the `home.pointerCursor` module where the link is placed at $XDG_DATA_HOME/.icons instead of the correct location $XDG_DATA_HOME/icons.

### Description

<!--

Please provide a brief description of your change.

-->

Fixes https://github.com/nix-community/home-manager/issues/4638

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee