### PR TITLE
antidote: use builtins.storeDir rather than /nix/store

### DIFF
--- a/modules/programs/antidote.nix
+++ b/modules/programs/antidote.nix
@@ -10,7 +10,7 @@ let
     '') pluginNames)}");
 
   parseHashId = path:
-    elemAt (builtins.match "/nix/store/([a-zA-Z0-9]+)-.*" path) 0;
+    elemAt (builtins.match "${builtins.storeDir}/([a-zA-Z0-9]+)-.*" path) 0;
 in {
   meta.maintainers = [ maintainers.hitsmaxft ];
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
The antidote module hardcodes `/nix/store`, which breaks in the (rare!) case where a custom store directory is being used.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
