### PR TITLE
Kanshi: Better configuration options

### DIFF
--- a/tests/modules/services/kanshi/default.nix
+++ b/tests/modules/services/kanshi/default.nix
@@ -1,1 +1,4 @@
-{ kanshi-basic-configuration = ./basic-configuration.nix; }
+{
+  kanshi-basic-configuration = ./basic-configuration.nix;
+  kanshi-new-configuration = ./new-configuration.nix;
+}

--- a/tests/modules/services/kanshi/new-configuration.conf
+++ b/tests/modules/services/kanshi/new-configuration.conf
@@ -1,0 +1,19 @@
+include "path/to/included/file"
+output "*" enable
+profile nomad {
+  output "eDP-1" enable
+}
+
+profile desktop {
+  output "eDP-1" disable
+  output "Iiyama North America PLE2483H-DP" enable position 0,0
+  output "Iiyama North America PLE2483H-DP 1158765348486" enable mode 1920x1080 position 1920,0 scale 2.100000 transform flipped-270
+  exec echo "1 two 3"
+  exec echo "4 five 6"
+}
+
+profile  {
+  output "LVDS-1" enable
+  exec echo "7 eight 9"
+}
+

--- a/tests/modules/services/kanshi/new-configuration.nix
+++ b/tests/modules/services/kanshi/new-configuration.nix
@@ -3,16 +3,25 @@
     services.kanshi = {
       enable = true;
       package = config.lib.test.mkStubPackage { };
-      profiles = {
-        nomad = {
-          outputs = [{
+      settings = [
+        { include = "path/to/included/file"; }
+        {
+          output = {
+            criteria = "*";
+            status = "enable";
+          };
+        }
+        {
+          profile.name = "nomad";
+          profile.outputs = [{
             criteria = "eDP-1";
             status = "enable";
           }];
-        };
-        desktop = {
-          exec = [ ''echo "1 two 3"'' ''echo "4 five 6"'' ];
-          outputs = [
+        }
+        {
+          profile.name = "desktop";
+          profile.exec = [ ''echo "1 two 3"'' ''echo "4 five 6"'' ];
+          profile.outputs = [
             {
               criteria = "eDP-1";
               status = "disable";
@@ -31,26 +40,16 @@
               transform = "flipped-270";
             }
           ];
-        };
-        backwardsCompat = {
-          outputs = [{
+        }
+        {
+          profile.outputs = [{
             criteria = "LVDS-1";
             status = "enable";
           }];
-          exec = ''echo "7 eight 9"'';
-        };
-      };
-      extraConfig = ''
-        profile test {
-          output "*" enable
+          profile.exec = ''echo "7 eight 9"'';
         }
-      '';
+      ];
     };
-
-    test.asserts.warnings.expected = [
-      "kanshi.profiles option is deprecated. Use kanshi.settings instead."
-      "kanshi.extraConfig option is deprecated. Use kanshi.settings instead."
-    ];
 
     nmt.script = ''
       serviceFile=home-files/.config/systemd/user/kanshi.service
@@ -58,7 +57,7 @@
 
       assertFileExists home-files/.config/kanshi/config
       assertFileContent home-files/.config/kanshi/config \
-                ${./basic-configuration.conf}
+                ${./new-configuration.conf}
     '';
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Update Kanshi's nix configuration to better reflect kanshi's configuration format.
Mark the previous format as deprecated.

Closes https://github.com/nix-community/home-manager/issues/5374

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
- Ran kanshi tests

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
