### PR TITLE
qt: fix basic usage when just `qt.enable = true` is set

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -159,8 +159,10 @@ in {
 
     # Necessary because home.sessionVariables doesn't support mkIf
     envVars = lib.filterAttrs (n: v: v != null) {
-      QT_QPA_PLATFORMTHEME =
-        styleNames.${cfg.platformTheme} or cfg.platformTheme;
+      QT_QPA_PLATFORMTHEME = if (cfg.platformTheme != null) then
+        styleNames.${cfg.platformTheme} or cfg.platformTheme
+      else
+        null;
       QT_STYLE_OVERRIDE = cfg.style.name;
     };
 
@@ -206,9 +208,10 @@ in {
     # Apply theming also to apps started by systemd.
     systemd.user.sessionVariables = envVars // envVarsExtra;
 
-    home.packages = (platformPackages.${cfg.platformTheme} or [ ])
-      ++ lib.optionals (cfg.style.package != null)
-      (lib.toList cfg.style.package);
+    home.packages = (lib.optionals (cfg.platformTheme != null)
+      platformPackages.${cfg.platformTheme})
+      ++ (lib.optionals (cfg.style.package != null)
+        (lib.toList cfg.style.package));
 
     xsession.importedVariables = [ "QT_PLUGIN_PATH" "QML2_IMPORT_PATH" ]
       ++ lib.optionals (cfg.platformTheme != null) [ "QT_QPA_PLATFORMTHEME" ]

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -209,7 +209,7 @@ in {
     systemd.user.sessionVariables = envVars // envVarsExtra;
 
     home.packages = (lib.optionals (cfg.platformTheme != null)
-      platformPackages.${cfg.platformTheme})
+      platformPackages.${cfg.platformTheme} or [ ])
       ++ (lib.optionals (cfg.style.package != null)
         (lib.toList cfg.style.package));
 

--- a/tests/modules/misc/qt/default.nix
+++ b/tests/modules/misc/qt/default.nix
@@ -1,5 +1,6 @@
 {
   qt-basic = ./qt-basic.nix;
   qt-platform-theme-gtk = ./qt-platform-theme-gtk.nix;
+  qt-platform-theme-gtk3 = ./qt-platform-theme-gtk3.nix;
   qt-platform-theme-gnome = ./qt-platform-theme-gnome.nix;
 }

--- a/tests/modules/misc/qt/default.nix
+++ b/tests/modules/misc/qt/default.nix
@@ -1,4 +1,5 @@
 {
+  qt-basic = ./qt-basic.nix;
   qt-platform-theme-gtk = ./qt-platform-theme-gtk.nix;
   qt-platform-theme-gnome = ./qt-platform-theme-gnome.nix;
 }

--- a/tests/modules/misc/qt/qt-basic.nix
+++ b/tests/modules/misc/qt/qt-basic.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    qt.enable = true;
+
+    nmt.script = ''
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QT_PLUGIN_PATH'
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QML2_IMPORT_PATH'
+    '';
+  };
+}

--- a/tests/modules/misc/qt/qt-platform-theme-gtk3.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gtk3.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    qt = {
+      enable = true;
+      platformTheme = "gtk3";
+    };
+
+    nmt.script = ''
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QT_QPA_PLATFORMTHEME="gtk3"'
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QT_PLUGIN_PATH'
+      assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+        'QML2_IMPORT_PATH'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

After #4579 the usage of the module when just `qt.enable = true` is set was broken with an evaluation error. This PR fixes it.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
