### PR TITLE
targets/darwin: allow configuring application linking

### DIFF
--- a/modules/targets/darwin/linkapps.nix
+++ b/modules/targets/darwin/linkapps.nix
@@ -1,9 +1,24 @@
 { config, lib, pkgs, ... }:
 
-{
-  config = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+let cfg = config.targets.darwin;
+in {
+  options.targets.darwin.linkApps = {
+    enable =
+      lib.mkEnableOption "linking macOS applications to the user environment"
+      // {
+        default = true;
+      };
+
+    directory = lib.mkOption {
+      type = lib.types.str;
+      default = "Applications/Home Manager Apps";
+      description = "Path to link apps relative to the home directory.";
+    };
+  };
+
+  config = lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && cfg.linkApps.enable) {
     # Install MacOS applications to the user environment.
-    home.file."Applications/Home Manager Apps".source = let
+    home.file.${cfg.linkApps.directory}.source = let
       apps = pkgs.buildEnv {
         name = "home-manager-applications";
         paths = config.home.packages;


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Not all packages supply a bundled macOS application, and I would like to configure where apps get placed since I use Raycast instead of Spotlight.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@midchildan 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
