### PR TITLE
kodi: make type for settings less restrictive

### DIFF
--- a/modules/programs/kodi.nix
+++ b/modules/programs/kodi.nix
@@ -165,9 +165,15 @@ in
       type =
         with types;
         let
-          valueType = either str (attrsOf valueType) // {
-            description = "attribute sets of strings";
-          };
+          valueType =
+            oneOf [
+              str
+              (attrsOf valueType)
+              (listOf valueType)
+            ]
+            // {
+              description = "attribute sets or lists of strings";
+            };
         in
         nullOr valueType;
       default = null;


### PR DESCRIPTION
### Description

Allow `list` of `attrset` in the kodi settings to be able to define path substitutions.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.kodi-example-settings`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
