### PR TITLE
nix-gc: add automatic garbage collector for nix

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -308,6 +308,7 @@ let
     ./services/muchsync.nix
     ./services/network-manager-applet.nix
     ./services/nextcloud-client.nix
+    ./services/nix-gc.nix
     ./services/notify-osd.nix
     ./services/opensnitch-ui.nix
     ./services/osmscout-server.nix

--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -1,0 +1,120 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.nix.gc;
+
+  mkCalendarInterval = frequency:
+    let
+      freq = {
+        "hourly" = [{ Minute = 0; }];
+        "weekly" = [{
+          Weekday = 1;
+          Hour = 0;
+          Minute = 0;
+        }];
+        "monthly" = [{
+          Day = 1;
+          Hour = 0;
+          Minute = 0;
+        }];
+        "semiannually" = [
+          {
+            Month = 1;
+            Day = 1;
+            Hour = 0;
+            Minute = 0;
+          }
+          {
+            Month = 7;
+            Day = 1;
+            Hour = 0;
+            Minute = 0;
+          }
+        ];
+        "annually" = [{
+          Month = 1;
+          Day = 1;
+          Hour = 0;
+          Minute = 0;
+        }];
+      };
+    in freq.${frequency};
+
+  nixPackage = if config.nix.enable && config.nix.package != null then
+    config.nix.package
+  else
+    pkgs.nix;
+in {
+  meta.maintainers = [ maintainers.shivaraj-bh ];
+
+  options = {
+    nix.gc = {
+      automatic = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Automatically run the garbage collector at a specific time.
+
+          Note: This will only garbage collect the current user's profiles.
+        '';
+      };
+
+      frequency = mkOption {
+        type =
+          types.enum [ "hourly" "weekly" "monthly" "semiannually" "annually" ];
+        default = "weekly";
+        example = "monthly";
+        description = ''
+          The frequency at which to run the garbage collector.
+
+          These enums are based on special expressions from the
+          {manpage}`systemd.time(7)`
+        '';
+      };
+
+      options = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "--max-freed $((64 * 1024**3))";
+        description = ''
+          Options given to {file}`nix-collect-garbage` when the
+          garbage collector is run automatically.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.automatic (mkMerge [
+    (mkIf pkgs.stdenv.isLinux {
+      systemd.user.services.nix-gc = {
+        Unit = { Description = "Nix Garbage Collector"; };
+        Service = {
+          ExecStart = "${nixPackage}/bin/nix-collect-garbage ${
+              lib.optionalString (cfg.options != null) cfg.options
+            }";
+        };
+      };
+      systemd.user.timers.nix-gc = {
+        Unit = { Description = "Nix Garbage Collector"; };
+        Timer = {
+          OnCalendar = "${cfg.frequency}";
+          Unit = "nix-gc.service";
+        };
+        Install = { WantedBy = [ "timers.target" ]; };
+      };
+    })
+
+    (mkIf pkgs.stdenv.isDarwin {
+      launchd.agents.nix-gc = {
+        enable = true;
+        config = {
+          ProgramArguments = [ "${nixPackage}/bin/nix-collect-garbage" ]
+            ++ lib.optional (cfg.options != null) cfg.options;
+          StartCalendarInterval = mkCalendarInterval cfg.frequency;
+        };
+      };
+    })
+  ]);
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -161,6 +161,7 @@ in import nmtSrc {
     ./modules/launchd
     ./modules/services/git-sync-darwin
     ./modules/services/imapnotify-darwin
+    ./modules/services/nix-gc-darwin
     ./modules/targets-darwin
   ] ++ lib.optionals isLinux [
     ./modules/config/i18n
@@ -234,6 +235,7 @@ in import nmtSrc {
     ./modules/services/mpd
     ./modules/services/mpd-mpris
     ./modules/services/mpdris2
+    ./modules/services/nix-gc
     ./modules/services/osmscout-server
     ./modules/services/pantalaimon
     ./modules/services/parcellite

--- a/tests/modules/services/nix-gc-darwin/basic.nix
+++ b/tests/modules/services/nix-gc-darwin/basic.nix
@@ -1,0 +1,19 @@
+{ ... }:
+
+{
+  nix.gc = {
+    automatic = true;
+    frequency = "monthly";
+    options = "--delete-older-than 30d";
+  };
+
+  test.stubs.nix = { name = "nix"; };
+
+  nmt.script = ''
+    serviceFile=LaunchAgents/org.nix-community.home.nix-gc.plist
+
+    assertFileExists "$serviceFile"
+
+    assertFileContent "$serviceFile" ${./expected-agent.plist}
+  '';
+}

--- a/tests/modules/services/nix-gc-darwin/default.nix
+++ b/tests/modules/services/nix-gc-darwin/default.nix
@@ -1,0 +1,1 @@
+{ nix-gc = ./basic.nix; }

--- a/tests/modules/services/nix-gc-darwin/expected-agent.plist
+++ b/tests/modules/services/nix-gc-darwin/expected-agent.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.nix-community.home.nix-gc</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>@nix@/bin/nix-collect-garbage</string>
+		<string>--delete-older-than 30d</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<array>
+		<dict>
+			<key>Day</key>
+			<integer>1</integer>
+			<key>Hour</key>
+			<integer>0</integer>
+			<key>Minute</key>
+			<integer>0</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/tests/modules/services/nix-gc/basic.nix
+++ b/tests/modules/services/nix-gc/basic.nix
@@ -1,0 +1,29 @@
+{ ... }:
+
+{
+  nix.gc = {
+    automatic = true;
+    frequency = "monthly";
+    options = "--delete-older-than 30d";
+  };
+
+  test.stubs.nix = { name = "nix"; };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/nix-gc.service
+
+    assertFileExists $serviceFile
+
+    serviceFile=$(normalizeStorePaths $serviceFile)
+
+    assertFileContent $serviceFile ${./expected.service}
+
+    timerFile=home-files/.config/systemd/user/nix-gc.timer
+
+    assertFileExists $timerFile
+
+    timerFile=$(normalizeStorePaths $timerFile)
+
+    assertFileContent $timerFile ${./expected.timer}
+  '';
+}

--- a/tests/modules/services/nix-gc/default.nix
+++ b/tests/modules/services/nix-gc/default.nix
@@ -1,0 +1,1 @@
+{ nix-gc = ./basic.nix; }

--- a/tests/modules/services/nix-gc/expected.service
+++ b/tests/modules/services/nix-gc/expected.service
@@ -1,0 +1,5 @@
+[Service]
+ExecStart=@nix@/bin/nix-collect-garbage --delete-older-than 30d
+
+[Unit]
+Description=Nix Garbage Collector

--- a/tests/modules/services/nix-gc/expected.timer
+++ b/tests/modules/services/nix-gc/expected.timer
@@ -1,0 +1,9 @@
+[Install]
+WantedBy=timers.target
+
+[Timer]
+OnCalendar=monthly
+Unit=nix-gc.service
+
+[Unit]
+Description=Nix Garbage Collector


### PR DESCRIPTION
### Description

Add `nix-gc` module that configures systemd unit for linux and launchd agent for macOS to automatically run the `nix-collect-garbage` executable at a specified `frequency`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
