### PR TITLE
nushell: fix nushell config path on darwin

### DIFF
--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.programs.nushell;
 
-  configDir = if pkgs.stdenv.isDarwin then
+  configDir = if pkgs.stdenv.isDarwin && !config.xdg.enable then
     "Library/Application Support/nushell"
   else
     "${config.xdg.configHome}/nushell";

--- a/tests/modules/programs/carapace/nushell.nix
+++ b/tests/modules/programs/carapace/nushell.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 
 {
   programs = {
@@ -7,7 +7,7 @@
   };
 
   nmt.script = let
-    configDir = if pkgs.stdenv.isDarwin then
+    configDir = if pkgs.stdenv.isDarwin && !config.xdg.enable then
       "home-files/Library/Application Support/nushell"
     else
       "home-files/.config/nushell";

--- a/tests/modules/programs/direnv/nushell.nix
+++ b/tests/modules/programs/direnv/nushell.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 
 {
   programs.nushell.enable = true;
@@ -7,7 +7,7 @@
   test.stubs.nushell = { };
 
   nmt.script = let
-    configFile = if pkgs.stdenv.isDarwin then
+    configFile = if pkgs.stdenv.isDarwin && !config.xdg.enable then
       "home-files/Library/Application Support/nushell/config.nu"
     else
       "home-files/.config/nushell/config.nu";

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 
 {
   programs.nushell = {
@@ -34,7 +34,7 @@
   test.stubs.nushell = { };
 
   nmt.script = let
-    configDir = if pkgs.stdenv.isDarwin then
+    configDir = if pkgs.stdenv.isDarwin && !config.xdg.enable then
       "home-files/Library/Application Support/nushell"
     else
       "home-files/.config/nushell";

--- a/tests/modules/programs/oh-my-posh/nushell.nix
+++ b/tests/modules/programs/oh-my-posh/nushell.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 
 {
   programs = {
@@ -16,12 +16,12 @@
   };
 
   nmt.script = let
-    configFile = if pkgs.stdenv.isDarwin then
+    configFile = if pkgs.stdenv.isDarwin && !config.xdg.enable then
       "home-files/Library/Application Support/nushell/config.nu"
     else
       "home-files/.config/nushell/config.nu";
 
-    envFile = if pkgs.stdenv.isDarwin then
+    envFile = if pkgs.stdenv.isDarwin && !config.xdg.enable then
       "home-files/Library/Application Support/nushell/env.nu"
     else
       "home-files/.config/nushell/env.nu";

--- a/tests/modules/programs/yazi/nushell-integration-enabled.nix
+++ b/tests/modules/programs/yazi/nushell-integration-enabled.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 
 let
   shellIntegration = ''
@@ -23,7 +23,7 @@ in {
   test.stubs.yazi = { };
 
   nmt.script = let
-    configPath = if pkgs.stdenv.isDarwin then
+    configPath = if pkgs.stdenv.isDarwin && !config.xdg.enable then
       "home-files/Library/Application Support/nushell/config.nu"
     else
       "home-files/.config/nushell/config.nu";


### PR DESCRIPTION
### Description

Fixes #5248 

I'm not sure about the exact situation on darwin, whether this should be set by default (i.e. remove the if check completely), since nushell only loads from that path when `XDG_CONFIG_HOME` is set. As this requires `config.xdg.enable = true`.

(when this is the right solution, I'll fix the other programs/modules that depend on nushell such as yazi etc.) 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
