### PR TITLE
home-manager: add backup overwrite option

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -113,9 +113,11 @@ in
               elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
                 # Next, try to move the file to a backup location if configured and possible
                 backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
-                if [[ -e "$backup" ]]; then
-                  errorEcho "Existing file '$backup' would be clobbered by backing up '$targetPath'"
+                if [[ -e "$backup" && -z "$HOME_MANAGER_BACKUP_OVERWRITE" ]]; then
+                  errorEcho "Existing file '$backup' would be clobbered by backing up '$targetPath', use HOME_MANAGER_BACKUP_OVERWRITE=1 if you want to overwrite the backup"
                   collision=1
+                elif [[ -e "$backup" && -n "$HOME_MANAGER_BACKUP_OVERWRITE" ]]; then
+                  warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', and existing backup '$backup' is on the way, old backup will be overwritten"
                 else
                   warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
                 fi
@@ -179,6 +181,9 @@ in
             if [[ -e "$targetPath" && ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
               # The target exists, back it up
               backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
+              if [[ -e "$backup" && "$HOME_MANAGER_BACKUP_OVERWRITE" ]]; then
+                run rm $VERBOSE_ARG "$backup"
+              fi
               run mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
             fi
 

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -21,6 +21,8 @@ in {
               "export HOME_MANAGER_BACKUP_EXT=${
                 lib.escapeShellArg cfg.backupFileExtension
               }"}
+              ${lib.optionalString (cfg.backupOverwrite)
+              "export HOME_MANAGER_BACKUP_OVERWRITE=1"}
               ${lib.optionalString cfg.verbose "export VERBOSE=1"}
               exec ${usercfg.home.activationPackage}/activate
             ''

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -62,6 +62,11 @@ in {
       '';
     };
 
+    backupOverwrite = mkEnableOption ''
+      When using backupFileExtension, whether to overwrite old
+      backups or not.
+    '';
+
     extraSpecialArgs = mkOption {
       type = types.attrs;
       default = { };

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -6,9 +6,15 @@ let
 
   cfg = config.home-manager;
 
-  serviceEnvironment = optionalAttrs (cfg.backupFileExtension != null) {
-    HOME_MANAGER_BACKUP_EXT = cfg.backupFileExtension;
-  } // optionalAttrs cfg.verbose { VERBOSE = "1"; };
+  serviceEnvironment = mkMerge [
+    (mkIf cfg.verbose { VERBOSE = "1"; })
+
+    (mkIf (cfg.backupFileExtension != null) {
+      HOME_MANAGER_BACKUP_EXT = cfg.backupFileExtension;
+    })
+
+    (mkIf cfg.backupOverwrite { HOME_MANAGER_BACKUP_OVERWRITE = "1"; })
+  ];
 
 in {
   imports = [ ./common.nix ];


### PR DESCRIPTION
### Description

When using --backup or backupFileExtension, if the backup exists, the activation process fails with:

https://github.com/nix-community/home-manager/blob/4d54c29bce71f8c261513e0662cc573d30f3e33e/modules/files.nix#L116-L119

This new options lets you remove the old backup automatically.

TODO:

- [x] Check if it works properly on NixOS
- [ ] Check if it works properly on home-manager standalone
- [ ] Check if it works properly on nix-darwin
- [ ] Add CLI flag

Closes: #4566

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
