### PR TITLE
helix: add ignores option

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -96,6 +96,16 @@ in {
       '';
     };
 
+    ignores = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ ".build/" "!.gitignore" ];
+      description = ''
+        List of paths that should be globally ignored for file picker.
+        Supports the usual ignore and negative ignore (unignore) rules used in `.gitignore` files.
+      '';
+    };
+
     themes = mkOption {
       type = types.attrsOf tomlFormat.type;
       default = { };
@@ -194,6 +204,9 @@ in {
         };
         "helix/languages.toml" = mkIf (cfg.languages != { }) {
           source = tomlFormat.generate "helix-languages-config" cfg.languages;
+        };
+        "helix/ignore" = mkIf (cfg.ignores != [ ]) {
+          text = concatStringsSep "\n" cfg.ignores + "\n";
         };
       };
 

--- a/tests/modules/programs/helix/example-settings.nix
+++ b/tests/modules/programs/helix/example-settings.nix
@@ -43,6 +43,8 @@ with lib;
         }];
       };
 
+      ignores = [ ".build/" "!.gitignore" ];
+
       themes = {
         base16 = let
           transparent = "none";
@@ -131,6 +133,9 @@ with lib;
       assertFileContent \
         home-files/.config/helix/languages.toml \
         ${./languages-expected.toml}
+      assertFileContent \
+        home-files/.config/helix/ignore \
+        ${./ignore-expected}
       assertFileContent \
         home-files/.config/helix/themes/base16.toml \
         ${./theme-base16-expected.toml}

--- a/tests/modules/programs/helix/ignore-expected
+++ b/tests/modules/programs/helix/ignore-expected
@@ -1,0 +1,2 @@
+.build/
+!.gitignore


### PR DESCRIPTION
### Description

Add global ingore file option. More information available here:
https://docs.helix-editor.com/configuration.html#editorfile-picker-section

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Philipp-M
