### PR TITLE
amberol: add module 

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1471,6 +1471,14 @@ in {
       }
 
       {
+        time = "2024-03-28T17:02:19+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.amberol'.
+        '';
+      }
+
+      {
         time = "2024-04-08T21:43:38+00:00";
         message = ''
           A new module is available: 'programs.bun'.
@@ -1514,6 +1522,19 @@ in {
 
           Poetry is a tool that helps you manage Python project dependencies and
           packages. See https://python-poetry.org/ for more.
+        '';
+      }
+
+      {
+        time = "2024-04-22T18:04:47+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.amberol'.
+
+          Amberol is a music player with no delusions of grandeur. If you just
+          want to play music available on your local system then Amberol is the
+          music player you are looking for. See https://apps.gnome.org/Amberol/
+          for more.
         '';
       }
     ];

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -261,8 +261,9 @@ let
     ./programs/zsh.nix
     ./programs/zsh/prezto.nix
     ./programs/zsh/zsh-abbr.nix
-    ./services/arrpc.nix
     ./services/activitywatch.nix
+    ./services/amberol.nix
+    ./services/arrpc.nix
     ./services/autorandr.nix
     ./services/avizo.nix
     ./services/barrier.nix

--- a/modules/services/amberol.nix
+++ b/modules/services/amberol.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  cfg = config.services.amberol;
+
+in {
+  meta.maintainers = with lib.maintainers; [ surfaceflinger ];
+
+  options.services.amberol = {
+    enable = lib.mkEnableOption "" // {
+      description = ''
+        Whether to enable Amberol music player as a daemon.
+
+        Note, it is necessary to add
+        ```nix
+        programs.dconf.enable = true;
+        ```
+        to your system configuration for the daemon to work correctly.
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "amberol" { };
+
+    enableRecoloring = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "UI recoloring using the album art.";
+    };
+
+    replaygain = lib.mkOption {
+      type = lib.types.enum [ "album" "track" "off" ];
+      default = "track";
+      description = "ReplayGain mode.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.amberol" pkgs
+        lib.platforms.linux)
+    ];
+
+    # Running amberol will just attach itself to gapplication service.
+    home.packages = [ cfg.package ];
+
+    dconf.settings."io/bassi/Amberol" = {
+      background-play = true;
+      enable-recoloring = cfg.enableRecoloring;
+      replay-gain = cfg.replaygain;
+    };
+
+    systemd.user.services.amberol = {
+      Unit = {
+        Description = "Amberol music player daemon";
+        Requires = [ "dbus.service" ];
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install.WantedBy = [ "graphical-session.target" ];
+
+      Service = {
+        ExecStart = "${lib.getExe cfg.package} --gapplication-service";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Description

Amberol is a small and simple music player.

Added a module for it that can allow us to customize (the only) 2 settings. It also enables the gapplication-service for background playback.

Please check if everything's fine as haven't worked on home-manager before, mostly copypasted from existing easyeffects module.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
