### PR TITLE
swaync: fix style path

### DIFF
--- a/modules/services/swaync.nix
+++ b/modules/services/swaync.nix
@@ -84,7 +84,7 @@ in {
       "swaync/config.json".source =
         jsonFormat.generate "config.json" cfg.settings;
       "swaync/style.css" = lib.mkIf (cfg.style != null) {
-        source = if lib.isStorePath cfg.style then
+        source = if builtins.isPath cfg.style || lib.isStorePath cfg.style then
           cfg.style
         else
           pkgs.writeText "swaync/style.css" cfg.style;


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

When the swaync.style option is set to a path: `style = ./swaync-style.css`, then the CSS file will just be a string to the store path. This fixes that problem.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@abayomi185 
