### PR TITLE
tealdeer: add option to toggle update on activation

### DIFF
--- a/modules/programs/tealdeer.nix
+++ b/modules/programs/tealdeer.nix
@@ -17,6 +17,14 @@ in {
   options.programs.tealdeer = {
     enable = mkEnableOption "Tealdeer";
 
+    updateOnActivation = mkOption {
+      type = with types; bool;
+      default = true;
+      description = ''
+        Whether to update tealdeer's cache on activation.
+      '';
+    };
+
     settings = mkOption {
       type = tomlFormat.type;
       default = { };
@@ -50,9 +58,11 @@ in {
       source = tomlFormat.generate "tealdeer-config" cfg.settings;
     };
 
-    home.activation.tealdeerCache = hm.dag.entryAfter [ "linkGeneration" ] ''
-      $VERBOSE_ECHO "Rebuilding tealdeer cache"
-      $DRY_RUN_CMD ${getExe pkgs.tealdeer} --update
-    '';
+    home.activation = mkIf cfg.updateOnActivation {
+      tealdeerCache = hm.dag.entryAfter [ "linkGeneration" ] ''
+        $VERBOSE_ECHO "Rebuilding tealdeer cache"
+        $DRY_RUN_CMD ${getExe pkgs.tealdeer} --update
+      '';
+    };
   };
 }


### PR DESCRIPTION
### Description

Add option to disable updating tealdeer cache on activation, since it's a network operation it can be quite annoying on shitty connections like trains and such.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
