### PR TITLE
himalaya: update for `v1`

### DIFF
--- a/modules/programs/himalaya.nix
+++ b/modules/programs/himalaya.nix
@@ -82,7 +82,7 @@ let
       sendmailConfig =
         lib.optionalAttrs (isNull account.smtp && !isNull account.msmtp) {
           sender = "sendmail";
-          sendmail.cmd = "${pkgs.msmtp}/bin/msmtp";
+          sendmail.cmd = lib.getExe pkgs.msmtp;
         };
 
       config = lib.attrsets.mergeAttrsList [
@@ -173,7 +173,7 @@ in {
           Install = { WantedBy = [ "default.target" ]; };
           Service = {
             ExecStart =
-              "${himalaya.package}/bin/himalaya envelopes watch --account %I";
+              "${lib.getExe himalaya.package} envelopes watch --account %I";
             ExecSearchPath = "/bin";
             Environment =
               lib.mapAttrsToList (key: val: "${key}=${val}") environment;

--- a/tests/modules/programs/himalaya/basic-expected.toml
+++ b/tests/modules/programs/himalaya/basic-expected.toml
@@ -1,32 +1,33 @@
 [accounts."hm@example.com"]
-backend = "imap"
 default = true
 display-name = "H. M. Test"
 email = "hm@example.com"
+[accounts."hm@example.com".backend]
+host = "imap.example.com"
+login = "home.manager"
+port = 993
+type = "imap"
+[accounts."hm@example.com".backend.auth]
+cmd = "password-command"
+type = "password"
 
-[accounts."hm@example.com".folder.alias]
+[accounts."hm@example.com".backend.encryption]
+type = "tls"
+
+[accounts."hm@example.com".folder.aliases]
 drafts = "Drafts"
 inbox = "Inbox"
 sent = "Sent"
 trash = "Trash"
 
-[accounts."hm@example.com".imap]
-encryption = "tls"
-host = "imap.example.com"
-login = "home.manager"
-port = 993
-
-[accounts."hm@example.com".imap.passwd]
-cmd = "password-command"
-
-[accounts."hm@example.com".message.send]
-backend = "smtp"
-
-[accounts."hm@example.com".smtp]
-encryption = "tls"
+[accounts."hm@example.com".message.send.backend]
 host = "smtp.example.com"
 login = "home.manager"
 port = 465
-
-[accounts."hm@example.com".smtp.passwd]
+type = "smtp"
+[accounts."hm@example.com".message.send.backend.auth]
 cmd = "password-command"
+type = "password"
+
+[accounts."hm@example.com".message.send.backend.encryption]
+type = "tls"


### PR DESCRIPTION
### Description

This PR make the home manager module compatible with Himalaya CLI `v1.x.x`. It also removes the watcher, as watching is not part of Himalaya anymore (see https://github.com/nix-community/home-manager/pull/5297#issuecomment-2567375413).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
