### PR TITLE
fix(rio): use XDG config for both linux and darwin

### DIFF
--- a/modules/programs/rio.nix
+++ b/modules/programs/rio.nix
@@ -3,8 +3,6 @@ let
   cfg = config.programs.rio;
 
   settingsFormat = pkgs.formats.toml { };
-
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
 in {
   options.programs.rio = {
     enable = lib.mkEnableOption null // {
@@ -20,8 +18,7 @@ in {
       type = settingsFormat.type;
       default = { };
       description = ''
-        Configuration written to <filename>$XDG_CONFIG_HOME/rio/config.toml</filename> on Linux or
-        <filename>$HOME/Library/Application Support/rio/config.toml</filename> on Darwin. See
+        Configuration written to <filename>$XDG_CONFIG_HOME/rio/config.toml</filename>. See
         <link xlink:href="https://raphamorim.io/rio/docs/#configuration-file"/> for options.
       '';
     };
@@ -34,19 +31,11 @@ in {
     }
 
     # Only manage configuration if not empty
-    (lib.mkIf (cfg.settings != { } && !isDarwin) {
+    (lib.mkIf (cfg.settings != { }) {
       xdg.configFile."rio/config.toml".source = if lib.isPath cfg.settings then
         cfg.settings
       else
         settingsFormat.generate "rio.toml" cfg.settings;
-    })
-
-    (lib.mkIf (cfg.settings != { } && isDarwin) {
-      home.file."Library/Application Support/rio/config.toml".source =
-        if lib.isPath cfg.settings then
-          cfg.settings
-        else
-          settingsFormat.generate "rio.toml" cfg.settings;
     })
   ]);
 }

--- a/tests/modules/programs/rio/example-settings.nix
+++ b/tests/modules/programs/rio/example-settings.nix
@@ -1,13 +1,6 @@
 { config, pkgs, ... }:
 
 let
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
-
-  path = if isDarwin then
-    "Library/Application Support/rio/config.toml"
-  else
-    ".config/rio/config.toml";
-
   expected = pkgs.writeText "rio-expected.toml" ''
     cursor = "_"
     padding-x = 0
@@ -26,7 +19,7 @@ in {
   };
 
   nmt.script = ''
-    assertFileExists home-files/"${path}"
-    assertFileContent home-files/"${path}" '${expected}'
+    assertFileExists home-files/.config/rio/config.toml
+    assertFileContent home-files/.config/rio/config.toml '${expected}'
   '';
 }


### PR DESCRIPTION
`rio` now uses the same config location for both Linux and macOS: 

> MacOS and Linux configuration file path is `~/.config/rio/config.toml`.

Ref: https://raphamorim.io/rio/docs/configuration-file

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@otavio 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
