### PR TITLE
tests: reduce closure sizes

### DIFF
--- a/tests/modules/i18n/input-method/fcitx5-stubs.nix
+++ b/tests/modules/i18n/input-method/fcitx5-stubs.nix
@@ -18,6 +18,21 @@
     fcitx5-qt = { outPath = null; };
     fcitx5-gtk = { outPath = null; };
     fcitx5-chinese-addons = { outPath = null; };
+
+    gtk2 = {
+      buildScript = ''
+        mkdir -p $out/bin
+        echo '#/usr/bin/env bash' > $out/bin/gtk-query-immodules-2.0
+        chmod +x $out/bin/*
+      '';
+    };
+    gtk3 = {
+      buildScript = ''
+        mkdir -p $out/bin
+        echo '#/usr/bin/env bash' > $out/bin/gtk-query-immodules-3.0
+        chmod +x $out/bin/*
+      '';
+    };
   };
 
   nixpkgs.overlays = [

--- a/tests/modules/programs/beets/mpdstats.nix
+++ b/tests/modules/programs/beets/mpdstats.nix
@@ -11,8 +11,12 @@
 
   programs.beets = {
     enable = true;
-    package = config.lib.test.mkStubPackage { outPath = "@beets@"; };
     mpdIntegration.enableStats = true;
+  };
+
+  test.stubs = {
+    beets = { };
+    mpd = { };
   };
 
   nmt.script = ''

--- a/tests/modules/programs/mpv/mpv-example-settings.nix
+++ b/tests/modules/programs/mpv/mpv-example-settings.nix
@@ -1,55 +1,51 @@
 { config, lib, pkgs, ... }:
 
 {
-  config = {
-    programs.mpv = {
-      enable = true;
-      package = pkgs.mpvDummy;
+  imports = [ ./mpv-stubs.nix ];
 
-      bindings = {
-        WHEEL_UP = "seek 10";
-        WHEEL_DOWN = "seek -10";
-        "Alt+0" = "set window-scale 0.5";
-      };
+  programs.mpv = {
+    enable = true;
 
-      config = {
-        force-window = true;
-        ytdl-format = "bestvideo+bestaudio";
-        cache-default = 4000000;
-      };
-
-      scriptOpts = {
-        osc = {
-          scalewindowed = 2.0;
-          vidscale = false;
-          visibility = "always";
-        };
-      };
-
-      profiles = {
-        fast = { vo = "vdpau"; };
-        "protocol.dvd" = {
-          profile-desc = "profile for dvd:// streams";
-          alang = "en";
-        };
-      };
-
-      defaultProfiles = [ "gpu-hq" ];
+    bindings = {
+      WHEEL_UP = "seek 10";
+      WHEEL_DOWN = "seek -10";
+      "Alt+0" = "set window-scale 0.5";
     };
 
-    test.stubs.mpvDummy = { };
+    config = {
+      force-window = true;
+      ytdl-format = "bestvideo+bestaudio";
+      cache-default = 4000000;
+    };
 
-    nmt.script = ''
-      assertFileContent \
-         home-files/.config/mpv/mpv.conf \
-         ${./mpv-example-settings-expected-config}
-      assertFileContent \
-         home-files/.config/mpv/input.conf \
-         ${./mpv-example-settings-expected-bindings}
-      assertFileContent \
-         home-files/.config/mpv/script-opts/osc.conf \
-         ${./mpv-example-settings-expected-osc-opts}
-    '';
+    scriptOpts = {
+      osc = {
+        scalewindowed = 2.0;
+        vidscale = false;
+        visibility = "always";
+      };
+    };
+
+    profiles = {
+      fast = { vo = "vdpau"; };
+      "protocol.dvd" = {
+        profile-desc = "profile for dvd:// streams";
+        alang = "en";
+      };
+    };
+
+    defaultProfiles = [ "gpu-hq" ];
   };
 
+  nmt.script = ''
+    assertFileContent \
+       home-files/.config/mpv/mpv.conf \
+       ${./mpv-example-settings-expected-config}
+    assertFileContent \
+       home-files/.config/mpv/input.conf \
+       ${./mpv-example-settings-expected-bindings}
+    assertFileContent \
+       home-files/.config/mpv/script-opts/osc.conf \
+       ${./mpv-example-settings-expected-osc-opts}
+  '';
 }

--- a/tests/modules/programs/mpv/mpv-invalid-settings.nix
+++ b/tests/modules/programs/mpv/mpv-invalid-settings.nix
@@ -1,25 +1,16 @@
 { config, lib, pkgs, ... }:
 
 {
-  config = {
-    programs.mpv = {
-      enable = true;
-      package = pkgs.mpvDummy;
-      scripts = [ pkgs.mpvScript ];
-    };
+  imports = [ ./mpv-stubs.nix ];
 
-    nixpkgs.overlays = [
-      (self: super: {
-        mpvScript =
-          pkgs.runCommandLocal "mpvScript" { scriptName = "something"; }
-          "mkdir $out";
-      })
-    ];
-    test.stubs.mpvDummy = { };
-
-    test.asserts.assertions.expected = [
-      ''
-        The programs.mpv "package" option is mutually exclusive with "scripts" option.''
-    ];
+  programs.mpv = {
+    enable = true;
+    package = pkgs.emptyDirectory;
+    scripts = [ pkgs.mpvScript ];
   };
+
+  test.asserts.assertions.expected = [
+    ''
+      The programs.mpv "package" option is mutually exclusive with "scripts" option.''
+  ];
 }

--- a/tests/modules/programs/mpv/mpv-stubs.nix
+++ b/tests/modules/programs/mpv/mpv-stubs.nix
@@ -1,0 +1,28 @@
+{ pkgs, ... }:
+
+{
+  nixpkgs.overlays = [
+    (self: super: {
+      mpvScript = pkgs.runCommandLocal "mpvScript" { scriptName = "something"; }
+        "mkdir $out";
+
+      mpv-unwrapped = super.mpv-unwrapped.overrideAttrs {
+        builder = pkgs.writeShellScript "dummy" ''
+          PATH=${pkgs.coreutils}/bin
+          mkdir -p $dev $man $out/bin $out/Applications/mpv.app/Contents/MacOS
+          touch $out/bin/{mpv,umpv} \
+                $out/Applications/mpv.app/Contents/MacOS/{mpv,mpv-bundle}
+          chmod +x $out/bin/{mpv,umpv} \
+                   $out/Applications/mpv.app/Contents/MacOS/{mpv,mpv-bundle}
+        '';
+      };
+
+      lua = pkgs.emptyDirectory.overrideAttrs {
+        luaversion = "0";
+        withPackages = ps: pkgs.emptyDirectory;
+      };
+    })
+  ];
+
+  test.stubs = { yt-dlp = { }; };
+}


### PR DESCRIPTION
### Description

Try to reduce the download size when running tests.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```