### PR TITLE
tealdeer: add cache update activation script

### DIFF
--- a/modules/programs/tealdeer.nix
+++ b/modules/programs/tealdeer.nix
@@ -49,5 +49,10 @@ in {
     home.file."${configDir}/tealdeer/config.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "tealdeer-config" cfg.settings;
     };
+
+    home.activation.tealdeerCache = hm.dag.entryAfter [ "linkGeneration" ] ''
+      $VERBOSE_ECHO "Rebuilding tealdeer cache"
+      $DRY_RUN_CMD ${getExe pkgs.tealdeer} --update
+    '';
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -140,6 +140,7 @@ in import nmtSrc {
     ./modules/programs/ssh
     ./modules/programs/starship
     ./modules/programs/taskwarrior
+    ./modules/programs/tealdeer
     ./modules/programs/texlive
     ./modules/programs/thefuck
     ./modules/programs/tmate

--- a/tests/modules/programs/tealdeer/default-settings.nix
+++ b/tests/modules/programs/tealdeer/default-settings.nix
@@ -1,0 +1,12 @@
+{ config, ... }: {
+  config = {
+    programs.tealdeer = {
+      package = config.lib.test.mkStubPackage { name = "tldr"; };
+      enable = true;
+    };
+
+    nmt.script = ''
+      assertFileRegex activate '/nix/store/.*tealdeer.*/bin/tldr --update'
+    '';
+  };
+}

--- a/tests/modules/programs/tealdeer/default.nix
+++ b/tests/modules/programs/tealdeer/default.nix
@@ -1,0 +1,1 @@
+{ tealdeer-default-settings = ./default-settings.nix; }


### PR DESCRIPTION
### Description

Since by default `tldr`'s cache [auto-update is disabled](https://dbrgn.github.io/tealdeer/config_updates.html#auto_update) this activation script will call `tldr --update` on home-manager switch. 

Build  similar to [`programs.bat`](https://github.com/nix-community/home-manager/blob/2d47379ad591bcb14ca95a90b6964b8305f6c913/modules/programs/bat.nix#L162-L168)

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

No maintainer 
