### PR TITLE
Better direnv nushell integration

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -134,21 +134,33 @@ in {
       mkAfter ''
         $env.config = ($env.config? | default {})
         $env.config.hooks = ($env.config.hooks? | default {})
-        $env.config.hooks.pre_prompt = ($env.config.hooks.pre_prompt? | default [] | append {||
-            let direnv = (${
-              getExe cfg.package
-            } export json | from json | default {})
-            if ($direnv | is-empty) {
-                return
-            }
-            $direnv
-            | items {|key, value|
-                {
-                    key: $key
-                    value: (do ($env.ENV_CONVERSIONS? | default {} | get -i $key | get -i from_string | default {|x| $x}) $value)
+        $env.config.hooks.pre_prompt = (
+            $env.config.hooks.pre_prompt?
+            | default []
+            | append {||
+                let direnv = (${getExe cfg.package} export json
+                | from json
+                | default {})
+                if ($direnv | is-empty) {
+                    return
                 }
-            } | transpose -ird | load-env
-        })
+                $direnv
+                | items {|key, value|
+                    {
+                        key: $key
+                        value: (do (
+                            $env.env_conversions?
+                            | default {}
+                            | get -i $key
+                            | get -i from_string
+                            | default {|x| $x}
+                        ) $value)
+                    }
+                }
+                | transpose -ird
+                | load-env
+            }
+        )
       '');
   };
 }

--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -114,18 +114,18 @@ in {
       # Using mkAfter to make it more likely to appear after other
       # manipulations of the prompt.
       mkAfter ''
-        eval "$(${cfg.package}/bin/direnv hook bash)"
+        eval "$(${getExe cfg.package} hook bash)"
       '');
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      eval "$(${cfg.package}/bin/direnv hook zsh)"
+      eval "$(${getExe cfg.package} hook zsh)"
     '';
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration (
       # Using mkAfter to make it more likely to appear after other
       # manipulations of the prompt.
       mkAfter ''
-        ${cfg.package}/bin/direnv hook fish | source
+        ${getExe cfg.package} hook fish | source
       '');
 
     programs.nushell.extraConfig = mkIf cfg.enableNushellIntegration (
@@ -135,7 +135,9 @@ in {
         $env.config = ($env.config? | default {})
         $env.config.hooks = ($env.config.hooks? | default {})
         $env.config.hooks.pre_prompt = ($env.config.hooks.pre_prompt? | default [] | append {||
-            let direnv = (${cfg.package}/bin/direnv export json | from json | default {})
+            let direnv = (${
+              getExe cfg.package
+            } export json | from json | default {})
             if ($direnv | is-empty) {
                 return
             }

--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -132,16 +132,21 @@ in {
       # Using mkAfter to make it more likely to appear after other
       # manipulations of the prompt.
       mkAfter ''
-        $env.config = ($env | default {} config).config
-        $env.config = ($env.config | default {} hooks)
-        $env.config = ($env.config | update hooks ($env.config.hooks | default [] pre_prompt))
-        $env.config = ($env.config | update hooks.pre_prompt ($env.config.hooks.pre_prompt | append {
-          code: "
-            let direnv = (${cfg.package}/bin/direnv export json | from json)
-            let direnv = if not ($direnv | is-empty) { $direnv } else { {} }
-            $direnv | load-env
-            "
-        }))
+        $env.config = ($env.config? | default {})
+        $env.config.hooks = ($env.config.hooks? | default {})
+        $env.config.hooks.pre_prompt = ($env.config.hooks.pre_prompt? | default [] | append {||
+            let direnv = (${cfg.package}/bin/direnv export json | from json | default {})
+            if ($direnv | is-empty) {
+                return
+            }
+            $direnv
+            | items {|key, value|
+                {
+                    key: $key
+                    value: (do ($env.ENV_CONVERSIONS? | default {} | get -i $key | get -i from_string | default {|x| $x}) $value)
+                }
+            } | transpose -ird | load-env
+        })
       '');
   };
 }

--- a/tests/modules/programs/direnv/nushell.nix
+++ b/tests/modules/programs/direnv/nushell.nix
@@ -14,6 +14,6 @@
   in ''
     assertFileExists "${configFile}"
     assertFileRegex "${configFile}" \
-      'let direnv = (/nix/store/.*direnv.*/bin/direnv export json \| from json | default {})'
+      '^\s*let direnv = (/nix/store/.*direnv.*/bin/direnv export json$'
   '';
 }

--- a/tests/modules/programs/direnv/nushell.nix
+++ b/tests/modules/programs/direnv/nushell.nix
@@ -14,6 +14,6 @@
   in ''
     assertFileExists "${configFile}"
     assertFileRegex "${configFile}" \
-      'let direnv = (/nix/store/.*direnv.*/bin/direnv export json | from json)'
+      'let direnv = (/nix/store/.*direnv.*/bin/direnv export json \| from json | default {})'
   '';
 }


### PR DESCRIPTION
### Description

Nushell allows defining a `ENV_CONVERSIONS` environment variable used to transform the variables passed between nu and the system (by default it will transform `PATH` and `Path` into lists). However, those transformations aren't applied when `load-env`ing them, as nu assumes the string passed to it is intended to be a string.

This PR makes the direnv hook read `ENV_CONVERSIONS` and apply the transformations accordingly. Other than being less surprising/annoying it also prevents some bugs like new binaries in the path not being autocompleted.

The nushell hook is written in such a way that it won't break if any expected value is missing.

While at it, I took the liberty of removing all the `/bin` paths in the file in favor of `lib.getExe` (but that can be removed if not desired 😁 ).

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
