### PR TITLE
khal: fix contact integration

### DIFF
--- a/modules/accounts/contacts.nix
+++ b/modules/accounts/contacts.nix
@@ -126,6 +126,7 @@ in {
         contactOpts
         (import ../programs/vdirsyncer-accounts.nix)
         (import ../programs/khal-accounts.nix)
+        (import ../programs/khal-contact-accounts.nix)
       ]);
       default = { };
       description = "List of contacts.";

--- a/modules/programs/khal-accounts.nix
+++ b/modules/programs/khal-accounts.nix
@@ -44,7 +44,7 @@ with lib;
       type = types.int;
       default = 10;
       description = ''
-        Priority of a calendar used for coloring.
+        Priority of a calendar used for coloring (calendar with highest priority is preferred).
       '';
     };
   };

--- a/modules/programs/khal-accounts.nix
+++ b/modules/programs/khal-accounts.nix
@@ -13,5 +13,39 @@ with lib;
         Keep khal from making any changes to this account.
       '';
     };
+
+    color = mkOption {
+      type = types.nullOr (types.enum [
+        "black"
+        "white"
+        "brown"
+        "yellow"
+        "dark gray"
+        "dark green"
+        "dark blue"
+        "light gray"
+        "light green"
+        "light blue"
+        "dark magenta"
+        "dark cyan"
+        "dark red"
+        "light magenta"
+        "light cyan"
+        "light red"
+      ]);
+      default = null;
+      description = ''
+        Color in which events in this calendar are displayed.
+      '';
+      example = "light green";
+    };
+
+    priority = mkOption {
+      type = types.int;
+      default = 10;
+      description = ''
+        Priority of a calendar used for coloring.
+      '';
+    };
   };
 }

--- a/modules/programs/khal-calendar-accounts.nix
+++ b/modules/programs/khal-calendar-accounts.nix
@@ -20,39 +20,5 @@ with lib;
         type is set to discover.
       '';
     };
-
-    color = mkOption {
-      type = types.nullOr (types.enum [
-        "black"
-        "white"
-        "brown"
-        "yellow"
-        "dark gray"
-        "dark green"
-        "dark blue"
-        "light gray"
-        "light green"
-        "light blue"
-        "dark magenta"
-        "dark cyan"
-        "dark red"
-        "light magenta"
-        "light cyan"
-        "light red"
-      ]);
-      default = null;
-      description = ''
-        Color in which events in this calendar are displayed.
-      '';
-      example = "light green";
-    };
-
-    priority = mkOption {
-      type = types.int;
-      default = 10;
-      description = ''
-        Priority of a calendar used for coloring.
-      '';
-    };
   };
 }

--- a/modules/programs/khal-contact-accounts.nix
+++ b/modules/programs/khal-contact-accounts.nix
@@ -1,0 +1,15 @@
+{ config, lib, ... }:
+
+with lib;
+
+{
+  options.khal = {
+    collections = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      description = ''
+        VCARD collections to be searched for contact birthdays.
+      '';
+    };
+  };
+}

--- a/modules/programs/khal.nix
+++ b/modules/programs/khal.nix
@@ -12,13 +12,14 @@ let
   khalCalendarAccounts =
     filterAttrs (_: a: a.khal.enable) config.accounts.calendar.accounts;
 
-  khalContactAccounts = mapAttrs (_: v: v // { type = "birthdays"; })
+  khalContactAccounts =
+    mapAttrs (_: v: recursiveUpdate v { khal.type = "birthdays"; })
     (filterAttrs (_: a: a.khal.enable) config.accounts.contact.accounts);
 
   khalAccounts = khalCalendarAccounts // khalContactAccounts;
 
   primaryAccount = findSingle (a: a.primary) null null
-    (mapAttrsToList (n: v: v // { name = n; }) khalAccounts);
+    (mapAttrsToList (n: v: v // { name = n; }) khalCalendarAccounts);
 
   definedAttrs = filterAttrs (_: v: !isNull v);
 
@@ -153,7 +154,7 @@ in {
     locale = mkOption {
       type = lib.types.submodule { options = localeOptions; };
       description = ''
-        khal locale settings. 
+        khal locale settings.
       '';
       default = { };
     };

--- a/tests/modules/programs/khal/config.nix
+++ b/tests/modules/programs/khal/config.nix
@@ -36,10 +36,24 @@
     basePath = "$XDG_CONFIG_HOME/card";
     accounts = {
       testcontacts = {
-        khal.enable = true;
+        khal = {
+          enable = true;
+          collections = [ "default" "automaticallyCollected" ];
+        };
         local.type = "filesystem";
         local.fileExt = ".vcf";
         name = "testcontacts";
+        remote = {
+          type = "http";
+          url = "https://example.com/contacts.vcf";
+        };
+      };
+
+      testcontactsNoCollections = {
+        khal.enable = true;
+        local.type = "filesystem";
+        local.fileExt = ".vcf";
+        name = "testcontactsNoCollections";
         remote = {
           type = "http";
           url = "https://example.com/contacts.vcf";

--- a/tests/modules/programs/khal/config.nix
+++ b/tests/modules/programs/khal/config.nix
@@ -32,6 +32,22 @@
     };
   };
 
+  accounts.contact = {
+    basePath = "$XDG_CONFIG_HOME/card";
+    accounts = {
+      testcontacts = {
+        khal.enable = true;
+        local.type = "filesystem";
+        local.fileExt = ".vcf";
+        name = "testcontacts";
+        remote = {
+          type = "http";
+          url = "https://example.com/contacts.vcf";
+        };
+      };
+    };
+  };
+
   test.stubs = { khal = { }; };
 
   nmt.script = ''

--- a/tests/modules/programs/khal/khal-config-expected
+++ b/tests/modules/programs/khal/khal-config-expected
@@ -7,6 +7,13 @@ type=calendar
 
 
 
+[[testcontacts]]
+path = /home/hm-user/$XDG_CONFIG_HOME/card/testcontacts/
+priority=10
+type=birthdays
+
+
+
 [default]
 default_calendar=test
 highlight_event_days=true

--- a/tests/modules/programs/khal/khal-config-expected
+++ b/tests/modules/programs/khal/khal-config-expected
@@ -7,8 +7,22 @@ type=calendar
 
 
 
-[[testcontacts]]
-path = /home/hm-user/$XDG_CONFIG_HOME/card/testcontacts/
+[[testcontacts-automaticallyCollected]]
+path = /home/hm-user/$XDG_CONFIG_HOME/card/testcontacts/automaticallyCollected
+priority=10
+type=birthdays
+
+
+
+[[testcontacts-default]]
+path = /home/hm-user/$XDG_CONFIG_HOME/card/testcontacts/default
+priority=10
+type=birthdays
+
+
+
+[[testcontactsNoCollections]]
+path = /home/hm-user/$XDG_CONFIG_HOME/card/testcontactsNoCollections/
 priority=10
 type=birthdays
 


### PR DESCRIPTION
### Description

Currently, birthday calendars added to Khal via `accounts.contact` throw `error: attribute 'type' missing`. This PR:

- Fixes a bug to correctly add `khal.type = "birthdays"` to these calendars;
- Moves options `color`/`priority` to global Khal configuration (these options can also be set for birthday calendars, and Nix currently throws an error if non-defined);
- Adds multiple calendars for each contact collection (fixing an issue similar to #4531):
  - New option `khal.collections`;
  - Also supports null-collections (as seen [here](https://github.com/nix-community/home-manager/issues/4531#issuecomment-1748332523));

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@teto (git blame)