### PR TITLE
aerc-accounts: support for maildirpp

### DIFF
--- a/modules/programs/aerc-accounts.nix
+++ b/modules/programs/aerc-accounts.nix
@@ -145,6 +145,11 @@ in {
             "maildir://${config.accounts.email.maildirBasePath}/${cfg.maildir.path}";
         };
 
+        maildirpp = cfg: {
+          source =
+            "maildirpp://${config.accounts.email.maildirBasePath}/${cfg.maildir.path}/Inbox";
+        };
+
         imap = { userName, imap, passwordCommand, aerc, ... }@cfg:
           let
             loginMethod' =
@@ -207,7 +212,10 @@ in {
         // (optAttr "aliases" account.aliases);
 
       sourceCfg = account:
-        if account.mbsync.enable || account.offlineimap.enable then
+        if account.mbsync.enable && account.mbsync.flatten == null
+        && account.mbsync.subFolders == "Maildir++" then
+          mkConfig.maildirpp account
+        else if account.mbsync.enable || account.offlineimap.enable then
           mkConfig.maildir account
         else if account.imap != null then
           mkConfig.imap account

--- a/tests/modules/programs/aerc/extraAccounts.expected
+++ b/tests/modules/programs/aerc/extraAccounts.expected
@@ -54,9 +54,17 @@ from = Foo Bar <addr@mail.invalid>
 outgoing = smtp+insecure+plain://foobar@smtp.host.invalid:42
 outgoing-cred-cmd = echo PaSsWorD!
 
-[i_maildir-mbsync]
+[i1_maildir-mbsync]
 from = Foo Bar <addr@mail.invalid>
-source = maildir:///home/hm-user/Maildir/i_maildir-mbsync
+source = maildir:///home/hm-user/Maildir/i1_maildir-mbsync
+
+[i2_maildirpp-mbsync]
+from = Foo Bar <addr@mail.invalid>
+source = maildirpp:///home/hm-user/Maildir/i2_maildirpp-mbsync/Inbox
+
+[i3_maildir_flatten-mbsync]
+from = Foo Bar <addr@mail.invalid>
+source = maildir:///home/hm-user/Maildir/i3_maildir_flatten-mbsync
 
 [j_maildir-offlineimap]
 from = Foo Bar <addr@mail.invalid>

--- a/tests/modules/programs/aerc/settings.nix
+++ b/tests/modules/programs/aerc/settings.nix
@@ -202,7 +202,16 @@ with lib;
           tls.useStartTls = true;
         };
       };
-      i_maildir-mbsync = basics // { mbsync.enable = true; };
+      i1_maildir-mbsync = basics // { mbsync.enable = true; };
+      i2_maildirpp-mbsync = basics // {
+        mbsync.enable = true;
+        mbsync.subFolders = "Maildir++";
+      };
+      i3_maildir_flatten-mbsync = basics // {
+        mbsync.enable = true;
+        mbsync.subFolders = "Maildir++";
+        mbsync.flatten = ".";
+      };
       j_maildir-offlineimap = basics // { offlineimap.enable = true; };
       k_notEnabled = basics // { aerc.enable = false; };
       l_smtp-auth-none = basics // {


### PR DESCRIPTION
aerc-accounts now is aware of the mbsync.subFolders setting

### Description
A account for aerc now uses a `maildirpp://` url if  `mbsync.subFolders` is set accordingly.
Closes #4652 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.


#### Maintainer CC

I'm not sure if @patwid or @lukasngl 🙈.