### PR TITLE
Fix GPG agent Nushell integration for Nushell 0.90

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -27,7 +27,7 @@ let
   '' + optionalString cfg.enableSshSupport ''
     ${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye | ignore
 
-    if not "SSH_AUTH_SOCK" in $env {
+    if not ("SSH_AUTH_SOCK" in $env) {
       $env.SSH_AUTH_SOCK = (${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)
     }
   '';


### PR DESCRIPTION
### Description
The `not` operator now takes higher precedence than `in`, so

```nu
  not "key" in $record_var
```

now needs to be

```nu
  not ("key" in $record_var)
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

The tests failed, but the error does not seem to be related to my changes.
```console
❯ nix develop --ignore-environment .#all
trace: warning: The cfg.enableGnomeExtensions argument for `firefox.override` is deprecated, please add `pkgs.gnome-browser-connector` to `nativeMessagingHosts.packages` instead
error: hash mismatch in fixed-output derivation '/nix/store/8w303pk2jybqi3qy3vb53gfplay3c4xj-lookup?op=get-options=mr-search=0x36cacf52d098cc0e78fb0cb13573356c25c424d4.drv':
         specified: sha256-9Zjsb/TtOyiPzMO/Jg3CtJwSxuw7QmX0pcfZT2/1w5E=
            got:    sha256-Pvm0CpH13pvnD/c+IJAkRElR5/IhZt8pg7RjT/dZdfM=
error: 1 dependencies of derivation '/nix/store/1kgxdgcr0hwvssvsra97gmih05f79i90-gpg-pubring.drv' failed to build
error: 1 dependencies of derivation '/nix/store/jdbxnpx6bpk5j71rsml08khyx6pa67nr-activation-script.drv' failed to build
error: 1 dependencies of derivation '/nix/store/k2w2jil737f12473610cfzx3hp8z35ri-home-manager-generation.drv' failed to build
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'nmt-run-all-tests'
         whose name attribute is located at /nix/store/bg5fbkfa5x53clcjf4p5p92k1l3w8x38-source/pkgs/stdenv/generic/make-derivation.nix:353:7

       … while evaluating attribute 'shellHook' of derivation 'nmt-run-all-tests'

         at /nix/store/fm1dwqb08lxr1gk02niyvb1j7v4181c0-source/default.nix:38:40:

           37|   runShellOnlyCommand = name: shellHook:
           38|     pkgs.runCommandLocal name { inherit shellHook; } ''
             |                                        ^
           39|       echo This derivation is only useful when run through nix-shell.

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: 1 dependencies of derivation '/nix/store/q1r5xg17ipfs4k36s63pz7b1jkipkfrd-nmt-report-gpg-immutable-keyfiles.drv' failed to build
```

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@rycee 
