### PR TITLE
thefuck: updated fish integration

### DIFF
--- a/modules/programs/thefuck.nix
+++ b/modules/programs/thefuck.nix
@@ -50,20 +50,8 @@ with lib;
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration shEvalCmd;
 
-    programs.fish.functions = mkIf cfg.enableFishIntegration {
-      fuck = {
-        description = "Correct your previous console command";
-        body = ''
-          set -l fucked_up_command $history[1]
-          env TF_SHELL=fish TF_ALIAS=fuck PYTHONIOENCODING=utf-8 ${cfg.package}/bin/thefuck $fucked_up_command THEFUCK_ARGUMENT_PLACEHOLDER $argv | read -l unfucked_command
-          if [ "$unfucked_command" != "" ]
-            eval $unfucked_command
-            builtin history delete --exact --case-sensitive -- $fucked_up_command
-            builtin history merge
-          end
-        '';
-      };
-    };
+    programs.fish.interactiveShellInit =
+      mkIf cfg.enableFishIntegration shEvalCmd;
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration shEvalCmd;
   };

--- a/tests/modules/programs/thefuck/integration-disabled.nix
+++ b/tests/modules/programs/thefuck/integration-disabled.nix
@@ -7,6 +7,7 @@
     thefuck.enableFishIntegration = false;
     thefuck.enableZshIntegration = false;
     bash.enable = true;
+    fish.enable = true;
     zsh.enable = true;
   };
 
@@ -14,7 +15,7 @@
 
   nmt.script = ''
     assertFileNotRegex home-files/.bashrc '@thefuck@/bin/thefuck'
-    assertPathNotExists home-files/.config/fish/functions/fuck.fish
+    assertFileNotRegex home-files/.config/fish/config.fish '@thefuck@/bin/thefuck'
     assertFileNotRegex home-files/.zshrc '@thefuck@/bin/thefuck'
   '';
 }

--- a/tests/modules/programs/thefuck/integration-enabled-instant.nix
+++ b/tests/modules/programs/thefuck/integration-enabled-instant.nix
@@ -7,6 +7,7 @@
       enableInstantMode = true;
     };
     bash.enable = true;
+    fish.enable = true;
     zsh.enable = true;
   };
 
@@ -16,6 +17,11 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
+      'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"' '"'"'--enable-experimental-instant-mode'"'"')"'
+
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
       'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"' '"'"'--enable-experimental-instant-mode'"'"')"'
 
     assertFileExists home-files/.zshrc

--- a/tests/modules/programs/thefuck/integration-enabled.nix
+++ b/tests/modules/programs/thefuck/integration-enabled.nix
@@ -16,18 +16,10 @@
       home-files/.bashrc \
       'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"')"'
 
-    assertFileExists home-files/.config/fish/functions/fuck.fish
+    assertFileExists home-files/.config/fish/config.fish
     assertFileContains \
-      home-files/.config/fish/functions/fuck.fish \
-      'function fuck --description="Correct your previous console command"
-          set -l fucked_up_command $history[1]
-          env TF_SHELL=fish TF_ALIAS=fuck PYTHONIOENCODING=utf-8 @thefuck@/bin/thefuck $fucked_up_command THEFUCK_ARGUMENT_PLACEHOLDER $argv | read -l unfucked_command
-          if [ "$unfucked_command" != "" ]
-              eval $unfucked_command
-              builtin history delete --exact --case-sensitive -- $fucked_up_command
-              builtin history merge
-          end
-      end'
+      home-files/.config/fish/config.fish \
+      'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"')"'
 
     assertFileExists home-files/.zshrc
     assertFileContains \


### PR DESCRIPTION
### Description

The documentation seems to indicate we can use the same way to init fish that we use in bash and zsh:

https://github.com/nvbn/thefuck/wiki/Shell-aliases#fish


This makes that change and updates the tests.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
