### PR TITLE
core: add extendModules attribute to homeManagerConfiguration result

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -28,28 +28,34 @@ let
     specialArgs = { modulesPath = builtins.toString ./.; } // extraSpecialArgs;
   };
 
-  module = showWarnings (let
-    failed = collectFailed rawModule.config;
-    failedStr = concatStringsSep "\n" (map (x: "- ${x}") failed);
-  in if failed == [ ] then
-    rawModule
-  else
-    throw ''
+  moduleChecks = raw:
+    showWarnings (let
+      failed = collectFailed raw.config;
+      failedStr = concatStringsSep "\n" (map (x: "- ${x}") failed);
+    in if failed == [ ] then
+      raw
+    else
+      throw ''
 
-      Failed assertions:
-      ${failedStr}'');
+        Failed assertions:
+        ${failedStr}'');
 
-in {
-  inherit (module) options config;
+  withExtraAttrs = rawModule:
+    let module = moduleChecks rawModule;
+    in {
+      inherit (module) options config;
 
-  activationPackage = module.config.home.activationPackage;
+      activationPackage = module.config.home.activationPackage;
 
-  # For backwards compatibility. Please use activationPackage instead.
-  activation-script = module.config.home.activationPackage;
+      # For backwards compatibility. Please use activationPackage instead.
+      activation-script = module.config.home.activationPackage;
 
-  newsDisplay = rawModule.config.news.display;
-  newsEntries = sort (a: b: a.time > b.time)
-    (filter (a: a.condition) rawModule.config.news.entries);
+      newsDisplay = rawModule.config.news.display;
+      newsEntries = sort (a: b: a.time > b.time)
+        (filter (a: a.condition) rawModule.config.news.entries);
 
-  inherit (module._module.args) pkgs;
-}
+      inherit (module._module.args) pkgs;
+
+      extendModules = args: withExtraAttrs (rawModule.extendModules args);
+    };
+in withExtraAttrs rawModule


### PR DESCRIPTION
### Description
home-manager.lib.homeManagerConfiguration now has an additional attribute that can be used to extend a home manager configuration with additional modules outside the project tree.

It works similar to the result of lib.nixosSystem from nixpkgs. This PR closes #4943 .

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC
@rycee 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
