### PR TITLE
yazi: updated shell integrations & added extraLuaConfig option

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -189,7 +189,7 @@ in {
       "yazi/theme.toml" = mkIf (cfg.theme != { }) {
         source = tomlFormat.generate "yazi-theme" cfg.theme;
       };
-      "yazi/init.lua" = mkIf (cfg.extraLuaConfig != { }) {
+      "yazi/init.lua" = mkIf (cfg.extraLuaConfig != "") {
         source = pkgs.writeText "yazi-extraluaConfig" cfg.extraLuaConfig;
       };
     };

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -137,33 +137,33 @@ in {
     };
 
     extraLuaConfig = mkOption {
-        type = types.lines;
-        default = "";
-        example = literalExpression ''
-          '''
-          -- Add symlink target to the status bar
-          function Status:name()
-            local h = cx.active.current.hovered
-            if h == nil then
-              return ui.Span("")
-            end
-
-            local linked = ""
-            if h.link_to ~= nil then
-              linked = " -> " .. tostring(h.link_to)
-            end
-            return ui.Span(" " .. h.name .. linked)
+      type = types.lines;
+      default = "";
+      example = literalExpression ''
+        '''
+        -- Add symlink target to the status bar
+        function Status:name()
+          local h = cx.active.current.hovered
+          if h == nil then
+            return ui.Span("")
           end
-          '''
-        '';
-        description = ''
-          Configuration written to
-          {file}`$XDG_CONFIG_HOME/yazi/init.lua`.
 
-          See <https://yazi-rs.github.io/docs/tips>
-          for more information
-        '';
-      };
+          local linked = ""
+          if h.link_to ~= nil then
+            linked = " -> " .. tostring(h.link_to)
+          end
+          return ui.Span(" " .. h.name .. linked)
+        end
+        '''
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/yazi/init.lua`.
+
+        See <https://yazi-rs.github.io/docs/tips>
+        for more information
+      '';
+    };
   };
 
   config = mkIf cfg.enable {


### PR DESCRIPTION
### Description

<!--Please provide a brief description of your change.-->
1 .Updated shell integrations to circumvent bugs caused due to aliasing of cd & cat by utils like zoxide or bat.
2. Added extraLuaConfig option to generate init.lua for yazi.

### Checklist

<!--Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC
@XYenon 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
