### PR TITLE
jujutsu: update module to respect XDG config placement

### DIFF
--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -34,16 +34,14 @@ in {
     settings = mkOption {
       type = tomlFormat.type;
       default = { };
-      example = literalExpression ''
-        {
-          user = {
-            name = "John Doe";
-            email = "jdoe@example.org";
-          };
-        }
-      '';
+      example = {
+        user = {
+          name = "John Doe";
+          email = "jdoe@example.org";
+        };
+      };
       description = ''
-        Options to add to the {file}`.jjconfig.toml` file. See
+        Options to add to the {file}`config.toml` file. See
         <https://github.com/martinvonz/jj/blob/main/docs/config.md>
         for options.
       '';
@@ -53,7 +51,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    home.file.".jjconfig.toml" = mkIf (cfg.settings != { }) {
+    xdg.configFile."jj/config.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "jujutsu-config" (cfg.settings
         // optionalAttrs (cfg.ediff) (let
           emacsDiffScript = pkgs.writeShellScriptBin "emacs-ediff" ''

--- a/tests/modules/programs/jujutsu/empty-config.nix
+++ b/tests/modules/programs/jujutsu/empty-config.nix
@@ -6,6 +6,6 @@
   test.stubs.jujutsu = { };
 
   nmt.script = ''
-    assertPathNotExists home-files/.jjconfig.toml
+    assertPathNotExists home-files/.config/jj/config.toml
   '';
 }

--- a/tests/modules/programs/jujutsu/example-config.nix
+++ b/tests/modules/programs/jujutsu/example-config.nix
@@ -13,9 +13,9 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.jjconfig.toml
+    assertFileExists home-files/.config/jj/config.toml
     assertFileContent \
-      home-files/.jjconfig.toml \
+      home-files/.config/jj/config.toml \
       ${
         builtins.toFile "expected.toml" ''
           [user]


### PR DESCRIPTION
### Description

Use the new supported XDG config place instead of home directory to make it cleaner

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

@shikanime
