### PR TITLE
session-variables: escape quotes in shell env vars

### DIFF
--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -1,8 +1,10 @@
 { lib }:
-
-rec {
+let
+  escapeQuotes =
+    lib.strings.stringAsChars (x: if x == ''"'' then ''\"'' else x);
+in rec {
   # Produces a Bourne shell like variable export statement.
-  export = n: v: ''export ${n}="${toString v}"'';
+  export = n: v: ''export ${n}="${escapeQuotes (toString v)}"'';
 
   # Given an attribute set containing shell variable names and their
   # assignment, this function produces a string containing an export

--- a/modules/lib/zsh.nix
+++ b/modules/lib/zsh.nix
@@ -1,12 +1,14 @@
 { lib }:
-
-rec {
+let
+  escapeQuotes =
+    lib.strings.stringAsChars (x: if x == ''"'' then ''\"'' else x);
+in rec {
   # Produces a Zsh shell like value
   toZshValue = v:
     if builtins.isBool v then
       if v then "true" else "false"
     else if builtins.isString v then
-      ''"${v}"''
+      ''"${escapeQuotes v}"''
     else if builtins.isList v then
       "(${lib.concatStringsSep " " (map toZshValue v)})"
     else

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -12,6 +12,7 @@ let
     export LOCALE_ARCHIVE_2_27="${config.i18n.glibcLocales}/lib/locale/locale-archive"
     export V1="v1"
     export V2="v2-v1"
+    export EDITOR="emacsclient -t -a \"\""
     export XDG_CACHE_HOME="/home/hm-user/.cache"
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
@@ -23,6 +24,7 @@ let
     if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
+    export EDITOR="emacsclient -t -a \"\""
     export V1="v1"
     export V2="v2-v1"
     export XDG_CACHE_HOME="/home/hm-user/.cache"
@@ -39,6 +41,7 @@ in {
     home.sessionVariables = {
       V1 = "v1";
       V2 = "v2-${config.home.sessionVariables.V1}";
+      EDITOR = ''emacsclient -t -a ""'';
     };
 
     nmt.script = ''

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -11,6 +11,7 @@ with lib;
       sessionVariables = {
         V1 = "v1";
         V2 = "v2-${config.programs.bash.sessionVariables.V1}";
+        EDITOR = ''emacsclient -t -a ""'';
       };
     };
 
@@ -22,6 +23,7 @@ with lib;
           builtins.toFile "session-variables-expected" ''
             . "/home/hm-user/.nix-profile/etc/profile.d/hm-session-vars.sh"
 
+            export EDITOR="emacsclient -t -a \"\""
             export V1="v1"
             export V2="v2-v1"
 

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -10,6 +10,7 @@ with lib;
       sessionVariables = {
         V1 = "v1";
         V2 = "v2-${config.programs.zsh.sessionVariables.V1}";
+        EDITOR = ''emacsclient -t -a ""'';
       };
     };
 
@@ -19,6 +20,7 @@ with lib;
       assertFileExists home-files/.zshenv
       assertFileRegex home-files/.zshenv 'export V1="v1"'
       assertFileRegex home-files/.zshenv 'export V2="v2-v1"'
+      assertFileRegex home-files/.zshenv 'export EDITOR="emacsclient -t -a \\"\\""'
     '';
   };
 }


### PR DESCRIPTION
Add support for environment variables with values containing quotes.

### Description

When trying to set EDITOR and VISUAL to the recommended value for emacsclient (`emacsclient -t -a ""`) 
I kept getting truncated values (`emacsclient -t -a`) in the resulting shell environment.
This PR adds support for environment variables with values containing quotes.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
