### PR TITLE
programs.fish: Configurable generation of completions.

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -253,6 +253,12 @@ in {
         '';
       };
 
+      generateCompletions = mkEnableOption
+        "the automatic generation of completions based upon installed man pages"
+        // {
+          default = true;
+        };
+
       shellAliases = mkOption {
         type = with types; attrsOf str;
         default = { };
@@ -390,9 +396,9 @@ in {
   };
 
   config = mkIf cfg.enable (mkMerge [
-    {
-      home.packages = [ cfg.package ];
+    { home.packages = [ cfg.package ]; }
 
+    (mkIf cfg.generateCompletions {
       # Support completion for `man` by building a cache for `apropos`.
       programs.man.generateCaches = mkDefault true;
 
@@ -456,7 +462,9 @@ in {
           set fish_complete_path $prev "${config.xdg.dataHome}/fish/home-manager_generated_completions" $post
         end
       '';
+    })
 
+    {
       xdg.configFile."fish/config.fish".source = fishIndent "config.fish" ''
         # ~/.config/fish/config.fish: DO NOT EDIT -- this file has been generated
         # automatically by home-manager.


### PR DESCRIPTION

### Description

Add a config option to optionally disable the generation of command completions based upon man pages.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [?] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

  The tests fail on the master branch for me my changes made no difference.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
