### PR TITLE
neomutt: allow binds to override vimKeys

### DIFF
--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -451,14 +451,14 @@ in {
 
         set delete = yes
 
+        ${optionalString cfg.vimKeys
+        "source ${pkgs.neomutt}/share/doc/neomutt/vim-keys/vim-keys.rc"}
+
         # Binds
         ${bindSection}
 
         # Macros
         ${macroSection}
-
-        ${optionalString cfg.vimKeys
-        "source ${pkgs.neomutt}/share/doc/neomutt/vim-keys/vim-keys.rc"}
 
         # Register accounts
         ${

--- a/tests/modules/programs/neomutt/neomutt-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-expected.conf
@@ -9,12 +9,12 @@ alternative_order text/enriched text/plain text
 
 set delete = yes
 
+
+
 # Binds
 
 
 # Macros
-
-
 
 
 # Register accounts

--- a/tests/modules/programs/neomutt/neomutt-not-primary-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-not-primary-expected.conf
@@ -9,12 +9,12 @@ alternative_order text/enriched text/plain text
 
 set delete = yes
 
+
+
 # Binds
 
 
 # Macros
-
-
 
 
 # Register accounts

--- a/tests/modules/programs/neomutt/neomutt-with-binds-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-with-binds-expected.conf
@@ -9,6 +9,8 @@ alternative_order text/enriched text/plain text
 
 set delete = yes
 
+
+
 # Binds
 bind editor <Tab> "complete-query"
 bind index,pager \Cp "sidebar-prev"
@@ -16,8 +18,6 @@ bind index,pager \Cp "sidebar-prev"
 # Macros
 macro index s "<save-message>?<tab>"
 macro index,pager c "<change-folder>?<change-dir><home>^K=<enter><tab>"
-
-
 
 # Register accounts
 # register account hm@example.com

--- a/tests/modules/programs/neomutt/neomutt-with-imap-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-with-imap-expected.conf
@@ -9,12 +9,12 @@ alternative_order text/enriched text/plain text
 
 set delete = yes
 
+
+
 # Binds
 
 
 # Macros
-
-
 
 
 # Register accounts

--- a/tests/modules/programs/neomutt/neomutt-with-imap-type-mailboxes-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-with-imap-type-mailboxes-expected.conf
@@ -9,12 +9,12 @@ alternative_order text/enriched text/plain text
 
 set delete = yes
 
+
+
 # Binds
 
 
 # Macros
-
-
 
 
 # Register accounts

--- a/tests/modules/programs/neomutt/neomutt-with-named-mailboxes-expected.conf
+++ b/tests/modules/programs/neomutt/neomutt-with-named-mailboxes-expected.conf
@@ -9,12 +9,12 @@ alternative_order text/enriched text/plain text
 
 set delete = yes
 
+
+
 # Binds
 
 
 # Macros
-
-
 
 
 # Register accounts


### PR DESCRIPTION
### Description
In the generated neomutt configuration, source the optional `vim-keys.rc` before applying the `binds` configuration, to allow the user to override keybindings from `vim-keys.rc`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. 

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```


