### PR TITLE
zsh: add zproof option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -356,6 +356,13 @@ in
         description = "Enable zsh autosuggestions";
       };
 
+      zproof.enable = mkOption {
+        default = false;
+        description = ''
+          Enable zproof in your zshrc.
+        '';
+      };
+
       syntaxHighlighting = mkOption {
         type = syntaxHighlightingModule;
         default = {};
@@ -534,6 +541,12 @@ in
         ++ optional cfg.oh-my-zsh.enable cfg.oh-my-zsh.package;
 
       home.file."${relToDotDir ".zshrc"}".text = concatStringsSep "\n" ([
+        # zproof must be loaded before everything else, since it
+        # benchmarks the shell initialization.
+        (optionalString cfg.zproof.enable ''
+          zmodload zsh/zprof
+        '')
+
         cfg.initExtraFirst
         "typeset -U path cdpath fpath manpath"
 
@@ -656,6 +669,11 @@ in
             (downKey: "bindkey \"${downKey}\" history-substring-search-down")
             (lib.toList cfg.historySubstringSearch.searchDownKey)
           }
+        '')
+
+        (optionalString cfg.zproof.enable
+        ''
+          zprof
         '')
       ]);
     }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds `programs.zsh.enableZproof`.
zproof is used to benchmark the shell initialisation -> helps to reduce loading time.
Needs to be the first & last line in `~/.zshrc`.
Since there isn't a `initExtraLast` option currently, it's hard to implement that without this option.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

I haven't found a `meta.maintainers` for zsh. Can somebody help me there?
