### PR TITLE
zsh: support associative arrays as local variables

### DIFF
--- a/modules/lib/zsh.nix
+++ b/modules/lib/zsh.nix
@@ -13,11 +13,15 @@ rec {
         shell = import ./shell.nix { inherit lib; };
       in
       "(${shell.formatShellArrayContent (map toString v)})"
+    else if builtins.isAttrs v then
+      "(${
+        lib.concatStringsSep " " (lib.mapAttrsToList (n: v: "[${lib.escapeShellArg n}]=${toZshValue v}") v)
+      })"
     else
       ''"${toString v}"'';
 
   # Produces a Zsh shell like definition statement
-  define = n: v: "${n}=${toZshValue v}";
+  define = n: v: "${lib.optionalString (builtins.isAttrs v) "typeset -A "}${n}=${toZshValue v}";
 
   # Given an attribute set containing shell variable names and their
   # assignments, this function produces a string containing a definition

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -316,6 +316,9 @@ in
               "dir"
               "vcs"
             ];
+            ZSH_HIGHLIGHT_STYLES = {
+              unknown-token = "bg=red,fg=white,bold";
+            };
           };
           description = ''
             Extra local variables defined at the top of {file}`.zshrc`.

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -20,6 +20,7 @@
   zsh-history-path-zdotdir-variable = import ./history-path.nix "zdotdir-variable";
   zsh-history-substring-search = ./history-substring-search.nix;
   zsh-legacy-warning = ./legacy-warning.nix;
+  zsh-local-variables = ./local-variables.nix;
   zsh-siteFunctions-mkcd = ./siteFunctions-mkcd.nix;
   zsh-plugins = ./plugins.nix;
   zsh-prezto = ./prezto.nix;

--- a/tests/modules/programs/zsh/local-variables.nix
+++ b/tests/modules/programs/zsh/local-variables.nix
@@ -10,12 +10,13 @@
         V2 = false;
         V3 = "some-string";
         V4 = 42;
-        V5 = [
-          V1
-          V2
-          V3
-          V4
-        ];
+        V5 = builtins.attrValues V6;
+        V6 = {
+          a = V1;
+          b = V2;
+          c = V3;
+          d = V4;
+        };
       };
     };
 
@@ -28,6 +29,7 @@
       assertFileRegex home-files/.zshrc '^V3="some-string"$'
       assertFileRegex home-files/.zshrc '^V4="42"$'
       assertFileRegex home-files/.zshrc '^V5=[(]'
+      assertFileContains home-files/.zshrc ${lib.escapeShellArg ''typeset -A V6=([a]=true [b]=false [c]="some-string" [d]="42")''}
     '';
   };
 }

--- a/tests/modules/programs/zsh/local-variables.nix
+++ b/tests/modules/programs/zsh/local-variables.nix
@@ -1,0 +1,33 @@
+{ lib, ... }:
+
+{
+  config = {
+    programs.zsh = {
+      enable = true;
+
+      localVariables = rec {
+        V1 = true;
+        V2 = false;
+        V3 = "some-string";
+        V4 = 42;
+        V5 = [
+          V1
+          V2
+          V3
+          V4
+        ];
+      };
+    };
+
+    test.stubs.zsh = { };
+
+    nmt.script = ''
+      assertFileExists home-files/.zshrc
+      assertFileRegex home-files/.zshrc '^V1=true$'
+      assertFileRegex home-files/.zshrc '^V2=false$'
+      assertFileRegex home-files/.zshrc '^V3="some-string"$'
+      assertFileRegex home-files/.zshrc '^V4="42"$'
+      assertFileRegex home-files/.zshrc '^V5=[(]'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

This adds support for `attrset` members in `programs.zsh.localVariables` and ensures they're reconstructed as ZSH associative arrays. This is particularly useful for the `ZSH_HIGHLIGHT_STYLES` associative array used by the, already included, `syntaxHighlighting` plugin.

One such example is added to the documentation.

New test case added to cover all previous types handled for this option. With the new type added on top of that of course.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 
