### PR TITLE
helix: remove outdated comment

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -75,7 +75,6 @@ in {
       default = { };
       example = literalExpression ''
         {
-          # the language-server option currently requires helix from the master branch at https://github.com/helix-editor/helix/
           language-server.typescript-language-server = with pkgs.nodePackages; {
             command = "''${typescript-language-server}/bin/typescript-language-server";
             args = [ "--stdio" "--tsserver-path=''${typescript}/lib/node_modules/typescript/lib" ];


### PR DESCRIPTION
The change to languages.toml referred to by the comment was released
with helix 23.10 which is the version currently on nixpkgs 23.11. See

- https://helix-editor.com/news/release-23-10-highlights/#multiple-language-servers
- https://github.com/NixOS/nixpkgs/blob/nixos-23.11/pkgs/applications/editors/helix/default.nix#L5
