### PR TITLE
fix(gpg-agent): fix broken variable reference

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -248,7 +248,7 @@ in {
           ++ optional (cfg.maxCacheTtlSsh != null)
           "max-cache-ttl-ssh ${toString cfg.maxCacheTtlSsh}"
           ++ optional (cfg.pinentryPackage != null)
-          "pinentry-program ${lib.getExe pinentryPackage}"
+          "pinentry-program ${lib.getExe cfg.pinentryPackage}"
           ++ [ cfg.extraConfig ]);
 
       home.sessionVariablesExtra = optionalString cfg.enableSshSupport ''

--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -5,11 +5,14 @@ with lib;
 {
   config = {
     services.gpg-agent.enable = true;
-    services.gpg-agent.pinentryPackage = null; # Don't build pinentry package.
+    services.gpg-agent.pinentryPackage = pkgs.pinentry-gnome3;
     programs.gpg.enable = true;
 
-    test.stubs.gnupg = { };
-    test.stubs.systemd = { }; # depends on gnupg.override
+    test.stubs = {
+      gnupg = { };
+      systemd = { }; # depends on gnupg.override
+      pinentry-gnome3 = { };
+    };
 
     nmt.script = ''
       in="${config.systemd.user.sockets.gpg-agent.Socket.ListenStream}"
@@ -18,6 +21,9 @@ with lib;
         echo $in
         fail "gpg-agent socket directory not set to default value"
       fi
+
+      configFile=home-files/.gnupg/gpg-agent.conf
+      assertFileRegex $configFile "pinentry-program @pinentry-gnome3@/bin/dummy"
     '';
   };
 }


### PR DESCRIPTION
### Description

Fix a reference to a non-existent variable.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee
