### PR TITLE
cliphist: option to include images in clipboard history

### DIFF
--- a/modules/services/cliphist.nix
+++ b/modules/services/cliphist.nix
@@ -9,6 +9,14 @@ in {
 
     package = lib.mkPackageOption pkgs "cliphist" { };
 
+    allowImages = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Store images in clipboard history.
+      '';
+    };
+
     systemdTarget = lib.mkOption {
       type = lib.types.str;
       default = "graphical-session.target";
@@ -41,6 +49,22 @@ in {
         Type = "simple";
         ExecStart =
           "${pkgs.wl-clipboard}/bin/wl-paste --watch ${cfg.package}/bin/cliphist store";
+        Restart = "on-failure";
+      };
+
+      Install = { WantedBy = [ cfg.systemdTarget ]; };
+    };
+
+    systemd.user.services.cliphist-images = lib.mkIf cfg.allowImages {
+      Unit = {
+        Description = "Clipboard management daemon - images";
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        Type = "simple";
+        ExecStart =
+          "${pkgs.wl-clipboard}/bin/wl-paste --type image --watch ${cfg.package}/bin/cliphist store";
         Restart = "on-failure";
       };
 


### PR DESCRIPTION
### Description

Adds an option to also store images in cliphist's store. This requires creating another systemd service which watches wl-paste with dedicated change type.

I didn't find in any explicit requirement about this in cliphist, however it did solve the issue for me. Also this is the way presented in hyprland docs and accepted solution in this issue https://github.com/sentriz/cliphist/issues/28

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Janik-Haag 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
