### PR TITLE
mpv: add extraInput option

### DIFF
--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -176,6 +176,20 @@ in {
           }
         '';
       };
+
+      extraInput = mkOption {
+        description = ''
+          Additional lines that are appended to {file}`$XDG_CONFIG_HOME/mpv/input.conf`.
+           See {manpage}`mpv(1)` for the full list of options.
+        '';
+        type = with types; lines;
+        default = "";
+        example = ''
+          esc         quit                        #! Quit
+          #           script-binding uosc/video   #! Video tracks
+          # additional comments
+        '';
+      };
     };
   };
 
@@ -199,8 +213,11 @@ in {
         ${optionalString (cfg.profiles != { }) (renderProfiles cfg.profiles)}
       '';
     })
-    (mkIf (cfg.bindings != { }) {
-      xdg.configFile."mpv/input.conf".text = renderBindings cfg.bindings;
+    (mkIf (cfg.bindings != { } || cfg.extraInput != "") {
+      xdg.configFile."mpv/input.conf".text = mkMerge [
+        (mkIf (cfg.bindings != { }) (renderBindings cfg.bindings))
+        (mkIf (cfg.extraInput != "") cfg.extraInput)
+      ];
     })
     {
       xdg.configFile = mapAttrs' (name: value:

--- a/tests/modules/programs/mpv/mpv-example-settings-expected-bindings
+++ b/tests/modules/programs/mpv/mpv-example-settings-expected-bindings
@@ -1,3 +1,4 @@
 Alt+0 set window-scale 0.5
 WHEEL_DOWN seek -10
 WHEEL_UP seek 10
+#           script-binding uosc/video                   #! Video tracks

--- a/tests/modules/programs/mpv/mpv-example-settings.nix
+++ b/tests/modules/programs/mpv/mpv-example-settings.nix
@@ -12,6 +12,10 @@
       "Alt+0" = "set window-scale 0.5";
     };
 
+    extraInput = ''
+      #           script-binding uosc/video                   #! Video tracks
+    '';
+
     config = {
       force-window = true;
       ytdl-format = "bestvideo+bestaudio";


### PR DESCRIPTION
### Description

Adds an option `programs.mpv.extraInput` for appending additional lines to `$XDG_CONFIG_DIR/mpv/input.conf`.

One use case for this is adding menu entries in uosc (an alternative osc). Especially when not assigned to a key. See https://github.com/tomasklaen/uosc?tab=readme-ov-file#menu-1.

Closes #5212.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@tadeokondrak @thiagokokada @chuangzhu 
