### PR TITLE
Hypridle: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1584,6 +1584,17 @@ in {
           https://conky.cc/ for more.
         '';
       }
+
+      {
+        time = "2024-05-05T07:22:01+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.hypridle'.
+
+          Hypridle is a program that monitors user activity and runs commands
+          when idle or active. See https://github.com/hyprwm/hypridle for more.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -302,6 +302,7 @@ let
     ./services/gromit-mpx.nix
     ./services/home-manager-auto-upgrade.nix
     ./services/hound.nix
+    ./services/hypridle.nix
     ./services/imapnotify.nix
     ./services/kanshi.nix
     ./services/kbfs.nix

--- a/modules/services/hypridle.nix
+++ b/modules/services/hypridle.nix
@@ -1,0 +1,95 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+
+  cfg = config.services.hypridle;
+in {
+  meta.maintainers = [ maintainers.khaneliman maintainers.fufexan ];
+
+  options.services.hypridle = {
+    enable = mkEnableOption "Hypridle, Hyprland's idle daemon";
+
+    package = mkPackageOption pkgs "hypridle" { };
+
+    settings = lib.mkOption {
+      type = with lib.types;
+        let
+          valueType = nullOr (oneOf [
+            bool
+            int
+            float
+            str
+            path
+            (attrsOf valueType)
+            (listOf valueType)
+          ]) // {
+            description = "Hypridle configuration value";
+          };
+        in valueType;
+      default = { };
+      description = ''
+        Hypridle configuration written in Nix. Entries with the same key
+        should be written as lists. Variables' and colors' names should be
+        quoted. See <https://wiki.hyprland.org/Hypr-Ecosystem/hypridle/> for more examples.
+      '';
+      example = lib.literalExpression ''
+        {
+          general = {
+            after_sleep_cmd = "hyprctl dispatch dpms on";
+            ignore_dbus_inhibit = false;
+            lock_cmd = "hyprlock";
+          };
+
+          listener = [
+            {
+              timeout = 900;
+              on-timeout = "hyprlock";
+            }
+            {
+              timeout = 1200;
+              on-timeout = "hyprctl dispatch dpms off";
+              on-resume = "hyprctl dispatch dpms on";
+            }
+          ];
+        }
+      '';
+    };
+
+    importantPrefixes = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ "$" ];
+      example = [ "$" ];
+      description = ''
+        List of prefix of attributes to source at the top of the config.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    xdg.configFile."hypr/hypridle.conf" = mkIf (cfg.settings != { }) {
+      text = lib.hm.generators.toHyprconf {
+        attrs = cfg.settings;
+        inherit (cfg) importantPrefixes;
+      };
+    };
+
+    systemd.user.services.hypridle = {
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+
+      Unit = {
+        ConditionEnvironment = "WAYLAND_DISPLAY";
+        Description = "hypridle";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+        X-Restart-Triggers =
+          [ "${config.xdg.configFile."hypr/hypridle.conf".source}" ];
+      };
+
+      Service = {
+        ExecStart = "${getExe cfg.package}";
+        Restart = "always";
+        RestartSec = "10";
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -239,6 +239,7 @@ in import nmtSrc {
     ./modules/services/gpg-agent
     ./modules/services/gromit-mpx
     ./modules/services/home-manager-auto-upgrade
+    ./modules/services/hypridle
     ./modules/services/imapnotify
     ./modules/services/kanshi
     ./modules/services/lieer

--- a/tests/modules/services/hypridle/basic-configuration.nix
+++ b/tests/modules/services/hypridle/basic-configuration.nix
@@ -1,0 +1,38 @@
+{ pkgs, ... }:
+
+{
+  services.hypridle = {
+    enable = true;
+    package = pkgs.hypridle;
+
+    settings = {
+      general = {
+        after_sleep_cmd = "hyprctl dispatch dpms on";
+        ignore_dbus_inhibit = false;
+        lock_cmd = "hyprlock";
+      };
+
+      listener = [
+        {
+          timeout = 900;
+          on-timeout = "hyprlock";
+        }
+        {
+          timeout = 1200;
+          on-timeout = "hyprctl dispatch dpms off";
+          on-resume = "hyprctl dispatch dpms on";
+        }
+      ];
+    };
+  };
+
+  test.stubs.hypridle = { };
+
+  nmt.script = ''
+    config=home-files/.config/hypr/hypridle.conf
+    clientServiceFile=home-files/.config/systemd/user/hypridle.service
+    assertFileExists $config
+    assertFileExists $clientServiceFile
+    assertFileContent $config ${./hypridle.conf}
+  '';
+}

--- a/tests/modules/services/hypridle/default.nix
+++ b/tests/modules/services/hypridle/default.nix
@@ -1,0 +1,1 @@
+{ hypridle-basic-configuration = ./basic-configuration.nix; }

--- a/tests/modules/services/hypridle/hypridle.conf
+++ b/tests/modules/services/hypridle/hypridle.conf
@@ -1,0 +1,16 @@
+general {
+  after_sleep_cmd=hyprctl dispatch dpms on
+  ignore_dbus_inhibit=false
+  lock_cmd=hyprlock
+}
+
+listener {
+  on-timeout=hyprlock
+  timeout=900
+}
+
+listener {
+  on-resume=hyprctl dispatch dpms on
+  on-timeout=hyprctl dispatch dpms off
+  timeout=1200
+}


### PR DESCRIPTION
### Description

Adding hypridle module so i can remove another input from my flake and just use the config in home-manager. Meant to do a long time ago but forgot to create PR.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@fufexan 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
