### PR TITLE
gtk: fix GTK 4 theme being ignored

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -35,6 +35,8 @@ let
           Package providing the theme. This package will be installed
           to your profile. If `null` then the theme
           is assumed to already be available in your profile.
+
+          For the theme to apply to GTK 4, this option is mandatory.
         '';
       };
 
@@ -233,6 +235,15 @@ in {
         gtk-cursor-theme-size = cfg.cursorTheme.size;
       };
 
+    gtk4Css =
+      lib.optionalString (cfg.theme != null && cfg.theme.package != null) ''
+        /**
+         * GTK 4 reads the theme configured by gtk-theme-name, but ignores it.
+         * It does however respect user CSS, so import the theme from here.
+        **/
+        @import url("file://${cfg.theme.package}/share/themes/${cfg.theme.name}/gtk-4.0/gtk.css");
+      '' + cfg4.extraCss;
+
     dconfIni = optionalAttrs (cfg.font != null) {
       font-name = let
         fontSize =
@@ -277,8 +288,7 @@ in {
     xdg.configFile."gtk-4.0/settings.ini".text =
       toGtk3Ini { Settings = gtkIni // cfg4.extraConfig; };
 
-    xdg.configFile."gtk-4.0/gtk.css" =
-      mkIf (cfg4.extraCss != "") { text = cfg4.extraCss; };
+    xdg.configFile."gtk-4.0/gtk.css" = mkIf (gtk4Css != "") { text = gtk4Css; };
 
     dconf.settings."org/gnome/desktop/interface" = dconfIni;
   });


### PR DESCRIPTION
### Description

Haven't dug into any code, but my best guess is GTK 4 ignores it on purpose since devs campaigned against theming: https://stopthemingmy.app

According to the following link, it's fine for users to do it as long as they don't expect support from app devs. And the campaign was against distributions applying custom themes by default.
https://github.com/GradienceTeam/Gradience/tree/0.4.1#%EF%B8%8F-gradience-stopthemingmyapp-and-adwaita-developers

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee
