### PR TITLE
programs: (WIP) add option to not install packages for enabled programs

### DIFF
--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -11,6 +11,7 @@ rec {
   maintainers = import ./maintainers.nix;
   strings = import ./strings.nix { inherit lib; };
   types = import ./types.nix { inherit gvariant lib; };
+  options = import ./options.nix { inherit lib; };
 
   shell = import ./shell.nix { inherit lib; };
   zsh = import ./zsh.nix { inherit lib; };

--- a/modules/lib/options.nix
+++ b/modules/lib/options.nix
@@ -1,0 +1,10 @@
+{ lib }:
+{
+  mkInstallOptionWithDefault =
+    default: name: lib.mkOption {
+      inherit default;
+      type = lib.types.bool;
+      example = true;
+      description = "Whether to install package ${name}";
+    };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -46,6 +46,7 @@ let
     ./misc/xdg-user-dirs.nix
     ./misc/xdg.nix
     ./misc/xfconf.nix
+    ./programs.nix
     ./programs/abook.nix
     ./programs/aerc.nix
     ./programs/afew.nix

--- a/modules/programs.nix
+++ b/modules/programs.nix
@@ -1,0 +1,11 @@
+{ config, lib, ... }:
+
+{
+  options.programs.installPackages = lib.mkOption {
+    type = lib.types.bool;
+    default = true;
+    description = "Whether to install packages for configured programs by default";
+  };
+
+  config = {};
+}

--- a/modules/programs/feh.nix
+++ b/modules/programs/feh.nix
@@ -5,6 +5,7 @@ with lib;
 let
 
   cfg = config.programs.feh;
+  mkInstallOption = hm.options.mkInstallOptionWithDefault config.programs.installPackages;
 
   bindingsOf = t: with types; attrsOf (nullOr (either t (listOf t)));
 
@@ -26,6 +27,8 @@ let
 in {
   options.programs.feh = {
     enable = mkEnableOption "feh - a fast and light image viewer";
+
+    install = mkInstallOption "feh";
 
     package = mkPackageOption pkgs "feh" { };
 
@@ -71,7 +74,7 @@ in {
         "To disable a keybinding, use `null` instead of an empty string.";
     }];
 
-    home.packages = [ cfg.package ];
+    home.packages = optional cfg.install cfg.package;
 
     xdg.configFile."feh/buttons" =
       mkIf (cfg.buttons != { }) { text = renderBindings cfg.buttons + "\n"; };


### PR DESCRIPTION
### Description

This is a work-in-progress implementation for issue #4763. I have raised this now to get some feedback on whether this is something that would be accepted by the project and whether the approach is sound, before I go through the effort of updating all the program submodules to use the new option.

There is a new global `options.programs.installPackages` option that sets the default behaviour for all programs, which itself is defaulted to true to maintain backwards compatibility.

The `program` submodules should expose their own `options.programs.<program>.install` option that can override this value.

I am not 100% sure the approach I have taken is the best. Ideally I'd like to expose a `mkInstallOption` function from somewhere sensible, however I couldn't work out how to expose a function from `config.programs` or how to pass config into `lib.options` so that I could set the default value from `options.programs.installPackages`.

My second concern is regarding the use of the nix store paths in config for packages that are not installed (See [this comment](https://github.com/nix-community/home-manager/pull/4808/commits/6c23bd9fe8346dd1c92a2fe466bf340d60dc87f8#r1435862722)). My current approach is to hope that the package is on the users "$PATH", however in necessary cases we could add another option for the user to specify these paths if that is not the case.

Finally, whilst I'd be happy to go through all of the packages to introduce the new option, this could definitely bloat the PR and require eyes from many maintainers. Therefore I was going to ask if I should just introduce the new option for one of the programs in this PR and then raise separate ones for others in separate PRs?

I'd be grateful for any feedback on this PR before I go much further with this.

Cheers

Daniel

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
