### PR TITLE
jujutsu: add ediff option

### DIFF
--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -22,6 +22,15 @@ in {
 
     package = mkPackageOption pkgs "jujutsu" { };
 
+    ediff = mkOption {
+      type = types.bool;
+      default = config.programs.emacs.enable;
+      defaultText = literalExpression "config.programs.emacs.enable";
+      description = ''
+        Enable ediff as a merge tool
+      '';
+    };
+
     settings = mkOption {
       type = tomlFormat.type;
       default = { };
@@ -45,7 +54,18 @@ in {
     home.packages = [ cfg.package ];
 
     home.file.".jjconfig.toml" = mkIf (cfg.settings != { }) {
-      source = tomlFormat.generate "jujutsu-config" cfg.settings;
+      source = tomlFormat.generate "jujutsu-config" (cfg.settings
+        // optionalAttrs (cfg.ediff) (let
+          emacsDiffScript = pkgs.writeShellScriptBin "emacs-ediff" ''
+            set -euxo pipefail
+            ${config.programs.emacs.package}/bin/emacsclient -c --eval "(ediff-merge-files-with-ancestor \"$1\" \"$2\" \"$3\" nil \"$4\")"
+          '';
+        in {
+          merge-tools.ediff = {
+            program = getExe emacsDiffScript;
+            merge-args = [ "$left" "$right" "$base" "$output" ];
+          };
+        }));
     };
   };
 }


### PR DESCRIPTION
based on https://github.com/martinvonz/jj/wiki/Emacs#ediff-as-a-merge-tool

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@shikanime

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
