### PR TITLE
bat: allow overriding package

### DIFF
--- a/modules/programs/bat.nix
+++ b/modules/programs/bat.nix
@@ -6,8 +6,6 @@ let
 
   cfg = config.programs.bat;
 
-  package = pkgs.bat;
-
   toConfigFile = attrs:
     let
       inherit (builtins) isBool attrNames;
@@ -51,6 +49,8 @@ in {
         Additional bat packages to install.
       '';
     };
+
+    package = mkPackageOption pkgs "bat" { };
 
     themes = mkOption {
       type = types.attrsOf (types.either types.lines (types.submodule {
@@ -138,7 +138,7 @@ in {
       ''];
     })
     {
-      home.packages = [ package ] ++ cfg.extraPackages;
+      home.packages = [ cfg.package ] ++ cfg.extraPackages;
 
       xdg.configFile = mkMerge ([({
         "bat/config" =
@@ -167,7 +167,7 @@ in {
           export XDG_CACHE_HOME=${escapeShellArg config.xdg.cacheHome}
           verboseEcho "Rebuilding bat theme cache"
           cd "${pkgs.emptyDirectory}"
-          run ${lib.getExe package} cache --build
+          run ${lib.getExe cfg.package} cache --build
         )
       '';
     }


### PR DESCRIPTION
### Description

Allow users to override the `bat` package used.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
