### PR TITLE
generators.toKDL: support repeated nodes, break JiK compat

### DIFF
--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -68,10 +68,8 @@
         in "${name} ${concatStringsSep " " flatElements}";
 
       # String -> ListOf Anything -> String
-      convertListOfNonFlatAttrsToKDL = name: list: ''
-        ${name} {
-        ${indentStrings (map (x: convertAttributeToKDL "-" x) list)}
-        }'';
+      convertListOfNonFlatAttrsToKDL = name: list:
+        "${concatStringsSep "\n" (map (x: convertAttributeToKDL name x) list)}";
 
       # String -> ListOf Anything  -> String
       convertListToKDL = name: list:

--- a/tests/lib/generators/tokdl-result.txt
+++ b/tests/lib/generators/tokdl-result.txt
@@ -27,15 +27,11 @@ listInAttrsInList {
 		}
 	}
 	list2 {
-		- {
-			a 8
-		}
+		a 8
 	}
 }
-nested {
-	- 1 2
-	- true false
-	- 
-	- null
-}
+repeated 1 2
+repeated true false
+repeated 
+repeated null
 unsafeString " \" \n 	 "

--- a/tests/lib/generators/tokdl.nix
+++ b/tests/lib/generators/tokdl.nix
@@ -20,7 +20,7 @@
       ''
       null
     ];
-    nested = [ [ 1 2 ] [ true false ] [ ] [ null ] ];
+    repeated = [ [ 1 2 ] [ true false ] [ ] [ null ] ];
     extraAttrs = {
       _args = [ 2 true ];
       _props = {
@@ -33,12 +33,12 @@
       };
     };
     listInAttrsInList = {
-      list1 = [
+      list1."-" = [
         { a = 1; }
         { b = true; }
         {
           c = null;
-          d = [{ e = "asdfadfasdfasdf"; }];
+          d."-" = [{ e = "asdfadfasdfasdf"; }];
         }
       ];
       list2 = [{ a = 8; }];


### PR DESCRIPTION
Replaces the list attr -> KDL conversion logic with a more flexible approach, allowing for multiple nodes with the same name in a scope. This unfortunately also breaks the existing JSON-in-KDL semantics in favor of ergonomics. As far as I can tell though, zellij is the only program using it, and it doesn't accept JiK anyway.

For example, the following KDL was previously impossible to generate, since nix attrs were mapped 1:1 to KDL nodes:
```kdl
resize {
	bind "k" "Up" { Resize "Increase Up"; }
	bind "j" "Down" { Resize "Increase Down"; }
}
```

Now, this can be achieved with the nix expression:

```nix
resize.bind = [
	{ _args = ["k" "Up"]; Resize = "Increase Up"; }
	{ _args = ["j" "Down"]; Resize = "Increase Down"; }
];
```

which would previously have generated the not-very-useful:

```kdl
resize {
	bind {
		- "k" "Up" { Resize "Increase Up"; }
		- "j" "Down" { Resize "Increase Down"; }
	}
}
```

which, in turn, can now be generated via:

```nix
resize.bind."-" = [
	{ _args = ["k" "Up"]; Resize = "Increase Up"; }
	{ _args = ["j" "Down"]; Resize = "Increase Down"; }
];
```

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] ~Change is backwards compatible.~
  It's explicitly not. I'm not sure that the previous behavior that's being broken was actually usable, so it doesn't seem worth keeping intact at the cost of ergonomics.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.


#### Maintainer CC

@h7x4 
@mainrs 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
