### PR TITLE
pyperland: added pyprland module to home-manager

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -518,4 +518,10 @@
     github = "zorrobert";
     githubId = 118135271;
   };
+  knoc-off = {
+    name = "Niko Selby";
+    email = "selby@niko.ink";
+    github = "knoc-off";
+    githubId = 36494048;
+  };
 }

--- a/modules/services/pyprland.nix
+++ b/modules/services/pyprland.nix
@@ -1,0 +1,56 @@
+{ options, config, lib, pkgs, ... }:
+let
+  cfg = config.services.pyprland;
+  settingsFormat = pkgs.formats.toml { };
+in with lib; {
+
+  meta.maintainers = [ maintainers.knoc-off ];
+  options.services.pyprland = {
+    enable = mkEnableOption "pyperland";
+
+    package = mkOption {
+      default = pkgs.pyprland;
+      type = types.package;
+      description = "The pyprland package to use";
+    };
+
+    extraPlugins = mkOption {
+      default = [ ];
+      type = with types; listOf str;
+      description = "Additional plugins to enable";
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+
+        options.scratchpads = mkOption {
+          default = { };
+          type = with types; attrsOf attrs;
+          description = "Scratchpad configurations";
+        };
+      };
+      default = { };
+      description = ''
+        Configuration for pyprland, see
+        <link xlink:href="https://github.com/hyprland-community/pyprland/wiki/Getting-started#configuring"/>
+        for supported values.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    services.pyprland.settings = {
+      pyprland = {
+        plugins = cfg.extraPlugins
+          ++ (optional (cfg.settings.scratchpads != { }) "scratchpads");
+      };
+    };
+
+    home.file.".config/hypr/pyprland.toml".source =
+      settingsFormat.generate "pyprland-config.toml" cfg.settings;
+  };
+}
+


### PR DESCRIPTION
### Description
pyperland is a hyperland plugin manager.
this wraps some setting into a toml, and has a bit of automation for scratchpads

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  - I dont think its needed
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).