### PR TITLE
home-manager: Extract inline shell script to a file

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -79,59 +79,14 @@ in
             (mapAttrsToList (n: v: v.target)
             (filterAttrs (n: v: v.force) cfg));
 
-        check = pkgs.writeText "check" ''
-          ${config.lib.bash.initHomeManagerLib}
+        storeDir = escapeShellArg builtins.storeDir;
 
-          # A symbolic link whose target path matches this pattern will be
-          # considered part of a Home Manager generation.
-          homeFilePattern="$(readlink -e ${escapeShellArg builtins.storeDir})/*-home-manager-files/*"
+        check = pkgs.substituteAll {
+          src = ./files/check-link-targets.sh;
 
-          forcedPaths=(${forcedPaths})
-
-          newGenFiles="$1"
-          shift
-          for sourcePath in "$@" ; do
-            relativePath="''${sourcePath#$newGenFiles/}"
-            targetPath="$HOME/$relativePath"
-
-            forced=""
-            for forcedPath in "''${forcedPaths[@]}"; do
-              if [[ $targetPath == $forcedPath* ]]; then
-                forced="yeah"
-                break
-              fi
-            done
-
-            if [[ -n $forced ]]; then
-              verboseEcho "Skipping collision check for $targetPath"
-            elif [[ -e "$targetPath" \
-                && ! "$(readlink "$targetPath")" == $homeFilePattern ]] ; then
-              # The target file already exists and it isn't a symlink owned by Home Manager.
-              if cmp -s "$sourcePath" "$targetPath"; then
-                # First compare the files' content. If they're equal, we're fine.
-                warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be skipped since they are the same"
-              elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
-                # Next, try to move the file to a backup location if configured and possible
-                backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
-                if [[ -e "$backup" ]]; then
-                  errorEcho "Existing file '$backup' would be clobbered by backing up '$targetPath'"
-                  collision=1
-                else
-                  warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
-                fi
-              else
-                # Fail if nothing else works
-                errorEcho "Existing file '$targetPath' is in the way of '$sourcePath'"
-                collision=1
-              fi
-            fi
-          done
-
-          if [[ -v collision ]] ; then
-            errorEcho "Please move the above files and try again or use 'home-manager switch -b backup' to back up existing files automatically."
-            exit 1
-          fi
-        '';
+          inherit (config.lib.bash) initHomeManagerLib;
+          inherit forcedPaths storeDir;
+        };
       in
       ''
         function checkNewGenCollision() {

--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -1,0 +1,53 @@
+# -*- mode: sh; sh-shell: bash -*-
+
+@initHomeManagerLib@
+
+# A symbolic link whose target path matches this pattern will be
+# considered part of a Home Manager generation.
+homeFilePattern="$(readlink -e @storeDir@)/*-home-manager-files/*"
+
+forcedPaths=(@forcedPaths@)
+
+newGenFiles="$1"
+shift
+for sourcePath in "$@" ; do
+  relativePath="${sourcePath#$newGenFiles/}"
+  targetPath="$HOME/$relativePath"
+
+  forced=""
+  for forcedPath in "${forcedPaths[@]}"; do
+    if [[ $targetPath == $forcedPath* ]]; then
+      forced="yeah"
+      break
+    fi
+  done
+
+  if [[ -n $forced ]]; then
+    verboseEcho "Skipping collision check for $targetPath"
+  elif [[ -e "$targetPath" \
+      && ! "$(readlink "$targetPath")" == $homeFilePattern ]] ; then
+    # The target file already exists and it isn't a symlink owned by Home Manager.
+    if cmp -s "$sourcePath" "$targetPath"; then
+      # First compare the files' content. If they're equal, we're fine.
+      warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be skipped since they are the same"
+    elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
+      # Next, try to move the file to a backup location if configured and possible
+      backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
+      if [[ -e "$backup" ]]; then
+        errorEcho "Existing file '$backup' would be clobbered by backing up '$targetPath'"
+        collision=1
+      else
+        warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
+      fi
+    else
+      # Fail if nothing else works
+      errorEcho "Existing file '$targetPath' is in the way of '$sourcePath'"
+      collision=1
+    fi
+  fi
+done
+
+if [[ -v collision ]] ; then
+  errorEcho "Please move the above files and try again or use 'home-manager switch -b backup' to back up existing files automatically."
+  exit 1
+fi


### PR DESCRIPTION
### Description

Extract a single inline-string shell script into a file, so that it is amenable to shellcheck and autoformatting. (To make this diff easier to review, I have not fixed the two existing shellcheck errors, nor have I formatted the file.)

Note that module/files.nix is currently excluded from autoformatting, but I have tried to structure this such that it doesn't look too awful when `nixfmt` is applied to it.

For reference, here's the diff displayed in Beyond Compare:
<img width="1676" alt="Screenshot 2024-04-05 at 14 19 22" src="https://github.com/nix-community/home-manager/assets/3138005/6ef899ab-5943-4df2-8e31-d75a999c4b1b">

This should be a no-op, so of course feel free to reject. If this is accepted, I may start doing this to more of the chonky inline shell scripts.

There's a solid argument for passing these things in as env vars instead, rather than doing string replacements; shout if you want that and I can try and work out how.

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`. No, this file is excluded from formatting.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@rycee 
