### PR TITLE
borgmatic: add option for pattern matching

### DIFF
--- a/tests/modules/programs/borgmatic/both-sourcedirectories-and-patterns.nix
+++ b/tests/modules/programs/borgmatic/both-sourcedirectories-and-patterns.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, ... }:
+
+let
+
+  backups = config.programs.borgmatic.backups;
+
+in {
+  programs.borgmatic = {
+    enable = true;
+    backups = {
+      main = {
+        location = {
+          sourceDirectories = [ "/my-stuff-to-backup" ];
+          patterns = [ "R /" "+ my-stuff-to-backup" ];
+          repositories = [ "/mnt/disk1" ];
+        };
+      };
+    };
+  };
+
+  test.stubs.borgmatic = { };
+
+  test.asserts.assertions.expected = [''
+    Borgmatic backup configuration "main" cannot specify both 'location.sourceDirectories' and 'location.patterns'.
+  ''];
+}

--- a/tests/modules/programs/borgmatic/default.nix
+++ b/tests/modules/programs/borgmatic/default.nix
@@ -1,5 +1,10 @@
 {
   borgmatic-program-basic-configuration = ./basic-configuration.nix;
+  borgmatic-program-patterns-configuration = ./patterns-configuration.nix;
+  borgmatic-program-both-sourcedirectories-and-patterns =
+    ./both-sourcedirectories-and-patterns.nix;
+  borgmatic-program-neither-sourcedirectories-nor-patterns =
+    ./neither-sourcedirectories-nor-patterns.nix;
   borgmatic-program-include-hm-symlinks = ./include-hm-symlinks.nix;
   borgmatic-program-exclude-hm-symlinks = ./exclude-hm-symlinks.nix;
   borgmatic-program-exclude-hm-symlinks-nothing-else =

--- a/tests/modules/programs/borgmatic/neither-sourcedirectories-nor-patterns.nix
+++ b/tests/modules/programs/borgmatic/neither-sourcedirectories-nor-patterns.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, ... }:
+
+let
+
+  backups = config.programs.borgmatic.backups;
+
+in {
+  programs.borgmatic = {
+    enable = true;
+    backups = { main = { location = { repositories = [ "/mnt/disk1" ]; }; }; };
+  };
+
+  test.stubs.borgmatic = { };
+
+  test.asserts.assertions.expected = [''
+    Borgmatic backup configuration "main" must specify one of 'location.sourceDirectories' or 'location.patterns'.
+  ''];
+}

--- a/tests/modules/programs/borgmatic/patterns-configuration.nix
+++ b/tests/modules/programs/borgmatic/patterns-configuration.nix
@@ -1,0 +1,58 @@
+{ config, pkgs, ... }:
+
+let
+
+  boolToString = bool: if bool then "true" else "false";
+  backups = config.programs.borgmatic.backups;
+
+in {
+  programs.borgmatic = {
+    enable = true;
+    backups = {
+      main = {
+        location = {
+          patterns = [
+            "R /home/user"
+            "+ home/user/stuff-to-backup"
+            "+ home/user/junk/important-file"
+            "- home/user/junk"
+          ];
+          repositories = [ "/mnt/backup-drive" ];
+        };
+      };
+    };
+  };
+
+  test.stubs.borgmatic = { };
+
+  nmt.script = ''
+    config_file=$TESTED/home-files/.config/borgmatic.d/main.yaml
+    assertFileExists $config_file
+
+    declare -A expectations
+
+    expectations[patterns[0]]="${
+      builtins.elemAt backups.main.location.patterns 0
+    }"
+    expectations[patterns[1]]="${
+      builtins.elemAt backups.main.location.patterns 1
+    }"
+    expectations[patterns[2]]="${
+      builtins.elemAt backups.main.location.patterns 2
+    }"
+    expectations[patterns[3]]="${
+      builtins.elemAt backups.main.location.patterns 3
+    }"
+
+    yq=${pkgs.yq-go}/bin/yq
+
+    for filter in "''${!expectations[@]}"; do
+      expected_value="''${expectations[$filter]}"
+      actual_value="$($yq ".$filter" $config_file)"
+
+      if [[ "$actual_value" != "$expected_value" ]]; then
+        fail "Expected '$filter' to be '$expected_value' but was '$actual_value'"
+      fi
+    done
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Add option option for pattern matching in Borgmatic backups. It is mutually exclusive with the existing `sourceDirectories` option, so assertions have been added to make sure that both aren't set at once (but also that at least one of them is).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@DamienCassou 