### PR TITLE
bun: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -77,6 +77,12 @@
     githubId = 32838899;
     name = "Daniel Wagenknecht";
   };
+  jack5079 = {
+    name = "Jack W.";
+    email = "nix@jack.cab";
+    github = "jack5079";
+    githubId = 29169102;
+  };
   jkarlson = {
     email = "jekarlson@gmail.com";
     github = "jkarlson";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1469,6 +1469,13 @@ in {
           A new module is available: 'services.activitywatch'.
         '';
       }
+
+      {
+        time = "2024-04-08T21:43:38+00:00";
+        message = ''
+          A new module is available: 'programs.bun'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -72,6 +72,7 @@ let
     ./programs/broot.nix
     ./programs/browserpass.nix
     ./programs/btop.nix
+    ./programs/bun.nix
     ./programs/carapace.nix
     ./programs/cava.nix
     ./programs/chromium.nix

--- a/modules/programs/bun.nix
+++ b/modules/programs/bun.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.bun;
+  tomlFormat = pkgs.formats.toml { };
+in {
+  meta.maintainers = [ lib.hm.maintainers.jack5079 ];
+
+  options.programs.bun = {
+    enable = lib.mkEnableOption "Bun JavaScript runtime";
+
+    package = lib.mkPackageOption pkgs "bun" { };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          smol = true;
+          telemetry = false;
+          test = {
+            coverage = true;
+            coverageThreshold = 0.9;
+          };
+          install.lockfile = {
+            print = "yarn";
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/.bunfig.toml`.
+
+        See <https://bun.sh/docs/runtime/bunfig>
+        for the full list of options.
+      '';
+    };
+
+    enableGitIntegration = lib.mkEnableOption "Git integration" // {
+      default = true;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile.".bunfig.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "bun-config" cfg.settings;
+    };
+
+    # https://bun.sh/docs/install/lockfile#how-do-i-git-diff-bun-s-lockfile
+    programs.git.attributes =
+      lib.mkIf cfg.enableGitIntegration [ "*.lockb binary diff=lockb" ];
+    programs.git.extraConfig.diff.lockb = lib.mkIf cfg.enableGitIntegration {
+      textconv = lib.getExe cfg.package;
+      binary = true;
+    };
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Bun is a fast JavaScript all-in-one runtime toolkit.

This module includes support for [bunfig.toml](https://bun.sh/docs/runtime/bunfig) and [adds support for bun.lockb files in `git diff`](https://bun.sh/docs/install/lockfile#how-do-i-git-diff-bun-s-lockfile) with `enableGitIntegration`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
