### PR TITLE
aerc: respect accounts' GPG configurations

### DIFF
--- a/modules/programs/aerc-accounts.nix
+++ b/modules/programs/aerc-accounts.nix
@@ -230,7 +230,14 @@ in {
         else
           { };
 
+      pgpCfg = account: {
+        "pgp-auto-sign" = account.gpg.signByDefault;
+        "pgp-opportunistic-encrypt" = account.gpg.encryptByDefault;
+        "pgp-key-id" = account.gpg.key;
+      };
+
     in (basicCfg account) // (sourceCfg account) // (outgoingCfg account)
+    // lib.optionalAttrs (!isNull account.gpg) (pgpCfg account)
     // account.aerc.extraAccounts;
 
   mkAccountConfig = name: account:

--- a/tests/modules/programs/aerc/extraAccounts.expected
+++ b/tests/modules/programs/aerc/extraAccounts.expected
@@ -91,3 +91,9 @@ from = test <test@email.invalid>
 outgoing = imap+plain://intentionallyWrong:PaSsWorD@smtp.host.invalid:1337
 postpone = dRaFts
 source = smtp+plain://intentionallyWrong:PaSsWorD@smtp.host.invalid:1337
+
+[q_gpg]
+from = Foo Bar <addr@mail.invalid>
+pgp-auto-sign = true
+pgp-key-id = 00112233445566778899AABBCCDDEEFF
+pgp-opportunistic-encrypt = true

--- a/tests/modules/programs/aerc/settings.nix
+++ b/tests/modules/programs/aerc/settings.nix
@@ -260,6 +260,13 @@ with lib;
           };
         };
       };
+      q_gpg = basics // {
+        gpg = {
+          signByDefault = true;
+          encryptByDefault = true;
+          key = "00112233445566778899AABBCCDDEEFF";
+        };
+      };
     };
   };
 }


### PR DESCRIPTION
Fixes #4828.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@lukasngl 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
