### PR TITLE
oh-my-posh: fix test under Darwin

### DIFF
--- a/tests/modules/programs/oh-my-posh/nushell.nix
+++ b/tests/modules/programs/oh-my-posh/nushell.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ pkgs, ... }:
 
 {
   programs = {
@@ -15,15 +15,25 @@
     nushell = { };
   };
 
-  nmt.script = ''
-    assertFileExists home-files/.config/nushell/env.nu
+  nmt.script = let
+    configFile = if pkgs.stdenv.isDarwin then
+      "home-files/Library/Application Support/nushell/config.nu"
+    else
+      "home-files/.config/nushell/config.nu";
+
+    envFile = if pkgs.stdenv.isDarwin then
+      "home-files/Library/Application Support/nushell/env.nu"
+    else
+      "home-files/.config/nushell/env.nu";
+  in ''
+    assertFileExists "${envFile}"
     assertFileRegex \
-      home-files/.config/nushell/env.nu \
+      "${envFile}" \
       '/bin/oh-my-posh init nu --config .*--print \| save --force /.*/home-files/\.cache/oh-my-posh/init\.nu'
 
-    assertFileExists home-files/.config/nushell/config.nu
+    assertFileExists "${configFile}"
     assertFileRegex \
-      home-files/.config/nushell/config.nu \
+      "${configFile}" \
       'source /.*/\.cache/oh-my-posh/init\.nu'
   '';
 }


### PR DESCRIPTION
### Description

Fix test failing when run in Darwin.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```