### PR TITLE
Fix activation under Nix 2.3 and stop run function from discarding error messages

### DIFF
--- a/lib/bash/home-manager.sh
+++ b/lib/bash/home-manager.sh
@@ -99,16 +99,26 @@ function _iVerbose() {
 # Runs the given command on live run, otherwise prints the command to standard
 # output.
 #
+# If given the command line option `--quiet`, then the command's standard output
+# is sent to `/dev/null` on a live run.
+#
 # If given the command line option `--silence`, then the command's standard and
 # error output is sent to `/dev/null` on a live run.
+#
+# The `--silence` and `--quiet` flags are mutually exclusive.
 function run() {
-    if [[ $1 == '--silence' ]]; then
+    if [[ $1 == '--quiet' ]]; then
+        local quiet=1
+        shift
+    elif [[ $1 == '--silence' ]]; then
         local silence=1
         shift
     fi
 
     if [[ -v DRY_RUN ]] ; then
         echo "$@"
+    elif [[ -v quiet ]] ; then
+        "$@" > /dev/null
     elif [[ -v silence ]] ; then
         "$@" > /dev/null 2>&1
     else

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -274,7 +274,7 @@ in
               run nix-env $VERBOSE_ARG --profile "$genProfilePath" --set "$newGenPath"
             fi
 
-            run --quiet nix-store --realise "$newGenPath" --add-root "$newGenGcPath"
+            run --quiet nix-store --realise "$newGenPath" --add-root "$newGenGcPath" --indirect
             if [[ -e "$legacyGenGcPath" ]]; then
               run rm $VERBOSE_ARG "$legacyGenGcPath"
             fi

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -274,7 +274,7 @@ in
               run nix-env $VERBOSE_ARG --profile "$genProfilePath" --set "$newGenPath"
             fi
 
-            run --silence nix-store --realise "$newGenPath" --add-root "$newGenGcPath"
+            run --quiet nix-store --realise "$newGenPath" --add-root "$newGenGcPath"
             if [[ -e "$legacyGenGcPath" ]]; then
               run rm $VERBOSE_ARG "$legacyGenGcPath"
             fi

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -405,10 +405,16 @@ in
         : Runs the given command on live run, otherwise prints the command to
         standard output.
 
+        {command}`run --quiet {command}`
+        : Runs the given command on live run and sends its standard output to
+        {file}`/dev/null`, otherwise prints the command to standard output.
+
         {command}`run --silence {command}`
         : Runs the given command on live run and sends its standard and error
         output to {file}`/dev/null`, otherwise prints the command to standard
         output.
+
+        The `--quiet` and `--silence` flags are mutually exclusive.
 
         A script block should also respect the {var}`VERBOSE` variable, and if
         set print information on standard out that may be useful for debugging

--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -115,7 +115,7 @@ function nixProfileRemove() {
         nixProfileList "$1" | xargs -rt $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
     else
         if nix-env -q | grep -q "^$1$"; then
-            run --silence nix-env -e "$1"
+            run --quiet nix-env -e "$1"
         fi
     fi
 }


### PR DESCRIPTION
<!--

Please provide a brief description of your change.

-->

### Description

This pull request contains two changes:

#### treewide: stop `run` from discarding error messages

Adds a `--quiet` flag to `run`, which functions similarly to (but is mutually exclusive with) its existing `--silence` flag. When applied, this redirects _only_ standard output (unlike `--silence`, which also redirects standard error) to `/dev/null`, allowing errors and other diagnostics to be seen. This commit also replaces various usages of `--silence` with `--quiet` where the latter seems more appropriate.

Before this change, gratuitous suppression of diagnostic output resulted in me running into the following (rather confusing) failure message:

```
Feb 25 00:51:03 dysnomia systemd[1]: Starting Home Manager environment for v...
Feb 25 00:51:03 dysnomia hm-activate-v[2558844]: Starting Home Manager activation
Feb 25 00:51:04 dysnomia hm-activate-v[2558844]: Activating checkFilesChanged
Feb 25 00:51:04 dysnomia hm-activate-v[2558844]: Activating checkLinkTargets
Feb 25 00:51:04 dysnomia hm-activate-v[2558844]: Activating writeBoundary
Feb 25 00:51:04 dysnomia hm-activate-v[2558844]: Activating installPackages
Feb 25 00:51:04 dysnomia hm-activate-v[2558844]: Activating linkGeneration
Feb 25 00:51:04 dysnomia hm-activate-v[2558844]: Cleaning up orphan links from /home/v
Feb 25 00:51:04 dysnomia hm-activate-v[2558844]: Creating profile generation 24
Feb 25 00:51:04 dysnomia systemd[1]: home-manager-v.service: Main process exited, code=exited, status=1/FAILURE
Feb 25 00:51:04 dysnomia systemd[1]: home-manager-v.service: Failed with result 'exit-code'.
Feb 25 00:51:04 dysnomia systemd[1]: Failed to start Home Manager environment for v.
```

With `--silence` substituted for `--quiet`, the output instead looks like the following (with the cause of the failure being much more apparent):

```
Feb 28 23:57:16 dysnomia systemd[1]: Starting Home Manager environment for v...
Feb 28 23:57:16 dysnomia hm-activate-v[3846052]: Starting Home Manager activation
Feb 28 23:57:16 dysnomia hm-activate-v[3846052]: Activating checkFilesChanged
Feb 28 23:57:16 dysnomia hm-activate-v[3846052]: Activating checkLinkTargets
Feb 28 23:57:17 dysnomia hm-activate-v[3846052]: Activating writeBoundary
Feb 28 23:57:17 dysnomia hm-activate-v[3846052]: Activating installPackages
Feb 28 23:57:17 dysnomia hm-activate-v[3846052]: Activating linkGeneration
Feb 28 23:57:17 dysnomia hm-activate-v[3846052]: Cleaning up orphan links from /home/v
Feb 28 23:57:17 dysnomia hm-activate-v[3846052]: Creating profile generation 37
Feb 28 23:57:17 dysnomia hm-activate-v[3846159]: error: path '/home/v/.local/state/home-manager/gcroots/current-home' is not a valid garbage collector root; it's not in the directory '/nix/var/nix/gcroots'
Feb 28 23:57:17 dysnomia systemd[1]: home-manager-v.service: Main process exited, code=exited, status=1/FAILURE
Feb 28 23:57:17 dysnomia systemd[1]: home-manager-v.service: Failed with result 'exit-code'.
Feb 28 23:57:17 dysnomia systemd[1]: Failed to start Home Manager environment for v.
```

#### files: fix activation under Nix 2.3

Adds the `--indirect` flag to a failing `nix-store --add-root` invocation in the activation script. This flag is required in Nix 2.3 if creating a garbage collector root outside of `/nix/var/nix/gcroots`. In subsequent versions of Nix, all garbage collector roots created by `--add-root` are indirect, and the flag is a no-op.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.