### PR TITLE
firefox: update extensions option description

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -683,6 +683,11 @@ in {
 
                 Note that it is necessary to manually enable these extensions
                 inside Firefox after the first installation.
+
+                To automatically enable extensions add
+                `"extensions.autoDisableScopes" = 0;`
+                to
+                [{option}`programs.firefox.profiles.<profile>.settings`](#opt-programs.firefox.profiles._name_.settings)
               '';
             };
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

The "extensions.autoDisableScopes" option defaults to 15, which disables nearly all extensions, see https://kb.mozillazine.org/About:config_entries#Extensions.

What I think would be preferable would be to have "extensions.autoDisableScopes" = 0; set as a default in settings. I don't know the best way to do that, [and it may cause problems for some](https://bugzilla.mozilla.org/show_bug.cgi?id=666437)?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

    - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 
