### PR TITLE
vim,neovim: set EDITOR to full binary path when `defaultEditor` set for vim and nvim

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -390,7 +390,10 @@ in {
 
     home.packages = [ cfg.finalPackage ];
 
-    home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };
+    home.sessionVariables = mkIf cfg.defaultEditor {
+      EDITOR = getBin
+        (pkgs.writeShellScript "editor" "exec ${getBin cfg.package}/bin/nvim");
+    };
 
     xdg.configFile =
       let hasLuaConfig = hasAttr "lua" config.programs.neovim.generatedConfigs;

--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -174,7 +174,10 @@ in {
 
     home.packages = [ cfg.package ];
 
-    home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "vim"; };
+    home.sessionVariables = mkIf cfg.defaultEditor {
+      EDITOR = getBin
+        (pkgs.writeShellScript "editor" "exec ${getBin cfg.package}/bin/vim");
+    };
 
     programs.vim = {
       package = vim;


### PR DESCRIPTION
### Description

Prior to this change the `EDITOR` variable was set only to the name of the
program that should be looked up in `PATH` to use as the editor, but this will
only work for user-level stuff, for stuff like `sudo -e` it won't work as the
`PATH` will not contain the location of such programs. This makes it so that
the when the `defaultEditor` variable is set to `true` then `EDITOR` will
point to the full binary location of the `vim` and `nvim` packages accordingly.

This is similar to how we set `defaultEditor` in the Emacs module.

Related #3496.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@ncfavier @teto