### PR TITLE
home-environment: fix incompatible profile error

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -585,11 +585,15 @@ in
       if config.submoduleSupport.externalPackageInstall
       then
         ''
-          if [[ -e ${cfg.profileDirectory}/manifest.json ]] ; then
+          # We don't use `cfg.profileDirectory` here because it defaults to
+          # `/etc/profiles/per-user/<user>` which is constructed by NixOS or
+          # nix-darwin and won't require uninstalling `home-manager-path`.
+          if [[ -e $HOME/.nix-profile/manifest.json \
+             || -e "''${XDG_STATE_HOME:-$HOME/.local/state}/nix/profile/manifest.json" ]] ; then
             nix profile list \
               | { grep 'home-manager-path$' || test $? = 1; } \
               | cut -d ' ' -f 4 \
-              | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
+              | xargs -rt $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
           else
             if nix-env -q | grep '^home-manager-path$'; then
               $DRY_RUN_CMD nix-env -e home-manager-path


### PR DESCRIPTION
### Description

This fixes the error:

    error: profile '/nix/var/nix/profiles/per-user/enzime/profile' is incompatible with 'nix-env'; please use 'nix profile' instead

This error occurs when using `home-manager.useUserPackages` set to `true`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).