### PR TITLE
git: add alternate signing methods

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1656,6 +1656,23 @@ in {
           See https://codeberg.org/dnkl/yambar for more.
         '';
       }
+
+      {
+        time = "2024-05-21T20:22:57+00:00";
+        condition = config.programs.git.signing != { };
+        message = ''
+          The Git module now supports signing via SSH and X.509 keys, in addition to OpenPGP/GnuPG,
+          via the `programs.git.signing.format` option.
+
+          The format defaults to `openpgp` for now, due to backwards compatibility reasons — this is
+          not guaranteed to last! GPG users should manually set `programs.git.signing.format` to
+          `openpgp` as soon as possible.
+
+          Accordingly, `programs.git.signing.gpgPath` has been renamed to the more generic option
+          `programs.git.signing.signer` as not everyone uses GPG.
+          Please migrate to the new option to suppress the generated warning.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -14,33 +14,6 @@ let
       supersectionType = attrsOf (either multipleType sectionType);
     in attrsOf supersectionType;
 
-  signModule = types.submodule {
-    options = {
-      key = mkOption {
-        type = types.nullOr types.str;
-        description = ''
-          The default GPG signing key fingerprint.
-
-          Set to `null` to let GnuPG decide what signing key
-          to use depending on commit’s author.
-        '';
-      };
-
-      signByDefault = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether commits and tags should be signed by default.";
-      };
-
-      gpgPath = mkOption {
-        type = types.str;
-        default = "${pkgs.gnupg}/bin/gpg2";
-        defaultText = "\${pkgs.gnupg}/bin/gpg2";
-        description = "Path to GnuPG binary to use.";
-      };
-    };
-  };
-
   includeModule = types.submodule ({ config, ... }: {
     options = {
       condition = mkOption {
@@ -132,10 +105,46 @@ in {
         description = "Git aliases to define.";
       };
 
-      signing = mkOption {
-        type = types.nullOr signModule;
-        default = null;
-        description = "Options related to signing commits using GnuPG.";
+      signing = {
+        key = mkOption {
+          type = types.nullOr types.str;
+          description = ''
+            The default signing key fingerprint.
+
+            Set to `null` to let the signer decide what signing key
+            to use depending on commit’s author.
+          '';
+        };
+
+        format = mkOption ({
+          type = types.enum [ "openpgp" "ssh" "x509" ];
+          description = ''
+            The signing method to use when signing commits and tags.
+            Valid values are `openpgp` (OpenPGP/GnuPG), `ssh`, (SSH) and `x509` (X.509 certificates).
+
+            Defaults to `openpgp` until state version 24.11 for backwards compatibility reasons.
+          '';
+        } // optionalAttrs (versionOlder config.home.stateVersion "24.11") {
+          default = "openpgp";
+        });
+
+        signByDefault = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Whether commits and tags should be signed by default.";
+        };
+
+        signer = mkOption {
+          type = types.str;
+
+          default = {
+            openpgp = getExe' pkgs.gnupg "gpg2";
+            ssh = getExe pkgs.ssh;
+            x509 = getExe' pkgs.gnupg "gpgsm";
+          }.${cfg.signing.format};
+
+          description = "Path to signer binary to use.";
+        };
       };
 
       extraConfig = mkOption {
@@ -353,9 +362,19 @@ in {
     };
   };
 
+  imports = [
+    (mkRenamedOptionModule [ "programs" "git" "signing" "gpgPath" ] [
+      "programs"
+      "git"
+      "signing"
+      "signer"
+    ])
+  ];
+
   config = mkIf cfg.enable (mkMerge [
     {
       home.packages = [ cfg.package ];
+
       assertions = [{
         assertion = let
           enabled =
@@ -415,12 +434,16 @@ in {
       (filterAttrs hasSmtp config.accounts.email.accounts);
     }
 
-    (mkIf (cfg.signing != null) {
-      programs.git.iniContent = {
+    (mkIf (cfg.signing != { }) {
+      programs.git.iniContent = let inherit (cfg.signing) format;
+      in {
         user.signingKey = mkIf (cfg.signing.key != null) cfg.signing.key;
         commit.gpgSign = mkDefault cfg.signing.signByDefault;
         tag.gpgSign = mkDefault cfg.signing.signByDefault;
-        gpg.program = cfg.signing.gpgPath;
+        gpg = {
+          inherit format;
+          ${format}.program = cfg.signing.signer;
+        };
       };
     })
 

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -116,7 +116,7 @@ in {
           '';
         };
 
-        format = mkOption ({
+        format = mkOption {
           type = types.enum [ "openpgp" "ssh" "x509" ];
           description = ''
             The signing method to use when signing commits and tags.
@@ -124,9 +124,9 @@ in {
 
             Defaults to `openpgp` until state version 24.11 for backwards compatibility reasons.
           '';
-        } // optionalAttrs (versionOlder config.home.stateVersion "24.11") {
-          default = "openpgp";
-        });
+          default =
+            mkIf (versionOlder config.home.stateVersion "24.11") "openpgp";
+        };
 
         signByDefault = mkOption {
           type = types.bool;

--- a/tests/modules/programs/git/default.nix
+++ b/tests/modules/programs/git/default.nix
@@ -3,6 +3,7 @@
   git-with-most-options = ./git.nix;
   git-with-msmtp = ./git-with-msmtp.nix;
   git-with-str-extra-config = ./git-with-str-extra-config.nix;
+  git-with-signing-key-id-legacy = ./git-with-signing-key-id-legacy.nix;
   git-with-signing-key-id = ./git-with-signing-key-id.nix;
   git-without-signing-key-id = ./git-without-signing-key-id.nix;
   git-with-hooks = ./git-with-hooks.nix;

--- a/tests/modules/programs/git/git-expected.conf
+++ b/tests/modules/programs/git/git-expected.conf
@@ -38,6 +38,9 @@
 	smudge = "git-lfs smudge -- %f"
 
 [gpg]
+	format = "openpgp"
+
+[gpg "openpgp"]
 	program = "path-to-gpg"
 
 [interactive]

--- a/tests/modules/programs/git/git-with-signing-key-id-expected.conf
+++ b/tests/modules/programs/git/git-with-signing-key-id-expected.conf
@@ -2,7 +2,10 @@
 	gpgSign = true
 
 [gpg]
-	program = "path-to-gpg"
+	format = "ssh"
+
+[gpg "ssh"]
+	program = "path-to-ssh"
 
 [tag]
 	gpgSign = true
@@ -10,4 +13,4 @@
 [user]
 	email = "user@example.org"
 	name = "John Doe"
-	signingKey = "00112233445566778899AABBCCDDEEFF"
+	signingKey = "ssh-ed25519 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"

--- a/tests/modules/programs/git/git-with-signing-key-id-legacy-expected.conf
+++ b/tests/modules/programs/git/git-with-signing-key-id-legacy-expected.conf
@@ -1,0 +1,16 @@
+[commit]
+	gpgSign = true
+
+[gpg]
+	format = "openpgp"
+
+[gpg "openpgp"]
+	program = "path-to-gpg"
+
+[tag]
+	gpgSign = true
+
+[user]
+	email = "user@example.org"
+	name = "John Doe"
+	signingKey = "00112233445566778899AABBCCDDEEFF"

--- a/tests/modules/programs/git/git-with-signing-key-id-legacy.nix
+++ b/tests/modules/programs/git/git-with-signing-key-id-legacy.nix
@@ -1,0 +1,28 @@
+{ lib, options, ... }: {
+  config = {
+    programs.git = {
+      enable = true;
+      userName = "John Doe";
+      userEmail = "user@example.org";
+
+      signing = {
+        gpgPath = "path-to-gpg";
+        key = "00112233445566778899AABBCCDDEEFF";
+        signByDefault = true;
+      };
+    };
+
+    test.asserts.warnings.expected = [
+      "The option `programs.git.signing.gpgPath' defined in ${
+        lib.showFiles options.programs.git.signing.gpgPath.files
+      } has been renamed to `programs.git.signing.signer'."
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/git/config
+      assertFileContent home-files/.config/git/config ${
+        ./git-with-signing-key-id-legacy-expected.conf
+      }
+    '';
+  };
+}

--- a/tests/modules/programs/git/git-with-signing-key-id.nix
+++ b/tests/modules/programs/git/git-with-signing-key-id.nix
@@ -6,8 +6,10 @@
       userEmail = "user@example.org";
 
       signing = {
-        gpgPath = "path-to-gpg";
-        key = "00112233445566778899AABBCCDDEEFF";
+        signer = "path-to-ssh";
+        format = "ssh";
+        key =
+          "ssh-ed25519 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         signByDefault = true;
       };
     };

--- a/tests/modules/programs/git/git.nix
+++ b/tests/modules/programs/git/git.nix
@@ -55,7 +55,8 @@ in {
           }
         ];
         signing = {
-          gpgPath = "path-to-gpg";
+          signer = "path-to-gpg";
+          format = "openpgp";
           key = "00112233445566778899AABBCCDDEEFF";
           signByDefault = true;
         };


### PR DESCRIPTION
### Description

The Git module now supports SSH and X.509 signing in addition to OpenPGP/GnuPG, via setting the `programs.git.signing.format` option. It defaults to `openpgp` for now as a backwards compatibility measure, but I feel like we shouldn't enforce GPG as the default on everyone, especially for people who use SSH signing like me.

Accordingly, `programs.git.signing.gpgPath` has been renamed to `programs.git.signing.signer`, as now the signer binary is not restricted to GnuPG. Users should only get a warning and everything should continue to work.

Fixes #4221, supersedes #4235

### Checklist


- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 