### PR TITLE
Hyprpaper: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1629,6 +1629,19 @@ in {
           locking utility. See https://github.com/hyprwm/hyprlock for more.
         '';
       }
+
+      {
+        time = "2024-05-10T13:35:19+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.hyprpaper'.
+
+          Hyprpaper is a blazing fast wallpaper utility for Hyprland with the
+          ability to dynamically change wallpapers through sockets. It will work
+          on all wlroots-based compositors, though. See
+          https://github.com/hyprwm/hyprpaper for more.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -306,6 +306,7 @@ let
     ./services/home-manager-auto-upgrade.nix
     ./services/hound.nix
     ./services/hypridle.nix
+    ./services/hyprpaper.nix
     ./services/imapnotify.nix
     ./services/kanshi.nix
     ./services/kbfs.nix

--- a/modules/services/hyprpaper.nix
+++ b/modules/services/hyprpaper.nix
@@ -1,0 +1,89 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+
+  cfg = config.services.hyprpaper;
+in {
+  meta.maintainers = [ maintainers.khaneliman maintainers.fufexan ];
+
+  options.services.hyprpaper = {
+    enable = mkEnableOption "Hyprpaper, Hyprland's wallpaper daemon";
+
+    package = mkPackageOption pkgs "hyprpaper" { };
+
+    settings = lib.mkOption {
+      type = with lib.types;
+        let
+          valueType = nullOr (oneOf [
+            bool
+            int
+            float
+            str
+            path
+            (attrsOf valueType)
+            (listOf valueType)
+          ]) // {
+            description = "Hyprpaper configuration value";
+          };
+        in valueType;
+      default = { };
+      description = ''
+        hyprpaper configuration written in Nix. Entries with the same key
+        should be written as lists. Variables' and colors' names should be
+        quoted. See <https://wiki.hyprland.org/Hypr-Ecosystem/hyprpaper/> for more examples.
+      '';
+      example = lib.literalExpression ''
+        {
+          ipc = "on";
+          splash = false;
+          splash_offset = 2.0;
+
+          preload =
+            [ "/share/wallpapers/buttons.png" "/share/wallpapers/cat_pacman.png" ];
+
+          wallpaper = [
+            "DP-3,/share/wallpapers/buttons.png"
+            "DP-1,/share/wallpapers/cat_pacman.png"
+          ];
+        }
+      '';
+    };
+
+    importantPrefixes = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ "$" ];
+      example = [ "$" ];
+      description = ''
+        List of prefix of attributes to source at the top of the config.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    xdg.configFile."hypr/hyprpaper.conf" = mkIf (cfg.settings != { }) {
+      text = lib.hm.generators.toHyprconf {
+        attrs = cfg.settings;
+        inherit (cfg) importantPrefixes;
+      };
+    };
+
+    systemd.user.services.hyprpaper = {
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+
+      Unit = {
+        ConditionEnvironment = "WAYLAND_DISPLAY";
+        Description = "hyprpaper";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+        X-Restart-Triggers =
+          [ "${config.xdg.configFile."hypr/hyprpaper.conf".source}" ];
+      };
+
+      Service = {
+        ExecStart = "${getExe cfg.package}";
+        Restart = "always";
+        RestartSec = "10";
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -243,6 +243,7 @@ in import nmtSrc {
     ./modules/services/gromit-mpx
     ./modules/services/home-manager-auto-upgrade
     ./modules/services/hypridle
+    ./modules/services/hyprpaper
     ./modules/services/imapnotify
     ./modules/services/kanshi
     ./modules/services/lieer

--- a/tests/modules/services/hyprpaper/basic-configuration.nix
+++ b/tests/modules/services/hyprpaper/basic-configuration.nix
@@ -1,0 +1,30 @@
+{ pkgs, ... }:
+
+{
+  services.hyprpaper = {
+    enable = true;
+    settings = {
+      ipc = "on";
+      splash = false;
+      splash_offset = 2.0;
+
+      preload =
+        [ "/share/wallpapers/buttons.png" "/share/wallpapers/cat_pacman.png" ];
+
+      wallpaper = [
+        "DP-3,/share/wallpapers/buttons.png"
+        "DP-1,/share/wallpapers/cat_pacman.png"
+      ];
+    };
+  };
+
+  test.stubs.hyprpaper = { };
+
+  nmt.script = ''
+    config=home-files/.config/hypr/hyprpaper.conf
+    clientServiceFile=home-files/.config/systemd/user/hyprpaper.service
+    assertFileExists $config
+    assertFileExists $clientServiceFile
+    assertFileContent $config ${./hyprpaper.conf}
+  '';
+}

--- a/tests/modules/services/hyprpaper/default.nix
+++ b/tests/modules/services/hyprpaper/default.nix
@@ -1,0 +1,1 @@
+{ hyprpaper-basic-configuration = ./basic-configuration.nix; }

--- a/tests/modules/services/hyprpaper/hyprpaper.conf
+++ b/tests/modules/services/hyprpaper/hyprpaper.conf
@@ -1,0 +1,7 @@
+ipc=on
+preload=/share/wallpapers/buttons.png
+preload=/share/wallpapers/cat_pacman.png
+splash=false
+splash_offset=2.000000
+wallpaper=DP-3,/share/wallpapers/buttons.png
+wallpaper=DP-1,/share/wallpapers/cat_pacman.png


### PR DESCRIPTION
### Description
Adding the hyprpaper module, similar to https://github.com/nix-community/home-manager/pull/5324

Looked like https://github.com/nix-community/home-manager/pull/5059 was abandoned so I created this along the same lines as the other hypr modules i'm setting up. 

Closes #5059
Closes #4632

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@fufexan 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
