### PR TITLE
k9s: allow defining custom theme file

### DIFF
--- a/modules/programs/k9s.nix
+++ b/modules/programs/k9s.nix
@@ -46,7 +46,7 @@ in {
     };
 
     skins = mkOption {
-      type = types.attrsOf yamlFormat.type;
+      type = with types; attrsOf (either yamlFormat.type path);
       default = { };
       description = ''
         Skin files written to {file}`$XDG_CONFIG_HOME/k9s/skins/` (linux)
@@ -54,13 +54,16 @@ in {
         <https://k9scli.io/topics/skins/> for supported values.
       '';
       example = literalExpression ''
-        my_blue_skin = {
-          k9s = {
-            body = {
-              fgColor = "dodgerblue";
+        {
+          my_blue_skin = {
+            k9s = {
+              body = {
+                fgColor = "dodgerblue";
+              };
             };
           };
-        };
+          my_red_skin = ./red_skin.yaml;
+        }
       '';
     };
 
@@ -174,7 +177,10 @@ in {
         "k9s/skins/${name}.yaml"
       else
         "Library/Application Support/k9s/skins/${name}.yaml") {
-          source = yamlFormat.generate "k9s-skin-${name}.yaml" value;
+          source = if lib.types.path.check value then
+            value
+          else
+            yamlFormat.generate "k9s-skin-${name}.yaml" value;
         }) cfg.skins;
 
     enableXdgConfig = !isDarwin || config.xdg.enable;

--- a/tests/modules/programs/k9s/example-settings.nix
+++ b/tests/modules/programs/k9s/example-settings.nix
@@ -39,6 +39,7 @@
           };
         };
       };
+      "default2" = ./example-skin-expected.yaml;
       "alt-skin" = {
         k9s = {
           body = {
@@ -91,6 +92,10 @@
     assertFileExists "home-files/${configDir}/skins/default.yaml"
     assertFileContent \
       "home-files/${configDir}/skins/default.yaml" \
+      ${./example-skin-expected.yaml}
+    assertFileExists "home-files/${configDir}/skins/default2.yaml"
+    assertFileContent \
+      "home-files/${configDir}/skins/default2.yaml" \
       ${./example-skin-expected.yaml}
     assertFileExists "home-files/${configDir}/skins/alt-skin.yaml"
     assertFileContent \


### PR DESCRIPTION
### Description

This adds a new option `programs.k9s.skinPath` to define a custom theme from a path/derivation.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@katexochen
@liyangau
