### PR TITLE
river: fix systemd activation

### DIFF
--- a/modules/services/window-managers/river.nix
+++ b/modules/services/window-managers/river.nix
@@ -9,7 +9,7 @@ let
   extraCommands = builtins.concatStringsSep " "
     (map (f: "&& ${f}") cfg.systemd.extraCommands);
   systemdActivation = ''
-    exec "${pkgs.dbus}/bin/dbus-update-activation-environment --systemd ${variables} ${extraCommands}"
+    ${pkgs.dbus}/bin/dbus-update-activation-environment --systemd ${variables} ${extraCommands}
   '';
 
   toValue = val:

--- a/tests/modules/services/window-managers/river/init
+++ b/tests/modules/services/window-managers/river/init
@@ -62,6 +62,6 @@ extra config
 
 
 ### SYSTEMD INTEGRATION ###
-exec "@dbus@/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP NIXOS_OZONE_WL XCURSOR_THEME XCURSOR_SIZE && systemctl --user stop river-session.target && systemctl --user start river-session.target"
+@dbus@/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP NIXOS_OZONE_WL XCURSOR_THEME XCURSOR_SIZE && systemctl --user stop river-session.target && systemctl --user start river-session.target
 
 


### PR DESCRIPTION
### Description
exec does not do any shell parsing and does not understand the && which is how the extraCommands are added after dbus activation. There seems to be no clear need for exec here anyway so just remove it and allow shell parsing.

The error you'll get when there are extraCommands (and there are by default) looks like this:

```sh
bash: /nix/store/3n8s5m00h7qqvbmahhr4fxskkbz85z03-dbus-1.14.10/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP NIXOS_OZONE_WL XCURSOR_THEME XCURSOR_SIZE && systemctl --user stop river-session.target && systemctl --user start river-session.target: No such file or directory
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@GaetanLepage