### PR TITLE
emacs: use `overrideScope` instead of `overrideScope'`

### DIFF
--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -9,7 +9,7 @@ let
   # Copied from all-packages.nix, with modifications to support
   # overrides.
   emacsPackages = let epkgs = pkgs.emacsPackagesFor cfg.package;
-  in epkgs.overrideScope' cfg.overrides;
+  in epkgs.overrideScope cfg.overrides;
 
   emacsWithPackages = emacsPackages.emacsWithPackages;
 


### PR DESCRIPTION
fix annoying warning:
```
building the system configuration...
trace: warning: `overrideScope'` (from `lib.makeScope`) has been renamed to `overrideScope`.
```

https://github.com/NixOS/nixpkgs/blob/master/lib/customisation.nix#L328