### PR TITLE
network-manager-applet: add XDG data directory

### DIFF
--- a/modules/services/network-manager-applet.nix
+++ b/modules/services/network-manager-applet.nix
@@ -21,6 +21,9 @@ in {
         lib.platforms.linux)
     ];
 
+    # The package provides some icons that are good to have available.
+    xdg.systemDirs.data = [ "${pkgs.networkmanagerapplet}/share" ];
+
     systemd.user.services.network-manager-applet = {
       Unit = {
         Description = "Network Manager applet";


### PR DESCRIPTION

### Description

The Network Manager Applet package provides, for example, some icons that are good to have accessible in an XDG data directory.


### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```