### PR TITLE
alacritty: add `theme` option

### DIFF
--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -9,6 +9,22 @@ in {
 
       package = lib.mkPackageOption pkgs "alacritty" { };
 
+      theme = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        example = "solarized_dark";
+        description = ''
+          A theme from the
+          [alacritty-theme](https://github.com/alacritty/alacritty-theme)
+          repository to import in the configuration.
+          See <https://github.com/alacritty/alacritty-theme/tree/master/themes>
+          for a list of available themes.
+          If you would like to import your own theme, use
+          {option}`programs.alacritty.settings.general.import` or
+          {option}`programs.alacritty.settings.colors` directly.
+        '';
+      };
+
       settings = lib.mkOption {
         type = tomlFormat.type;
         default = { };
@@ -40,7 +56,30 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [{
+      # If using the theme option, ensure that theme exists in the
+      # alacritty-theme package.
+      assertion = let
+        available = lib.pipe "${pkgs.alacritty-theme}/share/alacritty-theme" [
+          builtins.readDir
+          (lib.filterAttrs
+            (name: type: type == "regular" && lib.hasSuffix ".toml" name))
+          lib.attrNames
+          (lib.map (lib.removeSuffix ".toml"))
+        ];
+      in cfg.theme == null || (builtins.elem cfg.theme available);
+      message = "The alacritty theme '${cfg.theme}' does not exist.";
+    }];
+
     home.packages = [ cfg.package ];
+
+    programs.alacritty.settings = let
+      theme = "${pkgs.alacritty-theme}/share/alacritty-theme/${cfg.theme}.toml";
+    in lib.mkIf (cfg.theme != null) {
+      general.import =
+        lib.mkIf (lib.versionAtLeast cfg.package.version "0.14") [ theme ];
+      import = lib.mkIf (lib.versionOlder cfg.package.version "0.14") [ theme ];
+    };
 
     xdg.configFile."alacritty/alacritty.toml" = lib.mkIf (cfg.settings != { }) {
       source = (tomlFormat.generate "alacritty.toml" cfg.settings).overrideAttrs


### PR DESCRIPTION
### Description

Add `program.alacritty.theme` option, to import a theme from the [`alacritty-theme`] repository.

I've been using something similar in my config repo for a while, it was high time I upstreamed it.  ;3

[`alacritty-theme`]: https://github.com/alacritty/alacritty-theme


### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.$t` for the following tests:
  - alacritty-empty-settings
  - alacritty-example-settings
  - alacritty-merging-settings
  - alacritty-toml-config
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

No listed maintainer or recurrent committer.  @r-vdp was the last person to edit the module.