### PR TITLE
fusuma: fix #4945 and add missing dependencies

### DIFF
--- a/modules/services/fusuma.nix
+++ b/modules/services/fusuma.nix
@@ -96,10 +96,11 @@ in {
 
     extraPackages = mkOption {
       type = types.listOf types.package;
-      default = with pkgs; [ coreutils ];
-      defaultText = literalExpression "pkgs.coreutils";
+      default = with pkgs; [ xdotool coreutils xorg.xprop ];
+      defaultText =
+        literalExpression "pkgs.xdotool pkgs.coreutils pkgs.xorg.xprop";
       example = literalExpression ''
-        with pkgs; [ coreutils xdotool ];
+        with pkgs; [ xdotool coreutils xorg.xprop ];
       '';
       description = ''
         Extra packages needs to bring to the scope of fusuma service.
@@ -113,7 +114,7 @@ in {
         lib.platforms.linux)
     ];
 
-    xdg.configFile."fusuma/config.yaml".source = configYaml;
+    xdg.configFile."fusuma/config.yml".source = configYaml;
 
     systemd.user.services.fusuma = {
       Unit = {
@@ -124,8 +125,7 @@ in {
 
       Service = {
         Environment = with pkgs; "PATH=${makeBinPath cfg.extraPackages}";
-        ExecStart =
-          "${cfg.package}/bin/fusuma -c ${config.xdg.configHome}/fusuma/config.yaml";
+        ExecStart = "${cfg.package}/bin/fusuma";
       };
 
       Install = { WantedBy = [ "graphical-session.target" ]; };

--- a/tests/modules/services/fusuma/expected-service.service
+++ b/tests/modules/services/fusuma/expected-service.service
@@ -2,8 +2,8 @@
 WantedBy=graphical-session.target
 
 [Service]
-Environment=PATH=@coreutils@/bin:@xdotool@/bin
-ExecStart=@fusuma@/bin/fusuma -c /home/hm-user/.config/fusuma/config.yaml
+Environment=PATH=@coreutils@/bin:@xdotool@/bin:@xorg.xprop@/bin
+ExecStart=@fusuma@/bin/fusuma
 
 [Unit]
 After=graphical-session-pre.target

--- a/tests/modules/services/fusuma/service.nix
+++ b/tests/modules/services/fusuma/service.nix
@@ -7,6 +7,7 @@
     extraPackages = [
       (config.lib.test.mkStubPackage { outPath = "@coreutils@"; })
       (config.lib.test.mkStubPackage { outPath = "@xdotool@"; })
+      (config.lib.test.mkStubPackage { outPath = "@xorg.xprop@"; })
     ];
     settings = { };
   };

--- a/tests/modules/services/fusuma/settings.nix
+++ b/tests/modules/services/fusuma/settings.nix
@@ -18,7 +18,7 @@
 
   nmt.script = ''
     assertFileContent \
-      home-files/.config/fusuma/config.yaml \
+      home-files/.config/fusuma/config.yml \
       ${./expected-settings.yaml}
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds `pkgs.xorg.xprop` and `pkgs.xdotool` to the environment for `systemd.user.services.fusuma`, which is needed for fusuma to work correctly.

This PR also fixes #4945 by changing the name of the config file that will be created from `config.yaml` to `config.yml`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@iosmanthus @pluiedev

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
