### PR TITLE
firefox: bring back backward compatibility for extraPolicies

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -172,7 +172,7 @@ let
     else if versionAtLeast config.home.stateVersion "19.09" then
       package.override (old: {
         cfg = old.cfg or { } // fcfg;
-        extraPolicies = cfg.policies;
+        extraPolicies = (old.extraPolicies or { }) // cfg.policies;
       })
     else
       (pkgs.wrapFirefox.override { config = bcfg; }) package { };

--- a/tests/modules/programs/firefox/policies.nix
+++ b/tests/modules/programs/firefox/policies.nix
@@ -9,6 +9,9 @@
     programs.firefox = {
       enable = true;
       policies = { BlockAboutConfig = true; };
+      package = pkgs.firefox.override {
+        extraPolicies = { DownloadDirectory = "/foo"; };
+      };
     };
 
     nmt.script = ''
@@ -16,10 +19,17 @@
       config_file="${config.programs.firefox.finalPackage}/lib/firefox/distribution/policies.json"
 
       assertFileExists "$config_file"
+
       blockAboutConfig_actual_value="$($jq ".policies.BlockAboutConfig" $config_file)"
 
       if [[ $blockAboutConfig_actual_value != "true" ]]; then
         fail "Expected '$config_file' to set 'policies.BlockAboutConfig' to true"
+      fi
+
+      downloadDirectory_actual_value="$($jq ".policies.DownloadDirectory" $config_file)"
+
+      if [[ $downloadDirectory_actual_value != "\"/foo\"" ]]; then
+        fail "Expected '$config_file' to set 'policies.DownloadDirectory' to \"/foo\""
       fi
     '';
   };


### PR DESCRIPTION
### Description

This PR makes it possible to specify Firefox' extraPolicies through:

    programs.firefox.package = pkgs.firefox.override {
      extraPolicies = {... }
    }

This was possible in the past but was broken by:

  3feeb7715584fd45ed1389cec8fb15f6930e8dab
  firefox: add support for specifying policies (#4626)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@jian-lin @rycee 