### PR TITLE
qt: fix platform theme package install

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -258,7 +258,7 @@ in {
     # Apply theming also to apps started by systemd.
     systemd.user.sessionVariables = envVars // envVarsExtra;
 
-    home.packages = (lib.findFirst (x: x != null) [ ] [
+    home.packages = (lib.findFirst (x: x != [ ]) [ ] [
       (lib.optionals (platformTheme.package != null)
         (lib.toList platformTheme.package))
       (lib.optionals (platformTheme.name != null)

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -262,7 +262,7 @@ in {
       (lib.optionals (platformTheme.package != null)
         (lib.toList platformTheme.package))
       (lib.optionals (platformTheme.name != null)
-        platformPackages.${platformTheme.name})
+        platformPackages.${platformTheme.name} or [ ])
     ]) ++ (lib.optionals (cfg.style.package != null)
       (lib.toList cfg.style.package));
 


### PR DESCRIPTION
### Description
The PR #5156 broke the automatic installation of packages needed for the `qt.platformTheme.name` option in some cases: If `qt.platformTheme.package` is left to the default (null), then `home.packages` (in line 261) will be set to an empty list instead of the list defined in `platformPackages`. The reason for this is that `lib.optionals` doesn't return `null` if the condition is false but an empty list which will still be selected by the `lib.findFirst` function. This changes this so that `lib.findFirst` ignores empty lists. It doesn't need to check for `null` since `lib.optionals` already does that.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee @thiagokokada 

Also pinging autor of original PR @tschai-yim 