### PR TITLE
home-manager: Check VISUAL before EDITOR for editor

### DIFF
--- a/docs/home-manager.1
+++ b/docs/home-manager.1
@@ -97,7 +97,7 @@ Instantiate the configuration and print the resulting derivation\&.
 
 .It Cm edit
 .RS 16
-Open the home configuration using the editor indicated by \fBEDITOR\fR\&.
+Open the home configuration using the editor indicated by \fBVISUAL\fR or \fBEDITOR\fR\&.
 .RE
 .Pp
 

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -571,10 +571,14 @@ function presentNews() {
 }
 
 function doEdit() {
-    if [[ ! -v EDITOR || -z $EDITOR ]]; then
-        # shellcheck disable=2016
-        _i 'Please set the $EDITOR environment variable' >&2
-        return 1
+    if [[ ! -v VISUAL || -z $VISUAL ]]; then
+        if [[ ! -v EDITOR || -z $EDITOR ]]; then
+            # shellcheck disable=2016
+            _i 'Please set the $EDITOR or $VISUAL environment variable' >&2
+            return 1
+        fi
+    else
+        EDITOR=$VISUAL
     fi
 
     setConfigFile
@@ -888,7 +892,7 @@ function doHelp() {
     echo
     echo "  help         Print this help"
     echo
-    echo "  edit         Open the home configuration in \$EDITOR"
+    echo "  edit         Open the home configuration in \$VISUAL or \$EDITOR"
     echo
     echo "  option OPTION.NAME"
     echo "               Inspect configuration option named OPTION.NAME."


### PR DESCRIPTION
Check VISUAL for a visual editor before EDITOR, as per Unix convention
and as followed by Git, crontab, mutt, and other tools.
