### PR TITLE
nix.gc.frequency: let linux use any time config

### DIFF
--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -9,6 +9,10 @@ let
     let
       freq = {
         "hourly" = [{ Minute = 0; }];
+        "daily" = [{
+          Hour = 0;
+          Minute = 0;
+        }];
         "weekly" = [{
           Weekday = 1;
           Hour = 0;
@@ -62,8 +66,14 @@ in {
       };
 
       frequency = mkOption {
-        type =
-          types.enum [ "hourly" "weekly" "monthly" "semiannually" "annually" ];
+        type = types.enum [
+          "hourly"
+          "daily"
+          "weekly"
+          "monthly"
+          "semiannually"
+          "annually"
+        ];
         default = "weekly";
         example = "monthly";
         description = ''

--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -116,9 +116,9 @@ in {
     (mkIf pkgs.stdenv.isDarwin {
       assertions = [{
         assertion = builtins.elem cfg.frequency darwinIntervals;
-        message = ''
-          On Darwin nix.gc.frequency must be one of:
-                      ${toString darwinIntervals}.'';
+        message = "On Darwin nix.gc.frequency must be one of: ${
+            toString darwinIntervals
+          }. ";
       }];
       launchd.agents.nix-gc = {
         enable = true;

--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -4,6 +4,8 @@ with lib;
 
 let
   cfg = config.nix.gc;
+  darwinIntervals =
+    [ "hourly" "daily" "weekly" "monthly" "semiannually" "annually" ];
 
   mkCalendarInterval = frequency:
     let
@@ -66,21 +68,16 @@ in {
       };
 
       frequency = mkOption {
-        type = types.enum [
-          "hourly"
-          "daily"
-          "weekly"
-          "monthly"
-          "semiannually"
-          "annually"
-        ];
+        type = types.str;
         default = "weekly";
-        example = "monthly";
+        example = "03:15";
         description = ''
           The frequency at which to run the garbage collector.
 
-          These enums are based on special expressions from the
-          {manpage}`systemd.time(7)`
+          On Linux this is a string as defined by {manpage}`systemd.time(7)`.
+
+          On Darwin must be one of: ${toString darwinIntervals}.
+          Implemented based on special expressions from {manpage}`systemd.time(7)`
         '';
       };
 
@@ -117,6 +114,12 @@ in {
     })
 
     (mkIf pkgs.stdenv.isDarwin {
+      assertions = [{
+        assertion = builtins.elem cfg.frequency darwinIntervals;
+        message = ''
+          On Darwin nix.gc.frequency must be one of:
+                      ${toString darwinIntervals}.'';
+      }];
       launchd.agents.nix-gc = {
         enable = true;
         config = {


### PR DESCRIPTION
### Description

Let Linux use any time configuration with nix.gc.frequency

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@shivaraj-bh
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
