### PR TITLE
gh: add github gist to default credential hosts

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -104,7 +104,7 @@ in {
 
       hosts = mkOption {
         type = types.listOf types.str;
-        default = [ "https://github.com" ];
+        default = [ "https://github.com" "https://gist.github.com" ];
         description = "GitHub hosts to enable the gh git credential helper for";
         example = literalExpression ''
           [ "https://github.com" "https://github.example.com" ]


### PR DESCRIPTION
### Description

We should add `gist.github.com` to credential hosts in `.gitconfig` to match the default behavior of gh. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Gerschtli @berbiche 
