### PR TITLE
files: don't handle symlinks in a special way when home.file.<name>.recursive is set to true

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -321,7 +321,7 @@ in
               if [[ -d $source ]]; then
                 if [[ $recursive ]]; then
                   mkdir -p "$target"
-                  lndir -silent "$source" "$target"
+                  lndir -silent -ignorelinks "$source" "$target"
                 else
                   ln -s "$source" "$target"
                 fi


### PR DESCRIPTION
### Description
I'm using `pass` as my password manager.
In order to use it in Firefox, I use the passff extension. The passff extension needs the `passff-host` native messaging host to access the passwords. Here is what the file structure of the `passff-host` package looks like:
```
result
├── etc
│   ├── chromium
│   │   └── native-messaging-hosts
│   │       └── passff.json -> ../../../share/passff-host/passff.json
│   ├── opt
│   │   └── chrome
│   │       └── native-messaging-hosts
│   │           └── passff.json -> ../../../../share/passff-host/passff.json
│   └── vivaldi
│       └── native-messaging-hosts
│           └── passff.json -> ../../../share/passff-host/passff.json
├── lib
│   ├── librewolf
│   │   └── native-messaging-hosts
│   │       └── passff.json -> ../../../share/passff-host/passff.json
│   └── mozilla
│       └── native-messaging-hosts
│           └── passff.json -> ../../../share/passff-host/passff.json
└── share
    └── passff-host
        ├── passff.json
        └── passff.py
```
As you can see, `lib/mozilla/native-messaging-hosts/passff.json` is a relative symlink. This is perfectly reasonable.
When adding `programs.firefox.nativeMessagingHosts = [ pkgs.passff-host ]` to the home-manager configuration, the firefox module first joins all the `nativeMessagingHosts` using `symlinkJoin` and stores the result in a variable called `nativeMessagingHostsJoined`. This creates `ff_native-messaging-hosts` in the Nix store:
```
/nix/store/bv62k5yl7jwzkhyci838ir3vgz59gqsa-ff_native-messaging-hosts
├── bin
│   └── firefox -> /nix/store/0zqxaz44w75gjq32xj53i32jl2j91pzy-firefox-125.0.1/bin/firefox
├── etc
│   ├── chromium
│   │   └── native-messaging-hosts
│   │       └── passff.json -> ../../../share/passff-host/passff.json
│   ├── opt
│   │   └── chrome
│   │       └── native-messaging-hosts
│   │           └── passff.json -> ../../../../share/passff-host/passff.json
│   └── vivaldi
│       └── native-messaging-hosts
│           └── passff.json -> ../../../share/passff-host/passff.json
├── lib
│   ├── [...]
│   ├── librewolf
│   │   └── native-messaging-hosts
│   │       └── passff.json -> ../../../share/passff-host/passff.json
│   └── mozilla
│       ├── native-messaging-hosts
│       │   └── passff.json -> ../../../share/passff-host/passff.json
│       └── pkcs11-modules
└── share
    ├── [...]
    └── passff-host
        ├── passff.json -> /nix/store/pag1akgbmls1xa63h6rzmb0h6xxwwzmy-passff-host-1.2.4/share/passff-host/passff.json
        └── passff.py -> /nix/store/pag1akgbmls1xa63h6rzmb0h6xxwwzmy-passff-host-1.2.4/share/passff-host/passff.py
```
Still perfectly fine.
Then the `firefox` module sets
```nix
home.file.".mozilla/native-messaging-hosts" = {
  source = "${nativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
  recursive = true;
}
```
The `file` module then calls `lndir -silent "/nix/store/bv62k5yl7jwzkhyci838ir3vgz59gqsa-ff_native-messaging-hosts/lib/mozilla/native-messaging-hosts" ".mozilla/native-messaging-hosts"` To see the problem, here is the resulting directory tree:
```
.mozilla
├── [...]
└── native-messaging-hosts
    └── passff.json -> ../../../share/passff-host/passff.json
```
Obviously this symlink doesn't go anywhere. `lndir` created a broken symlink. To fix this, add the `-ignorelinks` argument to `lndir`, which causes it to instead just create a symlink to the symlink in `ff_native-messaging-hosts`:
```
.mozilla
├── [...]
└── native-messaging-hosts
    └── passff.json -> /nix/store/bv62k5yl7jwzkhyci838ir3vgz59gqsa-ff_native-messaging-hosts/lib/mozilla/native-messaging-hosts/passff.json
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible. (I'm honestly not 100% sure on this one)

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee @kira-bruneau @Lillecarl @mlyxshi