### PR TITLE
xdg-portal: add note about useUserPackages and pathsToLink

### DIFF
--- a/modules/misc/xdg-portal.nix
+++ b/modules/misc/xdg-portal.nix
@@ -2,9 +2,7 @@
 
 let
 
-  inherit (lib)
-    mapAttrsToList mkEnableOption mkIf mkMerge mkOption optional optionalString
-    types;
+  inherit (lib) mkIf mkMerge mkOption optional types;
 
   associationOptions = with types;
     attrsOf (coercedTo (either (listOf str) str)
@@ -14,8 +12,24 @@ in {
   meta.maintainers = [ lib.maintainers.misterio77 ];
 
   options.xdg.portal = {
-    enable = mkEnableOption
-      "[XDG desktop integration](https://github.com/flatpak/xdg-desktop-portal)";
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to enable [XDG desktop integration](https://github.com/flatpak/xdg-desktop-portal).
+
+        Note, if you use the NixOS module and have `useUserPackages = true`,
+        make sure to add
+
+        ``` nix
+        environment.pathsToLink = [ "/share/xdg-desktop-portal" "/share/applications" ];
+        ```
+
+        to your system configuration so that the portal definitions and DE
+        provided configurations get linked.
+      '';
+    };
 
     extraPortals = mkOption {
       type = types.listOf types.package;


### PR DESCRIPTION
### Description

Addresses https://github.com/nix-community/home-manager/pull/5158#issuecomment-2012171515

When using the NixOS module with `useUserPackages = true`, `share/xdg-desktop-portal` from `home-manager-path` won't get linked into the profile, similarly to bash completions and friends.

This PR adds a note on the fix, that is simply adding it to `pathsToLink` on the system configuration.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
