### PR TITLE
sway: systemd customization

### DIFF
--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -11,6 +11,7 @@
   sway-null-package = ./sway-null-package.nix;
   sway-post-2003 = ./sway-post-2003.nix;
   sway-systemd-autostart = ./sway-systemd-autostart.nix;
+  sway-systemd-variables = ./sway-systemd-variables.nix;
   sway-workspace-default = ./sway-workspace-default.nix;
   sway-workspace-output = ./sway-workspace-output.nix;
   swaynag-example-settings = ./swaynag-example-settings.nix;

--- a/tests/modules/services/window-managers/sway/sway-systemd-variables.conf
+++ b/tests/modules/services/window-managers/sway/sway-systemd-variables.conf
@@ -1,0 +1,108 @@
+font pango:monospace 8.000000
+floating_modifier Mod1
+default_border pixel 2
+default_floating_border pixel 2
+hide_edge_borders none
+focus_wrapping no
+focus_follows_mouse yes
+focus_on_window_activation smart
+mouse_warping output
+workspace_layout default
+workspace_auto_back_and_forth no
+client.focused #4c7899 #285577 #ffffff #2e9ef4 #285577
+client.focused_inactive #333333 #5f676a #ffffff #484e50 #5f676a
+client.unfocused #333333 #222222 #888888 #292d2e #222222
+client.urgent #2f343a #900000 #ffffff #900000 #900000
+client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
+client.background #ffffff
+
+bindsym Mod1+0 workspace number 10
+bindsym Mod1+1 workspace number 1
+bindsym Mod1+2 workspace number 2
+bindsym Mod1+3 workspace number 3
+bindsym Mod1+4 workspace number 4
+bindsym Mod1+5 workspace number 5
+bindsym Mod1+6 workspace number 6
+bindsym Mod1+7 workspace number 7
+bindsym Mod1+8 workspace number 8
+bindsym Mod1+9 workspace number 9
+bindsym Mod1+Down focus down
+bindsym Mod1+Left focus left
+bindsym Mod1+Return exec @foot@/bin/foot
+bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+Shift+1 move container to workspace number 1
+bindsym Mod1+Shift+2 move container to workspace number 2
+bindsym Mod1+Shift+3 move container to workspace number 3
+bindsym Mod1+Shift+4 move container to workspace number 4
+bindsym Mod1+Shift+5 move container to workspace number 5
+bindsym Mod1+Shift+6 move container to workspace number 6
+bindsym Mod1+Shift+7 move container to workspace number 7
+bindsym Mod1+Shift+8 move container to workspace number 8
+bindsym Mod1+Shift+9 move container to workspace number 9
+bindsym Mod1+Shift+Down move down
+bindsym Mod1+Shift+Left move left
+bindsym Mod1+Shift+Right move right
+bindsym Mod1+Shift+Up move up
+bindsym Mod1+Shift+c reload
+bindsym Mod1+Shift+e exec swaynag -t warning -m 'You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.' -b 'Yes, exit sway' 'swaymsg exit'
+bindsym Mod1+Shift+h move left
+bindsym Mod1+Shift+j move down
+bindsym Mod1+Shift+k move up
+bindsym Mod1+Shift+l move right
+bindsym Mod1+Shift+minus move scratchpad
+bindsym Mod1+Shift+q kill
+bindsym Mod1+Shift+space floating toggle
+bindsym Mod1+Up focus up
+bindsym Mod1+a focus parent
+bindsym Mod1+b splith
+bindsym Mod1+d exec @dmenu@/bin/dmenu_run
+bindsym Mod1+e layout toggle split
+bindsym Mod1+f fullscreen toggle
+bindsym Mod1+h focus left
+bindsym Mod1+j focus down
+bindsym Mod1+k focus up
+bindsym Mod1+l focus right
+bindsym Mod1+minus scratchpad show
+bindsym Mod1+r mode resize
+bindsym Mod1+s layout stacking
+bindsym Mod1+space focus mode_toggle
+bindsym Mod1+v splitv
+bindsym Mod1+w layout tabbed
+
+mode "resize" {
+  bindsym Down resize grow height 10 px
+  bindsym Escape mode default
+  bindsym Left resize shrink width 10 px
+  bindsym Return mode default
+  bindsym Right resize grow width 10 px
+  bindsym Up resize shrink height 10 px
+  bindsym h resize shrink width 10 px
+  bindsym j resize grow height 10 px
+  bindsym k resize shrink height 10 px
+  bindsym l resize grow width 10 px
+}
+
+bar {
+  font pango:monospace 8.000000
+  mode dock
+  hidden_state hide
+  position bottom
+  status_command @i3status@/bin/i3status
+  swaybar_command @sway@/bin/swaybar
+  workspace_buttons yes
+  strip_workspace_numbers no
+  tray_output *
+  colors {
+    background #000000
+    statusline #ffffff
+    separator #666666
+    focused_workspace #4c7899 #285577 #ffffff
+    active_workspace #333333 #5f676a #ffffff
+    inactive_workspace #333333 #222222 #888888
+    urgent_workspace #2f343a #900000 #ffffff
+    binding_mode #2f343a #900000 #ffffff
+  }
+}
+
+exec "/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd XCURSOR_THEME XCURSOR_SIZE; systemctl --user start sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-systemd-variables.nix
+++ b/tests/modules/services/window-managers/sway/sway-systemd-variables.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [ ./sway-stubs.nix ];
+
+  wayland.windowManager.sway = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    # overriding findutils causes issues
+    config.menu = "${pkgs.dmenu}/bin/dmenu_run";
+
+    systemd.variables = [ "XCURSOR_THEME" "XCURSOR_SIZE" ];
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/sway/config
+    assertFileContent $(normalizeStorePaths home-files/.config/sway/config) \
+      ${./sway-systemd-variables.conf}
+  '';
+}


### PR DESCRIPTION
### Description

Adds environment variable propagation and command customization to environment initialization, similar to how it's done in #4490.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Scrumplex @alexarice @sumnerevans @SebTM @oxalica 