### PR TITLE
init: nixgl module

### DIFF
--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -59,5 +59,6 @@ usage/configuration.md
 usage/rollbacks.md
 usage/dotfiles.md
 usage/graphical.md
+usage/gpu-non-nixos.md
 usage/updating.md
 ```

--- a/docs/manual/usage/gpu-non-nixos.md
+++ b/docs/manual/usage/gpu-non-nixos.md
@@ -1,0 +1,70 @@
+# GPU on non-NixOS systems {#sec-usage-gpu-non-nixos}
+
+To access the GPU, programs need access to OpenGL and Vulkan libraries. While
+this works transparently on NixOS, it does not on other Linux systems. A
+solution is provided by [NixGL](https://github.com/nix-community/nixGL), which
+can be integrated into Home Manager.
+
+To enable the integration, import NixGL into your home configuration, either as
+a channel, or as a flake input passed via `extraSpecialArgs`. Then, set the
+`nixGL.packages` option to the package set provided by NixGL.
+
+Once integration is enabled, it can be used in two ways: as Nix functions for
+wrapping programs installed via Home Manager, and as shell commands for running
+programs installed by other means (such as `nix shell`). In either case, there
+are several wrappers available. They can be broadly categorized
+
+- by vendor: as Mesa (for Free drivers of all vendors) and Nvidia (for
+  Nvidia-specific proprietary drivers).
+- by GPU selection: as primary and secondary (offloading).
+
+For example, the `mesa` wrapper provides support for running programs on the
+primary GPU for Intel, AMD and Nouveau drivers, while the `mesaPrime` wrapper
+does the same for the secondary GPU.
+
+**Note:** when using Nvidia wrappers together with flakes, your home
+configuration will not be pure and needs to be built using `home-manager switch
+--impure`. Otherwise, the build will fail, complaining about missing attribute
+`currentTime`.
+
+Wrapper functions are available under `config.lib.nixGL.wrappers`. However, it
+can be more convenient to use the `config.lib.nixGL.wrap` alias, which can be
+configured to use any of the wrappers. It is intended to provide a customization
+point when the same home configuration is used across several machines with
+different hardware. There is also the `config.lib.nixGL.wrapOffload` alias for
+two-GPU systems.
+
+Another convenience is that all wrapper functions are always available. However,
+when `nixGL.packages` option is unset, they are no-ops. This allows them to be
+used even when the home configuration is used on NixOS machines. The exception
+is the `prime-offload` script which ignores `nixGL.packages` and is installed
+into the environment whenever `nixGL.prime.installScript` is set. This script,
+which can be used to start a program on a secondary GPU, does not depend on
+NixGL and is useful on NixOS systems as well.
+
+Below is an abbreviated example for an Optimus laptop that makes use of both
+Mesa and Nvidia wrappers, where the latter is used in dGPU offloading mode. It
+demonstrates how to wrap `mpv` to run on the integrated Intel GPU, wrap FreeCAD
+to run on the Nvidia dGPU, and how to install the wrapper scripts. It also wraps
+Xonotic to run on the dGPU, but uses the wrapper function directly for
+demonstration purposes.
+
+```nix
+{ config, lib, pkgs, nixGL, ... }:
+{
+  nixGL.packages = nixGL.packages;
+  nixGL.defaultWrapper = "mesa";
+  nixGL.offloadWrapper = "nvidiaPrime";
+  nixGL.installScripts = [ "mesa" "nvidiaPrime" ];
+
+  programs.mpv = {
+    enable = true;
+    package = config.lib.nixGL.wrap pkgs.mpv;
+  };
+
+  home.packages = [
+    (config.lib.nixGL.wrapOffload pkgs.freecad)
+    (config.lib.nixGL.wrappers.nvidiaPrime pkgs.xonotic)
+  ];
+}
+```

--- a/docs/manual/usage/gpu-non-nixos.md
+++ b/docs/manual/usage/gpu-non-nixos.md
@@ -50,9 +50,9 @@ Xonotic to run on the dGPU, but uses the wrapper function directly for
 demonstration purposes.
 
 ```nix
-{ config, lib, pkgs, nixGL, ... }:
+{ config, lib, pkgs, nixgl, ... }:
 {
-  nixGL.packages = nixGL.packages;
+  nixGL.packages = nixgl.packages;
   nixGL.defaultWrapper = "mesa";
   nixGL.offloadWrapper = "nvidiaPrime";
   nixGL.installScripts = [ "mesa" "nvidiaPrime" ];
@@ -67,4 +67,15 @@ demonstration purposes.
     (config.lib.nixGL.wrappers.nvidiaPrime pkgs.xonotic)
   ];
 }
+```
+
+The above example assumes a flake-based setup where `nixgl` was passed from the
+flake. When using channels, the example would instead begin with
+
+```nix
+{ config, lib, pkgs, ... }:
+{
+  nixGL.packages = import <nixgl> { inherit pkgs; };
+  # The rest is the same as above
+  ...
 ```

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1801,6 +1801,18 @@ in {
           itself.
         '';
       }
+
+      {
+        time = "2024-10-25T08:18:30+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'nixGL'.
+
+          NixGL solve the "OpenGL" problem with nix. The 'nixGL' module provides
+          integration of NixGL into Home Manager. See the "GPU on non-NixOS
+          systems" section in the Home Manager mantual for more.
+        '';
+      }
     ];
   };
 }

--- a/modules/misc/nixgl.nix
+++ b/modules/misc/nixgl.nix
@@ -1,0 +1,64 @@
+{ config, lib, pkgs, ... }:
+
+let cfg = config.nixGL;
+in {
+  meta.maintainers = [ lib.maintainers.smona ];
+
+  options.nixGL.prefix = lib.mkOption {
+    type = lib.types.str;
+    default = "";
+    example = lib.literalExpression
+      ''"''${inputs.nixGL.packages.x86_64-linux.nixGLIntel}/bin/nixGLIntel"'';
+    description = ''
+      The nixGL command that `lib.nixGL.wrap` should wrap packages with.
+      This can be used to provide libGL access to applications on non-NixOS systems.
+
+      Some packages are wrapped by default (e.g. kitty, firefox), but you can wrap other packages
+      as well, with `(config.lib.nixGL.wrap <package>)`. If this option is empty (the default),
+      then `lib.nixGL.wrap` is a no-op.
+    '';
+  };
+
+  config = {
+    lib.nixGL.wrap = # Wrap a single package with the configured nixGL wrapper
+      pkg:
+
+      if cfg.prefix == "" then
+        pkg
+      else
+      # Wrap the package's binaries with nixGL, while preserving the rest of
+      # the outputs and derivation attributes.
+        (pkg.overrideAttrs (old: {
+          name = "nixGL-${pkg.name}";
+
+          # Make sure this is false for the wrapper derivation, so nix doesn't expect
+          # a new debug output to be produced. We won't be producing any debug info
+          # for the original package.
+          separateDebugInfo = false;
+
+          buildCommand = ''
+            set -eo pipefail
+
+            ${
+            # Heavily inspired by https://stackoverflow.com/a/68523368/6259505
+            pkgs.lib.concatStringsSep "\n" (map (outputName: ''
+              echo "Copying output ${outputName}"
+              set -x
+              cp -rs --no-preserve=mode "${
+                pkg.${outputName}
+              }" "''$${outputName}"
+              set +x
+            '') (old.outputs or [ "out" ]))}
+
+            rm -rf $out/bin/*
+            shopt -s nullglob # Prevent loop from running if no files
+            for file in ${pkg.out}/bin/*; do
+              echo "#!${pkgs.bash}/bin/bash" > "$out/bin/$(basename $file)"
+              echo "exec -a \"\$0\" ${cfg.prefix} $file \"\$@\"" >> "$out/bin/$(basename $file)"
+              chmod +x "$out/bin/$(basename $file)"
+            done
+            shopt -u nullglob # Revert nullglob back to its normal default state
+          '';
+        }));
+  };
+}

--- a/modules/misc/nixgl.nix
+++ b/modules/misc/nixgl.nix
@@ -35,7 +35,7 @@ in {
           # a new debug output to be produced. We won't be producing any debug info
           # for the original package.
           separateDebugInfo = false;
-
+          nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [ pkgs.makeWrapper ];
           buildCommand = ''
             set -eo pipefail
 

--- a/modules/misc/nixgl.nix
+++ b/modules/misc/nixgl.nix
@@ -57,6 +57,17 @@ in {
               echo "exec -a \"\$0\" ${cfg.prefix} $file \"\$@\"" >> "$out/bin/$(basename $file)"
               chmod +x "$out/bin/$(basename $file)"
             done
+
+            # If .desktop files refer to the old package, replace the references
+            for dsk in "$out/share/applications"/*.desktop ; do
+              if ! grep "${pkg.out}" "$dsk" > /dev/null; then
+                continue
+              fi
+              src="$(readlink "$dsk")"
+              rm "$dsk"
+              sed "s|${pkg.out}|$out|g" "$src" > "$dsk"
+            done
+
             shopt -u nullglob # Revert nullglob back to its normal default state
           '';
         }));

--- a/modules/misc/nixgl.nix
+++ b/modules/misc/nixgl.nix
@@ -63,7 +63,7 @@ in {
 
             # If .desktop files refer to the old package, replace the references
             for dsk in "$out/share/applications"/*.desktop ; do
-              if ! grep "${pkg.out}" "$dsk" > /dev/null; then
+              if ! grep -q "${pkg.out}" "$dsk"; then
                 continue
               fi
               src="$(readlink "$dsk")"

--- a/modules/misc/nixgl.nix
+++ b/modules/misc/nixgl.nix
@@ -41,7 +41,7 @@ in {
 
             ${
             # Heavily inspired by https://stackoverflow.com/a/68523368/6259505
-            pkgs.lib.concatStringsSep "\n" (map (outputName: ''
+            lib.concatStringsSep "\n" (map (outputName: ''
               echo "Copying output ${outputName}"
               set -x
               cp -rs --no-preserve=mode "${

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -31,6 +31,7 @@ let
     ./misc/gtk.nix
     ./misc/lib.nix
     ./misc/news.nix
+    ./misc/nixgl.nix
     ./misc/numlock.nix
     ./misc/pam.nix
     ./misc/qt.nix


### PR DESCRIPTION
### Description

This PR integrates `nixGL` into home manager in a way that does not introduce a `nixGL` dependency, and attempts to make user configuration as simple as possible. This accomplishes the same goal as #5332, namely making it simpler for users to run applications which require `libGL` on non-nixos systems managed by home manager. There's some elaboration on why I think this is a better API in the [original issue](https://github.com/nix-community/home-manager/issues/3968#issuecomment-2087810068).

It makes use of [a wrapper](https://github.com/guibou/nixGL/issues/114#issuecomment-1585323281) which I have been using for some months to run a few GPU-bound applications on Ubuntu. Judging by post reactions it seems that many other users have also found success with this wrapper. By default it is a a no-op, but if a user has configured a `nixGL.prefix`, then it will symlink all files from the original package into a new one, except for binaries which are replaced by a wrapper script calling them with the configured prefix. Unlike other wrappers proposed in #3968, all derivation attributes from the original package are preserved, so the result of the wrapper can be passed along to program modules for additional overriding. And since the program binary itself is replaced, the program will be launched in the nixGL context regardless of where it is called from (terminal, desktop file, etc).

The wrapper function is made available on `lib.nixGL.wrap`, so users can wrap applications which require libGL like so:

```nix
    home.packages = [ (config.lib.nixGL.wrap pkgs.example) ];

    programs.kitty.package = (config.lib.nixGL.wrap pkgs.kitty);
```

I'm very open to changing option/wrapper paths if it would help get this merged. Just having the wrapper and the option would be enough for users to wrap packages with nixGL ergonomically.

#### Wrapping packages by default

The default no-op behavior and derivation attribute preservation of this wrapper means that HM modules for applications could wrap their default package with nixGL. This would have the benefit of tracking which applications need `nixGL` to function properly on non-nixos systems, and saving end users time by making `nixGL.prefix` the only option they need to set to get these applications working. If a user wanted to _undo_ the default wrapping for certain applications, they could simply override `programs.<application>.package` to a non-wrapped package. This PR originally included examples for [`kitty`](https://github.com/nix-community/home-manager/commit/1ff6b802946d4671a55dbbb90eb30a66cf81dbc0) and [`firefox`](https://github.com/nix-community/home-manager/commit/53482ffc4299aab1f91286dd237e413a72261a69), which both benefit from `nixGL` on non-nixos systems. However, @exzombie brought up some valid concerns about doing this, particularly detecting and preventing double-wrapping, so in the interest of getting the wrapper itself merged this default wrapping has been removed, to be left for future improvement.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

  TODO

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@kira-bruneau @rycee 

Alternative to #5332 
Closes #3968
