### PR TITLE
gh-pages: add redirect from options.html to options.xhtml

### DIFF
--- a/options.html
+++ b/options.html
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+ <title>Redirecting to options.xhtml</title>
+ <link rel="canonical" href="options.xhtml">
+ <meta http-equiv="refresh" content="3; url=options.xhtml">
+ <script>
+   function redirect() {
+     window.location.replace("options.xhtml" + document.location.hash);
+   }
+   if (document.readyState === 'complete') {
+     redirect();
+   } else {
+     window.addEventListener("load", redirect);
+   }
+ </script>
+<link rel="stylesheet" type="text/css" href="style.css" /><link rel="stylesheet" type="text/css" href="highlightjs/tomorrow-night.min.css" /><link rel="stylesheet" type="text/css" href="highlightjs/highlight-style.css" />
+<script src="highlightjs/highlight.pack.js" type="text/javascript"></script><script src="highlightjs/loader.js" type="text/javascript"></script>
+ <meta name="generator" content="nixos-render-docs" />
+ <link rel="home" href="index.xhtml" title="Home Manager Manual" />
+ <link rel="up" href="index.xhtml" title="Home Manager Manual" /><link rel="prev" href="index.xhtml" title="Home Manager Manual" /><link rel="next" href="nixos-options.xhtml" title="Appendix B. NixOS Configuration Options" />
+ </head>
+ <body>
+   <p>Click <a href="options.xhtml">here</a> if you are not redirected in a few seconds.</p>
+ </body>
+</html>


### PR DESCRIPTION
### Description

Adds potential workaround for links that are pointing to html page instead of xhtml.
https://nix-community.github.io/home-manager/options.html
instead of:
https://nix-community.github.io/home-manager/options.xhtml

Issues/questions:
1. If there is a need for that redirect or people should just update links to xhtml.
2. If there is a need for similar redirects for other pages (like `nixos-options.html`).
One for `index.html` is problematic as it is loaded by default, so links to:
https://nix-community.github.io/home-manager
would point to:
https://nix-community.github.io/home-manager/index.html
and will always go through that redirect.
3. Potential changes to redirect page.

Link to test redirect from this PR:
https://ghpzin.github.io/home-manager/options.html#opt-_module.args
Current behavior - default 404:
https://nix-community.github.io/home-manager/options.html#opt-_module.args

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
