### PR TITLE
Fix GPG-agent pinentry-program setting

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -248,7 +248,7 @@ in {
           ++ optional (cfg.maxCacheTtlSsh != null)
           "max-cache-ttl-ssh ${toString cfg.maxCacheTtlSsh}"
           ++ optional (cfg.pinentryPackage != null)
-          "pinentry-program ${lib.getExe pinentryPackage}"
+          "pinentry-program ${lib.getExe cfg.pinentryPackage}"
           ++ [ cfg.extraConfig ]);
 
       home.sessionVariablesExtra = optionalString cfg.enableSshSupport ''

--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -5,7 +5,7 @@ with lib;
 {
   config = {
     services.gpg-agent.enable = true;
-    services.gpg-agent.pinentryPackage = null; # Don't build pinentry package.
+    services.gpg-agent.pinentryPackage = pkgs.cowsay;
     programs.gpg.enable = true;
 
     test.stubs.gnupg = { };
@@ -18,6 +18,9 @@ with lib;
         echo $in
         fail "gpg-agent socket directory not set to default value"
       fi
+
+      local configFile=home-files/.gnupg/gpg-agent.conf
+      assertFileRegex $configFile "pinentry-program /nix/store/.*/bin/cowsay
     '';
   };
 }


### PR DESCRIPTION
### Description

Fix a build error introduced in https://github.com/nix-community/home-manager/commit/01e4a5143e92251272850a8e0fbb4518bd099087.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@ambroisie
