### PR TITLE
hyprland: change plugins settings generation

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -199,19 +199,8 @@ in {
     home.packages = lib.optional (cfg.package != null) cfg.finalPackage;
 
     xdg.configFile."hypr/hyprland.conf" = let
-      combinedSettings = cfg.settings // {
-        plugin = let
-          mkEntry = entry:
-            if lib.types.package.check entry then
-              "${entry}/lib/lib${entry.pname}.so"
-            else
-              entry;
-        in map mkEntry cfg.plugins;
-      } // lib.mapAttrs' (n: v: lib.nameValuePair "plugin:${n}" v)
-        (lib.attrByPath [ "plugin" ] { } cfg.settings);
-
       shouldGenerate = cfg.systemd.enable || cfg.extraConfig != ""
-        || combinedSettings != { };
+        || cfg.settings != { } || cfg.plugins != [ ];
 
       toHyprconf = with lib;
         attrs: indentLevel:
@@ -230,17 +219,29 @@ in {
           };
           allFields = filterAttrs (n: v: !(isAttrs v)) attrs;
           importantFields = filterAttrs (n: _:
-            (hasPrefix "$" n) || (hasPrefix "bezier" n) || (n == "plugin")
+            (hasPrefix "$" n) || (hasPrefix "bezier" n)
             || (cfg.sourceFirst && (hasPrefix "source" n))) allFields;
           fields = builtins.removeAttrs allFields
             (mapAttrsToList (n: _: n) importantFields);
         in mkFields importantFields
         + concatStringsSep "\n" (mapAttrsToList mkSection sections)
         + mkFields fields;
+
+      pluginsToHyprconf = plugins:
+        toHyprconf {
+          plugin = let
+            mkEntry = entry:
+              if lib.types.package.check entry then
+                "${entry}/lib/lib${entry.pname}.so"
+              else
+                entry;
+          in map mkEntry cfg.plugins;
+        } 0;
     in lib.mkIf shouldGenerate {
       text = lib.optionalString cfg.systemd.enable systemdActivation
-        + lib.optionalString (combinedSettings != { })
-        (toHyprconf combinedSettings 0)
+        + lib.optionalString (cfg.plugins != [ ])
+        (pluginsToHyprconf cfg.plugins)
+        + lib.optionalString (cfg.settings != { }) (toHyprconf cfg.settings 0)
         + lib.optionalString (cfg.extraConfig != "") cfg.extraConfig;
 
       onChange = lib.mkIf (cfg.package != null) ''

--- a/tests/modules/services/window-managers/hyprland/simple-config.conf
+++ b/tests/modules/services/window-managers/hyprland/simple-config.conf
@@ -1,10 +1,10 @@
 exec-once = /nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+plugin=/path/to/plugin1
+plugin=/nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 $mod=SUPER
 bezier=smoothOut, 0.36, 0, 0.66, -0.56
 bezier=smoothIn, 0.25, 1, 0.5, 1
 bezier=overshot, 0.4,0.8,0.2,1.2
-plugin=/path/to/plugin1
-plugin=/nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 source=sourced.conf
 animations {
   animation=border, 1, 2, smoothIn
@@ -27,11 +27,13 @@ input {
   kb_layout=ro
 }
 
-plugin:plugin1 {
-  section {
-    other=dummy setting
+plugin {
+  plugin1 {
+    section {
+      other=dummy setting
+    }
+    dummy=plugin setting
   }
-  dummy=plugin setting
 }
 bindm=$mod, mouse:272, movewindow
 bindm=$mod, mouse:273, resizewindow


### PR DESCRIPTION
Sorry for being back so quickly, but digging in the hyprland source code (and debugging my config) I found out that the syntax that I used in #4915 will lead to a [silent](https://github.com/hyprwm/Hyprland/blob/f40e382fc6208d4fe2e53581ea27510cb62417dd/src/config/ConfigManager.cpp#L455C13-L455C40) wrong config parsing. The result is that all the sections after a `plugin:name` section are ignored (just the sections, not the fields).
There is no documentation, just the [source code](https://github.com/hyprwm/Hyprland/blob/main/src/config/ConfigManager.cpp#L1574). 
With this update the plugins paths are generate right before the full config and the plugins settings are generated like the other fields.


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix develop --ignore-environment .#hyprland-*`

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC
@fufexan 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
