### PR TITLE
alacritty: fix escape sequence in example and test

### DIFF
--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -32,7 +32,7 @@ in {
               {
                 key = "K";
                 mods = "Control";
-                chars = "\\x0c";
+                chars = "\\u000c";
               }
             ];
           }

--- a/tests/modules/programs/alacritty/settings-toml-expected.toml
+++ b/tests/modules/programs/alacritty/settings-toml-expected.toml
@@ -6,7 +6,7 @@ family = "SFMono"
 family = "SFMono"
 
 [[keyboard.bindings]]
-chars = "\x0c"
+chars = "\u000c"
 key = "K"
 mods = "Control"
 

--- a/tests/modules/programs/alacritty/toml_config.nix
+++ b/tests/modules/programs/alacritty/toml_config.nix
@@ -15,7 +15,7 @@
         keyboard.bindings = [{
           key = "K";
           mods = "Control";
-          chars = "\\x0c";
+          chars = "\\u000c";
         }];
 
         font = {


### PR DESCRIPTION
### Description

See https://github.com/nix-community/home-manager/pull/4817#discussion_r1441710049

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@ncfavier

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
