### PR TITLE
caffeine: remove ProtectHome service option

### DIFF
--- a/modules/services/caffeine.nix
+++ b/modules/services/caffeine.nix
@@ -28,7 +28,6 @@ in {
         Restart = "on-failure";
         PrivateTmp = true;
         ProtectSystem = "full";
-        ProtectHome = "yes";
         Type = "exec";
         Slice = "session.slice";
         ExecStart = "${pkgs.caffeine-ng}/bin/caffeine";


### PR DESCRIPTION
### Description

This pull request removes the `ProtectHome=yes` line from the systemd unit file for this service. This option causes caffeine to be unable to start via the systemd service. See #4696 for more information.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

    Got a weird error with `nix develop --ignore-environment .#all`:
    ```
    error: executing '/nix/store/q1c2flcykgr4wwg5a6h450hxbk4ch589-bash-5.2-p15/bin/bash': Argument list too long
    ```
    That's the only line of the log file.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@uvNikita 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
