### PR TITLE
lorri: unbreak due to too tight sandboxing

### DIFF
--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -52,6 +52,12 @@ in {
           PrivateTmp = true;
           ProtectSystem = "strict";
           ProtectHome = "read-only";
+          ReadWritePaths = [
+            # /run/user/1000 for the socket
+            "%t"
+            "/nix/var/nix/gcroots/per-user/%u"
+          ];
+          CacheDirectory = [ "lorri" ];
           Restart = "on-failure";
           Environment = let
             path = with pkgs;


### PR DESCRIPTION
lorri needs to be able to write to /run/user/uid for the socket, to its own cache directory ~/.cache/lorri and to the directory for gc roots.

I wonder how this ever worked. Did systemd change?

Please backport this change to 23.11

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

tests pass except for a hash mismatch with `trying https://keys.openpgp.org/pks/lookup?op=get&options=mr&search=0x36cacf52d098cc0e78fb0cb13573356c25c424d4`

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

cc @Gerschtli 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
