### PR TITLE
jujutsu: Remove superfluous shell completion

### DIFF
--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -10,6 +10,12 @@ let
 in {
   meta.maintainers = [ maintainers.shikanime ];
 
+  imports = let
+    mkRemovedShellIntegration = name:
+      mkRemovedOptionModule [ "programs" "jujutsu" "enable${name}Integration" ]
+      "This option is no longer necessary.";
+  in map mkRemovedShellIntegration [ "Bash" "Fish" "Zsh" ];
+
   options.programs.jujutsu = {
     enable =
       mkEnableOption "a Git-compatible DVCS that is both simple and powerful";
@@ -33,24 +39,6 @@ in {
         for options.
       '';
     };
-
-    enableBashIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Whether to enable Bash integration.";
-    };
-
-    enableZshIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Whether to enable Zsh integration.";
-    };
-
-    enableFishIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Whether to enable Fish integration.";
-    };
   };
 
   config = mkIf cfg.enable {
@@ -59,18 +47,5 @@ in {
     home.file.".jjconfig.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "jujutsu-config" cfg.settings;
     };
-
-    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      source <(${pkgs.jujutsu}/bin/jj util completion)
-    '';
-
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
-      source <(${pkgs.jujutsu}/bin/jj util completion --zsh)
-      compdef _jj ${pkgs.jujutsu}/bin/jj
-    '';
-
-    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-      ${pkgs.jujutsu}/bin/jj util completion --fish | source
-    '';
   };
 }


### PR DESCRIPTION
This issue has come up before, and the recommendation was to remove the shell completion logic from Home Manager. This pull request now does just that.

- https://github.com/martinvonz/jj/pull/2945
- https://github.com/nix-community/home-manager/pull/5016#issuecomment-1947449541
- https://github.com/nix-community/home-manager/pull/5037#pullrequestreview-1888843990

### Description

``` sh
$ for sh (--bash --fish --zsh); jj util completion "$sh" >/dev/null
Warning: `jj util completion --bash` will be removed in a future version, and this will be a hard error
Hint: Use `jj util completion bash` instead
Warning: `jj util completion --fish` will be removed in a future version, and this will be a hard error
Hint: Use `jj util completion fish` instead
Warning: `jj util completion --zsh` will be removed in a future version, and this will be a hard error
Hint: Use `jj util completion zsh` instead
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@shikanime 