### PR TITLE
imapnotify: enable STARTTLS if enabled in email account config

### DIFF
--- a/modules/services/imapnotify.nix
+++ b/modules/services/imapnotify.nix
@@ -72,6 +72,7 @@ let
       inherit (account.imap) host;
       inherit port;
       tls = account.imap.tls.enable;
+      tlsOptions.starttls = account.imap.tls.useStartTls;
       username = account.userName;
       passwordCmd =
         lib.concatMapStringsSep " " lib.escapeShellArg account.passwordCommand;

--- a/tests/modules/services/imapnotify/imapnotify-config.json
+++ b/tests/modules/services/imapnotify/imapnotify-config.json
@@ -1,0 +1,1 @@
+{"boxes":["Inbox"],"host":"imap.example.com","onNewMail":"@notmuch@/bin/notmuch new\n","passwordCmd":"'password-command'","port":993,"tls":true,"tlsOptions":{"starttls":false},"username":"home.manager"}

--- a/tests/modules/services/imapnotify/imapnotify.nix
+++ b/tests/modules/services/imapnotify/imapnotify.nix
@@ -35,5 +35,10 @@ with lib;
     serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
     assertFileExists $serviceFile
     assertFileContent $serviceFileNormalized ${./imapnotify.service}
+
+    configFile="home-files/.config/imapnotify/imapnotify-hm-example.com-config.json"
+    configFileNormalized="$(normalizeStorePaths "$configFile")"
+    assertFileExists $configFile
+    assertFileContent $configFileNormalized ${./imapnotify-config.json}
   '';
 }


### PR DESCRIPTION
### Description

Since version 2.3.10 goimapnotify supports starttls. In version 2.3.11 a typo in the settings was fixed, using tlsOptions.starttls to enable it.

This commit enables starttls in the goimapnotify config file if it is enabled in the email account's imap settings.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

Global tests failed because of a unrelated problem, but the module tests succeed.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC @NickHu 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
