### PR TITLE
zsh: fix zprof typo

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -253,6 +253,7 @@ in
 {
   imports = [
     (mkRenamedOptionModule [ "programs" "zsh" "enableSyntaxHighlighting" ] [ "programs" "zsh" "syntaxHighlighting" "enable" ])
+    (mkRenamedOptionModule [ "programs" "zsh" "zproof" ] [ "programs" "zsh" "zprof" ])
   ];
 
   options = {
@@ -356,10 +357,10 @@ in
         description = "Enable zsh autosuggestions";
       };
 
-      zproof.enable = mkOption {
+      zprof.enable = mkOption {
         default = false;
         description = ''
-          Enable zproof in your zshrc.
+          Enable zprof in your zshrc.
         '';
       };
 
@@ -541,9 +542,9 @@ in
         ++ optional cfg.oh-my-zsh.enable cfg.oh-my-zsh.package;
 
       home.file."${relToDotDir ".zshrc"}".text = concatStringsSep "\n" ([
-        # zproof must be loaded before everything else, since it
+        # zprof must be loaded before everything else, since it
         # benchmarks the shell initialization.
-        (optionalString cfg.zproof.enable ''
+        (optionalString cfg.zprof.enable ''
           zmodload zsh/zprof
         '')
 
@@ -671,7 +672,7 @@ in
           }
         '')
 
-        (optionalString cfg.zproof.enable
+        (optionalString cfg.zprof.enable
         ''
           zprof
         '')


### PR DESCRIPTION
### Description

I made in typo in #4745.
It's spelled `zprof` and not `zproof`.
Thanks for noticing! @mrBliss

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
