### PR TITLE
direnv: Fix nushell integration ENV_CONVERSIONS

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -149,7 +149,7 @@ in {
                     {
                         key: $key
                         value: (do (
-                            $env.env_conversions?
+                            $env.ENV_CONVERSIONS?
                             | default {}
                             | get -i $key
                             | get -i from_string


### PR DESCRIPTION
### Description

I had a base case of works on my machine™️ when testing #4787. I excitedly tried it today after cleaning up my config, and... it didn't work. At all. Turns out I had the direnv hook defined twice in my config and things kept (apparently) working fine.

I can confirm this works on a clean config now 🥲

Btw, I use nushell and direnv daily, so I'd be happy to keep maintaining this module in the foreseeable future :)

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
