### PR TITLE
psd: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -55,6 +55,12 @@
     github = "cvoges12";
     githubId = 38054771;
   };
+  danjujan = {
+    name = "Jan Schmitz";
+    email = "44864658+danjujan@users.noreply.github.com";
+    github = "danjujan";
+    githubId = 44864658;
+  };
   d-dervishi = {
     email = "david.dervishi@epfl.ch";
     github = "d-dervishi";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1537,6 +1537,18 @@ in {
           for more.
         '';
       }
+
+      {
+        time = "2024-04-28T18:30:24+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.psd'.
+
+          Profile-sync-daemon (psd) is a tiny pseudo-daemon designed to manage
+          your browser's profile in tmpfs and to periodically sync it back
+          to your physical disc (HDD/SSD).
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -337,6 +337,7 @@ let
     ./services/plex-mpv-shim.nix
     ./services/polybar.nix
     ./services/poweralertd.nix
+    ./services/psd.nix
     ./services/pueue.nix
     ./services/pulseeffects.nix
     ./services/random-background.nix

--- a/modules/services/psd.nix
+++ b/modules/services/psd.nix
@@ -1,0 +1,105 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.psd;
+
+in {
+  meta.maintainers = [ maintainers.danjujan ];
+
+  options.services.psd = {
+    enable = mkEnableOption "Profile-sync-daemon service";
+    resyncTimer = mkOption {
+      type = types.str;
+      default = "1h";
+      example = "1h 30min";
+      description = ''
+        The amount of time to wait before syncing browser profiles back to the
+        disk.
+
+        Takes a systemd.unit time span. The time unit defaults to seconds if
+        omitted.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.psd" pkgs lib.platforms.linux)
+    ];
+
+    home.packages = [ pkgs.profile-sync-daemon ];
+
+    systemd.user = {
+      services = {
+        psd = {
+          Unit = {
+            Description = "Profile-sync-daemon";
+            Wants = [ "psd-resync.service" ];
+            RequiresMountsFor = [ "/home/" ];
+            After = "winbindd.service";
+          };
+          Service = {
+            Type = "oneshot";
+            RemainAfterExit = "yes";
+            ExecStart =
+              "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon startup";
+            ExecStop =
+              "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon unsync";
+            Environment = [
+              "LAUNCHED_BY_SYSTEMD=1"
+              "PATH=$PATH:${
+                lib.makeBinPath (with pkgs; [
+                  rsync
+                  kmod
+                  gawk
+                  nettools
+                  util-linux
+                  profile-sync-daemon
+                ])
+              }"
+            ];
+          };
+          Install = { WantedBy = [ "default.target" ]; };
+        };
+
+        psd-resync = {
+          Unit = {
+            Description = "Timed profile resync";
+            After = [ "psd.service" ];
+            Wants = [ "psd-resync.timer" ];
+            PartOf = [ "psd.service" ];
+          };
+          Service = {
+            Type = "oneshot";
+            ExecStart =
+              "${pkgs.profile-sync-daemon}/bin/profile-sync-daemon resync";
+            Environment = [
+              "PATH=$PATH:${
+                lib.makeBinPath (with pkgs; [
+                  rsync
+                  kmod
+                  gawk
+                  nettools
+                  util-linux
+                  profile-sync-daemon
+                ])
+              }"
+            ];
+          };
+          Install = { WantedBy = [ "default.target" ]; };
+        };
+      };
+
+      timers.psd-resync = {
+        Unit = {
+          Description = "Timer for Profile-sync-daemon";
+          PartOf = [ "psd-resync.service" "psd.service" ];
+        };
+        Timer = { OnUnitActiveSec = "${cfg.resyncTimer}"; };
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Description

Add [Profile-sync-daemon](https://github.com/graysky2/profile-sync-daemon) module similar to https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/desktops/profile-sync-daemon.nix

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
