### PR TITLE
qt: add adwaita platform theme

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -6,6 +6,7 @@ let
   # Map platform names to their packages.
   platformPackages = with pkgs; {
     gnome = [ qgnomeplatform qgnomeplatform-qt6 ];
+    adwaita = [ qadwaitadecorations qadwaitadecorations-qt6 ];
     gtk = [ libsForQt5.qtstyleplugins qt6Packages.qt6gtk2 ];
     kde = [ libsForQt5.plasma-integration libsForQt5.systemsettings ];
     lxqt = [ lxqt.lxqt-qtplugin lxqt.lxqt-config ];
@@ -55,56 +56,85 @@ in {
     qt = {
       enable = lib.mkEnableOption "Qt 5 and 6 configuration";
 
-      platformTheme = lib.mkOption {
+      platformTheme = let
+        newOption = {
+          name = lib.mkOption {
+            type = with lib.types; nullOr str;
+            default = null;
+            example = "adwaita";
+            relatedPackages = [
+              "qgnomeplatform"
+              "qgnomeplatform-qt6"
+              "qadwaitadecorations"
+              "qadwaitadecorations-qt6"
+              [ "libsForQt5" "plasma-integration" ]
+              [ "libsForQt5" "qt5ct" ]
+              [ "libsForQt5" "qtstyleplugins" ]
+              [ "libsForQt5" "systemsettings" ]
+              [ "lxqt" "lxqt-config" ]
+              [ "lxqt" "lxqt-qtplugin" ]
+              [ "qt6Packages" "qt6ct" ]
+              [ "qt6Packages" "qt6gtk2" ]
+            ];
+            description = ''
+              Platform theme to use for Qt applications.
+
+              Some examples are
+
+              `gtk`
+              : Use GTK theme with
+                [`qtstyleplugins`](https://github.com/qt/qtstyleplugins)
+
+              `gtk3`
+              : Use [GTK3 integration](https://github.com/qt/qtbase/tree/dev/src/plugins/platformthemes/gtk3)
+                for file picker dialogs, font and theme configuration
+
+              `adwaita`
+              : Use Adwaita theme with
+                [`qadwaitadecorations`](https://github.com/FedoraQt/QGnomePlatform)
+
+              `gnome` (deprecated)
+              : Use GNOME theme with
+                [`qgnomeplatform`](https://github.com/FedoraQt/QGnomePlatform).
+                Is no longer maintained so prefer `adwaita`.
+
+              `lxqt`
+              : Use LXQt theme style set using the
+                [`lxqt-config-appearance`](https://github.com/lxqt/lxqt-config)
+                application
+
+              `qtct`
+              : Use Qt style set using
+                [`qt5ct`](https://github.com/desktop-app/qt5ct)
+                and [`qt6ct`](https://github.com/trialuser02/qt6ct)
+                applications
+
+              `kde`
+              : Use Qt settings from Plasma
+            '';
+          };
+          package = lib.mkOption {
+            type = with lib.types; nullOr (either package (listOf package));
+            default = null;
+            example =
+              lib.literalExpression "[pkgs.adwaita-qt pkgs.adwaita-qt6]";
+            description = ''
+              Theme package to be used in Qt5/Qt6 applications.
+              Auto-detected from {option}`qt.platformTheme.name` if possible.
+              See its documentation for available options.
+            '';
+          };
+        };
+      in lib.mkOption {
         type = with lib.types;
-          nullOr (enum [ "gtk" "gtk3" "gnome" "lxqt" "qtct" "kde" ]);
+          nullOr
+          (either (enum [ "gtk" "gtk3" "gnome" "adwaita" "lxqt" "qtct" "kde" ])
+            (lib.types.submodule { options = newOption; }));
         default = null;
-        example = "gnome";
-        relatedPackages = [
-          "qgnomeplatform"
-          "qgnomeplatform-qt6"
-          [ "libsForQt5" "plasma-integration" ]
-          [ "libsForQt5" "qt5ct" ]
-          [ "libsForQt5" "qtstyleplugins" ]
-          [ "libsForQt5" "systemsettings" ]
-          [ "lxqt" "lxqt-config" ]
-          [ "lxqt" "lxqt-qtplugin" ]
-          [ "qt6Packages" "qt6ct" ]
-          [ "qt6Packages" "qt6gtk2" ]
-        ];
         description = ''
-          Platform theme to use for Qt applications.
-
-          The options are
-
-          `gtk`
-          : Use GTK theme with
-            [`qtstyleplugins`](https://github.com/qt/qtstyleplugins)
-
-          `gtk3`
-          : Use [GTK3 integration](https://github.com/qt/qtbase/tree/dev/src/plugins/platformthemes/gtk3)
-            for file picker dialogs, font and theme configuration
-
-          `gnome`
-          : Use GNOME theme with
-            [`qgnomeplatform`](https://github.com/FedoraQt/QGnomePlatform)
-
-          `lxqt`
-          : Use LXQt theme style set using the
-            [`lxqt-config-appearance`](https://github.com/lxqt/lxqt-config)
-            application
-
-          `qtct`
-          : Use Qt style set using
-            [`qt5ct`](https://github.com/desktop-app/qt5ct)
-            and [`qt6ct`](https://github.com/trialuser02/qt6ct)
-            applications
-
-          `kde`
-          : Use Qt settings from Plasma
+          Deprecated. Use {option}`qt.platformTheme.name` instead.
         '';
       };
-
       style = {
         name = lib.mkOption {
           type = with lib.types; nullOr str;
@@ -149,6 +179,7 @@ in {
           description = ''
             Theme package to be used in Qt5/Qt6 applications.
             Auto-detected from {option}`qt.style.name` if possible.
+            See its documentation for available options.
           '';
         };
       };
@@ -156,11 +187,29 @@ in {
   };
 
   config = let
+    warnGnomeDeprecation = option: name:
+      lib.warnIf (name == "gnome")
+      "The value `gnome` for option `${option}` is deprecated. Use `adwaita` instead."
+      name;
+
+    platformTheme = if (builtins.isString cfg.platformTheme) then {
+      name = lib.warn
+        "The option `qt.platformTheme` has been renamed to `qt.platformTheme.name`."
+        (warnGnomeDeprecation "qt.platformTheme" cfg.platformTheme);
+      package = null;
+    } else if cfg.platformTheme == null then {
+      name = null;
+      package = null;
+    } else {
+      name =
+        warnGnomeDeprecation "cfg.platformTheme.name" cfg.platformTheme.name;
+      package = cfg.platformTheme.package;
+    };
 
     # Necessary because home.sessionVariables doesn't support mkIf
     envVars = lib.filterAttrs (n: v: v != null) {
-      QT_QPA_PLATFORMTHEME = if (cfg.platformTheme != null) then
-        styleNames.${cfg.platformTheme} or cfg.platformTheme
+      QT_QPA_PLATFORMTHEME = if (platformTheme.name != null) then
+        styleNames.${platformTheme.name} or platformTheme.name
       else
         null;
       QT_STYLE_OVERRIDE = cfg.style.name;
@@ -181,10 +230,10 @@ in {
 
   in lib.mkIf cfg.enable {
     assertions = [{
-      assertion = cfg.platformTheme == "gnome" -> cfg.style.name != null
+      assertion = platformTheme.name == "gnome" -> cfg.style.name != null
         && cfg.style.package != null;
       message = ''
-        `qt.platformTheme` "gnome" must have `qt.style` set to a theme that
+        `qt.platformTheme.name` "gnome" must have `qt.style` set to a theme that
         supports both Qt and Gtk, for example "adwaita", "adwaita-dark", or "breeze".
       '';
     }];
@@ -208,13 +257,16 @@ in {
     # Apply theming also to apps started by systemd.
     systemd.user.sessionVariables = envVars // envVarsExtra;
 
-    home.packages = (lib.optionals (cfg.platformTheme != null)
-      platformPackages.${cfg.platformTheme} or [ ])
-      ++ (lib.optionals (cfg.style.package != null)
-        (lib.toList cfg.style.package));
+    home.packages = (lib.findFirst (x: x != null) [ ] [
+      (lib.optionals (platformTheme.package != null)
+        (lib.toList platformTheme.package))
+      (lib.optionals (platformTheme.name != null)
+        platformPackages.${platformTheme.name})
+    ]) ++ (lib.optionals (cfg.style.package != null)
+      (lib.toList cfg.style.package));
 
     xsession.importedVariables = [ "QT_PLUGIN_PATH" "QML2_IMPORT_PATH" ]
-      ++ lib.optionals (cfg.platformTheme != null) [ "QT_QPA_PLATFORMTHEME" ]
+      ++ lib.optionals (platformTheme.name != null) [ "QT_QPA_PLATFORMTHEME" ]
       ++ lib.optionals (cfg.style.name != null) [ "QT_STYLE_OVERRIDE" ];
   };
 }

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -187,22 +187,17 @@ in {
   };
 
   config = let
-    warnGnomeDeprecation = option: name:
-      lib.warnIf (name == "gnome")
-      "The value `gnome` for option `${option}` is deprecated. Use `adwaita` instead."
-      name;
-
     platformTheme = if (builtins.isString cfg.platformTheme) then {
-      name = lib.warn
-        "The option `qt.platformTheme` has been renamed to `qt.platformTheme.name`."
-        (warnGnomeDeprecation "qt.platformTheme" cfg.platformTheme);
+      option = "qt.platformTheme";
+      name = cfg.platformTheme;
       package = null;
     } else if cfg.platformTheme == null then {
+      option = null;
       name = null;
       package = null;
     } else {
-      name =
-        warnGnomeDeprecation "cfg.platformTheme.name" cfg.platformTheme.name;
+      option = "qt.platformTheme.name";
+      name = cfg.platformTheme.name;
       package = cfg.platformTheme.package;
     };
 
@@ -237,6 +232,12 @@ in {
         supports both Qt and Gtk, for example "adwaita", "adwaita-dark", or "breeze".
       '';
     }];
+
+    warnings = (lib.lists.optional (platformTheme.option == "qt.platformTheme")
+      "The option `qt.platformTheme` has been renamed to `qt.platformTheme.name`.")
+      ++ (lib.lists.optional
+        (platformTheme.name == "gnome" && platformTheme.package == null)
+        "The value `gnome` for option `${platformTheme.option}` is deprecated. Use `adwaita` instead.");
 
     qt.style.package = lib.mkIf (cfg.style.name != null)
       (lib.mkDefault (stylePackages.${lib.toLower cfg.style.name} or null));

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -91,7 +91,7 @@ in {
 
               `adwaita`
               : Use Adwaita theme with
-                [`qadwaitadecorations`](https://github.com/FedoraQt/QGnomePlatform)
+                [`qadwaitadecorations`](https://github.com/FedoraQt/QAdwaitaDecorations)
 
               `gnome` (deprecated)
               : Use GNOME theme with

--- a/tests/modules/misc/qt/qt-basic.nix
+++ b/tests/modules/misc/qt/qt-basic.nix
@@ -1,5 +1,3 @@
-{ config, lib, pkgs, ... }:
-
 {
   config = {
     qt.enable = true;

--- a/tests/modules/misc/qt/qt-platform-theme-gnome.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gnome.nix
@@ -19,5 +19,9 @@
       assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
         'QML2_IMPORT_PATH'
     '';
+    test.asserts.warnings.expected = [
+      "The option `qt.platformTheme` has been renamed to `qt.platformTheme.name`."
+      "The value `gnome` for option `qt.platformTheme` is deprecated. Use `adwaita` instead."
+    ];
   };
 }

--- a/tests/modules/misc/qt/qt-platform-theme-gnome.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gnome.nix
@@ -1,9 +1,8 @@
-{ config, lib, pkgs, ... }:
-
 {
   config = {
     qt = {
       enable = true;
+      # Check if still backwards compatible
       platformTheme = "gnome";
       style.name = "adwaita";
     };

--- a/tests/modules/misc/qt/qt-platform-theme-gtk.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gtk.nix
@@ -1,10 +1,8 @@
-{ config, lib, pkgs, ... }:
-
 {
   config = {
     qt = {
       enable = true;
-      platformTheme = "gtk";
+      platformTheme.name = "gtk";
     };
     i18n.inputMethod.enabled = "fcitx5";
 

--- a/tests/modules/misc/qt/qt-platform-theme-gtk3.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gtk3.nix
@@ -1,10 +1,8 @@
-{ config, lib, pkgs, ... }:
-
 {
   config = {
     qt = {
       enable = true;
-      platformTheme = "gtk3";
+      platformTheme.name = "gtk3";
     };
 
     nmt.script = ''


### PR DESCRIPTION


### Description

<!--

Please provide a brief description of your change.

-->

This PR adds `adwaita` as an option to `qt.platformTheme` fixing #4702 and also https://github.com/NixOS/nixpkgs/issues/295345 (the `gnome` option breaks some Qt6 tray applications). It also extends the configuraton interface to match `qt.style` which has a `name` and `package` sub-option for edge cases.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee @thiagokokada

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
