### PR TITLE
ruff: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1302,6 +1302,13 @@ in
           A new module is available: 'programs.granted'.
         '';
       }
+
+      {
+        time = "2023-11-22T22:42:16+00:00";
+        message = ''
+          A new module is available: 'programs.ruff'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -190,6 +190,7 @@ let
     ./programs/rofi.nix
     ./programs/rtorrent.nix
     ./programs/rtx.nix
+    ./programs/ruff.nix
     ./programs/sagemath.nix
     ./programs/sbt.nix
     ./programs/scmpuff.nix

--- a/modules/programs/ruff.nix
+++ b/modules/programs/ruff.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.ruff;
+
+  settingsFormat = pkgs.formats.toml { };
+
+in {
+  meta.maintainers = [ hm.maintainers.GaetanLepage ];
+
+  options.programs.ruff = {
+    enable = mkEnableOption
+      "ruff, an extremely fast Python linter and code formatter, written in Rust";
+
+    package = mkPackageOption pkgs "ruff" { };
+
+    settings = mkOption {
+      type = settingsFormat.type;
+      example = lib.literalExpression ''
+        {
+          line-length = 100;
+          per-file-ignores = { "__init__.py" = [ "F401" ]; };
+          lint = {
+            select = [ "E4" "E7" "E9" "F" ];
+            ignore = [ ];
+          };
+        }
+      '';
+      description = ''
+        Ruff configuration.
+        For available settings see <https://docs.astral.sh/ruff/settings>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."ruff/ruff.toml".source =
+      settingsFormat.generate "ruff.toml" cfg.settings;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -133,6 +133,7 @@ import nmt {
     ./modules/programs/rio
     ./modules/programs/ripgrep
     ./modules/programs/rtx
+    ./modules/programs/ruff
     ./modules/programs/sagemath
     ./modules/programs/sbt
     ./modules/programs/scmpuff

--- a/tests/modules/programs/ruff/default.nix
+++ b/tests/modules/programs/ruff/default.nix
@@ -1,0 +1,1 @@
+{ ruff-program = ./ruff.nix; }

--- a/tests/modules/programs/ruff/expected.toml
+++ b/tests/modules/programs/ruff/expected.toml
@@ -1,0 +1,8 @@
+line-length = 100
+
+[lint]
+ignore = []
+select = ["E4", "E7", "E9", "F"]
+
+[per-file-ignores]
+"__init__.py" = ["F401"]

--- a/tests/modules/programs/ruff/ruff.nix
+++ b/tests/modules/programs/ruff/ruff.nix
@@ -1,0 +1,23 @@
+{ ... }:
+
+{
+  programs.ruff = {
+    enable = true;
+
+    settings = {
+      line-length = 100;
+      per-file-ignores = { "__init__.py" = [ "F401" ]; };
+      lint = {
+        select = [ "E4" "E7" "E9" "F" ];
+        ignore = [ ];
+      };
+    };
+  };
+
+  test.stubs.ruff = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/ruff/ruff.toml
+    assertFileContent home-files/.config/ruff/ruff.toml ${./expected.toml}
+  '';
+}


### PR DESCRIPTION
### Description

ruff is Python linter and code formatter, written in Rust.

https://docs.astral.sh/ruff/

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
