### PR TITLE
lib/generators.nix: init toHyprconf generator

### DIFF
--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -1,6 +1,49 @@
 { lib }:
 
 {
+  toHyprconf = { attrs, indentLevel ? 0, importantPrefixes ? [ "$" ], }:
+    let
+      inherit (lib)
+        all concatMapStringsSep concatStrings concatStringsSep filterAttrs foldl
+        generators hasPrefix isAttrs isList mapAttrsToList replicate;
+
+      initialIndent = concatStrings (replicate indentLevel "  ");
+
+      toHyprconf' = indent: attrs:
+        let
+          sections =
+            filterAttrs (n: v: isAttrs v || (isList v && all isAttrs v)) attrs;
+
+          mkSection = n: attrs:
+            if lib.isList attrs then
+              (concatMapStringsSep "\n" (a: mkSection n a) attrs)
+            else ''
+              ${indent}${n} {
+              ${toHyprconf' "  ${indent}" attrs}${indent}}
+            '';
+
+          mkFields = generators.toKeyValue {
+            listsAsDuplicateKeys = true;
+            inherit indent;
+          };
+
+          allFields =
+            filterAttrs (n: v: !(isAttrs v || (isList v && all isAttrs v)))
+            attrs;
+
+          isImportantField = n: _:
+            foldl (acc: prev: if hasPrefix prev n then true else acc) false
+            importantPrefixes;
+
+          importantFields = filterAttrs isImportantField allFields;
+
+          fields = builtins.removeAttrs allFields
+            (mapAttrsToList (n: _: n) importantFields);
+        in mkFields importantFields
+        + concatStringsSep "\n" (mapAttrsToList mkSection sections)
+        + mkFields fields;
+    in toHyprconf' initialIndent attrs;
+
   toKDL = { }:
     let
       inherit (lib) concatStringsSep splitString mapAttrsToList any;

--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -9,7 +9,6 @@ let
   systemdActivation = ''
     exec-once = ${pkgs.dbus}/bin/dbus-update-activation-environment --systemd ${variables} ${extraCommands}
   '';
-
 in {
   meta.maintainers = [ lib.maintainers.fufexan ];
 
@@ -178,6 +177,16 @@ in {
     '' // {
       default = true;
     };
+
+    importantPrefixes = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ "$" "bezier" "name" ]
+        ++ lib.optionals cfg.sourceFirst [ "source" ];
+      example = [ "$" "bezier" ];
+      description = ''
+        List of prefix of attributes to source at the top of the config.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -199,65 +208,28 @@ in {
       shouldGenerate = cfg.systemd.enable || cfg.extraConfig != ""
         || cfg.settings != { } || cfg.plugins != [ ];
 
-      toHyprconf = with lib;
-        attrs: indentLevel:
-        let
-          indent = concatStrings (replicate indentLevel "  ");
-
-          sections = filterAttrs (n: v: isAttrs v && n != "device") attrs;
-
-          mkSection = n: attrs: ''
-            ${indent}${n} {
-            ${toHyprconf attrs (indentLevel + 1)}${indent}}
-          '';
-
-          mkDeviceCategory = device: ''
-            ${indent}device {
-              name=${device.name}
-            ${
-              toHyprconf (filterAttrs (n: _: "name" != n) device)
-              (indentLevel + 1)
-            }${indent}}
-          '';
-
-          deviceCategory = lib.optionalString (hasAttr "device" attrs)
-            (if isList attrs.device then
-              (concatMapStringsSep "\n" (d: mkDeviceCategory d) attrs.device)
-            else
-              mkDeviceCategory attrs.device);
-
-          mkFields = generators.toKeyValue {
-            listsAsDuplicateKeys = true;
-            inherit indent;
-          };
-          allFields = filterAttrs (n: v: !(isAttrs v) && n != "device") attrs;
-
-          importantFields = filterAttrs (n: _:
-            (hasPrefix "$" n) || (hasPrefix "bezier" n)
-            || (cfg.sourceFirst && (hasPrefix "source" n))) allFields;
-
-          fields = builtins.removeAttrs allFields
-            (mapAttrsToList (n: _: n) importantFields);
-        in mkFields importantFields + deviceCategory
-        + concatStringsSep "\n" (mapAttrsToList mkSection sections)
-        + mkFields fields;
-
       pluginsToHyprconf = plugins:
-        toHyprconf {
-          plugin = let
-            mkEntry = entry:
-              if lib.types.package.check entry then
-                "${entry}/lib/lib${entry.pname}.so"
-              else
-                entry;
-          in map mkEntry cfg.plugins;
-        } 0;
+        lib.hm.generators.toHyprconf {
+          attrs = {
+            plugin = let
+              mkEntry = entry:
+                if lib.types.package.check entry then
+                  "${entry}/lib/lib${entry.pname}.so"
+                else
+                  entry;
+            in map mkEntry cfg.plugins;
+          };
+          inherit (cfg) importantPrefixes;
+        };
     in lib.mkIf shouldGenerate {
       text = lib.optionalString cfg.systemd.enable systemdActivation
         + lib.optionalString (cfg.plugins != [ ])
         (pluginsToHyprconf cfg.plugins)
-        + lib.optionalString (cfg.settings != { }) (toHyprconf cfg.settings 0)
-        + lib.optionalString (cfg.extraConfig != "") cfg.extraConfig;
+        + lib.optionalString (cfg.settings != { })
+        (lib.hm.generators.toHyprconf {
+          attrs = cfg.settings;
+          inherit (cfg) importantPrefixes;
+        }) + lib.optionalString (cfg.extraConfig != "") cfg.extraConfig;
 
       onChange = lib.mkIf (cfg.package != null) ''
         ( # Execute in subshell so we don't poision environment with vars

--- a/tests/modules/services/window-managers/hyprland/default.nix
+++ b/tests/modules/services/window-managers/hyprland/default.nix
@@ -1,4 +1,6 @@
 {
   hyprland-simple-config = ./simple-config.nix;
+  hyprland-multiple-devices-config = ./multiple-devices-config.nix;
+  hyprland-sourceFirst-false-config = ./sourceFirst-false-config.nix;
   hyprland-inconsistent-config = ./inconsistent-config.nix;
 }

--- a/tests/modules/services/window-managers/hyprland/multiple-devices-config.conf
+++ b/tests/modules/services/window-managers/hyprland/multiple-devices-config.conf
@@ -23,6 +23,11 @@ device {
   enable=true
 }
 
+device {
+  name=some:device-secondary
+  enable=true
+}
+
 input {
   touchpad {
     scroll_factor=0.300000

--- a/tests/modules/services/window-managers/hyprland/multiple-devices-config.nix
+++ b/tests/modules/services/window-managers/hyprland/multiple-devices-config.nix
@@ -1,0 +1,88 @@
+{ config, lib, ... }:
+
+{
+  wayland.windowManager.hyprland = {
+    enable = true;
+    package = lib.makeOverridable
+      (attrs: config.lib.test.mkStubPackage { name = "hyprland"; }) { };
+    plugins =
+      [ "/path/to/plugin1" (config.lib.test.mkStubPackage { name = "foo"; }) ];
+    settings = {
+      source = [ "sourced.conf" ];
+
+      decoration = {
+        shadow_offset = "0 5";
+        "col.shadow" = "rgba(00000099)";
+      };
+
+      "$mod" = "SUPER";
+
+      animations = {
+        enabled = true;
+        animation = [
+          "border, 1, 2, smoothIn"
+          "fade, 1, 4, smoothOut"
+          "windows, 1, 3, overshot, popin 80%"
+        ];
+      };
+
+      bezier = [
+        "smoothOut, 0.36, 0, 0.66, -0.56"
+        "smoothIn, 0.25, 1, 0.5, 1"
+        "overshot, 0.4,0.8,0.2,1.2"
+      ];
+
+      input = {
+        kb_layout = "ro";
+        follow_mouse = 1;
+        accel_profile = "flat";
+        touchpad = { scroll_factor = 0.3; };
+      };
+
+      bindm = [
+        # mouse movements
+        "$mod, mouse:272, movewindow"
+        "$mod, mouse:273, resizewindow"
+        "$mod ALT, mouse:272, resizewindow"
+      ];
+
+      device = [
+        {
+          name = "some:device";
+          enable = true;
+        }
+        {
+          name = "some:device-secondary";
+          enable = true;
+        }
+      ];
+
+      plugin = {
+        plugin1 = {
+          dummy = "plugin setting";
+          section = { other = "dummy setting"; };
+        };
+      };
+    };
+    extraConfig = ''
+      # window resize
+      bind = $mod, S, submap, resize
+
+      submap = resize
+      binde = , right, resizeactive, 10 0
+      binde = , left, resizeactive, -10 0
+      binde = , up, resizeactive, 0 -10
+      binde = , down, resizeactive, 0 10
+      bind = , escape, submap, reset
+      submap = reset
+    '';
+  };
+
+  nmt.script = ''
+    config=home-files/.config/hypr/hyprland.conf
+    assertFileExists "$config"
+
+    normalizedConfig=$(normalizeStorePaths "$config")
+    assertFileContent "$normalizedConfig" ${./multiple-devices-config.conf}
+  '';
+}

--- a/tests/modules/services/window-managers/hyprland/sourceFirst-false-config.conf
+++ b/tests/modules/services/window-managers/hyprland/sourceFirst-false-config.conf
@@ -1,0 +1,13 @@
+exec-once = /nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
+bezier=smoothOut, 0.36, 0, 0.66, -0.56
+bezier=smoothIn, 0.25, 1, 0.5, 1
+bezier=overshot, 0.4,0.8,0.2,1.2
+input {
+  touchpad {
+    scroll_factor=0.300000
+  }
+  accel_profile=flat
+  follow_mouse=1
+  kb_layout=ro
+}
+source=sourced.conf

--- a/tests/modules/services/window-managers/hyprland/sourceFirst-false-config.nix
+++ b/tests/modules/services/window-managers/hyprland/sourceFirst-false-config.nix
@@ -1,0 +1,34 @@
+{ config, lib, ... }:
+
+{
+  wayland.windowManager.hyprland = {
+    enable = true;
+    package = lib.makeOverridable
+      (attrs: config.lib.test.mkStubPackage { name = "hyprland"; }) { };
+    settings = {
+      source = [ "sourced.conf" ];
+
+      bezier = [
+        "smoothOut, 0.36, 0, 0.66, -0.56"
+        "smoothIn, 0.25, 1, 0.5, 1"
+        "overshot, 0.4,0.8,0.2,1.2"
+      ];
+
+      input = {
+        kb_layout = "ro";
+        follow_mouse = 1;
+        accel_profile = "flat";
+        touchpad = { scroll_factor = 0.3; };
+      };
+    };
+    sourceFirst = false;
+  };
+
+  nmt.script = ''
+    config=home-files/.config/hypr/hyprland.conf
+    assertFileExists "$config"
+
+    normalizedConfig=$(normalizeStorePaths "$config")
+    assertFileContent "$normalizedConfig" ${./sourceFirst-false-config.conf}
+  '';
+}


### PR DESCRIPTION
### Description
Creating a library module to be used amongst the various hypr ecosystem modules. In response to https://github.com/nix-community/home-manager/pull/5324#issuecomment-2080203195. I had to refactor the function when moving to a separate module so I created a test to verify that it didn't break anything. 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@fufexan 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
