### PR TITLE
docs: fix nix-darwin module configuration example

### DIFF
--- a/docs/manual/installation/nix-darwin.md
+++ b/docs/manual/installation/nix-darwin.md
@@ -38,7 +38,7 @@ For example, a nix-darwin configuration may include the lines
 users.users.eve = {
   name = "eve";
   home = "/Users/eve";
-}
+};
 home-manager.users.eve = { pkgs, ... }: {
   home.packages = [ pkgs.atool pkgs.httpie ];
   programs.bash.enable = true;


### PR DESCRIPTION
The example is missing a `;` which causes this error when you attempt a `darwin-rebuild switch`.

```
       error: syntax error, unexpected '=', expecting ';'

       at /Users/968713/.nixpkgs/darwin-configuration.nix:17:30:

           16|   }
           17|   home-manager.users.eve = { pkgs, ... }: {
             |                              ^
           18|     home.packages = [
```

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
