### PR TITLE
swayosd: update executable

### DIFF
--- a/modules/services/swayosd.nix
+++ b/modules/services/swayosd.nix
@@ -16,12 +16,22 @@ in {
 
     package = mkPackageOption pkgs "swayosd" { };
 
-    maxVolume = mkOption {
-      type = types.nullOr types.ints.unsigned;
+    topMargin = mkOption {
+      type = types.nullOr (types.addCheck types.float (f: f >= 0.0 && f <= 1.0)
+        // {
+          description = "float between 0.0 and 1.0 (inclusive)";
+        });
       default = null;
-      example = 120;
+      example = 1.0;
+      description = "OSD margin from top edge (0.5 would be screen center).";
+    };
+
+    display = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "eDP-1";
       description = ''
-        Sets the maximum volume.
+        X display to use.
       '';
     };
   };
@@ -45,9 +55,10 @@ in {
 
         Service = {
           Type = "simple";
-          ExecStart = "${cfg.package}/bin/swayosd"
-            + (optionalString (cfg.maxVolume != null)
-              " --max-volume ${toString cfg.maxVolume}");
+          ExecStart = "${cfg.package}/bin/swayosd-server"
+            + (optionalString (cfg.display != null) " --display ${cfg.display}")
+            + (optionalString (cfg.topMargin != null)
+              " --top-margin ${toString cfg.topMargin}");
           Restart = "always";
         };
 

--- a/tests/modules/services/swayosd/swayosd.nix
+++ b/tests/modules/services/swayosd/swayosd.nix
@@ -7,7 +7,8 @@
       name = "swayosd";
       outPath = "@swayosd@";
     };
-    maxVolume = 10;
+    display = "DISPLAY";
+    topMargin = 0.1;
   };
 
   nmt.script = ''
@@ -19,7 +20,7 @@
           WantedBy=graphical-session.target
 
           [Service]
-          ExecStart=@swayosd@/bin/swayosd --max-volume 10
+          ExecStart=@swayosd@/bin/swayosd-server --display DISPLAY --top-margin 0.100000
           Restart=always
           Type=simple
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Replaces swayosd dinary with swayosd-server new one.
Closes  #4857

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible. NOTE! max volume parameter removed due to changed cli interface

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
