### PR TITLE
tealdeer: documentation typo

### DIFF
--- a/modules/programs/tealdeer.nix
+++ b/modules/programs/tealdeer.nix
@@ -50,7 +50,7 @@ in {
       The activation script should be fast and idempotent, so the option was removed.
       Please use
 
-        `programs.teadleer.settings.updates.auto_update = true`
+        `programs.tealdeer.settings.updates.auto_update = true`
 
       instead, to make sure tealdeer's cache is updated periodically.
     '')


### PR DESCRIPTION
### Description

_Almost_ harmless typo (I learned about it by blindly copying it into my config and getting a build error 🙈)

### Checklist

- [x] Change is backwards compatible.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@pedorich-n 