### PR TITLE
Allow passing reference-lock-file for flakes

### DIFF
--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -303,7 +303,7 @@ _home-manager_completions ()
               "-L" "--print-build-logs" \
               "--show-trace" "--flake" "--substitute" "--builders" "--version" \
               "--update-input" "--override-input" "--experimental-features" \
-              "--extra-experimental-features" "--refresh")
+              "--extra-experimental-features" "--reference-lock-file"  "--refresh")
 
     # ^ « home-manager »'s options.
 

--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -26,6 +26,7 @@ _arguments \
   '--update-input[update flake input]:NAME:()' \
   '--experimental-features[set experimental Nix features]:VALUE:()' \
   '--extra-experimental-features:[append to experimental Nix features]:VALUE:()' \
+  '--reference-lock-file[flake.lock path]:VALUE:()' \
   '1: :->cmds' \
   '*:: :->args' && ret=0
 
@@ -70,6 +71,7 @@ case "$state" in
           '--override-input[override flake input]:NAME VALUE:()' \
           '--update-input[update flake input]:NAME:()' \
           '--experimental-features[set experimental Nix features]:VALUE:()' \
+          '--reference-lock-file[flake.lock path]:VALUE:()' \
           '--extra-experimental-features:[append to experimental Nix features]:VALUE:()'
         ;;
       init)

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -1003,6 +1003,11 @@ while [[ $# -gt 0 ]]; do
             PASSTHROUGH_OPTS+=("$opt" "$1")
             shift
             ;;
+        --reference-lock-file)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
+            PASSTHROUGH_OPTS+=("$opt" "$1")
+            shift
+            ;;
         --extra-experimental-features)
             [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             PASSTHROUGH_OPTS+=("$opt" "$1")


### PR DESCRIPTION
### Description
I needed to use a different folder for the flake.lock, this is supported by nix but was not supported by home-manager

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
