### PR TITLE
rio: remove redundant `lib.mdDoc` call

### DIFF
--- a/modules/programs/rio.nix
+++ b/modules/programs/rio.nix
@@ -6,7 +6,7 @@ let
 in {
   options.programs.rio = {
     enable = lib.mkEnableOption null // {
-      description = lib.mdDoc ''
+      description = ''
         Enable Rio, a terminal built to run everywhere, as a native desktop applications by
         Rust/WebGPU or even in the browsers powered by WebAssembly/WebGPU.
       '';


### PR DESCRIPTION
This is an error as of https://github.com/NixOS/nixpkgs/pull/303841

It seems to have been missed in https://github.com/nix-community/home-manager/pull/4215

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@otavio @emilazy

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
