### PR TITLE
firefox: add default containers

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -73,7 +73,24 @@ let
         version = 4;
         lastUserContextId =
           elemAt (mapAttrsToList (_: container: container.id) containers) 0;
-        identities = mapAttrsToList containerToIdentity containers;
+        identities = mapAttrsToList containerToIdentity containers ++ [
+          {
+            userContextId = 4294967294; # 2^32 - 2
+            name = "userContextIdInternal.thumbnail";
+            icon = "";
+            color = "";
+            accessKey = "";
+            public = false;
+          }
+          {
+            userContextId = 4294967295; # 2^32 - 1
+            name = "userContextIdInternal.webextStorageLocal";
+            icon = "";
+            color = "";
+            accessKey = "";
+            public = false;
+          }
+        ];
       }}
     '';
 
@@ -661,6 +678,20 @@ in {
         message = "Must have exactly one default Firefox profile but found "
           + toString (length defaults) + optionalString (length defaults > 1)
           (", namely " + concatStringsSep ", " defaults);
+      })
+
+      (let
+        getContainers = profiles:
+          flatten
+          (mapAttrsToList (_: value: (attrValues value.containers)) profiles);
+
+        findInvalidContainerIds = profiles:
+          filter (container: container.id >= 4294967294)
+          (getContainers profiles);
+      in {
+        assertion = cfg.profiles == { }
+          || length (findInvalidContainerIds cfg.profiles) == 0;
+        message = "Container id must be smaller than 4294967294 (2^32 - 2)";
       })
 
       (mkNoDuplicateAssertion cfg.profiles "profile")

--- a/tests/modules/programs/firefox/container-id-out-of-range.nix
+++ b/tests/modules/programs/firefox/container-id-out-of-range.nix
@@ -1,0 +1,27 @@
+{ config, lib, ... }:
+
+{
+  imports = [ ./setup-firefox-mock-overlay.nix ];
+
+  config = lib.mkIf config.test.enableBig {
+    test.asserts.assertions.expected =
+      [ "Container id must be smaller than 4294967294 (2^32 - 2)" ];
+
+    programs.firefox = {
+      enable = true;
+
+      profiles.my-profile = {
+        isDefault = true;
+        id = 1;
+
+        containers = {
+          "shopping" = {
+            id = 4294967294;
+            color = "blue";
+            icon = "circle";
+          };
+        };
+      };
+    };
+  };
+}

--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -4,5 +4,6 @@
   firefox-deprecated-native-messenger = ./deprecated-native-messenger.nix;
   firefox-duplicate-profile-ids = ./duplicate-profile-ids.nix;
   firefox-duplicate-container-ids = ./duplicate-container-ids.nix;
+  firefox-container-id-out-of-range = ./container-id-out-of-range.nix;
   firefox-policies = ./policies.nix;
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

`userContextIdInternal.webextStorageLocal` is used by certain extensions without they don't work correctly <https://searchfox.org/mozilla-central/rev/762f24e00a9548d80ebba1b985c871ba6d9b829d/toolkit/components/contextualidentity/ContextualIdentityService.sys.mjs#93-96>. `userContextIdInternal.thumbnail` is some default added by firefox, so I just added it as well.

> This userContextId is used by ExtensionStorageIDB.jsm to create an IndexedDB database
> opened with the extension principal but not directly accessible to the extension code
> (do not change the userContextId assigned here, otherwise the installed extensions will
> not be able to access the data previously stored with the browser.storage.local API).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

- @DamienCassou 
- @rycee 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
