### PR TITLE
espanso: enable module on darwin

### DIFF
--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -1,10 +1,8 @@
 { pkgs, config, lib, ... }:
 let
   inherit (lib)
-    mkOption mkEnableOption mkIf maintainers literalExpression types platforms
+    mkOption mkEnableOption mkIf maintainers literalExpression types
     mkRemovedOptionModule versionAtLeast;
-
-  inherit (lib.hm.assertions) assertPlatform;
 
   cfg = config.services.espanso;
   espansoVersion = cfg.package.version;
@@ -99,15 +97,12 @@ in {
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      (assertPlatform "services.espanso" pkgs platforms.linux)
-      {
-        assertion = versionAtLeast espansoVersion "2";
-        message = ''
-          The services.espanso module only supports Espanso version 2 or later.
-        '';
-      }
-    ];
+    assertions = [{
+      assertion = versionAtLeast espansoVersion "2";
+      message = ''
+        The services.espanso module only supports Espanso version 2 or later.
+      '';
+    }];
 
     home.packages = [ cfg.package ];
 
@@ -130,6 +125,21 @@ in {
         Restart = "on-failure";
       };
       Install = { WantedBy = [ "default.target" ]; };
+    };
+
+    launchd.agents.espanso = {
+      enable = true;
+      config = {
+        ProgramArguments = [ "${cfg.package}/bin/espanso" "launcher" ];
+        EnvironmentVariables.PATH =
+          "${cfg.package}/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+        KeepAlive = {
+          Crashed = true;
+          SuccessfulExit = false;
+        };
+        ProcessType = "Background";
+        RunAtLoad = true;
+      };
     };
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -163,6 +163,7 @@ in import nmtSrc {
     ./modules/xresources
   ] ++ lib.optionals isDarwin [
     ./modules/launchd
+    ./modules/services/espanso-darwin
     ./modules/services/git-sync-darwin
     ./modules/services/imapnotify-darwin
     ./modules/services/nix-gc-darwin

--- a/tests/modules/services/espanso-darwin/basic-configuration.nix
+++ b/tests/modules/services/espanso-darwin/basic-configuration.nix
@@ -1,0 +1,55 @@
+{ ... }: {
+  services.espanso = {
+    enable = true;
+    configs = { default = { show_notifications = false; }; };
+    matches = {
+      base = {
+        matches = [
+          {
+            trigger = ":now";
+            replace = "It's {{currentdate}} {{currenttime}}";
+          }
+          {
+            trigger = ":hello";
+            replace = ''
+              line1
+              line2'';
+          }
+          {
+            regex = ":hi(?P<person>.*)\\.";
+            replace = "Hi {{person}}!";
+          }
+        ];
+        global_vars = [
+          {
+            name = "currentdate";
+            type = "date";
+            params = { format = "%d/%m/%Y"; };
+          }
+          {
+            name = "currenttime";
+            type = "date";
+            params = { format = "%R"; };
+          }
+        ];
+      };
+    };
+  };
+
+  test.stubs.espanso = { };
+
+  nmt.script = ''
+    serviceFile="LaunchAgents/org.nix-community.home.espanso.plist"
+    serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+    assertFileExists $serviceFile
+    assertFileContent $serviceFileNormalized ${./launchd.plist}
+
+    configFile=home-files/.config/espanso/config/default.yml
+    assertFileExists "$configFile"
+    assertFileContent "$configFile" ${../espanso/basic-configuration.yaml}
+
+    matchFile=home-files/.config/espanso/match/base.yml
+    assertFileExists "$matchFile"
+    assertFileContent "$matchFile" ${../espanso/basic-matches.yaml}
+  '';
+}

--- a/tests/modules/services/espanso-darwin/default.nix
+++ b/tests/modules/services/espanso-darwin/default.nix
@@ -1,0 +1,1 @@
+{ espanso-darwin-basic-configuration = ./basic-configuration.nix; }

--- a/tests/modules/services/espanso-darwin/launchd.plist
+++ b/tests/modules/services/espanso-darwin/launchd.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>@espanso@/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+	</dict>
+	<key>KeepAlive</key>
+	<dict>
+		<key>Crashed</key>
+		<true/>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>Label</key>
+	<string>org.nix-community.home.espanso</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>@espanso@/bin/espanso</string>
+		<string>launcher</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
### Description

This enables espanso as a service on darwin.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@lucasew
@bobvanderlinden
@liyangau
