### PR TITLE
spotify-player: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -71,6 +71,12 @@
     github = "Dines97";
     githubId = 19364873;
   };
+  diniamo = {
+    name = "diniamo";
+    email = "diniamo69@gmail.com";
+    github = "diniamo";
+    githubId = 55629891;
+  };
   dwagenk = {
     email = "dwagenk@mailbox.org";
     github = "dwagenk";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1491,6 +1491,13 @@ in {
           A new module is available: 'programs.tofi'.
         '';
       }
+
+      {
+        time = "2024-04-19T10:01:55+00:00";
+        message = ''
+          A new module is available: 'programs.spotify-player'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -211,6 +211,7 @@ let
     ./programs/sioyek.nix
     ./programs/skim.nix
     ./programs/sm64ex.nix
+    ./programs/spotify-player.nix
     ./programs/sqls.nix
     ./programs/ssh.nix
     ./programs/starship.nix

--- a/modules/programs/spotify-player.nix
+++ b/modules/programs/spotify-player.nix
@@ -1,0 +1,154 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkEnableOption mkPackageOption mkOption types literalExpression mkIf;
+
+  cfg = config.programs.spotify-player;
+  tomlFormat = pkgs.formats.toml { };
+
+in {
+  meta.maintainers = with lib.hm.maintainers; [ diniamo ];
+
+  options.programs.spotify-player = {
+    enable = mkEnableOption "spotify-player";
+
+    package = mkPackageOption pkgs "spotify-player" { };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          theme = "default";
+          playback_window_position = "Top";
+          copy_command = {
+            command = "wl-copy";
+            args = [];
+          };
+          device = {
+            audio_cache = false;
+            normalization = false;
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/spotify-player/app.toml`.
+
+        See
+        <https://github.com/aome510/spotify-player/blob/master/docs/config.md#general>
+        for the full list of options.
+      '';
+    };
+
+    themes = mkOption {
+      type = types.listOf tomlFormat.type;
+      default = [ ];
+      example = literalExpression ''
+        [
+          {
+            name = "default2";
+            palette = {
+              black = "black";
+              red = "red";
+              green = "green";
+              yellow = "yellow";
+              blue = "blue";
+              magenta = "magenta";
+              cyan = "cyan";
+              white = "white";
+              bright_black = "bright_black";
+              bright_red = "bright_red";
+              bright_green = "bright_green";
+              bright_yellow = "bright_yellow";
+              bright_blue = "bright_blue";
+              bright_magenta = "bright_magenta";
+              bright_cyan = "bright_cyan";
+              bright_white = "bright_white";
+            };
+            component_style = {
+              block_title = { fg = "Magenta"; };
+              border = {};
+              playback_track = { fg = "Cyan"; modifiers = ["Bold"]; };
+              playback_artists = { fg = "Cyan"; modifiers = ["Bold"]; };
+              playback_album = { fg = "Yellow"; };
+              playback_metadata = { fg = "BrightBlack"; };
+              playback_progress_bar = { bg = "BrightBlack"; fg = "Green"; };
+              current_playing = { fg = "Green"; modifiers = ["Bold"]; };
+              page_desc = { fg = "Cyan"; modifiers = ["Bold"]; };
+              table_header = { fg = "Blue"; };
+              selection = { modifiers = ["Bold" "Reversed"]; };
+            };
+          }
+        ]
+      '';
+      description = ''
+        Configuration written to the `themes` field of
+        {file}`$XDG_CONFIG_HOME/spotify-player/theme.toml`.
+
+        See
+        <https://github.com/aome510/spotify-player/blob/master/docs/config.md#themes>
+        for the full list of options.
+      '';
+    };
+
+    keymaps = mkOption {
+      type = types.listOf tomlFormat.type;
+      default = [ ];
+      example = literalExpression ''
+        [
+          {
+            command = "NextTrack";
+            key_sequence = "g n";
+          }
+          {
+            command = "PreviousTrack";
+            key_sequence = "g p";
+          }
+          {
+            command = "Search";
+            key_sequence = "C-c C-x /";
+          }
+          {
+            command = "ResumePause";
+            key_sequence = "M-enter";
+          }
+          {
+            command = "None";
+            key_sequence = "q";
+          }
+        ]
+      '';
+      description = ''
+        Configuration written to the `keymaps` field of
+        {file}`$XDG_CONFIG_HOME/spotify-player/keymap.toml`.
+
+        See
+        <https://github.com/aome510/spotify-player/blob/master/docs/config.md#keymaps>
+        for the full list of options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = {
+      "spotify-player/app.toml" = mkIf (cfg.settings != { }) {
+        source = tomlFormat.generate "spotify-player-app" cfg.settings;
+      };
+
+      "spotify-player/theme.toml" = mkIf (cfg.themes != [ ]) {
+        source =
+          tomlFormat.generate "spotify-player-theme" { inherit (cfg) themes; };
+      };
+
+      "spotify-player/keymap.toml" = mkIf (cfg.keymaps != [ ]) {
+        source = tomlFormat.generate "spotify-player-keymap" {
+          inherit (cfg) keymaps;
+        };
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -140,6 +140,7 @@ in import nmtSrc {
     ./modules/programs/sftpman
     ./modules/programs/sioyek
     ./modules/programs/sm64ex
+    ./modules/programs/spotify-player
     ./modules/programs/ssh
     ./modules/programs/starship
     ./modules/programs/taskwarrior

--- a/tests/modules/programs/spotify-player/app.toml
+++ b/tests/modules/programs/spotify-player/app.toml
@@ -1,0 +1,9 @@
+playback_window_position = "Top"
+theme = "default"
+[copy_command]
+args = []
+command = "wl-copy"
+
+[device]
+audio_cache = false
+normalization = false

--- a/tests/modules/programs/spotify-player/default.nix
+++ b/tests/modules/programs/spotify-player/default.nix
@@ -1,0 +1,1 @@
+{ spotify-player-settings = ./settings.nix; }

--- a/tests/modules/programs/spotify-player/keymap.toml
+++ b/tests/modules/programs/spotify-player/keymap.toml
@@ -1,0 +1,19 @@
+[[keymaps]]
+command = "NextTrack"
+key_sequence = "g n"
+
+[[keymaps]]
+command = "PreviousTrack"
+key_sequence = "g p"
+
+[[keymaps]]
+command = "Search"
+key_sequence = "C-c C-x /"
+
+[[keymaps]]
+command = "ResumePause"
+key_sequence = "M-enter"
+
+[[keymaps]]
+command = "None"
+key_sequence = "q"

--- a/tests/modules/programs/spotify-player/settings.nix
+++ b/tests/modules/programs/spotify-player/settings.nix
@@ -1,0 +1,103 @@
+{
+  programs.spotify-player = {
+    enable = true;
+
+    settings = {
+      theme = "default";
+      playback_window_position = "Top";
+      copy_command = {
+        command = "wl-copy";
+        args = [ ];
+      };
+      device = {
+        audio_cache = false;
+        normalization = false;
+      };
+    };
+
+    themes = [{
+      name = "default2";
+      palette = {
+        black = "black";
+        red = "red";
+        green = "green";
+        yellow = "yellow";
+        blue = "blue";
+        magenta = "magenta";
+        cyan = "cyan";
+        white = "white";
+        bright_black = "bright_black";
+        bright_red = "bright_red";
+        bright_green = "bright_green";
+        bright_yellow = "bright_yellow";
+        bright_blue = "bright_blue";
+        bright_magenta = "bright_magenta";
+        bright_cyan = "bright_cyan";
+        bright_white = "bright_white";
+      };
+      component_style = {
+        block_title = { fg = "Magenta"; };
+        border = { };
+        playback_track = {
+          fg = "Cyan";
+          modifiers = [ "Bold" ];
+        };
+        playback_artists = {
+          fg = "Cyan";
+          modifiers = [ "Bold" ];
+        };
+        playback_album = { fg = "Yellow"; };
+        playback_metadata = { fg = "BrightBlack"; };
+        playback_progress_bar = {
+          bg = "BrightBlack";
+          fg = "Green";
+        };
+        current_playing = {
+          fg = "Green";
+          modifiers = [ "Bold" ];
+        };
+        page_desc = {
+          fg = "Cyan";
+          modifiers = [ "Bold" ];
+        };
+        table_header = { fg = "Blue"; };
+        selection = { modifiers = [ "Bold" "Reversed" ]; };
+      };
+    }];
+
+    keymaps = [
+      {
+        command = "NextTrack";
+        key_sequence = "g n";
+      }
+      {
+        command = "PreviousTrack";
+        key_sequence = "g p";
+      }
+      {
+        command = "Search";
+        key_sequence = "C-c C-x /";
+      }
+      {
+        command = "ResumePause";
+        key_sequence = "M-enter";
+      }
+      {
+        command = "None";
+        key_sequence = "q";
+      }
+    ];
+  };
+
+  test.stubs.spotify-player = { };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/spotify-player/app.toml ${./app.toml}
+    assertFileContent home-files/.config/spotify-player/theme.toml ${
+      ./theme.toml
+    }
+    assertFileContent home-files/.config/spotify-player/keymap.toml ${
+      ./keymap.toml
+    }
+  '';
+}

--- a/tests/modules/programs/spotify-player/theme.toml
+++ b/tests/modules/programs/spotify-player/theme.toml
@@ -1,0 +1,58 @@
+[[themes]]
+name = "default2"
+
+[themes.component_style]
+[themes.component_style.block_title]
+fg = "Magenta"
+
+[themes.component_style.border]
+
+[themes.component_style.current_playing]
+fg = "Green"
+modifiers = ["Bold"]
+
+[themes.component_style.page_desc]
+fg = "Cyan"
+modifiers = ["Bold"]
+
+[themes.component_style.playback_album]
+fg = "Yellow"
+
+[themes.component_style.playback_artists]
+fg = "Cyan"
+modifiers = ["Bold"]
+
+[themes.component_style.playback_metadata]
+fg = "BrightBlack"
+
+[themes.component_style.playback_progress_bar]
+bg = "BrightBlack"
+fg = "Green"
+
+[themes.component_style.playback_track]
+fg = "Cyan"
+modifiers = ["Bold"]
+
+[themes.component_style.selection]
+modifiers = ["Bold", "Reversed"]
+
+[themes.component_style.table_header]
+fg = "Blue"
+
+[themes.palette]
+black = "black"
+blue = "blue"
+bright_black = "bright_black"
+bright_blue = "bright_blue"
+bright_cyan = "bright_cyan"
+bright_green = "bright_green"
+bright_magenta = "bright_magenta"
+bright_red = "bright_red"
+bright_white = "bright_white"
+bright_yellow = "bright_yellow"
+cyan = "cyan"
+green = "green"
+magenta = "magenta"
+red = "red"
+white = "white"
+yellow = "yellow"


### PR DESCRIPTION
### Description

Adds a module for `spotify-player` with the fields `enable`, `package`, `settings`, `themes`, `keymaps`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

