### PR TITLE
deleted str replacents that are not needed in new zoxide versions.

### DIFF
--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -87,8 +87,6 @@ in {
           mkdir $zoxide_cache
         }
         ${cfg.package}/bin/zoxide init nushell ${cfgOptions} |
-          str replace "def-env" "def --env" --all |  # https://github.com/ajeetdsouza/zoxide/pull/632
-          str replace --all "-- $rest" "-- ...$rest" |
           save --force ${config.xdg.cacheHome}/zoxide/init.nu
       '';
       extraConfig = ''


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
since zoxide [9.3](git@github.com:gabevenberg/home-manager.git), no string replacements are needed for nushell integration. This should maintain backwards compatibility as even nix stable is on 9.3 (latest is 9.4)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ x ] Change is backwards compatible.

- [ x ] Code formatted with `./format`.

- [ x ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ x ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
