### PR TITLE
himalaya: adjust code for v1.0.0-beta.3

### DIFF
--- a/modules/programs/himalaya.nix
+++ b/modules/programs/himalaya.nix
@@ -169,7 +169,7 @@ in {
         config.accounts.email.accounts;
       accountsConfig = lib.mapAttrs mkAccountConfig enabledAccounts;
       globalConfig = compactAttrs himalaya.settings;
-      allConfig = globalConfig // accountsConfig;
+      allConfig = globalConfig // { accounts = accountsConfig; };
     in tomlFormat.generate "himalaya-config.toml" allConfig;
     systemd.user.services = let
       inherit (config.services.himalaya-watch) enable environment settings;

--- a/tests/modules/programs/himalaya/basic-expected.toml
+++ b/tests/modules/programs/himalaya/basic-expected.toml
@@ -1,32 +1,32 @@
-["hm@example.com"]
+[accounts."hm@example.com"]
 backend = "imap"
 default = true
 display-name = "H. M. Test"
 email = "hm@example.com"
 
-["hm@example.com".folder.alias]
+[accounts."hm@example.com".folder.alias]
 drafts = "Drafts"
 inbox = "Inbox"
 sent = "Sent"
 trash = "Trash"
 
-["hm@example.com".imap]
+[accounts."hm@example.com".imap]
 encryption = "tls"
 host = "imap.example.com"
 login = "home.manager"
 port = 993
 
-["hm@example.com".imap.passwd]
+[accounts."hm@example.com".imap.passwd]
 cmd = "password-command"
 
-["hm@example.com".message.send]
+[accounts."hm@example.com".message.send]
 backend = "smtp"
 
-["hm@example.com".smtp]
+[accounts."hm@example.com".smtp]
 encryption = "tls"
 host = "smtp.example.com"
 login = "home.manager"
 port = 465
 
-["hm@example.com".smtp.passwd]
+[accounts."hm@example.com".smtp.passwd]
 cmd = "password-command"


### PR DESCRIPTION
### Description

Account configurations are now prefixed by `accounts.` in the TOML file, hence the modification of the home manager module.

I open this PR as draft because the nixpkgs PR is not yet merged: https://github.com/NixOS/nixpkgs/pull/291335

See the full changelog at https://github.com/soywod/himalaya/releases/tag/v1.0.0-beta.3

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
