### PR TITLE
experimental(generators.toKDL): brand new ugly (but correct) kdl structure

### DIFF
--- a/tests/lib/generators/tokdl-result.txt
+++ b/tests/lib/generators/tokdl-result.txt
@@ -1,14 +1,19 @@
 a 1
 b "string"
-bigFlatItems 23847590283751 1.239000 "multiline \" \" \"\nstring\n" null
 c "multiline string\nwith special characters:\n\t \n \\" \"\n"
+unsafeString " \" \n 	 "
+flatItems 1 2 "asdf" true null
+bigFlatItems 23847590283751 1.239000 "multiline \" \" \"\nstring\n" null
+repeated 1 2
+repeated true false
+repeated
+repeated null
 extraAttrs 2 true arg1=1 arg2=false {
 	nested {
 		a 1
 		b null
 	}
 }
-flatItems 1 2 "asdf" true null
 listInAttrsInList {
 	list1 {
 		- {
@@ -27,15 +32,6 @@ listInAttrsInList {
 		}
 	}
 	list2 {
-		- {
-			a 8
-		}
+		a 8
 	}
 }
-nested {
-	- 1 2
-	- true false
-	- 
-	- null
-}
-unsafeString " \" \n 	 "

--- a/tests/lib/generators/tokdl.nix
+++ b/tests/lib/generators/tokdl.nix
@@ -1,49 +1,126 @@
-{ config, lib, ... }:
-
-{
-  home.file."tokdl-result.txt".text = lib.hm.generators.toKDL { } {
-    a = 1;
-    b = "string";
-    c = ''
-      multiline string
-      with special characters:
-      \t \n \" "
-    '';
-    unsafeString = " \" \n 	 ";
-    flatItems = [ 1 2 "asdf" true null ];
-    bigFlatItems = [
-      23847590283751
-      1.239
-      ''
-        multiline " " "
-        string
-      ''
-      null
-    ];
-    nested = [ [ 1 2 ] [ true false ] [ ] [ null ] ];
-    extraAttrs = {
-      _args = [ 2 true ];
-      _props = {
+{ lib, ... }: {
+  home.file."tokdl-result.txt".text = lib.hm.generators.toKDL { } [
+    {
+      name = "a";
+      args = 1;
+    }
+    {
+      name = "b";
+      args = "string";
+    }
+    {
+      name = "c";
+      args = ''
+        multiline string
+        with special characters:
+        \t \n \" "
+      '';
+    }
+    {
+      name = "unsafeString";
+      args = " \" \n 	 ";
+    }
+    {
+      name = "flatItems";
+      args = [ 1 2 "asdf" true null ];
+    }
+    {
+      name = "bigFlatItems";
+      args = [
+        23847590283751
+        1.239
+        ''
+          multiline " " "
+          string
+        ''
+        null
+      ];
+    }
+    {
+      name = "repeated";
+      args = [ 1 2 ];
+    }
+    {
+      name = "repeated";
+      args = [ true false ];
+    }
+    { name = "repeated"; }
+    {
+      name = "repeated";
+      args = [ null ];
+    }
+    {
+      name = "extraAttrs";
+      args = [ 2 true ];
+      props = {
         arg1 = 1;
         arg2 = false;
       };
-      nested = {
-        a = 1;
-        b = null;
+      children = {
+        name = "nested";
+        children = [
+          {
+            name = "a";
+            args = [ 1 ];
+          }
+          {
+            name = "b";
+            args = [ null ];
+          }
+        ];
       };
-    };
-    listInAttrsInList = {
-      list1 = [
-        { a = 1; }
-        { b = true; }
+    }
+    {
+      name = "listInAttrsInList";
+      children = [
         {
-          c = null;
-          d = [{ e = "asdfadfasdfasdf"; }];
+          name = "list1";
+          children = [
+            {
+              name = "-";
+              children = {
+                name = "a";
+                args = [ 1 ];
+              };
+            }
+            {
+              name = "-";
+              children = {
+                name = "b";
+                args = [ true ];
+              };
+            }
+            {
+              name = "-";
+              children = [
+                {
+                  name = "c";
+                  args = [ null ];
+                }
+                {
+                  name = "d";
+                  children = {
+                    name = "-";
+                    children = {
+                      name = "e";
+                      args = [ "asdfadfasdfasdf" ];
+                    };
+                  };
+                }
+              ];
+            }
+          ];
+        }
+        {
+          name = "list2";
+          children = [{
+            name = "a";
+            args = [ 8 ];
+          }];
         }
       ];
-      list2 = [{ a = 8; }];
-    };
-  };
+    }
+  ];
 
   nmt.script = ''
     assertFileContent \


### PR DESCRIPTION
### Description

Represent KDL more accurately in nix, complete with ordering and optional typing.

I don't expect any sane person to actually write their KDL documents in this structure, but it makes a decent target for higher-level expressions to generate.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] ~Change is backwards compatible.~
  Nope.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.


#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

#### Prior Art

My previous attempt: #5272
An earlier attempt: #4614 