### PR TITLE
eza: use `mkDefault` for aliases

### DIFF
--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -75,7 +75,7 @@ with lib;
 
     optionsAlias = { eza = "eza ${args}"; };
 
-    aliases = {
+    aliases = builtins.mapAttrs (_name: value: lib.mkDefault value) {
       ls = "eza";
       ll = "eza -l";
       la = "eza -a";


### PR DESCRIPTION
### Description

Using `mkDefault` for the individual aliases makes it easier to override or
replace individual entries by the user, without having to use `mkForce` which
is often confusing for new users.

### Checklist


- [X] Change is backwards compatible. (more than the previous PR!)

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

* @cafkafk

