### PR TITLE
bug: Make zoxide v0.9.2 work w/Nushell >= v0.88

### DIFF
--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -86,7 +86,9 @@ in {
         if not ($zoxide_cache | path exists) {
           mkdir $zoxide_cache
         }
-        ${cfg.package}/bin/zoxide init nushell ${cfgOptions} | save --force ${config.xdg.cacheHome}/zoxide/init.nu
+        ${cfg.package}/bin/zoxide init nushell ${cfgOptions} |
+          str replace "def-env" "def --env" --all |  # https://github.com/ajeetdsouza/zoxide/pull/632
+          save --force ${config.xdg.cacheHome}/zoxide/init.nu
       '';
       extraConfig = ''
         source ${config.xdg.cacheHome}/zoxide/init.nu


### PR DESCRIPTION
### Description
Nushell v0.88 removes all support (already deprecated) for `def-env`.

[Zoxide still hasn't released a version which updates their config relying on `def-env`](https://github.com/nix-community/home-manager/issues/4818)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
   - NOT done. This triggers an error in some other HM-configurable program on my machine. Without having looked into it, this makes me feel like someone else didn't check.
   ```
	$ nix develop --ignore-environment .#all
	[160 built, 56 copied (527.6 MiB), 86.0 MiB DL] evaluating derivation 'git+file:///home/x10an14/Documents/github/home-manage
	trace: warning: The cfg.enableGnomeExtensions argument for `firefox.override` is deprecated, please add `pkgs.gnome-browser-connector` to `nativeMessagingHosts.packages` instead
	error: hash mismatch in fixed-output derivation '/nix/store/kiddsys4690v680mhnvlx4zpgz50bb02-lookup?op=get-options=mr-search=0x36cacf52d098cc0e78fb0cb13573356c25c424d4.drv':
	         specified: sha256-9Zjsb/TtOyiPzMO/Jg3CtJwSxuw7QmX0pcfZT2/1w5E=
	            got:    sha256-Pvm0CpH13pvnD/c+IJAkRElR5/IhZt8pg7RjT/dZdfM=
	error: 1 dependencies of derivation '/nix/store/07qfnkm1l1zz8519x3y824a5jibkjgbg-gpg-pubring.drv' failed to build
	error: 1 dependencies of derivation '/nix/store/jwf65c2n5566vnm9p6ya02h17s91iwpr-activation-script.drv' failed to build
	error: 1 dependencies of derivation '/nix/store/jmi43w7yrhvvwp34mwdwqbq389fs9wsi-home-manager-generation.drv' failed to build
	error:
	       … while calling the 'derivationStrict' builtin

	         at /builtin/derivation.nix:9:12: (source not available)

	       … while evaluating derivation 'nmt-run-all-tests'
	         whose name attribute is located at /nix/store/55ql4j8d47xjvfa8xggjddgfwny4n9j7-source/pkgs/stdenv/generic/make-derivation.nix:348:7

	       … while evaluating attribute 'shellHook' of derivation 'nmt-run-all-tests'

	         at /nix/store/3vax7vf054q4vvb1bj8sd9lvr8dcsfjb-source/default.nix:38:40:

	           37|   runShellOnlyCommand = name: shellHook:
	           38|     pkgs.runCommandLocal name { inherit shellHook; } ''
	             |                                        ^
	           39|       echo This derivation is only useful when run through nix-shell.

	       (stack trace truncated; use '--show-trace' to show the full trace)

	       error: 1 dependencies of derivation '/nix/store/ajvfhdfahj57sbidjavkgwcbjnrr0nck-nmt-report-gpg-immutable-keyfiles.drv' failed to build
   ```
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@adamcstephens @r-vdp 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

EDIT: Clarified what's been tested truthfully.
