### PR TITLE
mcfly: Add mcfly-fzf integration

### DIFF
--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -5,6 +5,24 @@ let
 
   cfg = config.programs.mcfly;
 
+  bashIntegration = ''
+    eval "$(${getExe pkgs.mcfly} init bash)"
+  '' + optionalString cfg.fzf.enable ''
+    eval "$(${getExe pkgs.mcfly-fzf} init bash)"
+  '';
+
+  fishIntegration = ''
+    ${getExe pkgs.mcfly} init fish | source
+  '' + optionalString cfg.fzf.enable ''
+    ${getExe pkgs.mcfly-fzf} init fish | source
+  '';
+
+  zshIntegration = ''
+    eval "$(${getExe pkgs.mcfly} init zsh)"
+  '' + optionalString cfg.fzf.enable ''
+    eval "$(${getExe pkgs.mcfly-fzf} init zsh)"
+  '';
+
 in {
   meta.maintainers = [ ];
 
@@ -29,6 +47,8 @@ in {
         Key scheme to use.
       '';
     };
+
+    fzf.enable = mkEnableOption "McFly fzf integration";
 
     enableLightTheme = mkOption {
       default = false;
@@ -75,19 +95,13 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
-      home.packages = [ pkgs.mcfly ];
+      home.packages = [ pkgs.mcfly ] ++ optional cfg.fzf.enable pkgs.mcfly-fzf;
 
-      programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-        eval "$(${pkgs.mcfly}/bin/mcfly init bash)"
-      '';
+      programs.bash.initExtra = mkIf cfg.enableBashIntegration bashIntegration;
 
-      programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-        eval "$(${pkgs.mcfly}/bin/mcfly init zsh)"
-      '';
+      programs.zsh.initExtra = mkIf cfg.enableZshIntegration zshIntegration;
 
-      programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
-        ${pkgs.mcfly}/bin/mcfly init fish | source
-      '';
+      programs.fish.shellInit = mkIf cfg.enableFishIntegration fishIntegration;
 
       home.sessionVariables.MCFLY_KEY_SCHEME = cfg.keyScheme;
     }


### PR DESCRIPTION
### Description
This PR adds integration for [mc-fly](https://github.com/bnprks/mcfly-fzf), what it does it just adds `eval "$(${pkgs.mcfly-fzf}/bin/mcfly-fzf init $shell)"` to each of the shells (bash, zsh, and fish) right after mcfly's initialization script. This is ensures mcfly-fzf is loaded in order (it has to be loaded after mcfly); also checks if any of the shell integrations are disabled (since if those are disabled, then there's no way to add the initialization script for it anyway). 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@marsam 
@aisamu 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
