### PR TITLE
osmscout-server: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1348,6 +1348,14 @@ in
           A new module is available: 'programs.gradle'.
         '';
       }
+
+      {
+        time = "2023-12-28T08:28:26+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.osmscout-server'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -306,6 +306,7 @@ let
     ./services/nextcloud-client.nix
     ./services/notify-osd.nix
     ./services/opensnitch-ui.nix
+    ./services/osmscout-server.nix
     ./services/owncloud-client.nix
     ./services/pantalaimon.nix
     ./services/parcellite.nix

--- a/modules/services/osmscout-server.nix
+++ b/modules/services/osmscout-server.nix
@@ -1,0 +1,76 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.osmscout-server;
+in {
+  meta.maintainers = [ maintainers.Thra11 ];
+
+  options = {
+    services.osmscout-server = {
+      enable = mkEnableOption "OSM Scout Server";
+
+      package = mkPackageOption pkgs "osmscout-server" { };
+
+      network = {
+        startWhenNeeded = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Enable systemd socket activation.
+          '';
+        };
+
+        listenAddress = mkOption {
+          type = types.str;
+          default = "127.0.0.1";
+          description = ''
+            The address for the server to listen on.
+          '';
+        };
+
+        port = mkOption {
+          type = types.port;
+          default = 8553;
+          description = ''
+            The TCP port on which the server will listen.
+          '';
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.osmscout-server" pkgs
+        lib.platforms.linux)
+    ];
+
+    systemd.user.services.osmscout-server = {
+      Unit = { Description = "OSM Scout Server"; };
+
+      Install = mkIf (!cfg.network.startWhenNeeded) {
+        WantedBy = [ "default.target" ];
+      };
+
+      Service = {
+        ExecStart = "'${cfg.package}/bin/osmscout-server' --systemd --quiet";
+      };
+    };
+
+    systemd.user.sockets.osmscout-server = mkIf cfg.network.startWhenNeeded {
+      Unit = { Description = "OSM Scout Server Socket"; };
+
+      Socket = {
+        ListenStream =
+          "${cfg.network.listenAddress}:${toString cfg.network.port}";
+        TriggerLimitIntervalSec = "60s";
+        TriggerLimitBurst = 1;
+      };
+
+      Install = { WantedBy = [ "sockets.target" ]; };
+    };
+
+    home.packages = [ cfg.package ];
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -235,6 +235,7 @@ import nmt {
     ./modules/services/mpd
     ./modules/services/mpd-mpris
     ./modules/services/mpdris2
+    ./modules/services/osmscout-server
     ./modules/services/pantalaimon
     ./modules/services/parcellite
     ./modules/services/pass-secret-service

--- a/tests/modules/services/osmscout-server/basic-setup.nix
+++ b/tests/modules/services/osmscout-server/basic-setup.nix
@@ -1,0 +1,43 @@
+{ config, ... }:
+
+{
+  services.osmscout-server = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@osmscout-server@"; };
+    network = {
+      startWhenNeeded = true;
+      listenAddress = "0.0.0.0";
+      port = 55555;
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/systemd/user/osmscout-server.service \
+      ${
+        builtins.toFile "osmscout-server.service" ''
+          [Service]
+          ExecStart='@osmscout-server@/bin/osmscout-server' --systemd --quiet
+
+          [Unit]
+          Description=OSM Scout Server
+        ''
+      }
+    assertFileContent \
+      home-files/.config/systemd/user/osmscout-server.socket \
+      ${
+        builtins.toFile "osmscout-server.socket" ''
+          [Install]
+          WantedBy=sockets.target
+
+          [Socket]
+          ListenStream=0.0.0.0:55555
+          TriggerLimitBurst=1
+          TriggerLimitIntervalSec=60s
+
+          [Unit]
+          Description=OSM Scout Server Socket
+        ''
+      }
+  '';
+}

--- a/tests/modules/services/osmscout-server/default.nix
+++ b/tests/modules/services/osmscout-server/default.nix
@@ -1,0 +1,1 @@
+{ osmscout-server = ./basic-setup.nix; }


### PR DESCRIPTION
### Description

Osmscout-server includes a setting in its UI to create a systemd user service and socket to run the server on demand. This does not function correctly on NixOS, for two reasons:
1. It assumes that the binary path is stable (e.g. /usr/bin/osmscout-server), which is not the case on NixOS.
2. It auto-detects the unwrapped binary path, which doesn't work.

This module allows the user to access the same functionality on NixOS.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).