### PR TITLE
eza: replaced enableAliases with shell integration options

### DIFF
--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -4,16 +4,40 @@ with lib;
 
 {
   imports = let
+    msg = ''
+      'programs.eza.enableAliases' has been deprecated and replaced with integration
+      options per shell, for example, 'programs.eza.enableBashIntegration'.
+
+      Note, the default for these options is 'true' so if you want to enable the
+      aliases you can simply remove 'rograms.eza.enableAliases' from your
+      configuration.'';
     mkRenamed = opt:
       mkRenamedOptionModule [ "programs" "exa" opt ] [ "programs" "eza" opt ];
-  in map mkRenamed [ "enable" "enableAliases" "extraOptions" "icons" "git" ];
+  in (map mkRenamed [ "enable" "extraOptions" "icons" "git" ])
+  ++ [ (mkRemovedOptionModule [ "programs" "eza" "enableAliases" ] msg) ];
 
   meta.maintainers = [ maintainers.cafkafk ];
 
   options.programs.eza = {
     enable = mkEnableOption "eza, a modern replacement for {command}`ls`";
 
-    enableAliases = mkEnableOption "recommended eza aliases (ls, ll…)";
+    enableBashIntegration = mkEnableOption "Bash integration" // {
+      default = true;
+    };
+
+    enableZshIntegration = mkEnableOption "Zsh integration" // {
+      default = true;
+    };
+
+    enableFishIntegration = mkEnableOption "Fish integration" // {
+      default = true;
+    };
+
+    enableIonIntegration = mkEnableOption "Ion integration" // {
+      default = true;
+    };
+
+    enableNushellIntegration = mkEnableOption "Nushell integration";
 
     extraOptions = mkOption {
       type = types.listOf types.str;
@@ -49,9 +73,9 @@ with lib;
     args = escapeShellArgs (optional cfg.icons "--icons"
       ++ optional cfg.git "--git" ++ cfg.extraOptions);
 
+    optionsAlias = { eza = "eza ${args}"; };
+
     aliases = {
-      eza = "eza ${args}";
-    } // optionalAttrs cfg.enableAliases {
       ls = "eza";
       ll = "eza -l";
       la = "eza -a";
@@ -61,14 +85,19 @@ with lib;
   in mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    programs.bash.shellAliases = aliases;
+    programs.bash.shellAliases = optionsAlias
+      // optionalAttrs cfg.enableBashIntegration aliases;
 
-    programs.zsh.shellAliases = aliases;
+    programs.zsh.shellAliases = optionsAlias
+      // optionalAttrs cfg.enableZshIntegration aliases;
 
-    programs.fish.shellAliases = aliases;
+    programs.fish.shellAliases = optionsAlias
+      // optionalAttrs cfg.enableFishIntegration aliases;
 
-    programs.ion.shellAliases = aliases;
+    programs.ion.shellAliases = optionsAlias
+      // optionalAttrs cfg.enableIonIntegration aliases;
 
-    programs.nushell.shellAliases = aliases;
+    programs.nushell.shellAliases = optionsAlias
+      // optionalAttrs cfg.enableNushellIntegration aliases;
   };
 }


### PR DESCRIPTION
### Description
This commit replaces the enableAliases option with enable$SHELLIntegration options for each shell. This lets works more similarly to other programs in home-manager and lets users choose which shell's should use these aliases. 


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@cafkafk 
