### PR TITLE
hyprland: add support for XDG autostart using systemd

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -102,6 +102,10 @@ in {
         ];
         description = "Extra commands to be run after D-Bus activation.";
       };
+
+      enableXdgAutostart = lib.mkEnableOption ''
+        autostart of applications using
+        {manpage}`systemd-xdg-autostart-generator(8)`'';
     };
 
     xwayland.enable = lib.mkEnableOption "XWayland" // { default = true; };
@@ -247,8 +251,12 @@ in {
         Description = "Hyprland compositor session";
         Documentation = [ "man:systemd.special(7)" ];
         BindsTo = [ "graphical-session.target" ];
-        Wants = [ "graphical-session-pre.target" ];
+        Wants = [ "graphical-session-pre.target" ]
+          ++ lib.optional cfg.systemd.enableXdgAutostart
+          "xdg-desktop-autostart.target";
         After = [ "graphical-session-pre.target" ];
+        Before = lib.mkIf cfg.systemd.enableXdgAutostart
+          [ "xdg-desktop-autostart.target" ];
       };
     };
 


### PR DESCRIPTION
### Description

Using the option `wayland.windowManager.hyprland.systemd.xdgAutostart`, users can now choose to start applications present in `$XDG_CONFIG_HOME/autostart` when starting their sway session.

See 0144ac418ef633bfc9dbd89b8c199ad3a617c59f and https://github.com/nix-community/home-manager/pull/3747

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@fufexan

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
