### PR TITLE
hyprland-per-window-layout: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -289,6 +289,7 @@ let
     ./services/gromit-mpx.nix
     ./services/home-manager-auto-upgrade.nix
     ./services/hound.nix
+    ./services/hyprland-per-window-layout.nix
     ./services/imapnotify.nix
     ./services/kanshi.nix
     ./services/kbfs.nix

--- a/modules/services/hyprland-per-window-layout.nix
+++ b/modules/services/hyprland-per-window-layout.nix
@@ -1,0 +1,86 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.hyprland-per-window-layout;
+  tomlFormat = pkgs.formats.toml { };
+
+  configFile = tomlFormat.generate "options.toml" cfg.settings;
+in {
+  meta.maintainers = with lib.maintainers; [ azazak123 ];
+
+  options.services.hyprland-per-window-layout = {
+    enable = mkEnableOption
+      "hyprland-per-window-layout, per window keyboard layout (language) for Hyprland Wayland compositor";
+
+    package = mkPackageOption pkgs "hyprland-per-window-layout" { };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          # list of keyboards to operate on
+          # use `hyprctl devices -j` to list all keyboards
+          keyboards = [
+            "lenovo-keyboard"
+          ];
+
+          # layout_index => window classes list
+          # use `hyprctl clients` to get class names
+          default_layouts = [{
+            "1" = [
+              "org.telegram.desktop"
+            ];
+          }];
+        }
+      '';
+      description = ''
+        Configuration included in `options.toml`.
+        For available options see <https://github.com/coffebar/hyprland-per-window-layout/blob/main/configuration.md>
+      '';
+    };
+
+    systemdTarget = mkOption {
+      type = types.str;
+      default = "graphical-session.target";
+      example = "hyprland-session.target";
+      description = ''
+        The systemd target that will automatically start the hyprland-per-window-layout service.
+
+        When setting this value to `"hyprland-session.target"`,
+        make sure to also enable {option}`wayland.windowManager.hyprland.systemd.enable`,
+        otherwise the service may never be started.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.hyprland-per-window-layout"
+        pkgs lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."hyprland-per-window-layout/options.toml" =
+      mkIf (cfg.settings != { }) { source = configFile; };
+
+    systemd.user.services.hyprland-per-window-layout = {
+      Unit = {
+        Description =
+          "Per window keyboard layout (language) for Hyprland Wayland compositor";
+        PartOf = [ cfg.systemdTarget ];
+        X-Restart-Triggers = mkIf (cfg.settings != { }) "${configFile}";
+      };
+
+      Service = {
+        Type = "simple";
+        Restart = "on-failure";
+        Environment = [ "PATH=${pkgs.hyprland}/bin" ];
+        ExecStart = "${cfg.package}/bin/hyprland-per-window-layout";
+      };
+
+      Install = { WantedBy = [ cfg.systemdTarget ]; };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -228,6 +228,7 @@ in import nmtSrc {
     ./modules/services/gpg-agent
     ./modules/services/gromit-mpx
     ./modules/services/home-manager-auto-upgrade
+    ./modules/services/hyprland-per-window-layout
     ./modules/services/imapnotify
     ./modules/services/kanshi
     ./modules/services/lieer

--- a/tests/modules/services/hyprland-per-window-layout/default.nix
+++ b/tests/modules/services/hyprland-per-window-layout/default.nix
@@ -1,0 +1,3 @@
+{
+  hyprland-per-window-layout-service = ./hyprland-per-window-layout-service.nix;
+}

--- a/tests/modules/services/hyprland-per-window-layout/hyprland-per-window-layout-service-expected.service
+++ b/tests/modules/services/hyprland-per-window-layout/hyprland-per-window-layout-service-expected.service
@@ -1,0 +1,13 @@
+[Install]
+WantedBy=hyprland-session.target
+
+[Service]
+Environment=PATH=@hyprland@/bin
+ExecStart=@hyprland-per-window-layout@/bin/hyprland-per-window-layout
+Restart=on-failure
+Type=simple
+
+[Unit]
+Description=Per window keyboard layout (language) for Hyprland Wayland compositor
+PartOf=hyprland-session.target
+X-Restart-Triggers=/nix/store/00000000000000000000000000000000-options.toml

--- a/tests/modules/services/hyprland-per-window-layout/hyprland-per-window-layout-service-expected.toml
+++ b/tests/modules/services/hyprland-per-window-layout/hyprland-per-window-layout-service-expected.toml
@@ -1,0 +1,3 @@
+keyboards = ["lenovo-keyboard"]
+[[default_layouts]]
+1 = ["org.telegram.desktop"]

--- a/tests/modules/services/hyprland-per-window-layout/hyprland-per-window-layout-service.nix
+++ b/tests/modules/services/hyprland-per-window-layout/hyprland-per-window-layout-service.nix
@@ -1,0 +1,34 @@
+{ config, ... }:
+
+{
+  services.hyprland-per-window-layout = {
+    enable = true;
+    systemdTarget = "hyprland-session.target";
+
+    settings = {
+      keyboards = [ "lenovo-keyboard" ];
+
+      default_layouts = [{ "1" = [ "org.telegram.desktop" ]; }];
+    };
+  };
+
+  test.stubs = {
+    hyprland = { };
+    hyprland-per-window-layout = { };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/hyprland-per-window-layout.service
+    optionsFile=home-files/.config/hyprland-per-window-layout/options.toml
+
+    assertFileExists $serviceFile
+    assertFileExists $optionsFile
+
+    assertFileContent $(normalizeStorePaths $serviceFile) ${
+      ./hyprland-per-window-layout-service-expected.service
+    }
+    assertFileContent $optionsFile ${
+      ./hyprland-per-window-layout-service-expected.toml
+    }
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add a home-manager module for [hyprland-per-window-layout](https://github.com/coffebar/hyprland-per-window-layout) - per window keyboard layout (language) for Hyprland wayland compositor.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
