### PR TITLE
helix: change wrapping when adding extraPackages to suffix

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -188,7 +188,7 @@ in {
           nativeBuildInputs = [ pkgs.makeWrapper ];
           postBuild = ''
             wrapProgram $out/bin/hx \
-              --prefix PATH : ${lib.makeBinPath cfg.extraPackages}
+              --suffix PATH : ${lib.makeBinPath cfg.extraPackages}
           '';
         })
       ]


### PR DESCRIPTION
### Description

This makes extraPackages the default, but they do not shadow the env.

So you can still have packages (e.g. LSPs) with a different version than the global one in you local env like nix's shells.

### Checklist

- [ ] Change is backwards compatible.

  I guess this is not really backwards compatible but to me this is the expected behaviour. This PR is there to discuss my point.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

  I checked and it seems there is no test to update. I'm not sure adding a test is necessary.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

@Philipp-M
