### PR TITLE
firefox: add librewolf support

### DIFF
--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -6,4 +6,5 @@
   firefox-duplicate-container-ids = ./duplicate-container-ids.nix;
   firefox-container-id-out-of-range = ./container-id-out-of-range.nix;
   firefox-policies = ./policies.nix;
+  firefox-librewolf = ./librewolf.nix;
 }

--- a/tests/modules/programs/firefox/librewolf.nix
+++ b/tests/modules/programs/firefox/librewolf.nix
@@ -1,0 +1,58 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [ ./setup-firefox-mock-overlay.nix ];
+
+  config = lib.mkIf config.test.enableBig {
+    home.stateVersion = "23.11";
+    programs.firefox = {
+      enable = true;
+      package = pkgs.librewolf;
+
+      profiles.basic.isDefault = true;
+
+      profiles.test = {
+        id = 1;
+        settings = {
+          "general.smoothScroll" = false;
+          "browser.newtabpage.pinned" = [{
+            title = "NixOS";
+            url = "https://nixos.org";
+          }];
+        };
+        search = {
+          force = true;
+          default = "DuckDuckGo";
+          privateDefault = "DuckDuckGo";
+        };
+      };
+    };
+
+    nmt.script = ''
+      assertFileRegex \
+        home-path/bin/librewolf \
+        MOZ_APP_LAUNCHER
+
+      assertDirectoryExists home-files/.librewolf/basic
+
+      assertFileContent \
+        home-files/.librewolf/test/user.js \
+        ${./profile-settings-expected-user.js}
+
+      function assertFirefoxSearchContent() {
+        compressedSearch=$(normalizeStorePaths "$1")
+
+        decompressedSearch=$(dirname $compressedSearch)/search.json
+        ${pkgs.mozlz4a}/bin/mozlz4a -d "$compressedSearch" >(${pkgs.jq}/bin/jq . > "$decompressedSearch")
+
+        assertFileContent \
+          $decompressedSearch \
+          "$2"
+      }
+
+      assertFirefoxSearchContent \
+        home-files/.librewolf/test/search.json.mozlz4 \
+        ${./profile-settings-expected-search-with-librewolf.json}
+    '';
+  };
+}

--- a/tests/modules/programs/firefox/profile-settings-expected-search-with-librewolf.json
+++ b/tests/modules/programs/firefox/profile-settings-expected-search-with-librewolf.json
@@ -1,0 +1,17 @@
+{
+  "engines": [
+    {
+      "_isAppProvided": true,
+      "_metaData": {},
+      "_name": "DuckDuckGo"
+    }
+  ],
+  "metaData": {
+    "current": "DuckDuckGo",
+    "hash": "ZIx5PXpJILB0NZQARse1Y6PRrlroZEb6VMvu1FY2sow=",
+    "private": "DuckDuckGo",
+    "privateHash": "ZIx5PXpJILB0NZQARse1Y6PRrlroZEb6VMvu1FY2sow=",
+    "useSavedOrder": false
+  },
+  "version": 6
+}

--- a/tests/modules/programs/firefox/setup-firefox-mock-overlay.nix
+++ b/tests/modules/programs/firefox/setup-firefox-mock-overlay.nix
@@ -7,16 +7,23 @@
         meta.description = "I pretend to be Firefox";
         passthru.gtk3 = null;
       } ''
-        mkdir -p "$out"/{bin,lib}
+        mkdir -p "$out"/{bin,lib/firefox}
         touch "$out/bin/firefox"
         chmod 755 "$out/bin/firefox"
+        echo "Name=Firefox" > "$out/lib/firefox/application.ini"
       '';
 
-      chrome-gnome-shell =
-        pkgs.runCommandLocal "dummy-chrome-gnome-shell" { } ''
-          mkdir -p $out/lib/mozilla/native-messaging-hosts
-          touch $out/lib/mozilla/native-messaging-hosts/dummy
-        '';
+      librewolf-unwrapped = pkgs.runCommandLocal "librewolf-0" {
+        meta.description = "I pretend to be LibreWolf";
+        passthru.gtk3 = null;
+        passthru.extraPrefsFiles = null;
+        passthru.extraPoliciesFiles = null;
+      } ''
+        mkdir -p "$out"/{bin,lib/librewolf}
+        touch "$out/bin/librewolf"
+        chmod 755 "$out/bin/librewolf"
+        echo "Name=LibreWolf" > "$out/lib/librewolf/application.ini"
+      '';
     })
   ];
 }


### PR DESCRIPTION
closes #2803 and #4179

This adds LibreWolf support and tests, including using the correct profile path and generating the correct search json hash.

The way Firefox (& forks) profiles work on Linux is you have ~/.mozilla for some more "global" stuff like native messaging hosts, and ~/.\<vendor\>/\<appName\> for more "local" stuff like profiles or crash reports. However, if vendor isn't set, ~/.\<appName\> is used instead. Additionally, Firefox forks usually change ~/.mozilla to match ~/.\<vendor\> or ~/.\<appName\>.

This is a huge mess so I don't expect it to work for every Firefox fork out there - instead, I only provide support for the browser I personally use, and if anyone wishes to add another one, they'd fine it relatively easy to do now that all you need to do is make sure the values at the top are consistent with where the browser stores its data.

Some of it could perhaps be moved to nixpkgs, but, again, considering how messy this *can* be (I don't know how bad things are in practice), this may or may not be a good idea.

Alternatively, the ~/.mozilla and ~/.mozilla/firefox paths could be made configurable (in addition to this "default path" logic)

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes. - **unrelated tests fail, so no**

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee @kira-bruneau 