### PR TITLE
gradle: Don't enable programs.java

### DIFF
--- a/modules/programs/gradle.nix
+++ b/modules/programs/gradle.nix
@@ -110,7 +110,5 @@ in {
     home.sessionVariables = mkIf (cfg.home != defaultHomeDirectory) {
       GRADLE_USER_HOME = gradleHome;
     };
-
-    programs.java.enable = true;
   };
 }


### PR DESCRIPTION
The gradle package from nixpkgs will install a default Java version and
pass it to the gradle executable without polluting the global env.
Users can customize this by overriding the gradle package like so:

```nix
  programs.gradle = {
    package = (pkgs.gradle.override {
      java = pkgs.jdk21;
    });
  }
```