### PR TITLE
kdeconnect: require "tray.target" on the correct service

### DIFF
--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -42,7 +42,7 @@ in {
             "Adds communication between your desktop and your smartphone";
           After = [ "graphical-session-pre.target" ];
           PartOf = [ "graphical-session.target" ];
-        } // lib.optionalAttrs cfg.indicator { Requires = [ "tray.target" ]; };
+        };
 
         Install = { WantedBy = [ "graphical-session.target" ]; };
 
@@ -70,6 +70,7 @@ in {
             "stalonetray.service"
           ];
           PartOf = [ "graphical-session.target" ];
+          Requires = [ "tray.target" ];
         };
 
         Install = { WantedBy = [ "graphical-session.target" ]; };


### PR DESCRIPTION
### Description

The PR #5299[0] actually adds the requirement on "tray.target" for the kdeconnect service, when kdeconnect-indicator is set to true. What it should do is add the requirement directly to the latter. This commit fixes it.

[0]: https://github.com/nix-community/home-manager/pull/5299#issue-2252834123

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
