### PR TITLE
fish: escape abbr expansions once again

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -207,7 +207,8 @@ let
       modifiers = if isAttrs def then mods else "";
       expansion = if isAttrs def then def.expansion else def;
     in "abbr --add ${modifiers} -- ${name}"
-    + optionalString (expansion != null) " \"${expansion}\"") cfg.shellAbbrs);
+    + optionalString (expansion != null) " ${escapeShellArg expansion}")
+    cfg.shellAbbrs);
 
   aliasesStr = concatStringsSep "\n"
     (mapAttrsToList (k: v: "alias ${k} ${escapeShellArg v}") cfg.shellAliases);

--- a/tests/modules/programs/fish/abbrs.nix
+++ b/tests/modules/programs/fish/abbrs.nix
@@ -26,8 +26,13 @@
         };
         "4DIRS" = {
           setCursor = "!";
-          expansion =
-            "$(string join \\n -- 'for dir in */' 'cd $dir' '!' 'cd ..' 'end')";
+          expansion = ''
+            for dir in */
+              cd $dir
+              !
+              cd ..
+            end
+          '';
         };
         dotdot = {
           regex = "^\\.\\.+$";
@@ -41,19 +46,24 @@
         "if fish.shellAbbrs is set, check fish.config contains valid abbreviations";
       script = ''
         assertFileContains home-files/.config/fish/config.fish \
-          'abbr --add -- l less'
+          "abbr --add -- l less"
         assertFileContains home-files/.config/fish/config.fish \
-          'abbr --add -- gco "git checkout"'
+          "abbr --add -- gco 'git checkout'"
         assertFileContains home-files/.config/fish/config.fish \
-          'abbr --add --position anywhere -- -C --color'
+          "abbr --add --position anywhere -- -C --color"
         assertFileContains home-files/.config/fish/config.fish \
-          'abbr --add --position anywhere --set-cursor -- L "% | less"'
+          "abbr --add --position anywhere --set-cursor -- L '% | less'"
         assertFileContains home-files/.config/fish/config.fish \
-          'abbr --add --function last_history_item --position anywhere -- !!'
+          "abbr --add --function last_history_item --position anywhere -- !!"
         assertFileContains home-files/.config/fish/config.fish \
           "abbr --add --function vim_edit --position command --regex '.+\.txt' -- vim_edit_texts"
         assertFileContains home-files/.config/fish/config.fish \
-          'abbr --add '"'"'--set-cursor=!'"'"' -- 4DIRS "$(string join \n -- '"'"'for dir in */'"'"' '"'"'cd $dir'"'"' '"'"'!'"'"' '"'"'cd ..'"'"' '"'"'end'"'"')'
+          "abbr --add '--set-cursor=!' -- 4DIRS 'for dir in */
+          cd \$dir
+          !
+          cd ..
+        end
+        '"
         assertFileContains home-files/.config/fish/config.fish \
           "abbr --add --function multicd --regex '^\.\.+$' -- dotdot"
       '';


### PR DESCRIPTION
Commit 8cedd6 `fish: support flexible abbreviations` removed shell escaping for fish shell abbr values. This was a dangerous breaking change offered little value and made writing abbr expansions more difficult. This commit restores automatic shell escaping of fish abbr values.

### Description
Fixes #4710 

In my opinion these abbr should be escaped like they always have been. Currently this config:
```nix
shellAbbrs = {
  foo = "printf \"great job\"";
  bar = "mkdir $(date %H:%M:%S%Z)";
};
```
will yield:
```
  abbr --add -- foo "printf "great job
  abbr --add -- bar "mkdir $(date %H:%M:%S%Z)"
```
This `foo` abbr is messed up with the quotes and `bar` abbr's `date` command will run once when the shell is started and hardcode the time into the abbr. This is just confusing behavior that is completely solved by going back to escaping the abbrs.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

NOTE: This change reverts a dubious backwards incompatible change made previously, so it's technically not backwards compatible but it will maintain backwards compatibility for users using the `23.11` branch.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
