### PR TITLE
docs: fix link texts in release notes

### DIFF
--- a/docs/manual/usage/configuration.md
+++ b/docs/manual/usage/configuration.md
@@ -87,7 +87,7 @@ follows:
 ```
 
 -   Nixpkgs packages can be installed to the user profile using
-    [???](opt-home.packages).
+    [home.packages](#opt-home.packages).
 
 -   The option names of a program module typically start with
     `programs.<package name>`.

--- a/docs/release-notes/rl-1903.md
+++ b/docs/release-notes/rl-1903.md
@@ -6,7 +6,7 @@ The 19.03 release branch became the stable branch in April, 2019.
 
 This release has the following notable changes:
 
--   The [opt-home.file._name_.source](#opt-home.file._name_.source) option now allows source
+-   The [home.file._name_.source](#opt-home.file._name_.source) option now allows source
     files to be hidden, that is, having a name starting with the `.`
     character. It also allows the source file name to contain characters
     not typically allowed for Nix store paths. For example, your
@@ -17,7 +17,7 @@ This release has the following notable changes:
     ```
 
 -   The type used for the systemd unit options under
-    [opt-systemd.user.sockets](#opt-systemd.user.sockets),
+    [systemd.user.sockets](#opt-systemd.user.sockets),
     etc. has been changed to offer more robust merging of
     configurations. If you don't override values within systemd units
     then you are not affected by this change. Unfortunately, if you do
@@ -44,9 +44,9 @@ This release has the following notable changes:
 ## State Version Changes {#sec-release-19.03-state-version-changes}
 
 The state version in this release includes the changes below. These
-changes are only active if the [opt-home.stateVersion](#opt-home.stateVersion) option is
+changes are only active if the [home.stateVersion](#opt-home.stateVersion) option is
 set to "19.03" or later.
 
--   There is now an option [opt-programs.beets.enable](#opt-programs.beets.enable) that
+-   There is now an option [programs.beets.enable](#opt-programs.beets.enable) that
     defaults to `false`. Before the module would be active if the
-    [opt-programs.beets.settings](#opt-programs.beets.settings) option was non-empty.
+    [programs.beets.settings](#opt-programs.beets.settings) option was non-empty.

--- a/docs/release-notes/rl-1909.md
+++ b/docs/release-notes/rl-1909.md
@@ -20,9 +20,9 @@ The state version in this release includes the changes below. These
 changes are only active if the `home.stateVersion` option is set to
 \"19.09\" or later.
 
--   The [opt-programs.firefox.package](#opt-programs.firefox.package) option now expects a
+-   The [programs.firefox.package](#opt-programs.firefox.package) option now expects a
     wrapped Firefox package and defaults to `pkgs.firefox`.
 
--   The options [opt-home.keyboard.layout](#opt-home.keyboard.layout) and
-    [opt-home.keyboard.variant](#opt-home.keyboard.variant) now default to `null`, which
+-   The options [home.keyboard.layout](#opt-home.keyboard.layout) and
+    [home.keyboard.variant](#opt-home.keyboard.variant) now default to `null`, which
     indicates that the system value should be used.

--- a/docs/release-notes/rl-2003.md
+++ b/docs/release-notes/rl-2003.md
@@ -6,8 +6,8 @@ The 20.03 release branch became the stable branch in April, 2020.
 
 This release has the following notable changes:
 
--   Assigning a list to the [opt-home.file](#opt-home.file),
-    [opt-xdg.dataFile](#opt-xdg.dataFile) options is
+-   Assigning a list to the [home.file](#opt-home.file),
+    [xdg.dataFile](#opt-xdg.dataFile) options is
     now deprecated and will produce a warning message if used.
     Specifically, if your configuration currently contains something
     like
@@ -71,7 +71,7 @@ This release has the following notable changes:
     no longer packages compton, and instead packages the (mostly)
     compatible fork called picom.
 
--   The list form of the [opt-programs.ssh.matchBlocks](#opt-programs.ssh.matchBlocks) option has
+-   The list form of the [programs.ssh.matchBlocks](#opt-programs.ssh.matchBlocks) option has
     been deprecated and configurations requiring match blocks in a
     defined order should switch to using DAG entries instead. For
     example, a configuration
@@ -111,7 +111,7 @@ The state version in this release includes the changes below. These
 changes are only active if the `home.stateVersion` option is set to
 \"20.03\" or later.
 
--   The [opt-programs.zsh.history.path](#opt-programs.zsh.history.path) option is no longer
+-   The [programs.zsh.history.path](#opt-programs.zsh.history.path) option is no longer
     prepended by `$HOME`, which allows specifying absolute paths, for
     example, using the xdg module. Also, the default value is fixed to
     `$HOME/.zsh_history` and `dotDir` path is not prepended to it

--- a/docs/release-notes/rl-2009.md
+++ b/docs/release-notes/rl-2009.md
@@ -15,14 +15,14 @@ The state version in this release includes the changes below. These
 changes are only active if the `home.stateVersion` option is set to
 \"20.09\" or later.
 
--   The options [opt-home.homeDirectory](#opt-home.homeDirectory) and
-    [opt-home.username](#opt-home.username) no longer have default values and must
+-   The options [home.homeDirectory](#opt-home.homeDirectory) and
+    [home.username](#opt-home.username) no longer have default values and must
     therefore be provided in your configuration. Previously their values
     would default to the content of the environment variables `HOME` and
     `USER`, respectively.
 
-    Further, the options [opt-xdg.cacheHome](#opt-xdg.cacheHome),
-    [opt-xdg.dataHome](#opt-xdg.dataHome) will no
+    Further, the options [xdg.cacheHome](#opt-xdg.cacheHome),
+    [xdg.dataHome](#opt-xdg.dataHome) will no
     longer be affected by the `XDG_CACHE_HOME`, `XDG_CONFIG_HOME`, and
     `XDG_DATA_HOME` environment variables. They now unconditionally
     default to
@@ -45,10 +45,10 @@ changes are only active if the `home.stateVersion` option is set to
     will automatically include these options, when necessary.
 
 -   Git's `smtpEncryption` option is now set to `tls` only if both
-    [opt-accounts.email.accounts._name_.smtp.tls.enable](#opt-accounts.email.accounts._name_.smtp.tls.enable) and
-    [opt-accounts.email.accounts._name_.smtp.tls.useStartTls](#opt-accounts.email.accounts._name_.smtp.tls.useStartTls) are
+    [accounts.email.accounts._name_.smtp.tls.enable](#opt-accounts.email.accounts._name_.smtp.tls.enable) and
+    [accounts.email.accounts._name_.smtp.tls.useStartTls](#opt-accounts.email.accounts._name_.smtp.tls.useStartTls) are
     `true`. If only
-    [opt-accounts.email.accounts._name_.smtp.tls.enable](#opt-accounts.email.accounts._name_.smtp.tls.enable) is
+    [accounts.email.accounts._name_.smtp.tls.enable](#opt-accounts.email.accounts._name_.smtp.tls.enable) is
     `true`, `ssl` is used instead.
 
 -   The `nixpkgs` module no longer references `<nixpkgs>`. Before it

--- a/docs/release-notes/rl-2105.md
+++ b/docs/release-notes/rl-2105.md
@@ -27,7 +27,7 @@ This release has the following notable changes:
     ];
     ```
 
--   The [opt-programs.mpv.package](#opt-programs.mpv.package) option has been changed to
+-   The [programs.mpv.package](#opt-programs.mpv.package) option has been changed to
     allow custom derivations. The following configuration is now
     possible:
 
@@ -41,11 +41,11 @@ This release has the following notable changes:
     });
     ```
 
-    As a result of this change, [opt-programs.mpv.package](#opt-programs.mpv.package) is no
+    As a result of this change, [programs.mpv.package](#opt-programs.mpv.package) is no
     longer the resulting derivation. Use the newly introduced
     `programs.mpv.finalPackage` instead.
 
--   The [opt-programs.rofi.extraConfig](#opt-programs.rofi.extraConfig) option is now an attribute
+-   The [programs.rofi.extraConfig](#opt-programs.rofi.extraConfig) option is now an attribute
     set rather than a string. To migrate, move each line into the
     attribute set, removing the `rofi.` prefix from the keys. For
     example,
@@ -66,7 +66,7 @@ This release has the following notable changes:
     };
     ```
 
--   The [opt-programs.rofi.theme](#opt-programs.rofi.theme) option now supports defining a
+-   The [programs.rofi.theme](#opt-programs.rofi.theme) option now supports defining a
     theme using an attribute set, the following configuration is now
     possible:
 
@@ -95,7 +95,7 @@ This release has the following notable changes:
 
 -   The `services.redshift.extraOptions` and
     `services.gammastep.extraOptions` options were removed in favor of
-    [opt-services.redshift.settings](#opt-services.redshift.settings) and
+    [services.redshift.settings](#opt-services.redshift.settings) and
     `services.gammastep.settings`, that are now an attribute set rather
     than a string. They also support new features not available before,
     for example:
@@ -140,10 +140,10 @@ This release has the following notable changes:
 -   Home Manager now respects the `NO_COLOR` environment variable as per
     <https://no-color.org/>.
 
--   Qt module now supports [opt-qt.style.name](#opt-qt.style.name) to specify a theme
-    name and [opt-qt.style.package](#opt-qt.style.package) to specify a theme package. If
-    you have set [opt-qt.platformTheme](#opt-qt.platformTheme) to `gnome`, a
-    [opt-qt.style.package](#opt-qt.style.package) compatible with both Qt and Gtk is now
+-   Qt module now supports [qt.style.name](#opt-qt.style.name) to specify a theme
+    name and [qt.style.package](#opt-qt.style.package) to specify a theme package. If
+    you have set [qt.platformTheme](#opt-qt.platformTheme) to `gnome`, a
+    [qt.style.package](#opt-qt.style.package) compatible with both Qt and Gtk is now
     required to be set. For instance:
 
     ``` nix
@@ -166,9 +166,9 @@ This release has the following notable changes:
     };
     ```
 
--   The [opt-programs.htop.settings](#opt-programs.htop.settings) option is introduced to
+-   The [programs.htop.settings](#opt-programs.htop.settings) option is introduced to
     replace individual options in `programs.htop`. To migrate, set the
-    htop options directly in [opt-programs.htop.settings](#opt-programs.htop.settings). For
+    htop options directly in [programs.htop.settings](#opt-programs.htop.settings). For
     example:
 
     ``` nix

--- a/docs/release-notes/rl-2111.md
+++ b/docs/release-notes/rl-2111.md
@@ -35,11 +35,11 @@ This release has the following notable changes:
     powerful.
 
     You can replicate your old configuration by moving those options to
-    [opt-programs.rofi.theme](#opt-programs.rofi.theme). Keep in mind that the syntax is
+    [programs.rofi.theme](#opt-programs.rofi.theme). Keep in mind that the syntax is
     different so you may need to do some changes.
 
 -   Taskwarrior version 2.6.0 respects XDG Specification for the config
-    file now. Option [opt-programs.taskwarrior.config](#opt-programs.taskwarrior.config) and friends
+    file now. Option [programs.taskwarrior.config](#opt-programs.taskwarrior.config) and friends
     now generate the config file at `$XDG_CONFIG_HOME/task/taskrc`
     instead of `~/.taskrc`.
 
@@ -49,11 +49,11 @@ The state version in this release includes the changes below. These
 changes are only active if the `home.stateVersion` option is set to
 \"21.11\" or later.
 
--   The [opt-home.keyboard](#opt-home.keyboard) option now defaults to `null`, meaning
+-   The [home.keyboard](#opt-home.keyboard) option now defaults to `null`, meaning
     that Home Manager won't do any keyboard layout management. For
     example, `setxkbmap` won't be run in X sessions.
 
--   The [opt-programs.pet.settings](#opt-programs.pet.settings) option no longer place its
+-   The [programs.pet.settings](#opt-programs.pet.settings) option no longer place its
     value inside a `General` attribute. For example,
 
     ``` nix
@@ -66,8 +66,8 @@ changes are only active if the `home.stateVersion` option is set to
     programs.pet.settings.General.editor = "nvim";
     ```
 
--   The [opt-programs.waybar.settings](#opt-programs.waybar.settings) option now allows defining
-    modules directly under [opt-programs.waybar.settings](#opt-programs.waybar.settings). For
+-   The [programs.waybar.settings](#opt-programs.waybar.settings) option now allows defining
+    modules directly under [programs.waybar.settings](#opt-programs.waybar.settings). For
     example,
 
     ``` nix

--- a/docs/release-notes/rl-2205.md
+++ b/docs/release-notes/rl-2205.md
@@ -29,8 +29,8 @@ The state version in this release includes the changes below. These
 changes are only active if the `home.stateVersion` option is set to
 \"22.05\" or later.
 
--   The [opt-programs.waybar.settings](#opt-programs.waybar.settings) option now allows defining
-    modules directly under [opt-programs.waybar.settings](#opt-programs.waybar.settings).
+-   The [programs.waybar.settings](#opt-programs.waybar.settings) option now allows defining
+    modules directly under [programs.waybar.settings](#opt-programs.waybar.settings).
     Defining modules under `programs.waybar.settings.modules` will now
     be an error. For example,
 

--- a/docs/release-notes/rl-2211.md
+++ b/docs/release-notes/rl-2211.md
@@ -6,7 +6,7 @@ The 22.11 release branch became the stable branch in November, 2022.
 
 This release has the following notable changes:
 
--   The [opt-home.stateVersion](#opt-home.stateVersion) option no longer has a default
+-   The [home.stateVersion](#opt-home.stateVersion) option no longer has a default
     value. It used to default to "18.09", which was the Home Manager
     version that introduced the option. If your configuration does not
     explicitly set this option then you need to add
@@ -71,18 +71,18 @@ This release has the following notable changes:
     }
     ```
 
-    Of course, you can move the assignment of [opt-home.username](#opt-home.username),
-    [opt-home.stateVersion](#opt-home.stateVersion) to
+    Of course, you can move the assignment of [home.username](#opt-home.username),
+    [home.stateVersion](#opt-home.stateVersion) to
     some other file or simply place them in your `home.nix`.
 
 -   The `services.picom` module has been refactored to use structural
     settings.
 
     As a result `services.picom.extraOptions` has been removed in favor
-    of [opt-services.picom.settings](#opt-services.picom.settings). Also, `services.picom.blur*`
+    of [services.picom.settings](#opt-services.picom.settings). Also, `services.picom.blur*`
     were removed since upstream changed the blur settings to be more
     flexible. You can migrate the blur settings to use
-    [opt-services.picom.settings](#opt-services.picom.settings) instead.
+    [services.picom.settings](#opt-services.picom.settings) instead.
 
 -   The `services.compton` module has been removed. It was deprecated in
     release 20.03. Use `services.picom` instead.
@@ -93,9 +93,9 @@ The state version in this release includes the changes below. These
 changes are only active if the `home.stateVersion` option is set to
 \"22.11\" or later.
 
--   The [opt-services.mpd.musicDirectory](#opt-services.mpd.musicDirectory) option now defaults to
-    the value of [opt-xdg.userDirs.music](#opt-xdg.userDirs.music) if
-    [opt-xdg.userDirs.enable](#opt-xdg.userDirs.enable) is enabled. Otherwise it is
+-   The [services.mpd.musicDirectory](#opt-services.mpd.musicDirectory) option now defaults to
+    the value of [xdg.userDirs.music](#opt-xdg.userDirs.music) if
+    [xdg.userDirs.enable](#opt-xdg.userDirs.enable) is enabled. Otherwise it is
     undefined and must be specified in the user configuration.
 
 -   The activation script now resets `PATH` before running. Before, the

--- a/docs/release-notes/rl-2305.md
+++ b/docs/release-notes/rl-2305.md
@@ -47,13 +47,13 @@ changes are only active if the `home.stateVersion` option is set to
 
 -   The options
 
-    -   [opt-xsession.windowManager.i3.config.window.titlebar](#opt-xsession.windowManager.i3.config.window.titlebar)
+    -   [xsession.windowManager.i3.config.window.titlebar](#opt-xsession.windowManager.i3.config.window.titlebar)
 
-    -   [opt-xsession.windowManager.i3.config.floating.titlebar](#opt-xsession.windowManager.i3.config.floating.titlebar)
+    -   [xsession.windowManager.i3.config.floating.titlebar](#opt-xsession.windowManager.i3.config.floating.titlebar)
 
-    -   [opt-wayland.windowManager.sway.config.window.titlebar](#opt-wayland.windowManager.sway.config.window.titlebar)
+    -   [wayland.windowManager.sway.config.window.titlebar](#opt-wayland.windowManager.sway.config.window.titlebar)
 
-    -   [opt-wayland.windowManager.sway.config.floating.titlebar](#opt-wayland.windowManager.sway.config.floating.titlebar)
+    -   [wayland.windowManager.sway.config.floating.titlebar](#opt-wayland.windowManager.sway.config.floating.titlebar)
 
     now default to `true` which is consistent with the default values
     for those options used by `i3` and `sway`.

--- a/docs/release-notes/rl-2311.md
+++ b/docs/release-notes/rl-2311.md
@@ -6,8 +6,8 @@ The 23.11 release branch became stable in November, 2023.
 
 This release has the following notable changes:
 
--   When using [opt-programs.fish.enable](#opt-programs.fish.enable), the setup code for
-    [opt-home.sessionVariables](#opt-home.sessionVariables) is now translated with
+-   When using [programs.fish.enable](#opt-programs.fish.enable), the setup code for
+    [home.sessionVariables](#opt-home.sessionVariables) is now translated with
     [babelfish](https://github.com/bouk/babelfish). This should result
     in significantly faster shell startup times but could theoretically
     break if you have very complex bash expressions in a session


### PR DESCRIPTION
### Description

This PR updates links in the release notes from rendering as e.g. `opt-home.user` to rendering as `home.user`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
