### PR TITLE
gpg-agent: Fix nushell integration

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -27,9 +27,7 @@ let
   '' + optionalString cfg.enableSshSupport ''
     ${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye | ignore
 
-    if not "SSH_AUTH_SOCK" in $env {
-      $env.SSH_AUTH_SOCK = (${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)
-    }
+    $env.SSH_AUTH_SOCK = ($env.SSH_AUTH_SOCK? | default (${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket))
   '';
 
   # mimic `gpgconf` output for use in `systemd` unit definitions.


### PR DESCRIPTION
### Description

This PR fixes the `gpg-agent` nushell integration. I found the error in both the latest release (`0.90.1`) and nightly (to be released as `0.90.2`).

#### Before
```nushell
Error: nu::shell::type_mismatch

  × Type mismatch.
    ╭─[/home/joaquin/.config/nushell/env.nu:71:8]
 70 │
 71 │ if not "SSH_AUTH_SOCK" in $env {
    ·        ───────┬───────
    ·               ╰── expected bool, found string
 72 │   $env.SSH_AUTH_SOCK = (/nix/store/4x8gd05ld93qf021f7ksws7iy3m2xlz2-gnupg-2.4.4/bin/gpgconf --list-dirs agent-ssh-socket)
    ╰────
```

#### After
```nushell
# no errors
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee @Philipp-M (`gpg-agent` and `nushell` module maintainers)