### PR TITLE
git-credential-oauth: add extraFlags option

### DIFF
--- a/modules/programs/git-credential-oauth.nix
+++ b/modules/programs/git-credential-oauth.nix
@@ -12,13 +12,26 @@ in {
       enable = lib.mkEnableOption "Git authentication handler for OAuth";
 
       package = lib.mkPackageOption pkgs "git-credential-oauth" { };
+
+      extraFlags = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = lib.literalExpression ''[ "-device" ]'';
+        description = ''
+          Extra command-line arguments passed to git-credential-oauth.
+
+          For valid arguments, see {manpage}`git-credential-oauth(1)`.
+        '';
+      };
     };
   };
 
   config = lib.mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    programs.git.extraConfig.credential.helper =
-      [ "${cfg.package}/bin/git-credential-oauth" ];
+    programs.git.extraConfig.credential.helper = [
+      ("${cfg.package}/bin/git-credential-oauth" + lib.mkIf cfg.extraFlags
+        " ${lib.strings.concatStringsSep " " cfg.extraFlags}")
+    ];
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds a new `extraFlags` option to the `programs.git-credential-oauth` module.

This facilitates a legitimate use-case for browserless systems. From the README:
> On systems without a web browser, set the -device flag to authenticate
> on another device using [OAuth device flow]:
```ini
  [credential]
	  helper = cache --timeout 7200	# two hours
	  helper = oauth -device
  ```

[OAuth device flow]: https://www.rfc-editor.org/rfc/rfc8628

~~Please note that, for the documentation about the man-page to be accurate, https://github.com/NixOS/nixpkgs/pull/302922 must be merged~~ (done a while ago).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@tomodachi94 (it's me, I'm the maintainer :see_no_evil:)

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
