### PR TITLE
firefox: fix folders not showing in toolbar (#4568)

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -97,13 +97,14 @@ let
       directoryToHTML = indentLevel: directory: ''
         ${indent indentLevel}<DT>${
           if directory.toolbar then
-            ''<H3 PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar''
+            ''
+              <H3 ADD_DATE="1" LAST_MODIFIED="1" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar''
           else
-            "<H3>${escapeXML directory.name}"
+            ''<H3 ADD_DATE="1" LAST_MODIFIED="1">${escapeXML directory.name}''
         }</H3>
         ${indent indentLevel}<DL><p>
         ${allItemsToHTML (indentLevel + 1) directory.bookmarks}
-        ${indent indentLevel}</p></DL>'';
+        ${indent indentLevel}</DL><p>'';
 
       itemToHTMLOrRecurse = indentLevel: item:
         if item ? "url" then
@@ -126,7 +127,7 @@ let
       <H1>Bookmarks Menu</H1>
       <DL><p>
       ${bookmarkEntries}
-      </p></DL>
+      </DL>
     '';
 
   mkNoDuplicateAssertion = entities: entityKind:
@@ -377,7 +378,11 @@ in {
                     toolbar = mkOption {
                       type = types.bool;
                       default = false;
-                      description = "If directory should be shown in toolbar.";
+                      description = ''
+                        Make this the toolbar directory. Note, this does _not_
+                        mean that this directory will be added to the toolbar,
+                        this directory _is_ the toolbar.
+                      '';
                     };
                   };
                 }) // {

--- a/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
+++ b/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
@@ -6,20 +6,20 @@
 <TITLE>Bookmarks</TITLE>
 <H1>Bookmarks Menu</H1>
 <DL><p>
-  <DT><H3 PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
+  <DT><H3 ADD_DATE="1" LAST_MODIFIED="1" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
   <DL><p>
     <DT><A HREF="https://nixos.wiki/wiki/Home_Manager" ADD_DATE="1" LAST_MODIFIED="1">Home Manager</A>
-  </p></DL>
+  </DL><p>
   <DT><A HREF="https://en.wikipedia.org/wiki/Special:Search?search=%s&amp;go=Go" ADD_DATE="1" LAST_MODIFIED="1" SHORTCUTURL="wiki" TAGS="wiki">wikipedia</A>
   <DT><A HREF="https://www.kernel.org" ADD_DATE="1" LAST_MODIFIED="1">kernel.org</A>
-  <DT><H3>Nix sites</H3>
+  <DT><H3 ADD_DATE="1" LAST_MODIFIED="1">Nix sites</H3>
   <DL><p>
     <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>
     <DT><A HREF="https://nixos.wiki/" ADD_DATE="1" LAST_MODIFIED="1" TAGS="wiki,nix">wiki</A>
-    <DT><H3>Nix sites</H3>
+    <DT><H3 ADD_DATE="1" LAST_MODIFIED="1">Nix sites</H3>
     <DL><p>
       <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>
       <DT><A HREF="https://nixos.wiki/" ADD_DATE="1" LAST_MODIFIED="1">wiki</A>
-    </p></DL>
-  </p></DL>
-</p></DL>
+    </DL><p>
+  </DL><p>
+</DL>


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Previously the generated `bookmarks.html` was malformed which lead to the inability to add folders to the toolbar(#4568)

I've also updated the documentation to reflect that the `toolbar` option doesnt add the folder to the toolbar, but that folder is the toolbar itself.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee @kira-bruneau 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
