### PR TITLE
[wip] targets/generic-linux: add enableKdeApplicationCache

### DIFF
--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -26,6 +26,14 @@ in {
         GNU/Linux distributions other than NixOS.
       '';
     };
+
+    enableKdeApplicationCache = mkEnableOption "" // {
+      description = ''
+        Whether to enable the management of the KDE application cache.
+        When using KDE Plasma, desktop applications installed via
+        home-manager may not appear in menus with this option disabled.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -103,5 +111,13 @@ in {
       TERMINFO_DIRS =
         "${profileDirectory}/share/terminfo:$TERMINFO_DIRS\${TERMINFO_DIRS:+:}${distroTerminfoDirs}";
     };
+
+    home.activation.updateKdeApplicationCache =
+      if cfg.enableKdeApplicationCache then
+        hm.dag.entryAfter [ "installPackages" ] ''
+          run /usr/bin/kbuildsycoca5 --noincremental
+        ''
+      else
+        null;
   };
 }


### PR DESCRIPTION
### Description

This option allows home-manager to trigger kbuildsycoca to refresh the KDE .desktop file cache, making desktop applications appear in menus.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
