### PR TITLE
Enable caseSensitive by default in prezto module

### DIFF
--- a/modules/programs/zsh/prezto.nix
+++ b/modules/programs/zsh/prezto.nix
@@ -16,7 +16,8 @@ let
 
       caseSensitive = mkOption {
         type = types.nullOr types.bool;
-        default = null;
+        # See <https://github.com/nix-community/home-manager/issues/2255>.
+        default = true;
         example = true;
         description =
           "Set case-sensitivity for completion, history lookup, etc.";


### PR DESCRIPTION
See https://github.com/nix-community/home-manager/issues/2255.

This causes a really noticeable slowdown that is quite hard to track down!

### Description

Implements the fix from https://github.com/nix-community/home-manager/issues/2255

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible. *Unsure: this changes the option default?*

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@NickHu 

