### PR TITLE
home-manager: use coreutils for readlink

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -84,7 +84,7 @@ in
 
           # A symbolic link whose target path matches this pattern will be
           # considered part of a Home Manager generation.
-          homeFilePattern="$(readlink -e ${escapeShellArg builtins.storeDir})/*-home-manager-files/*"
+          homeFilePattern="$(${pkgs.coreutils}/bin/readlink -e ${escapeShellArg builtins.storeDir})/*-home-manager-files/*"
 
           forcedPaths=(${forcedPaths})
 
@@ -105,7 +105,7 @@ in
             if [[ -n $forced ]]; then
               verboseEcho "Skipping collision check for $targetPath"
             elif [[ -e "$targetPath" \
-                && ! "$(readlink "$targetPath")" == $homeFilePattern ]] ; then
+                && ! "$(${pkgs.coreutils}/bin/readlink "$targetPath")" == $homeFilePattern ]] ; then
               # The target file already exists and it isn't a symlink owned by Home Manager.
               if cmp -s "$sourcePath" "$targetPath"; then
                 # First compare the files' content. If they're equal, we're fine.
@@ -136,7 +136,7 @@ in
       ''
         function checkNewGenCollision() {
           local newGenFiles
-          newGenFiles="$(readlink -e "$newGenPath/home-files")"
+          newGenFiles="$(${pkgs.coreutils}/bin/readlink -e "$newGenPath/home-files")"
           find "$newGenFiles" \( -type f -or -type l \) \
               -exec bash ${check} "$newGenFiles" {} +
         }
@@ -199,7 +199,7 @@ in
 
           # A symbolic link whose target path matches this pattern will be
           # considered part of a Home Manager generation.
-          homeFilePattern="$(readlink -e ${escapeShellArg builtins.storeDir})/*-home-manager-files/*"
+          homeFilePattern="$(${pkgs.coreutils}/bin/readlink -e ${escapeShellArg builtins.storeDir})/*-home-manager-files/*"
 
           newGenFiles="$1"
           shift 1
@@ -207,7 +207,7 @@ in
             targetPath="$HOME/$relativePath"
             if [[ -e "$newGenFiles/$relativePath" ]] ; then
               verboseEcho "Checking $targetPath: exists"
-            elif [[ ! "$(readlink "$targetPath")" == $homeFilePattern ]] ; then
+            elif [[ ! "$(${pkgs.coreutils}/bin/readlink "$targetPath")" == $homeFilePattern ]] ; then
               warnEcho "Path '$targetPath' does not link into a Home Manager generation. Skipping delete."
             else
               verboseEcho "Checking $targetPath: gone (deleting)"
@@ -236,7 +236,7 @@ in
             _i "Creating home file links in %s" "$HOME"
 
             local newGenFiles
-            newGenFiles="$(readlink -e "$newGenPath/home-files")"
+            newGenFiles="$(${pkgs.coreutils}/bin/readlink -e "$newGenPath/home-files")"
             find "$newGenFiles" \( -type f -or -type l \) \
               -exec bash ${link} "$newGenFiles" {} +
           }
@@ -249,8 +249,8 @@ in
             _i "Cleaning up orphan links from %s" "$HOME"
 
             local newGenFiles oldGenFiles
-            newGenFiles="$(readlink -e "$newGenPath/home-files")"
-            oldGenFiles="$(readlink -e "$oldGenPath/home-files")"
+            newGenFiles="$(${pkgs.coreutils}/bin/readlink -e "$newGenPath/home-files")"
+            oldGenFiles="$(${pkgs.coreutils}/bin/readlink -e "$oldGenPath/home-files")"
 
             # Apply the cleanup script on each leaf in the old
             # generation. The find command below will print the

