### PR TITLE
freetube: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1561,6 +1561,17 @@ in {
           https://github.com/ErikReider/SwayNotificationCenter for more.
         '';
       }
+
+      {
+        time = "2024-04-30T18:28:28+00:00";
+        message = ''
+          A new module is available: 'programs.freetube'.
+
+          FreeTube is a YouTube client built around using YouTube more
+          privately. You can enjoy your favorite content and creators without
+          your habits being tracked. See https://freetubeapp.io/ for more.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -92,6 +92,7 @@ let
     ./programs/firefox.nix
     ./programs/fish.nix
     ./programs/foot.nix
+    ./programs/freetube.nix
     ./programs/fuzzel.nix
     ./programs/fzf.nix
     ./programs/gallery-dl.nix

--- a/modules/programs/freetube.nix
+++ b/modules/programs/freetube.nix
@@ -1,0 +1,60 @@
+{ lib, pkgs, config, ... }:
+
+let
+  inherit (lib)
+    concatStringsSep mapAttrsToList mkIf mkEnableOption mkPackageOption mkOption
+    literalExpression;
+
+  cfg = config.programs.freetube;
+
+  settings = settings:
+    let
+      convertSetting = name: value:
+        builtins.toJSON {
+          "_id" = name;
+          "value" = value;
+        };
+    in concatStringsSep "\n" (mapAttrsToList convertSetting settings) + "\n";
+in {
+  meta.maintainers = with lib.maintainers; [ vonixxx ];
+
+  options.programs.freetube = {
+    enable = mkEnableOption "FreeTube, a YT client for Windows, Mac, and Linux";
+
+    package = mkPackageOption pkgs "freetube" { };
+
+    settings = mkOption {
+      type = lib.types.attrs;
+      default = { };
+      example = literalExpression ''
+        {
+          allowDashAv1Formats = true;
+          checkForUpdates     = false;
+          defaultQuality      = "1080";
+          baseTheme           = "catppuccinMocha";
+        }
+      '';
+      description = ''
+        Configuration settings for FreeTube.
+
+        All configurable options can be deduced by enabling them through the
+        GUI and observing the changes in {file}`settings.db`.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."FreeTube/hm_settings.db" = {
+      source = pkgs.writeText "hm_settings.db" (settings cfg.settings);
+
+      onChange = let
+        hmSettingsDb = "${config.xdg.configHome}/FreeTube/hm_settings.db";
+        settingsDb = "${config.xdg.configHome}/FreeTube/settings.db";
+      in ''
+        run install -Dm644 $VERBOSE_ARG '${hmSettingsDb}' '${settingsDb}'
+      '';
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -190,6 +190,7 @@ in import nmtSrc {
     ./modules/programs/boxxy
     ./modules/programs/firefox
     ./modules/programs/foot
+    ./modules/programs/freetube
     ./modules/programs/fuzzel
     ./modules/programs/getmail
     ./modules/programs/gnome-terminal

--- a/tests/modules/programs/freetube/basic-configuration.db
+++ b/tests/modules/programs/freetube/basic-configuration.db
@@ -1,0 +1,8 @@
+{"_id":"allowDashAv1Formats","value":true}
+{"_id":"checkForBlogPosts","value":false}
+{"_id":"checkForUpdates","value":false}
+{"_id":"commentAutoLoadEnabled","value":true}
+{"_id":"defaultQuality","value":"1080"}
+{"_id":"hideHeaderLogo","value":true}
+{"_id":"listType","value":"list"}
+{"_id":"useRssFeeds","value":true}

--- a/tests/modules/programs/freetube/basic-configuration.nix
+++ b/tests/modules/programs/freetube/basic-configuration.nix
@@ -1,0 +1,30 @@
+{ config, pkgs, ... }:
+
+{
+  programs.freetube = {
+    enable = true;
+    settings = {
+      useRssFeeds = true;
+      hideHeaderLogo = true;
+      allowDashAv1Formats = true;
+      commentAutoLoadEnabled = true;
+
+      checkForUpdates = false;
+      checkForBlogPosts = false;
+
+      listType = "list";
+      defaultQuality = "1080";
+    };
+  };
+
+  test.stubs.freetube = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/FreeTube/hm_settings.db
+    assertFileContent home-files/.config/FreeTube/hm_settings.db \
+      ${./basic-configuration.db}
+
+    assertFileContains activate \
+      "install -Dm644 \$VERBOSE_ARG '/home/hm-user/.config/FreeTube/hm_settings.db' '/home/hm-user/.config/FreeTube/settings.db'"
+  '';
+}

--- a/tests/modules/programs/freetube/default.nix
+++ b/tests/modules/programs/freetube/default.nix
@@ -1,0 +1,1 @@
+{ freetube-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

FreeTube is a YouTube client for Windows, Mac, and Linux.

This module enables declarative configuration of its options.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
