### PR TITLE
cava: nullable package

### DIFF
--- a/modules/programs/cava.nix
+++ b/modules/programs/cava.nix
@@ -14,7 +14,7 @@ in {
   options.programs.cava = {
     enable = mkEnableOption "Cava audio visualizer";
 
-    package = mkPackageOption pkgs "cava" { };
+    package = mkPackageOption pkgs "cava" { nullable = true; };
 
     settings = mkOption {
       type = iniFmt.type;
@@ -39,7 +39,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.optional (cfg.package != null) cfg.package;
 
     xdg.configFile."cava/config" = mkIf (cfg.settings != { }) {
       text = ''


### PR DESCRIPTION
### Description
Currently, cava (in nixpkgs) isn't supported in darwin so I need to be able to mark the package as nullable to just configure my config through nix and retrieve the package from brew.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@bddvlpr 
