### PR TITLE
msmtp: add configurable package

### DIFF
--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -51,6 +51,13 @@ in {
     programs.msmtp = {
       enable = mkEnableOption "msmtp";
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.msmtp;
+        defaultText = literalExpression "pkgs.msmtp";
+        description = "The msmtp package to use.";
+      };
+
       extraConfig = mkOption {
         type = types.lines;
         default = "";
@@ -81,7 +88,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.msmtp ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."msmtp/config".text = configFile msmtpAccounts;
 


### PR DESCRIPTION
-------

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).