### PR TITLE
gallery-dl: add package option

### DIFF
--- a/modules/programs/gallery-dl.nix
+++ b/modules/programs/gallery-dl.nix
@@ -14,6 +14,8 @@ in {
   options.programs.gallery-dl = {
     enable = mkEnableOption "gallery-dl";
 
+    package = mkPackageOption pkgs "gallery-dl" { };
+
     settings = mkOption {
       type = jsonFormat.type;
       default = { };
@@ -32,7 +34,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ pkgs.gallery-dl ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."gallery-dl/config.json" = mkIf (cfg.settings != { }) {
       source = jsonFormat.generate "gallery-dl-settings" cfg.settings;

--- a/tests/modules/programs/gallery-dl/gallery-dl.nix
+++ b/tests/modules/programs/gallery-dl/gallery-dl.nix
@@ -1,8 +1,10 @@
-{ ... }:
+{ config, ... }:
 
 {
   programs.gallery-dl = {
     enable = true;
+
+    package = config.lib.test.mkStubPackage { };
 
     settings = {
       cache.file = "~/gallery-dl/cache.sqlite3";


### PR DESCRIPTION
### Description

Adds `package` option to `programs.gallery-dl` so that users can customize the package.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
