### PR TITLE
[23.11] home-environment: fix installPackages with recent Nix versions

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -589,7 +589,7 @@ in
             nix profile list \
               | { grep 'home-manager-path$' || test $? = 1; } \
               | cut -d ' ' -f 4 \
-              | xargs -t $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
+              | xargs -rt $DRY_RUN_CMD nix profile remove $VERBOSE_ARG
           else
             if nix-env -q | grep '^home-manager-path$'; then
               $DRY_RUN_CMD nix-env -e home-manager-path


### PR DESCRIPTION
### Description

Recent Nix versions fail when running `nix profile remove` with no argument. If packages are externally managed, and we have nothing to remove, do not run the `nix profile remove` command.

This was fixed on master, but I have a setup on NixOS 23.11 which uses an unstable Nix version, so this is a very "minimal" backport of the fix.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

I have a test issue that seems unrelated:

```
error: hash mismatch in fixed-output derivation '/nix/store/pyna25yf5k1bl14pi0lcy2a8lvb6691f-lookup?op=get-options=mr-search=0x36cacf52d098cc0e78fb0cb13573356c25c424d4.drv':
         specified: sha256-9Zjsb/TtOyiPzMO/Jg3CtJwSxuw7QmX0pcfZT2/1w5E=
            got:    sha256-Pvm0CpH13pvnD/c+IJAkRElR5/IhZt8pg7RjT/dZdfM=
error: 1 dependencies of derivation '/nix/store/8lq1zp4xm5bl3lsnyvbdrpf6dx7cyg99-gpg-pubring.drv' failed to build
error: 1 dependencies of derivation '/nix/store/yq2skaz1q9frdlifwn9968xm46vvqyg1-activation-script.drv' failed to build
error: 1 dependencies of derivation '/nix/store/h61lplld7233i86vnx65niibpsamnz0k-home-manager-files.drv' failed to build
error: 2 dependencies of derivation '/nix/store/jbv6ffywzmnd0cwgv7wj3hpx2w5m1bnf-home-manager-generation.drv' failed to build
```

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee? Not completely sure
