### PR TITLE
thefuck: add nushell integration

### DIFF
--- a/modules/programs/thefuck.nix
+++ b/modules/programs/thefuck.nix
@@ -32,6 +32,14 @@ with lib;
         Whether to enable Zsh integration.
       '';
     };
+
+    enableNushellIntegration = mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        Whether to enable Nushell integration.
+      '';
+    };
   };
 
   config = let
@@ -66,5 +74,11 @@ with lib;
     };
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration shEvalCmd;
+
+    programs.nushell = mkIf cfg.enableNushellIntegration {
+      extraConfig = ''
+        alias fuck = ${cfg.package}/bin/thefuck $"(history | last 1 | get command | get 0)"
+      '';
+    };
   };
 }

--- a/tests/modules/programs/thefuck/integration-disabled.nix
+++ b/tests/modules/programs/thefuck/integration-disabled.nix
@@ -6,8 +6,10 @@
     thefuck.enableBashIntegration = false;
     thefuck.enableFishIntegration = false;
     thefuck.enableZshIntegration = false;
+    thefuck.enableNushellIntegration = false;
     bash.enable = true;
     zsh.enable = true;
+    nushell.enable = true;
   };
 
   test.stubs.thefuck = { };
@@ -16,5 +18,6 @@
     assertFileNotRegex home-files/.bashrc '@thefuck@/bin/thefuck'
     assertPathNotExists home-files/.config/fish/functions/fuck.fish
     assertFileNotRegex home-files/.zshrc '@thefuck@/bin/thefuck'
+    assertFileNotRegex home-files/.config/nushell/config.nu '@thefuck@/bin/thefuck'
   '';
 }

--- a/tests/modules/programs/thefuck/integration-enabled.nix
+++ b/tests/modules/programs/thefuck/integration-enabled.nix
@@ -6,6 +6,7 @@
     bash.enable = true;
     fish.enable = true;
     zsh.enable = true;
+    nushell.enable = true;
   };
 
   test.stubs.thefuck = { };
@@ -33,5 +34,10 @@
     assertFileContains \
       home-files/.zshrc \
       'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"')"'
+
+    assertFileExists home-files/.config/nushell/config.nu
+    assertFileContains \
+      home-files/.config/nushell/config.nu \
+      'alias fuck = @thefuck@/bin/thefuck $"(history | last 1 | get command | get 0)"'
   '';
 }


### PR DESCRIPTION
### Description

Add `nushell` integration to `thefuck`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@ilaumjd 