### PR TITLE
foot: set PATH in server's systemd unit file

### DIFF
--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -68,6 +68,7 @@ in {
         };
 
         Service = {
+          Environment = "PATH=${makeBinPath [ cfg.package ]}";
           ExecStart = "${cfg.package}/bin/foot --server";
           Restart = "on-failure";
           OOMPolicy = "continue";

--- a/tests/modules/programs/foot/systemd-user-service-expected.service
+++ b/tests/modules/programs/foot/systemd-user-service-expected.service
@@ -2,6 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
+Environment=PATH=@foot@/bin
 ExecStart=@foot@/bin/foot --server
 OOMPolicy=continue
 Restart=on-failure


### PR DESCRIPTION
### Description

Adds foot bin path to systemd service environment. If left out, foot's terminal spawning shortcut will not work as the `footclient` binary is not on the server's PATH.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@plabadens 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
