### PR TITLE
xonsh: add module and some shell integrations

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -113,6 +113,12 @@
     github = "jack5079";
     githubId = 29169102;
   };
+  inmaldrerah = {
+    name = "In'Maldrerah Eyllisitryanmitore";
+    email = "i@httpssec.com";
+    github = "inmaldrerah";
+    githubId = 71413779;
+  };
   jkarlson = {
     email = "jekarlson@gmail.com";
     github = "jkarlson";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -253,6 +253,7 @@ let
     ./programs/wofi.nix
     ./programs/wpaperd.nix
     ./programs/xmobar.nix
+    ./programs/xonsh.nix
     ./programs/xplr.nix
     ./programs/yambar.nix
     ./programs/yazi.nix

--- a/modules/programs/xonsh.nix
+++ b/modules/programs/xonsh.nix
@@ -1,0 +1,85 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.xonsh;
+
+  linesOrSource = types.submodule ({ config, ... }: {
+    options = {
+      text = mkOption {
+        type = types.lines;
+        default =
+          if config.source != null then builtins.readFile config.source else "";
+        defaultText = literalExpression
+          "if source is defined, the content of source, otherwise empty";
+        description = ''
+          Text of the xonshrc file.
+          If unset then the source option will be preferred.
+        '';
+      };
+
+      source = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          Path of the xonshrc file to use.
+          If the text option is set, it will be preferred.
+        '';
+      };
+    };
+  });
+in {
+  meta.maintainers = [ hm.maintainers.inmaldrerah ];
+
+  options.programs.xonsh = {
+    enable = mkEnableOption "xonsh";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.xonsh;
+      defaultText = literalExpression "pkgs.xonsh";
+      description = "The package to use for xonsh.";
+    };
+
+    rcFiles = mkOption {
+      type = types.attrsOf linesOrSource;
+      default = { };
+      example = literalExpression ''
+        {
+          "example.xsh".text = \'\'
+            # Some code here
+          \'\';
+        }
+      '';
+      description = ''
+        The run control file to be used for xonsh.
+
+        See <https://xon.sh/xonshrc.html> for more information.
+      '';
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Additional configuration to add as a standalone xonshrc file.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = mkMerge [
+      (listToAttrs (map (set: {
+        name = "xonsh/rc.d/" + set.name;
+        value.text = set.value.text;
+      }) (filter (set: set.value.text != "")
+        (attrsets.attrsToList cfg.rcFiles))))
+      (mkIf (cfg.extraConfig != "") {
+        "xonsh/rc.d/user-extra.xsh".text = cfg.extraConfig;
+      })
+    ];
+  };
+}

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -39,6 +39,21 @@ let
       rm -fp $tmp
     }
   '';
