### PR TITLE
todoman: add todoman module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -424,6 +424,12 @@
     github = "mainrs";
     githubId = 5113257;
   };
+  mikilio = {
+    name = "mikilio";
+    email = "official.mikilio+dev@gmail.com";
+    github = "mikilio";
+    githubId = 86004375;
+  };
   kmaasrud = {
     name = "Knut Magnus Aasrud";
     email = "km@aasrud.com";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -236,6 +236,7 @@ let
     ./programs/tmate.nix
     ./programs/tmux.nix
     ./programs/tofi.nix
+    ./programs/todoman.nix
     ./programs/topgrade.nix
     ./programs/translate-shell.nix
     ./programs/urxvt.nix

--- a/modules/programs/todoman.nix
+++ b/modules/programs/todoman.nix
@@ -56,7 +56,7 @@ in {
 
     xdg.configFile."todoman/config.py".text = lib.concatLines [
       ''path = "${config.accounts.calendar.basePath}/${cfg.glob}"''
-      cfg.config
+      cfg.extraConfig
     ];
   };
 }

--- a/modules/programs/todoman.nix
+++ b/modules/programs/todoman.nix
@@ -1,0 +1,62 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.todoman;
+
+  format = pkgs.formats.keyValue { };
+
+in {
+
+  meta.maintainers = [ hm.maintainers.mikilio ];
+
+  options.programs.todoman = {
+    enable = lib.mkEnableOption "todoman";
+
+    glob = mkOption {
+      type = types.str;
+      default = "*";
+      description = ''
+        The glob expansion which matches all directories relevant.
+      '';
+      example = "*/*";
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Text for configuration of todoman.
+        The syntax is Python.
+
+        See [docs](`https://todoman.readthedocs.io/en/stable/man.html#id5`).
+        for the full list of options.
+      '';
+      example = ''
+        date_format = "%Y-%m-%d";
+        time_format = "%H:%M";
+        default_list = "Personal";
+        default_due = 48;
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = config.accounts.calendar ? basePath;
+      message = ''
+        A base directory for calendars must be specified via
+        `accounts.calendar.basePath` to generate config for todoman
+      '';
+    }];
+
+    home.packages = [ pkgs.todoman ];
+
+    xdg.configFile."todoman/config.py".text = lib.concatLines [
+      ''path = "${config.accounts.calendar.basePath}/${cfg.glob}"''
+      cfg.config
+    ];
+  };
+}

--- a/tests/modules/programs/todoman/config.nix
+++ b/tests/modules/programs/todoman/config.nix
@@ -1,0 +1,21 @@
+{
+  programs.todoman = {
+    enable = true;
+    glob = "*/*";
+    extraConfig = ''
+      date_format = "%d.%m.%Y"
+      default_list = "test"
+    '';
+  };
+
+  accounts.calendar.basePath = "base/path/calendar";
+
+  test.stubs = { todoman = { }; };
+
+  nmt.script = ''
+    configFile=home-files/.config/todoman/config.py
+    assertFileExists $configFile
+    assertFileContent $configFile ${./todoman-config-expected}
+  '';
+}
+

--- a/tests/modules/programs/todoman/default.nix
+++ b/tests/modules/programs/todoman/default.nix
@@ -1,0 +1,1 @@
+{ todoman-config = ./config.nix; }

--- a/tests/modules/programs/todoman/todoman-config-expected
+++ b/tests/modules/programs/todoman/todoman-config-expected
@@ -1,0 +1,3 @@
+path = "/home/hm-user/base/path/calendar/*/*"
+date_format = "%d.%m.%Y"
+default_list = "test"


### PR DESCRIPTION
Adds Mikilio as maintainer for new module for todoman a standards-based task manager based on iCalendar

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@rycee 