### PR TITLE
sway: do not use pkgs.sway when cfg.package = null

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -331,13 +331,6 @@ let
         ++ [ cfg.extraConfig ]);
   };
 
-  defaultSwayPackage = pkgs.sway.override {
-    extraSessionCommands = cfg.extraSessionCommands;
-    extraOptions = cfg.extraOptions;
-    withBaseWrapper = cfg.wrapperFeatures.base;
-    withGtkWrapper = cfg.wrapperFeatures.gtk;
-  };
-
 in {
   meta.maintainers = with maintainers; [
     Scrumplex
@@ -357,7 +350,12 @@ in {
 
     package = mkOption {
       type = with types; nullOr package;
-      default = defaultSwayPackage;
+      default = pkgs.sway.override {
+        extraSessionCommands = cfg.extraSessionCommands;
+        extraOptions = cfg.extraOptions;
+        withBaseWrapper = cfg.wrapperFeatures.base;
+        withGtkWrapper = cfg.wrapperFeatures.gtk;
+      };
       defaultText = literalExpression "${pkgs.sway}";
       description = ''
         Sway package to use. Will override the options

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -258,7 +258,6 @@ let
 
   variables = concatStringsSep " " cfg.systemd.variables;
   extraCommands = concatStringsSep " && " cfg.systemd.extraCommands;
-  swayPackage = if cfg.package == null then pkgs.sway else cfg.package;
   systemdActivation = ''
     exec "${pkgs.dbus}/bin/dbus-update-activation-environment --systemd ${variables}; ${extraCommands}"'';
 
@@ -269,7 +268,7 @@ let
     checkPhase = lib.optionalString cfg.checkConfig ''
       export DBUS_SESSION_BUS_ADDRESS=/dev/null
       export XDG_RUNTIME_DIR=$(mktemp -d)
-      ${pkgs.xvfb-run}/bin/xvfb-run ${swayPackage}/bin/sway --config "$target" --validate --unsupported-gpu
+      ${pkgs.xvfb-run}/bin/xvfb-run ${cfg.package}/bin/sway --config "$target" --validate --unsupported-gpu
     '';
 
     text = concatStringsSep "\n"
@@ -362,7 +361,8 @@ in {
         'wrapperFeatures', 'extraSessionCommands', and 'extraOptions'.
         Set to `null` to not add any Sway package to your
         path. This should be done if you want to use the NixOS Sway
-        module to install Sway.
+        module to install Sway. Beware setting to `null` will also disable
+        reloading Sway when new config is activated.
       '';
     };
 
@@ -478,9 +478,9 @@ in {
 
     checkConfig = mkOption {
       type = types.bool;
-      default = true;
-      description =
-        "If enabled (the default), validates the generated config file.";
+      default = cfg.package != null;
+      defaultText = literalExpression "cfg.package != null";
+      description = "If enabled, validates the generated config file.";
     };
 
     extraConfig = mkOption {
@@ -515,6 +515,11 @@ in {
       assertions = [
         (hm.assertions.assertPlatform "wayland.windowManager.sway" pkgs
           platforms.linux)
+        {
+          assertion = cfg.checkConfig -> cfg.package != null;
+          message =
+            "programs.sway.checkConfig requires non-null programs.sway.package";
+        }
       ];
 
       home.packages = optional (cfg.package != null) cfg.package
@@ -522,10 +527,10 @@ in {
 
       xdg.configFile."sway/config" = {
         source = configFile;
-        onChange = ''
+        onChange = lib.optionalString (cfg.package != null) ''
           swaySocket="''${XDG_RUNTIME_DIR:-/run/user/$UID}/sway-ipc.$UID.$(${pkgs.procps}/bin/pgrep --uid $UID -x sway || true).sock"
           if [ -S "$swaySocket" ]; then
-            ${swayPackage}/bin/swaymsg -s $swaySocket reload
+            ${cfg.package}/bin/swaymsg -s $swaySocket reload
           fi
         '';
       };


### PR DESCRIPTION
### Description

- Implicitly disable checkConfig when `cfg.package = null` as we don’t
  have any exe to use for the check
- Implicitly disable `swaymsg reload` on activation, since we have no
  exe to use for running it

See https://github.com/nix-community/home-manager/issues/5307

### Checklist

Need to think about if there is a good test to write for this…I did run existing Sway tests and all OK.

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Scrumplex @alexarice @sumnerevans @oxalica