### PR TITLE
introduce `accounts.email.order` for aerc accounts

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -509,6 +509,13 @@ in {
       default = { };
       description = "List of email accounts.";
     };
+
+    order = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description =
+        "Order of email accounts from [](#opt-accounts.email.accounts).";
+    };
   };
 
   config = mkIf (cfg.accounts != { }) {

--- a/modules/programs/aerc.nix
+++ b/modules/programs/aerc.nix
@@ -23,6 +23,9 @@ let
 
   aerc-accounts =
     attrsets.filterAttrs (_: v: v.aerc.enable) config.accounts.email.accounts;
+  aerc-accounts-order =
+    builtins.filter (n: config.accounts.email.accounts.${n}.aerc.enable)
+    config.accounts.email.order;
 
   configDir = if (pkgs.stdenv.isDarwin && !config.xdg.enable) then
     "Library/Preferences/aerc"
@@ -136,11 +139,15 @@ in {
     });
 
     primaryAccount = attrsets.filterAttrs (_: v: v.primary) aerc-accounts;
-    otherAccounts = attrsets.filterAttrs (_: v: !v.primary) aerc-accounts;
+    orderedAccountsList =
+      builtins.map (n: { ${n} = aerc-accounts."${n}"; }) aerc-accounts-order;
+    unorderedAccounts = attrsets.filterAttrs
+      (n: v: !v.primary && !builtins.elem n aerc-accounts-order) aerc-accounts;
 
     primaryAccountAccounts = mapAttrs accounts.mkAccount primaryAccount;
-
-    accountsExtraAccounts = mapAttrs accounts.mkAccount otherAccounts;
+    orderedAccountsAccountsList =
+      builtins.map (mapAttrs accounts.mkAccount) orderedAccountsList;
+    unorderedAccountsAccounts = mapAttrs accounts.mkAccount unorderedAccounts;
 
     accountsExtraConfig = mapAttrs accounts.mkAccountConfig aerc-accounts;
 
@@ -155,7 +162,9 @@ in {
         false;
 
     genAccountsConf = ((cfg.extraAccounts != "" && cfg.extraAccounts != { })
-      || !(isRecursivelyEmpty accountsExtraAccounts)
+      || !(isRecursivelyEmpty unorderedAccountsAccounts)
+      || !(builtins.all (v: v)
+        (builtins.map isRecursivelyEmpty orderedAccountsAccountsList))
       || !(isRecursivelyEmpty primaryAccountAccounts));
 
     genAercConf = ((cfg.extraConfig != "" && cfg.extraConfig != { })
@@ -197,12 +206,10 @@ in {
 
     home.file = {
       "${configDir}/accounts.conf" = mkIf genAccountsConf {
-        text = joinCfg [
-          header
-          (mkINI cfg.extraAccounts)
-          (mkINI primaryAccountAccounts)
-          (mkINI accountsExtraAccounts)
-        ];
+        text = joinCfg
+          ([ header (mkINI cfg.extraAccounts) (mkINI primaryAccountAccounts) ]
+            ++ (builtins.map mkINI orderedAccountsAccountsList)
+            ++ [ (mkINI unorderedAccountsAccounts) ]);
       };
 
       "${configDir}/aerc.conf" = mkIf genAercConf {


### PR DESCRIPTION
### Description

Nix does not preserve attrset order, instead sorting attributes by alphabetical order https://github.com/NixOS/nixpkgs/issues/81986.

However, aerc displays accounts based on their order in `.config/aerc/accounts.conf`.

This PR introduces a `accounts.email.order` list that provides an optional order for accounts in `accounts.email.accounts`.

I implement support for this in the `aerc` module, and I suspect other front-ends might also be able to benefit from this.

 If a partial order is provided those will be ordered after the primary account, and any unordered accounts will be included with the previous alphabetical behavior after.

### Checklist

- [x] Change is backwards compatible.
    - The primary account is still displayed first and if no order list is provided the previous behavior is maintained.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@lukasngl