### PR TITLE
foot: unset PATH in server's systemd unit file

### DIFF
--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -68,7 +68,6 @@ in {
         };
 
         Service = {
-          Environment = "PATH=${makeBinPath [ cfg.package ]}";
           ExecStart = "${cfg.package}/bin/foot --server";
           Restart = "on-failure";
           OOMPolicy = "continue";

--- a/tests/modules/programs/foot/systemd-user-service-expected.service
+++ b/tests/modules/programs/foot/systemd-user-service-expected.service
@@ -2,7 +2,6 @@
 WantedBy=graphical-session.target
 
 [Service]
-Environment=PATH=@foot@/bin
 ExecStart=@foot@/bin/foot --server
 OOMPolicy=continue
 Restart=on-failure


### PR DESCRIPTION
This reverts commit 40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0 #5254 

Fixes #5302 

### Description

This change caused footclient to launch with the set path on some systems, making the shell unusable. There may be a way to keep it working while fixing the initial problem #5254 was solving, but I think this should be done in the meantime. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@plabadens 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
