### PR TITLE
arrpc: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1392,6 +1392,13 @@ in {
           This module replaces 'programs.rtx', which has been removed.
         '';
       }
+
+      {
+        time = "2024-01-27T10:12:40+00:00";
+        message = ''
+          A new module is available: 'services.arrpc'
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -251,6 +251,7 @@ let
     ./programs/zsh.nix
     ./programs/zsh/prezto.nix
     ./programs/zsh/zsh-abbr.nix
+    ./services/arrpc.nix
     ./services/autorandr.nix
     ./services/avizo.nix
     ./services/barrier.nix

--- a/modules/services/arrpc.nix
+++ b/modules/services/arrpc.nix
@@ -1,0 +1,39 @@
+{ config, pkgs, lib, ... }:
+let
+  inherit (lib) mkIf mkOption mkPackageOption mkEnableOption types;
+
+  cfg = config.services.arrpc;
+in {
+  meta.maintainers = [ lib.maintainers.NotAShelf ];
+
+  options.services.arrpc = {
+    enable = mkEnableOption "arrpc";
+    package = mkPackageOption pkgs "arrpc" { };
+
+    systemdTarget = mkOption {
+      type = types.str;
+      default = "graphical-session.target";
+      example = "sway-session.target";
+      description = ''
+        Systemd target to bind to.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.arRPC = {
+      Unit = {
+        Description =
+          "Discord Rich Presence for browsers, and some custom clients";
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        ExecStart = lib.getExe cfg.package;
+        Restart = "always";
+      };
+
+      Install.WantedBy = [ cfg.systemdTarget ];
+    };
+  };
+}


### PR DESCRIPTION
### Description

Adds a module for the [arRPC](https://arrpc.openasar.dev/) project. Adaptation of my previously standalone [arrpc-flake](https://github.com/NotAShelf/arrpc-flake). Adds a user service bound to the graphical service (as arRPC is useless without it) that can be used for monitoring custom Discord RPC events.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

