### PR TITLE
zellij: use exact cmd instead of relying on $PATH being set

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -6,6 +6,7 @@ let
 
   cfg = config.programs.zellij;
   yamlFormat = pkgs.formats.yaml { };
+  zellijCmd = getExe cfg.package;
 
 in {
   meta.maintainers = [ hm.maintainers.mainrs ];
@@ -69,16 +70,16 @@ in {
       };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkOrder 200 ''
-      eval "$(zellij setup --generate-auto-start bash)"
+      eval "$(${zellijCmd} setup --generate-auto-start bash)"
     '');
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration (mkOrder 200 ''
-      eval "$(zellij setup --generate-auto-start zsh)"
+      eval "$(${zellijCmd} setup --generate-auto-start zsh)"
     '');
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration
       (mkOrder 200 ''
-        eval (zellij setup --generate-auto-start fish | string collect)
+        eval (${zellijCmd} setup --generate-auto-start fish | string collect)
       '');
   };
 }

--- a/tests/modules/programs/zellij/enable-shells.nix
+++ b/tests/modules/programs/zellij/enable-shells.nix
@@ -26,16 +26,16 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
-      'eval "$(zellij setup --generate-auto-start bash)"'
+      'eval "$(@zellij@/bin/dummy setup --generate-auto-start bash)"'
 
     assertFileExists home-files/.zshrc
     assertFileContains \
       home-files/.zshrc \
-      'eval "$(zellij setup --generate-auto-start zsh)"'
+      'eval "$(@zellij@/bin/dummy setup --generate-auto-start zsh)"'
 
     assertFileExists home-files/.config/fish/config.fish
     assertFileContains \
       home-files/.config/fish/config.fish \
-      'eval (zellij setup --generate-auto-start fish | string collect)'
+      'eval (@zellij@/bin/dummy setup --generate-auto-start fish | string collect)'
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Use exact command when calling `zellij` instead of relying on it being in the `PATH` already.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] **Change is backwards compatible**: it **may** not be if someone was overriding the path with a different `zellij`. I'm unsure if this is important or not for home-manager ?

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] ~~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~~ irrelevant

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
