### PR TITLE
offlineimap: disable starttls if tls is disabled

### DIFF
--- a/modules/programs/offlineimap.nix
+++ b/modules/programs/offlineimap.nix
@@ -42,6 +42,7 @@ let
         starttls = imap.tls.useStartTls;
       } else {
         ssl = false;
+        starttls = false;
       };
 
       remotePassEval =


### PR DESCRIPTION
### Description

Fixes #5097

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@teto Do you know if this makes sense? Should it be `starttls = imap.tls.useStartTls` instead, although that seems a bit odd to me. Thanks!