### PR TITLE
treewide: backwards compatible variable testing

### DIFF
--- a/lib/bash/home-manager.sh
+++ b/lib/bash/home-manager.sh
@@ -105,14 +105,19 @@ function _iVerbose() {
 # Note, the run function is exported. I.e., it is available also to called Bash
 # script.
 function run() {
+	# This function gets exported, and passed on down to child shell
+	# processes. Some of those might not be controlled by Nix, particularly in
+	# user activation scripts calling on /bin/sh, so stick to a bash dialect
+	# that is compatible with older versions.
+	local silence=0
     if [[ $1 == '--silence' ]]; then
-        local silence=1
+        silence=1
         shift
     fi
 
-    if [[ -v DRY_RUN ]] ; then
+    if [[ x == "${DRY_RUN:+x}" ]] ; then
         echo "$@"
-    elif [[ -v silence ]] ; then
+    elif [[ 1 == "$silence" ]] ; then
         "$@" > /dev/null 2>&1
     else
         "$@"


### PR DESCRIPTION

### Description

Fixes #4950 by not using any of them fancy new bash features from the last decade since Apple stopped shipping updates to Bash with its OS.

Context: I use a common lisp script compiled by SBCL in my user activation script, which calls out the the "shell", which apparently uses `/bin/sh` deep down inside. Of course that could be fixed upstream or in the SBCL derivation, but it seems like whack-a-mole given how varied user activation scripts can be.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
