### PR TITLE
zsh: Add `programs.zsh.oh-my-zsh.customPkgs` option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -511,6 +511,13 @@ in
   };
 
   config = mkIf cfg.enable (mkMerge [
+    {
+      assertions = [{
+        assertion = with config.programs.zsh.oh-my-zsh; custom == "" || length customPkgs == 0;
+        message = ''The options `programs.zsh.oh-my-zsh.custom' and `programs.zsh.oh-my-zsh.customPkgs' are mutually exclusive.'';
+      }];
+    }
+
     (mkIf (cfg.envExtra != "") {
       home.file."${relToDotDir ".zshenv"}".text = cfg.envExtra;
     })

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -199,7 +199,7 @@ let
       customPkgs = mkOption {
         default = [];
         type = types.listOf types.package;
-        example = "$HOME/my_customizations";
+        example = "[ pkgs.nix-zsh-completions ]";
         description = ''
           List of custom packages that should be placed into `$ZSH_CUSTOM`.
           See <https://github.com/robbyrussell/oh-my-zsh/wiki/Customization> for more information.

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -6,6 +6,7 @@
   zsh-history-path-old-custom = ./history-path-old-custom.nix;
   zsh-history-ignore-pattern = ./history-ignore-pattern.nix;
   zsh-history-substring-search = ./history-substring-search.nix;
+  zsh-omz-custom-invalid = ./omz-custom-invalid.nix;
   zsh-prezto = ./prezto.nix;
   zsh-syntax-highlighting = ./syntax-highlighting.nix;
   zsh-abbr = ./zsh-abbr.nix;

--- a/tests/modules/programs/zsh/omz-custom-invalid.nix
+++ b/tests/modules/programs/zsh/omz-custom-invalid.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+{
+  config = {
+    programs.zsh = {
+      enable = true;
+      oh-my-zsh = {
+        enable = true;
+        custom = "plz-fail";
+        customPkgs = [ pkgs.zshPlugin ];
+      };
+    };
+
+    test.stubs.zshPlugin = { };
+
+    test.asserts.assertions.expected = [
+      "The options `programs.zsh.oh-my-zsh.custom' and `programs.zsh.oh-my-zsh.customPkgs' are mutually exclusive."
+    ];
+  };
+}


### PR DESCRIPTION
### Description

Set `oh-my-zsh`'s `$ZSH_CUSTOM` env var with pointing towards a package. A port of NixOS' `programs.zsh.ohMyZsh.customPkgs`. Closes #4757.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

*Note: there is no test for oh-my-zsh altgother. Nor do I see any mention of it in tests. I think writing a whole test for oh-my-zsh might be out of scope for this PR of one option.*

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

*note: I am unsure if I should format commits with the component as `zsh` or `oh-my-zsh`. I am leaving it as `zsh` for now, as I edited the `zsh.nix` file, not an `oh-my-zsh.nix` file. Please correct me if I am wrong.*

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

*I have no clue who to tag here - `modules/programs/zsh.nix` does not appear to have a `meta.maintainers`. *