### PR TITLE
docs: use relative paths to static resources

### DIFF
--- a/docs/home-manager-manual.nix
+++ b/docs/home-manager-manual.nix
@@ -32,17 +32,19 @@ in stdenv.mkDerivation {
       --replace \
         '@OPTIONS_JSON@' \
         ${home-manager-options.nix-darwin}/share/doc/nixos/options.json
+
+    cp ${nmd}/static/style.css out/style.css
     cp -t out/highlightjs ${nmd}/static/highlightjs/tomorrow-night.min.css
     cp ${./highlight-style.css} out/highlightjs/highlight-style.css
 
     nixos-render-docs manual html \
       --manpage-urls ./manpage-urls.json \
       --revision ${lib.trivial.revisionWithDefault revision} \
-      --stylesheet ${nmd}/static/style.css \
-      --stylesheet $out/share/doc/home-manager/highlightjs/tomorrow-night.min.css \
-      --stylesheet $out/share/doc/home-manager/highlightjs/highlight-style.css \
-      --script $out/share/doc/home-manager/highlightjs/highlight.pack.js \
-      --script $out/share/doc/home-manager/highlightjs/loader.js \
+      --stylesheet style.css \
+      --stylesheet highlightjs/tomorrow-night.min.css \
+      --stylesheet highlightjs/highlight-style.css \
+      --script highlightjs/highlight.pack.js \
+      --script highlightjs/loader.js \
       --toc-depth 1 \
       --section-toc-depth 1 \
       manual.md \


### PR DESCRIPTION
### Description

Fixes #4753

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.