### PR TITLE
gpg-agent: don't set a default for pinentry

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -198,7 +198,7 @@ in {
       pinentryFlavor = mkOption {
         type = types.nullOr (types.enum pkgs.pinentry.flavors);
         example = "gnome3";
-        default = "gtk2";
+        default = null;
         description = ''
           Which pinentry interface to use. If not
           `null`, it sets
@@ -210,8 +210,6 @@ in {
           ```nix
           services.dbus.packages = [ pkgs.gcr ];
           ```
-          For this reason, the default is `gtk2` for
-          now.
         '';
       };
 


### PR DESCRIPTION
NixOS stopped building gtk2 pinentry by default in https://github.com/NixOS/nixpkgs/pull/270266 and it does not appear to me that there is a reasonable other default.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
