### PR TITLE
home-manager: remove the export of `run`

### DIFF
--- a/lib/bash/home-manager.sh
+++ b/lib/bash/home-manager.sh
@@ -101,9 +101,6 @@ function _iVerbose() {
 #
 # If given the command line option `--silence`, then the command's standard and
 # error output is sent to `/dev/null` on a live run.
-#
-# Note, the run function is exported. I.e., it is available also to called Bash
-# script.
 function run() {
     if [[ $1 == '--silence' ]]; then
         local silence=1
@@ -118,4 +115,3 @@ function run() {
         "$@"
     fi
 }
-export -f run

--- a/modules/systemd-activate.sh
+++ b/modules/systemd-activate.sh
@@ -110,5 +110,10 @@ function systemdPostReload() {
 oldGenPath="$1"
 newGenPath="$2"
 
-run systemctl --user daemon-reload
+if [[ -v DRY_RUN ]]; then
+    echo systemctl --user daemon-reload
+else
+    systemctl --user daemon-reload
+fi
+
 systemdPostReload


### PR DESCRIPTION
### Description

Fixes #4950

### Checklist

- [ ] Change is backwards compatible: Not strictly, but I think this is important enough to warrant a change.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```