### PR TITLE
services.eww: init

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -171,6 +171,12 @@
     github = "LucasWagler";
     githubId = 32136449;
   };
+  madnat = {
+    name = "Jakub Kopański";
+    email = "nix@jakub.famisoft.pl";
+    github = "jkopanski";
+    githubId = 611423;
+  };
   matrss = {
     name = "Matthias Riße";
     email = "matrss@users.noreply.github.com";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1443,6 +1443,13 @@ in {
           A new module is available: 'programs.joplin-desktop'.
         '';
       }
+
+      {
+        time = "2024-03-13T17:04:13+00:00";
+        message = ''
+          A new module is available: 'services.eww'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -280,6 +280,7 @@ let
     ./services/emacs.nix
     ./services/etesync-dav.nix
     ./services/espanso.nix
+    ./services/eww.nix
     ./services/flameshot.nix
     ./services/fluidsynth.nix
     ./services/fnott.nix

--- a/modules/services/eww.nix
+++ b/modules/services/eww.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, ... }:
+
+let cfg = config.services.eww;
+
+in {
+  meta.maintainers = [ lib.hm.maintainers.madnat ];
+
+  options = {
+    services.eww = {
+      enable = lib.mkEnableOption "ElKowars wacky widgets daemon";
+
+      package = lib.mkPackageOption pkgs "eww" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.eww" pkgs lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    systemd.user.services.eww = {
+      Unit = {
+        Description = "ElKowars wacky widgets daemon";
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = let eww = lib.getExe cfg.package;
+      in {
+        Type = "simple";
+        ExecStart = "${eww} daemon --no-daemonize";
+        ExecStop = "${eww} kill";
+        ExecReload = "${eww} reload";
+      };
+
+      Install.WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -223,6 +223,7 @@ in import nmtSrc {
     ./modules/services/dropbox
     ./modules/services/emacs
     ./modules/services/espanso
+    ./modules/services/eww
     ./modules/services/flameshot
     ./modules/services/fluidsynth
     ./modules/services/fnott

--- a/tests/modules/services/eww/basic-configuration.nix
+++ b/tests/modules/services/eww/basic-configuration.nix
@@ -1,0 +1,14 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    services.eww = { enable = true; };
+
+    test.stubs.eww = { name = "eww"; };
+
+    nmt.script = ''
+      serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/eww.service)
+      assertFileContent "$serviceFile" ${./basic-configuration.service}
+    '';
+  };
+}

--- a/tests/modules/services/eww/basic-configuration.service
+++ b/tests/modules/services/eww/basic-configuration.service
@@ -1,0 +1,13 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecReload=@eww@/bin/eww reload
+ExecStart=@eww@/bin/eww daemon --no-daemonize
+ExecStop=@eww@/bin/eww kill
+Type=simple
+
+[Unit]
+After=graphical-session.target
+Description=ElKowars wacky widgets daemon
+PartOf=graphical-session.target

--- a/tests/modules/services/eww/default.nix
+++ b/tests/modules/services/eww/default.nix
@@ -1,0 +1,1 @@
+{ eww-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

There is no point in making eww a program (as it is now) as it does nothing more that install eww package.  Eww uses it's own configuration language, therefore it's not likely going to be configured via nix settings etc.  Current `programs.eww.config` option seems to be broken as per: #4595 #4886 .  Personally I think we should remove eww from programs.

There was a packaging request: #4265

Perhaps `programs.eww` should be removed?

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

new module but there is a `programs.eww`: @mainrs

