### PR TITLE
home-manager: add Nix sanity check

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -137,6 +137,10 @@ function setHomeManagerPathVariables() {
         return
     fi
 
+    _iVerbose "Sanity checking Nix"
+    nix-build -q --expr '{}' --no-out-link > /dev/null 2>&1 || true
+    nix-env -q > /dev/null 2>&1 || true
+
     declare -r globalNixStateDir="${NIX_STATE_DIR:-/nix/var/nix}"
     declare -r globalProfilesDir="$globalNixStateDir/profiles/per-user/$USER"
     declare -r globalGcrootsDir="$globalNixStateDir/gcroots/per-user/$USER"

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -154,7 +154,7 @@ function setHomeManagerPathVariables() {
         declare -gr HM_PROFILE_DIR="$globalProfilesDir"
     else
         _iError 'Could not find suitable profile directory, tried %s and %s' \
-                "$HM_STATE_DIR/profiles" "$globalProfilesDir" >&2
+                "$userNixStateDir/profiles" "$globalProfilesDir" >&2
         exit 1
     fi
 }

--- a/home-manager/po/home-manager.pot
+++ b/home-manager/po/home-manager.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2023-09-13 23:46+0200\n"
+"POT-Creation-Date: 2024-02-15 16:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,36 +18,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: home-manager/home-manager:81
+#: home-manager/home-manager:58
 msgid "No configuration file found at %s"
 msgstr ""
 
 #. translators: The first '%s' specifier will be replaced by either
 #. 'home.nix' or 'flake.nix'.
-#: home-manager/home-manager:98 home-manager/home-manager:102
-#: home-manager/home-manager:192
+#: home-manager/home-manager:75 home-manager/home-manager:79
+#: home-manager/home-manager:178
 msgid ""
 "Keeping your Home Manager %s in %s is deprecated,\n"
 "please move it to %s"
 msgstr ""
 
-#: home-manager/home-manager:109
+#: home-manager/home-manager:86
 msgid "No configuration file found. Please create one at %s"
 msgstr ""
 
-#: home-manager/home-manager:124
+#: home-manager/home-manager:101
 msgid "Home Manager not found at %s."
 msgstr ""
 
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
-#: home-manager/home-manager:132
+#: home-manager/home-manager:109
 msgid ""
 "The fallback Home Manager path %s has been deprecated and a file/directory "
 "was found there."
 msgstr ""
 
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
-#: home-manager/home-manager:135
+#: home-manager/home-manager:112
 msgid ""
 "To remove this warning, do one of the following.\n"
 "\n"
@@ -68,38 +68,42 @@ msgid ""
 "     $ rm -r \"%s\""
 msgstr ""
 
-#: home-manager/home-manager:174
+#: home-manager/home-manager:140
+msgid "Sanity checking Nix"
+msgstr ""
+
+#: home-manager/home-manager:160
 msgid "Could not find suitable profile directory, tried %s and %s"
 msgstr ""
 
 #. translators: Here "flake" is a noun that refers to the Nix Flakes feature.
-#: home-manager/home-manager:229
+#: home-manager/home-manager:215
 msgid "Can't inspect options of a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:291 home-manager/home-manager:314
-#: home-manager/home-manager:1034
+#: home-manager/home-manager:288 home-manager/home-manager:311
+#: home-manager/home-manager:1030
 msgid "%s: unknown option '%s'"
 msgstr ""
 
-#: home-manager/home-manager:296 home-manager/home-manager:1035
+#: home-manager/home-manager:293 home-manager/home-manager:1031
 msgid "Run '%s --help' for usage help"
 msgstr ""
 
-#: home-manager/home-manager:322 home-manager/home-manager:421
+#: home-manager/home-manager:319 home-manager/home-manager:423
 msgid "The file %s already exists, leaving it unchanged..."
 msgstr ""
 
-#: home-manager/home-manager:324 home-manager/home-manager:423
+#: home-manager/home-manager:321 home-manager/home-manager:425
 msgid "Creating %s..."
 msgstr ""
 
-#: home-manager/home-manager:465
+#: home-manager/home-manager:467
 msgid "Creating initial Home Manager generation..."
 msgstr ""
 
 #. translators: The "%s" specifier will be replaced by a file path.
-#: home-manager/home-manager:470
+#: home-manager/home-manager:472
 msgid ""
 "All done! The home-manager tool should now be installed and you can edit\n"
 "\n"
@@ -110,7 +114,7 @@ msgid ""
 msgstr ""
 
 #. translators: The "%s" specifier will be replaced by a URL.
-#: home-manager/home-manager:475
+#: home-manager/home-manager:477
 msgid ""
 "Uh oh, the installation failed! Please create an issue at\n"
 "\n"
@@ -120,11 +124,11 @@ msgid ""
 msgstr ""
 
 #. translators: Here "flake" is a noun that refers to the Nix Flakes feature.
-#: home-manager/home-manager:486
+#: home-manager/home-manager:488
 msgid "Can't instantiate a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:562
+#: home-manager/home-manager:564
 msgid ""
 "There is %d unread and relevant news item.\n"
 "Read it by running the command \"%s news\"."
@@ -134,72 +138,72 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: home-manager/home-manager:576
+#: home-manager/home-manager:578
 msgid "Unknown \"news.display\" setting \"%s\"."
 msgstr ""
 
-#: home-manager/home-manager:583
+#: home-manager/home-manager:586
 #, sh-format
-msgid "Please set the $EDITOR environment variable"
+msgid "Please set the $EDITOR or $VISUAL environment variable"
 msgstr ""
 
-#: home-manager/home-manager:598
+#: home-manager/home-manager:604
 msgid "Cannot run build in read-only directory"
 msgstr ""
 
-#: home-manager/home-manager:676
+#: home-manager/home-manager:685
 msgid "No generation with ID %s"
 msgstr ""
 
-#: home-manager/home-manager:678
+#: home-manager/home-manager:687
 msgid "Cannot remove the current generation %s"
 msgstr ""
 
-#: home-manager/home-manager:680
+#: home-manager/home-manager:689
 msgid "Removing generation %s"
 msgstr ""
 
-#: home-manager/home-manager:699
+#: home-manager/home-manager:710
 msgid "No generations to expire"
 msgstr ""
 
-#: home-manager/home-manager:710
+#: home-manager/home-manager:721
 msgid "No home-manager packages seem to be installed."
 msgstr ""
 
-#: home-manager/home-manager:792
+#: home-manager/home-manager:803
 msgid "Unknown argument %s"
 msgstr ""
 
-#: home-manager/home-manager:816
+#: home-manager/home-manager:827
 msgid "This will remove Home Manager from your system."
 msgstr ""
 
-#: home-manager/home-manager:819
+#: home-manager/home-manager:830
 msgid "This is a dry run, nothing will actually be uninstalled."
 msgstr ""
 
-#: home-manager/home-manager:823
+#: home-manager/home-manager:834
 msgid "Really uninstall Home Manager?"
 msgstr ""
 
-#: home-manager/home-manager:829
+#: home-manager/home-manager:840
 msgid "Switching to empty Home Manager configuration..."
 msgstr ""
 
-#: home-manager/home-manager:857
+#: home-manager/home-manager:855
 msgid "Yay!"
 msgstr ""
 
-#: home-manager/home-manager:862
+#: home-manager/home-manager:860
 msgid "Home Manager is uninstalled but your home.nix is left untouched."
 msgstr ""
 
-#: home-manager/home-manager:1074
+#: home-manager/home-manager:1070
 msgid "expire-generations expects one argument, got %d."
 msgstr ""
 
-#: home-manager/home-manager:1096
+#: home-manager/home-manager:1092
 msgid "Unknown command: %s"
 msgstr ""
 

--- a/modules/po/hm-modules.pot
+++ b/modules/po/hm-modules.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager Modules\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2023-09-13 23:46+0200\n"
+"POT-Creation-Date: 2024-02-15 16:04+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,23 +17,23 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: modules/files.nix:234
+#: modules/files.nix:236
 msgid "Creating home file links in %s"
 msgstr ""
 
-#: modules/files.nix:247
+#: modules/files.nix:249
 msgid "Cleaning up orphan links from %s"
 msgstr ""
 
-#: modules/files.nix:263
+#: modules/files.nix:265
 msgid "Creating profile generation %s"
 msgstr ""
 
-#: modules/files.nix:280
+#: modules/files.nix:282
 msgid "No change so reusing latest profile generation %s"
 msgstr ""
 
-#: modules/home-environment.nix:640
+#: modules/home-environment.nix:622
 msgid ""
 "Oops, Nix failed to install your new Home Manager profile!\n"
 "\n"
@@ -49,7 +49,7 @@ msgid ""
 "Then try activating your Home Manager configuration again."
 msgstr ""
 
-#: modules/home-environment.nix:673
+#: modules/home-environment.nix:655
 msgid "Activating %s"
 msgstr ""
 
@@ -57,15 +57,15 @@ msgstr ""
 msgid "Migrating profile from %s to %s"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:53
+#: modules/lib-bash/activation-init.sh:54
 msgid "Could not find suitable profile directory, tried %s and %s"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:81
+#: modules/lib-bash/activation-init.sh:83
 msgid "Sanity checking oldGenNum and oldGenPath"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:84
+#: modules/lib-bash/activation-init.sh:86
 msgid ""
 "The previous generation number and path are in conflict! These\n"
 "must be either both empty or both set but are now set to\n"
@@ -81,34 +81,34 @@ msgid ""
 "and trying home-manager switch again. Good luck!"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:95
+#: modules/lib-bash/activation-init.sh:127
 msgid "Error: USER is set to \"%s\" but we expect \"%s\""
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:104
+#: modules/lib-bash/activation-init.sh:136
 msgid "Error: HOME is set to \"%s\" but we expect \"%s\""
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:119
+#: modules/lib-bash/activation-init.sh:153
 msgid "Starting Home Manager activation"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:123
+#: modules/lib-bash/activation-init.sh:157
 msgid "Sanity checking Nix"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:133
+#: modules/lib-bash/activation-init.sh:170
 msgid "This is a dry run"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:137
+#: modules/lib-bash/activation-init.sh:174
 msgid "This is a live run"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:143
+#: modules/lib-bash/activation-init.sh:180
 msgid "Using Nix version: %s"
 msgstr ""
 
-#: modules/lib-bash/activation-init.sh:146
+#: modules/lib-bash/activation-init.sh:183
 msgid "Activation variables:"
 msgstr ""


### PR DESCRIPTION
### Description

This should ensure that the necessary profile directories are created. Also fix an incorrect log message.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.