### PR TITLE
programs.bat: handle existing cache in activation script

### DIFF
--- a/modules/programs/bat.nix
+++ b/modules/programs/bat.nix
@@ -159,10 +159,14 @@ in {
         };
       })));
 
+      # NOTE: run `bat cache --build` in an empty directory to work
+      # around failure when ~/cache exists
+      # https://github.com/sharkdp/bat/issues/1726
       home.activation.batCache = hm.dag.entryAfter [ "linkGeneration" ] ''
         (
           export XDG_CACHE_HOME=${escapeShellArg config.xdg.cacheHome}
           verboseEcho "Rebuilding bat theme cache"
+          cd "${pkgs.emptyDirectory}"
           run ${lib.getExe package} cache --build
         )
       '';


### PR DESCRIPTION
### Description

Fixes #4826

When `programs.bat.enable = true` and `~/cache` is present, activation currently fails due to `cache` in `bat cache --build` being interpreted as a path instead of a subcommand.

This PR modifies the activation script to run `bat cache --build` in an empty directory.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@lovesegfault 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
