### PR TITLE
files: adjust error message in checkLinkTargets activation script

### DIFF
--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -48,6 +48,12 @@ for sourcePath in "$@" ; do
 done
 
 if [[ -v collision ]] ; then
-  errorEcho "Please move the above files and try again or use 'home-manager switch -b backup' to back up existing files automatically."
+  errorEcho "Please do one of the following:
+- Move or remove the above files and try again.
+- In standalone mode, use 'home-manager switch -b backup' to back up
+  files automatically.
+- When used as a NixOS or nix-darwin module, set
+    'home-manager.backupFileExtension'
+  to, for example, 'backup' and rebuild."
   exit 1
 fi


### PR DESCRIPTION
### Description

The checkLinkTarget activation script currently prints an error message that is misleading when home-manager is used as an NixOS module. I.e., it suggests moving files or using `home-manager switch -b backup`.

Closes #5350

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 
