### PR TITLE
swayidle: always restart systemd unit on failure

### DIFF
--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -122,6 +122,7 @@ in {
 
       Service = {
         Type = "simple";
+        Restart = "always";
         # swayidle executes commands using "sh -c", so the PATH needs to contain a shell.
         Environment = [ "PATH=${makeBinPath [ pkgs.bash ]}" ];
         ExecStart =

--- a/tests/modules/services/swayidle/basic-configuration.nix
+++ b/tests/modules/services/swayidle/basic-configuration.nix
@@ -46,6 +46,7 @@
 
     assertFileExists $serviceFile
     assertFileRegex $serviceFile 'ExecStart=.*/bin/swayidle ${expectedArgs}'
+    assertFileRegex $serviceFile 'Restart=always'
     assertFileRegex $serviceFile 'Environment=.*PATH=${
       lib.makeBinPath [ pkgs.bash ]
     }'


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Occasionally, swayidle crashes with a failure to connect to the Wayland session. Ideally, swayidle should automatically restart instead of leaving the system in a vulnerable state.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@c0deaddict 