### PR TITLE
Set module class to `"homeManager"`

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -55,7 +55,11 @@ let
   hmPath = toString ./..;
 
   buildOptionsDocs = args@{ modules, includeModuleSystemOptions ? true, ... }:
-    let options = (lib.evalModules { inherit modules; }).options;
+    let
+      options = (lib.evalModules {
+        inherit modules;
+        class = "homeManager";
+      }).options;
     in pkgs.buildPackages.nixosOptionsDoc ({
       options = if includeModuleSystemOptions then
         options
@@ -160,6 +164,7 @@ in {
         inherit lib pkgs;
         check = false;
       } ++ [ scrubbedPkgsModule ];
+      class = "homeManager";
     };
   in builtins.toJSON result.config.meta.maintainers);
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -26,6 +26,7 @@ let
   rawModule = extendedLib.evalModules {
     modules = [ configuration ] ++ hmModules;
     specialArgs = { modulesPath = builtins.toString ./.; } // extraSpecialArgs;
+    class = "homeManager";
   };
 
   moduleChecks = raw:

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -13,6 +13,7 @@ let
 
   hmModule = types.submoduleWith {
     description = "Home Manager module";
+    class = "homeManager";
     specialArgs = {
       lib = extendedLib;
       osConfig = config;


### PR DESCRIPTION
### Motivation

Enable a basic type check for module imports, so that a simple error appears when e.g. a NixOS module is loaded into Home Manager.

While currently almost no modules are "typed" like this yet, this will increase to a non-zero fraction, so supporting this feature will be beneficial.

It is important for applications (including Home Manager) to initiate this improvement, by choosing a name for `class`, as we can not expect others to guess the name and hope for the best.

### Description

This enables a module system feature documented here: https://nixos.org/manual/nixpkgs/stable/index.html#module-system-lib-evalModules-param-class

For example, it allows a mistake to be caught, which is loading a NixOS module into home-manager. This only works when the offending module declares what it's for with a `_class` attribute.

It is not expected that users declare the `_type`, because the payoff is small. It is only expected to be set by generic code, such as functions or libraries that help with the "publishing" of modules (e.g. flake-parts, flake-utils).

The class feature has been available in the module system since https://github.com/NixOS/nixpkgs/pull/197547, merged May 6, 2023. It has been part of all releases since 23.05-beta. The last NixOS release that did _not_ support it has been end-of-life for close to a year now.

Example:

```nix
(lib.homeManagerConfiguration {
  pkgs = nixpkgs.legacyPackages.x86_64-linux;
  modules = [{ _class = "nixos"; imports = [ ./foo.nix ]; }];
}).activation-script
```

Corresponding error:

    error: The module <unknown-file> was imported into homeManager instead of nixos.

(`<unknown-file>` can be improved by also setting `_file`, if known;
 a much older feature)


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.
  - Down to Nixpkgs `lib` 23.05.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
  - You've made me `grep -v OK`. Would appreciate a summary of the test result at the end.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  - Yes, assuming your entrypoint (`homeManagerConfiguration` or `modules/default.nix`) is tested.
  - The class feature itself is tested upstream and it's a simple feature, for which I (personally) would not require a test.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - N/A Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
