### PR TITLE
gh: add version config

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -126,7 +126,7 @@ in {
     home.packages = [ cfg.package ];
 
     xdg.configFile."gh/config.yml".source =
-      yamlFormat.generate "gh-config.yml" cfg.settings;
+      yamlFormat.generate "gh-config.yml" (cfg.settings // { version = "1"; });
 
     programs.git.extraConfig.credential = mkIf cfg.gitCredentialHelper.enable
       (builtins.listToAttrs (map (host:


### PR DESCRIPTION
### Description

Gh cli throws error when the config doesn't contain this setting, preventing you from using the program with the home-manager controlled configuration. 

https://github.com/cli/cli/issues/8462

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
