### PR TITLE
bash: add bash package to home.packages

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -190,6 +190,8 @@ in {
         HISTIGNORE = escapeShellArg (concatStringsSep ":" cfg.historyIgnore);
       }));
   in mkIf cfg.enable {
+    home.packages = [ pkgs.bashInteractive ];
+
     home.file.".bash_profile".source = writeBashScript "bash_profile" ''
       # include .profile if it exists
       [[ -f ~/.profile ]] && . ~/.profile


### PR DESCRIPTION
### Description

Fixes #5295

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```