### PR TITLE
neovim: enable use of external package manager

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -198,6 +198,28 @@ in {
         '';
       };
 
+      extraWrapperArgs = mkOption {
+        type = with types; listOf str;
+        default = [ ];
+        example = literalExpression ''
+          [
+            "--suffix"
+            "LIBRARY_PATH"
+            ":"
+            "''${lib.makeLibraryPath [ pkgs.stdenv.cc.cc pkgs.zlib ]}"
+            "--suffix"
+            "PKG_CONFIG_PATH"
+            ":"
+            "''${lib.makeSearchPathOutput "dev" "lib/pkgconfig" [ pkgs.stdenv.cc.cc pkgs.zlib ]}"
+          ]
+        '';
+        description = ''
+          Extra arguments to be passed to the neovim wrapper.
+          This option sets environment variables required for building and running binaries
+          with external package managers like mason.nvim.
+        '';
+      };
+
       generatedConfigViml = mkOption {
         type = types.lines;
         visible = true;
@@ -415,7 +437,8 @@ in {
 
     programs.neovim.finalPackage = pkgs.wrapNeovimUnstable cfg.package
       (neovimConfig // {
-        wrapperArgs = (lib.escapeShellArgs neovimConfig.wrapperArgs) + " "
+        wrapperArgs = (lib.escapeShellArgs
+          (neovimConfig.wrapperArgs ++ cfg.extraWrapperArgs)) + " "
           + extraMakeWrapperArgs + " " + extraMakeWrapperLuaCArgs + " "
           + extraMakeWrapperLuaArgs;
         wrapRc = false;

--- a/tests/modules/programs/neovim/runtime.nix
+++ b/tests/modules/programs/neovim/runtime.nix
@@ -20,6 +20,17 @@ with lib;
             };
           }
         ];
+        extraWrapperArgs = let buildDeps = with pkgs; [ stdenv.cc.cc zlib ];
+        in [
+          "--suffix"
+          "LIBRARY_PATH"
+          ":"
+          "${lib.makeLibraryPath buildDeps}"
+          "--suffix"
+          "PKG_CONFIG_PATH"
+          ":"
+          "${lib.makeSearchPathOutput "dev" "lib/pkgconfig" buildDeps}"
+        ];
       }
       {
         extraPython3Packages = ps: with ps; [ jedi pynvim ];
@@ -33,7 +44,10 @@ with lib;
 
     nmt.script = ''
       ftplugin="home-files/.config/nvim/after/ftplugin/c.vim"
+      nvimbin="home-path/bin/nvim"
       assertFileExists "$ftplugin"
+      assertFileRegex "$nvimbin" 'LIBRARY_PATH'
+      assertFileRegex "$nvimbin" 'PKG_CONFIG_PATH'
     '';
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

#5224
Maybe it's better to leave room for custom wrapArgs (like `extraArgs`)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@emilazy @teto 