### PR TITLE
programs.khal: ability to set RGB color

### DIFF
--- a/modules/programs/khal-accounts.nix
+++ b/modules/programs/khal-accounts.nix
@@ -15,27 +15,11 @@ with lib;
     };
 
     color = mkOption {
-      type = types.nullOr (types.enum [
-        "black"
-        "white"
-        "brown"
-        "yellow"
-        "dark gray"
-        "dark green"
-        "dark blue"
-        "light gray"
-        "light green"
-        "light blue"
-        "dark magenta"
-        "dark cyan"
-        "dark red"
-        "light magenta"
-        "light cyan"
-        "light red"
-      ]);
+      type = types.nullOr types.str;
       default = null;
       description = ''
         Color in which events in this calendar are displayed.
+        For instance 'light green' or an RGB color '#ff0000'
       '';
       example = "light green";
     };

--- a/modules/programs/khal.nix
+++ b/modules/programs/khal.nix
@@ -45,10 +45,11 @@ let
         + (optionalString
           (value.khal.type == "birthdays" && value.khal ? thisCollection)
           value.khal.thisCollection)
-      }"
-    ] ++ optional (value.khal.readOnly) "readonly = True" ++ [
-      (toKeyValueIfDefined (getAttrs [ "type" "color" "priority" ] value.khal))
-    ] ++ [ "\n" ]);
+      }\n        "
+    ] ++ optional (value.khal.readOnly) "readonly = True"
+      ++ optional (value.khal.color != null) "color = '${value.khal.color}'"
+      ++ [ (toKeyValueIfDefined (getAttrs [ "type" "priority" ] value.khal)) ]
+      ++ [ "\n" ]);
 
   localeFormatOptions = let
     T = lib.types;

--- a/tests/modules/programs/khal/config.nix
+++ b/tests/modules/programs/khal/config.nix
@@ -19,6 +19,7 @@
         khal = {
           enable = true;
           readOnly = true;
+          color = "#ff0000";
           type = "calendar";
         };
         local.type = "filesystem";

--- a/tests/modules/programs/khal/khal-config-expected
+++ b/tests/modules/programs/khal/khal-config-expected
@@ -1,7 +1,9 @@
 [calendars]
 [[test]]
 path = /home/hm-user/$XDG_CONFIG_HOME/cal/test/
+        
 readonly = True
+color = '#ff0000'
 priority=10
 type=calendar
 
@@ -9,6 +11,7 @@ type=calendar
 
 [[testcontacts-automaticallyCollected]]
 path = /home/hm-user/$XDG_CONFIG_HOME/card/testcontacts/automaticallyCollected
+        
 priority=10
 type=birthdays
 
@@ -16,6 +19,7 @@ type=birthdays
 
 [[testcontacts-default]]
 path = /home/hm-user/$XDG_CONFIG_HOME/card/testcontacts/default
+        
 priority=10
 type=birthdays
 
@@ -23,6 +27,7 @@ type=birthdays
 
 [[testcontactsNoCollections]]
 path = /home/hm-user/$XDG_CONFIG_HOME/card/testcontactsNoCollections/
+        
 priority=10
 type=birthdays
 


### PR DESCRIPTION
The current module constrains to values in enum but khal supports RGB colors as well
khal.readthedocs.io/en/latest/configure.html#the-calendars-section ! (be careful when setting an RGB value, it has to be quoted else it is ignored, got bitten by it with a manual config )

NB: It's also not possible to set addresses khal.readthedocs.io/en/latest/configure.html#the-calendars-section


fix the rgb part of https://github.com/nix-community/home-manager/issues/5148

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
