### PR TITLE
hyprland: fix systemd variables example

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -88,7 +88,7 @@ in {
           "WAYLAND_DISPLAY"
           "XDG_CURRENT_DESKTOP"
         ];
-        example = [ "-all" ];
+        example = [ "--all" ];
         description = ''
           Environment variables to be imported in the systemd & D-Bus user
           environment.


### PR DESCRIPTION
### Description
Using the current example causes the dbus-update-activation-environment command to fail, also leading to the target not being started. 

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@fufexan 
