### PR TITLE
darwin: more options: dock orientation etc

### DIFF
--- a/modules/targets/darwin/user-defaults/opts-allhosts.nix
+++ b/modules/targets/darwin/user-defaults/opts-allhosts.nix
@@ -41,6 +41,19 @@ in {
         description = "Sets the measurement unit.";
       };
 
+      ApplePressAndHoldEnabled = mkNullableOption {
+        type = types.bool;
+        example = true;
+        description =
+          "Repeat a key when it is held down (false) or display the accented character selector (true)";
+      };
+
+      AppleShowAllExtensions = mkNullableOption {
+        type = types.bool;
+        example = true;
+        description = "Always show file extensions in Finder";
+      };
+
       AppleTemperatureUnit = mkNullableOption {
         type = types.enum [ "Celsius" "Fahrenheit" ];
         example = "Celsius";
@@ -48,6 +61,16 @@ in {
       };
 
       AppleMetricUnits = mkNullableEnableOption "the metric system";
+
+      KeyRepeat = mkNullableOption {
+        type = types.int;
+        example = 2;
+        description = ''
+          Interval between key repetitions when holding down a key. Lower is
+          faster. When setting through the control panel, 2 is the lowest value,
+          and 120 the highest.
+        '';
+      };
 
       NSAutomaticCapitalizationEnabled =
         mkNullableEnableOption "automatic capitalization";
@@ -85,14 +108,50 @@ in {
     };
 
     "com.apple.dock" = {
+      autohide = mkNullableOption {
+        type = types.bool;
+        example = true;
+        description = "Hide the Dock automatically";
+      };
+      expose-group-apps = mkNullableEnableOption
+        "grouping of windows by application in Mission Control";
+      orientation = mkNullableOption {
+        type = types.enum [ "left" "bottom" "right" ];
+        example = "left";
+        description = "Position of the Dock on the screen";
+      };
+      size-immutable = mkNullableEnableOption "locking of the dock size";
       tilesize = mkNullableOption {
         type = types.int;
         example = 64;
         description = "Sets the size of the dock.";
       };
-      size-immutable = mkNullableEnableOption "locking of the dock size";
-      expose-group-apps = mkNullableEnableOption
-        "grouping of windows by application in Mission Control";
+    };
+
+    "com.apple.finder" = {
+      AppleShowAllFiles = mkNullableOption {
+        type = types.bool;
+        example = true;
+        description = "Show hidden files in Finder";
+      };
+
+      FXRemoveOldTrashItems = mkNullableOption {
+        type = types.bool;
+        example = true;
+        description = "Automatically delete items from trash after 30 days";
+      };
+
+      ShowPathBar = mkNullableOption {
+        type = types.bool;
+        example = true;
+        description = "Show the path bar at the bottom of a Finder window";
+      };
+
+      ShowStatusBar = mkNullableOption {
+        type = types.bool;
+        example = true;
+        description = "Show the status bar at the bottom of a Finder window";
+      };
     };
 
     "com.apple.menuextra.battery".ShowPercent = mkNullableOption {
@@ -104,6 +163,41 @@ in {
 
         Whether to show battery percentage in the menu bar.
       '';
+    };
+
+    "com.apple.menuextra.clock" = {
+      IsAnalog = mkNullableEnableOption
+        "showing an analog clock instead of a digital one";
+
+      Show24Hour = mkNullableEnableOption
+        "showing a 24-hour clock, instead of a 12-hour clock";
+
+      ShowAMPM = mkNullableOption {
+        type = types.bool;
+        description = ''
+          Show the AM/PM label. Useful if Show24Hour is false. Default is null.
+        '';
+      };
+
+      ShowDate = mkNullableOption {
+        type = types.enum [ 0 1 2 ];
+        description = ''
+          Show the full date. Default is null.
+
+          0 = Show the date
+          1 = Don't show
+          2 = Don't show
+
+          TODO: I don't know what the difference is between 1 and 2.
+        '';
+      };
+
+      ShowDayOfMonth = mkNullableEnableOption "showing the day of the month";
+
+      ShowDayOfWeek = mkNullableEnableOption "showing the day of the week";
+
+      ShowSeconds = mkNullableEnableOption
+        "showing the clock with second precision, instead of minutes";
     };
 
     "com.apple.Safari" = {


### PR DESCRIPTION
### Description
Adding a few defaults options as I move this from nix-darwin. home-manager is the right place for this as they are per-user, not nix-darwin (which should be a NixOS analogue for darwin, iow not handle per-user settings).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
