### PR TITLE
oh-my-posh: enable nushell integration

### DIFF
--- a/modules/programs/oh-my-posh.nix
+++ b/modules/programs/oh-my-posh.nix
@@ -70,6 +70,14 @@ in {
         Whether to enable Fish integration.
       '';
     };
+
+    enableNushellIntegration = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to enable Nushell integration.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -90,5 +98,18 @@ in {
     programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
       ${cfg.package}/bin/oh-my-posh init fish ${configArgument} | source
     '';
+
+    programs.nushell = mkIf cfg.enableNushellIntegration {
+      extraEnv = ''
+        let oh_my_posh_cache = "${config.xdg.cacheHome}/oh-my-posh"
+        if not ($oh_my_posh_cache | path exists) {
+          mkdir $oh_my_posh_cache
+        }
+        ${cfg.package}/bin/oh-my-posh init nu ${configArgument} --print | save --force ${config.xdg.cacheHome}/oh-my-posh/init.nu
+      '';
+      extraConfig = ''
+        source ${config.xdg.cacheHome}/oh-my-posh/init.nu
+      '';
+    };
   };
 }

--- a/tests/modules/programs/oh-my-posh/default.nix
+++ b/tests/modules/programs/oh-my-posh/default.nix
@@ -2,4 +2,5 @@
   oh-my-posh-bash = ./bash.nix;
   oh-my-posh-zsh = ./zsh.nix;
   oh-my-posh-fish = ./fish.nix;
+  oh-my-posh-nushell = ./nushell.nix;
 }

--- a/tests/modules/programs/oh-my-posh/nushell.nix
+++ b/tests/modules/programs/oh-my-posh/nushell.nix
@@ -1,0 +1,29 @@
+{ ... }:
+
+{
+  programs = {
+    nushell.enable = true;
+
+    oh-my-posh = {
+      enable = true;
+      useTheme = "jandedobbeleer";
+    };
+  };
+
+  test.stubs = {
+    oh-my-posh = { };
+    nushell = { };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/nushell/env.nu
+    assertFileRegex \
+      home-files/.config/nushell/env.nu \
+      '/bin/oh-my-posh init nu --config .*--print \| save --force /.*/home-files/\.cache/oh-my-posh/init\.nu'
+
+    assertFileExists home-files/.config/nushell/config.nu
+    assertFileRegex \
+      home-files/.config/nushell/config.nu \
+      'source /.*/\.cache/oh-my-posh/init\.nu'
+  '';
+}


### PR DESCRIPTION
### Description

Adds nushell integration for the oh-my-posh module, similar to atuin, zoxide, etc.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@arjan-s
