### PR TITLE
cliphist: add extraOptions option

### DIFF
--- a/modules/services/cliphist.nix
+++ b/modules/services/cliphist.nix
@@ -17,6 +17,14 @@ in {
       '';
     };
 
+    extraOptions = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ "-max-dedupe-search" "10" "-max-items" "500" ];
+      description = ''
+        Flags to append to the cliphist command.
+      '';
+    };
+
     systemdTarget = lib.mkOption {
       type = lib.types.str;
       default = "graphical-session.target";
@@ -31,7 +39,8 @@ in {
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = let extraOptionsStr = lib.escapeShellArgs cfg.extraOptions;
+  in lib.mkIf cfg.enable {
     assertions = [
       (lib.hm.assertions.assertPlatform "services.cliphist" pkgs
         lib.platforms.linux)
@@ -48,7 +57,7 @@ in {
       Service = {
         Type = "simple";
         ExecStart =
-          "${pkgs.wl-clipboard}/bin/wl-paste --watch ${cfg.package}/bin/cliphist store";
+          "${pkgs.wl-clipboard}/bin/wl-paste --watch ${cfg.package}/bin/cliphist ${extraOptionsStr} store";
         Restart = "on-failure";
       };
 
@@ -64,7 +73,7 @@ in {
       Service = {
         Type = "simple";
         ExecStart =
-          "${pkgs.wl-clipboard}/bin/wl-paste --type image --watch ${cfg.package}/bin/cliphist store";
+          "${pkgs.wl-clipboard}/bin/wl-paste --type image --watch ${cfg.package}/bin/cliphist ${extraOptionsStr} store";
         Restart = "on-failure";
       };
 

--- a/tests/modules/services/cliphist/cliphist-extra-options.nix
+++ b/tests/modules/services/cliphist/cliphist-extra-options.nix
@@ -1,0 +1,24 @@
+{ ... }: {
+  services.cliphist = {
+    enable = true;
+    allowImages = true;
+    extraOptions = [ "-max-dedupe-search" "10" "-max-items" "500" ];
+  };
+
+  test.stubs = {
+    cliphist = { };
+    wl-clipboard = { };
+  };
+
+  nmt.script = ''
+    servicePath=home-files/.config/systemd/user
+
+    assertFileExists $servicePath/cliphist.service
+    assertFileExists $servicePath/cliphist-images.service
+
+    assertFileRegex $servicePath/cliphist.service " '-max-dedupe-search' '10' "
+    assertFileRegex $servicePath/cliphist.service " '-max-items' '500' "
+    assertFileRegex $servicePath/cliphist-images.service " '-max-dedupe-search' '10' "
+    assertFileRegex $servicePath/cliphist-images.service " '-max-items' '500' "
+  '';
+}

--- a/tests/modules/services/cliphist/default.nix
+++ b/tests/modules/services/cliphist/default.nix
@@ -1,1 +1,4 @@
-{ cliphist-sway-session-target = ./cliphist-sway-session-target.nix; }
+{
+  cliphist-sway-session-target = ./cliphist-sway-session-target.nix;
+  cliphist-extra-options = ./cliphist-extra-options.nix;
+}


### PR DESCRIPTION
Add an extraOptions option that would be appended to the cliphist command.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@Janik-Haag 
