### PR TITLE
lorri service cachedir

### DIFF
--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -7,7 +7,7 @@ let
   cfg = config.services.lorri;
 
 in {
-  meta.maintainers = [ maintainers.gerschtli ];
+  meta.maintainers = [ maintainers.gerschtli maintainers.nyarly ];
 
   options.services.lorri = {
     enable = mkEnableOption "lorri build daemon";
@@ -55,6 +55,10 @@ in {
           ReadWritePaths = [
             # /run/user/1000 for the socket
             "%t"
+            # Needs to update own cache
+            "%C/lorri"
+            # Needs %C/nix/fetcher-cache-v1.sqlite
+            "%C/nix"
             "/nix/var/nix/gcroots/per-user/%u"
           ];
           CacheDirectory = [ "lorri" ];


### PR DESCRIPTION
- **lorri: systemd allow access to cache directories**

### Description

Lorri fails builds with fetchers if it can't write to .cache/nix;
This PR adds that to ReadWrite

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@gerschtli

Am also adding myself as a maintainer, as I've been doing my best to maintain Lorri itself.
