### PR TITLE
hyprland: plugin and source with higher priority

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -229,7 +229,7 @@ in {
           };
           allFields = filterAttrs (n: v: !(isAttrs v)) attrs;
           importantFields = filterAttrs (n: _:
-            (hasPrefix "$" n) || (hasPrefix "bezier" n)
+            (hasPrefix "$" n) || (hasPrefix "bezier" n) || (n == "plugin")
             || (cfg.sourceFirst && (hasPrefix "source" n))) allFields;
           fields = builtins.removeAttrs allFields
             (mapAttrsToList (n: _: n) importantFields);

--- a/tests/modules/services/window-managers/hyprland/simple-config.conf
+++ b/tests/modules/services/window-managers/hyprland/simple-config.conf
@@ -3,6 +3,8 @@ $mod=SUPER
 bezier=smoothOut, 0.36, 0, 0.66, -0.56
 bezier=smoothIn, 0.25, 1, 0.5, 1
 bezier=overshot, 0.4,0.8,0.2,1.2
+plugin=/path/to/plugin1
+plugin=/nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 source=sourced.conf
 animations {
   animation=border, 1, 2, smoothIn
@@ -27,8 +29,6 @@ input {
 bindm=$mod, mouse:272, movewindow
 bindm=$mod, mouse:273, resizewindow
 bindm=$mod ALT, mouse:272, resizewindow
-plugin=/path/to/plugin1
-plugin=/nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 # window resize
 bind = $mod, S, submap, resize
 


### PR DESCRIPTION
### Description

`plugin` and `source` are moved to beginning of config file.

These often are necessary for other configuration, e.g. defining variables or enabling other layouts


### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.


#### Maintainer CC

cc @fufexan 