### PR TITLE
vdirsyncer: set `postHook` to null when not set

### DIFF
--- a/modules/programs/vdirsyncer.nix
+++ b/modules/programs/vdirsyncer.nix
@@ -26,9 +26,11 @@ let
     filterAttrs (_: v: v != null)
     ((getAttrs [ "type" "fileExt" "encoding" ] a.local) // {
       path = a.local.path;
-      postHook = optionalString (a.vdirsyncer.postHook != null)
+      postHook = if a.vdirsyncer.postHook != null then
         (pkgs.writeShellScriptBin "post-hook" a.vdirsyncer.postHook
-          + "/bin/post-hook");
+          + "/bin/post-hook")
+      else
+        null;
     });
 
   remoteStorage = a:


### PR DESCRIPTION
### Description

The `postHook` option was being processed and reset to a string, even if the user set it to null, causing issues under certain conditions.

Using `if-then-else` instead of `optionalString` keeps the option as null, instead of setting it to an empty string.

Fix #4975.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@teto @somasis 