### PR TITLE
wob: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1392,6 +1392,15 @@ in {
           This module replaces 'programs.rtx', which has been removed.
         '';
       }
+
+      {
+        time = "2024-01-27T22:53:00+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.wob'.
+        '';
+      }
+
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -364,6 +364,7 @@ let
     ./services/window-managers/spectrwm.nix
     ./services/window-managers/xmonad.nix
     ./services/wlsunset.nix
+    ./services/wob.nix
     ./services/xcape.nix
     ./services/xembed-sni-proxy.nix
     ./services/xidlehook.nix

--- a/modules/services/wob.nix
+++ b/modules/services/wob.nix
@@ -1,0 +1,79 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    getExe literalExpression mkEnableOption mkIf mkOption mkPackageOption
+    optional;
+
+  cfg = config.services.wob;
+  settingsFormat = pkgs.formats.ini { };
+
+  configFile = settingsFormat.generate "wob.ini" cfg.settings;
+in {
+  meta.maintainers = with lib.maintainers; [ Scrumplex ];
+
+  options.services.wob = {
+    enable = mkEnableOption "wob";
+    package = mkPackageOption pkgs "wob" { };
+
+    settings = mkOption {
+      type = settingsFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          "" = {
+            border_size = 10;
+            height = 50;
+          };
+          "output.foo".name = "DP-1";
+          "style.muted".background_color = "032cfc";
+        }
+      '';
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/wob/wob.ini`.
+        See {manpage}`wob.ini(5)` for documentation.
+      '';
+    };
+
+    systemd = mkEnableOption "systemd service and socket for wob"
+      // mkOption { default = true; };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.wob" pkgs lib.platforms.linux)
+    ];
+
+    systemd.user = mkIf cfg.systemd {
+      services.wob = {
+        Unit = {
+          Description =
+            "A lightweight overlay volume/backlight/progress/anything bar for Wayland";
+          Documentation = "man:wob(1)";
+          PartOf = "graphical-session.target";
+          After = "graphical-session.target";
+          ConditionEnvironment = "WAYLAND_DISPLAY";
+        };
+        Service = {
+          StandardInput = "socket";
+          ExecStart = builtins.concatStringsSep " " ([ (getExe cfg.package) ]
+            ++ optional (cfg.settings != { }) "--config ${configFile}");
+        };
+        Install.WantedBy = [ "graphical-session.target" ];
+      };
+
+      sockets.wob = {
+        Socket = {
+          ListenFIFO = "%t/wob.sock";
+          SocketMode = "0600";
+          RemoveOnStop = "yes";
+          FlushPending = "yes";
+        };
+        Install.WantedBy = [ "sockets.target" ];
+      };
+    };
+
+    xdg.configFile."wob/wob.ini" =
+      mkIf (cfg.settings != { }) { source = configFile; };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -261,6 +261,7 @@ in import nmtSrc {
     ./modules/services/window-managers/spectrwm
     ./modules/services/window-managers/sway
     ./modules/services/wlsunset
+    ./modules/services/wob
     ./modules/services/xsettingsd
     ./modules/systemd
     ./modules/targets-linux

--- a/tests/modules/services/wob/default.nix
+++ b/tests/modules/services/wob/default.nix
@@ -1,0 +1,1 @@
+{ wob-service = ./wob-service.nix; }

--- a/tests/modules/services/wob/wob-service-expected.ini
+++ b/tests/modules/services/wob/wob-service-expected.ini
@@ -1,0 +1,2 @@
+[]
+background_color=ddddddff

--- a/tests/modules/services/wob/wob-service-expected.service
+++ b/tests/modules/services/wob/wob-service-expected.service
@@ -1,0 +1,13 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@wob@/bin/wob --config /nix/store/00000000000000000000000000000000-wob.ini
+StandardInput=socket
+
+[Unit]
+After=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+Description=A lightweight overlay volume/backlight/progress/anything bar for Wayland
+Documentation=man:wob(1)
+PartOf=graphical-session.target

--- a/tests/modules/services/wob/wob-service-expected.socket
+++ b/tests/modules/services/wob/wob-service-expected.socket
@@ -1,0 +1,8 @@
+[Install]
+WantedBy=sockets.target
+
+[Socket]
+FlushPending=yes
+ListenFIFO=%t/wob.sock
+RemoveOnStop=yes
+SocketMode=0600

--- a/tests/modules/services/wob/wob-service.nix
+++ b/tests/modules/services/wob/wob-service.nix
@@ -1,0 +1,29 @@
+{ config, ... }:
+
+{
+  services.wob = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "wob";
+      outPath = "@wob@";
+    };
+    systemd = true;
+
+    settings."".background_color = "ddddddff";
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/wob.service
+    socketFile=home-files/.config/systemd/user/wob.socket
+    configFile=home-files/.config/wob/wob.ini
+
+    assertFileExists $serviceFile
+    assertFileExists $socketFile
+    assertFileExists $configFile
+    assertFileContent $(normalizeStorePaths $serviceFile) ${
+      ./wob-service-expected.service
+    }
+    assertFileContent $socketFile ${./wob-service-expected.socket}
+    assertFileContent $configFile ${./wob-service-expected.ini}
+  '';
+}


### PR DESCRIPTION
### Description

Adds a HM module for [wob](https://github.com/francma/wob).

The only odd thing about this one is that the ini config's default section has to be an empty string (`""`).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
