### PR TITLE
Use nmt and nmd from Nixpkgs

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -7,10 +7,7 @@
 
 let
 
-  nmdSrc = fetchTarball {
-    url = "https://rycee.net/nmd.tar.gz";
-    sha256 = "123pvsnwnha0zivk77yzdvqakn96l17n8lwa78s2h1njlgkw0ng2";
-  };
+  nmdSrc = pkgs.nix-lib-nmd;
 
   nmd = import nmdSrc {
     inherit lib;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4,12 +4,6 @@ let
 
   lib = import ../modules/lib/stdlib-extended.nix pkgs.lib;
 
-  nmt = fetchTarball {
-    url =
-      "https://gitlab.com/api/v4/projects/rycee%2Fnmt/repository/archive.tar.gz?sha=4df00c569b1badfedffecd7ccd60f794550486db";
-    sha256 = "1cyly1zazgj8z6bazml4js7lqaqvpp8lw045aqchlpvp42bl1lp4";
-  };
-
   modules = import ../modules/modules.nix {
     inherit lib pkgs;
     check = false;
@@ -39,7 +33,7 @@ let
   isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
   isLinux = pkgs.stdenv.hostPlatform.isLinux;
 
-in import nmt {
+in import pkgs.nix-lib-nmt {
   inherit lib pkgs modules;
   testedAttrPath = [ "home" "activationPackage" ];
   tests = builtins.foldl' (a: b: a // (import b)) { } ([


### PR DESCRIPTION
### Description

Fixes #4879

Depends on https://github.com/NixOS/nixpkgs/pull/280467 being in NixOS unstable.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```