### PR TITLE
hishtory: add module programs.hishtory

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -454,6 +454,15 @@
     github = "wcarlsen";
     githubId = 17003032;
   };
+  willemml = {
+    github = "willemml";
+    email = "17758796+willemml@users.noreply.github.com";
+    githubId = 17758796;
+    keys = [{
+      longkeyid = "rsa4096/0xC3DE5DF6198DACBD";
+      fingerprint = "860B 5C62 BF1F CE42 72D2  6BF8 C3DE 5DF6 198D ACBD";
+    }];
+  };
   "9p4" = {
     name = "9p4";
     email = "vcs@ersei.net";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -104,6 +104,7 @@ let
     ./programs/helix.nix
     ./programs/hexchat.nix
     ./programs/himalaya.nix
+    ./programs/hishtory.nix
     ./programs/home-manager.nix
     ./programs/hstr.nix
     ./programs/htop.nix

--- a/modules/programs/hishtory.nix
+++ b/modules/programs/hishtory.nix
@@ -1,0 +1,103 @@
+{ pkgs, config, lib, ... }:
+let
+  inherit (lib)
+    mkIf mkEnableOption mkPackageOption mkOption literalExpression types;
+  cfg = config.programs.hishtory;
+  shellConfPath = "${cfg.package.outPath}/share/hishtory";
+in {
+  meta.maintainers = [ lib.maintainers.willemml ];
+
+  config.home.packages = mkIf cfg.enable [ cfg.package ];
+
+  config.programs.bash.bashrcExtra =
+    mkIf cfg.enableBashIntegration "source '${shellConfPath}/config.bash'";
+  config.programs.fish.loginShellInit =
+    mkIf cfg.enableFishIntegration "source '${shellConfPath}/config.fish'";
+  config.programs.zsh.initExtra =
+    mkIf cfg.enableZshIntegration "source '${shellConfPath}/config.zsh'";
+
+  config.home.activation.hishtoryActivation = let
+    hishtory = "${pkgs.hishtory.out}/bin/hishtory";
+    config-cmd = cmd: name: value:
+      if (value != "" && value != [ ] && value != null) then
+        "${hishtory} ${cmd} ${name} ${toString value}"
+      else
+        "";
+    config-set = config-cmd "config-set";
+  in mkIf (cfg.enable && cfg.enableConfig)
+  (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    ${hishtory} config-get custom-columns | cut -f1 -d ":" | xargs -I {} ${hishtory} config-delete custom-columns {}
+
+    ${config-cmd "config-set" "displayed-columns" "''"}
+    ${toString (lib.forEach cfg.settings.displayed-columns (value:
+      (config-cmd "config-add" "displayed-columns" ''
+        '${value}'
+      '')))}
+    ${config-cmd "config-delete" "displayed-columns" "''"}
+
+    ${config-set "enable-control-r" cfg.settings.enable-control-r}
+    ${config-set "beta-mode" cfg.settings.beta-mode}
+    ${config-set "timestamp-format" "'${cfg.settings.timestamp-format}'"}
+    ${config-set "filter-duplicate-commands"
+    cfg.settings.filter-duplicate-commands}
+
+    ${(toString (lib.attrsets.mapAttrsToList (name: value: ''
+      ${hishtory} config-add custom-columns ${name} '${value}'
+    '') cfg.settings.custom-columns))}
+  '');
+
+  options.programs.hishtory = let
+    trueFalseOption = desc:
+      mkOption {
+        type = types.bool;
+        example = true;
+        default = false;
+        apply = value: if value then "true" else "false";
+        description = "Whether to enable ${desc}.";
+      };
+  in {
+    enable = mkEnableOption "hishtory";
+
+    enableZshIntegration = mkEnableOption "hishtory's Zsh integration";
+    enableFishIntegration = mkEnableOption "hishtory's Fish integration";
+    enableBashIntegration = mkEnableOption "hishtory's Bash integration";
+
+    enableConfig = mkEnableOption "configuration of hishtory via home-manager";
+
+    settings = {
+      custom-columns = mkOption {
+        default = { };
+        example = literalExpression ''
+          {
+            git_remote = "(git remote -v 2>/dev/null | grep origin 1>/dev/null ) && git remote get-url origin || true";
+          }
+        '';
+        description = ''
+          An attribute set that maps custom-columns (the top level attribute names in
+          this option) to command strings or directly to build outputs.
+        '';
+        type = types.attrsOf types.str;
+      };
+      enable-control-r = trueFalseOption "Control+R integration for your shell";
+      displayed-columns = mkOption {
+        default =
+          [ "Hostname" "CWD" "Timestamp" "Runtime" "Exit Code" "Command" ];
+        example = literalExpression "[git_remote]";
+        description = "A list of custom columns to display.";
+        type = types.listOf types.str;
+      };
+      beta-mode = trueFalseOption "beta features";
+      filter-duplicate-commands =
+        trueFalseOption "filtering of duplicate commands";
+      timestamp-format = mkOption {
+        default = "Jan 2 2006 15:04:05 MST";
+        example = "2006/Jan/2 15:04";
+        description =
+          "Custom timestamp format, should be in the format used by Go's time.Format(...).";
+        type = types.str;
+      };
+    };
+
+    package = mkPackageOption pkgs "hishtory" { };
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds `programs.hishtory` module to enable use of [hishtory](https://github.com/ddworken/hishtory). Due to the way this program's configuration is stored it's configuration must be updated using shell commands in the activation script. Because of this, configuration of the program by home-manager (beyond basic installation) is optional, and by default disabled. If anyone familiar with the program has suggestions on how this configuration stage could be better implemented, please let me know.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
