### PR TITLE
zoxide: fix nushell 0.89 deprectation

### DIFF
--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -88,6 +88,7 @@ in {
         }
         ${cfg.package}/bin/zoxide init nushell ${cfgOptions} |
           str replace "def-env" "def --env" --all |  # https://github.com/ajeetdsouza/zoxide/pull/632
+          str replace --all "-- $rest" "-- ...$rest" |
           save --force ${config.xdg.cacheHome}/zoxide/init.nu
       '';
       extraConfig = ''


### PR DESCRIPTION
Hi, this is my first pull request to home-manager, so I would appreciate if someone could double-check that my fix does not break backwards compatibility (or anything else). I don't think it does, as the current version of home-manager has the broken versions. Please let me know if I'm wrong here.

### Description

Since nushell 0.89, automatically spreading lists is deprecated. This commit introduces a string replace for the zoxide init script to replace the deprecated code.
See: https://github.com/ajeetdsouza/zoxide/issues/662

Fixes: #4916


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
