### PR TITLE
gh: automatically insert version key to settings

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -126,7 +126,27 @@ in {
     home.packages = [ cfg.package ];
 
     xdg.configFile."gh/config.yml".source =
-      yamlFormat.generate "gh-config.yml" cfg.settings;
+      yamlFormat.generate "gh-config.yml" ({ version = "1"; } // cfg.settings);
+
+    # Version 2.40.0+ of gh needs to migrate account formats, this needs to
+    # happen before the version = 1 is placed in the configuration file. Running
+    # `gh help` is sufficient to perform the migration. If the migration already
+    # has occurred, then this is a no-op.
+    #
+    # See https://github.com/nix-community/home-manager/issues/4744 for details.
+    home.activation.migrateGhAccounts =
+      hm.dag.entryBetween [ "linkGeneration" ] [ "writeBoundary" ] ''
+        if [[ -e "${config.xdg.configHome}/gh/config.yml" ]]; then
+          (
+            TMP_DIR=$(mktemp -d)
+            trap "rm --force --recursive $TMP_DIR" EXIT
+            cp "${config.xdg.configHome}/gh/hosts.yml" $TMP_DIR/
+            export GH_CONFIG_DIR=$TMP_DIR
+            $DRY_RUN_CMD ${getExe cfg.package} help 2>&1 > $DRY_RUN_NULL
+            cp $TMP_DIR/hosts.yml "${config.xdg.configHome}/gh/hosts.yml"
+          )
+        fi
+      '';
 
     programs.git.extraConfig.credential = mkIf cfg.gitCredentialHelper.enable
       (builtins.listToAttrs (map (host:

--- a/tests/modules/programs/gh/config-file.nix
+++ b/tests/modules/programs/gh/config-file.nix
@@ -18,6 +18,7 @@
             co: pr checkout
           editor: vim
           git_protocol: https
+          version: '1'
         ''
       }
     '';

--- a/tests/modules/programs/gh/warnings.nix
+++ b/tests/modules/programs/gh/warnings.nix
@@ -28,6 +28,7 @@
             co: pr checkout
           editor: vim
           git_protocol: https
+          version: '1'
         ''
       }
     '';


### PR DESCRIPTION
### Description

Fixes #4744

~~Currently can cause problems with data migrations so leaving it as a draft until a call can be made on a better solution: https://github.com/nix-community/home-manager/issues/4744#issuecomment-1847220726~~

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
