### PR TITLE
zellij: add '_name' meta-attr to KDL generator

### DIFF
--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -1,6 +1,4 @@
-{ lib }:
-
-{
+{ lib, ... }: {
   toKDL = { }:
     let
       inherit (lib) concatStringsSep splitString mapAttrsToList any;
@@ -11,8 +9,8 @@
         # Although the input of this function is a list of strings,
         # the strings themselves *will* contain newlines, so you need
         # to normalize the list by joining and resplitting them.
-        unlines = lib.splitString "\n";
-        lines = lib.concatStringsSep "\n";
+        unlines = splitString "\n";
+        lines = concatStringsSep "\n";
         indentAll = lines: concatStringsSep "\n" (map (x: "	" + x) lines);
       in stringsWithNewlines: indentAll (unlines (lines stringsWithNewlines));
 
@@ -54,10 +52,13 @@
               (s: s + " ")
             ]);
 
+          nameString = if (attrs ? "_name") then attrs._name else name;
+
           children =
-            lib.filterAttrs (name: _: !(elem name [ "_args" "_props" ])) attrs;
+            lib.filterAttrs (name: _: !(elem name [ "_args" "_props" "_name" ]))
+            attrs;
         in ''
-          ${name} ${optArgsString}${optPropsString}{
+          ${nameString} ${optArgsString}${optPropsString}{
           ${indentStrings (mapAttrsToList convertAttributeToKDL children)}
           }'';
 

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -1,12 +1,8 @@
 { config, lib, pkgs, ... }:
-
 with lib;
-
 let
-
   cfg = config.programs.zellij;
   yamlFormat = pkgs.formats.yaml { };
-
 in {
   meta.maintainers = [ hm.maintainers.mainrs ];
 
@@ -29,6 +25,17 @@ in {
         {
           theme = "custom";
           themes.custom.fg = "#ffffff";
+          keybinds = {
+            _props = { clear-defaults = true; };
+            normal = [
+              { _name = "bind"; _args = [ "Ctrl q" "Alt F4" ]; Quit = []; }
+              { _name = "bind"; _args = [ "Alt l" ]; MoveFocusOrTab = "Right"; }
+            ];
+            locked = [
+              { _name = "bind"; _args = [ "Ctrl q" "Alt F4" ]; Quit = []; }
+              { _name = "bind"; _args = [ "Alt l" ]; MoveFocusOrTab = "Right"; }
+            ];
+          };
         }
       '';
       description = ''

--- a/tests/lib/generators/tokdl-result.txt
+++ b/tests/lib/generators/tokdl-result.txt
@@ -32,6 +32,20 @@ listInAttrsInList {
 		}
 	}
 }
+literalNodes {
+	node "arg1" "arg2" prop1=1 prop2=2 {
+		child1 
+		child2 
+	}
+	node "arg2" prop1=1 prop2=2 {
+		child1 
+		child2 
+	}
+	node "arg2" prop2=2 {
+		child1 
+		child2 
+	}
+}
 nested {
 	- 1 2
 	- true false
@@ -39,3 +53,29 @@ nested {
 	- null
 }
 unsafeString " \" \n 	 "
+zellijExampleSettings {
+	keybinds clear-defaults=true {
+		locked {
+			bind "Ctrl q" "Alt F4" {
+				Quit 
+			}
+			bind "Alt l" {
+				MoveFocusOrTab "Right"
+			}
+		}
+		normal {
+			bind "Ctrl q" "Alt F4" {
+				Quit 
+			}
+			bind "Alt l" {
+				MoveFocusOrTab "Right"
+			}
+		}
+	}
+	theme "custom"
+	themes {
+		custom {
+			fg "#ffffff"
+		}
+	}
+}

--- a/tests/lib/generators/tokdl.nix
+++ b/tests/lib/generators/tokdl.nix
@@ -1,6 +1,4 @@
-{ config, lib, ... }:
-
-{
+{ lib, ... }: {
   home.file."result.txt".text = lib.hm.generators.toKDL { } {
     a = 1;
     b = "string";
@@ -32,6 +30,35 @@
         b = null;
       };
     };
+    literalNodes = [
+      {
+        _name = "node";
+        _args = [ "arg1" "arg2" ];
+        _props = {
+          prop1 = 1;
+          prop2 = 2;
+        };
+        child1 = [ ];
+        child2 = [ ];
+      }
+      {
+        _name = "node";
+        _args = [ "arg2" ];
+        _props = {
+          prop1 = 1;
+          prop2 = 2;
+        };
+        child1 = [ ];
+        child2 = [ ];
+      }
+      {
+        _name = "node";
+        _args = [ "arg2" ];
+        _props = { prop2 = 2; };
+        child1 = [ ];
+        child2 = [ ];
+      }
+    ];
     listInAttrsInList = {
       list1 = [
         { a = 1; }
@@ -42,6 +69,37 @@
         }
       ];
       list2 = [{ a = 8; }];
+    };
+    zellijExampleSettings = {
+      theme = "custom";
+      themes.custom.fg = "#ffffff";
+      keybinds = {
+        _props = { clear-defaults = true; };
+        normal = [
+          {
+            _name = "bind";
+            _args = [ "Ctrl q" "Alt F4" ];
+            Quit = [ ];
+          }
+          {
+            _name = "bind";
+            _args = [ "Alt l" ];
+            MoveFocusOrTab = "Right";
+          }
+        ];
+        locked = [
+          {
+            _name = "bind";
+            _args = [ "Ctrl q" "Alt F4" ];
+            Quit = [ ];
+          }
+          {
+            _name = "bind";
+            _args = [ "Alt l" ];
+            MoveFocusOrTab = "Right";
+          }
+        ];
+      };
     };
   };
 


### PR DESCRIPTION
### Description

This enables the KDL generator to serialize nodes with the same name, such as in a Zellij config containing multiple keybindings. That said, I think it's rather crude, so am definitely open to feedback. Perhaps something similar has been done elsewhere in a cleaner manner?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.
  - I'm pretty sure this is technically untrue. Anything serialized with KDL elsewhere that has a `_name` field will now suddenly appear differently.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
