### PR TITLE
swayosd: add custom style option

### DIFF
--- a/modules/services/swayosd.nix
+++ b/modules/services/swayosd.nix
@@ -26,6 +26,15 @@ in {
       description = "OSD margin from top edge (0.5 would be screen center).";
     };
 
+    stylePath = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/etc/xdg/swayosd/style.css";
+      description = ''
+        Use a custom Stylesheet file instead of looking for one.
+      '';
+    };
+
     display = mkOption {
       type = types.nullOr types.str;
       default = null;
@@ -57,6 +66,8 @@ in {
           Type = "simple";
           ExecStart = "${cfg.package}/bin/swayosd-server"
             + (optionalString (cfg.display != null) " --display ${cfg.display}")
+            + (optionalString (cfg.stylePath != null)
+              " --style ${escapeShellArg cfg.stylePath}")
             + (optionalString (cfg.topMargin != null)
               " --top-margin ${toString cfg.topMargin}");
           Restart = "always";

--- a/tests/modules/services/swayosd/swayosd.nix
+++ b/tests/modules/services/swayosd/swayosd.nix
@@ -8,6 +8,7 @@
       outPath = "@swayosd@";
     };
     display = "DISPLAY";
+    stylePath = "/etc/xdg/swayosd/style.css";
     topMargin = 0.1;
   };
 
@@ -20,7 +21,7 @@
           WantedBy=graphical-session.target
 
           [Service]
-          ExecStart=@swayosd@/bin/swayosd-server --display DISPLAY --top-margin 0.100000
+          ExecStart=@swayosd@/bin/swayosd-server --display DISPLAY --style '/etc/xdg/swayosd/style.css' --top-margin 0.100000
           Restart=always
           Type=simple
 


### PR DESCRIPTION
### Description
Add custom style path file option

> The new option is part of this new version https://github.com/NixOS/nixpkgs/pull/305672 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like
    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@pltanton 
