### PR TITLE
make zsh session vars safer

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -529,7 +529,7 @@ in
         . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
         # Only source this once
-        if [[ -z "$__HM_ZSH_SESS_VARS_SOURCED" ]]; then
+        if [[ -z "''${__HM_ZSH_SESS_VARS_SOURCED-}" ]]; then
           export __HM_ZSH_SESS_VARS_SOURCED=1
           ${envVarsStr}
         fi


### PR DESCRIPTION
### Description

If the shell is launched with `-u` flag, references to unset variables result in errors. Since in this case the variable is expected to be unset, there is no reason for this code to result in error. This commit prevents this potential error by providing a fallback value (the empty string) for the variable.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->