### PR TITLE
home-manager: error out on missing option argument

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -11,6 +11,12 @@ export TEXTDOMAINDIR=@OUT@/share/locale
 # shellcheck disable=1091
 source @HOME_MANAGER_LIB@
 
+function errMissingOptArg() {
+    # translators: For example: "home-manager: missing argument for --cores"
+    _iError "%s: missing argument for %s" "$0" "$1" >&2
+    exit 1
+}
+
 function setNixProfileCommands() {
     if  [[ -e $HOME/.nix-profile/manifest.json \
         || -e ${XDG_STATE_HOME:-$HOME/.local/state}/nix/profile/manifest.json ]] ; then
@@ -277,10 +283,12 @@ function doInit() {
                 switch=1
                 ;;
             --home-manager-url)
+                [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
                 homeManagerUrl="$1"
                 shift
                 ;;
             --nixpkgs-url)
+                [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
                 nixpkgsUrl="$1"
                 shift
                 ;;
@@ -951,22 +959,27 @@ while [[ $# -gt 0 ]]; do
             COMMAND="$opt"
             ;;
         -A)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             HOME_MANAGER_CONFIG_ATTRIBUTE="$1"
             shift
             ;;
         -I)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             EXTRA_NIX_PATH+=("$1")
             shift
             ;;
         -b)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             export HOME_MANAGER_BACKUP_EXT="$1"
             shift
             ;;
         -f|--file)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             HOME_MANAGER_CONFIG="$1"
             shift
             ;;
         --flake)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             FLAKE_ARG="$1"
             shift
             ;;
@@ -974,18 +987,23 @@ while [[ $# -gt 0 ]]; do
             PASSTHROUGH_OPTS+=("$opt")
             ;;
         --update-input)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             PASSTHROUGH_OPTS+=("$opt" "$1")
             shift
             ;;
         --override-input)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
+            [[ -v 2 && $2 != -* ]] || errMissingOptArg "$opt $1"
             PASSTHROUGH_OPTS+=("$opt" "$1" "$2")
             shift 2
             ;;
         --experimental-features)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             PASSTHROUGH_OPTS+=("$opt" "$1")
             shift
             ;;
         --extra-experimental-features)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             PASSTHROUGH_OPTS+=("$opt" "$1")
             shift
             ;;
@@ -1003,10 +1021,13 @@ while [[ $# -gt 0 ]]; do
             export DRY_RUN=1
             ;;
         --option|--arg|--argstr)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
+            [[ -v 2 ]] || errMissingOptArg "$opt $1"
             PASSTHROUGH_OPTS+=("$opt" "$1" "$2")
             shift 2
             ;;
         -j|--max-jobs|--cores|--builders)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             PASSTHROUGH_OPTS+=("$opt" "$1")
             shift
             ;;

--- a/home-manager/po/home-manager.pot
+++ b/home-manager/po/home-manager.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2024-02-15 16:04+0100\n"
+"POT-Creation-Date: 2024-04-17 23:19+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,36 +18,41 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: home-manager/home-manager:58
+#. translators: For example: "home-manager: missing argument for --cores"
+#: home-manager/home-manager:16
+msgid "%s: missing argument for %s"
+msgstr ""
+
+#: home-manager/home-manager:64
 msgid "No configuration file found at %s"
 msgstr ""
 
 #. translators: The first '%s' specifier will be replaced by either
 #. 'home.nix' or 'flake.nix'.
-#: home-manager/home-manager:75 home-manager/home-manager:79
-#: home-manager/home-manager:178
+#: home-manager/home-manager:81 home-manager/home-manager:85
+#: home-manager/home-manager:184
 msgid ""
 "Keeping your Home Manager %s in %s is deprecated,\n"
 "please move it to %s"
 msgstr ""
 
-#: home-manager/home-manager:86
+#: home-manager/home-manager:92
 msgid "No configuration file found. Please create one at %s"
 msgstr ""
 
-#: home-manager/home-manager:101
+#: home-manager/home-manager:107
 msgid "Home Manager not found at %s."
 msgstr ""
 
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
-#: home-manager/home-manager:109
+#: home-manager/home-manager:115
 msgid ""
 "The fallback Home Manager path %s has been deprecated and a file/directory "
 "was found there."
 msgstr ""
 
 #. translators: This message will be seen by very few users that likely are familiar with English. So feel free to leave this untranslated.
-#: home-manager/home-manager:112
+#: home-manager/home-manager:118
 msgid ""
 "To remove this warning, do one of the following.\n"
 "\n"
@@ -68,42 +73,42 @@ msgid ""
 "     $ rm -r \"%s\""
 msgstr ""
 
-#: home-manager/home-manager:140
+#: home-manager/home-manager:146
 msgid "Sanity checking Nix"
 msgstr ""
 
-#: home-manager/home-manager:160
+#: home-manager/home-manager:166
 msgid "Could not find suitable profile directory, tried %s and %s"
 msgstr ""
 
 #. translators: Here "flake" is a noun that refers to the Nix Flakes feature.
-#: home-manager/home-manager:215
+#: home-manager/home-manager:221
 msgid "Can't inspect options of a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:288 home-manager/home-manager:311
-#: home-manager/home-manager:1030
+#: home-manager/home-manager:296 home-manager/home-manager:319
+#: home-manager/home-manager:1051
 msgid "%s: unknown option '%s'"
 msgstr ""
 
-#: home-manager/home-manager:293 home-manager/home-manager:1031
+#: home-manager/home-manager:301 home-manager/home-manager:1052
 msgid "Run '%s --help' for usage help"
 msgstr ""
 
