### PR TITLE
kitty: allow redefining `kitty-themes` package

### DIFF
--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -69,6 +69,15 @@ in {
       '';
     };
 
+    themePackage = mkOption {
+      type = types.package;
+      default = pkgs.kitty-themes;
+      defaultText = literalExpression "pkgs.kitty-themes";
+      description = ''
+        Kitty themes package to install.
+      '';
+    };
+
     darwinLaunchOptions = mkOption {
       type = types.nullOr (types.listOf types.str);
       default = null;
@@ -193,11 +202,11 @@ in {
         '')
 
         (optionalString (cfg.theme != null) ''
-          include ${pkgs.kitty-themes}/share/kitty-themes/${
+          include ${cfg.themePackage}/share/kitty-themes/${
             let
               matching = filter (x: x.name == cfg.theme) (builtins.fromJSON
                 (builtins.readFile
-                  "${pkgs.kitty-themes}/share/kitty-themes/themes.json"));
+                  "${cfg.themePackage}/share/kitty-themes/themes.json"));
             in throwIf (length matching == 0)
             "kitty-themes does not contain a theme named ${cfg.theme}"
             (head matching).file


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
  - One test in firefox failed, but I am sure it is not my fault.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
There is no one maintainer as I can see.