### PR TITLE
vdirsyncer: only create postHook script when non-empty

### DIFF
--- a/modules/programs/vdirsyncer-accounts.nix
+++ b/modules/programs/vdirsyncer-accounts.nix
@@ -137,8 +137,8 @@ in {
     };
 
     postHook = mkOption {
-      type = types.lines;
-      default = "";
+      type = types.nullOr types.lines;
+      default = null;
       description = ''
         Command to call for each item creation and modification.
         The command will be called with the path of the new/updated

--- a/modules/programs/vdirsyncer.nix
+++ b/modules/programs/vdirsyncer.nix
@@ -26,8 +26,9 @@ let
     filterAttrs (_: v: v != null)
     ((getAttrs [ "type" "fileExt" "encoding" ] a.local) // {
       path = a.local.path;
-      postHook = pkgs.writeShellScriptBin "post-hook" a.vdirsyncer.postHook
-        + "/bin/post-hook";
+      postHook = optionalString (a.vdirsyncer.postHook != null)
+        (pkgs.writeShellScriptBin "post-hook" a.vdirsyncer.postHook
+          + "/bin/post-hook");
     });
 
   remoteStorage = a:


### PR DESCRIPTION
### Description

Saves some unnecessary cycles and store entries.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@teto

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
