### PR TITLE
home-manager: sort list packages output

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -722,7 +722,7 @@ function doListPackages() {
     local outPath
     outPath="$($LIST_OUTPATH_CMD | grep -o '/.*home-manager-path$')"
     if [[ -n "$outPath" ]] ; then
-        nix-store -q --references "$outPath" | sed 's/[^-]*-//'
+        nix-store -q --references "$outPath" | sed 's/[^-]*-//' | sort --ignore-case
     else
         _i 'No home-manager packages seem to be installed.' >&2
     fi


### PR DESCRIPTION
### Description

Prints the package list in sorted order (ignoring case). Fixes #4788

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```