### PR TITLE
nix-your-shell: new module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -156,6 +156,7 @@ let
     ./programs/newsboat.nix
     ./programs/nheko.nix
     ./programs/nix-index.nix
+    ./programs/nix-your-shell.nix
     ./programs/nnn.nix
     ./programs/noti.nix
     ./programs/notmuch.nix

--- a/modules/programs/nix-your-shell.nix
+++ b/modules/programs/nix-your-shell.nix
@@ -1,11 +1,12 @@
 { config, lib, pkgs, ... }:
 let
-  inherit (lib) genAttrs getExe;
   cfg = config.programs.nix-your-shell;
 
-  # In principle `bash` is supported too, but...  😹
-  shells = [ "fish" "ion" "nushell" "zsh" ];
-  programs = [ "nix" "nix-shell" ];
+  exe = lib.getExe pkgs.nix-your-shell;
+  mkShellAliases = shell: {
+    nix = "${exe} ${shell} nix --";
+    nix-shell = "${exe} ${shell} nix-shell --";
+  };
 in {
   meta.maintainers = with lib.maintainers; [ nicoo ];
 
@@ -14,8 +15,10 @@ in {
     to run the same shell inside the new environment.
   '';
 
-  config.programs = lib.mkIf cfg.enable (genAttrs shells (shell: {
-    shellAliases = genAttrs programs
-      (program: "${getExe pkgs.nix-your-shell} ${shell} ${program} --");
-  }));
+  config.programs = lib.mkIf cfg.enable {
+    fish.shellAliases = mkShellAliases "fish";
+    ion.shellAliases = mkShellAliases "ion";
+    nushell.shellAliases = mkShellAliases "nushell";
+    zsh.shellAliases = mkShellAliases "zsh";
+  };
 }

--- a/modules/programs/nix-your-shell.nix
+++ b/modules/programs/nix-your-shell.nix
@@ -3,17 +3,29 @@ let
   cfg = config.programs.nix-your-shell;
 
   exe = lib.getExe pkgs.nix-your-shell;
+  args = lib.concatStringsSep " " cfg.extraArgs;
+
   mkShellAliases = shell: {
-    nix = "${exe} ${shell} nix --";
-    nix-shell = "${exe} ${shell} nix-shell --";
+    nix = "${exe} ${args} ${shell} nix --";
+    nix-shell = "${exe} ${args} ${shell} nix-shell --";
   };
 in {
   meta.maintainers = with lib.maintainers; [ nicoo ];
 
-  options.programs.nix-your-shell.enable = lib.mkEnableOption ''
-    `nix-your-shell`, a wrapper for `nix develop` or `nix-shell`
-    to run the same shell inside the new environment.
-  '';
+  options.programs.nix-your-shell = {
+    enable = lib.mkEnableOption ''
+      `nix-your-shell`, a wrapper for `nix develop` or `nix-shell`
+      to run the same shell inside the new environment.
+    '';
+
+    extraArgs = lib.mkOption {
+      default = [ ];
+      description = ''
+        additional command-line arguments, to be passed to `nix-your-shell`
+      '';
+      type = with lib.types; listOf str;
+    };
+  };
 
   config.programs = lib.mkIf cfg.enable {
     fish.shellAliases = mkShellAliases "fish";

--- a/modules/programs/nix-your-shell.nix
+++ b/modules/programs/nix-your-shell.nix
@@ -18,6 +18,10 @@ in {
       to run the same shell inside the new environment.
     '';
 
+    nom = lib.mkEnableOption ''
+      `nix-output-monitor` to provide better visualisation of build progress.
+    '';
+
     extraArgs = lib.mkOption {
       default = [ ];
       description = ''
@@ -32,5 +36,7 @@ in {
     ion.shellAliases = mkShellAliases "ion";
     nushell.shellAliases = mkShellAliases "nushell";
     zsh.shellAliases = mkShellAliases "zsh";
+
+    nix-your-shell.extraArgs = lib.optional cfg.nom "--nom";
   };
 }

--- a/modules/programs/nix-your-shell.nix
+++ b/modules/programs/nix-your-shell.nix
@@ -4,7 +4,7 @@ let
   cfg = config.programs.nix-your-shell;
 
   # In principle `bash` is supported too, but...  😹
-  shells = [ "fish" "nushell" "zsh" ];
+  shells = [ "fish" "ion" "nushell" "zsh" ];
   programs = [ "nix" "nix-shell" ];
 in {
   meta.maintainers = with lib.maintainers; [ nicoo ];

--- a/modules/programs/nix-your-shell.nix
+++ b/modules/programs/nix-your-shell.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib) genAttrs getExe;
+  cfg = config.programs.nix-your-shell;
+
+  # In principle `bash` is supported too, but...  😹
+  shells = [ "fish" "nushell" "zsh" ];
+  programs = [ "nix" "nix-shell" ];
+in {
+  meta.maintainers = with lib.maintainers; [ nicoo ];
+
+  options.programs.nix-your-shell.enable = lib.mkEnableOption ''
+    `nix-your-shell`, a wrapper for `nix develop` or `nix-shell`
+    to run the same shell inside the new environment.
+  '';
+
+  config.programs = lib.mkIf cfg.enable (genAttrs shells (shell: {
+    shellAliases = genAttrs programs
+      (program: "${getExe pkgs.nix-your-shell} ${shell} ${program} --");
+  }));
+}


### PR DESCRIPTION
### Description

Add a module for `nix-your-shell`, a wrapper for `nix develop` and `nix-shell`
to run the same shell inside the environment (instead of always Bash)


### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
