### PR TITLE
kdeconnect: make package configurable

### DIFF
--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -5,7 +5,7 @@ with lib;
 let
 
   cfg = config.services.kdeconnect;
-  package = pkgs.plasma5Packages.kdeconnect-kde;
+  package = cfg.package;
 
 in {
   meta.maintainers = [ maintainers.adisbladis ];
@@ -13,6 +13,8 @@ in {
   options = {
     services.kdeconnect = {
       enable = mkEnableOption "KDE connect";
+
+      package = mkPackageOption pkgs [ "plasma5Packages" "kdeconnect-kde" ] { };
 
       indicator = mkOption {
         type = types.bool;


### PR DESCRIPTION
### Description

kde 6 is available in unstable and there didn't seem to be a way to change to the kde6 version of kdeconnect. Not sure if just exposing package is the best way to do this or if there's something more preferred

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
firefox-profile-settings fails before and after my change, seems to be fixed by https://github.com/nix-community/home-manager/pull/5147

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@adisbladis 

