### PR TITLE
joplin-desktop: add basic options

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -494,4 +494,10 @@
     github = "britter";
     githubId = 1327662;
   };
+  zorrobert = {
+    name = "zorrobert";
+    email = "zorrobert@mailbox.org";
+    github = "zorrobert";
+    githubId = 118135271;
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -124,6 +124,7 @@ let
     ./programs/jq.nix
     ./programs/jujutsu.nix
     ./programs/joshuto.nix
+    ./programs/joplin-desktop.nix
     ./programs/just.nix
     ./programs/k9s.nix
     ./programs/kakoune.nix

--- a/modules/programs/joplin-desktop.nix
+++ b/modules/programs/joplin-desktop.nix
@@ -1,0 +1,129 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.programs.joplin-desktop;
+  # config path is the same for linux and mac
+  configPath = (config.home.homeDirectory + "/.config/joplin-desktop");
+in {
+  options.programs.joplin-desktop = {
+    enable = lib.mkEnableOption "joplin-desktop";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.joplin-desktop;
+      defaultText = lib.literalExpression "pkgs.joplin-desktop";
+      description = "Package containing the joplin-desktop program.";
+    };
+    extraConfig = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = ''
+        Use this to add options to the Joplin config file. Settings are written in JSON, so "sync.interval":600 is written as "sync.interval" = 600'';
+      example = {
+        "newNoteFocus" = "title";
+        "markdown.plugin.mark" = true;
+      };
+    };
+    ### General
+    general = {
+      editor = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "kate";
+        description =
+          "The editor command (may include arguments) that will be used to open a note. If none is provided Joplin will try to auto-detect the default editor.";
+      };
+    };
+    ### Sync
+    sync = {
+      target = lib.mkOption {
+        type = lib.types.enum [
+          null
+          "none"
+          "file-system"
+          "onedrive"
+          "nextcloud"
+          "webdav"
+          "dropbox"
+          "s3"
+          "joplin-server"
+          "joplin-cloud"
+        ];
+        default = null;
+        description = "What is the type of sync target.";
+        example = "dropbox";
+      };
+      interval = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = null;
+        description = ''
+          Sync Interval in seconds. Only values shown as options in the settings are valid.
+          Disabled: 0
+          5 Min: 300
+          10 Min: 600
+          30 Min: 1800
+          1 hour: 3600
+          12 Hours: 43200
+          24 Hours: 86400
+        '';
+        example = 600;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    # write new config to temporary read-only file
+    home.file."home-manager-settings.json" = {
+      target = (configPath + "/home-manager-settings.json");
+      text = builtins.toJSON ((
+        # check if config file exists
+        if builtins.pathExists (configPath + "/settings.json") then
+          let
+            currentConfig = builtins.readFile (configPath + "/settings.json");
+            # check if file is not empty
+          in if ((currentConfig == "") || (currentConfig == "{}")) then
+            { }
+          else
+            builtins.fromJSON currentConfig
+        else
+          { }
+      ) 
+      # filter out null values and empty strings before merging with current config
+      # this is so that an undefined option does not override the current config
+      // lib.attrsets.filterAttrs (n: v: (v != null) && (v != "")) ({
+        # TODO: find a better way to convert nix attribute names to strings:
+        # sync.interval = ... -> "sync.interval" = ...
+        "editor" = config.programs.joplin-desktop.general.editor;
+        "sync.interval" = config.programs.joplin-desktop.sync.interval;
+      } // {
+        "sync.target" =
+          if (config.programs.joplin-desktop.sync.target != null) then
+            lib.strings.toInt (
+              # convert name of sync target into number that joplin expects
+              builtins.replaceStrings [
+                "none"
+                "file-system"
+                "onedrive"
+                "nextcloud"
+                "webdav"
+                "dropbox"
+                "s3"
+                "joplin-server"
+                "joplin-cloud"
+              ] [ "0" "2" "3" "5" "6" "7" "8" "9" "10" ]
+              config.programs.joplin-desktop.sync.target)
+          else
+            null;
+      } // config.programs.joplin-desktop.extraConfig));
+    };
+
+    # copy the contents of the temporary file to the real config file
+    home.activation = {
+      hm-activate-joplin-desktop-config =
+        lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+          cat ${configPath}/home-manager-settings.json > ${configPath}/settings.json
+        '';
+    };
+  };
+  meta.maintainers = [ lib.maintainers.zorrobert ];
+}

