### PR TITLE
picom: use getExe instead of hardcoded binary

### DIFF
--- a/modules/services/picom.nix
+++ b/modules/services/picom.nix
@@ -5,7 +5,7 @@ let
   inherit (lib)
     boolToString concatMapStringsSep concatStringsSep escape literalExpression
     mapAttrsToList mkEnableOption mkRenamedOptionModule mkRemovedOptionModule
-    mkDefault mkIf mkOption optional types warn;
+    mkDefault mkIf mkOption optional types warn getExe;
 
   cfg = config.services.picom;
   opt = options.services.picom;
@@ -318,7 +318,7 @@ in {
 
       Service = {
         ExecStart = concatStringsSep " " ([
-          "${cfg.package}/bin/picom"
+          "${getExe cfg.package}"
           "--config ${config.xdg.configFile."picom/picom.conf".source}"
         ] ++ cfg.extraArgs);
         Restart = "always";

--- a/tests/modules/services/picom/picom-basic-configuration-expected.service
+++ b/tests/modules/services/picom/picom-basic-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@picom@/bin/picom --config /nix/store/00000000000000000000000000000000-hm_picompicom.conf --legacy-backends
+ExecStart=@picom@/bin/dummy --config /nix/store/00000000000000000000000000000000-hm_picompicom.conf --legacy-backends
 Restart=always
 RestartSec=3
 


### PR DESCRIPTION
### Description

Motivation is to be able to use different packages such as [compfy](https://github.com/allusive-dev/compfy).
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
