### PR TITLE
secret-service: add module for managing secrets in the D-Bus secret service

### DIFF
--- a/modules/misc/news/2026/03/2026-03-04_10-47-58.nix
+++ b/modules/misc/news/2026/03/2026-03-04_10-47-58.nix
@@ -1,0 +1,16 @@
+{ pkgs, ... }:
+{
+  time = "2026-03-04T09:47:58+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'services.secret-service'.
+
+    The D-Bus secret service API allows applications to store and access
+    secrets securely in a service running in the user's login session. It
+    is implemented by various backends such as gnome-keyring, kwallet, and
+    keepassxc. This module adds functionality to declaratively manage
+    secrets in the secret service. The defined secrets get inserted into
+    the secret service after the session started and the default collection
+    is unlocked, and are removed again when the session ends.
+  '';
+}

--- a/modules/services/secret-service/default.nix
+++ b/modules/services/secret-service/default.nix
@@ -1,0 +1,161 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.services.secret-service;
+in
+{
+  meta.maintainers = [ lib.maintainers.zebreus ];
+
+  options = {
+    services.secret-service = {
+      enable = lib.mkEnableOption ''
+        Enable managing secrets in the D-Bus secret service.
+      '';
+
+      secrets = lib.mkOption {
+        default = [ ];
+        description = ''
+          List of secrets
+        '';
+        type = lib.types.listOf (
+          lib.types.submodule (
+            { lib, name, ... }:
+            {
+              options = {
+                label = lib.mkOption {
+                  type = lib.types.str;
+                  default = name;
+                  description = ''
+                    The label of this secret. Will be displayed to the user.
+                  '';
+                };
+                secretCommand = lib.mkOption {
+                  type = lib.types.str;
+                  example = "cat /run/agenix/important_secret.txt";
+                  description = ''
+                    The command to run to get the secret.
+
+                    This command will get run once on every session start and the result will be
+                    stored in the secret service. The command will be written into the Nix store
+                    and is world-readable so make sure to not include any secrets in the command.
+                  '';
+                };
+                attributes = lib.mkOption {
+                  type = lib.types.attrsOf lib.types.str;
+                  default = { };
+                  description = ''
+                    Attributes for the secret.
+                  '';
+                };
+              };
+            }
+          )
+        );
+      };
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.secret-service" pkgs lib.platforms.linux)
+    ];
+    systemd.user = {
+      startServices = lib.mkDefault "sd-switch";
+      services.manage-secret-service-secrets =
+        let
+          storeSecretCommands = lib.concatStringsSep "\n" (
+            map (
+              {
+                label,
+                secretCommand,
+                attributes,
+              }:
+              let
+                attributesToString =
+                  attrs:
+                  lib.concatStringsSep " " (
+                    lib.mapAttrsToList (name: value: "${lib.escapeShellArg name} ${lib.escapeShellArg value}") attrs
+                  );
+              in
+              ''
+                # shellcheck disable=all
+                ${secretCommand} | sed -z '$ s/\\n$//' | storeManagedSecret ${lib.escapeShellArg label} ${attributesToString attributes}
+              ''
+            ) cfg.secrets
+          );
+
+          sharedFunctions = builtins.readFile ./helpers.bash;
+
+          runtimeInputs = with pkgs; [
+            coreutils
+            dbus
+            gnused
+            gnugrep
+            libsecret
+          ];
+
+          startScript = pkgs.writeShellApplication {
+            inherit runtimeInputs;
+            name = "updateSecrets";
+            text = ''
+              ${sharedFunctions}
+
+              waitForUnlock || exit 1
+
+              set -e
+              removeManagedSecrets
+              ${storeSecretCommands}
+            '';
+          };
+
+          stopScript = pkgs.writeShellApplication {
+            inherit runtimeInputs;
+            name = "removeSecrets";
+            text = ''
+              ${sharedFunctions}
+
+              if ! checkUnlock ; then
+                echo "Collection is locked, skipping secret removal"
+                exit 0
+              fi
+
+              set -e
+              removeManagedSecrets
+            '';
+          };
+        in
+        {
+          Unit = {
+            Description = "insert secrets into the secret service";
+            After = [
+              "default.target"
+              "dbus.service"
+            ];
+          };
+
+          Service = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = "${lib.getExe startScript}";
+            ExecStop = "${lib.getExe stopScript}";
+            Restart = "on-failure";
+            RestartSec = 30;
+            TimeoutStopSec = 30;
+            # The start script blocks until the secret service is unlocked
+            TimeoutStartSec = "infinity";
+            # Restart should be fine, as the stop script is not dependent on the configuration for now
+            X-SwitchMethod = "restart";
+          };
+
+          Install = {
+            WantedBy = [ "default.target" ];
+          };
+        };
+    };
+  };
+}

--- a/modules/services/secret-service/helpers.bash
+++ b/modules/services/secret-service/helpers.bash
@@ -1,0 +1,66 @@
+set -o pipefail
+
+# Check if the default collection exists and is unlocked
+# If the first argument is set, it has to be the default collection, otherwise it will return 1
+function checkUnlock {
+    local default_collection
+    default_collection="$(dbus-send --dest=org.freedesktop.secrets --print-reply=literal /org/freedesktop/secrets org.freedesktop.Secret.Service.ReadAlias 'string:default' | head -n1 | tr -d " " || true)"
+    [[ "$default_collection" =~ ^/org/freedesktop/secrets/collection.*$ ]] || return 1
+
+    local changed_collection="${1:-$default_collection}"
+    [[ "$changed_collection" != "$default_collection" ]] && return 1
+
+    local currently_locked
+    currently_locked="$(dbus-send --dest=org.freedesktop.secrets --print-reply=literal "$default_collection" org.freedesktop.DBus.Properties.Get string:org.freedesktop.Secret.Collection string:Locked | grep -Po "(true|false)")"
+    [[ "$currently_locked" != "false" ]] && return 1
+    return 0
+}
+
+# Wait for the default collection to be unlocked
+function waitForUnlock {
+    # Instantly return if the collection is already unlocked
+    checkUnlock && return 0
+
+    echo "Waiting for the default collection to be unlocked..."
+    local next_line_contains_name=false
+    while read -r line; do
+        if [[ $next_line_contains_name == true ]]; then
+            local collection
+            collection="$(echo "$line" | grep -Po '(?<=")/org/freedesktop/secrets/collection/[^"/]+')"
+            if checkUnlock "$collection"; then
+                echo "Default collection was unlocked."
+                return 0
+            fi
+            next_line_contains_name=false
+            continue
+        fi
+        # Check if the line contains the property we are interested in
+        if [[ $line =~ ^.*CollectionChanged.*$ ]]; then
+            next_line_contains_name=true
+        fi
+    done < <(
+        dbus-monitor --session "type='signal',interface='org.freedesktop.Secret.Service',member='CollectionChanged',sender='org.freedesktop.secrets',path='/org/freedesktop/secrets'"
+    )
+
+    echo "Error: dbus-monitor exited unexpectedly. Cannot insert secrets."
+    exit 1
+}
+
+# Removes all managed secrets
+function removeManagedSecrets {
+    echo "Removing previous secrets"
+    secret-tool clear home-manager-secret dont-modify-this-manually || true
+}
+
+# Store a secret and mark it as managed by home-manager
+# Reads the secret from stdin
+function storeManagedSecret {
+    local secret
+    secret="$(cat)"
+    local secret_hash
+    secret_hash="$(printf '%s\0' "$@" "$secret" | sha256sum | cut -f1 -d' ')"
+    local label="$1"
+    shift
+    echo "Storing secret \"$label\""
+    printf '%s' "$secret" | secret-tool store home-manager-secret dont-modify-this-manually home-manager-secret-hash "$secret_hash" --label="$label" "$@"
+}

--- a/tests/modules/services/secret-service/basic-configuration.nix
+++ b/tests/modules/services/secret-service/basic-configuration.nix
@@ -1,0 +1,45 @@
+{ ... }:
+{
+  config = {
+    services.secret-service = {
+      enable = true;
+      secrets = [
+        {
+          label = "Super secret password";
+          # Decodes to "password123"
+          secretCommand = "echo cGFzc3dvcmQxMjM= | base64 -d";
+          attributes = {
+            "some-attribute" = "that value";
+          };
+        }
+      ];
+    };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/manage-secret-service-secrets.service
+      assertFileExists $serviceFile
+
+      # Assert that the systemd unit has the sd-switch setting
+      assertFileRegex $serviceFile 'X-SwitchMethod=restart'
+
+      assertFileRegex $serviceFile 'ExecStart=.*updateSecrets'
+      startScript="$(grep -Po '(?<=ExecStart=).*updateSecrets' $TESTED/$serviceFile)"
+      assertFileExists "$startScript"
+
+      assertFileRegex $serviceFile 'ExecStop=.*removeSecrets'
+      stopScript="$(grep -Po '(?<=ExecStop=).*removeSecrets' $TESTED/$serviceFile)"
+      assertFileExists $stopScript
+
+      # Assert that only the secret command and not the secret is in the start script
+      assertFileNotRegex $startScript password123
+      assertFileRegex $startScript cGFzc3dvcmQxMjM=
+
+      # Assert that the attributes are properly quoted
+      assertFileRegex $startScript "some-attribute 'that value'"
+
+      # Assert that neither the secret nor the secret command is not in the stop script
+      assertFileNotRegex $stopScript password123
+      assertFileNotRegex $stopScript cGFzc3dvcmQxMjM=
+    '';
+  };
+}

--- a/tests/modules/services/secret-service/default.nix
+++ b/tests/modules/services/secret-service/default.nix
@@ -1,0 +1,4 @@
+{ lib, pkgs, ... }:
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  secret-service-basic-configuration = ./basic-configuration.nix;
+}


### PR DESCRIPTION
### Description

The D-Bus secret service API allows applications to store and access secrets securely in a service running in the user's login session. It is implemented by various backends such as gnome-keyring, kwallet, and keepassxc. This module adds functionality to declaratively manage secrets in the secret service. The defined secrets get inserted into the secret service after the session started and the default collection is unlocked, and removed again when the session ends.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix develop --ignore-environment .#all` using Flakes.
- [x] Test cases updated/added.
- [x] Commit messages are formatted correctly
- [x] Added myself as module maintainer.