### PR TITLE
mopidy: make scan service depend on `mopidy-local`

### DIFF
--- a/modules/services/mopidy.nix
+++ b/modules/services/mopidy.nix
@@ -48,6 +48,8 @@ let
   configFilePaths = concatStringsSep ":"
     ([ "${config.xdg.configHome}/mopidy/mopidy.conf" ] ++ cfg.extraConfigFiles);
 
+  hasMopidyLocal = builtins.elem pkgs.mopidy-local cfg.extensionPackages;
+
 in {
   meta.maintainers = [ hm.maintainers.foo-dogsquared ];
 
@@ -133,7 +135,7 @@ in {
       Install.WantedBy = [ "default.target" ];
     };
 
-    systemd.user.services.mopidy-scan = {
+    systemd.user.services.mopidy-scan = mkIf hasMopidyLocal {
       Unit = {
         Description = "mopidy local files scanner";
         Documentation = [ "https://mopidy.com/" ];

--- a/tests/modules/services/mopidy/basic-configuration.nix
+++ b/tests/modules/services/mopidy/basic-configuration.nix
@@ -3,6 +3,7 @@
 {
   services.mopidy = {
     enable = true;
+    extensionPackages = [ ];
     settings = {
       file = {
         enabled = true;
@@ -29,7 +30,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/systemd/user/mopidy.service
-    assertFileExists home-files/.config/systemd/user/mopidy-scan.service
+    assertPathNotExists home-files/.config/systemd/user/mopidy-scan.service
 
     assertFileExists home-files/.config/mopidy/mopidy.conf
     assertFileContent home-files/.config/mopidy/mopidy.conf \

--- a/tests/modules/services/mopidy/default.nix
+++ b/tests/modules/services/mopidy/default.nix
@@ -1,1 +1,5 @@
-{ mopidy-basic-configuration = ./basic-configuration.nix; }
+{
+  mopidy-basic-configuration = ./basic-configuration.nix;
+  mopidy-scan = ./mopidy-scan.nix;
+}
+

--- a/tests/modules/services/mopidy/mopidy-scan.nix
+++ b/tests/modules/services/mopidy/mopidy-scan.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+
+{
+  services.mopidy = {
+    enable = true;
+    extensionPackages = [ pkgs.mopidy-local ];
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/systemd/user/mopidy.service
+    assertFileExists home-files/.config/systemd/user/mopidy-scan.service
+  '';
+}


### PR DESCRIPTION
### Description

The systemd service `mopidy-scan` provided by this module depends on `mopidy local` which is only available via an optional extension package. When the extension isn't installed, the service fails to start.
This PR checks if `mopidy-local` is part of `cfg.extensionPackages` before enabling the service.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@foo-dogsquared