### PR TITLE
firefox: implement native messaging hosts

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -21,6 +21,11 @@ let
   profilesPath =
     if isDarwin then "${firefoxConfigPath}/Profiles" else firefoxConfigPath;
 
+  nativeMessagingHostsJoined = pkgs.symlinkJoin {
+    name = "home_ff_nmhs";
+    paths = cfg.package.nativeMessagingHosts or cfg.nativeMessagingHosts;
+  };
+
   # The extensions path shared by all profiles; will not be supported
   # by future Firefox versions.
   extensionPath = "extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}";
@@ -225,6 +230,14 @@ in {
           this should be a wrapped Firefox package. For earlier state
           versions it should be an unwrapped Firefox package.
           Set to `null` to disable installing Firefox.
+        '';
+      };
+
+      nativeMessagingHosts = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        description = mdDoc ''
+          Additional packages containing native messaging hosts that should be made available to Firefox extensions.
         '';
       };
 
@@ -673,7 +686,11 @@ in {
       will be removed in the future. Please change to overriding the package
       configuration using 'programs.firefox.package' instead. You can refer to
       its example for how to do this.
-    '';
+    '' ++ optional (cfg.package.nativeMessagingHosts or null != null
+      && cfg.nativeMessagingHosts != [ ]) ''
+        Using both 'programs.firefox.package.nativeMessagingHosts' and
+        'programs.firefox.nativeMessagingHosts' is not supported, the latter will be ignored.
+      '';
 
     programs.firefox.finalPackage = wrapPackage cfg.package;
 
@@ -682,6 +699,8 @@ in {
     home.file = mkMerge ([{
       "${firefoxConfigPath}/profiles.ini" =
         mkIf (cfg.profiles != { }) { text = profilesIni; };
+      "${mozillaConfigPath}/native-messaging-hosts".source =
+        "${nativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
     }] ++ flip mapAttrsToList cfg.profiles (_: profile: {
       "${profilesPath}/${profile.path}/.keep".text = "";
 

--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -236,8 +236,9 @@ in {
       nativeMessagingHosts = mkOption {
         type = types.listOf types.package;
         default = [ ];
-        description = mdDoc ''
-          Additional packages containing native messaging hosts that should be made available to Firefox extensions.
+        description = ''
+          Additional packages containing native messaging hosts that should be
+          made available to Firefox extensions.
         '';
       };
 


### PR DESCRIPTION
Fixes #1586, #1487

### Description

Links FF native messaging hosts to ~/.mozilla uses cfg.package.nativeMessagingHosts if it's defined, but for ease of use we also add a package list to the module (easier discovery).

I haven't gotten native messaging to work without linking to ~/.mozilla, not sure what I'm doing wrong, but this solves the issue.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@rycee @kira-bruneau 

- [x] Allow edits by maintainers