### PR TITLE
hyprland: do not override existing plugins settings in config

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -207,7 +207,8 @@ in {
             else
               entry;
         in map mkEntry cfg.plugins;
-      };
+      } // lib.mapAttrs' (n: v: lib.nameValuePair "plugin:${n}" v)
+        (lib.attrByPath [ "plugin" ] { } cfg.settings);
 
       shouldGenerate = cfg.systemd.enable || cfg.extraConfig != ""
         || combinedSettings != { };

--- a/tests/modules/services/window-managers/hyprland/simple-config.conf
+++ b/tests/modules/services/window-managers/hyprland/simple-config.conf
@@ -26,6 +26,13 @@ input {
   follow_mouse=1
   kb_layout=ro
 }
+
+plugin:plugin1 {
+  section {
+    other=dummy setting
+  }
+  dummy=plugin setting
+}
 bindm=$mod, mouse:272, movewindow
 bindm=$mod, mouse:273, resizewindow
 bindm=$mod ALT, mouse:272, resizewindow

--- a/tests/modules/services/window-managers/hyprland/simple-config.nix
+++ b/tests/modules/services/window-managers/hyprland/simple-config.nix
@@ -45,6 +45,13 @@
         "$mod, mouse:273, resizewindow"
         "$mod ALT, mouse:272, resizewindow"
       ];
+
+      plugin = {
+        plugin1 = {
+          dummy = "plugin setting";
+          section = { other = "dummy setting"; };
+        };
+      };
     };
     extraConfig = ''
       # window resize


### PR DESCRIPTION
The plugin setting in the hyprland config is used both for defining plugin paths and configuring the plugins. This fix removes the silent override of the plugins settings converting them to the `plugin:<name> { ...settings }` syntax.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@fufexan 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
