### PR TITLE
vdirsyncer: fix verify option type

### DIFF
--- a/modules/programs/vdirsyncer-accounts.nix
+++ b/modules/programs/vdirsyncer-accounts.nix
@@ -93,9 +93,9 @@ in {
     };
 
     verify = mkOption {
-      type = types.nullOr types.bool;
+      type = types.nullOr types.path;
       default = null;
-      description = "Verify SSL certificate.";
+      description = "Null or path to certificate to verify SSL against";
     };
 
     verifyFingerprint = mkOption {

--- a/modules/programs/vdirsyncer-accounts.nix
+++ b/modules/programs/vdirsyncer-accounts.nix
@@ -96,6 +96,7 @@ in {
       type = types.nullOr types.path;
       default = null;
       description = "Null or path to certificate to verify SSL against";
+      example = "/path/to/cert.pem";
     };
 
     verifyFingerprint = mkOption {

--- a/modules/programs/vdirsyncer.nix
+++ b/modules/programs/vdirsyncer.nix
@@ -92,7 +92,7 @@ let
     else if (n == "passwordPrompt") then
       ''password.fetch = ["prompt", "${v}"]''
     else if (n == "verify") then
-      "verify = ${if v then "true" else "false"}"
+      ''verify = "${v}"''
     else if (n == "verifyFingerprint") then
       ''verify_fingerprint = "${v}"''
     else if (n == "auth") then


### PR DESCRIPTION
### Description

Vdirsyncer options for calendar/contacts accounts specify the "verify" option as types.bool. However, this is not how vdirsyncer treats the option - it expects a path to certificate to verify against.

<!--



-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@teto 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
