### PR TITLE
treewide: prefer the official wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ License
 This project is licensed under the terms of the [MIT license](LICENSE).
 
 [#home-manager]: https://webchat.oftc.net/?channels=home-manager
-[Nix Flakes]: https://nixos.wiki/wiki/Flakes
+[Nix Flakes]: https://wiki.nixos.org/wiki/Flakes
 [NixOS]: https://nixos.org/
 [Nix]: https://nixos.org/explore.html
 [Nixpkgs]: https://github.com/NixOS/nixpkgs

--- a/docs/manual/installation.md
+++ b/docs/manual/installation.md
@@ -24,7 +24,7 @@ Home Manager can be used in three primary ways:
 :::{.note}
 In this chapter we describe how to install Home Manager in the standard
 way using channels. If you prefer to use [Nix
-Flakes](https://nixos.wiki/wiki/Flakes) then please see the instructions
+Flakes](https://wiki.nixos.org/wiki/Flakes) then please see the instructions
 in [nix flakes](#ch-nix-flakes).
 :::
 

--- a/docs/manual/nix-flakes.md
+++ b/docs/manual/nix-flakes.md
@@ -1,7 +1,7 @@
 # Nix Flakes {#ch-nix-flakes}
 
 Home Manager is compatible with [Nix
-Flakes](https://nixos.wiki/wiki/Flakes). But please be aware that this
+Flakes](https://wiki.nixos.org/wiki/Flakes). But please be aware that this
 support is still experimental and may change in backwards
 incompatible ways.
 

--- a/docs/manual/nix-flakes/standalone.md
+++ b/docs/manual/nix-flakes/standalone.md
@@ -58,5 +58,5 @@ If you only want to update a single flake input, then the command
 You can also pass flake-related options such as `--recreate-lock-file`
 or `--update-input <input>` to `home-manager` when building or
 switching, and these options will be forwarded to `nix build`. See the
-[NixOS Wiki page](https://nixos.wiki/wiki/Flakes) for details.
+[NixOS Wiki page](https://wiki.nixos.org/wiki/Flakes) for details.
 :::

--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -459,7 +459,7 @@ in {
                       {
                         name = "wiki";
                         tags = [ "wiki" "nix" ];
-                        url = "https://nixos.wiki/";
+                        url = "https://wiki.nixos.org/";
                       }
                     ];
                   }
@@ -545,8 +545,8 @@ in {
                     };
 
                     "NixOS Wiki" = {
-                      urls = [{ template = "https://nixos.wiki/index.php?search={searchTerms}"; }];
-                      iconUpdateURL = "https://nixos.wiki/favicon.png";
+                      urls = [{ template = "https://wiki.nixos.org/index.php?search={searchTerms}"; }];
+                      iconUpdateURL = "https://wiki.nixos.org/favicon.png";
                       updateInterval = 24 * 60 * 60 * 1000; # every day
                       definedAliases = [ "@nw" ];
                     };

--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -84,7 +84,7 @@ in {
         {
           w = "https://en.wikipedia.org/wiki/Special:Search?search={}&go=Go&ns0=1";
           aw = "https://wiki.archlinux.org/?search={}";
-          nw = "https://nixos.wiki/index.php?search={}";
+          nw = "https://wiki.nixos.org/index.php?search={}";
           g = "https://www.google.com/search?hl=en&q={}";
         }
       '';

--- a/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
+++ b/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
@@ -8,18 +8,18 @@
 <DL><p>
   <DT><H3 ADD_DATE="1" LAST_MODIFIED="1" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
   <DL><p>
-    <DT><A HREF="https://nixos.wiki/wiki/Home_Manager" ADD_DATE="1" LAST_MODIFIED="1">Home Manager</A>
+    <DT><A HREF="https://wiki.nixos.org/wiki/Home_Manager" ADD_DATE="1" LAST_MODIFIED="1">Home Manager</A>
   </DL><p>
   <DT><A HREF="https://en.wikipedia.org/wiki/Special:Search?search=%s&amp;go=Go" ADD_DATE="1" LAST_MODIFIED="1" SHORTCUTURL="wiki" TAGS="wiki">wikipedia</A>
   <DT><A HREF="https://www.kernel.org" ADD_DATE="1" LAST_MODIFIED="1">kernel.org</A>
   <DT><H3 ADD_DATE="1" LAST_MODIFIED="1">Nix sites</H3>
   <DL><p>
     <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>
-    <DT><A HREF="https://nixos.wiki/" ADD_DATE="1" LAST_MODIFIED="1" TAGS="wiki,nix">wiki</A>
+    <DT><A HREF="https://wiki.nixos.org/" ADD_DATE="1" LAST_MODIFIED="1" TAGS="wiki,nix">wiki</A>
     <DT><H3 ADD_DATE="1" LAST_MODIFIED="1">Nix sites</H3>
     <DL><p>
       <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>
-      <DT><A HREF="https://nixos.wiki/" ADD_DATE="1" LAST_MODIFIED="1">wiki</A>
+      <DT><A HREF="https://wiki.nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">wiki</A>
     </DL><p>
   </DL><p>
 </DL>

--- a/tests/modules/programs/firefox/profile-settings-expected-search.json
+++ b/tests/modules/programs/firefox/profile-settings-expected-search.json
@@ -31,8 +31,8 @@
       "_definedAliases": [
         "@nw"
       ],
-      "_iconURL": "https://nixos.wiki/favicon.png",
-      "_iconUpdateURL": "https://nixos.wiki/favicon.png",
+      "_iconURL": "https://wiki.nixos.org/favicon.png",
+      "_iconUpdateURL": "https://wiki.nixos.org/favicon.png",
       "_isAppProvided": false,
       "_loadPath": "[home-manager]/programs.firefox.profiles.search.search.engines.\"NixOS Wiki\"",
       "_metaData": {
@@ -42,7 +42,7 @@
       "_updateInterval": 86400000,
       "_urls": [
         {
-          "template": "https://nixos.wiki/index.php?search={searchTerms}"
+          "template": "https://wiki.nixos.org/index.php?search={searchTerms}"
         }
       ]
     },

--- a/tests/modules/programs/firefox/profile-settings.nix
+++ b/tests/modules/programs/firefox/profile-settings.nix
@@ -27,7 +27,7 @@
             toolbar = true;
             bookmarks = [{
               name = "Home Manager";
-              url = "https://nixos.wiki/wiki/Home_Manager";
+              url = "https://wiki.nixos.org/wiki/Home_Manager";
             }];
           }
           {
@@ -51,7 +51,7 @@
               {
                 name = "wiki";
                 tags = [ "wiki" "nix" ];
-                url = "https://nixos.wiki/";
+                url = "https://wiki.nixos.org/";
               }
               {
                 name = "Nix sites";
@@ -62,7 +62,7 @@
                   }
                   {
                     name = "wiki";
-                    url = "https://nixos.wiki/";
+                    url = "https://wiki.nixos.org/";
                   }
                 ];
               }
@@ -102,9 +102,10 @@
 
             "NixOS Wiki" = {
               urls = [{
-                template = "https://nixos.wiki/index.php?search={searchTerms}";
+                template =
+                  "https://wiki.nixos.org/index.php?search={searchTerms}";
               }];
-              iconUpdateURL = "https://nixos.wiki/favicon.png";
+              iconUpdateURL = "https://wiki.nixos.org/favicon.png";
               updateInterval = 24 * 60 * 60 * 1000;
               definedAliases = [ "@nw" ];
             };


### PR DESCRIPTION
### Description

This changes the links from the unofficial wiki to the official wiki.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
