### PR TITLE
gh: test for existence of hosts file

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -136,7 +136,7 @@ in {
     # See https://github.com/nix-community/home-manager/issues/4744 for details.
     home.activation.migrateGhAccounts =
       hm.dag.entryBetween [ "linkGeneration" ] [ "writeBoundary" ] ''
-        if [[ -e "${config.xdg.configHome}/gh/config.yml" ]]; then
+        if [[ -e "${config.xdg.configHome}/gh/hosts.yml" ]]; then
           (
             TMP_DIR=$(mktemp -d)
             trap "rm --force --recursive $TMP_DIR" EXIT


### PR DESCRIPTION
### Description

Having the module enabled but never using gh will result in the config file
existing without a hosts.yml. In that scenario we won't have anything to
migrate, so only test for hosts.yml.

Fixes #4812 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee
