### PR TITLE
home-manger: fix runtime closure

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,12 @@
 { pkgs ? import <nixpkgs> { } }:
 
-rec {
+let
+  path = builtins.path {
+    path = ./.;
+    name = "home-manager-source";
+  };
+
+in rec {
   docs = let releaseInfo = pkgs.lib.importJSON ./release.json;
   in with import ./docs {
     inherit pkgs;
@@ -12,12 +18,12 @@ rec {
     jsonModuleMaintainers = jsonModuleMaintainers; # Unstable, mainly for CI.
   };
 
-  home-manager = pkgs.callPackage ./home-manager { path = toString ./.; };
+  home-manager = pkgs.callPackage ./home-manager { inherit path; };
 
   install =
     pkgs.callPackage ./home-manager/install.nix { inherit home-manager; };
 
   nixos = import ./nixos;
 
-  path = ./.;
+  inherit path;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
             inherit pkgs;
             inherit (releaseInfo) release isReleaseBranch;
           };
-          hmPkg = pkgs.callPackage ./home-manager { path = "${./.}"; };
+          hmPkg = pkgs.callPackage ./home-manager { path = "${self}"; };
         in {
           default = hmPkg;
           home-manager = hmPkg;


### PR DESCRIPTION
### Description

Without this fix a `nix-buid . -A home-manager` would successfully
create a `home-manager`. And one could use the included binary until
the next garbage collection, after that it would fail with an
error that it can not find the `home-manager` sources.

Similarily a `nix-copy-closure`d `home-manager` would fail with the
same error on the copies target machine.

This problem existed on both, the flake as well as the non-flake build
of `home-manager`.

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
