### PR TITLE
thunderbird: change settings type to json

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -7,6 +7,11 @@ let
 
   cfg = config.programs.thunderbird;
 
+  thunderbirdJson = types.attrsOf (pkgs.formats.json { }).type // {
+    description =
+      "Thunderbird preference (int, bool, string, and also attrs, list, float as a JSON string)";
+  };
+
   enabledAccounts = attrValues
     (filterAttrs (_: a: a.thunderbird.enable) config.accounts.email.accounts);
 
@@ -161,11 +166,21 @@ in {
               };
 
               settings = mkOption {
-                type = with types; attrsOf (oneOf [ bool int str ]);
+                type = thunderbirdJson;
                 default = { };
                 example = literalExpression ''
                   {
                     "mail.spellcheck.inline" = false;
+                    "mailnews.database.global.views.global.columns" = {
+                      selectCol = {
+                        visible = false;
+                        ordinal = 1;
+                      };
+                      threadCol = {
+                        visible = true;
+                        ordinal = 2;
+                      };
+                    };
                   }
                 '';
                 description = ''
@@ -216,7 +231,7 @@ in {
       };
 
       settings = mkOption {
-        type = with types; attrsOf (oneOf [ bool int str ]);
+        type = thunderbirdJson;
         default = { };
         example = literalExpression ''
           {

--- a/tests/modules/programs/thunderbird/thunderbird-expected-second.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-second.js
@@ -28,6 +28,7 @@ user_pref("mail.smtpserver.smtp_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da
 user_pref("mail.smtpserver.smtp_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.username", "home.manager.jr");
 user_pref("mail.smtpservers", "smtp_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("privacy.donottrackheader.enabled", true);
+user_pref("second", {"nested":{"evenFurtherNested":[1,2,3]}});
 user_pref("second.setting", "some-test-setting");
 
 

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -53,7 +53,10 @@
         '';
       };
 
-      second.settings = { "second.setting" = "some-test-setting"; };
+      second.settings = {
+        "second.setting" = "some-test-setting";
+        second.nested.evenFurtherNested = [ 1 2 3 ];
+      };
     };
 
     settings = {


### PR DESCRIPTION
### Description

This sets Thunderbird's `settings` option to use a JSON type, just like the Firefox module, so that nested sets can be used.

Tests failed due to something gpg-related before this change.

It might also be worthwhile to extract out Firefox and Thunderbird's modules to some generic Mozilla module so that these common options can be shared 🤷.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@d-dervishi 
@jkarlson
