### PR TITLE
[Backport 23.11] yazi: shell integration

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -30,8 +30,12 @@ let
 
   nushellIntegration = ''
     def --env ya [args?] {
-      let tmp = $"($env.TEMP)(char path_sep)yazi-cwd." + (random chars -l 5)
-      yazi $args --cwd-file $tmp
+      let tmp = (mktemp -t "yazi-cwd.XXXXX")
+      if ($args == null) {
+        yazi --cwd-file $tmp
+      } else {
+        yazi $args --cwd-file $tmp
+      }
       let cwd = (open $tmp)
       if $cwd != "" and $cwd != $env.PWD {
         cd $cwd

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -8,7 +8,7 @@ let
 
   bashIntegration = ''
     function ya() {
-      tmp="$(mktemp -t "yazi-cwd.XXXXX")"
+      local tmp="$(mktemp -t "yazi-cwd.XXXXX")"
       yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
         cd -- "$cwd"
@@ -29,18 +29,14 @@ let
   '';
 
   nushellIntegration = ''
-    def --env ya [args?] {
+    def --env ya [...args] {
       let tmp = (mktemp -t "yazi-cwd.XXXXX")
-      if ($args == null) {
-        yazi --cwd-file $tmp
-      } else {
-        yazi $args --cwd-file $tmp
-      }
+      yazi ...$args --cwd-file $tmp
       let cwd = (open $tmp)
       if $cwd != "" and $cwd != $env.PWD {
         cd $cwd
       }
-      rm -f $tmp
+      rm -fp $tmp
     }
   '';
 in {

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -21,7 +21,7 @@ let
     function ya
       set tmp (mktemp -t "yazi-cwd.XXXXX")
       yazi --cwd-file="$tmp"
-      if set cwd (cat -- "$tmp") && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]
+      if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
         cd -- "$cwd"
       end
       rm -f -- "$tmp"
@@ -29,10 +29,10 @@ let
   '';
 
   nushellIntegration = ''
-    def-env ya [] {
-      let tmp = (mktemp -t "yazi-cwd.XXXXX")
+    def --env ya [] {
+      let tmp = $"($env.TEMP)(char path_sep)yazi-cwd." + (random chars -l 5)
       yazi --cwd-file $tmp
-      let cwd = (cat -- $tmp)
+      let cwd = (open $tmp)
       if $cwd != "" and $cwd != $env.PWD {
         cd $cwd
       }
@@ -82,7 +82,7 @@ in {
         Configuration written to
         {file}`$XDG_CONFIG_HOME/yazi/keymap.toml`.
 
-        See <https://github.com/sxyazi/yazi/blob/main/config/docs/keymap.md>
+        See <https://yazi-rs.github.io/docs/configuration/keymap>
         for the full list of options.
       '';
     };
@@ -107,7 +107,7 @@ in {
         Configuration written to
         {file}`$XDG_CONFIG_HOME/yazi/yazi.toml`.
 
-        See <https://github.com/sxyazi/yazi/blob/main/config/docs/yazi.md>
+        See <https://yazi-rs.github.io/docs/configuration/yazi>
         for the full list of options.
       '';
     };
@@ -131,7 +131,7 @@ in {
         Configuration written to
         {file}`$XDG_CONFIG_HOME/yazi/theme.toml`.
 
-        See <https://github.com/sxyazi/yazi/blob/main/config/docs/theme.md>
+        See <https://yazi-rs.github.io/docs/configuration/theme>
         for the full list of options
       '';
     };

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -9,7 +9,7 @@ let
   bashIntegration = ''
     function ya() {
       tmp="$(mktemp -t "yazi-cwd.XXXXX")"
-      yazi --cwd-file="$tmp"
+      yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
         cd -- "$cwd"
       fi
@@ -20,7 +20,7 @@ let
   fishIntegration = ''
     function ya
       set tmp (mktemp -t "yazi-cwd.XXXXX")
-      yazi --cwd-file="$tmp"
+      yazi $argv --cwd-file="$tmp"
       if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
         cd -- "$cwd"
       end
@@ -29,9 +29,9 @@ let
   '';
 
   nushellIntegration = ''
-    def --env ya [] {
+    def --env ya [args?] {
       let tmp = $"($env.TEMP)(char path_sep)yazi-cwd." + (random chars -l 5)
-      yazi --cwd-file $tmp
+      yazi $args --cwd-file $tmp
       let cwd = (open $tmp)
       if $cwd != "" and $cwd != $env.PWD {
         cd $cwd

--- a/tests/modules/programs/yazi/bash-integration-enabled.nix
+++ b/tests/modules/programs/yazi/bash-integration-enabled.nix
@@ -3,7 +3,7 @@
 let
   shellIntegration = ''
     function ya() {
-      tmp="$(mktemp -t "yazi-cwd.XXXXX")"
+      local tmp="$(mktemp -t "yazi-cwd.XXXXX")"
       yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
         cd -- "$cwd"

--- a/tests/modules/programs/yazi/bash-integration-enabled.nix
+++ b/tests/modules/programs/yazi/bash-integration-enabled.nix
@@ -4,7 +4,7 @@ let
   shellIntegration = ''
     function ya() {
       tmp="$(mktemp -t "yazi-cwd.XXXXX")"
-      yazi --cwd-file="$tmp"
+      yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
         cd -- "$cwd"
       fi

--- a/tests/modules/programs/yazi/fish-integration-enabled.nix
+++ b/tests/modules/programs/yazi/fish-integration-enabled.nix
@@ -5,7 +5,7 @@ let
     function ya
       set tmp (mktemp -t "yazi-cwd.XXXXX")
       yazi --cwd-file="$tmp"
-      if set cwd (cat -- "$tmp") && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]
+      if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
         cd -- "$cwd"
       end
       rm -f -- "$tmp"

--- a/tests/modules/programs/yazi/fish-integration-enabled.nix
+++ b/tests/modules/programs/yazi/fish-integration-enabled.nix
@@ -4,7 +4,7 @@ let
   shellIntegration = ''
     function ya
       set tmp (mktemp -t "yazi-cwd.XXXXX")
-      yazi --cwd-file="$tmp"
+      yazi $argv --cwd-file="$tmp"
       if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
         cd -- "$cwd"
       end

--- a/tests/modules/programs/yazi/nushell-integration-enabled.nix
+++ b/tests/modules/programs/yazi/nushell-integration-enabled.nix
@@ -3,8 +3,12 @@
 let
   shellIntegration = ''
     def --env ya [args?] {
-      let tmp = $"($env.TEMP)(char path_sep)yazi-cwd." + (random chars -l 5)
-      yazi $args --cwd-file $tmp
+      let tmp = (mktemp -t "yazi-cwd.XXXXX")
+      if ($args == null) {
+        yazi --cwd-file $tmp
+      } else {
+        yazi $args --cwd-file $tmp
+      }
       let cwd = (open $tmp)
       if $cwd != "" and $cwd != $env.PWD {
         cd $cwd

--- a/tests/modules/programs/yazi/nushell-integration-enabled.nix
+++ b/tests/modules/programs/yazi/nushell-integration-enabled.nix
@@ -2,18 +2,14 @@
 
 let
   shellIntegration = ''
-    def --env ya [args?] {
+    def --env ya [...args] {
       let tmp = (mktemp -t "yazi-cwd.XXXXX")
-      if ($args == null) {
-        yazi --cwd-file $tmp
-      } else {
-        yazi $args --cwd-file $tmp
-      }
+      yazi ...$args --cwd-file $tmp
       let cwd = (open $tmp)
       if $cwd != "" and $cwd != $env.PWD {
         cd $cwd
       }
-      rm -f $tmp
+      rm -fp $tmp
     }
   '';
 in {

--- a/tests/modules/programs/yazi/nushell-integration-enabled.nix
+++ b/tests/modules/programs/yazi/nushell-integration-enabled.nix
@@ -2,10 +2,10 @@
 
 let
   shellIntegration = ''
-    def-env ya [] {
-      let tmp = (mktemp -t "yazi-cwd.XXXXX")
+    def --env ya [] {
+      let tmp = $"($env.TEMP)(char path_sep)yazi-cwd." + (random chars -l 5)
       yazi --cwd-file $tmp
-      let cwd = (cat -- $tmp)
+      let cwd = (open $tmp)
       if $cwd != "" and $cwd != $env.PWD {
         cd $cwd
       }

--- a/tests/modules/programs/yazi/nushell-integration-enabled.nix
+++ b/tests/modules/programs/yazi/nushell-integration-enabled.nix
@@ -2,9 +2,9 @@
 
 let
   shellIntegration = ''
-    def --env ya [] {
+    def --env ya [args?] {
       let tmp = $"($env.TEMP)(char path_sep)yazi-cwd." + (random chars -l 5)
-      yazi --cwd-file $tmp
+      yazi $args --cwd-file $tmp
       let cwd = (open $tmp)
       if $cwd != "" and $cwd != $env.PWD {
         cd $cwd

--- a/tests/modules/programs/yazi/zsh-integration-enabled.nix
+++ b/tests/modules/programs/yazi/zsh-integration-enabled.nix
@@ -3,7 +3,7 @@
 let
   shellIntegration = ''
     function ya() {
-      tmp="$(mktemp -t "yazi-cwd.XXXXX")"
+      local tmp="$(mktemp -t "yazi-cwd.XXXXX")"
       yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
         cd -- "$cwd"

--- a/tests/modules/programs/yazi/zsh-integration-enabled.nix
+++ b/tests/modules/programs/yazi/zsh-integration-enabled.nix
@@ -4,7 +4,7 @@ let
   shellIntegration = ''
     function ya() {
       tmp="$(mktemp -t "yazi-cwd.XXXXX")"
-      yazi --cwd-file="$tmp"
+      yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
         cd -- "$cwd"
       fi


### PR DESCRIPTION
### Description

Backport https://github.com/nix-community/home-manager/pull/4699 https://github.com/nix-community/home-manager/pull/4746 https://github.com/nix-community/home-manager/pull/4846 to 23.11

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
