### PR TITLE
hyprland: improve config reload

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -237,11 +237,11 @@ in {
         + lib.optionalString (cfg.extraConfig != "") cfg.extraConfig;
 
       onChange = lib.mkIf (cfg.package != null) ''
-        (  # execute in subshell so that `shopt` won't affect other scripts
-          shopt -s nullglob  # so that nothing is done if /tmp/hypr/ does not exist or is empty
-          for instance in /tmp/hypr/*; do
-            HYPRLAND_INSTANCE_SIGNATURE=''${instance##*/} ${cfg.finalPackage}/bin/hyprctl reload config-only \
-              || true  # ignore dead instance(s)
+        ( # Execute in subshell so we don't poision environment with vars
+          # This var must be set for hyprctl to function, but the value doesn't matter.
+          export HYPRLAND_INSTANCE_SIGNATURE="bogus"
+          for i in $(${cfg.finalPackage}/bin/hyprctl instances -j | jq ".[].instance" -r); do
+            HYPRLAND_INSTANCE_SIGNATURE=$i ${cfg.finalPackage}/bin/hyprctl reload config-only
           done
         )
       '';


### PR DESCRIPTION
### Description

When using the previous approach I've always gotten errors that I can't reload config on the .lock file that exists in /tmp when you run a standard configured hyprland.
This commit improves this by using hyprctl to find instances to reload instead.
We can remove the HYPRLAND_INSTANCE_SIGNATURE bogus assignment once https://github.com/hyprwm/Hyprland/issues/4088 is resolved.

Note: I've set my home-manager url to my local repo and run a home-switch, verified that hyprland reloads the config and that there's no error message anymore.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@fufexan 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
