### PR TITLE
Jplana/k9s darwin xdg

### DIFF
--- a/modules/programs/k9s.nix
+++ b/modules/programs/k9s.nix
@@ -80,7 +80,7 @@ in {
       type = yamlFormat.type;
       default = { };
       description = ''
-        Hotkeys written to {file}`$XDG_CONFIG_HOME/k9s/hotkey.yaml`. See
+        Hotkeys written to {file}`$XDG_CONFIG_HOME/k9s/hotkeys.yaml`. See
         <https://k9scli.io/topics/hotkeys/> for supported values.
       '';
       example = literalExpression ''
@@ -101,7 +101,7 @@ in {
       type = yamlFormat.type;
       default = { };
       description = ''
-        Plugins written to {file}`$XDG_CONFIG_HOME/k9s/plugin.yaml`. See
+        Plugins written to {file}`$XDG_CONFIG_HOME/k9s/plugins.yaml`. See
         <https://k9scli.io/topics/plugins/> for supported values.
       '';
       example = literalExpression ''
@@ -178,11 +178,11 @@ in {
         source = yamlFormat.generate "k9s-aliases" cfg.aliases;
       };
 
-      "k9s/hotkey.yaml" = mkIf (cfg.hotkey != { }) {
+      "k9s/hotkeys.yaml" = mkIf (cfg.hotkey != { }) {
         source = yamlFormat.generate "k9s-hotkey" cfg.hotkey;
       };
 
-      "k9s/plugin.yaml" = mkIf (cfg.plugin != { }) {
+      "k9s/plugins.yaml" = mkIf (cfg.plugin != { }) {
         source = yamlFormat.generate "k9s-plugin" cfg.plugin;
       };
 

--- a/modules/programs/k9s.nix
+++ b/modules/programs/k9s.nix
@@ -6,6 +6,7 @@ let
 
   cfg = config.programs.k9s;
   yamlFormat = pkgs.formats.yaml { };
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
 in {
   meta.maintainers = with maintainers; [
@@ -33,7 +34,8 @@ in {
       type = yamlFormat.type;
       default = { };
       description = ''
-        Configuration written to {file}`$XDG_CONFIG_HOME/k9s/config.yaml`. See
+        Configuration written to {file}`$XDG_CONFIG_HOME/k9s/config.yaml` (linux)
+        or {file}`Library/Application Support/k9s/config.yaml` (darwin), See
         <https://k9scli.io/topics/config/> for supported values.
       '';
       example = literalExpression ''
@@ -47,7 +49,8 @@ in {
       type = types.attrsOf yamlFormat.type;
       default = { };
       description = ''
-        Skin files written to {file}`$XDG_CONFIG_HOME/k9s/skins/`. See
+        Skin files written to {file}`$XDG_CONFIG_HOME/k9s/skins/` (linux)
+        or {file}`Library/Application Support/k9s/skins/` (darwin). See
         <https://k9scli.io/topics/skins/> for supported values.
       '';
       example = literalExpression ''
@@ -65,7 +68,8 @@ in {
       type = yamlFormat.type;
       default = { };
       description = ''
-        Aliases written to {file}`$XDG_CONFIG_HOME/k9s/aliases.yaml`. See
+        Aliases written to {file}`$XDG_CONFIG_HOME/k9s/aliases.yaml` (linux)
+        or {file}`Library/Application Support/k9s/aliases.yaml` (darwin). See
         <https://k9scli.io/topics/aliases/> for supported values.
       '';
       example = literalExpression ''
@@ -80,7 +84,8 @@ in {
       type = yamlFormat.type;
       default = { };
       description = ''
-        Hotkeys written to {file}`$XDG_CONFIG_HOME/k9s/hotkeys.yaml`. See
+        Hotkeys written to {file}`$XDG_CONFIG_HOME/k9s/hotkeys.yaml` (linux)
+        or {file}`Library/Application Support/k9s/hotkeys.yaml` (darwin). See
         <https://k9scli.io/topics/hotkeys/> for supported values.
       '';
       example = literalExpression ''
@@ -101,7 +106,8 @@ in {
       type = yamlFormat.type;
       default = { };
       description = ''
-        Plugins written to {file}`$XDG_CONFIG_HOME/k9s/plugins.yaml`. See
+        Plugins written to {file}`$XDG_CONFIG_HOME/k9s/plugins.yaml (linux)`
+        or {file}`Library/Application Support/k9s/plugins.yaml` (darwin). See
         <https://k9scli.io/topics/plugins/> for supported values.
       '';
       example = literalExpression ''
@@ -132,7 +138,9 @@ in {
       type = yamlFormat.type;
       default = { };
       description = ''
-        Resource column views written to {file}`$XDG_CONFIG_HOME/k9s/views.yaml`.
+        Resource column views written to
+        {file}`$XDG_CONFIG_HOME/k9s/views.yaml (linux)`
+        or {file}`Library/Application Support/k9s/views.yaml` (darwin).
         See <https://k9scli.io/topics/columns/> for supported values.
       '';
       example = literalExpression ''
@@ -162,13 +170,19 @@ in {
       { };
 
     skinFiles = mapAttrs' (name: value:
-      nameValuePair "k9s/skins/${name}.yaml" {
-        source = yamlFormat.generate "k9s-skin-${name}.yaml" value;
-      }) cfg.skins;
+      nameValuePair (if !(isDarwin && !config.xdg.enable) then
+        "k9s/skins/${name}.yaml"
+      else
+        "Library/Application Support/k9s/skins/${name}.yaml") {
+          source = yamlFormat.generate "k9s-skin-${name}.yaml" value;
+        }) cfg.skins;
+
+    enableXdgConfig = !isDarwin || config.xdg.enable;
+
   in mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile = {
+    xdg.configFile = mkIf enableXdgConfig ({
       "k9s/config.yaml" = mkIf (cfg.settings != { }) {
         source = yamlFormat.generate "k9s-config"
           (lib.recursiveUpdate skinSetting cfg.settings);
@@ -189,6 +203,33 @@ in {
       "k9s/views.yaml" = mkIf (cfg.views != { }) {
         source = yamlFormat.generate "k9s-views" cfg.views;
       };
-    } // skinFiles;
+    } // skinFiles);
+
+    home.file = mkIf (!enableXdgConfig) ({
+      "Library/Application Support/k9s/config.yaml" =
+        mkIf (cfg.settings != { }) {
+          source = yamlFormat.generate "k9s-config"
+            (lib.recursiveUpdate skinSetting cfg.settings);
+        };
+
+      "Library/Application Support/k9s/aliases.yaml" =
+        mkIf (cfg.aliases != { }) {
+          source = yamlFormat.generate "k9s-aliases" cfg.aliases;
+        };
+
+      "Library/Application Support/k9s/hotkeys.yaml" =
+        mkIf (cfg.hotkey != { }) {
+          source = yamlFormat.generate "k9s-hotkey" cfg.hotkey;
+        };
+
+      "Library/Application Support/k9s/plugins.yaml" =
+        mkIf (cfg.plugin != { }) {
+          source = yamlFormat.generate "k9s-plugin" cfg.plugin;
+        };
+
+      "Library/Application Support/k9s/views.yaml" = mkIf (cfg.views != { }) {
+        source = yamlFormat.generate "k9s-views" cfg.views;
+      };
+    } // skinFiles);
   };
 }

--- a/tests/modules/programs/k9s/empty-settings.nix
+++ b/tests/modules/programs/k9s/empty-settings.nix
@@ -1,11 +1,17 @@
-{ ... }:
+{ pkgs, lib, ... }: {
 
-{
   programs.k9s.enable = true;
+
+  xdg.enable = lib.mkIf pkgs.stdenv.isDarwin (lib.mkForce false);
 
   test.stubs.k9s = { };
 
-  nmt.script = ''
-    assertPathNotExists home-files/.config/k9s
+  nmt.script = let
+    configDir = if !pkgs.stdenv.isDarwin then
+      ".config/k9s"
+    else
+      "Library/Application Support/k9s";
+  in ''
+    assertPathNotExists home-files/${configDir}
   '';
 }

--- a/tests/modules/programs/k9s/example-settings.nix
+++ b/tests/modules/programs/k9s/example-settings.nix
@@ -1,6 +1,8 @@
-{ config, ... }:
+{ config, pkgs, lib, ... }:
 
 {
+  xdg.enable = lib.mkIf pkgs.stdenv.isDarwin (lib.mkForce false);
+
   programs.k9s = {
     enable = true;
     package = config.lib.test.mkStubPackage { };
@@ -76,34 +78,39 @@
     };
   };
 
-  nmt.script = ''
-    assertFileExists home-files/.config/k9s/config.yaml
+  nmt.script = let
+    configDir = if !pkgs.stdenv.isDarwin then
+      ".config/k9s"
+    else
+      "Library/Application Support/k9s";
+  in ''
+    assertFileExists "home-files/${configDir}/config.yaml"
     assertFileContent \
-      home-files/.config/k9s/config.yaml \
+      "home-files/${configDir}/config.yaml" \
       ${./example-config-expected.yaml}
-    assertFileExists home-files/.config/k9s/skins/default.yaml
+    assertFileExists "home-files/${configDir}/skins/default.yaml"
     assertFileContent \
-      home-files/.config/k9s/skins/default.yaml \
+      "home-files/${configDir}/skins/default.yaml" \
       ${./example-skin-expected.yaml}
-    assertFileExists home-files/.config/k9s/skins/alt-skin.yaml
+    assertFileExists "home-files/${configDir}/skins/alt-skin.yaml"
     assertFileContent \
-      home-files/.config/k9s/skins/alt-skin.yaml \
+      "home-files/${configDir}/skins/alt-skin.yaml" \
       ${./example-skin-expected-alt.yaml}
-    assertFileExists home-files/.config/k9s/hotkeys.yaml
+    assertFileExists "home-files/${configDir}/hotkeys.yaml"
     assertFileContent \
-      home-files/.config/k9s/hotkeys.yaml \
+      "home-files/${configDir}/hotkeys.yaml" \
       ${./example-hotkey-expected.yaml}
-    assertFileExists home-files/.config/k9s/aliases.yaml
+    assertFileExists "home-files/${configDir}/aliases.yaml"
     assertFileContent \
-      home-files/.config/k9s/aliases.yaml \
+      "home-files/${configDir}/aliases.yaml" \
       ${./example-aliases-expected.yaml}
-    assertFileExists home-files/.config/k9s/plugins.yaml
+    assertFileExists "home-files/${configDir}/plugins.yaml"
     assertFileContent \
-      home-files/.config/k9s/plugins.yaml \
+      "home-files/${configDir}/plugins.yaml" \
       ${./example-plugin-expected.yaml}
-    assertFileExists home-files/.config/k9s/views.yaml
+    assertFileExists "home-files/${configDir}/views.yaml"
     assertFileContent \
-      home-files/.config/k9s/views.yaml \
+      "home-files/${configDir}/views.yaml" \
       ${./example-views-expected.yaml}
   '';
 }

--- a/tests/modules/programs/k9s/example-settings.nix
+++ b/tests/modules/programs/k9s/example-settings.nix
@@ -89,17 +89,17 @@
     assertFileContent \
       home-files/.config/k9s/skins/alt-skin.yaml \
       ${./example-skin-expected-alt.yaml}
-    assertFileExists home-files/.config/k9s/hotkey.yaml
+    assertFileExists home-files/.config/k9s/hotkeys.yaml
     assertFileContent \
-      home-files/.config/k9s/hotkey.yaml \
+      home-files/.config/k9s/hotkeys.yaml \
       ${./example-hotkey-expected.yaml}
     assertFileExists home-files/.config/k9s/aliases.yaml
     assertFileContent \
       home-files/.config/k9s/aliases.yaml \
       ${./example-aliases-expected.yaml}
-    assertFileExists home-files/.config/k9s/plugin.yaml
+    assertFileExists home-files/.config/k9s/plugins.yaml
     assertFileContent \
-      home-files/.config/k9s/plugin.yaml \
+      home-files/.config/k9s/plugins.yaml \
       ${./example-plugin-expected.yaml}
     assertFileExists home-files/.config/k9s/views.yaml
     assertFileContent \


### PR DESCRIPTION
### Description

module k9s: Adds support for darwin configuration files without xdg (using the `~/Library/Application Support/k9s/` folder instead of `~/.config/k9s` in this platform)
module k9s: fix some typos in some of the configuration file names (I checked [latest published release](https://github.com/derailed/k9s/blob/v0.32.4/internal/config/files.go#L144) for this)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@katexochen
@liyangau 
@hm.maintainers.LucasWagler