### PR TITLE
nh: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1789,6 +1789,18 @@ in {
           cmus is a small, fast and powerful console music player.
         '';
       }
+
+      {
+        time = "2024-10-20T07:53:54+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'programs.nh'.
+
+          nh is yet another Nix CLI helper. Adding functionality on top of the
+          existing solutions, like nixos-rebuild, home-manager cli or nix
+          itself.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -172,6 +172,7 @@ let
     ./programs/neovide.nix
     ./programs/neovim.nix
     ./programs/newsboat.nix
+    ./programs/nh.nix
     ./programs/nheko.nix
     ./programs/nix-index.nix
     ./programs/nnn.nix

--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -1,0 +1,94 @@
+{ config, osConfig, lib, pkgs, ... }:
+
+let
+
+  cfg = config.programs.nh;
+
+in {
+  meta.maintainers = with lib.maintainers; [ johnrtitor ];
+
+  options.programs.nh = {
+    enable = lib.mkEnableOption "nh, yet another Nix CLI helper";
+
+    package = lib.mkPackageOption pkgs "nh" { };
+
+    flake = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        The path that will be used for the {env}`FLAKE` environment variable.
+
+        {env}`FLAKE` is used by nh as the default flake for performing actions,
+        like {command}`nh os switch`.
+      '';
+    };
+
+    clean = {
+      enable = lib.mkEnableOption ''
+        periodic garbage collection for user profile and nix store with nh clean
+        user'';
+
+      dates = lib.mkOption {
+        type = lib.types.singleLineStr;
+        default = "weekly";
+        description = ''
+          How often cleanup is performed.
+
+          The format is described in {manpage}`systemd.time(7)`.
+        '';
+      };
+
+      extraArgs = lib.mkOption {
+        type = lib.types.singleLineStr;
+        default = "";
+        example = "--keep 5 --keep-since 3d";
+        description = ''
+          Options given to nh clean when the service is run automatically.
+
+          See `nh clean all --help` for more information.
+        '';
+      };
+    };
+  };
+
+  config = {
+    warnings = lib.optionals (!(cfg.clean.enable -> !osConfig.nix.gc.automatic))
+      [
+        "programs.nh.clean.enable and nix.gc.automatic (system-wide in configuration.nix) are both enabled. Please use one or the other to avoid conflict."
+      ];
+
+    assertions = [{
+      assertion = (cfg.flake != null) -> !(lib.hasSuffix ".nix" cfg.flake);
+      message = "nh.flake must be a directory, not a nix file";
+    }];
+
+    home = lib.mkIf cfg.enable {
+      packages = [ cfg.package ];
+      sessionVariables = lib.mkIf (cfg.flake != null) { FLAKE = cfg.flake; };
+    };
+
+    systemd.user = lib.mkIf cfg.clean.enable {
+      services.nh-clean = {
+        Unit.Description = "Nh clean (user)";
+
+        Service = {
+          Type = "oneshot";
+          ExecStart =
+            "exec ${lib.getExe cfg.package} clean user ${cfg.clean.extraArgs}";
+          Environment = "PATH=$PATH:${config.nix.package}";
+        };
+      };
+
+      timers.nh-clean = {
+        Unit.Description = "Run nh clean";
+
+        Timer = {
+          OnCalendar = cfg.clean.dates;
+          Persistent = true;
+        };
+
+        Install.WantedBy = [ "timers.target" ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Description
nh is a Nix CLI helper designed to provide beautiful outputs when rebuilding system or garbage collecting. Module already exists for NixOS, and so should for home manager too.

This PR
- adds `programs.nh` option
- Add nh to news
- Add johnrtitor as maintainer

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

initial PR, I'll be maintaining this HM module