### PR TITLE
alacritty: post 0.13 cleanup

### DIFF
--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -4,9 +4,7 @@ with lib;
 
 let
   cfg = config.programs.alacritty;
-  useToml = lib.versionAtLeast cfg.package.version "0.13";
   tomlFormat = pkgs.formats.toml { };
-  configFileName = "alacritty.${if useToml then "toml" else "yml"}";
 in {
   options = {
     programs.alacritty = {
@@ -52,24 +50,15 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."alacritty/${configFileName}" =
-      lib.mkIf (cfg.settings != { }) (lib.mkMerge [
-        (lib.mkIf useToml {
-          source =
-            (tomlFormat.generate configFileName cfg.settings).overrideAttrs
-            (finalAttrs: prevAttrs: {
-              buildCommand = lib.concatStringsSep "\n" [
-                prevAttrs.buildCommand
-                # TODO: why is this needed? Is there a better way to retain escape sequences?
-                "substituteInPlace $out --replace '\\\\' '\\'"
-              ];
-            });
-        })
-        # TODO remove this once we don't need to support Alacritty < 0.12 anymore
-        (lib.mkIf (!useToml) {
-          text =
-            replaceStrings [ "\\\\" ] [ "\\" ] (builtins.toJSON cfg.settings);
-        })
-      ]);
+    xdg.configFile."alacritty/alacritty.toml" = lib.mkIf (cfg.settings != { }) {
+      source = (tomlFormat.generate "alacritty.toml" cfg.settings).overrideAttrs
+        (finalAttrs: prevAttrs: {
+          buildCommand = lib.concatStringsSep "\n" [
+            prevAttrs.buildCommand
+            # TODO: why is this needed? Is there a better way to retain escape sequences?
+            "substituteInPlace $out --replace '\\\\' '\\'"
+          ];
+        });
+    };
   };
 }

--- a/tests/modules/programs/alacritty/empty-settings.nix
+++ b/tests/modules/programs/alacritty/empty-settings.nix
@@ -1,7 +1,3 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
-
 {
   config = {
     programs.alacritty.enable = true;

--- a/tests/modules/programs/alacritty/example-settings-expected.toml
+++ b/tests/modules/programs/alacritty/example-settings-expected.toml
@@ -1,5 +1,5 @@
 [[keyboard.bindings]]
-chars = "\x0c"
+chars = "\u000c"
 key = "K"
 mods = "Control"
 

--- a/tests/modules/programs/alacritty/example-settings.nix
+++ b/tests/modules/programs/alacritty/example-settings.nix
@@ -1,12 +1,10 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
   config = {
     programs.alacritty = {
       enable = true;
-      package = config.lib.test.mkStubPackage { version = "0.13.0"; };
+      package = config.lib.test.mkStubPackage { };
 
       settings = {
         window.dimensions = {
@@ -17,7 +15,7 @@ with lib;
         keyboard.bindings = [{
           key = "K";
           mods = "Control";
-          chars = "\\x0c";
+          chars = "\\u000c";
         }];
       };
     };

--- a/tests/modules/programs/alacritty/settings-merging-expected.yml
+++ b/tests/modules/programs/alacritty/settings-merging-expected.yml
@@ -1,1 +1,0 @@
-{"font":{"bold":{"family":"SFMono"},"normal":{"family":"SFMono"}},"key_bindings":[{"chars":"\x0c","key":"K","mods":"Control"}],"window":{"dimensions":{"columns":200,"lines":3}}}

--- a/tests/modules/programs/alacritty/settings-merging.nix
+++ b/tests/modules/programs/alacritty/settings-merging.nix
@@ -1,12 +1,10 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, lib, ... }:
 
 {
   config = {
     programs.alacritty = {
       enable = true;
-      package = config.lib.test.mkStubPackage { version = "0.12.3"; };
+      package = config.lib.test.mkStubPackage { };
 
       settings = {
         window.dimensions = {
@@ -14,10 +12,10 @@ with lib;
           columns = 200;
         };
 
-        key_bindings = [{
+        keyboard.bindings = [{
           key = "K";
           mods = "Control";
-          chars = "\\x0c";
+          chars = "\\u000c";
         }];
 
         font = let
@@ -32,8 +30,8 @@ with lib;
 
     nmt.script = ''
       assertFileContent \
-        home-files/.config/alacritty/alacritty.yml \
-        ${./settings-merging-expected.yml}
+        home-files/.config/alacritty/alacritty.toml \
+        ${./settings-toml-expected.toml}
     '';
   };
 }

--- a/tests/modules/programs/alacritty/toml_config.nix
+++ b/tests/modules/programs/alacritty/toml_config.nix
@@ -4,7 +4,7 @@
   config = {
     programs.alacritty = {
       enable = true;
-      package = config.lib.test.mkStubPackage { version = "0.13.0"; };
+      package = config.lib.test.mkStubPackage { };
 
       settings = {
         window.dimensions = {


### PR DESCRIPTION
### Description

This is based on top of #4853. It removes the compat code for 0.12, which is no longer in nixpkgs.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@ncfavier

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
