### PR TITLE
bemenu: allow using floats to set width-factor in bemenu.settings

### DIFF
--- a/modules/programs/bemenu.nix
+++ b/modules/programs/bemenu.nix
@@ -15,7 +15,7 @@ in {
     package = mkPackageOption pkgs "bemenu" { };
 
     settings = mkOption {
-      type = with types; attrsOf (oneOf [ str int bool ]);
+      type = with types; attrsOf (oneOf [ str number bool ]);
       default = { };
       example = literalExpression ''
         {
@@ -32,6 +32,7 @@ in {
           hf = "#f9e2af";
           af = "#cdd6f4";
           ab = "#1e1e2e";
+          width-factor = 0.3;
         }
       '';
       description =

--- a/tests/modules/programs/bemenu/basic-configuration.nix
+++ b/tests/modules/programs/bemenu/basic-configuration.nix
@@ -15,12 +15,13 @@
       hf = "#f9e2af";
       af = "#cdd6f4";
       ab = "#1e1e2e";
+      width-factor = 0.3;
     };
   };
 
   nmt.script = ''
     assertFileExists home-path/etc/profile.d/hm-session-vars.sh
     assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
-      "export BEMENU_OPTS=\"'--ab' '#1e1e2e' '--af' '#cdd6f4' '--fb' '#1e1e2e' '--ff' '#cdd6f4' '--hb' '#1e1e2e' '--hf' '#f9e2af' '--ignorecase' '--line-height' '28' '--nb' '#1e1e2e' '--nf' '#cdd6f4' '--prompt' 'open' '--tb' '#1e1e2e' '--tf' '#f38ba8'\""
+      "export BEMENU_OPTS=\"'--ab' '#1e1e2e' '--af' '#cdd6f4' '--fb' '#1e1e2e' '--ff' '#cdd6f4' '--hb' '#1e1e2e' '--hf' '#f9e2af' '--ignorecase' '--line-height' '28' '--nb' '#1e1e2e' '--nf' '#cdd6f4' '--prompt' 'open' '--tb' '#1e1e2e' '--tf' '#f38ba8' '--width-factor' '0.300000'\""
   '';
 }


### PR DESCRIPTION
The CLI option --width-factor controls the width of the launcher and is set to a value between 0-1.

### Description

Change allowed type list from `[str int bool]` to `[str float bool]` to make it possible to set --width-factor which requires float value.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - ~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~

#### Maintainer CC

@omernaveedxyz