--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -98,7 +98,7 @@ in {
             oldDir=""
             err=0
             if [[ -n "''${oldGenPath:-}" ]]; then
-              oldDir="$(readlink -m "$oldGenPath/LaunchAgents")" || err=$?
+              oldDir="$(${pkgs.coreutils}/bin/readlink -m "$oldGenPath/LaunchAgents")" || err=$?
               if (( err )); then
                 oldDir=""
               fi
@@ -138,12 +138,12 @@ in {
             oldDir=""
             err=0
             if [[ -n "''${oldGenPath:-}" ]]; then
-              oldDir="$(readlink -m "$oldGenPath/LaunchAgents")" || err=$?
+              oldDir="$(${pkgs.coreutils}/bin/readlink -m "$oldGenPath/LaunchAgents")" || err=$?
               if (( err )); then
                 oldDir=""
               fi
             fi
-            newDir="$(readlink -m "$newGenPath/LaunchAgents")"
+            newDir="$(${pkgs.coreutils}/bin/readlink -m "$newGenPath/LaunchAgents")"
             dstDir=${escapeShellArg dstDir}
             domain="gui/$UID"
             err=0

--- a/tests/integration/nixos/basics.nix
+++ b/tests/integration/nixos/basics.nix
@@ -83,11 +83,11 @@
       # There should be a GC root and Home Manager profile and they should point
       # to the same path in the Nix store.
       gcroot = "/home/alice/.local/state/home-manager/gcroots/current-home"
-      gcrootTarget = machine.succeed(f"readlink {gcroot}")
+      gcrootTarget = machine.succeed(f"${pkgs.coreutils}/bin/readlink {gcroot}")
 
       profile = "/home/alice/.local/state/nix/profiles"
-      profileTarget = machine.succeed(f"readlink {profile}/home-manager")
-      profile1Target = machine.succeed(f"readlink {profile}/{profileTarget}")
+      profileTarget = machine.succeed(f"${pkgs.coreutils}/bin/readlink {profile}/home-manager")
+      profile1Target = machine.succeed(f"${pkgs.coreutils}/bin/readlink {profile}/{profileTarget}")
 
       assert gcrootTarget == profile1Target, \
         f"expected GC root and profile to point to same, but pointed to {gcrootTarget} and {profile1Target}"

--- a/tests/integration/standalone/flake-basics.nix
+++ b/tests/integration/standalone/flake-basics.nix
@@ -71,11 +71,11 @@
       # There should be a GC root and Home Manager profile and they should point
       # to the same path in the Nix store.
       gcroot = "/home/alice/.local/state/home-manager/gcroots/current-home"
-      gcrootTarget = machine.succeed(f"readlink {gcroot}")
+      gcrootTarget = machine.succeed(f"${pkgs.coreutils}/bin/readlink {gcroot}")
 
       profile = "/home/alice/.local/state/nix/profiles"
-      profileTarget = machine.succeed(f"readlink {profile}/home-manager")
-      profile1Target = machine.succeed(f"readlink {profile}/{profileTarget}")
+      profileTarget = machine.succeed(f"${pkgs.coreutils}/bin/readlink {profile}/home-manager")
+      profile1Target = machine.succeed(f"${pkgs.coreutils}/bin/readlink {profile}/{profileTarget}")
 
       assert gcrootTarget == profile1Target, \
         f"expected GC root and profile to point to same, but pointed to {gcrootTarget} and {profile1Target}"

--- a/tests/integration/standalone/standard-basics.nix
+++ b/tests/integration/standalone/standard-basics.nix
@@ -68,11 +68,11 @@
       # There should be a GC root and Home Manager profile and they should point
       # to the same path in the Nix store.
       gcroot = "/home/alice/.local/state/home-manager/gcroots/current-home"
-      gcrootTarget = machine.succeed(f"readlink {gcroot}")
+      gcrootTarget = machine.succeed(f"${pkgs.coreutils}/bin/readlink {gcroot}")
 
       profile = "/home/alice/.local/state/nix/profiles"
-      profileTarget = machine.succeed(f"readlink {profile}/home-manager")
-      profile1Target = machine.succeed(f"readlink {profile}/{profileTarget}")
+      profileTarget = machine.succeed(f"${pkgs.coreutils}/bin/readlink {profile}/home-manager")
+      profile1Target = machine.succeed(f"${pkgs.coreutils}/bin/readlink {profile}/{profileTarget}")
 
       assert gcrootTarget == profile1Target, \
         f"expected GC root and profile to point to same, but pointed to {gcrootTarget} and {profile1Target}"

--- a/tests/modules/files/out-of-store-symlink.nix
+++ b/tests/modules/files/out-of-store-symlink.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ pkgs, config, ... }:
 
 let
 
@@ -10,13 +10,13 @@ in {
   nmt.script = ''
     assertLinkExists "home-files/oos"
 
-    storePath="$(readlink $TESTED/home-files/oos)"
+    storePath="$(${pkgs.coreutils}/bin/readlink $TESTED/home-files/oos)"
 
     if [[ ! -L $storePath ]]; then
       fail "Expected $storePath to be a symbolic link, but it was not."
     fi
 
-    actual="$(readlink "$storePath")"
+    actual="$(${pkgs.coreutils}/bin/readlink "$storePath")"
     expected="${toString filePath}"
     if [[ $actual != $expected ]]; then
       fail "Symlink home-files/oos should point to $expected via the Nix store, but it actually points to $actual."

--- a/tests/modules/programs/git/git-with-hooks.nix
+++ b/tests/modules/programs/git/git-with-hooks.nix
@@ -17,7 +17,7 @@
     hookPath=$(getGitConfig core.hooksPath)
     assertLinkExists $hookPath/pre-commit
 
-    actual="$(readlink "$hookPath/pre-commit")"
+    actual="$(${pkgs.coreutils}/bin/readlink "$hookPath/pre-commit")"
     expected="${./git-pre-commit-hook.sh}"
     if [[ $actual != $expected ]]; then
       fail "Symlink $hookPath/pre-commit should point to $expected via the Nix store, but it actually points to $actual."


### PR DESCRIPTION
### Description

I'm using HM on macOS and ran into some issues:

```
Activating setupLaunchAgents
readlink: illegal option -- m
usage: readlink [-fn] [file ...]
readlink: illegal option -- m
usage: readlink [-fn] [file ...]
```

Similar issue to https://github.com/nix-community/home-manager/issues/3516 which was fixed in https://github.com/nix-community/home-manager/pull/3517, but there were a few more readlink commands in the existing Nix code. 

Also related: https://github.com/nix-community/home-manager/pull/11

There might be more tools conflict on macOS that need to be replaced with GNU equivalents from coreutils, but readlink was what I ran into.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

  - I seem to get the same build failure when running the tests against my branch and against master, so I'd say they pass. 😅 

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 