### PR TITLE
nixos-module: Add activation timeout option

### DIFF
--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -92,6 +92,15 @@ in {
         Per-user Home Manager configuration.
       '';
     };
+
+    activationTimeout = mkOption {
+      type = types.str;
+      default = "5m";
+      example = "1h";
+      description = ''
+        Timeout of the activation script.
+      '';
+    };
   };
 
   config = (mkMerge [

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -49,7 +49,7 @@ in {
             User = usercfg.home.username;
             Type = "oneshot";
             RemainAfterExit = "yes";
-            TimeoutStartSec = "5m";
+            TimeoutStartSec = cfg.activationTimeout;
             SyslogIdentifier = "hm-activate-${username}";
 
             ExecStart = let


### PR DESCRIPTION
### Description
I wanted to manage a doom emacs installation inside the home-manager activation script. However I ran into the 5m timeout when syncing the config. This PR adds an option to set this timeout.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
