### PR TITLE
Zellij: add fish completions & autostart options

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -585,6 +585,12 @@
     keys =
       [{ fingerprint = "75F0 AB7C FE01 D077 AEE6  CAFD 353E 4A18 EE0F AB72"; }];
   };
+  tennox = {
+    name = "Manu";
+    github = "tennox";
+    githubId = 2084639;
+    matrix = "@tennox:matrix.org";
+  };
   tensor5 = {
     github = "tensor5";
     githubId = 1545895;

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -9,7 +9,7 @@ let
   zellijCmd = getExe cfg.package;
 
 in {
-  meta.maintainers = [ hm.maintainers.mainrs ];
+  meta.maintainers = with hm.maintainers; [ mainrs tennox ];
 
   options.programs.zellij = {
     enable = mkEnableOption "zellij";
@@ -47,11 +47,31 @@ in {
     enableBashIntegration =
       lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableFishIntegration =
-      lib.hm.shell.mkFishIntegrationOption { inherit config; };
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption {
+      inherit config;
+      extraDescription =
+        "Enables both enableFishAutoStart and enableFishCompletions";
+    };
 
     enableZshIntegration =
       lib.hm.shell.mkZshIntegrationOption { inherit config; };
+
+    enableFishCompletions = mkEnableOption "load zellij completions" // {
+      default = true;
+    };
+    enableFishAutoStart =
+      mkEnableOption "autostart zellij in interactive sessions" // {
+        default = false;
+      };
+    autoStartAttachIfSessionExists = mkEnableOption
+      "attach to the default session, if a zellij session already exists (otherwise starting a new session)"
+      // {
+        default = false;
+      };
+    autoStartExitShellOnZellijExit =
+      mkEnableOption "exit the shell when zellij exits." // {
+        default = false;
+      };
   };
 
   config = mkIf cfg.enable {
@@ -77,9 +97,22 @@ in {
       eval "$(${zellijCmd} setup --generate-auto-start zsh)"
     '');
 
-    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration
-      (mkOrder 200 ''
-        eval (${zellijCmd} setup --generate-auto-start fish | string collect)
-      '');
+    home.sessionVariables = {
+      ZELLIJ_AUTO_ATTACH =
+        if cfg.autoStartAttachIfSessionExists then "true" else "false";
+      ZELLIJ_AUTO_EXIT =
+        if cfg.autoStartExitShellOnZellijExit then "true" else "false";
+    };
+
+    programs.fish.interactiveShellInit = mkIf (cfg.enableFishIntegration
+      || cfg.enableFishAutoStart || cfg.enableFishCompletions) (mkOrder 200
+        ((if cfg.enableFishIntegration || cfg.enableFishCompletions then ''
+          eval (${zellijCmd} setup --generate-completion fish | string collect)
+        '' else
+          "") + (if cfg.enableFishIntegration || cfg.enableFishAutoStart then ''
+            eval (${zellijCmd} setup --generate-auto-start fish | string collect)
+          '' else
+            "")));
+
   };
 }

--- a/tests/modules/programs/zellij/enable-shells.nix
+++ b/tests/modules/programs/zellij/enable-shells.nix
@@ -7,6 +7,10 @@
       enableBashIntegration = true;
       enableZshIntegration = true;
       enableFishIntegration = true;
+      enableFishAutoStart = true;
+      enableFishCompletions = true;
+      autoStartAttachIfSessionExists = true;
+      autoStartExitShellOnZellijExit = true;
     };
     bash.enable = true;
     zsh.enable = true;
@@ -32,5 +36,15 @@
     assertFileContains \
       home-files/.config/fish/config.fish \
       'eval (@zellij@/bin/zellij setup --generate-auto-start fish | string collect)'
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      'eval (@zellij@/bin/dummy setup --generate-completion fish | string collect)'
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileContains \
+      home-path/etc/profile.d/hm-session-vars.sh \
+      'export ZELLIJ_AUTO_ATTACH="true"'
+    assertFileContains \
+      home-path/etc/profile.d/hm-session-vars.sh \
+      'export ZELLIJ_AUTO_EXIT="true"'
   '';
 }


### PR DESCRIPTION
### Description
First, I just wanted to add completions to the fish integration, then I figured I often want completions but not autostart, then I added the autostart options listed in [zellij docs](https://zellij.dev/documentation/integration.html#fish), and finally adapted the tests.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@mainrs 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
