### PR TITLE
micro: add option to specify key bindings

### DIFF
--- a/modules/programs/micro.nix
+++ b/modules/programs/micro.nix
@@ -31,6 +31,26 @@ in {
           for supported values.
         '';
       };
+
+      keybinds = mkOption {
+        type = jsonFormat.type;
+        default = {
+          "Alt-/" = "lua:comment.comment";
+          "CtrlUnderscore" = "lua:comment.comment";
+        };
+        example = literalExpression ''
+          {
+            "Ctrl-y" = "Undo";
+            "Ctrl-z" = "Redo";
+          }
+        '';
+        description = ''
+          Configuration written to
+          {file}`$XDG_CONFIG_HOME/micro/bindings.json`. See
+          <https://github.com/zyedidia/micro/blob/master/runtime/help/keybindings.md>
+          for supported values.
+        '';
+      };
     };
   };
 
@@ -39,5 +59,8 @@ in {
 
     xdg.configFile."micro/settings.json".source =
       jsonFormat.generate "micro-settings" cfg.settings;
+
+    xdg.configFile."micro/bindings.json".source =
+      jsonFormat.generate "micro-keybinds" cfg.keybinds;
   };
 }

--- a/tests/modules/programs/micro/micro.nix
+++ b/tests/modules/programs/micro/micro.nix
@@ -8,6 +8,11 @@
       autosu = false;
       cursorline = false;
     };
+
+    keybinds = {
+      "Ctrl-y" = "Undo";
+      "Ctrl-z" = "Redo";
+    };
   };
 
   test.stubs.micro = { };
@@ -18,6 +23,14 @@
       {
         "autosu": false,
         "cursorline": false
+      }
+    ''}
+
+    assertFileContent home-files/.config/micro/bindings.json \
+    ${builtins.toFile "micro-expected-keybinds.json" ''
+      {
+        "Ctrl-y": "Undo",
+        "Ctrl-z": "Redo"
       }
     ''}
   '';


### PR DESCRIPTION
### Description

Introduces option to customize key bindings in Micro, allowing users to tailor their experience. 

Detailed information can be found [here](https://github.com/zyedidia/micro/blob/master/runtime/help/keybindings.md).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@MForster 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
