### PR TITLE
bacon: Improve options

### DIFF
--- a/modules/programs/bacon.nix
+++ b/modules/programs/bacon.nix
@@ -17,6 +17,7 @@ in {
 
     settings = mkOption {
       type = settingsFormat.type;
+      default = { };
       example = {
         jobs.default = {
           command = [ "cargo" "build" "--all-features" "--color" "always" ];


### PR DESCRIPTION
### Description

- Added a `package` option to override the default package without using overlays.
- Made settings to default to empty, this is the current upstream default behavior (<https://raw.githubusercontent.com/Canop/bacon/main/defaults/default-prefs.toml>).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@shimunn 
