### PR TITLE
i3/sway: remove sebtm maintainer

### DIFF
--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -202,7 +202,7 @@ let
     '';
 
 in {
-  meta.maintainers = with maintainers; [ sumnerevans sebtm ];
+  meta.maintainers = with maintainers; [ sumnerevans ];
 
   options = {
     xsession.windowManager.i3 = {

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -326,7 +326,6 @@ in {
     Scrumplex
     alexarice
     sumnerevans
-    sebtm
     oxalica
   ];
 


### PR DESCRIPTION
### Description

I'm currently not planning to switch back to sway so I would like to remove myself.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
