### PR TITLE
nix-init: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1607,6 +1607,13 @@ in {
           between windows, and is also a widget engine.
         '';
       }
+
+      {
+        time = "2024-05-07T16:33:07+00:00";
+        message = ''
+          A new module is available: 'programs.nix-init'.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -169,6 +169,7 @@ let
     ./programs/newsboat.nix
     ./programs/nheko.nix
     ./programs/nix-index.nix
+    ./programs/nix-init.nix
     ./programs/nnn.nix
     ./programs/noti.nix
     ./programs/notmuch.nix

--- a/modules/programs/nix-init.nix
+++ b/modules/programs/nix-init.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, ... }:
+let tomlFormat = pkgs.formats.toml { };
+in with lib; {
+  meta.maintainers = [ maintainers.uncenter ];
+
+  options.programs.nix-init = {
+    enable = mkEnableOption
+      "nix-init - Generate Nix packages from URLs with hash prefetching, dependency inference, license detection, and more";
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          maintainers = [
+            "figsoda"
+          ];
+          nixpkgs = "<nixpkgs>";
+          commit = true;
+          access-tokens = {
+            github.com = "ghp_blahblahblah...";
+            gitlab.com = {
+              command = [
+                "secret-tool"
+                "or"
+                "whatever"
+                "you"
+                "use"
+              ];
+            };
+            gitlab.gnome.org = {
+              file = "/path/to/api/token";
+            };
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/nix-init/config.toml`.
+
+        See <https://github.com/nix-community/nix-init#configuration> for the full list
+        of options.
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "nix-init" { };
+  };
+
+  config = let cfg = config.programs.nix-init;
+  in mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."nix-init/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "config.toml" cfg.settings;
+    };
+  };
+}


### PR DESCRIPTION
### Description

Adds [`nix-init`](https://github.com/nix-community/nix-init), a CLI for generating Nix packages from URLs with hash prefetching, dependency inference, license detection, and more.

This PR writes the configured settings to nix-init's XDG configuration file.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
