### PR TITLE
qt: add null checks for cfg.platformTheme

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -158,11 +158,12 @@ in {
   config = let
 
     # Necessary because home.sessionVariables doesn't support mkIf
-    envVars = lib.filterAttrs (n: v: v != null) {
-      QT_QPA_PLATFORMTHEME =
-        styleNames.${cfg.platformTheme} or cfg.platformTheme;
-      QT_STYLE_OVERRIDE = cfg.style.name;
-    };
+    envVars =
+      lib.filterAttrs (n: v: v != null) { QT_STYLE_OVERRIDE = cfg.style.name; }
+      // lib.optionalAttrs (cfg.platformTheme != null) {
+        QT_QPA_PLATFORMTHEME =
+          cfg.styleNames.${cfg.platformTheme} or cfg.platformTheme;
+      };
 
     envVarsExtra = let
       inherit (config.home) profileDirectory;
@@ -206,7 +207,8 @@ in {
     # Apply theming also to apps started by systemd.
     systemd.user.sessionVariables = envVars // envVarsExtra;
 
-    home.packages = (platformPackages.${cfg.platformTheme} or [ ])
+    home.packages = lib.optionals (cfg.platformTheme != null)
+      (platformPackages.${cfg.platformTheme} or [ ])
       ++ lib.optionals (cfg.style.package != null)
       (lib.toList cfg.style.package);
 


### PR DESCRIPTION
### Description

This fixes an evaluation error that occurs when `qt.platformTheme` is `null`, intruduced [here](https://github.com/nix-community/home-manager/commit/9a4725afa67db35cdf7be89f30527d745194cafa).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee @thiagokokada 