### PR TITLE
gh: only run migration when required

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -137,7 +137,7 @@ in {
     home.activation.migrateGhAccounts =
       let ghHosts = "${config.xdg.configHome}/gh/hosts.yml";
       in hm.dag.entryBetween [ "linkGeneration" ] [ "writeBoundary" ] ''
-        if [[ ! -L "${ghHosts}" && -f "${ghHosts}" ]]; then
+        if [[ ! -L "${ghHosts}" && -f "${ghHosts}" && $(grep --invert-match --quiet '^version:' ${ghHosts}) ]]; then
           (
             TMP_DIR=$(mktemp -d)
             trap "rm --force --recursive $TMP_DIR" EXIT


### PR DESCRIPTION
### Description

We currently run the migration unconditionally which can cause the `home-manager-$user.service` unit to fail if the gh auth token is stored in the OS keychain, since the keychain is not accessible when the service runs on system boot. Adding a simple test to skip the migration if it's already done works around this problem.

Fixes #4816 

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee
