### PR TITLE
awscli: Only write config files when not empty

### DIFF
--- a/modules/programs/awscli.nix
+++ b/modules/programs/awscli.nix
@@ -57,11 +57,16 @@ in {
   config = lib.mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    home.file."${config.home.homeDirectory}/.aws/config".source =
-      iniFormat.generate "aws-config-${config.home.username}" cfg.settings;
+    home.file."${config.home.homeDirectory}/.aws/config" =
+      lib.mkIf (cfg.settings != { }) {
+        source =
+          iniFormat.generate "aws-config-${config.home.username}" cfg.settings;
+      };
 
-    home.file."${config.home.homeDirectory}/.aws/credentials".source =
-      iniFormat.generate "aws-credentials-${config.home.username}"
-      cfg.credentials;
+    home.file."${config.home.homeDirectory}/.aws/credentials" =
+      lib.mkIf (cfg.credentials != { }) {
+        source = iniFormat.generate "aws-credentials-${config.home.username}"
+          cfg.credentials;
+      };
   };
 }


### PR DESCRIPTION

### Description

This change allows one to have writetable config or credentials files by not providing options for the config or the credentials file.
In my case, external tools write to `credentials`, which is why I don't want it to be managed by home-manager.
The change is to wrap the file generation in a `lib.mkIf (cfg.credentials != { })`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