-#: home-manager/home-manager:319 home-manager/home-manager:423
+#: home-manager/home-manager:327 home-manager/home-manager:431
 msgid "The file %s already exists, leaving it unchanged..."
 msgstr ""
 
-#: home-manager/home-manager:321 home-manager/home-manager:425
+#: home-manager/home-manager:329 home-manager/home-manager:433
 msgid "Creating %s..."
 msgstr ""
 
-#: home-manager/home-manager:467
+#: home-manager/home-manager:475
 msgid "Creating initial Home Manager generation..."
 msgstr ""
 
 #. translators: The "%s" specifier will be replaced by a file path.
-#: home-manager/home-manager:472
+#: home-manager/home-manager:480
 msgid ""
 "All done! The home-manager tool should now be installed and you can edit\n"
 "\n"
@@ -114,7 +119,7 @@ msgid ""
 msgstr ""
 
 #. translators: The "%s" specifier will be replaced by a URL.
-#: home-manager/home-manager:477
+#: home-manager/home-manager:485
 msgid ""
 "Uh oh, the installation failed! Please create an issue at\n"
 "\n"
@@ -124,11 +129,11 @@ msgid ""
 msgstr ""
 
 #. translators: Here "flake" is a noun that refers to the Nix Flakes feature.
-#: home-manager/home-manager:488
+#: home-manager/home-manager:496
 msgid "Can't instantiate a flake configuration"
 msgstr ""
 
-#: home-manager/home-manager:564
+#: home-manager/home-manager:572
 msgid ""
 "There is %d unread and relevant news item.\n"
 "Read it by running the command \"%s news\"."
@@ -138,72 +143,72 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: home-manager/home-manager:578
+#: home-manager/home-manager:586
 msgid "Unknown \"news.display\" setting \"%s\"."
 msgstr ""
 
-#: home-manager/home-manager:586
+#: home-manager/home-manager:594
 #, sh-format
 msgid "Please set the $EDITOR or $VISUAL environment variable"
 msgstr ""
 
-#: home-manager/home-manager:604
+#: home-manager/home-manager:612
 msgid "Cannot run build in read-only directory"
 msgstr ""
 
-#: home-manager/home-manager:685
+#: home-manager/home-manager:693
 msgid "No generation with ID %s"
 msgstr ""
 
-#: home-manager/home-manager:687
+#: home-manager/home-manager:695
 msgid "Cannot remove the current generation %s"
 msgstr ""
 
-#: home-manager/home-manager:689
+#: home-manager/home-manager:697
 msgid "Removing generation %s"
 msgstr ""
 
-#: home-manager/home-manager:710
+#: home-manager/home-manager:718
 msgid "No generations to expire"
 msgstr ""
 
-#: home-manager/home-manager:721
+#: home-manager/home-manager:729
 msgid "No home-manager packages seem to be installed."
 msgstr ""
 
-#: home-manager/home-manager:803
+#: home-manager/home-manager:811
 msgid "Unknown argument %s"
 msgstr ""
 
-#: home-manager/home-manager:827
+#: home-manager/home-manager:835
 msgid "This will remove Home Manager from your system."
 msgstr ""
 
-#: home-manager/home-manager:830
+#: home-manager/home-manager:838
 msgid "This is a dry run, nothing will actually be uninstalled."
 msgstr ""
 
-#: home-manager/home-manager:834
+#: home-manager/home-manager:842
 msgid "Really uninstall Home Manager?"
 msgstr ""
 
-#: home-manager/home-manager:840
+#: home-manager/home-manager:848
 msgid "Switching to empty Home Manager configuration..."
 msgstr ""
 
-#: home-manager/home-manager:855
+#: home-manager/home-manager:863
 msgid "Yay!"
 msgstr ""
 
-#: home-manager/home-manager:860
+#: home-manager/home-manager:868
 msgid "Home Manager is uninstalled but your home.nix is left untouched."
 msgstr ""
 
-#: home-manager/home-manager:1070
+#: home-manager/home-manager:1091
 msgid "expire-generations expects one argument, got %d."
 msgstr ""
 
-#: home-manager/home-manager:1092
+#: home-manager/home-manager:1113
 msgid "Unknown command: %s"
 msgstr ""
 

--- a/modules/po/hm-modules.pot
+++ b/modules/po/hm-modules.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Home Manager Modules\n"
 "Report-Msgid-Bugs-To: https://github.com/nix-community/home-manager/issues\n"
-"POT-Creation-Date: 2024-02-15 16:04+0100\n"
+"POT-Creation-Date: 2024-04-17 23:19+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,23 +17,23 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: modules/files.nix:236
+#: modules/files.nix:191
 msgid "Creating home file links in %s"
 msgstr ""
 
-#: modules/files.nix:249
+#: modules/files.nix:204
 msgid "Cleaning up orphan links from %s"
 msgstr ""
 
-#: modules/files.nix:265
+#: modules/files.nix:220
 msgid "Creating profile generation %s"
 msgstr ""
 
-#: modules/files.nix:282
+#: modules/files.nix:237
 msgid "No change so reusing latest profile generation %s"
 msgstr ""
 
-#: modules/home-environment.nix:622
+#: modules/home-environment.nix:634
 msgid ""
 "Oops, Nix failed to install your new Home Manager profile!\n"
 "\n"
@@ -49,7 +49,7 @@ msgid ""
 "Then try activating your Home Manager configuration again."
 msgstr ""
 
-#: modules/home-environment.nix:655
+#: modules/home-environment.nix:667
 msgid "Activating %s"
 msgstr ""
 


### PR DESCRIPTION
### Description

Instead of an error

    line 958: $1: unbound variable

we now emit an error such as

    missing argument for --cores

Note, this is not perfect. In many cases you still get sub-optimal error messages.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```