### PR TITLE
fcitx5: fix reference to fcitx5-with-addons

### DIFF
--- a/tests/modules/i18n/input-method/fcitx5-stubs.nix
+++ b/tests/modules/i18n/input-method/fcitx5-stubs.nix
@@ -15,7 +15,6 @@
     };
     fcitx5-configtool = { outPath = null; };
     fcitx5-lua = { outPath = null; };
-    fcitx5-qt = { outPath = null; };
     fcitx5-gtk = { outPath = null; };
     fcitx5-chinese-addons = { outPath = null; };
 
@@ -36,9 +35,18 @@
   };
 
   nixpkgs.overlays = [
-    (self: super: {
-      fcitx5-with-addons =
-        super.fcitx5-with-addons.override { inherit (self) fcitx5-qt; };
+    (final: super: {
+      libsForQt5 = super.libsForQt5.overrideScope' (qt5prev: qt5final: {
+        fcitx5-qt = super.mkStubPackage { outPath = null; };
+      });
+
+      qt6Packages = super.qt6Packages.overrideScope' (qt6prev: qt6final: {
+        fcitx5-qt = super.mkStubPackage { outPath = null; };
+      });
+
+      fcitx5-with-addons = super.fcitx5-with-addons.override {
+        inherit (final) libsForQt5 qt6Packages;
+      };
     })
   ];
 }

--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -70,12 +70,11 @@ in {
   config = {
     lib.test.mkStubPackage = mkStubPackage;
 
-    nixpkgs.overlays = mkIf (config.test.stubs != { }) [
-      (self: super:
+    nixpkgs.overlays = [ (self: super: { inherit mkStubPackage; }) ]
+      ++ optional (config.test.stubs != { }) (self: super:
         mapAttrs (n: v:
           mkStubPackage (v // optionalAttrs (v.version == null) {
             version = super.${n}.version or null;
-          })) config.test.stubs)
-    ];
+          })) config.test.stubs);
   };
 }


### PR DESCRIPTION
### Description

Should hopefully fix the tests. I guess there may be more work to fully support qt6 but I'll leave that for somebody else.

CC recent committers @thiagokokada @sefidel

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```