### PR TITLE
wallust: added new module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -7,6 +7,12 @@
 # [1] https://github.com/NixOS/nixpkgs/blob/fca0d6e093c82b31103dc0dacc48da2a9b06e24b/maintainers/maintainer-list.nix#LC1
 
 {
+  DaniD3v = {
+    name = "DaniD3v";
+    email = "sch220233@spengergasse.at";
+    github = "DaniD3v";
+    githubId = 124387056;
+  };
   amesgen = {
     name = "amesgen";
     email = "amesgen@amesgen.de";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -379,6 +379,7 @@ let
     ./services/xscreensaver.nix
     ./services/xsettingsd.nix
     ./services/xsuspender.nix
+    ./programs/wallust.nix
     ./systemd.nix
     ./targets/darwin
     ./targets/generic-linux.nix

--- a/modules/programs/wallust.nix
+++ b/modules/programs/wallust.nix
@@ -1,0 +1,93 @@
+{ pkgs, config, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.wallust;
+  tomlFormat = pkgs.formats.toml { };
+
+  templateModule = { ... }: {
+    options = {
+      template = mkOption {
+        type = types.path;
+
+        example = ''
+          fetchurl {
+            url = "https://raw.githubusercontent.com/dylanaraps/pywal/master/pywal/templates/colors.json";
+            hash = "";
+          };
+        '';
+        description = "The template source file";
+      };
+
+      target = mkOption {
+        type = types.str;
+
+        example = "$XDG_CACHE_HOME/wal/colors.json";
+        description = "The destination of the processed template";
+      };
+    };
+  };
+
+in {
+  options.programs.wallust = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+
+      example = true;
+      description = "Whether to enable wallust.";
+    };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+
+      example = ''
+        {
+          backend = "fastresize";
+          color_space = "labfast";
+        }
+      '';
+      description = ''
+        Wallust configuration file.
+
+        Written to {file}`$XDG_CONFIG_HOME/wallust/wallust.toml`
+        An example configuration can be found at <https://codeberg.org/explosion-mental/wallust/src/tag/2.10.0/wallust.toml>
+      '';
+    };
+
+    templates = mkOption {
+      type = with types; listOf (submodule templateModule);
+      default = [ ];
+
+      example = literalExpression ''
+        [
+          {
+            template = ../../../dotfiles/pywal/colors.json;
+            target = "''${config.xdg.cacheHome}/wal/colors.json";
+          }
+        ];
+      '';
+      description =
+        "A list of templates and their target destinations that wallust is supposed to process.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.wallust ];
+
+    xdg.configFile."wallust/wallust.toml" = let
+      defaultCfg = {
+        backend = "fastresize";
+        color_space = "labfast";
+        threshold = 20;
+        filter = "dark16";
+      };
+      mergedCfg = defaultCfg // cfg.settings // { entry = cfg.templates; };
+
+    in { source = tomlFormat.generate "wallust.toml" mergedCfg; };
+  };
+
+  meta.maintainers = [ hm.maintainers.temp ]; # TODO
+}

--- a/modules/programs/wallust.nix
+++ b/modules/programs/wallust.nix
@@ -89,5 +89,5 @@ in {
     in { source = tomlFormat.generate "wallust.toml" mergedCfg; };
   };
 
-  meta.maintainers = [ hm.maintainers.temp ]; # TODO
+  meta.maintainers = [ hm.maintainers.DaniD3v ];
 }


### PR DESCRIPTION
### Description

