### PR TITLE
gtk2: add force option

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -139,6 +139,14 @@ in {
       };
 
       gtk2 = {
+        force = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to force replace the existing configuration.
+          '';
+        };
+
         extraConfig = mkOption {
           type = types.lines;
           default = "";
@@ -269,9 +277,12 @@ in {
       cfg.cursorTheme
     ];
 
-    home.file.${cfg2.configLocation}.text =
-      concatMapStrings (l: l + "\n") (mapAttrsToList formatGtk2Option gtkIni)
-      + cfg2.extraConfig + "\n";
+    home.file.${cfg2.configLocation} = {
+      force = cfg2.force;
+      text =
+        concatMapStrings (l: l + "\n") (mapAttrsToList formatGtk2Option gtkIni)
+        + cfg2.extraConfig + "\n";
+    };
 
     home.sessionVariables.GTK2_RC_FILES = cfg2.configLocation;
 


### PR DESCRIPTION
Add a gtk.gtk2.force option so that users can force overwrite the configuration file if other applications (e.g. KDE Plasma) updates them.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee 