### PR TITLE
programs.qutebrowser.keyBindings: actually implement unbinding

### DIFF
--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -9,7 +9,7 @@ let
   formatLine = o: n: v:
     let
       formatValue = v:
-        if builtins.isNull v then
+        if v == null then
           "None"
         else if builtins.isBool v then
           (if v then "True" else "False")
@@ -29,7 +29,10 @@ let
   formatKeyBindings = m: b:
     let
       formatKeyBinding = m: k: c:
-        ''config.bind("${k}", "${escape [ ''"'' ] c}", mode="${m}")'';
+        if c == null then
+          ''config.unbind("${k}", mode="${m}")''
+        else
+          ''config.bind("${k}", "${escape [ ''"'' ] c}", mode="${m}")'';
     in concatStringsSep "\n" (mapAttrsToList (formatKeyBinding m) b);
 
   formatQuickmarks = n: s: "${n} ${s}";
@@ -131,7 +134,7 @@ in {
     };
 
     keyBindings = mkOption {
-      type = with types; attrsOf (attrsOf (separatedString " ;; "));
+      type = with types; attrsOf (attrsOf (nullOr (separatedString " ;; ")));
       default = { };
       description = ''
         Key bindings mapping keys to commands in different modes. This setting

--- a/tests/modules/programs/qutebrowser/keybindings.nix
+++ b/tests/modules/programs/qutebrowser/keybindings.nix
@@ -8,6 +8,7 @@
 
     keyBindings = {
       normal = {
+        ":" = null;
         "<Ctrl-v>" = "spawn mpv {url}";
         ",l" = ''config-cycle spellcheck.languages ["en-GB"] ["en-US"]'';
         "<F1>" = lib.mkMerge [
@@ -35,6 +36,7 @@
           config.load_autoconfig(False)
           c.bindings.default = {}
           config.bind(",l", "config-cycle spellcheck.languages [\"en-GB\"] [\"en-US\"]", mode="normal")
+          config.unbind(":", mode="normal")
           config.bind("<Ctrl-v>", "spawn mpv {url}", mode="normal")
           config.bind("<F1>", "config-cycle tabs.show never always ;; config-cycle statusbar.show in-mode always ;; config-cycle scrolling.bar never always", mode="normal")
           config.bind("<Ctrl-y>", "prompt-yes", mode="prompt")''


### PR DESCRIPTION
### Description

The documentation for the option says...

> If you want a default binding to be passed through to the website, bind it to null.

but if you actually try to set a key to `null`, it causes an error.

> A definition for option `programs.qutebrowser.keyBindings."<Ctrl+Shift+Tab>".normal is not of type 'strings concatenated with " ;; "'.

So this commit implements unbinding as it is documented.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
