### PR TITLE
direnv: Make stdlib mergeable/sortable

### DIFF
--- a/tests/modules/programs/direnv/nix-direnv.nix
+++ b/tests/modules/programs/direnv/nix-direnv.nix
@@ -10,9 +10,7 @@ with lib;
 
     nmt.script = ''
       assertFileExists home-files/.bashrc
-      assertFileRegex \
-        home-files/.config/direnv/direnvrc \
-        'source /nix/store/.*nix-direnv.*/share/nix-direnv/direnvrc'
+      assertFileExists home-files/.config/direnv/lib/hm-nix-direnv.sh
     '';
   };
 }

--- a/tests/modules/programs/direnv/stdlib-and-nix-direnv.nix
+++ b/tests/modules/programs/direnv/stdlib-and-nix-direnv.nix
@@ -12,9 +12,7 @@ in {
 
     nmt.script = ''
       assertFileExists home-files/.bashrc
-      assertFileRegex \
-        home-files/.config/direnv/direnvrc \
-        'source /nix/store/.*nix-direnv.*/share/nix-direnv/direnvrc'
+      assertFileExists home-files/.config/direnv/lib/hm-nix-direnv.sh
       assertFileRegex \
         home-files/.config/direnv/direnvrc \
         '${expectedContent}'

--- a/tests/modules/programs/direnv/stdlib.nix
+++ b/tests/modules/programs/direnv/stdlib.nix
@@ -10,6 +10,7 @@ in {
     programs.direnv.stdlib = expectedContent;
 
     nmt.script = ''
+      assertPathNotExists home-files/.config/direnv/lib/hm-nix-direnv.sh
       assertFileExists home-files/.bashrc
       assertFileRegex \
         home-files/.config/direnv/direnvrc \


### PR DESCRIPTION
### Description

This PR allows using the module system to create the `direnvrc` file.

#### Motivation
I wanted to globally run `nix_direnv_manual_reload` in `direnvrc`, but wasn't able to because sourcing `nix-direnv` was hardcoded at the end of the file. The only possible solution was to disable `nix-direnv` and manually add it to the config (doable, but not ideal).

#### Changes

Based on review comments, sourcing the `nix-direnv` file was removed altogether in favour of adding it to direnv's lib. In practice, this makes it load _before_ the `direnvrc`, instead of at the end of it. I'm open to change it back with the premise of avoiding creating unneeded files in the user's home (which I'm all for 🙂). 

~~Now, the contents are `mkMerge`d, allowing `mkAfter`, `mkBefore`, and family to be used to enforce the order of the lines.~~

~~I also made it so `nix-direnv` is loaded first by default, to more closely follow [the NixOS module](https://github.com/NixOS/nixpkgs/blob/d691274a972b3165335d261cc4671335f5c67de9/nixos/modules/programs/direnv.nix#L113).~~

~~I'm not incredibly familiar with the module system yet, so I don't know if the internal `finalStdlib` pattern to get the result of a merge is the best possible option for this. A trivial alternative would be moving the `nix-direnv` sourcing up and leaving everything as-is. I'm open to feedback!~~

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 