### PR TITLE
home-manager: fix missing string context

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,8 +78,7 @@
           in throwForRemovedArgs (import ./modules {
             inherit pkgs lib check extraSpecialArgs;
             configuration = { ... }: {
-              imports = modules
-                ++ [{ programs.home-manager.path = toString ./.; }];
+              imports = modules ++ [{ programs.home-manager.path = "${./.}"; }];
               nixpkgs = {
                 config = nixpkgs.lib.mkDefault pkgs.config;
                 inherit (pkgs) overlays;
@@ -112,7 +111,7 @@
             inherit pkgs;
             inherit (releaseInfo) release isReleaseBranch;
           };
-          hmPkg = pkgs.callPackage ./home-manager { path = toString ./.; };
+          hmPkg = pkgs.callPackage ./home-manager { path = "${./.}"; };
 
           testPackages = let
             tests = import ./tests { inherit pkgs; };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee 
I added myself as a maintainer of the `home-manager` module as my changes directly affect it, however this might not the followed convention (I'm not sure) so I am OK on removing myself from it.

Fixes:
#4824

References:
https://discourse.nixos.org/t/home-manager-not-found/31337
https://www.reddit.com/r/Nix/comments/15mhb50/recurring_home_manager_not_found_error_after/