### PR TITLE
yazi: pass additional args to ya alias

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -9,7 +9,7 @@ let
   bashIntegration = ''
     function ya() {
       tmp="$(mktemp -t "yazi-cwd.XXXXX")"
-      yazi --cwd-file="$tmp"
+      yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
         cd -- "$cwd"
       fi
@@ -20,7 +20,7 @@ let
   fishIntegration = ''
     function ya
       set tmp (mktemp -t "yazi-cwd.XXXXX")
-      yazi --cwd-file="$tmp"
+      yazi $argv --cwd-file="$tmp"
       if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
         cd -- "$cwd"
       end
@@ -29,9 +29,9 @@ let
   '';
 
   nushellIntegration = ''
-    def --env ya [] {
+    def --env ya [args?] {
       let tmp = $"($env.TEMP)(char path_sep)yazi-cwd." + (random chars -l 5)
-      yazi --cwd-file $tmp
+      yazi $args --cwd-file $tmp
       let cwd = (open $tmp)
       if $cwd != "" and $cwd != $env.PWD {
         cd $cwd

--- a/tests/modules/programs/yazi/bash-integration-enabled.nix
+++ b/tests/modules/programs/yazi/bash-integration-enabled.nix
@@ -4,7 +4,7 @@ let
   shellIntegration = ''
     function ya() {
       tmp="$(mktemp -t "yazi-cwd.XXXXX")"
-      yazi --cwd-file="$tmp"
+      yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
         cd -- "$cwd"
       fi

--- a/tests/modules/programs/yazi/fish-integration-enabled.nix
+++ b/tests/modules/programs/yazi/fish-integration-enabled.nix
@@ -4,7 +4,7 @@ let
   shellIntegration = ''
     function ya
       set tmp (mktemp -t "yazi-cwd.XXXXX")
-      yazi --cwd-file="$tmp"
+      yazi $argv --cwd-file="$tmp"
       if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
         cd -- "$cwd"
       end

--- a/tests/modules/programs/yazi/nushell-integration-enabled.nix
+++ b/tests/modules/programs/yazi/nushell-integration-enabled.nix
@@ -2,9 +2,9 @@
 
 let
   shellIntegration = ''
-    def --env ya [] {
+    def --env ya [args?] {
       let tmp = $"($env.TEMP)(char path_sep)yazi-cwd." + (random chars -l 5)
-      yazi --cwd-file $tmp
+      yazi $args --cwd-file $tmp
       let cwd = (open $tmp)
       if $cwd != "" and $cwd != $env.PWD {
         cd $cwd

--- a/tests/modules/programs/yazi/zsh-integration-enabled.nix
+++ b/tests/modules/programs/yazi/zsh-integration-enabled.nix
@@ -4,7 +4,7 @@ let
   shellIntegration = ''
     function ya() {
       tmp="$(mktemp -t "yazi-cwd.XXXXX")"
-      yazi --cwd-file="$tmp"
+      yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
         cd -- "$cwd"
       fi


### PR DESCRIPTION
### Description

Passes additional arguments from the ya alias to the yazi command. This allows commands like `ya /etc/nixos` and `ya --help` to be used.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@XYenon 