### PR TITLE
home-environment: prepend to PATH in `sessionPath`

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -577,7 +577,7 @@ in
 
         ${config.lib.shell.exportAll cfg.sessionVariables}
       '' + lib.optionalString (cfg.sessionPath != [ ]) ''
-        export PATH="$PATH''${PATH:+:}${concatStringsSep ":" cfg.sessionPath}"
+        export PATH="${concatStringsSep ":" cfg.sessionPath}''${PATH:+:}$PATH"
       '' + cfg.sessionVariablesExtra;
     };
 

--- a/tests/modules/home-environment/session-path.nix
+++ b/tests/modules/home-environment/session-path.nix
@@ -10,6 +10,6 @@
     hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
     assertFileExists $hmSessVars
     assertFileContains $hmSessVars \
-      'export PATH="$PATH''${PATH:+:}bar:baz:foo"'
+      'export PATH="bar:baz:foo''${PATH:+:}$PATH"'
   '';
 }


### PR DESCRIPTION
### Description

See [this comment](https://github.com/nix-community/home-manager/issues/3324#issuecomment-1819312069) to justify this change.

### Checklist

- [X] Change is backwards compatible.
  * This doesn't change anything for people who don't shadow system executables, and truly it un-breaks people that do.
- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee
