### PR TITLE
Fish: init command-not-found and zoxide only in interactive shells

### DIFF
--- a/modules/programs/nix-index.nix
+++ b/modules/programs/nix-index.nix
@@ -48,7 +48,7 @@ in {
     '';
 
     # See https://github.com/bennofs/nix-index/issues/126
-    programs.fish.shellInit = let
+    programs.fish.interactiveShellInit = let
       wrapper = pkgs.writeScript "command-not-found" ''
         #!${pkgs.bash}/bin/bash
         source ${cfg.package}/etc/profile.d/command-not-found.sh

--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -76,7 +76,7 @@ in {
       eval "$(${cfg.package}/bin/zoxide init zsh ${cfgOptions})"
     '';
 
-    programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
+    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
       ${cfg.package}/bin/zoxide init fish ${cfgOptions} | source
     '';
 


### PR DESCRIPTION
### Description

We don't need these in non-interactive shells, so there's no point initialising them in that case.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