Added new module: [wallust](https://codeberg.org/explosion-mental/wallust)


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

The full log is here
```
trace: warning: The cfg.enableGnomeExtensions argument for `firefox.override` is deprecated, please add `pkgs.gnome-browser-connector` to `nativeMessagingHosts.packages` instead
trace: warning: Assigning a plain list to extraLuaPackages is deprecated.
       Please assign a function taking a package set as argument, so
         extraLuaPackages = [ pkgs.lua51Packages.xxx ];
       should become
         extraLuaPackages = ps: [ ps.xxx ];

trace: warning: Assigning a plain list to extraPython3Packages is deprecated.
       Please assign a function taking a package set as argument, so
         extraPython3Packages = [ pkgs.python3Packages.xxx ];
       should become
         extraPython3Packages = ps: [ ps.xxx ];

trace: warning: Assigning a plain list to extraLuaPackages is deprecated.
       Please assign a function taking a package set as argument, so
         extraLuaPackages = [ pkgs.lua51Packages.xxx ];
       should become
         extraLuaPackages = ps: [ ps.xxx ];

abook-no-settings: OK
abook-with-settings: OK
activitywatch-basic-setup: OK
activitywatch-empty-server-settings: OK
aerc-assertion: OK
aerc-noSettings: OK
aerc-settings: OK
alacritty-empty-settings: OK
alacritty-example-settings: OK
alacritty-merging-settings: OK
alacritty-toml-config: OK
alot: OK
antidote-program: OK
aria2-settings: OK
atuin-bash: OK
atuin-empty-settings: OK
atuin-example-settings: OK
atuin-fish: OK
atuin-no-shell: OK
atuin-set-flags: OK
atuin-zsh: OK
autojump: OK
autorandr-basic-configuration: OK
autorandr-scale: OK
avizo-with-settings: OK
avizo-without-settings: OK
awscli: OK
bacon-program: OK
barrier-basic-configuration: OK
bash-completion: OK
bash-logout: OK
bash-session-variables: OK
bat: OK
bat-deprecated-options: OK
beets-mpdstats: OK
beets-mpdstats-external: OK
beets-mpdupdate: OK
bemenu-basic-configuration: OK
bemenu-empty-configuration: OK
borgmatic-program-basic-configuration: OK
borgmatic-program-both-sourcedirectories-and-patterns: OK
borgmatic-program-exclude-hm-symlinks: OK
borgmatic-program-exclude-hm-symlinks-nothing-else: OK
borgmatic-program-include-hm-symlinks: OK
borgmatic-program-neither-sourcedirectories-nor-patterns: OK
borgmatic-program-patterns-configuration: OK
borgmatic-service-basic-configuration: OK
bottom-empty-settings: OK
bottom-example-settings: OK
boxxy-empty-settings: OK
boxxy-example-settings: OK
broot: OK
browserpass: OK
bspwm-configuration: OK
btop-empty-settings: OK
btop-example-settings: OK
cachix: OK
carapace-bash: OK
carapace-fish: OK
carapace-nushell: OK
carapace-zsh: OK
cava-basic-configuration: OK
cliphist-sway-session-target: OK
clipman-sway-session-target: OK
comodoro-program: OK
comodoro-service: OK
darcs-author: OK
darcs-boring: OK
darkman-basic-configuration: OK
debug: OK
devilspie2-configuration: OK
dircolors-settings: OK
direnv-bash: OK
direnv-nix-direnv: OK
direnv-nushell: OK
direnv-stdlib: OK
direnv-stdlib-and-nix-direnv: OK
dropbox-basic-configuration: OK
editorconfig-simple-config: OK
emacs-default-editor: OK
emacs-extra-config: OK
emacs-service-27: OK
emacs-service-28: OK
emacs-service-28-after-graphical-session-target: OK
emacs-socket-27: OK
emacs-socket-28: OK
emacs-socket-and-startWithUserSession: OK
espanso-basic-configuration: OK
feh-bindings: OK
feh-empty-config: OK
files-disabled: OK
files-executable: OK
files-hidden-source: OK
files-out-of-store-symlink: OK
files-source-with-spaces: OK
files-target-conflict: OK
files-target-with-shellvar: OK
files-text: OK
firefox-container-id-out-of-range: OK
firefox-deprecated-native-messenger: OK
firefox-duplicate-container-ids: OK
firefox-duplicate-profile-ids: OK
firefox-policies: OK
firefox-state-version-19_09: OK
fish-abbrs: OK
fish-format-scripts: OK
fish-functions: OK
fish-no-functions: OK
fish-plugins: OK
flameshot-empty-settings: OK
flameshot-example-settings: OK
fluidsynth: OK
fnott-example-settings: OK
fnott-systemd-user-service: OK
fontconfig-no-font-package: OK
fontconfig-single-font-package: OK
foot-empty-settings: OK
foot-example-settings: OK
foot-systemd-user-service: OK
fusuma-example-settings: OK
fusuma-systemd-user-service: OK
fuzzel-empty-settings: OK
fuzzel-example-settings: OK
gallery-dl: OK
gammastep-basic-configuration: OK
generators-tokdl: OK
generators-toscfg-empty: OK
generators-toscfg-example: OK
getmail: OK
gh-config-file: OK
gh-credential-helper: OK
gh-dash-config: OK
gh-extensions: OK
gh-warnings: OK
git-cliff-example-settings: OK
git-sync: OK
git-with-email: OK
git-with-hooks: OK
git-with-most-options: OK
git-with-msmtp: OK
git-with-signing-key-id: OK
git-with-str-extra-config: OK
git-without-signing-key-id: OK
gnome-terminal-1: OK
gnome-terminal-bad-profile-name: OK
gpg-agent-default-homedir: OK
gpg-agent-override-homedir: OK
gpg-immutable-keyfiles: OK
gpg-mutable-keyfiles: OK
gpg-override-defaults: OK
gradle-alternate-home-settings: OK
gradle-empty-settings: OK
gradle-example-settings: OK
gradle-init-scripts-settings: OK
granted-integration-disabled: OK
granted-integration-enabled: OK
gromit-mpx-basic-configuration: OK
gromit-mpx-default-configuration: OK
gtk2-basic-config: OK
gtk2-config-file-location: OK
gtk3-basic-settings: OK
helix-example-settings: OK
herbstluftwm-no-tags: OK
herbstluftwm-simple-config: OK
hexchat-basic-configuration: OK
himalaya-basic: OK
home-manager-auto-upgrade-basic-configuration: OK
home-session-path: OK
home-session-variables: OK
htop-empty-settings: OK
htop-example-settings: OK
htop-header_layout: OK
htop-settings-without-fields: OK
hyfetch-empty-settings: OK
hyfetch-settings: OK
hyprland-inconsistent-config: OK
hyprland-simple-config: OK
i18n: OK
i18n-custom-locales: OK
i3-bar-focused-colors: OK
i3-followmouse: OK
i3-fonts: OK
i3-fonts-deprecated: OK
i3-keybindings: OK
i3-null-config: OK
i3-workspace-default: OK
i3-workspace-output: OK
i3blocks-with-ordered-blocks: OK
i3status-rust-with-custom: OK
i3status-rust-with-default: OK
i3status-rust-with-extra-settings: OK
i3status-rust-with-multiple-bars: OK
i3status-rust-with-version-02xx: OK
i3status-rust-with-version-0311: OK
i3status-with-custom: OK
i3status-with-default: OK
imapnotify: OK
imv-basic-configuration: OK
imv-empty-configuration: OK
input-method-fcitx5-configuration: OK
input-method-kime-configuration: OK
irssi-example-settings: OK
joplin-desktop-basic-configuration: OK
jujutsu-empty-config: OK
jujutsu-example-config: OK
k9s-deprecated-options: OK
k9s-empty-settings: OK
k9s-example-settings: OK
k9s-partial-skin-settings: OK
kakoune-no-plugins: OK
kakoune-use-plugins: OK
kakoune-whitespace-highlighter: OK
kakoune-whitespace-highlighter-corner-cases: OK
kanshi-basic-configuration: OK
khal-config: OK
khard_basic_config: OK
khard_empty_config: OK
khard_multiple_accounts: OK
kitty-example-settings: OK
kodi-example-addon-settings: OK
kodi-example-settings: OK
kodi-example-sources: OK
ledger: OK
less-with-custom-keys: OK
lf-all-options: OK
lf-minimal-options: OK
lf-no-pv-keybind: OK
lib-types-dag-merge: OK
lib-types-dag-submodule: OK
lib-types-gvariant-merge: OK
lieer: OK
lieer-service: OK
looking-glass-client-empty-settings: OK
looking-glass-client-example-settings: OK
lsd-example-settings: OK
man-apropos: OK
man-no-manpath: OK
mangohud-basic-configuration: OK
manual: OK
mbsync: OK
micro: OK
mise-bash-integration: OK
mise-custom-settings: OK
mise-default-settings: OK
mise-fish-integration: OK
mise-zsh-integration: OK
mopidy-basic-configuration: OK
mpd-basic-configuration: OK
mpd-before-state-version-22_11: OK
mpd-mpris-configuration-basic: OK
mpd-mpris-configuration-with-local-mpd: OK
mpd-mpris-configuration-with-password: OK
mpd-xdg-music-dir: OK
mpdris2-basic-configuration: OK
mpdris2-with-password: OK
mpv-example-settings: OK
mpv-invalid-settings: OK
mu-basic-configuration: OK
mujmap-defaults: OK
mujmap-fqdn-and-session-url-specified: OK
ncmpcpp-empty-settings: OK
ncmpcpp-example-settings: OK
ncmpcpp-issue-3560: OK
ncmpcpp-use-mpd-config: OK
ne-defprefs: OK
ne-passthroughs: OK
neomutt-no-folder-change: OK
neomutt-not-primary: OK
neomutt-simple: OK
neomutt-unmailboxes: OK
neomutt-with-binds: OK
neomutt-with-binds-invalid-settings: OK
neomutt-with-binds-with-warning: OK
neomutt-with-gpg: OK
neomutt-with-imap: OK
neomutt-with-imap-type-mailboxes: OK
neomutt-with-msmtp: OK
neomutt-with-named-mailboxes: OK
neomutt-with-signature: OK
neomutt-with-signature-command: OK
neomutt-with-starttls: OK
neovim-coc-config: OK
neovim-extra-lua-init: OK
neovim-no-init: OK
neovim-plugin-config: OK
neovim-runtime: OK
newsboat-basics: OK
newsboat-basics-2003: OK
newsboat-basics-2105: OK
nheko-empty-settings: OK
nheko-example-settings: OK
nix-empty-settings: OK
nix-example-registry: OK
nix-example-settings: OK
nix-gc: OK
nix-index-assert-on-command-not-found: OK
nix-index-integrations: OK
nnn: OK
numlock: OK
nushell-example-settings: OK
oh-my-posh-bash: OK
oh-my-posh-fish: OK
oh-my-posh-nushell: OK
oh-my-posh-zsh: OK
openstackclient: OK
osmscout-server: OK
pam-session-variables: OK
pam-yubico-no-ids: OK
pam-yubico-with-ids: OK
pandoc-citation-styles: OK
pandoc-defaults: OK
pandoc-templates: OK
pantalaimon-basic-configuration: OK
papis: OK
parcellite: OK
pass-secret-service-basic-configuration: OK
pass-secret-service-default-configuration: OK
pasystray-service: OK
pbgopy: OK
pet-settings_21_05: OK
pet-settings_21_11: OK
pet-snippets: OK
picom-basic-configuration: OK
pistol-associations: OK
pistol-config: OK
pistol-double-association: OK
pistol-missing-association: OK
playerctld-basic: OK
pls-bash: OK
pls-fish: OK
pls-zsh: OK
polybar-basic-configuration: OK
polybar-empty-configuration: OK
powerline-go-bash: OK
powerline-go-bashmodulesright: OK
powerline-go-fish: OK
powerline-go-zsh: OK
powerline-go-zshmodulesright: OK
pqiv-settings: OK
pubs-example-settings: OK
pyenv-bash: OK
pyenv-fish: OK
pyenv-zsh: OK
qcal-http: OK
qcal-mixed: OK
qcal-webdav: OK
qt-basic: OK
qt-platform-theme-gnome: OK
qt-platform-theme-gtk: OK
qt-platform-theme-gtk3: OK
qutebrowser-greasemonkey: OK
qutebrowser-keybindings: OK
qutebrowser-quickmarks: OK
qutebrowser-settings: OK
ranger-configuration: OK
rbw-empty-settings: OK
rbw-settings: OK
rbw-simple-settings: OK
readline-using-all-options: OK
recoll-basic-configuration: OK
recoll-config-format-order: OK
redshift-basic-configuration: OK
rio-empty-settings: OK
rio-example-settings: OK
ripgrep-custom-arguments: OK
ripgrep-default-arguments: OK
river-configuration: OK
rofi-config-with-deprecated-options: OK
rofi-custom-theme: OK
rofi-pass-config: OK
rofi-pass-root: OK
rofi-valid-config: OK
ruff-program: OK
sagemath: OK
sapling-basic: OK
sapling-most: OK
sbt-credentials: OK
sbt-deprecated-options: OK
sbt-plugins: OK
sbt-repositories: OK
sbt-user-config-path: OK
scmpuff-bash: OK
scmpuff-fish: OK
scmpuff-no-aliases: OK
scmpuff-no-bash: OK
scmpuff-no-fish: OK
scmpuff-no-shell: OK
scmpuff-no-zsh: OK
scmpuff-zsh: OK
screen-locker-basic-configuration: OK
screen-locker-moved-options: OK
screen-locker-no-xautolock: OK
senpai-empty-settings: OK
senpai-example-settings: OK
sftpman-assert-on-no-sshkey: OK
sftpman-example-settings: OK
signaturepdf-basic-configuration: OK
sioyek: OK
sm64ex: OK
specialisation: OK
spectrwm-simple-config: OK
ssh-defaults: OK
ssh-forwards-dynamic-bind-path-with-port-asserts: OK
ssh-forwards-dynamic-valid-bind-no-asserts: OK
ssh-forwards-local-bind-path-with-port-asserts: OK
ssh-forwards-local-host-path-with-port-asserts: OK
ssh-forwards-remote-bind-path-with-port-asserts: OK
ssh-forwards-remote-host-path-with-port-asserts: OK
ssh-includes: OK
ssh-match-blocks: OK
ssh-match-blocks-match-and-hosts: OK
starship-fish-with-transience: OK
starship-fish-without-transience: OK
starship-settings: OK
sway-bar-focused-colors: OK
sway-bindkeys-to-code-and-extra-config: OK
sway-default: OK
sway-followmouse: OK
sway-followmouse-legacy: OK
sway-modules: OK
sway-no-xwayland: OK
sway-null-config: OK
sway-null-package: OK
sway-post-2003: OK
sway-systemd-autostart: OK
sway-workspace-default: OK
sway-workspace-output: OK
swayidle-basic-configuration: OK
swaylock-disabled: OK
swaylock-enabled: OK
swaylock-legacy: OK
swaylock-settings: OK
swaynag-empty-settings: OK
swaynag-example-settings: OK
swayosd: OK
swayr-basic-configuration: OK
swayr-empty-configuration: OK
sxhkd-configuration: OK
sxhkd-service: OK
syncthing-extra-options: OK
syncthing-tray: OK
syncthing-tray-as-bool-triggers-warning: OK
systemd-empty-user-config: OK
systemd-services: OK
systemd-services-disabled-for-root: OK
systemd-session-variables: OK
systemd-slices: OK
systemd-timers: OK
systemd-user-config: OK
targets-generic-linux: OK
taskwarrior: OK
tealdeer-custom-settings: OK
tealdeer-default-settings: OK
terminator-config-file: OK
texlive-minimal: OK
thefuck-integration-disabled: OK
thefuck-integration-enabled: OK
thefuck-integration-enabled-instant: OK
thunderbird: OK
tmate: OK
tmux-default-shell: OK
tmux-disable-confirmation-prompt: OK
tmux-emacs-with-plugins: OK
tmux-mouse-enabled: OK
tmux-not-enabled: OK
tmux-prefix: OK
tmux-secure-socket-enabled: OK
tmux-shortcut-without-prefix: OK
tmux-vi-all-true: OK
topgrade-settings: OK
translate-shell: OK
trayer-basic-configuration: OK
twmn-basic-configuration: OK
udiskie-basic: OK
udiskie-no-tray: OK
vim-vint-basic-configuration: OK
vscode-keybindings: OK
vscode-snippets: OK
vscode-tasks: OK
vscode-update-checks: OK
watson-empty-settings: OK
watson-example-settings: OK
waybar-deprecated-modules-option: OK
waybar-settings-complex: OK
waybar-settings-with-attrs: OK
waybar-styling: OK
waybar-systemd-with-graphical-session-target: OK
wezterm-bash-integration-default: OK
wezterm-bash-integration-disabled: OK
wezterm-bash-integration-enabled: OK
wezterm-empty-setting: OK
wezterm-example-setting: OK
wezterm-zsh-integration-default: OK
wezterm-zsh-integration-disabled: OK
wezterm-zsh-integration-enabled: OK
wlogout-layout-multiple: OK
wlogout-layout-single: OK
wlogout-styling: OK
wlsunset-service: OK
wob-service: OK
wofi-basic-configuration: OK
wofi-empty-configuration: OK
wpaperd-example-settings: OK
xdg-default-locations: OK
xdg-desktop-entries: OK
xdg-file-gen: OK
xdg-mime-apps-basics: OK
xdg-portal: OK
xdg-system-dirs: OK
xdg-user-dirs-null: OK
xmobar-basic-configuration: OK
xresources: OK
xresources-empty-properties: OK
xsession-basic: OK
xsession-keyboard-without-layout: OK
xsettingsd-basic-configuration: OK
yazi-bash-integration-enabled: OK
yazi-fish-integration-enabled: OK
yazi-nushell-integration-enabled: OK
yazi-settings: OK
yazi-zsh-integration-enabled: OK
yt-dlp-extraConfig: OK
yt-dlp-simple-config: OK
zellij-enable-shells: OK
zk: OK
zplug-modules: OK
zsh-abbr: OK
zsh-history-ignore-pattern: OK
zsh-history-path-new-custom: OK
zsh-history-path-new-default: OK
zsh-history-path-old-custom: OK
zsh-history-path-old-default: OK
zsh-history-substring-search: OK
zsh-prezto: OK
zsh-session-variables: OK
zsh-syntax-highlighting: OK
firefox-profile-settings: FAILED
Expected home-files/.mozilla/firefox/containers/containers.json to be same as /nix/store/22gkd3v4f6y5yz182nx9gi5w1czvjgb6-profile-settings-expected-containers.json but were different:
--- actual
+++ expected
@@ -1 +1 @@
-{"identities":[{"color":"yellow","icon":"circle","name":"shopping","public":true,"userContextId":6},{"accessKey":"","color":"","icon":"","name":"userContextIdInternal.thumbnail","public":false,"userContextId":4294967294},{"accessKey":"","color":"","icon":"","name":"userContextIdInternal.webextStorageLocal","public":false,"userContextId":4294967295}],"lastUserContextId":6,"version":4}
+{"identities":[{"color":"yellow","icon":"circle","name":"shopping","public":true,"userContextId":6}],"lastUserContextId":6,"version":4}
For further reference please introspect /nix/store/gh0mdlk9l2xjrxydscbd94amp0m7w2p5-nmt-report-firefox-profile-settings
```

I doubt these failed test cases have anything to do with my module tho

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- No test case yet. If a test case is really necessary I can write one.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
