### PR TITLE
poetry: init module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1506,6 +1506,16 @@ in {
           A new module is available: 'services.remmina'.
         '';
       }
+
+      {
+        time = "2024-04-21T20:53:09+00:00";
+        message = ''
+          A new module is available: 'programs.poetry'.
+
+          Poetry is a tool that helps you manage Python project dependencies and
+          packages. See https://python-poetry.org/ for more.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -186,6 +186,7 @@ let
     ./programs/pistol.nix
     ./programs/piston-cli.nix
     ./programs/pls.nix
+    ./programs/poetry.nix
     ./programs/powerline-go.nix
     ./programs/pqiv.nix
     ./programs/pubs.nix

--- a/modules/programs/poetry.nix
+++ b/modules/programs/poetry.nix
@@ -1,0 +1,55 @@
+{ pkgs, config, lib, ... }:
+
+let
+
+  inherit (lib) mkEnableOption mkPackageOption mkOption literalExpression;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Application Support"
+  else
+    config.xdg.configHome;
+
+  cfg = config.programs.poetry;
+
+in {
+  meta.maintainers = with lib.maintainers; [ mirkolenz ];
+
+  options.programs.poetry = {
+    enable = mkEnableOption "poetry";
+
+    package = mkPackageOption pkgs "poetry" {
+      example = "pkgs.poetry.withPlugins (ps: with ps; [ poetry-plugin-up ])";
+      extraDescription = "May be used to install custom poetry plugins.";
+    };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          virtualenvs.create = true;
+          virtualenvs.in-project = true;
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/pypoetry/config.toml` on Linux or
+        {file}`$HOME/Library/Application Support/pypoetry/config.toml` on Darwin.
+        See
+        <https://python-poetry.org/docs/configuration/>
+        for more information.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.file."${configDir}/pypoetry/config.toml" =
+      lib.mkIf (cfg.settings != { }) {
+        source = tomlFormat.generate "poetry-config" cfg.settings;
+      };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -122,6 +122,7 @@ in import nmtSrc {
     ./modules/programs/pet
     ./modules/programs/pistol
     ./modules/programs/pls
+    ./modules/programs/poetry
     ./modules/programs/powerline-go
     ./modules/programs/pubs
     ./modules/programs/pyenv

--- a/tests/modules/programs/poetry/custom-settings.nix
+++ b/tests/modules/programs/poetry/custom-settings.nix
@@ -1,0 +1,27 @@
+{ pkgs, ... }:
+
+{
+  programs.poetry = {
+    enable = true;
+    settings = {
+      virtualenvs.create = true;
+      virtualenvs.in-project = true;
+    };
+  };
+
+  test.stubs.poetry = { };
+
+  nmt.script = let
+    expectedConfDir =
+      if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+    expectedConfigPath = "home-files/${expectedConfDir}/pypoetry/config.toml";
+    expectedConfigContent = pkgs.writeText "poetry.config-custom.expected" ''
+      [virtualenvs]
+      create = true
+      in-project = true
+    '';
+  in ''
+    assertFileExists "${expectedConfigPath}"
+    assertFileContent "${expectedConfigPath}" "${expectedConfigContent}"
+  '';
+}

--- a/tests/modules/programs/poetry/default-settings.nix
+++ b/tests/modules/programs/poetry/default-settings.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+{
+  programs.poetry = { enable = true; };
+
+  test.stubs.poetry = { };
+
+  nmt.script = let
+    expectedConfDir =
+      if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+    expectedConfigPath = "home-files/${expectedConfDir}/pypoetry/config.toml";
+  in ''
+    assertPathNotExists "${expectedConfigPath}"
+  '';
+}

--- a/tests/modules/programs/poetry/default.nix
+++ b/tests/modules/programs/poetry/default.nix
@@ -1,0 +1,4 @@
+{
+  poetry-default-settings = ./default-settings.nix;
+  poetry-custom-settings = ./custom-settings.nix;
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Create new module for poetry. I added the corresponding tests based on those used by `tealdeer`, but strangely the test `poetry-custom-config` is failing even though it works if I include the new module in my own nixos configuration. That is also why this PR is marked as draft at the moment. I would be more than happy for suggestions as to why the test is failing.

Edit: I identified the issue: I forgot to include the new module in the file `modules/modules.nix`, so it was not picked up during the tests. I marked the PR as ready to review.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
