### PR TITLE
init: workarounds.nixgl module

### DIFF
--- a/modules/misc/nixgl.nix
+++ b/modules/misc/nixgl.nix
@@ -1,0 +1,115 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.targets.genericLinux.nixgl;
+
+  # Expects a packageConfiguration hashset
+  # Adapted from https://nixos.wiki/wiki/Nix_Cookbook
+  wrapWithNixGL = pkgConfig:
+    (let
+      binary = if (builtins.hasAttr "binary" pkgConfig) then
+        pkgConfig.binary
+      else
+        null;
+      package = pkgConfig.package;
+
+      bin = if binary == null then package.pname else binary;
+      nixGL = import cfg.src { inherit pkgs; };
+      wrapperPkg = lib.attrsets.getAttrFromPath cfg.wrapperPkgPath nixGL;
+      wrapperBinPath = "${wrapperPkg}/bin/${cfg.wrapperBinName}";
+    in pkgs.runCommand "nixgl-${package.pname}" {
+      buildInputs = [ pkgs.makeWrapper ];
+    } ''
+      mkdir $out
+      # Link every top-level folder from pkgs.hello to our new target
+      ln -s ${package}/* $out
+      # Except the bin folder
+      rm $out/bin
+      mkdir $out/bin
+      # We create the bin folder ourselves and link every binary in it
+      ln -s ${package}/bin/* $out/bin
+      # Except the target binary
+      rm $out/bin/${bin}
+      # Because we create this ourself, by creating a wrapper
+      makeWrapper ${wrapperBinPath} $out/bin/${bin} \
+        --add-flags ${package}/bin/${bin}
+    '');
+  packageConfiguration = with lib;
+    types.submodule {
+      options = {
+        binary = mkOption {
+          type = types.nullOr types.str;
+          example = "alacritty";
+          default = null;
+          description = ''
+            Name of the binary in bin/ of the package.
+            By default this uses `package.pname`.
+          '';
+        };
+        package = mkOption {
+          type = types.package;
+          example = "pkgs.alacritty";
+          description = ''
+            The package to be wrapped.
+            It's expected to have a `pname` attribute.
+          '';
+        };
+      };
+    };
+in {
+  meta.maintainers = with lib.maintainers; [ michaelCTS ];
+
+  options.targets.genericLinux.nixgl = {
+
+    src = lib.mkOption {
+      type = lib.types.package;
+      example = ''
+        pkgs.fetchFromGithub {
+          owner = "nix-community";
+          repo = "nixGL";
+          rev = "v1.3";
+          hash = "SOMEHASH-HERE";
+        }
+      '';
+      description = ''
+        Path to a downloaded source of nixGL.
+        You can download the nixGL version of your choice and point to it here.
+      '';
+    };
+
+    wrapperBinName = lib.mkOption {
+      type = lib.types.str;
+      example = "nixGL";
+      default = "nixGL";
+      description =
+        "Name of the nixGL binary to be called from within the wrapper package";
+    };
+
+    wrapperPkgPath = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      example = [ "auto" "nixGLNvidia" ];
+      default = [ "auto" "nixGLDefault" ];
+      description = "Attribute path within `src` attrset to the nixGL package";
+    };
+
+    packages = lib.mkOption {
+      type = lib.types.listOf packageConfiguration;
+      default = [ ];
+      example = "[{ package = pkgs.alacritty; }]";
+      description = ''
+        List of packages that will be wrapped with nixGL in order to be able to use nixgl.
+        Without the wrapper, graphical applications cannot access nixgl and thus have no
+        graphical acceleration.
+      '';
+    };
+
+  };
+
+  config = {
+    lib.nixGl.wrap = wrapWithNixGL;
+    home.packages = builtins.map config.lib.nixGl.wrap
+      config.targets.genericLinux.nixgl.packages;
+  };
+
+}
+

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -49,6 +49,7 @@ in import nmtSrc {
     ./modules/misc/fontconfig
     ./modules/misc/manual
     ./modules/misc/nix
+    ./modules/misc/nixgl
     ./modules/misc/specialisation
     ./modules/programs/aerc
     ./modules/programs/alacritty


### PR DESCRIPTION
### Description

The option allows packages to be wrapped by nixgl in order to make GUI applications work when installed with home-manager. The goal of this PR is just to make it easy to use graphically accelerated programs installed with home-manager in a desktop environment. 

No need to install and run `nixGL $program`. Just add the package to `workaround.nixgl.packages` like so `[ { pkg = pkgs.some_package; }]`.

Anything more advanced can come in further PRs by other people.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->


Closes #3968