### PR TITLE
sway: fix failing tests

### DIFF
--- a/modules/programs/gradle.nix
+++ b/modules/programs/gradle.nix
@@ -34,7 +34,9 @@ let
     }));
   });
 in {
-  meta.maintainers = [ maintainers.britter ];
+  meta.maintainers = [
+    # maintainers.britter
+  ];
 
   options.programs.gradle = {
     enable = mkEnableOption "Gradle Build Tool";

--- a/tests/modules/programs/thefuck/integration-disabled.nix
+++ b/tests/modules/programs/thefuck/integration-disabled.nix
@@ -14,7 +14,7 @@
 
   nmt.script = ''
     assertFileNotRegex home-files/.bashrc '@thefuck@/bin/thefuck'
-    assertFileNotExists home-files/.config/fish/functions/fuck.fish
+    assertPathNotExists home-files/.config/fish/functions/fuck.fish
     assertFileNotRegex home-files/.zshrc '@thefuck@/bin/thefuck'
   '';
 }

--- a/tests/modules/services/window-managers/sway/sway-stubs.nix
+++ b/tests/modules/services/window-managers/sway/sway-stubs.nix
@@ -5,7 +5,7 @@
     dmenu = { };
     foot = { };
     i3status = { };
-    sway = { };
+    sway = { version = "1"; };
     sway-unwrapped = { version = "1"; };
     swaybg = { };
     xwayland = { };


### PR DESCRIPTION
### Description

Due to a recent change in Nixpkgs, the version field is required for the sway package.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```