### PR TITLE
pqiv: add extraConfig option

### DIFF
--- a/modules/programs/pqiv.nix
+++ b/modules/programs/pqiv.nix
@@ -3,12 +3,10 @@
 with lib;
 
 let
-
   cfg = config.programs.pqiv;
   iniFormat = pkgs.formats.ini { };
-
 in {
-  meta.maintainers = with lib.maintainers; [ donovanglover ];
+  meta.maintainers = with lib.maintainers; [ donovanglover iynaix ];
 
   options.programs.pqiv = {
     enable = mkEnableOption "pqiv image viewer";
@@ -24,10 +22,9 @@ in {
       type = iniFormat.type;
       default = { };
       description = ''
-        Configuration written to
-        <filename>$XDG_CONFIG_HOME/pqivrc</filename>. See <link
-        xlink:href="https://github.com/phillipberndt/pqiv/blob/master/pqiv.1"/>
-        for a list of available options. To set a boolean flag, set the value to 1.
+        Configuration written to {file}`$XDG_CONFIG_HOME/pqivrc`. See
+        {manpage}`pqiv(1)` for a list of available options. To set a
+        boolean flag, set the value to 1.
       '';
       example = literalExpression ''
         {
@@ -41,6 +38,25 @@ in {
         };
       '';
     };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra lines to be added to {file}`$XDG_CONFIG_HOME/pqivrc`. See
+        {manpage}`pqiv(1)` for a list of available options.
+      '';
+      example = literalExpression ''
+        [actions]
+        set_cursor_auto_hide(1)
+
+        [keybindings]
+        t { montage_mode_enter() }
+        @MONTAGE {
+          t { montage_mode_return_cancel() }
+        }
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -49,8 +65,12 @@ in {
 
     home.packages = [ cfg.package ];
 
-    xdg.configFile."pqivrc" = mkIf (cfg.settings != { }) {
-      source = iniFormat.generate "pqivrc" cfg.settings;
-    };
+    xdg.configFile."pqivrc" =
+      mkIf (cfg.settings != { } && cfg.extraConfig != "") {
+        text = lib.concatLines [
+          (generators.toINI { } cfg.settings)
+          cfg.extraConfig
+        ];
+      };
   };
 }

--- a/tests/modules/programs/pqiv/settings.nix
+++ b/tests/modules/programs/pqiv/settings.nix
@@ -10,6 +10,10 @@
         thumbnail-size = "256x256";
       };
     };
+    extraConfig = ''
+      [keybindings]
+      t { montage_mode_enter() }
+    '';
   };
 
   nmt.script = ''
@@ -19,6 +23,10 @@
         [options]
         hide-info-box=1
         thumbnail-size=256x256
+
+        [keybindings]
+        t { montage_mode_enter() }
+
       ''
     }
   '';


### PR DESCRIPTION
### Description

Adds a `extraConfig` text option to `programs.pqiv`, so that non-INI config such as `actions` or `keybindings` can be added.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@donovanglover 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
