### PR TITLE
jujutsu: update deprecated zsh completion command

### DIFF
--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -65,7 +65,7 @@ in {
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      source <(${pkgs.jujutsu}/bin/jj util completion --zsh)
+      source <(${pkgs.jujutsu}/bin/jj util completion zsh)
       compdef _jj ${pkgs.jujutsu}/bin/jj
     '';
 


### PR DESCRIPTION
### Description

The command used to generate jujutsu shell completions for zsh is being marked as deprecated and will turn into a hard error in the near future. This PR fixes the command to what upstream indicates.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible. _(After checking docs I'm still not sure what should I put here, sorry.)_

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC
@shikanime 
