### PR TITLE
git: sendemail: add realName to From field

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -392,7 +392,7 @@ in {
           nameValuePair "sendemail.${name}" (if account.msmtp.enable then {
             smtpServer = "${pkgs.msmtp}/bin/msmtp";
             envelopeSender = "auto";
-            from = address;
+            from = "${realName} <${address}>";
           } else
             {
               smtpEncryption = if smtp.tls.enable then
@@ -407,7 +407,7 @@ in {
                 mkIf smtp.tls.enable (toString smtp.tls.certificatesFile);
               smtpServer = smtp.host;
               smtpUser = userName;
-              from = address;
+              from = "${realName} <${address}>";
             } // optionalAttrs (smtp.port != null) {
               smtpServerPort = smtp.port;
             });

--- a/tests/modules/programs/git/git-with-email-expected.conf
+++ b/tests/modules/programs/git/git-with-email-expected.conf
@@ -1,12 +1,12 @@
 [sendemail "hm-account"]
-	from = "hm@example.org"
+	from = "H. M. Test Jr. <hm@example.org>"
 	smtpEncryption = "tls"
 	smtpServer = "smtp.example.org"
 	smtpSslCertPath = "/etc/test/certificates.crt"
 	smtpUser = "home.manager.jr"
 
 [sendemail "hm@example.com"]
-	from = "hm@example.com"
+	from = "H. M. Test <hm@example.com>"
 	smtpEncryption = "ssl"
 	smtpServer = "smtp.example.com"
 	smtpSslCertPath = "/etc/ssl/certs/ca-certificates.crt"

--- a/tests/modules/programs/git/git-with-email.nix
+++ b/tests/modules/programs/git/git-with-email.nix
@@ -33,8 +33,8 @@ with lib;
         ./git-with-email-expected.conf
       }
 
-      assertGitConfig "sendemail.hm@example.com.from" "hm@example.com"
-      assertGitConfig "sendemail.hm-account.from" "hm@example.org"
+      assertGitConfig "sendemail.hm@example.com.from" "H. M. Test <hm@example.com>"
+      assertGitConfig "sendemail.hm-account.from" "H. M. Test Jr. <hm@example.org>"
     '';
   };
 }

--- a/tests/modules/programs/git/git-with-msmtp-expected.conf
+++ b/tests/modules/programs/git/git-with-msmtp-expected.conf
@@ -1,5 +1,5 @@
 [sendemail "hm-account"]
-	from = "hm@example.org"
+	from = "H. M. Test Jr. <hm@example.org>"
 	smtpEncryption = "tls"
 	smtpServer = "smtp.example.org"
 	smtpSslCertPath = "/etc/ssl/certs/ca-certificates.crt"
@@ -7,7 +7,7 @@
 
 [sendemail "hm@example.com"]
 	envelopeSender = "auto"
-	from = "hm@example.com"
+	from = "H. M. Test <hm@example.com>"
 	smtpServer = "@msmtp@/bin/msmtp"
 
 [user]

--- a/tests/modules/programs/git/git-with-msmtp.nix
+++ b/tests/modules/programs/git/git-with-msmtp.nix
@@ -7,6 +7,7 @@ with lib;
 
   config = {
     accounts.email.accounts."hm@example.com".msmtp.enable = true;
+
     programs.git = {
       enable = true;
       package = pkgs.gitMinimal;
@@ -33,8 +34,8 @@ with lib;
       assertFileContent home-files/.config/git/config \
         ${./git-with-msmtp-expected.conf}
 
-      assertGitConfig "sendemail.hm@example.com.from" "hm@example.com"
-      assertGitConfig "sendemail.hm-account.from" "hm@example.org"
+      assertGitConfig "sendemail.hm@example.com.from" "H. M. Test <hm@example.com>"
+      assertGitConfig "sendemail.hm-account.from" "H. M. Test Jr. <hm@example.org>"
       assertGitConfig "sendemail.hm@example.com.smtpServer" "${pkgs.msmtp}/bin/msmtp"
       assertGitConfig "sendemail.hm@example.com.envelopeSender" "auto"
     '';


### PR DESCRIPTION
### Description

We currently have no way of specifying the sender's name inside the `From` field, making a patch sent through `git send-email` appear as coming from "xxx@domain.com".

In this commit we make this field follow the standard `realName <email>` format whenever applicable.


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee