### PR TITLE
bemenu: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -317,6 +317,12 @@
     github = "nurelin";
     githubId = 5276274;
   };
+  omernaveedxyz = {
+    name = "Omer Naveed";
+    email = "omer@omernaveed.dev";
+    github = "omernaveedxyz";
+    githubId = 112912585;
+  };
   otavio = {
     email = "otavio.salvador@ossystems.com.br";
     github = "otavio";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1363,6 +1363,14 @@ in
           A new module is available: 'programs.sftpman'.
         '';
       }
+
+      {
+        time = "2023-12-29T08:22:40+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'programs.bemenu'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -63,6 +63,7 @@ let
     ./programs/bat.nix
     ./programs/bacon.nix
     ./programs/beets.nix
+    ./programs/bemenu.nix
     ./programs/borgmatic.nix
     ./programs/bottom.nix
     ./programs/boxxy.nix

--- a/modules/programs/bemenu.nix
+++ b/modules/programs/bemenu.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.bemenu;
+
+in {
+  meta.maintainers = [ hm.maintainers.omernaveedxyz ];
+
+  options.programs.bemenu = {
+    enable = mkEnableOption "bemenu";
+
+    package = mkPackageOption pkgs "bemenu" { };
+
+    settings = mkOption {
+      type = with types; attrsOf (oneOf [ str int bool ]);
+      default = { };
+      example = literalExpression ''
+        {
+          line-height = 28;
+          prompt = "open";
+          ignorecase = true;
+          fb = "#1e1e2e";
+          ff = "#cdd6f4";
+          nb = "#1e1e2e";
+          nf = "#cdd6f4";
+          tb = "#1e1e2e";
+          hb = "#1e1e2e";
+          tf = "#f38ba8";
+          hf = "#f9e2af";
+          af = "#cdd6f4";
+          ab = "#1e1e2e";
+        }
+      '';
+      description =
+        "Configuration options for bemenu. See {manpage}`bemenu(1)`.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions =
+      [ (hm.assertions.assertPlatform "programs.bemenu" pkgs platforms.linux) ];
+
+    home.packages = [ cfg.package ];
+
+    home.sessionVariables = mkIf (cfg.settings != { }) {
+      BEMENU_OPTS = cli.toGNUCommandLineShell { } cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -181,6 +181,7 @@ import nmt {
     ./modules/programs/autorandr
     ./modules/programs/awscli
     ./modules/programs/beets  # One test relies on services.mpd
+    ./modules/programs/bemenu
     ./modules/programs/borgmatic
     ./modules/programs/boxxy
     ./modules/programs/firefox

--- a/tests/modules/programs/bemenu/basic-configuration.nix
+++ b/tests/modules/programs/bemenu/basic-configuration.nix
@@ -1,0 +1,26 @@
+{
+  programs.bemenu = {
+    enable = true;
+    settings = {
+      line-height = 28;
+      prompt = "open";
+      ignorecase = true;
+      fb = "#1e1e2e";
+      ff = "#cdd6f4";
+      nb = "#1e1e2e";
+      nf = "#cdd6f4";
+      tb = "#1e1e2e";
+      hb = "#1e1e2e";
+      tf = "#f38ba8";
+      hf = "#f9e2af";
+      af = "#cdd6f4";
+      ab = "#1e1e2e";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+      "export BEMENU_OPTS=\"'--ab' '#1e1e2e' '--af' '#cdd6f4' '--fb' '#1e1e2e' '--ff' '#cdd6f4' '--hb' '#1e1e2e' '--hf' '#f9e2af' '--ignorecase' '--line-height' '28' '--nb' '#1e1e2e' '--nf' '#cdd6f4' '--prompt' 'open' '--tb' '#1e1e2e' '--tf' '#f38ba8'\""
+  '';
+}

--- a/tests/modules/programs/bemenu/default.nix
+++ b/tests/modules/programs/bemenu/default.nix
@@ -1,0 +1,4 @@
+{
+  bemenu-empty-configuration = ./empty-configuration.nix;
+  bemenu-basic-configuration = ./basic-configuration.nix;
+}

--- a/tests/modules/programs/bemenu/empty-configuration.nix
+++ b/tests/modules/programs/bemenu/empty-configuration.nix
@@ -1,0 +1,9 @@
+{
+  programs.bemenu = { enable = true; };
+
+  nmt.script = ''
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh \
+      "export BEMENU_OPTS"
+  '';
+}


### PR DESCRIPTION
### Description

Add bemenu module https://github.com/Cloudef/bemenu with ability to configure options through `BEMENU_OPTS` environment variable.

Configuration of bemenu globally is done through setting this environment variable as opposed to using a config file as mentioned [here](https://github.com/Cloudef/bemenu/issues/15) and [here](https://github.com/Cloudef/bemenu/issues/158).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