--- a/modules/programs/joplin-desktop.nix
+++ b/modules/programs/joplin-desktop.nix
@@ -40,37 +40,19 @@ in {
     ### Sync
     sync = {
       target = lib.mkOption {
-        type = lib.types.enum [
-          null
-          "none"
-          "file-system"
-          "onedrive"
-          "nextcloud"
-          "webdav"
-          "dropbox"
-          "s3"
-          "joplin-server"
-          "joplin-cloud"
-        ];
+        type = lib.types.enum [ null "none" "file-system" "onedrive" "nextcloud" "webdav" "dropbox" "s3" "joplin-server" "joplin-cloud" ];
         default = null;
         description = "What is the type of sync target.";
         example = "dropbox";
       };
 
       interval = lib.mkOption {
-        type = lib.types.enum [ null 300 600 1800 3600 43200 86400 ];
+        type = lib.types.enum [ null "disabled" "5m" "10m" "30m" "1h" "12h" "1d" ];
         default = null;
         description = ''
-          Sync Interval in seconds. Only values shown as options in the settings are valid.
-          Disabled: 0
-          5 Min: 300
-          10 Min: 600
-          30 Min: 1800
-          1 hour: 3600
-          12 Hours: 43200
-          24 Hours: 86400
+          Set the Synchronisation interval. The following values can be used: "disabled" "5m" "10m" "30m" "1h" "12h" "1d"
         '';
-        example = 600;
+        example = "10m";
       };
     };
   };
@@ -86,18 +68,30 @@ in {
               {
                 # TODO: find a better way to convert nix attribute names to strings:
                 # sync.interval = ... -> "sync.interval" = ...
+
                 "editor" = config.programs.joplin-desktop.general.editor;
-                "sync.interval" = config.programs.joplin-desktop.sync.interval;
-              } // {
-                "sync.target" =
-                  if (config.programs.joplin-desktop.sync.target != null)
-                  then lib.strings.toInt (
-                    # convert name of sync target into number that joplin expects
-                    builtins.replaceStrings [ "none" "file-system" "onedrive" "nextcloud" "webdav" "dropbox" "s3" "joplin-server" "joplin-cloud" ]
-                    [ "0" "2" "3" "5" "6" "7" "8" "9" "10" ]
-                    config.programs.joplin-desktop.sync.target
-                  )
-                  else null;
+
+                "sync.target" = {
+                  "none"          = 0;
+                  "file-system"   = 2;
+                  "onedrive"      = 3;
+                  "nextcloud"     = 5;
+                  "webdav"        = 6;
+                  "dropbox"       = 7;
+                  "s3"            = 8;
+                  "joplin-server" = 9;
+                  "joplin-cloud"  = 10;
+                }.${config.programs.joplin-desktop.sync.target} or null;
+
+                "sync.interval" = {
+                  "disabled"  =     0;
+                  "5m"        =   300;
+                  "10m"       =   600;
+                  "30m"       =  1800;
+                  "1h"        =  3600;
+                  "12h"       = 43200;
+                  "1d"        = 86400;
+                }.${config.programs.joplin-desktop.sync.interval} or null;
               } // config.programs.joplin-desktop.extraConfig
             )
           );

--- a/modules/programs/joplin-desktop.nix
+++ b/modules/programs/joplin-desktop.nix
@@ -1,27 +1,31 @@
 { config, lib, pkgs, ... }:
+
 let
+
   cfg = config.programs.joplin-desktop;
