### PR TITLE
jujutsu: fix completions commands

### DIFF
--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -65,12 +65,12 @@ in {
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      source <(${pkgs.jujutsu}/bin/jj util completion --zsh)
+      source <(${pkgs.jujutsu}/bin/jj util completion zsh)
       compdef _jj ${pkgs.jujutsu}/bin/jj
     '';
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-      ${pkgs.jujutsu}/bin/jj util completion --fish | source
+      ${pkgs.jujutsu}/bin/jj util completion fish | source
     '';
   };
 }


### PR DESCRIPTION
### Description

starting in jujutsu [0.14.0](https://github.com/martinvonz/jj/releases/tag/v0.14.0), jujutsu prefers `jj util completion <shell>` instead of `jj util completion --<shell>`. When the flag variation is used, jujutsu prints the following on shell startup:
```
Warning: `jj util completion --zsh` will be removed in a future version, and this will be a hard error
Hint: Use `jj util completion zsh` instead
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@shikanime 