### PR TITLE
alacritty: make module compatible with alacritty 0.13

### DIFF
--- a/tests/modules/programs/alacritty/default.nix
+++ b/tests/modules/programs/alacritty/default.nix
@@ -2,4 +2,5 @@
   alacritty-example-settings = ./example-settings.nix;
   alacritty-empty-settings = ./empty-settings.nix;
   alacritty-merging-settings = ./settings-merging.nix;
+  alacritty-toml-config = ./toml_config.nix;
 }

--- a/tests/modules/programs/alacritty/example-settings-expected.toml
+++ b/tests/modules/programs/alacritty/example-settings-expected.toml
@@ -1,0 +1,8 @@
+[[keyboard.bindings]]
+chars = "\x0c"
+key = "K"
+mods = "Control"
+
+[window.dimensions]
+columns = 200
+lines = 3

--- a/tests/modules/programs/alacritty/example-settings-expected.yml
+++ b/tests/modules/programs/alacritty/example-settings-expected.yml
@@ -1,1 +1,0 @@
-{"key_bindings":[{"chars":"\x0c","key":"K","mods":"Control"}],"window":{"dimensions":{"columns":200,"lines":3}}}

--- a/tests/modules/programs/alacritty/settings-merging.nix
+++ b/tests/modules/programs/alacritty/settings-merging.nix
@@ -6,7 +6,7 @@ with lib;
   config = {
     programs.alacritty = {
       enable = true;
-      package = config.lib.test.mkStubPackage { };
+      package = config.lib.test.mkStubPackage { version = "0.12.3"; };
 
       settings = {
         window.dimensions = {

--- a/tests/modules/programs/alacritty/settings-toml-expected.toml
+++ b/tests/modules/programs/alacritty/settings-toml-expected.toml
@@ -1,0 +1,15 @@
+[font]
+[font.bold]
+family = "SFMono"
+
+[font.normal]
+family = "SFMono"
+
+[[keyboard.bindings]]
+chars = "\x0c"
+key = "K"
+mods = "Control"
+
+[window.dimensions]
+columns = 200
+lines = 3

--- a/tests/modules/programs/alacritty/toml_config.nix
+++ b/tests/modules/programs/alacritty/toml_config.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
   config = {
@@ -19,13 +17,18 @@ with lib;
           mods = "Control";
           chars = "\\x0c";
         }];
+
+        font = {
+          normal.family = "SFMono";
+          bold.family = "SFMono";
+        };
       };
     };
 
     nmt.script = ''
       assertFileContent \
         home-files/.config/alacritty/alacritty.toml \
-        ${./example-settings-expected.toml}
+        ${./settings-toml-expected.toml}
     '';
   };
 }


### PR DESCRIPTION
### Description

The config file is in TOML from 0.13 onwards.
This PR makes the alacritty module compatible with 0.13 while retaining compatibility with previous versions.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
