### PR TITLE
zsh: support shellAliases beginning with a `-`

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -15,7 +15,7 @@ let
   localVarsStr = config.lib.zsh.defineAll cfg.localVariables;
 
   aliasesStr = concatStringsSep "\n" (
-    mapAttrsToList (k: v: "alias ${k}=${lib.escapeShellArg v}") cfg.shellAliases
+    mapAttrsToList (k: v: "alias -- ${lib.escapeShellArg k}=${lib.escapeShellArg v}") cfg.shellAliases
   );
 
   dirHashesStr = concatStringsSep "\n" (
@@ -637,8 +637,8 @@ in
         # Aliases
         ${aliasesStr}
         ''
-      ] 
-      ++ (mapAttrsToList (k: v: "alias -g ${k}=${lib.escapeShellArg v}") cfg.shellGlobalAliases) 
+      ]
+      ++ (mapAttrsToList (k: v: "alias -g -- ${lib.escapeShellArg k}=${lib.escapeShellArg v}") cfg.shellGlobalAliases)
       ++ [ (''
         # Named Directory Hashes
         ${dirHashesStr}

--- a/tests/modules/programs/pls/zsh.nix
+++ b/tests/modules/programs/pls/zsh.nix
@@ -23,10 +23,10 @@ with lib;
       assertFileExists home-files/.zshrc
       assertFileContains \
         home-files/.zshrc \
-        "alias ls='@pls@/bin/pls'"
+        "alias -- 'ls'='@pls@/bin/pls'"
       assertFileContains \
         home-files/.zshrc \
-        "alias ll='@pls@/bin/pls -d perms -d user -d group -d size -d mtime -d git'"
+        "alias -- 'll'='@pls@/bin/pls -d perms -d user -d group -d size -d mtime -d git'"
     '';
   };
 }


### PR DESCRIPTION
### Description

This patch improves `programs.zsh.shellAliases` so that it doesn't choke on an alias whose name begins with (or consists entirely of) a `-`.

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
    **_yes, but_ something failed and I'm not sure it's related to my change:**
```console
home-manager on  zsh-aliases 
❯ nix develop --ignore-environment .#all
error: hash mismatch in fixed-output derivation '/nix/store/1gc9h74vp75ibbvbhqlkgrm044v6zkwq-lookup?op=get-options=mr-search=0x36cacf52d098cc0e78fb0cb13573356c25c424d4.drv':
         specified: sha256-9Zjsb/TtOyiPzMO/Jg3CtJwSxuw7QmX0pcfZT2/1w5E=
            got:    sha256-Pvm0CpH13pvnD/c+IJAkRElR5/IhZt8pg7RjT/dZdfM=
error: 1 dependencies of derivation '/nix/store/q63vwwi40imdsxcdw53nkb9lx9g6a9md-gpg-pubring.drv' failed to build
error: 1 dependencies of derivation '/nix/store/xvfvc2fdak9mbkqs8pnyzfz0qr7l0fc3-activation-script.drv' failed to build
error: 1 dependencies of derivation '/nix/store/zgq3idr1kc12s4wy23wdswsw9a5kf9x5-home-manager-generation.drv' failed to build
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'nmt-run-all-tests'
         whose name attribute is located at /nix/store/bg5fbkfa5x53clcjf4p5p92k1l3w8x38-source/pkgs/stdenv/generic/make-derivation.nix:353:7

       … while evaluating attribute 'shellHook' of derivation 'nmt-run-all-tests'

         at /nix/store/fm1dwqb08lxr1gk02niyvb1j7v4181c0-source/default.nix:38:40:

           37|   runShellOnlyCommand = name: shellHook:
           38|     pkgs.runCommandLocal name { inherit shellHook; } ''
             |                                        ^
           39|       echo This derivation is only useful when run through nix-shell.

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: 1 dependencies of derivation '/nix/store/b2i75l494nli0s3dipy664g2l18m5nbd-nmt-report-gpg-immutable-keyfiles.drv' failed to build
```

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
A lot of people have touched the shellAliases code, so here's a few @'s. Sorry to anyone who isn't directly related to or involved with this!
@teto @uvNikita @infinisil @Ma27 @rycee 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
