### PR TITLE
mpv: create doc output in tests

### DIFF
--- a/tests/modules/programs/mpv/mpv-stubs.nix
+++ b/tests/modules/programs/mpv/mpv-stubs.nix
@@ -9,7 +9,7 @@
       mpv-unwrapped = super.mpv-unwrapped.overrideAttrs {
         builder = pkgs.writeShellScript "dummy" ''
           PATH=${pkgs.coreutils}/bin
-          mkdir -p $dev $man $out/bin $out/Applications/mpv.app/Contents/MacOS
+          mkdir -p $dev $doc $man $out/bin $out/Applications/mpv.app/Contents/MacOS
           touch $out/bin/{mpv,umpv} \
                 $out/Applications/mpv.app/Contents/MacOS/{mpv,mpv-bundle}
           chmod +x $out/bin/{mpv,umpv} \

--- a/tests/modules/programs/neomutt/hm-example.com-imap-expected.conf
+++ b/tests/modules/programs/neomutt/hm-example.com-imap-expected.conf
@@ -3,7 +3,6 @@ set ssl_force_tls = yes
 set certificate_file=/etc/ssl/certs/ca-certificates.crt
 
 # GPG section
-set crypt_use_gpgme = yes
 set crypt_autosign = no
 set crypt_opportunistic_encrypt = no
 set pgp_use_gpg_agent = yes

--- a/tests/modules/programs/neomutt/neomutt-with-imap-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-with-imap-expected.conf
@@ -3,6 +3,7 @@ set header_cache = "/home/hm-user/.cache/neomutt/headers/"
 set message_cachedir = "/home/hm-user/.cache/neomutt/messages/"
 set editor = "$EDITOR"
 set implicit_autoview = yes
+set crypt_use_gpgme = yes
 
 alternative_order text/enriched text/plain text
 

--- a/tests/modules/programs/neomutt/neomutt-with-imap-type-mailboxes-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-with-imap-type-mailboxes-expected.conf
@@ -3,6 +3,7 @@ set header_cache = "/home/hm-user/.cache/neomutt/headers/"
 set message_cachedir = "/home/hm-user/.cache/neomutt/messages/"
 set editor = "$EDITOR"
 set implicit_autoview = yes
+set crypt_use_gpgme = yes
 
 alternative_order text/enriched text/plain text
 


### PR DESCRIPTION
### Description

Fix tests

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```