### PR TITLE
nix-gc: add daily frequency option

### DIFF
--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -9,6 +9,10 @@ let
     let
       freq = {
         "hourly" = [{ Minute = 0; }];
+        "daily" = [{
+          Hour = 0;
+          Minute = 0;
+        }];
         "weekly" = [{
           Weekday = 1;
           Hour = 0;
@@ -62,8 +66,14 @@ in {
       };
 
       frequency = mkOption {
-        type =
-          types.enum [ "hourly" "weekly" "monthly" "semiannually" "annually" ];
+        type = types.enum [
+          "hourly"
+          "daily"
+          "weekly"
+          "monthly"
+          "semiannually"
+          "annually"
+        ];
         default = "weekly";
         example = "monthly";
         description = ''


### PR DESCRIPTION
### Description

The systemd.time documentation defines the shorthands `daily` and
`minutely` which are currently not included in the nix-gc module.
    
This commit adds the `daily` option, but omits `minutely` since it's not
a timescale that would make sense to run a gc for.
    
https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html

---

Note that I am unable to test if the daily option works under MacOS. It should, as it follows the same pattern as the other date declarations. Still, would love someone to check it.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@shivaraj-bh 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->