### PR TITLE
home-manager: fix nix-build option `-q`

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -138,7 +138,7 @@ function setHomeManagerPathVariables() {
     fi
 
     _iVerbose "Sanity checking Nix"
-    nix-build -q --expr '{}' --no-out-link > /dev/null 2>&1 || true
+    nix-build --quiet --expr '{}' --no-out-link > /dev/null 2>&1 || true
     nix-env -q > /dev/null 2>&1 || true
 
     declare -r globalNixStateDir="${NIX_STATE_DIR:-/nix/var/nix}"

--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -155,7 +155,7 @@ _i "Starting Home Manager activation"
 # Verify that we can connect to the Nix store and/or daemon. This will
 # also create the necessary directories in profiles and gcroots.
 _iVerbose "Sanity checking Nix"
-nix-build --expr '{}' --no-out-link
+nix-build --quiet --expr '{}' --no-out-link
 
 # Also make sure that the Nix profiles path is created.
 nix-env -q > /dev/null 2>&1 || true


### PR DESCRIPTION
### Description

The `-q` option does not actually exist, nix-build expects `--quiet`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```