### PR TITLE
gtk: GTK4 theming should be opt-in

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -237,8 +237,8 @@ in {
         gtk-cursor-theme-size = cfg.cursorTheme.size;
       };
 
-    gtk4Css =
-      lib.optionalString (cfg4.enableTheme && cfg.theme != null && cfg.theme.package != null) ''
+    gtk4Css = lib.optionalString
+      (cfg4.enableTheme && cfg.theme != null && cfg.theme.package != null) ''
         /**
          * GTK 4 reads the theme configured by gtk-theme-name, but ignores it.
          * It does however respect user CSS, so import the theme from here.

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -215,6 +215,8 @@ in {
             {file}`$XDG_CONFIG_HOME/gtk-4.0/gtk.css`.
           '';
         };
+
+        enableTheme = mkEnableOption "Add gtkk theme to user CSS";
       };
     };
   };
@@ -236,7 +238,7 @@ in {
       };
 
     gtk4Css =
-      lib.optionalString (cfg.theme != null && cfg.theme.package != null) ''
+      lib.optionalString (cfg4.enableTheme && cfg.theme != null && cfg.theme.package != null) ''
         /**
          * GTK 4 reads the theme configured by gtk-theme-name, but ignores it.
          * It does however respect user CSS, so import the theme from here.


### PR DESCRIPTION
### Description

Add an option to enable the GTK4 theming added in #4770 and disable it by default. Fixes #5133.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@rycee 