+
+  jsonFormat = pkgs.formats.json { };
+
   # config path is the same for linux and mac
   configPath = (config.home.homeDirectory + "/.config/joplin-desktop");
+
 in {
   options.programs.joplin-desktop = {
     enable = lib.mkEnableOption "joplin-desktop";
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.joplin-desktop;
-      defaultText = lib.literalExpression "pkgs.joplin-desktop";
-      description = "Package containing the joplin-desktop program.";
-    };
+
+    package = lib.mkPackageOption pkgs "joplin-desktop" { };
+
     extraConfig = lib.mkOption {
       type = lib.types.attrs;
       default = { };
       description = ''
-        Use this to add options to the Joplin config file. Settings are written in JSON, so "sync.interval":600 is written as "sync.interval" = 600'';
+        Use this to add other options to the Joplin config file. Settings are written in JSON, so "sync.interval":600 would be written as "sync.interval" = 600'';
       example = {
         "newNoteFocus" = "title";
         "markdown.plugin.mark" = true;
       };
     };
+
     ### General
     general = {
       editor = lib.mkOption {
@@ -32,6 +36,7 @@ in {
           "The editor command (may include arguments) that will be used to open a note. If none is provided Joplin will try to auto-detect the default editor.";
       };
     };
+
     ### Sync
     sync = {
       target = lib.mkOption {
@@ -51,8 +56,9 @@ in {
         description = "What is the type of sync target.";
         example = "dropbox";
       };
+
       interval = lib.mkOption {
-        type = lib.types.nullOr lib.types.int;
+        type = lib.types.enum [ null 300 600 1800 3600 43200 86400 ];
         default = null;
         description = ''
           Sync Interval in seconds. Only values shown as options in the settings are valid.
@@ -72,58 +78,38 @@ in {
   config = lib.mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    # write new config to temporary read-only file
-    home.file."home-manager-settings.json" = {
-      target = (configPath + "/home-manager-settings.json");
-      text = builtins.toJSON ((
-        # check if config file exists
-        if builtins.pathExists (configPath + "/settings.json") then
-          let
-            currentConfig = builtins.readFile (configPath + "/settings.json");
-            # check if file is not empty
-          in if ((currentConfig == "") || (currentConfig == "{}")) then
-            { }
-          else
-            builtins.fromJSON currentConfig
-        else
-          { }
-      ) 
-      # filter out null values and empty strings before merging with current config
-      # this is so that an undefined option does not override the current config
-      // lib.attrsets.filterAttrs (n: v: (v != null) && (v != "")) ({
-        # TODO: find a better way to convert nix attribute names to strings:
-        # sync.interval = ... -> "sync.interval" = ...
-        "editor" = config.programs.joplin-desktop.general.editor;
-        "sync.interval" = config.programs.joplin-desktop.sync.interval;
-      } // {
-        "sync.target" =
-          if (config.programs.joplin-desktop.sync.target != null) then
-            lib.strings.toInt (
-              # convert name of sync target into number that joplin expects
-              builtins.replaceStrings [
-                "none"
-                "file-system"
-                "onedrive"
-                "nextcloud"
-                "webdav"
-                "dropbox"
-                "s3"
-                "joplin-server"
-                "joplin-cloud"
-              ] [ "0" "2" "3" "5" "6" "7" "8" "9" "10" ]
-              config.programs.joplin-desktop.sync.target)
-          else
-            null;
-      } // config.programs.joplin-desktop.extraConfig));
-    };
-
-    # copy the contents of the temporary file to the real config file
     home.activation = {
       hm-activate-joplin-desktop-config =
-        lib.hm.dag.entryAfter [ "linkGeneration" ] ''
-          cat ${configPath}/home-manager-settings.json > ${configPath}/settings.json
+        let
+          newConfig = jsonFormat.generate "joplin-settings.json" (
+            lib.attrsets.filterAttrs (n: v: (v != null) && (v != "")) (
+              {
+                # TODO: find a better way to convert nix attribute names to strings:
+                # sync.interval = ... -> "sync.interval" = ...
+                "editor" = config.programs.joplin-desktop.general.editor;
+                "sync.interval" = config.programs.joplin-desktop.sync.interval;
+              } // {
+                "sync.target" =
+                  if (config.programs.joplin-desktop.sync.target != null)
+                  then lib.strings.toInt (
+                    # convert name of sync target into number that joplin expects
+                    builtins.replaceStrings [ "none" "file-system" "onedrive" "nextcloud" "webdav" "dropbox" "s3" "joplin-server" "joplin-cloud" ]
+                    [ "0" "2" "3" "5" "6" "7" "8" "9" "10" ]
+                    config.programs.joplin-desktop.sync.target
+                  )
+                  else null;
+              } // config.programs.joplin-desktop.extraConfig
+            )
+          );
+        in lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+          # ensure that settings.json exists
+          touch ${configPath}/settings.json
+          # config has to be written to temporary variable because jq cannot edit files in place
+          config="$(jq -s '.[0] + .[1]' ${configPath}/settings.json ${newConfig})"
+          printf '%s\n' "$config" > ${configPath}/settings.json
         '';
     };
   };
+
   meta.maintainers = [ lib.maintainers.zorrobert ];
 }

--- a/modules/programs/joplin-desktop.nix
+++ b/modules/programs/joplin-desktop.nix
@@ -40,14 +40,26 @@ in {
     ### Sync
     sync = {
       target = lib.mkOption {
-        type = lib.types.enum [ null "none" "file-system" "onedrive" "nextcloud" "webdav" "dropbox" "s3" "joplin-server" "joplin-cloud" ];
+        type = lib.types.enum [
+          null
+          "none"
+          "file-system"
+          "onedrive"
+          "nextcloud"
+          "webdav"
+          "dropbox"
+          "s3"
+          "joplin-server"
+          "joplin-cloud"
+        ];
         default = null;
         description = "What is the type of sync target.";
         example = "dropbox";
       };
 
       interval = lib.mkOption {
-        type = lib.types.enum [ null "disabled" "5m" "10m" "30m" "1h" "12h" "1d" ];
+        type =
+          lib.types.enum [ null "disabled" "5m" "10m" "30m" "1h" "12h" "1d" ];
         default = null;
         description = ''
           Set the Synchronisation interval. The following values can be used: "disabled" "5m" "10m" "30m" "1h" "12h" "1d"
@@ -61,47 +73,43 @@ in {
     home.packages = [ cfg.package ];
 
     home.activation = {
-      hm-activate-joplin-desktop-config =
-        let
-          newConfig = jsonFormat.generate "joplin-settings.json" (
-            lib.attrsets.filterAttrs (n: v: (v != null) && (v != "")) (
-              {
-                # TODO: find a better way to convert nix attribute names to strings:
-                # sync.interval = ... -> "sync.interval" = ...
+      hm-activate-joplin-desktop-config = let
+        newConfig = jsonFormat.generate "joplin-settings.json"
+          (lib.attrsets.filterAttrs (n: v: (v != null) && (v != "")) ({
+            # TODO: find a better way to convert nix attribute names to strings:
+            # sync.interval = ... -> "sync.interval" = ...
 
-                "editor" = config.programs.joplin-desktop.general.editor;
+            "editor" = config.programs.joplin-desktop.general.editor;
 
-                "sync.target" = {
-                  "none"          = 0;
-                  "file-system"   = 2;
-                  "onedrive"      = 3;
-                  "nextcloud"     = 5;
-                  "webdav"        = 6;
-                  "dropbox"       = 7;
-                  "s3"            = 8;
-                  "joplin-server" = 9;
-                  "joplin-cloud"  = 10;
-                }.${config.programs.joplin-desktop.sync.target} or null;
+            "sync.target" = {
+              "none" = 0;
+              "file-system" = 2;
+              "onedrive" = 3;
+              "nextcloud" = 5;
+              "webdav" = 6;
+              "dropbox" = 7;
+              "s3" = 8;
+              "joplin-server" = 9;
+              "joplin-cloud" = 10;
+            }.${config.programs.joplin-desktop.sync.target} or null;
 
-                "sync.interval" = {
-                  "disabled"  =     0;
-                  "5m"        =   300;
-                  "10m"       =   600;
-                  "30m"       =  1800;
-                  "1h"        =  3600;
-                  "12h"       = 43200;
-                  "1d"        = 86400;
-                }.${config.programs.joplin-desktop.sync.interval} or null;
-              } // config.programs.joplin-desktop.extraConfig
-            )
-          );
-        in lib.hm.dag.entryAfter [ "linkGeneration" ] ''
-          # ensure that settings.json exists
-          touch ${configPath}/settings.json
-          # config has to be written to temporary variable because jq cannot edit files in place
-          config="$(jq -s '.[0] + .[1]' ${configPath}/settings.json ${newConfig})"
-          printf '%s\n' "$config" > ${configPath}/settings.json
-        '';
+            "sync.interval" = {
+              "disabled" = 0;
+              "5m" = 300;
+              "10m" = 600;
+              "30m" = 1800;
+              "1h" = 3600;
+              "12h" = 43200;
+              "1d" = 86400;
+            }.${config.programs.joplin-desktop.sync.interval} or null;
+          } // config.programs.joplin-desktop.extraConfig));
+      in lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+        # ensure that settings.json exists
+        touch ${configPath}/settings.json
+        # config has to be written to temporary variable because jq cannot edit files in place
+        config="$(jq -s '.[0] + .[1]' ${configPath}/settings.json ${newConfig})"
+        printf '%s\n' "$config" > ${configPath}/settings.json
+      '';
     };
   };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -88,6 +88,7 @@ in import nmtSrc {
     ./modules/programs/i3status
     ./modules/programs/irssi
     ./modules/programs/jujutsu
+    ./modules/programs/joplin-desktop
     ./modules/programs/k9s
     ./modules/programs/kakoune
     ./modules/programs/khal

--- a/tests/modules/programs/joplin-desktop/basic-configuration.json
+++ b/tests/modules/programs/joplin-desktop/basic-configuration.json
@@ -1,0 +1,1 @@
+{"newNoteFocus":"title","richTextBannerDismissed":true,"sync.interval":600,"sync.target":7}

--- a/tests/modules/programs/joplin-desktop/basic-configuration.nix
+++ b/tests/modules/programs/joplin-desktop/basic-configuration.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    programs.joplin-desktop = {
+      enable = true;
+      package = pkgs.joplin-desktop;
+      sync = {
+        target = "dropbox";
+        interval = 600;
+      };
+      extraConfig = {
+        "richTextBannerDismissed" = true;
+        "newNoteFocus" = "title";
+      };
+    };
+  };
+}

--- a/tests/modules/programs/joplin-desktop/basic-configuration.nix
+++ b/tests/modules/programs/joplin-desktop/basic-configuration.nix
@@ -7,7 +7,7 @@
       package = pkgs.joplin-desktop;
       sync = {
         target = "dropbox";
-        interval = 600;
+        interval = "10m";
       };
       extraConfig = {
         "richTextBannerDismissed" = true;

--- a/tests/modules/programs/joplin-desktop/default.nix
+++ b/tests/modules/programs/joplin-desktop/default.nix
@@ -1,0 +1,1 @@
+{ joplin-desktop-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

This module adds basic options to configure [joplin-desktop](https://joplinapp.org/) via home-manager.
Joplin uses a JSON file for its configuration. To avoid overriding an existing configuration, settings already in that file will be kept and only overridden if they are set via home-manager options.

The errors listed below still need to be solved but I don't know how to do that. I'm new to writing home-manager modules (or nix modules), so feedback about the code or tips how to simplify things are very welcome. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->