### PR TITLE
kdeconnect: require "tray.target" for kdeconnect-indicator

### DIFF
--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -24,7 +24,6 @@ in {
         default = false;
         description = "Whether to enable kdeconnect-indicator service.";
       };
-
     };
   };
 
@@ -43,7 +42,7 @@ in {
             "Adds communication between your desktop and your smartphone";
           After = [ "graphical-session-pre.target" ];
           PartOf = [ "graphical-session.target" ];
-        };
+        } // lib.optionalAttrs cfg.indicator { Requires = [ "tray.target" ]; };
 
         Install = { WantedBy = [ "graphical-session.target" ]; };
 
@@ -82,6 +81,5 @@ in {
         };
       };
     })
-
   ];
 }


### PR DESCRIPTION
### Description

Since kdeconnect-indicator is a tray application, it should require "tray.target", as is the case for flameshot[0].

[0]: https://github.com/nix-community/home-manager/blob/b1a5b3d6a524c80c7dd20888bff227d52adf5f03/modules/services/flameshot.nix#L58

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
