### PR TITLE
firefox: Add `containersForce`

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -573,6 +573,17 @@ in {
               };
             };
 
+            containersForce = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Whether to force replace the existing containers
+                configuration. This is recommended since Firefox will
+                replace the symlink on every launch, but note that you'll
+                lose any existing configuration by enabling this.
+              '';
+            };
+
             containers = mkOption {
               type = types.attrsOf (types.submodule ({ name, ... }: {
                 options = {
@@ -762,6 +773,7 @@ in {
 
       "${profilesPath}/${profile.path}/containers.json" =
         mkIf (profile.containers != { }) {
+          force = profile.containersForce;
           text = mkContainersJson profile.containers;
         };
 


### PR DESCRIPTION
### Description

Firefox, upon exit, creates the default containers.json file in place of the one that home-manager created. This leads to errors when switching to a new profile, as home-manager is careful with overwriting existing files. The added option toggles that behaviour.

Closes: https://github.com/nix-community/home-manager/issues/4989

---

I guess it would be best if this was inlined into the existing `containers` field, in a backwards compatible way; e.g.,

``` nix
containers = {
  force = true;

  "name" = {
    id    = 1;
    color = "purple";
  };
```

but I haven't managed to make that work.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@rycee @kira-bruneau