### PR TITLE
Added a `programs.jujutsu.configFile` file option to configure output…

### DIFF
--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -1,12 +1,8 @@
 { config, lib, pkgs, ... }:
-
 with lib;
-
 let
-
   cfg = config.programs.jujutsu;
   tomlFormat = pkgs.formats.toml { };
-
 in {
   meta.maintainers = [ maintainers.shikanime ];
 
@@ -21,6 +17,17 @@ in {
       mkEnableOption "a Git-compatible DVCS that is both simple and powerful";
 
     package = mkPackageOption pkgs "jujutsu" { };
+
+    configFile = mkOption {
+      default = ".jjconfig.toml";
+      example = literalExpression ''
+        ".jjconfig.toml"
+        ".config/jj/config.toml"
+      '';
+      description = ''
+        Location of the jj configuration file rrelative to the home directory.
+      '';
+    };
 
     settings = mkOption {
       type = tomlFormat.type;
@@ -44,7 +51,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    home.file.".jjconfig.toml" = mkIf (cfg.settings != { }) {
+    home.file."${cfg.configFile}" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "jujutsu-config" cfg.settings;
     };
   };

--- a/tests/modules/programs/jujutsu/alternate-location.nix
+++ b/tests/modules/programs/jujutsu/alternate-location.nix
@@ -1,0 +1,26 @@
+{ config, ... }: {
+  programs.jujutsu = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    configFile = ".config/jj/config.toml";
+    settings = {
+      user = {
+        name = "John Doe";
+        email = "jdoe@example.org";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/jj/config.toml
+    assertFileContent \
+      home-files/.config/jj/config.toml \
+      ${
+        builtins.toFile "expected.toml" ''
+          [user]
+          email = "jdoe@example.org"
+          name = "John Doe"
+        ''
+      }
+  '';
+}

--- a/tests/modules/programs/jujutsu/default.nix
+++ b/tests/modules/programs/jujutsu/default.nix
@@ -1,4 +1,5 @@
 {
   jujutsu-example-config = ./example-config.nix;
   jujutsu-empty-config = ./empty-config.nix;
+  jujutsu-alternate-location = ./alternate-location.nix;
 }


### PR DESCRIPTION
### Description

Added a `programs.jujutsu.configFile` option to configure output location of `programs.jujutsu.settings`

I'm not sure if there's a convention on how to name options that relocate the config files.

### Checklist

- [X] Change is backwards compatible.

The option defaults to the exact string that was previously used.

- [X] Code formatted with `./format`.

`./format` slightly changed the formatting in parts of the file I didn't touch, I assume the format rules have changed since this file was last edited.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@shikanime 