### PR TITLE
gh: idempotently consider existing symlinks

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -135,15 +135,16 @@ in {
     #
     # See https://github.com/nix-community/home-manager/issues/4744 for details.
     home.activation.migrateGhAccounts =
-      hm.dag.entryBetween [ "linkGeneration" ] [ "writeBoundary" ] ''
-        if [[ -e "${config.xdg.configHome}/gh/hosts.yml" ]]; then
+      let ghHosts = "${config.xdg.configHome}/gh/hosts.yml";
+      in hm.dag.entryBetween [ "linkGeneration" ] [ "writeBoundary" ] ''
+        if [[ ! -L "${ghHosts}" && -f "${ghHosts}" ]]; then
           (
             TMP_DIR=$(mktemp -d)
             trap "rm --force --recursive $TMP_DIR" EXIT
-            cp "${config.xdg.configHome}/gh/hosts.yml" $TMP_DIR/
+            cp "${ghHosts}" $TMP_DIR/
             export GH_CONFIG_DIR=$TMP_DIR
             $DRY_RUN_CMD ${getExe cfg.package} help 2>&1 > $DRY_RUN_NULL
-            cp $TMP_DIR/hosts.yml "${config.xdg.configHome}/gh/hosts.yml"
+            cp $TMP_DIR/hosts.yml "${ghHosts}"
           )
         fi
       '';


### PR DESCRIPTION
### Description

Closes: https://github.com/nix-community/home-manager/issues/4814

> fix(modules/programs/gh): idempotently consider existing symlinks
>
> > -e file
> >        True if file exists.
> > -f file
> >        True if file exists and is a regular file.
> > [...]
> > -L file
> >        True if file exists and is a symbolic link.
> >
> > (Source: bash(1))

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@Gerschtli, @berbiche, @msfjarvis, @rycee