### PR TITLE
waybar: accept null as package

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -148,11 +148,11 @@ in {
     enable = mkEnableOption "Waybar";
 
     package = mkOption {
-      type = package;
+      type = nullOr package;
       default = pkgs.waybar;
       defaultText = literalExpression "pkgs.waybar";
       description = ''
-        Waybar package to use. Set to `null` to use the default package.
+        Waybar package to use. Set to `null` to skip the package installation.
       '';
     };
 
@@ -282,7 +282,7 @@ in {
         })
       ];
 
-      home.packages = [ cfg.package ];
+      home.packages = lib.optionals (cfg.package != null) [ cfg.package ];
 
       xdg.configFile."waybar/config" = mkIf (settings != [ ]) {
         source = configSource;

--- a/tests/modules/programs/waybar/default.nix
+++ b/tests/modules/programs/waybar/default.nix
@@ -5,4 +5,5 @@
   waybar-settings-complex = ./settings-complex.nix;
   waybar-settings-with-attrs = ./settings-with-attrs.nix;
   waybar-deprecated-modules-option = ./deprecated-modules-option.nix;
+  waybar-package-null = ./package-null.nix;
 }

--- a/tests/modules/programs/waybar/package-null.nix
+++ b/tests/modules/programs/waybar/package-null.nix
@@ -1,0 +1,25 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    home.stateVersion = "23.11";
+
+    programs.waybar = {
+      package = null;
+      enable = true;
+    };
+
+    test.stubs.waybar = {
+      buildScript = "mkdir -p $out/bin; touch $out/bin/waybar";
+      outPath = null;
+    };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/waybar/style.css
+      assertPathNotExists home-files/.config/waybar/config
+      assertPathNotExists home-path/bin/waybar
+    '';
+  };
+}


### PR DESCRIPTION
### Description

I use `home-manager` in Fedora Silverblue toolbox to configure my home.
I do not need waybar package installed, it is installed by my OS.

Seem this could be nicely achieved by:

    package = null;

Docs currently say:

    Waybar package to use. Set to `null` to install the default package.

What is a bit misleading, you cannot set it to really to a `null` value, you can omit it.

This MR provides a way to provide a null value to skip the package installation.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```
