### PR TITLE
tealdeer: module improvements

### DIFF
--- a/modules/programs/tealdeer.nix
+++ b/modules/programs/tealdeer.nix
@@ -4,31 +4,64 @@ with lib;
 let
   cfg = config.programs.tealdeer;
 
-  tomlFormat = pkgs.formats.toml { };
-
   configDir = if pkgs.stdenv.isDarwin then
     "Library/Application Support"
   else
     config.xdg.configHome;
 
+  tomlFormat = pkgs.formats.toml { };
+
+  settingsFormat = let
+    updatesSection = types.submodule {
+      options = {
+        auto_update = mkEnableOption "auto-update";
+
+        auto_update_interval_hours = mkOption {
+          type = types.ints.positive;
+          default = 720;
+          example = literalExpression "24";
+          description = ''
+            Duration, since the last cache update, after which the cache will be refreshed.
+            This parameter is ignored if {var}`auto_update` is set to `false`.
+          '';
+        };
+      };
+    };
+  in types.submodule {
+    freeformType = tomlFormat.type;
+    options = {
+      updates = mkOption {
+        type = updatesSection;
+        default = { };
+        description = ''
+          Tealdeer can refresh the cache automatically when it is outdated.
+          This behavior can be configured in the updates section.
+        '';
+      };
+    };
+  };
+
 in {
-  meta.maintainers = [ ];
+  meta.maintainers = [ hm.maintainers.pedorich-n ];
+
+  imports = [
+    (mkRemovedOptionModule [ "programs" "tealdeer" "updateOnActivation" ] ''
+      Updating tealdeer's cache requires network access.
+      The activation script should be fast and idempotent, so the option was removed.
+      Please use
+
+        `programs.teadleer.settings.updates.auto_update = true`
+
+      instead, to make sure tealdeer's cache is updated periodically.
+    '')
+  ];
 
   options.programs.tealdeer = {
     enable = mkEnableOption "Tealdeer";
 
-    updateOnActivation = mkOption {
-      type = with types; bool;
-      default = true;
-      description = ''
-        Whether to update tealdeer's cache on activation.
-      '';
-    };
-
     settings = mkOption {
-      type = tomlFormat.type;
-      default = { };
-      defaultText = literalExpression "{ }";
+      type = types.nullOr settingsFormat;
+      default = null;
       example = literalExpression ''
         {
           display = {
@@ -43,10 +76,8 @@ in {
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/tealdeer/config.toml` on Linux or
-        {file}`$HOME/Library/Application Support/tealdeer/config.toml`
-        on Darwin. See
-        <https://dbrgn.github.io/tealdeer/config.html>
-        for more information.
+        {file}`$HOME/Library/Application Support/tealdeer/config.toml` on Darwin.
+        See <https://dbrgn.github.io/tealdeer/config.html> for more information.
       '';
     };
   };
@@ -54,15 +85,9 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ pkgs.tealdeer ];
 
-    home.file."${configDir}/tealdeer/config.toml" = mkIf (cfg.settings != { }) {
-      source = tomlFormat.generate "tealdeer-config" cfg.settings;
-    };
-
-    home.activation = mkIf cfg.updateOnActivation {
-      tealdeerCache = hm.dag.entryAfter [ "linkGeneration" ] ''
-        $VERBOSE_ECHO "Rebuilding tealdeer cache"
-        $DRY_RUN_CMD ${getExe pkgs.tealdeer} --update
-      '';
-    };
+    home.file."${configDir}/tealdeer/config.toml" =
+      mkIf (cfg.settings != null && cfg.settings != { }) {
+        source = tomlFormat.generate "tealdeer-config" cfg.settings;
+      };
   };
 }

--- a/tests/modules/programs/tealdeer/custom-settings.nix
+++ b/tests/modules/programs/tealdeer/custom-settings.nix
@@ -1,0 +1,35 @@
+{ config, pkgs, ... }: {
+  config = {
+    programs.tealdeer = {
+      package = config.lib.test.mkStubPackage { name = "tldr"; };
+      enable = true;
+      settings = {
+        updates = {
+          auto_update = true;
+          auto_update_interval_hours = 72;
+        };
+        display = { use_pager = false; };
+      };
+    };
+
+    nmt.script = let
+      expectedConfDir = if pkgs.stdenv.isDarwin then
+        "Library/Application Support"
+      else
+        ".config";
+      expectedConfigPath = "home-files/${expectedConfDir}/tealdeer/config.toml";
+    in ''
+      assertFileExists "${expectedConfigPath}"
+      assertFileContent "${expectedConfigPath}" ${
+        pkgs.writeText "tealdeer.config-custom.expected" ''
+          [display]
+          use_pager = false
+
+          [updates]
+          auto_update = true
+          auto_update_interval_hours = 72
+        ''
+      }
+    '';
+  };
+}

--- a/tests/modules/programs/tealdeer/default-settings.nix
+++ b/tests/modules/programs/tealdeer/default-settings.nix
@@ -1,12 +1,18 @@
-{ config, ... }: {
+{ config, pkgs, ... }: {
   config = {
     programs.tealdeer = {
       package = config.lib.test.mkStubPackage { name = "tldr"; };
       enable = true;
     };
 
-    nmt.script = ''
-      assertFileRegex activate '/nix/store/.*tealdeer.*/bin/tldr --update'
+    nmt.script = let
+      expectedConfDir = if pkgs.stdenv.isDarwin then
+        "Library/Application Support"
+      else
+        ".config";
+      expectedConfigPath = "home-files/${expectedConfDir}/tealdeer/config.toml";
+    in ''
+      assertPathNotExists "${expectedConfigPath}"
     '';
   };
 }

--- a/tests/modules/programs/tealdeer/default.nix
+++ b/tests/modules/programs/tealdeer/default.nix
@@ -1,1 +1,4 @@
-{ tealdeer-default-settings = ./default-settings.nix; }
+{
+  tealdeer-default-settings = ./default-settings.nix;
+  tealdeer-custom-settings = ./custom-settings.nix;
+}


### PR DESCRIPTION


### Description

As discussed in https://github.com/nix-community/home-manager/pull/4968#issuecomment-1927480035:

- Cache update on HM activation removed;
- `freeformType` settings;
- More tests added;
- Platform-dependent tests;
- Maintainer added;

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

N/A