### PR TITLE
darkman: allow no configuration

### DIFF
--- a/modules/services/darkman.nix
+++ b/modules/services/darkman.nix
@@ -52,6 +52,7 @@ in {
 
     settings = mkOption {
       type = types.submodule { freeformType = yamlFormat.type; };
+      default = { };
       example = literalExpression ''
         {
           lat = 52.3;
@@ -96,7 +97,7 @@ in {
         Documentation = "man:darkman(1)";
         PartOf = [ "graphical-session.target" ];
         BindsTo = [ "graphical-session.target" ];
-        X-Restart-Triggers =
+        X-Restart-Triggers = mkIf (cfg.settings != { })
           [ "${config.xdg.configFile."darkman/config.yaml".source}" ];
       };
 

--- a/tests/modules/services/darkman/default.nix
+++ b/tests/modules/services/darkman/default.nix
@@ -1,1 +1,4 @@
-{ darkman-basic-configuration = ./basic-configuration.nix; }
+{
+  darkman-basic-configuration = ./basic-configuration.nix;
+  darkman-no-configuration = ./no-configuration.nix;
+}

--- a/tests/modules/services/darkman/no-configuration.nix
+++ b/tests/modules/services/darkman/no-configuration.nix
@@ -1,0 +1,37 @@
+{
+  services.darkman.enable = true;
+
+  test.stubs = {
+    python = { };
+    darkman = { };
+  };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/darkman.service)
+
+    assertFileExists $serviceFile
+    assertFileContent $serviceFile ${
+      builtins.toFile "expected" ''
+        [Install]
+        WantedBy=graphical-session.target
+
+        [Service]
+        BusName=nl.whynothugo.darkman
+        ExecStart=@darkman@/bin/dummy run
+        Restart=on-failure
+        Slice=background.slice
+        TimeoutStopSec=15
+        Type=dbus
+
+        [Unit]
+        BindsTo=graphical-session.target
+        Description=Darkman system service
+        Documentation=man:darkman(1)
+        PartOf=graphical-session.target
+      ''
+    }
+    assertPathNotExists home-files/.local/share/dark-mode.d/color-scheme-dark
+    assertPathNotExists home-files/.local/share/light-mode.d/color-scheme-light
+  '';
+}
+


### PR DESCRIPTION
### Description

Closes #4779

Signed-off-by: Sumner Evans <me@sumnerevans.com>
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@xlambein

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
