### PR TITLE
bash: add "ignoreboth" as valid option for programs.bash.historyControl

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -68,7 +68,7 @@ in {
 
       historyControl = mkOption {
         type =
-          types.listOf (types.enum [ "erasedups" "ignoredups" "ignorespace" ]);
+          types.listOf (types.enum [ "erasedups" "ignoredups" "ignorespace" "ignoreboth" ]);
         default = [ ];
         description = "Controlling how commands are saved on the history list.";
       };


### PR DESCRIPTION
### Description

I'd like to see this option added, otherwise it errors out on an invalid value, even though this is a valid value for that setting, as shorthand for setting ignorespace and ignoredups (see `man bash`).


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.\
    (change made through editing on GitHub...)

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.\
    (change shouldn't affect tests)

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).\
    (I don't think it needs one)

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
    (I didn't read the guidelines in time, and would suggest adding the component when squash-merging this)

#### Maintainer CC

@rycee