### PR TITLE
bat: support boolean flags in config (fixes #4657)

### DIFF
--- a/tests/modules/programs/bat/bat.nix
+++ b/tests/modules/programs/bat/bat.nix
@@ -11,6 +11,10 @@ with lib;
         theme = "TwoDark";
         pager = "less -FR";
         map-syntax = [ "*.jenkinsfile:Groovy" "*.props:Java Properties" ];
+        show-all = true;
+
+        # False boolean options should not appear in the config
+        lessopen = false;
       };
 
       themes.testtheme.src = pkgs.writeText "testtheme.tmTheme" ''
@@ -32,6 +36,7 @@ with lib;
           --map-syntax='*.props:Java Properties'
           --pager='less -FR'
           --theme='TwoDark'
+          --show-all
         ''
       }
 


### PR DESCRIPTION
### Description

Previously, users cannot enable boolean flags like `--show-all` in bat's config since all options were expected to be either a string, or a list of strings. With this commit boolean flags are simply appended to the end of the config if they are set to `true`, and discarded otherwise.

For example, the config
```nix
{
  theme = "TwoDark";
  show-all = true;
  lessopen = false;
}
```
would produce a config file that looks like
```
--theme='TwoDark'
--show-all
```

Fixes #4657

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
