### PR TITLE
fcitx5: fix reference to fcitx5-with-addons

### DIFF
--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -5,7 +5,8 @@ with lib;
 let
   im = config.i18n.inputMethod;
   cfg = im.fcitx5;
-  fcitx5Package = pkgs.fcitx5-with-addons.override { inherit (cfg) addons; };
+  fcitx5Package =
+    pkgs.libsForQt5.fcitx5-with-addons.override { inherit (cfg) addons; };
 in {
   options = {
     i18n.inputMethod.fcitx5 = {

--- a/tests/modules/i18n/input-method/fcitx5-stubs.nix
+++ b/tests/modules/i18n/input-method/fcitx5-stubs.nix
@@ -13,10 +13,8 @@
                  $out/bin/fcitx5-config-qt
       '';
     };
-    fcitx5-configtool = { outPath = null; };
     fcitx5-lua = { outPath = null; };
     fcitx5-gtk = { outPath = null; };
-    fcitx5-chinese-addons = { outPath = null; };
 
     gtk2 = {
       buildScript = ''
@@ -35,18 +33,21 @@
   };
 
   nixpkgs.overlays = [
-    (final: super: {
-      libsForQt5 = super.libsForQt5.overrideScope' (qt5prev: qt5final: {
-        fcitx5-qt = super.mkStubPackage { outPath = null; };
+    (final: prev: {
+      libsForQt5 = prev.libsForQt5.overrideScope (qt5final: qt5prev: {
+        fcitx5-chinese-addons = prev.mkStubPackage { outPath = null; };
+        fcitx5-configtool = prev.mkStubPackage { outPath = null; };
+        fcitx5-qt = prev.mkStubPackage { outPath = null; };
+
+        fcitx5-with-addons = qt5prev.fcitx5-with-addons.override {
+          inherit (final) libsForQt5 qt6Packages;
+        };
       });
 
-      qt6Packages = super.qt6Packages.overrideScope' (qt6prev: qt6final: {
-        fcitx5-qt = super.mkStubPackage { outPath = null; };
+      qt6Packages = prev.qt6Packages.overrideScope (qt6final: qt6prev: {
+        fcitx5-qt = prev.mkStubPackage { outPath = null; };
       });
 
-      fcitx5-with-addons = super.fcitx5-with-addons.override {
-        inherit (final) libsForQt5 qt6Packages;
-      };
     })
   ];
 }


### PR DESCRIPTION
### Description

Fixes reference to fcitx5.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```