### PR TITLE
hyprland: add option sourceFirst

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1317,6 +1317,23 @@ in
           A new module is available: 'services.signaturepdf'.
         '';
       }
+
+      {
+        time = "2023-12-10T08:43:02+00:00";
+        condition = config.wayland.windowManager.hyprland.settings ? source;
+        message = ''
+          Entries in
+
+            wayland.windowManager.hyprland.settings.source
+
+          are now placed at the start of the configuration file. If you relied
+          on the previous placement of the 'source' entries, please set
+
+             wayland.windowManager.hyprland.sourceFirst = false
+
+          to keep the previous behaviour.
+        '';
+      }
     ];
   };
 }

--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -175,6 +175,12 @@ in {
         Extra configuration lines to add to `~/.config/hypr/hyprland.conf`.
       '';
     };
+
+    sourceFirst = lib.mkEnableOption ''
+      putting source entries at the top of the configuration
+    '' // {
+      default = true;
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -222,9 +228,9 @@ in {
             inherit indent;
           };
           allFields = filterAttrs (n: v: !(isAttrs v)) attrs;
-          importantFields =
-            filterAttrs (n: _: (hasPrefix "$" n) || (hasPrefix "bezier" n))
-            allFields;
+          importantFields = filterAttrs (n: _:
+            (hasPrefix "$" n) || (hasPrefix "bezier" n)
+            || (cfg.sourceFirst && (hasPrefix "source" n))) allFields;
           fields = builtins.removeAttrs allFields
             (mapAttrsToList (n: _: n) importantFields);
         in mkFields importantFields

--- a/tests/modules/services/window-managers/hyprland/simple-config.conf
+++ b/tests/modules/services/window-managers/hyprland/simple-config.conf
@@ -3,6 +3,7 @@ $mod=SUPER
 bezier=smoothOut, 0.36, 0, 0.66, -0.56
 bezier=smoothIn, 0.25, 1, 0.5, 1
 bezier=overshot, 0.4,0.8,0.2,1.2
+source=sourced.conf
 animations {
   animation=border, 1, 2, smoothIn
   animation=fade, 1, 4, smoothOut

--- a/tests/modules/services/window-managers/hyprland/simple-config.nix
+++ b/tests/modules/services/window-managers/hyprland/simple-config.nix
@@ -8,6 +8,8 @@
     plugins =
       [ "/path/to/plugin1" (config.lib.test.mkStubPackage { name = "foo"; }) ];
     settings = {
+      source = [ "sourced.conf" ];
+
       decoration = {
         shadow_offset = "0 5";
         "col.shadow" = "rgba(00000099)";


### PR DESCRIPTION
### Description

Add the option sourceFirst to the hyprland module. When this option is enabled source entries will be put near the top of the file, so that the variables declared in other files can be used by the other configuration entries.

Add "source" to the list of important prefixes when the former option is enabled.

Resolves: #4729 

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@fufexan 
