### PR TITLE
Documentation: Standalone Installation Note

### DIFF
--- a/docs/manual/installation/standalone.md
+++ b/docs/manual/installation/standalone.md
@@ -35,6 +35,14 @@
 
     Once finished, Home Manager should be active and available in your
     user environment.
+    
+::: {.note}
+If you are having issues here related to home-manager not being found and added the channel as a user earlier, try running
+``` shell
+$ nix-shell '<home-manager>' -A install -I ~/.nix-defexpr/channels
+```
+instead. This tells nix-shell to search the correct path.
+:::
 
 4.  If you do not plan on having Home Manager manage your shell
     configuration then you must source the


### PR DESCRIPTION
Added a note to the standalone installation instructions, which recommends adding -I ~/.nix-defexpr/channels to the nix-shell command if home-manager cannot be found.

### Description
This is just a documentation update -- I've previously run into 
issues where after adding the home-manager channel as a user,
it would not show up in the $NIX_PATH, I thought it'd be a good idea to mention it. 