### PR TITLE
newsraft: init

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -13,6 +13,11 @@
     github = "amesgen";
     githubId = 15369874;
   };
+  arthsmn = {
+    name = "Arthur Cerqueira";
+    github = "arthsmn";
+    githubId = 150680976;
+  };
   austreelis = {
     email = "github@accounts.austreelis.net";
     github = "Austreelis";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -162,6 +162,7 @@ let
     ./programs/neomutt.nix
     ./programs/neovim.nix
     ./programs/newsboat.nix
+    ./programs/newsraft.nix
     ./programs/nheko.nix
     ./programs/nix-index.nix
     ./programs/nnn.nix

--- a/modules/programs/newsraft.nix
+++ b/modules/programs/newsraft.nix
@@ -1,0 +1,110 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.newsraft;
+
+  nrSection = types.submodule {
+    options = {
+      name = mkOption { type = types.nonEmptyStr; };
+
+      urls = mkOption { type = with types; listOf nonEmptyStr; };
+    };
+  };
+
+  feedsFile = let
+    AttrToListNr = attr:
+      mapAttrsToList
+      (_: value: if (isString value) then "@ ${value}" else value) attr;
+    convertAttrs = attrs:
+      mapAttrs
+      (name: value: if (name == "wrong") then map AttrToListNr value else value)
+      attrs;
+  in concatStringsSep "\n" (flatten (mapAttrsToList (_: value: value)
+    (convertAttrs (lib.partition (field: !isAttrs field) cfg.feeds))));
+
+  settingsFile = let
+    # because toString turns true into "1" and false into ""
+    anyToStr = val:
+      if (isBool val) then (if val then "true" else "false") else toString val;
+    renderSettings = attr:
+      mapAttrsToList (name: value: "set ${name} ${anyToStr value}") attr;
+    renderBindings = attr:
+      mapAttrsToList (key: value: "bind ${key} ${value}") attr;
+  in concatStringsSep "\n" ((renderSettings cfg.settings)
+    ++ (renderBindings cfg.bindings) ++ [ cfg.extraConfig ]);
+in {
+  meta.maintainers = [ maintainers.arthsmn ];
+
+  options.programs.newsraft = {
+    enable = mkEnableOption "Newsraft feed reader";
+
+    feeds = mkOption {
+      type = with types; listOf (oneOf [ nonEmptyStr nrSection ]);
+      default = { };
+      example = ''
+        [
+          "https://nixos.org/blog/announcements-rss.xml"
+
+          {
+            name = "Tech";
+            urls = ["https://news.ycombinator.com/rss" "https://www.phoronix.com/rss.php"];
+          }
+        ]
+      '';
+      description =
+        "The feed list for newsraft. It can be either a list of links (strings) or attributes for sections (with a name field and a list of feeds). If an auto update timer needs to be set, you should set either in the end of the link, or in the name of the section.";
+    };
+
+    settings = mkOption {
+      type = with types; attrsOf (oneOf [ ints.unsigned str bool ]);
+      default = { };
+      example = {
+        scrolloff = 12;
+        copy-to-clipboard-command = "wl-copy";
+        section-menu-paramount-explore = true;
+
+        color-status-good-fg = "default";
+        color-status-good-bg = "bold green";
+      };
+      description =
+        "The settings for newsraft. For colors, set both the color and the optional format attribute together.";
+    };
+
+    bindings = mkOption {
+      type = with types; attrsOf nonEmptyStr;
+      default = { };
+      example = {
+        f = "exec feh %l";
+        "^P" = "mark-unread-all";
+      };
+      description = ''
+        The bindings for newsraft. If the binding isn't a simple string (eg. ^P), you have to wrap it with parenthesis (eg. "^P").'';
+    };
+
+    extraConfig = mkOption {
+      type = types.nonEmptyStr;
+      default = "";
+      example = ''
+        unbind r
+      '';
+      description =
+        "Extra raw configuration lines to be added to newsraft config.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = cfg.enable -> cfg.feeds != [ ];
+      message = "You have to specify at least one feed.";
+    }];
+
+    home.packages = [ pkgs.newsraft ];
+
+    xdg.configFile."newsraft/feeds".text = feedsFile + "\n";
+    xdg.configFile."newsraft/config".text =
+      mkIf (cfg.settings != { } || cfg.bindings != { } || cfg.extraConfig != "")
+      (settingsFile + "\n");
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -111,6 +111,7 @@ in import nmtSrc {
     ./modules/programs/neomutt
     ./modules/programs/neovim
     ./modules/programs/newsboat
+    ./modules/programs/newsraft
     ./modules/programs/nheko
     ./modules/programs/nix-index
     ./modules/programs/nnn

--- a/tests/modules/programs/newsraft/default.nix
+++ b/tests/modules/programs/newsraft/default.nix
@@ -1,0 +1,1 @@
+{ newsraft-tests = ./tests.nix; }

--- a/tests/modules/programs/newsraft/newsraft-feeds
+++ b/tests/modules/programs/newsraft/newsraft-feeds
@@ -1,0 +1,4 @@
+https://nixos.org/blog/announcements-rss.xml
+@ Tech
+https://news.ycombinator.com/rss
+https://www.phoronix.com/rss.php

--- a/tests/modules/programs/newsraft/newsraft-settings
+++ b/tests/modules/programs/newsraft/newsraft-settings
@@ -1,0 +1,8 @@
+set color-status-good-bg bold green
+set color-status-good-fg default
+set copy-to-clipboard-command wl-copy
+set scrolloff 12
+set section-menu-paramount-explore true
+bind ^P mark-unread-all
+bind f exec feh %l
+unbind r

--- a/tests/modules/programs/newsraft/tests.nix
+++ b/tests/modules/programs/newsraft/tests.nix
@@ -1,0 +1,49 @@
+{ ... }:
+
+{
+  config = {
+    programs.newsraft = {
+      enable = true;
+
+      feeds = [
+        "https://nixos.org/blog/announcements-rss.xml"
+
+        {
+          name = "Tech";
+          urls = [
+            "https://news.ycombinator.com/rss"
+            "https://www.phoronix.com/rss.php"
+          ];
+        }
+      ];
+
+      settings = {
+        scrolloff = 12;
+        copy-to-clipboard-command = "wl-copy";
+        section-menu-paramount-explore = true;
+
+        color-status-good-fg = "default";
+        color-status-good-bg = "bold green";
+      };
+
+      bindings = {
+        f = "exec feh %l";
+        "^P" = "mark-unread-all";
+      };
+
+      extraConfig = "unbind r";
+    };
+
+    test.stubs.newsraft = { };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/newsraft/feeds \
+        ${./newsraft-feeds}
+
+      assertFileContent \
+        home-files/.config/newsraft/config \
+        ${./newsraft-settings}
+    '';
+  };
+}


### PR DESCRIPTION
### Description
I've added myself as a maintainer, created a newsraft module and added the related tests.

Edit: as the version 0.24, newsraft is using a more complex way of declaring things, I'll fix this.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).