### PR TITLE
Include service in integration tests

### DIFF
--- a/modules/services/pueue.nix
+++ b/modules/services/pueue.nix
@@ -6,7 +6,8 @@ let
 
   cfg = config.services.pueue;
   yamlFormat = pkgs.formats.yaml { };
-  configFile = yamlFormat.generate "pueue.yaml" cfg.settings;
+  configFile =
+    yamlFormat.generate "pueue.yaml" ({ shared = { }; } // cfg.settings);
 
 in {
   meta.maintainers = [ maintainers.AndersonTorres ];
@@ -39,8 +40,7 @@ in {
 
     home.packages = [ cfg.package ];
 
-    xdg.configFile =
-      mkIf (cfg.settings != { }) { "pueue/pueue.yml".source = configFile; };
+    xdg.configFile."pueue/pueue.yml".source = configFile;
 
     systemd.user = {
       services.pueued = {

--- a/tests/integration/standalone/alice-home-next.nix
+++ b/tests/integration/standalone/alice-home-next.nix
@@ -9,4 +9,11 @@
   home.sessionVariables.EDITOR = "emacs";
   programs.bash.enable = true;
   programs.home-manager.enable = true;
+
+  # Enable a light-weight systemd service.
+  services.pueue.enable = true;
+
+  # We focus on sd-switch since that hopefully will become the default in the
+  # future.
+  systemd.user.startServices = "sd-switch";
 }

--- a/tests/integration/standalone/flake-basics.nix
+++ b/tests/integration/standalone/flake-basics.nix
@@ -7,8 +7,19 @@
   nodes.machine = { ... }: {
     imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
     virtualisation.memorySize = 2048;
-    nix.settings.extra-experimental-features = [ "nix-command" "flakes" ];
-    users.users.alice = { isNormalUser = true; };
+    nix = {
+      registry.home-manager.to = {
+        type = "path";
+        path = ../../..;
+      };
+      settings.extra-experimental-features = [ "nix-command" "flakes" ];
+    };
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
+    };
   };
 
   testScript = ''
@@ -16,17 +27,30 @@
     machine.wait_for_unit("network-online.target")
     machine.wait_for_unit("multi-user.target")
 
-    home_manager = "${../../..}"
-    nixpkgs = "${pkgs.path}"
+    def login_as_alice():
+      machine.wait_until_tty_matches("1", "login: ")
+      machine.send_chars("alice\n")
+      machine.wait_until_tty_matches("1", "Password: ")
+      machine.send_chars("foobar\n")
+      machine.wait_until_tty_matches("1", "alice\@machine")
 
-    machine.succeed(f"nix registry add home-manager path:{home_manager}")
-    machine.succeed(f"nix registry add nixpkgs path:{nixpkgs}")
+    def logout_alice():
+      machine.send_chars("exit\n")
 
-    def as_alice(cmd):
-      return machine.succeed(f"su - alice -c '{cmd}'")
+    def alice_cmd(cmd):
+      return f"su -l alice --shell /bin/sh -c $'export XDG_RUNTIME_DIR=/run/user/$UID ; {cmd}'"
 
-    with subtest("Home Manager init"):
-      as_alice(f"nix run path:{home_manager} -- init --home-manager-url home-manager --nixpkgs-url nixpkgs --switch")
+    def succeed_as_alice(cmd):
+      return machine.succeed(alice_cmd(cmd))
+
+    def fail_as_alice(cmd):
+      return machine.fail(alice_cmd(cmd))
+
+    # Create a persistent login so that Alice has a systemd session.
+    login_as_alice()
+
+    with subtest("Home Manager installation"):
+      succeed_as_alice("nix run home-manager -- init --home-manager-url home-manager --nixpkgs-url nixpkgs --switch")
 
       actual = machine.succeed("ls /home/alice/.config/home-manager")
       expected = "flake.lock\nflake.nix\nhome.nix\n"
@@ -57,31 +81,50 @@
         f"expected GC root and profile to point to same, but pointed to {gcrootTarget} and {profile1Target}"
 
     with subtest("Home Manager switch"):
-      as_alice("cp ${
+      fail_as_alice("hello")
+
+      succeed_as_alice("cp ${
         ./alice-home-next.nix
       } /home/alice/.config/home-manager/home.nix")
 
-      as_alice("home-manager switch")
-      as_alice("hello")
+      actual = succeed_as_alice("home-manager switch")
+      expected = "Started pueued.service - active"
+      assert expected in actual, \
+        f"expected home-manager switch to contain {expected}, but got {actual}"
 
-      actual = as_alice("echo -n $EDITOR")
+      succeed_as_alice("hello")
+
+      actual = succeed_as_alice("echo $EDITOR").strip()
       assert "emacs" == actual, \
         f"expected $EDITOR to contain emacs, but found {actual}"
 
+      actual = machine.succeed("systemctl --user -M alice@.host status pueued.service")
+      expected = "running"
+      assert expected in actual, \
+        f"expected systemctl status pueued status to contain {expected}, but got {actual}"
+
+      actual = succeed_as_alice("pueue status")
+      expected = "running"
+      assert expected in actual, \
+        f"expected pueue status to contain {expected}, but got {actual}"
+
     with subtest("Home Manager generations"):
-      actual = as_alice("home-manager generations")
+      actual = succeed_as_alice("home-manager generations")
       expected = ": id 1 ->"
       assert expected in actual, \
         f"expected generations to contain {expected}, but found {actual}"
 
     with subtest("Home Manager uninstallation"):
-      as_alice("yes | home-manager uninstall -L")
+      succeed_as_alice("yes | home-manager uninstall -L")
 
-      as_alice("! hello")
+      fail_as_alice("hello")
       machine.succeed("test ! -e /home/alice/.cache/.keep")
 
+      # TODO: Fix uninstall to fully remove the share directory.
       machine.succeed("test ! -e /home/alice/.local/share/home-manager/gcroots")
       machine.succeed("test ! -e /home/alice/.local/state/home-manager")
       machine.succeed("test ! -e /home/alice/.local/state/nix/profiles/home-manager")
+
+    logout_alice()
   '';
 }

--- a/tests/integration/standalone/standard-basics.nix
+++ b/tests/integration/standalone/standard-basics.nix
@@ -7,7 +7,12 @@
   nodes.machine = { ... }: {
     imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
     virtualisation.memorySize = 2048;
-    users.users.alice = { isNormalUser = true; };
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
+    };
   };
 
   testScript = ''
@@ -17,19 +22,39 @@
 
     home_manager = "${../../..}"
 
-    def as_alice(cmd):
-      return machine.succeed(f"su - alice -c '{cmd}'")
+    def login_as_alice():
+      machine.wait_until_tty_matches("1", "login: ")
+      machine.send_chars("alice\n")
+      machine.wait_until_tty_matches("1", "Password: ")
+      machine.send_chars("foobar\n")
+      machine.wait_until_tty_matches("1", "alice\@machine")
+
+    def logout_alice():
+      machine.send_chars("exit\n")
+
+    def alice_cmd(cmd):
+      return f"su -l alice --shell /bin/sh -c $'export XDG_RUNTIME_DIR=/run/user/$UID ; {cmd}'"
+
+    def succeed_as_alice(cmd):
+      return machine.succeed(alice_cmd(cmd))
+
+    def fail_as_alice(cmd):
+      return machine.fail(alice_cmd(cmd))
+
+    # Create a persistent login so that Alice has a systemd session.
+    login_as_alice()
 
     # Set up a home-manager channel.
-    as_alice("mkdir -p /home/alice/.nix-defexpr/channels")
-    as_alice(f"ln -s {home_manager} /home/alice/.nix-defexpr/channels/home-manager")
+    succeed_as_alice(" ; ".join([
+      "mkdir -p /home/alice/.nix-defexpr/channels",
+      f"ln -s {home_manager} /home/alice/.nix-defexpr/channels/home-manager"
+    ]))
 
     with subtest("Home Manager installation"):
-      as_alice("nix-shell \"<home-manager>\" -A install")
+      succeed_as_alice("nix-shell \"<home-manager>\" -A install")
 
       actual = machine.succeed("ls /home/alice/.config/home-manager")
-      expected = "home.nix\n"
-      assert actual == expected, \
+      assert actual == "home.nix\n", \
         f"unexpected content of /home/alice/.config/home-manager: {actual}"
 
       machine.succeed("diff -u ${
@@ -53,32 +78,50 @@
         f"expected GC root and profile to point to same, but pointed to {gcrootTarget} and {profile1Target}"
 
     with subtest("Home Manager switch"):
-      as_alice("cp ${
+      fail_as_alice("hello")
+
+      succeed_as_alice("cp ${
         ./alice-home-next.nix
       } /home/alice/.config/home-manager/home.nix")
 
-      as_alice("home-manager switch")
-      as_alice("hello")
+      actual = succeed_as_alice("home-manager switch")
+      expected = "Started pueued.service - active"
+      assert expected in actual, \
+        f"expected home-manager switch to contain {expected}, but got {actual}"
 
-      actual = as_alice("echo -n $EDITOR")
+      succeed_as_alice("hello")
+
+      actual = succeed_as_alice("echo $EDITOR").strip()
       assert "emacs" == actual, \
         f"expected $EDITOR to contain emacs, but found {actual}"
 
+      actual = machine.succeed("systemctl --user -M alice@.host status pueued.service")
+      expected = "running"
+      assert expected in actual, \
+        f"expected systemctl status pueued status to contain {expected}, but got {actual}"
+
+      actual = succeed_as_alice("pueue status")
+      expected = "running"
+      assert expected in actual, \
+        f"expected pueue status to contain {expected}, but got {actual}"
+
     with subtest("Home Manager generations"):
-      actual = as_alice("home-manager generations")
+      actual = succeed_as_alice("home-manager generations")
       expected = ": id 1 ->"
       assert expected in actual, \
         f"expected generations to contain {expected}, but found {actual}"
 
     with subtest("Home Manager uninstallation"):
-      as_alice("yes | home-manager uninstall -L")
+      succeed_as_alice("yes | home-manager uninstall -L")
 
-      as_alice("! hello")
+      fail_as_alice("hello")
       machine.succeed("test ! -e /home/alice/.cache/.keep")
 
-      # TODO: Fix uninstall to fully remove the directory.
+      # TODO: Fix uninstall to fully remove the share directory.
       machine.succeed("test ! -e /home/alice/.local/share/home-manager/gcroots")
       machine.succeed("test ! -e /home/alice/.local/state/home-manager")
       machine.succeed("test ! -e /home/alice/.local/state/nix/profiles/home-manager")
+
+    logout_alice()
   '';
 }


### PR DESCRIPTION
### Description

This adds a service (pueue since it is pretty light weight) to the integration tests.

Note, this also fixes #4295 by including a `shared` field by default.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```