### PR TITLE
 sway: Check config file validity 

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -261,62 +261,66 @@ let
   systemdActivation = ''
     exec "${pkgs.dbus}/bin/dbus-update-activation-environment --systemd ${variables}; ${extraCommands}"'';
 
-  configFile = pkgs.writeText "sway.conf" (concatStringsSep "\n"
-    ((optional (cfg.extraConfigEarly != "") cfg.extraConfigEarly)
-      ++ (if cfg.config != null then
-        with cfg.config;
-        ([
-          (fontConfigStr fonts)
-          "floating_modifier ${floating.modifier}"
-          (windowBorderString window floating)
-          "hide_edge_borders ${window.hideEdgeBorders}"
-          "focus_wrapping ${focus.wrapping}"
-          "focus_follows_mouse ${focus.followMouse}"
-          "focus_on_window_activation ${focus.newWindow}"
-          "mouse_warping ${
-            if builtins.isString (focus.mouseWarping) then
-              focus.mouseWarping
-            else if focus.mouseWarping then
-              "output"
-            else
-              "none"
-          }"
-          "workspace_layout ${workspaceLayout}"
-          "workspace_auto_back_and_forth ${
-            lib.hm.booleans.yesNo workspaceAutoBackAndForth
-          }"
-          "client.focused ${colorSetStr colors.focused}"
-          "client.focused_inactive ${colorSetStr colors.focusedInactive}"
-          "client.unfocused ${colorSetStr colors.unfocused}"
-          "client.urgent ${colorSetStr colors.urgent}"
-          "client.placeholder ${colorSetStr colors.placeholder}"
-          "client.background ${colors.background}"
-          (keybindingsStr {
-            keybindings = keybindingDefaultWorkspace;
-            bindsymArgs =
-              lib.optionalString (cfg.config.bindkeysToCode) "--to-code";
-          })
-          (keybindingsStr {
-            keybindings = keybindingsRest;
-            bindsymArgs =
-              lib.optionalString (cfg.config.bindkeysToCode) "--to-code";
-          })
-          (keycodebindingsStr keycodebindings)
-        ] ++ mapAttrsToList inputStr input
-          ++ mapAttrsToList outputStr output # outputs
-          ++ mapAttrsToList seatStr seat # seats
-          ++ mapAttrsToList (modeStr cfg.config.bindkeysToCode) modes # modes
-          ++ mapAttrsToList assignStr assigns # assigns
-          ++ map barStr bars # bars
-          ++ optional (gaps != null) gapsStr # gaps
-          ++ map floatingCriteriaStr floating.criteria # floating
-          ++ map windowCommandsStr window.commands # window commands
-          ++ map startupEntryStr startup # startup
-          ++ map workspaceOutputStr workspaceOutputAssign # custom mapping
-        )
-      else
-        [ ]) ++ (optional cfg.systemd.enable systemdActivation)
-      ++ (optional (!cfg.xwayland) "xwayland disable") ++ [ cfg.extraConfig ]));
+  configFile = pkgs.writeTextFile {
+    name = "sway.conf";
+    text = (concatStringsSep "\n"
+      ((optional (cfg.extraConfigEarly != "") cfg.extraConfigEarly)
+        ++ (if cfg.config != null then
+          with cfg.config;
+          ([
+            (fontConfigStr fonts)
+            "floating_modifier ${floating.modifier}"
+            (windowBorderString window floating)
+            "hide_edge_borders ${window.hideEdgeBorders}"
+            "focus_wrapping ${focus.wrapping}"
+            "focus_follows_mouse ${focus.followMouse}"
+            "focus_on_window_activation ${focus.newWindow}"
+            "mouse_warping ${
+              if builtins.isString (focus.mouseWarping) then
+                focus.mouseWarping
+              else if focus.mouseWarping then
+                "output"
+              else
+                "none"
+            }"
+            "workspace_layout ${workspaceLayout}"
+            "workspace_auto_back_and_forth ${
+              lib.hm.booleans.yesNo workspaceAutoBackAndForth
+            }"
+            "client.focused ${colorSetStr colors.focused}"
+            "client.focused_inactive ${colorSetStr colors.focusedInactive}"
+            "client.unfocused ${colorSetStr colors.unfocused}"
+            "client.urgent ${colorSetStr colors.urgent}"
+            "client.placeholder ${colorSetStr colors.placeholder}"
+            "client.background ${colors.background}"
+            (keybindingsStr {
+              keybindings = keybindingDefaultWorkspace;
+              bindsymArgs =
+                lib.optionalString (cfg.config.bindkeysToCode) "--to-code";
+            })
+            (keybindingsStr {
+              keybindings = keybindingsRest;
+              bindsymArgs =
+                lib.optionalString (cfg.config.bindkeysToCode) "--to-code";
+            })
+            (keycodebindingsStr keycodebindings)
+          ] ++ mapAttrsToList inputStr input
+            ++ mapAttrsToList outputStr output # outputs
+            ++ mapAttrsToList seatStr seat # seats
+            ++ mapAttrsToList (modeStr cfg.config.bindkeysToCode) modes # modes
+            ++ mapAttrsToList assignStr assigns # assigns
+            ++ map barStr bars # bars
+            ++ optional (gaps != null) gapsStr # gaps
+            ++ map floatingCriteriaStr floating.criteria # floating
+            ++ map windowCommandsStr window.commands # window commands
+            ++ map startupEntryStr startup # startup
+            ++ map workspaceOutputStr workspaceOutputAssign # custom mapping
+          )
+        else
+          [ ]) ++ (optional cfg.systemd.enable systemdActivation)
+        ++ (optional (!cfg.xwayland) "xwayland disable")
+        ++ [ cfg.extraConfig ]));
+  };
 
   defaultSwayPackage = pkgs.sway.override {
     extraSessionCommands = cfg.extraSessionCommands;

--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -5,6 +5,7 @@
   sway-default = ./sway-default.nix;
   sway-followmouse = ./sway-followmouse.nix;
   sway-followmouse-legacy = ./sway-followmouse-legacy.nix;
+  sway-check-config = ./sway-check-config.nix;
   sway-modules = ./sway-modules.nix;
   sway-no-xwayland = ./sway-no-xwayland.nix;
   sway-null-config = ./sway-null-config.nix;

--- a/tests/modules/services/window-managers/sway/sway-bar-focused-colors.nix
+++ b/tests/modules/services/window-managers/sway/sway-bar-focused-colors.nix
@@ -6,6 +6,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
     # overriding findutils causes issues
     config.menu = "${pkgs.dmenu}/bin/dmenu_run";
 

--- a/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.nix
+++ b/tests/modules/services/window-managers/sway/sway-bindkeys-to-code-and-extra-config.nix
@@ -6,6 +6,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
     # overriding findutils causes issues
     config.menu = "${pkgs.dmenu}/bin/dmenu_run";
     config.bindkeysToCode = true;

--- a/tests/modules/services/window-managers/sway/sway-check-config.nix
+++ b/tests/modules/services/window-managers/sway/sway-check-config.nix
@@ -1,0 +1,12 @@
+{ config, lib, ... }:
+
+lib.mkIf config.test.enableBig {
+  wayland.windowManager.sway = {
+    enable = true;
+    checkConfig = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/sway/config
+  '';
+}

--- a/tests/modules/services/window-managers/sway/sway-default.nix
+++ b/tests/modules/services/window-managers/sway/sway-default.nix
@@ -6,6 +6,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
     # overriding findutils causes issues
     config.menu = "${pkgs.dmenu}/bin/dmenu_run";
   };

--- a/tests/modules/services/window-managers/sway/sway-followmouse-legacy.nix
+++ b/tests/modules/services/window-managers/sway/sway-followmouse-legacy.nix
@@ -6,6 +6,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
 
     config = {
       focus.followMouse = false;

--- a/tests/modules/services/window-managers/sway/sway-followmouse.nix
+++ b/tests/modules/services/window-managers/sway/sway-followmouse.nix
@@ -6,6 +6,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
 
     config = {
       focus.followMouse = "always";

--- a/tests/modules/services/window-managers/sway/sway-modules.nix
+++ b/tests/modules/services/window-managers/sway/sway-modules.nix
@@ -6,6 +6,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
     # overriding findutils causes issues
     config = {
       menu = "${pkgs.dmenu}/bin/dmenu_run";

--- a/tests/modules/services/window-managers/sway/sway-no-xwayland.nix
+++ b/tests/modules/services/window-managers/sway/sway-no-xwayland.nix
@@ -6,6 +6,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
     config = null;
     systemd.enable = false;
     xwayland = false;

--- a/tests/modules/services/window-managers/sway/sway-null-config.nix
+++ b/tests/modules/services/window-managers/sway/sway-null-config.nix
@@ -6,6 +6,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
     config = null;
     systemd.enable = false;
   };

--- a/tests/modules/services/window-managers/sway/sway-null-package.nix
+++ b/tests/modules/services/window-managers/sway/sway-null-package.nix
@@ -9,6 +9,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = null;
+    checkConfig = false;
     config.menu = "${pkgs.dmenu}/bin/dmenu_run";
   };
 

--- a/tests/modules/services/window-managers/sway/sway-post-2003.nix
+++ b/tests/modules/services/window-managers/sway/sway-post-2003.nix
@@ -8,6 +8,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
     # overriding findutils causes issues
     config.menu = "${pkgs.dmenu}/bin/dmenu_run";
   };

--- a/tests/modules/services/window-managers/sway/sway-systemd-autostart.nix
+++ b/tests/modules/services/window-managers/sway/sway-systemd-autostart.nix
@@ -6,6 +6,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
     # overriding findutils causes issues
     config.menu = "${pkgs.dmenu}/bin/dmenu_run";
 

--- a/tests/modules/services/window-managers/sway/sway-workspace-default.nix
+++ b/tests/modules/services/window-managers/sway/sway-workspace-default.nix
@@ -6,6 +6,7 @@
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
     # overriding findutils causes issues
     config.menu = "${pkgs.dmenu}/bin/dmenu_run";
     config.defaultWorkspace = "workspace number 9";

--- a/tests/modules/services/window-managers/sway/sway-workspace-output.nix
+++ b/tests/modules/services/window-managers/sway/sway-workspace-output.nix
@@ -15,6 +15,7 @@ in {
   wayland.windowManager.sway = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
     # overriding findutils causes issues
     config.menu = "${pkgs.dmenu}/bin/dmenu_run";
 


### PR DESCRIPTION
### Description

Helps avoid successful build but Sway failing to start.

To meaningfully test this, I had to actually use `pkgs.sway` in the test
rather than the stub, but left all other tests using the stub and
changed them to skipping the test.

Only ran Sway tests, not all tests.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Scrumplex @alexarice @sumnerevans @SebTM @oxalica 
