### PR TITLE
gpg-agent: improve pinentry-flavor

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -193,15 +193,8 @@ in {
           Which pinentry interface to use. If not
           `null`, it sets
           {option}`pinentry-program` in
-          {file}`gpg-agent.conf`. Beware that
-          `pinentry-gnome3` may not work on non-Gnome
-          systems. You can fix it by adding the following to your
-          system configuration:
-          ```nix
-          services.dbus.packages = [ pkgs.gcr ];
-          ```
-          For this reason, the default is `gtk2` for
-          now.
+          {file}`gpg-agent.conf`.
+          The default is `gtk2`.
         '';
       };
 
@@ -236,6 +229,9 @@ in {
           ++ optional (cfg.pinentryFlavor != null)
           "pinentry-program ${pkgs.pinentry.${cfg.pinentryFlavor}}/bin/pinentry"
           ++ [ cfg.extraConfig ]);
+
+      services.dbus.packages =
+        mkIf (cfg.pinentryFlavor == "gnome3") [ pkgs.gcr ];
 
       home.sessionVariablesExtra = optionalString cfg.enableSshSupport ''
         if [[ -z "$SSH_AUTH_SOCK" ]]; then


### PR DESCRIPTION
### Description

Fix pinentry-flavor gnome3 on non-gnome systems. Analogous to what nixos does already. The nixos module goes even further by infering the default pinentry flavor based on the configured desktop environment. Also the nixos module falls back to pinentry-flavor curses rather than gtk2.

Nixos module: https://github.com/NixOS/nixpkgs/blob/f37dd68fe080c16a4e0a0733ca0006d31e6d5ca4/nixos/modules/programs/gnupg.nix

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

Not sure, @dixslyf
