### PR TITLE
xdg-user-dirs: check for existing symlink

### DIFF
--- a/modules/misc/xdg-user-dirs.nix
+++ b/modules/misc/xdg-user-dirs.nix
@@ -137,7 +137,8 @@ in {
 
     home.activation.createXdgUserDirectories = mkIf cfg.createDirectories (let
       directoriesList = attrValues directories;
-      mkdir = (dir: ''run mkdir -p $VERBOSE_ARG "${dir}"'');
+      mkdir =
+        (dir: ''[[ -L "${dir}" ]] || run mkdir -p $VERBOSE_ARG "${dir}"'');
     in lib.hm.dag.entryAfter [ "linkGeneration" ]
     (strings.concatMapStringsSep "\n" mkdir directoriesList));
   };


### PR DESCRIPTION
### Description

When a non-directory, such as a file or a dead symlink, already exists, mkdir -p fails with "cannot create directory ‘...’: File exists".

This is a problem when, for example, a symlink points to a directory on a filesystem that isn't mounted yet.

This PR simply checks for an existing symlink before calling mkdir.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@pacien 