### PR TITLE
signaturepdf: add service

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1309,6 +1309,14 @@ in
           A new module is available: 'programs.ruff'.
         '';
       }
+
+      {
+        time = "2023-11-26T23:18:01+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.signaturepdf'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -326,6 +326,7 @@ let
     ./services/safeeyes.nix
     ./services/screen-locker.nix
     ./services/sctd.nix
+    ./services/signaturepdf.nix
     ./services/spotifyd.nix
     ./services/ssh-agent.nix
     ./services/stalonetray.nix

--- a/modules/services/signaturepdf.nix
+++ b/modules/services/signaturepdf.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.signaturepdf;
+  extraConfigToArgs = extraConfig:
+    lib.flatten
+    (lib.mapAttrsToList (name: value: [ "-d" "${name}=${value}" ]) extraConfig);
+in {
+  meta.maintainers = [ lib.maintainers.DamienCassou ];
+
+  options.services.signaturepdf = with lib; {
+    enable = mkEnableOption
+      "signaturepdf; signing, organizing, editing metadatas or compressing PDFs";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.signaturepdf;
+      defaultText = "pkgs.signaturepdf";
+      description = "signaturepdf derivation to use.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8080;
+      example = 8081;
+      description = "The port on which the application runs";
+    };
+
+    extraConfig = mkOption {
+      default = { };
+      type = with types;
+        let primitive = oneOf [ str int bool float ];
+        in attrsOf primitive;
+      example = {
+        upload_max_filesize = "24M";
+        post_max_size = "24M";
+        max_file_uploads = "201";
+      };
+      description = "Additional configuration optional.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    xdg.desktopEntries = {
+      signaturepdf = {
+        name = "SignaturePDF";
+        exec = "${pkgs.xdg-utils}/bin/xdg-open http://localhost:${
+            toString cfg.port
+          }";
+        terminal = false;
+        icon = "${cfg.package}/share/signaturepdf/public/favicon.ico";
+      };
+    };
+
+    systemd.user.services.signaturepdf = {
+      Unit = {
+        Description =
+          "signaturepdf; signing, organizing, editing metadatas or compressing PDFs";
+      };
+
+      Service = {
+        ExecStart = "${cfg.package}/bin/signaturepdf ${toString cfg.port} ${
+            lib.escapeShellArgs (extraConfigToArgs cfg.extraConfig)
+          }";
+      };
+
+      Install = { WantedBy = [ "default.target" ]; };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -244,6 +244,7 @@ import nmt {
     ./modules/services/recoll
     ./modules/services/redshift-gammastep
     ./modules/services/screen-locker
+    ./modules/services/signaturepdf
     ./modules/services/swayidle
     ./modules/services/swayosd
     ./modules/services/sxhkd

--- a/tests/modules/services/signaturepdf/basic-configuration.desktop
+++ b/tests/modules/services/signaturepdf/basic-configuration.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Exec=@xdg-utils@/bin/xdg-open http://localhost:9494
+Icon=/signaturepdf/share/signaturepdf/public/favicon.ico
+Name=SignaturePDF
+Terminal=false
+Type=Application
+Version=1.4

--- a/tests/modules/services/signaturepdf/basic-configuration.nix
+++ b/tests/modules/services/signaturepdf/basic-configuration.nix
@@ -1,0 +1,24 @@
+{ config, pkgs, ... }:
+
+{
+  services.signaturepdf = {
+    enable = true;
+    port = 9494;
+    extraConfig = { upload_max_filesize = "24M"; };
+  };
+
+  test.stubs = {
+    signaturepdf = { outPath = "/signaturepdf"; };
+    xdg-utils = { };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/systemd/user/signaturepdf.service \
+      ${./basic-configuration.service}
+
+    assertFileContent \
+      home-path/share/applications/signaturepdf.desktop \
+      ${./basic-configuration.desktop}
+  '';
+}

--- a/tests/modules/services/signaturepdf/basic-configuration.service
+++ b/tests/modules/services/signaturepdf/basic-configuration.service
@@ -1,0 +1,8 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=/signaturepdf/bin/signaturepdf 9494 '-d' 'upload_max_filesize=24M'
+
+[Unit]
+Description=signaturepdf; signing, organizing, editing metadatas or compressing PDFs

--- a/tests/modules/services/signaturepdf/default.nix
+++ b/tests/modules/services/signaturepdf/default.nix
@@ -1,0 +1,1 @@
+{ signaturepdf-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

New signaturepdf service. https://github.com/24eme/signaturepdf/

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
