### PR TITLE
xdg-portal: update env vars, match nixos module

### DIFF
--- a/modules/misc/xdg-portal.nix
+++ b/modules/misc/xdg-portal.nix
@@ -82,28 +82,9 @@ in {
 
   config = let
     cfg = config.xdg.portal;
-
-    joinedPortals = pkgs.buildEnv {
-      name = "xdg-portals";
-      paths = cfg.extraPortals;
-      pathsToLink =
-        [ "/share/xdg-desktop-portal/portals" "/share/applications" ];
-    };
-
-    portalConfigPath = n:
-      "share/xdg-desktop-portal/${
-        optionalString (n != "common") "${n}-"
-      }portals.conf";
-    mkPortalConfig = desktop: conf:
-      pkgs.writeTextDir (portalConfigPath desktop)
-      (lib.generators.toINI { } { preferred = conf; });
-
-    joinedPortalConfigs = pkgs.buildEnv {
-      name = "xdg-portal-configs";
-      ignoreCollisions = true; # Let config override configPackages cfgs
-      paths = (mapAttrsToList mkPortalConfig cfg.config) ++ cfg.configPackages;
-      pathsToLink = [ "/share/xdg-desktop-portal" ];
-    };
+    packages = [ pkgs.xdg-desktop-portal ] ++ cfg.extraPortals;
+    portalsDir =
+      "${config.home.profileDirectory}/share/xdg-desktop-portal/portals";
   in mkIf cfg.enable {
     warnings = optional (cfg.configPackages == [ ] && cfg.config == { }) ''
       xdg-desktop-portal 1.17 reworked how portal implementations are loaded, you
@@ -129,29 +110,21 @@ in {
     ];
 
     home = {
-      sessionVariables =
-        mkIf cfg.xdgOpenUsePortal { NIXOS_XDG_OPEN_USE_PORTAL = "1"; };
-
-      # Make extraPortals systemd units available to the user
-      packages = [ pkgs.xdg-desktop-portal ] ++ cfg.extraPortals;
+      packages = packages ++ cfg.configPackages;
+      sessionVariables = mkMerge [
+        (mkIf cfg.xdgOpenUsePortal { NIXOS_XDG_OPEN_USE_PORTAL = "1"; })
+        { NIX_XDG_DESKTOP_PORTAL_DIR = portalsDir; }
+      ];
+    };
+    systemd.user.sessionVariables = {
+      NIX_XDG_DESKTOP_PORTAL_DIR = portalsDir;
     };
 
-    systemd.user.services.xdg-desktop-portal = {
-      Unit = {
-        Description = "Portal service";
-        PartOf = "graphical-session.target";
-      };
-
-      Service = {
-        Environment = [
-          "XDG_DESKTOP_PORTAL_DIR=${joinedPortals}/share/xdg-desktop-portal/portals"
-        ] ++ (optional (cfg.configPackages != [ ])
-          "NIXOS_XDG_DESKTOP_PORTAL_CONFIG_DIR=${joinedPortalConfigs}/share/xdg-desktop-portal");
-        Type = "dbus";
-        BusName = "org.freedesktop.portal.Desktop";
-        ExecStart = "${pkgs.xdg-desktop-portal}/libexec/xdg-desktop-portal";
-        Slice = "session.slice";
-      };
-    };
+    xdg.configFile = lib.concatMapAttrs (desktop: conf:
+      lib.optionalAttrs (conf != { }) {
+        "xdg-desktop-portal/${
+          lib.optionalString (desktop != "common") "${desktop}-"
+        }portals.conf".text = lib.generators.toINI { } { preferred = conf; };
+      }) cfg.config;
   };
 }

--- a/tests/modules/misc/xdg/portal.nix
+++ b/tests/modules/misc/xdg/portal.nix
@@ -10,28 +10,18 @@ lib.mkIf config.test.enableBig {
   };
 
   nmt.script = ''
-    xdgDesktopPortal=home-files/.config/systemd/user/xdg-desktop-portal.service
-    assertFileExists $xdgDesktopPortal
+    assertFileExists home-path/share/systemd/user/xdg-desktop-portal.service
+    assertFileExists home-path/share/systemd/user/xdg-desktop-portal-wlr.service
+    assertFileExists home-path/share/systemd/user/xdg-desktop-portal-hyprland.service
 
-    xdgDesktopPortalWlr=home-path/share/systemd/user/xdg-desktop-portal-wlr.service
-    assertFileExists $xdgDesktopPortalWlr
-
-    xdgDesktopPortalHyprland=home-path/share/systemd/user/xdg-desktop-portal-hyprland.service
-    assertFileExists $xdgDesktopPortalHyprland
-
-    portalsDir="$(cat $TESTED/$xdgDesktopPortal | grep Environment=XDG_DESKTOP_PORTAL_DIR | cut -d '=' -f3)"
-    portalConfigsDir="$(cat $TESTED/$xdgDesktopPortal | grep Environment=NIXOS_XDG_DESKTOP_PORTAL_CONFIG_DIR | cut -d '=' -f3)"
-
-    assertFileContent $portalsDir/hyprland.portal \
+    assertFileContent home-path/share/xdg-desktop-portal/portals/hyprland.portal \
       ${pkgs.xdg-desktop-portal-hyprland}/share/xdg-desktop-portal/portals/hyprland.portal
-
-    assertFileContent $portalsDir/wlr.portal \
+    assertFileContent home-path/share/xdg-desktop-portal/portals/wlr.portal \
       ${pkgs.xdg-desktop-portal-wlr}/share/xdg-desktop-portal/portals/wlr.portal
 
-    assertFileContent $portalConfigsDir/hyprland-portals.conf \
+    assertFileContent home-path/share/xdg-desktop-portal/hyprland-portals.conf \
       ${pkgs.hyprland}/share/xdg-desktop-portal/hyprland-portals.conf
-
-    assertFileContent $portalConfigsDir/sway-portals.conf \
+    assertFileContent home-files/.config/xdg-desktop-portal/sway-portals.conf \
       ${./sway-portals-expected.conf}
   '';
 }


### PR DESCRIPTION
### Description

Nixpkgs has recently(ish) made a few major changes to its xdg-desktop-portal package (https://github.com/NixOS/nixpkgs/pull/268197), which silently breaks our module here:
- The NIXOS_XDG_DESKTOP_PORTAL_CONFIG_DIR variable patch has been removed (in favor of putting portal configurations in /etc or XDG_CONFIG_HOME).
- A new variable, NIX_XDG_DESKTOP_PORTAL_DIR, was introduced in a patch to avoid setting XDG_DESKTOP_PORTAL_DIR (which also affected portal configuration reading, not only portal definitions)

I updated our module to match the changes, but this breakage also made me revisit this module and look into some improvements.

Long story short, I think it's worth it to make it more similar to the NixOS one, as it will make behavior more predictable and consistent.

The main change is relying on the upstream linked systemd unit (instead of using systemd.user.services), and setting the environment variables globally instead of scoping it to the unit, as it's a very global thing anyway.

This might not be backwards compatible for people already facing #4922/#4972. Maybe I should also provide the unit to ~/.config?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
