### PR TITLE
systemd: avoid creating an empty user.conf

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -4,7 +4,9 @@ let
 
   cfg = config.systemd.user;
 
-  inherit (lib) getAttr hm isBool literalExpression mkIf mkMerge mkOption types;
+  inherit (lib)
+    any attrValues getAttr hm isBool literalExpression mkIf mkMerge mkOption
+    types;
 
   settingsFormat = pkgs.formats.ini { listsAsDuplicateKeys = true; };
 
@@ -93,7 +95,7 @@ let
       + "\n";
   };
 
-  settings = mkIf (cfg.settings != { }) {
+  settings = mkIf (any (v: v != { }) (attrValues cfg.settings)) {
     "systemd/user.conf".source =
       settingsFormat.generate "user.conf" cfg.settings;
   };

--- a/tests/modules/systemd/default.nix
+++ b/tests/modules/systemd/default.nix
@@ -3,6 +3,7 @@
   systemd-services-disabled-for-root = ./services-disabled-for-root.nix;
   systemd-session-variables = ./session-variables.nix;
   systemd-user-config = ./user-config.nix;
+  systemd-empty-user-config = ./empty-user-config.nix;
   systemd-slices = ./slices.nix;
   systemd-timers = ./timers.nix;
 }

--- a/tests/modules/systemd/empty-user-config.nix
+++ b/tests/modules/systemd/empty-user-config.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+
+{
+  nmt.script = ''
+    userConf=home-files/.config/systemd/user.conf
+    assertPathNotExists $userConf
+  '';
+}


### PR DESCRIPTION
Due to the defaults in `systemd.user.settings`, the default value when there are no settings explicitly set is `{ Manager = { }; }`. This means an empty file is created even when `systemd.user.settings` is never used in home-manager configuration.

Since user’s `user.conf` is preferred to the global `/etc/systemd/user.conf`, this can cause any values set in the latter to be discarded.

-------

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->