+
+  xonshIntegration = ''
+    def __yazi_init():
+      def ya(args):
+        tmp = $(mktemp -t "yazi-cwd.XXXXX")
+        $[yazi @(args) @(f"--cwd-file={tmp}")]
+        cwd = fp"{tmp}".read_text()
+        if cwd != "" and cwd != $PWD:
+          xonsh.dirstack.cd(cwd)
+        $[rm -f -- @(tmp)]
+
+      aliases['ya'] = ya
+    __yazi_init()
+    del __yazi_init
+  '';
 in {
   meta.maintainers = [ maintainers.xyenon ];
 
@@ -59,6 +74,8 @@ in {
     enableFishIntegration = mkEnableOption "Fish integration";
 
     enableNushellIntegration = mkEnableOption "Nushell integration";
+
+    enableXonshIntegration = mkEnableOption "Xonsh integration";
 
     keymap = mkOption {
       type = tomlFormat.type;
@@ -149,6 +166,9 @@ in {
 
     programs.nushell.extraConfig =
       mkIf cfg.enableNushellIntegration nushellIntegration;
+
+    programs.xonsh.rcFiles."yazi.xsh".text =
+      mkIf cfg.enableXonshIntegration xonshIntegration;
 
     xdg.configFile = {
       "yazi/keymap.toml" = mkIf (cfg.keymap != { }) {

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -43,11 +43,11 @@ let
   xonshIntegration = ''
     def __yazi_init():
       def yy(args):
-        tmp = $(mktemp -t "yazi-cwd.XXXXX")
+        tmp = $(mktemp -t "yazi-cwd.XXXXX").strip()
         $[yazi @(args) @(f"--cwd-file={tmp}")]
         cwd = fp"{tmp}".read_text()
         if cwd != "" and cwd != $PWD:
-          xonsh.dirstack.cd(cwd)
+          xonsh.dirstack.cd((cwd,))
         $[rm -f -- @(tmp)]
 
       aliases['yy'] = yy

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -42,7 +42,7 @@ let
 
   xonshIntegration = ''
     def __yazi_init():
-      def ya(args):
+      def yy(args):
         tmp = $(mktemp -t "yazi-cwd.XXXXX")
         $[yazi @(args) @(f"--cwd-file={tmp}")]
         cwd = fp"{tmp}".read_text()
@@ -50,7 +50,7 @@ let
           xonsh.dirstack.cd(cwd)
         $[rm -f -- @(tmp)]
 
-      aliases['ya'] = ya
+      aliases['yy'] = yy
     __yazi_init()
     del __yazi_init
   '';

--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -63,6 +63,14 @@ in {
         Whether to enable Nushell integration.
       '';
     };
+
+    enableXonshIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Xonsh integration.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -93,5 +101,10 @@ in {
         source ${config.xdg.cacheHome}/zoxide/init.nu
       '';
     };
+
+    programs.xonsh.rcFiles."zoxide.xsh".text =
+      mkIf cfg.enableXonshIntegration ''
+        execx($(${cfg.package}/bin/zoxide init xonsh), 'exec', __xonsh__.ctx, filename='zoxide')
+      '';
   };
 }

--- a/tests/modules/programs/yazi/default.nix
+++ b/tests/modules/programs/yazi/default.nix
@@ -4,4 +4,5 @@
   yazi-zsh-integration-enabled = ./zsh-integration-enabled.nix;
   yazi-fish-integration-enabled = ./fish-integration-enabled.nix;
   yazi-nushell-integration-enabled = ./nushell-integration-enabled.nix;
+  yazi-xonsh-integration-enabled = ./xonsh-integration-enabled.nix;
 }

--- a/tests/modules/programs/yazi/xonsh-integration-enabled.nix
+++ b/tests/modules/programs/yazi/xonsh-integration-enabled.nix
@@ -1,0 +1,31 @@
+{ ... }:
+
+let
+  shellIntegration = ''
+    def __yazi_init():
+      def ya(args):
+        tmp = $(mktemp -t "yazi-cwd.XXXXX")
+        $[yazi @(args) @(f"--cwd-file={tmp}")]
+        cwd = fp"{tmp}".read_text()
+        if cwd != "" and cwd != $PWD:
+          xonsh.dirstack.cd(cwd)
+        $[rm -f -- @(tmp)]
+
+      aliases['ya'] = ya
+    __yazi_init()
+    del __yazi_init
+  '';
+in {
+  programs.xonsh.enable = true;
+
+  programs.yazi = {
+    enable = true;
+    enableXonshIntegration = true;
+  };
+
+  test.stubs.yazi = { };
+
+  nmt.script = ''
+    assertFileContains home-files/.config/xonsh/rc.d/yazi.xsh '${shellIntegration}'
+  '';
+}


### PR DESCRIPTION
### Description

Add a module for shell Xonsh and some shell integrations for it.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@XYenon for yazi integration
@jpteb for zoxide integration, as the latest editor, since it seems the original maintainer had left the community (sadly)

Do I also need to CC the maintainer of the xonsh package in nixpkgs?