### PR TITLE
docs, tests: revert to fetchTarball for nmd and nmt

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -7,7 +7,10 @@
 
 let
 
-  nmdSrc = pkgs.nix-lib-nmd;
+  nmdSrc = fetchTarball {
+    url = "https://git.sr.ht/~rycee/nmd/archive/v0.5.0.tar.gz";
+    sha256 = "0hnd86jd19zb5j3hmpwmdmdiasg65lgahqv7n8frl9p1vdqz6z67";
+  };
 
   nmd = import nmdSrc {
     inherit lib;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4,6 +4,11 @@ let
 
   lib = import ../modules/lib/stdlib-extended.nix pkgs.lib;
 
+  nmtSrc = fetchTarball {
+    url = "https://git.sr.ht/~rycee/nmt/archive/v0.5.1.tar.gz";
+    sha256 = "0qhn7nnwdwzh910ss78ga2d00v42b0lspfd7ybl61mpfgz3lmdcj";
+  };
+
   modules = import ../modules/modules.nix {
     inherit lib pkgs;
     check = false;
@@ -33,7 +38,7 @@ let
   isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
   isLinux = pkgs.stdenv.hostPlatform.isLinux;
 
-in import pkgs.nix-lib-nmt {
+in import nmtSrc {
   inherit lib pkgs modules;
   testedAttrPath = [ "home" "activationPackage" ];
   tests = builtins.foldl' (a: b: a // (import b)) { } ([


### PR DESCRIPTION

### Description

Turns out pulling nmt and nmd from Nixpkgs causes an IFD, even when the packages are fixed-output derivations. I don't particularly understand why referring to a fixed-output derivation inside Nixpkgs would cause an IFD but after experimenting a bit I could not find any good way to resolve it.

Thus, since Sourcehut is up and well, we can revert to simply fetching nmd and nmt directly.

See discussion in <https://github.com/nix-community/home-manager/pull/4884>.

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```