### PR TITLE
mise: fix test

### DIFF
--- a/tests/modules/programs/mise/custom-settings.nix
+++ b/tests/modules/programs/mise/custom-settings.nix
@@ -21,7 +21,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/mise/config.toml
-    assertPathExists home-files/.config/mise/settings.toml
+    assertFileExists home-files/.config/mise/settings.toml
 
     assertFileContent home-files/.config/mise/config.toml ${
       pkgs.writeText "mise.config.expected" ''


### PR DESCRIPTION
### Description

`assertPathExists` is not a valid `nmt` assertion. I think I copy-pasted `assertPathNotExists` and removed `Not` 😓 

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@pedorich-n 
