### PR TITLE
neomutt: move crypt_use_gpgme from account to global config

### DIFF
--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -224,7 +224,6 @@ let
       set certificate_file=${toString config.accounts.email.certificatesFile}
 
       # GPG section
-      set crypt_use_gpgme = yes
       set crypt_autosign = ${lib.hm.booleans.yesNo (gpg.signByDefault or false)}
       set crypt_opportunistic_encrypt = ${
         lib.hm.booleans.yesNo (gpg.encryptByDefault or false)
@@ -351,6 +350,7 @@ in {
         set message_cachedir = "${config.xdg.cacheHome}/neomutt/messages/"
         set editor = "${cfg.editor}"
         set implicit_autoview = yes
+        set crypt_use_gpgme = yes
 
         alternative_order text/enriched text/plain text
 

--- a/tests/modules/programs/neomutt/hm-example.com-expected
+++ b/tests/modules/programs/neomutt/hm-example.com-expected
@@ -3,7 +3,6 @@ set ssl_force_tls = yes
 set certificate_file=/etc/ssl/certs/ca-certificates.crt
 
 # GPG section
-set crypt_use_gpgme = yes
 set crypt_autosign = no
 set crypt_opportunistic_encrypt = no
 set pgp_use_gpg_agent = yes

--- a/tests/modules/programs/neomutt/hm-example.com-gpg-expected.conf
+++ b/tests/modules/programs/neomutt/hm-example.com-gpg-expected.conf
@@ -3,7 +3,6 @@ set ssl_force_tls = yes
 set certificate_file=/etc/ssl/certs/ca-certificates.crt
 
 # GPG section
-set crypt_use_gpgme = yes
 set crypt_autosign = yes
 set crypt_opportunistic_encrypt = yes
 set pgp_use_gpg_agent = yes

--- a/tests/modules/programs/neomutt/hm-example.com-msmtp-expected.conf
+++ b/tests/modules/programs/neomutt/hm-example.com-msmtp-expected.conf
@@ -3,7 +3,6 @@ set ssl_force_tls = yes
 set certificate_file=/etc/ssl/certs/ca-certificates.crt
 
 # GPG section
-set crypt_use_gpgme = yes
 set crypt_autosign = no
 set crypt_opportunistic_encrypt = no
 set pgp_use_gpg_agent = yes

--- a/tests/modules/programs/neomutt/hm-example.com-no-folder-change-expected.conf
+++ b/tests/modules/programs/neomutt/hm-example.com-no-folder-change-expected.conf
@@ -3,7 +3,6 @@ set ssl_force_tls = yes
 set certificate_file=/etc/ssl/certs/ca-certificates.crt
 
 # GPG section
-set crypt_use_gpgme = yes
 set crypt_autosign = no
 set crypt_opportunistic_encrypt = no
 set pgp_use_gpg_agent = yes

--- a/tests/modules/programs/neomutt/hm-example.com-signature-command-expected
+++ b/tests/modules/programs/neomutt/hm-example.com-signature-command-expected
@@ -3,7 +3,6 @@ set ssl_force_tls = yes
 set certificate_file=/etc/ssl/certs/ca-certificates.crt
 
 # GPG section
-set crypt_use_gpgme = yes
 set crypt_autosign = no
 set crypt_opportunistic_encrypt = no
 set pgp_use_gpg_agent = yes

--- a/tests/modules/programs/neomutt/hm-example.com-signature-expected
+++ b/tests/modules/programs/neomutt/hm-example.com-signature-expected
@@ -3,7 +3,6 @@ set ssl_force_tls = yes
 set certificate_file=/etc/ssl/certs/ca-certificates.crt
 
 # GPG section
-set crypt_use_gpgme = yes
 set crypt_autosign = no
 set crypt_opportunistic_encrypt = no
 set pgp_use_gpg_agent = yes

--- a/tests/modules/programs/neomutt/hm-example.com-starttls-expected
+++ b/tests/modules/programs/neomutt/hm-example.com-starttls-expected
@@ -3,7 +3,6 @@ set ssl_force_tls = yes
 set certificate_file=/etc/ssl/certs/ca-certificates.crt
 
 # GPG section
-set crypt_use_gpgme = yes
 set crypt_autosign = no
 set crypt_opportunistic_encrypt = no
 set pgp_use_gpg_agent = yes

--- a/tests/modules/programs/neomutt/neomutt-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-expected.conf
@@ -3,6 +3,7 @@ set header_cache = "/home/hm-user/.cache/neomutt/headers/"
 set message_cachedir = "/home/hm-user/.cache/neomutt/messages/"
 set editor = "$EDITOR"
 set implicit_autoview = yes
+set crypt_use_gpgme = yes
 
 alternative_order text/enriched text/plain text
 

--- a/tests/modules/programs/neomutt/neomutt-not-primary-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-not-primary-expected.conf
@@ -3,6 +3,7 @@ set header_cache = "/home/hm-user/.cache/neomutt/headers/"
 set message_cachedir = "/home/hm-user/.cache/neomutt/messages/"
 set editor = "$EDITOR"
 set implicit_autoview = yes
+set crypt_use_gpgme = yes
 
 alternative_order text/enriched text/plain text
 

--- a/tests/modules/programs/neomutt/neomutt-with-binds-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-with-binds-expected.conf
@@ -3,6 +3,7 @@ set header_cache = "/home/hm-user/.cache/neomutt/headers/"
 set message_cachedir = "/home/hm-user/.cache/neomutt/messages/"
 set editor = "$EDITOR"
 set implicit_autoview = yes
+set crypt_use_gpgme = yes
 
 alternative_order text/enriched text/plain text
 

--- a/tests/modules/programs/neomutt/neomutt-with-named-mailboxes-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-with-named-mailboxes-expected.conf
@@ -3,6 +3,7 @@ set header_cache = "/home/hm-user/.cache/neomutt/headers/"
 set message_cachedir = "/home/hm-user/.cache/neomutt/messages/"
 set editor = "$EDITOR"
 set implicit_autoview = yes
+set crypt_use_gpgme = yes
 
 alternative_order text/enriched text/plain text
 


### PR DESCRIPTION

### Description
Move `crypt_use_gpgme` configuration option from the account config to the global config.
Fixes config load error since newer versions of neomutt don't allow `crypt_use_gpgme` to be loaded dynamically (from folder hooks).

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@fpletz @ncfavier @sumnerevans