### PR TITLE
fd: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1476,6 +1476,13 @@ in {
           A new module is available: 'programs.bun'.
         '';
       }
+
+      {
+        time = "2024-04-18T22:30:49+00:00";
+        message = ''
+          A new module is available: 'programs.fd'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -86,6 +86,7 @@ let
     ./programs/emacs.nix
     ./programs/eww.nix
     ./programs/eza.nix
+    ./programs/fd.nix
     ./programs/feh.nix
     ./programs/firefox.nix
     ./programs/fish.nix

--- a/modules/programs/fd.nix
+++ b/modules/programs/fd.nix
@@ -1,0 +1,59 @@
+{ config, lib, pkgs, ... }:
+with lib; {
+  meta.maintainers = [ maintainers.uncenter ];
+
+  options.programs.fd = {
+    enable = mkEnableOption
+      "fd, a simple, fast and user-friendly alternative to {command}`find`";
+
+    ignores = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ ".git/" "*.bak" ];
+      description = "List of paths that should be globally ignored.";
+    };
+
+    hidden = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Search hidden files and directories ({option}`--hidden` argument).
+      '';
+    };
+
+    extraOptions = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "--no-ignore" "--absolute-path" ];
+      description = ''
+        Extra command line options passed to fd.
+      '';
+    };
+
+    package = mkPackageOption pkgs "fd" { };
+  };
+
+  config = let
+    cfg = config.programs.fd;
+
+    args = escapeShellArgs (optional cfg.hidden "--hidden" ++ cfg.extraOptions);
+
+    optionsAlias = { fd = "fd ${args}"; };
+  in mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.bash.shellAliases = optionsAlias;
+
+    programs.zsh.shellAliases = optionsAlias;
+
+    programs.fish.shellAliases = optionsAlias;
+
+    programs.ion.shellAliases = optionsAlias;
+
+    programs.nushell.shellAliases = optionsAlias;
+
+    xdg.configFile."fd/ignore" = mkIf (cfg.ignores != [ ]) {
+      text = concatStringsSep "\n" cfg.ignores + "\n";
+    };
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

`fd` is a simple, fast and user-friendly alternative to `find`.

This module includes support for the [`.fdignore`/`$XDG_CONFIG_HOME/fd/ignore`](https://github.com/sharkdp/fd#excluding-specific-files-or-directories) global ignore file (`ignores`), the search hidden files and directories `--hidden` option (`hidden`), and `extraOptions` for additional CLI flags.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

N/A

### Additional comments

I've refrained from adding myself to `modules/lib/maintainers.nix` as I have an upstream PR that adds myself as a maintainer in nixpkgs: https://github.com/NixOS/nixpkgs/pull/303399/files#diff-c1fcec3afa1da96245de1d7954ca721c979a5f25aee0e8b59d59d3d21e31f8fa.
