### PR TITLE
Update override-package-module.md

### DIFF
--- a/docs/manual/faq.md
+++ b/docs/manual/faq.md
@@ -6,5 +6,5 @@ faq/session-variables.md
 faq/multiple-users-machines.md
 faq/ca-desrt-dconf.md
 faq/unstable.md
-faq/override-package-module.md
+faq/change-package-module.md
 ```

--- a/docs/manual/faq/change-package-module.md
+++ b/docs/manual/faq/change-package-module.md
@@ -1,4 +1,4 @@
-# How do I override the package used by a module? {#_how_do_i_override_the_package_used_by_a_module}
+# How do I change the package used by a module? {#_how_do_i_change_the_package_used_by_a_module}
 
 By default Home Manager will install the package provided by your chosen
 `nixpkgs` channel but occasionally you might end up needing to change
@@ -6,13 +6,35 @@ this package. This can typically be done in two ways.
 
 1.  If the module provides a `package` option, such as
     `programs.beets.package`, then this is the recommended way to
-    perform the override. For example,
+    perform the change. For example,
 
     ``` nix
-    programs.beets.package = pkgs.beets.override { enableCheck = true; };
+    programs.beets.package = pkgs.beets.override { pluginOverrides = { beatport.enable = false; }; };
     ```
 
-2.  If no `package` option is available then you can typically override
+    See [Nix pill 17](https://nixos.org/guides/nix-pills/nixpkgs-overriding-packages.html)
+    for more information on package overrides. Alternatively, if you want
+    to use the `beets` package from Nixpkgs unstable, then a configuration like
+
+    ``` nix
+    { pkgs, config, ... }:
+
+    let
+
+      pkgsUnstable = import <nixpkgs-unstable> {};
+
+    in
+
+    {
+      programs.beets.package = pkgsUnstable.beets;
+
+      # …
+    }
+    ```
+
+    should work OK.
+
+3.  If no `package` option is available then you can typically change
     the relevant package using an
     [overlay](https://nixos.org/nixpkgs/manual/#chap-overlays).
 

--- a/modules/programs/beets.nix
+++ b/modules/programs/beets.nix
@@ -32,8 +32,8 @@ in {
         type = types.package;
         default = pkgs.beets;
         defaultText = literalExpression "pkgs.beets";
-        example =
-          literalExpression "(pkgs.beets.override { enableCheck = true; })";
+        example = literalExpression
+          "(pkgs.beets.override { pluginOverrides = { beatport.enable = false; }; })";
         description = ''
           The `beets` package to use.
           Can be used to specify extensions.


### PR DESCRIPTION


### Description

The beets package no longer has the "enableCheck" option so this was confusing. Also the word override was used to mean two different things so I modified the faq to use the word "change" and linked to documentation regarding package overrides.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
