### PR TITLE
listenbrainz-mpd: use sdnotify when possible

### DIFF
--- a/modules/services/listenbrainz-mpd.nix
+++ b/modules/services/listenbrainz-mpd.nix
@@ -40,6 +40,10 @@ in {
         ExecStart = "${cfg.package}/bin/listenbrainz-mpd";
         Restart = "always";
         RestartSec = 5;
+        Type = if lib.versionAtLeast cfg.package.version "2.3.2" then
+          "notify"
+        else
+          "simple";
       };
       Install.WantedBy = [ "default.target" ];
     };


### PR DESCRIPTION
### Description
The ability for listenbrainz-mpd to notify systemd when it's ready was added in 2.3.2: <https://codeberg.org/elomatreb/listenbrainz-mpd/releases/tag/v2.3.2>

listenbrainz-mpd in Nixpkgs is built with the `systemd` feature enabled, so this just works.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Scrumplex 
