### PR TITLE
Backport lazy set profile path variables

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -369,8 +369,10 @@ $xdgVars
     # '';
   };
 
-  # You can also manage environment variables but you will have to manually
-  # source
+  # Home Manager can also manage your environment variables through
+  # 'home.sessionVariables'. If you don't want to manage your shell through Home
+  # Manager then you have to manually source 'hm-session-vars.sh' located at
+  # either
   #
   #  ~/.nix-profile/etc/profile.d/hm-session-vars.sh
   #
@@ -378,7 +380,6 @@ $xdgVars
   #
   #  /etc/profiles/per-user/$USER/etc/profile.d/hm-session-vars.sh
   #
-  # if you don't want to manage your shell through Home Manager.
   home.sessionVariables = {
     # EDITOR = "emacs";
   };

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -127,6 +127,11 @@ function setHomeManagerNixPath() {
 
 # Sets some useful Home Manager related paths as global read-only variables.
 function setHomeManagerPathVariables() {
+    # If called twice then just exit early.
+    if [[ -v HM_DATA_HOME ]]; then
+        return
+    fi
+
     declare -r globalNixStateDir="${NIX_STATE_DIR:-/nix/var/nix}"
     declare -r globalProfilesDir="$globalNixStateDir/profiles/per-user/$USER"
     declare -r globalGcrootsDir="$globalNixStateDir/gcroots/per-user/$USER"

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -623,6 +623,8 @@ function doSwitch() {
 }
 
 function doListGens() {
+    setHomeManagerPathVariables
+
     # Whether to colorize the generations output.
     local color="never"
     if [[ ! -v NO_COLOR && -t 1 ]]; then
@@ -640,6 +642,7 @@ function doListGens() {
 # Removes linked generations. Takes as arguments identifiers of
 # generations to remove.
 function doRmGenerations() {
+    setHomeManagerPathVariables
     setVerboseAndDryRun
 
     pushd "$HM_PROFILE_DIR" > /dev/null
@@ -661,6 +664,8 @@ function doRmGenerations() {
 }
 
 function doExpireGenerations() {
+    setHomeManagerPathVariables
+
     local generations
     generations="$( \
         find "$HM_PROFILE_DIR" -name 'home-manager-*-link' -not -newermt "$1" \
@@ -759,6 +764,7 @@ function doShowNews() {
 }
 
 function doUninstall() {
+    setHomeManagerPathVariables
     setVerboseAndDryRun
     setNixProfileCommands
 
@@ -892,8 +898,6 @@ PASSTHROUGH_OPTS=()
 COMMAND=""
 COMMAND_ARGS=()
 FLAKE_ARG=""
-
-setHomeManagerPathVariables
 
 while [[ $# -gt 0 ]]; do
     opt="$1"


### PR DESCRIPTION
### Description

Fixes #4674

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```