### PR TITLE
aerc: notmuch support

### DIFF
--- a/modules/programs/aerc-accounts.nix
+++ b/modules/programs/aerc-accounts.nix
@@ -114,6 +114,8 @@ in {
         };
 
         smtpOauth2Params = oauth2Params;
+
+        notmuch.enable = mkEnableOption "notmuch";
       };
     });
   };
@@ -140,6 +142,13 @@ in {
           "";
 
       mkConfig = {
+        notmuch = cfg:
+          {
+            source = "notmuch://${config.accounts.email.maildirBasePath}";
+            maildir-account-path = "${cfg.maildir.path}";
+            maildir-store = "${config.accounts.email.maildirBasePath}";
+          };
+
         maildir = cfg: {
           source =
             "maildir://${config.accounts.email.maildirBasePath}/${cfg.maildir.path}";
@@ -212,7 +221,9 @@ in {
         // (optAttr "aliases" account.aliases);
 
       sourceCfg = account:
-        if account.mbsync.enable && account.mbsync.flatten == null
+        if account.aerc.notmuch.enable then
+          mkConfig.notmuch account
+        else if account.mbsync.enable && account.mbsync.flatten == null
         && account.mbsync.subFolders == "Maildir++" then
           mkConfig.maildirpp account
         else if account.mbsync.enable || account.offlineimap.enable then


### PR DESCRIPTION
### Description

This configures a notmuch backend for aerc as specified by `man aerc-notmuch`.

### Checklist

- [x] Change is backwards compatible.
    - Any people using notmuch and aerc will be upgraded to a notmuch backend.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@lukasngl