### PR TITLE
xdg-autostart: add module

### DIFF
--- a/modules/misc/xdg-autostart.nix
+++ b/modules/misc/xdg-autostart.nix
@@ -1,0 +1,40 @@
+{ config, lib, ... }:
+let
+  inherit (builtins) baseNameOf listToAttrs map unsafeDiscardStringContext;
+  inherit (lib) literalExpression mkEnableOption mkIf mkOption types;
+
+  cfg = config.xdg.autostart;
+
+  /* "/nix/store/x-foo/application.desktop" -> {
+       name = "autostart/application.desktop";
+       value = { source = "/nix/store/x-foo/application.desktop"; };
+     }
+  */
+  mapDesktopEntry = entry: {
+    name = "autostart/${unsafeDiscardStringContext (baseNameOf entry)}";
+    value.source = entry;
+  };
+in {
+  meta.maintainers = with lib.maintainers; [ Scrumplex ];
+
+  options.xdg.autostart = {
+    enable = mkEnableOption "creation of XDG autostart entries";
+
+    entries = mkOption {
+      type = with types; listOf path;
+      description = ''
+        Paths to desktop files that should be linked to `XDG_CONFIG_HOME/autostart`
+      '';
+      default = [ ];
+      example = literalExpression ''
+        [
+          "''${pkgs.evolution}/share/applications/org.gnome.Evolution.desktop"
+        ]
+      '';
+    };
+  };
+
+  config = mkIf (cfg.enable && cfg.entries != [ ]) {
+    xdg.configFile = listToAttrs (map mapDesktopEntry cfg.entries);
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -42,6 +42,7 @@ let
     ./misc/uninstall.nix
     ./misc/version.nix
     ./misc/vte.nix
+    ./misc/xdg-autostart.nix
     ./misc/xdg-desktop-entries.nix
     ./misc/xdg-mime-apps.nix
     ./misc/xdg-mime.nix

--- a/tests/modules/misc/xdg/autostart.nix
+++ b/tests/modules/misc/xdg/autostart.nix
@@ -1,0 +1,20 @@
+{ pkgs, ... }: {
+  config = {
+    xdg.autostart = {
+      enable = true;
+      entries = [
+        "${pkgs.evolution}/share/applications/org.gnome.Evolution.desktop"
+        "${pkgs.tdesktop}/share/applications/org.telegram.desktop.desktop"
+      ];
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/autostart/org.gnome.Evolution.desktop
+      assertFileContent home-files/.config/autostart/org.gnome.Evolution.desktop \
+        ${pkgs.evolution}/share/applications/org.gnome.Evolution.desktop
+      assertFileExists home-files/.config/autostart/org.telegram.desktop.desktop
+      assertFileContent home-files/.config/autostart/org.telegram.desktop.desktop \
+        ${pkgs.tdesktop}/share/applications/org.telegram.desktop.desktop
+    '';
+  };
+}

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -9,4 +9,5 @@
   xdg-mime = ./mime.nix;
   xdg-mime-disabled = ./mime-disabled.nix;
   xdg-mime-package = ./mime-packages.nix;
+  xdg-autostart = ./autostart.nix;
 }


### PR DESCRIPTION
### Description

This module allows creating autostart entries using Home Manager.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
