### PR TITLE
vscode: Add openvscode-server to the vscode module.

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -15,12 +15,14 @@ let
     "vscode" = "Code";
     "vscode-insiders" = "Code - Insiders";
     "vscodium" = "VSCodium";
+    "openvscode-server" = "OpenVSCode Server";
   }.${vscodePname};
 
   extensionDir = {
     "vscode" = "vscode";
     "vscode-insiders" = "vscode-insiders";
     "vscodium" = "vscode-oss";
+    "openvscode-server" = "openvscode-server";
   }.${vscodePname};
 
   userDir = if pkgs.stdenv.hostPlatform.isDarwin then


### PR DESCRIPTION
In order to manage the extensions and configs from openvscode-server, the only additional requirement was some mapping missing between the name of the package and the default configDir/extensionDir

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
