### PR TITLE
firefox: fix darwin NativeMessagingHostsPath

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -21,6 +21,11 @@ let
   profilesPath =
     if isDarwin then "${firefoxConfigPath}/Profiles" else firefoxConfigPath;
 
+  nativeMessagingHostsPath = if isDarwin then
+    "${mozillaConfigPath}/NativeMessagingHosts"
+  else
+    "${mozillaConfigPath}/native-messaging-hosts";
+
   nativeMessagingHostsJoined = pkgs.symlinkJoin {
     name = "home_ff_nmhs";
     paths = cfg.package.nativeMessagingHosts or cfg.nativeMessagingHosts;
@@ -731,7 +736,7 @@ in {
     home.file = mkMerge ([{
       "${firefoxConfigPath}/profiles.ini" =
         mkIf (cfg.profiles != { }) { text = profilesIni; };
-      "${mozillaConfigPath}/native-messaging-hosts".source =
+      "${nativeMessagingHostsPath}".source =
         "${nativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
     }] ++ flip mapAttrsToList cfg.profiles (_: profile: {
       "${profilesPath}/${profile.path}/.keep".text = "";


### PR DESCRIPTION
### Description

https://wiki.mozilla.org/WebExtensions/Native_Messaging

```
Mac 	User 	~/Library/Application Support/Mozilla/NativeMessagingHosts/<name>.json
Linux 	User 	~/.mozilla/native-messaging-hosts/<name>.json
```

Related: #4952 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
