### PR TITLE
tmux: True Color support

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -94,6 +94,11 @@ let
       bind-key -N "Kill the current pane" x kill-pane
     ''}
 
+    ${optionalString cfg.trueColor ''
+      set -g default-terminal "tmux-256color"
+      set -ag terminal-overrides ",xterm-256color:RGB"
+    ''}
+
     set  -g mouse             ${boolToStr cfg.mouse}
     setw -g aggressive-resize ${boolToStr cfg.aggressiveResize}
     setw -g clock-mode-style  ${if cfg.clock24 then "24" else "12"}
@@ -292,6 +297,8 @@ in {
       tmuxp.enable = mkEnableOption "tmuxp";
 
       tmuxinator.enable = mkEnableOption "tmuxinator";
+
+      trueColor = mkEnableOption "true color support";
 
       plugins = mkOption {
         type = with types;

--- a/tests/modules/programs/tmux/default-shell.conf
+++ b/tests/modules/programs/tmux/default-shell.conf
@@ -23,6 +23,8 @@ set -g mode-keys   emacs
 
 
 
+
+
 set  -g mouse             off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12

--- a/tests/modules/programs/tmux/default.nix
+++ b/tests/modules/programs/tmux/default.nix
@@ -8,4 +8,5 @@
   tmux-shortcut-without-prefix = ./shortcut-without-prefix.nix;
   tmux-prefix = ./prefix.nix;
   tmux-mouse-enabled = ./mouse-enabled.nix;
+  tmux-truecolor-enabled = ./truecolor-enabled.nix;
 }

--- a/tests/modules/programs/tmux/disable-confirmation-prompt.conf
+++ b/tests/modules/programs/tmux/disable-confirmation-prompt.conf
@@ -23,6 +23,8 @@ bind-key -N "Kill the current window" & kill-window
 bind-key -N "Kill the current pane" x kill-pane
 
 
+
+
 set  -g mouse             off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12

--- a/tests/modules/programs/tmux/mouse-enabled.conf
+++ b/tests/modules/programs/tmux/mouse-enabled.conf
@@ -21,6 +21,8 @@ set -g mode-keys   emacs
 
 
 
+
+
 set  -g mouse             on
 setw -g aggressive-resize off
 setw -g clock-mode-style  12

--- a/tests/modules/programs/tmux/prefix.conf
+++ b/tests/modules/programs/tmux/prefix.conf
@@ -26,6 +26,8 @@ bind -N "Send the prefix key through to the application" \
 
 
 
+
+
 set  -g mouse             off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12

--- a/tests/modules/programs/tmux/shortcut-without-prefix.conf
+++ b/tests/modules/programs/tmux/shortcut-without-prefix.conf
@@ -27,6 +27,8 @@ bind C-a last-window
 
 
 
+
+
 set  -g mouse             off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12

--- a/tests/modules/programs/tmux/truecolor-enabled.conf
+++ b/tests/modules/programs/tmux/truecolor-enabled.conf
@@ -8,14 +8,12 @@ set  -g default-terminal "screen"
 set  -g base-index      0
 setw -g pane-base-index 0
 
-new-session
-
-bind -N "Split the pane into two, left and right" v split-window -h
-bind -N "Split the pane into two, top and bottom" s split-window -v
 
 
-set -g status-keys vi
-set -g mode-keys   vi
+
+
+set -g status-keys emacs
+set -g mode-keys   emacs
 
 
 
@@ -23,11 +21,13 @@ set -g mode-keys   vi
 
 
 
+set -g default-terminal "tmux-256color"
+set -ag terminal-overrides ",xterm-256color:RGB"
 
 
 set  -g mouse             off
-setw -g aggressive-resize on
-setw -g clock-mode-style  24
+setw -g aggressive-resize off
+setw -g clock-mode-style  12
 set  -s escape-time       500
 set  -g history-limit     2000
 

--- a/tests/modules/programs/tmux/truecolor-enabled.nix
+++ b/tests/modules/programs/tmux/truecolor-enabled.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.tmux = {
+      enable = true;
+      trueColor = true;
+    };
+
+    nixpkgs.overlays = [
+      (self: super: {
+        tmuxPlugins = super.tmuxPlugins // {
+          sensible = super.tmuxPlugins.sensible // { rtp = "@sensible_rtp@"; };
+        };
+      })
+    ];
+
+    nmt.script = ''
+      assertFileExists home-files/.config/tmux/tmux.conf
+      assertFileContent home-files/.config/tmux/tmux.conf \
+        ${./truecolor-enabled.conf}
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Adds True Color support based on [this gist](https://gist.github.com/andersevenrud/015e61af2fd264371032763d4ed965b6). There is a failing test in some unrelated module so I couldn't run _all_ tests, but I have tested each tmux test individually and fixed them accordingly.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
