### PR TITLE
fish: handle theme plugins

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -228,7 +228,6 @@ let
       echo "end"
       echo "setup_hm_session_vars") > $out
     '';
-
 in {
   imports = [
     (mkRemovedOptionModule [ "programs" "fish" "promptInit" ] ''
@@ -548,5 +547,16 @@ in {
           '';
       }) cfg.plugins));
     })
+    (let
+      themes = foldl (themeList: plugin:
+        if pathIsDirectory "${plugin.src}/themes" then
+          themeList ++ filesystem.listFilesRecursive "${plugin.src}/themes"
+        else
+          themeList) [ ] cfg.plugins;
+    in (mkIf (length themes > 0) {
+      xdg.configFile = mkMerge ((map (theme:
+        let basename = last (builtins.split "/" (toString theme));
+        in { "fish/themes/${basename}".source = theme; }) themes));
+    }))
   ]);
 }

--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -4,4 +4,5 @@
   fish-functions = ./functions.nix;
   fish-no-functions = ./no-functions.nix;
   fish-plugins = ./plugins.nix;
+  fish-themes = ./themes.nix;
 }

--- a/tests/modules/programs/fish/themes.nix
+++ b/tests/modules/programs/fish/themes.nix
@@ -1,0 +1,34 @@
+{ lib, pkgs, ... }:
+let
+  dummy-theme-plugin = pkgs.runCommandLocal "theme" { } ''
+    mkdir -p "$out"/themes
+    echo "fish_color_normal 575279" > "$out/themes/dummy-theme-plugin.theme"
+  '';
+
+  copied-theme = pkgs.writeText "theme.theme" ''
+    fish_color_normal 575279
+  '';
+in {
+  config = {
+    programs.fish = {
+      enable = true;
+      plugins = [{
+        name = "foo";
+        src = dummy-theme-plugin;
+      }];
+    };
+
+    # Needed to avoid error with dummy fish package.
+    xdg.dataFile."fish/home-manager_generated_completions".source =
+      lib.mkForce (builtins.toFile "empty" "");
+
+    nmt = {
+      description = "if fish plugin contains themes directory copy the themes";
+      script = ''
+        assertDirectoryExists home-files/.config/fish/themes
+        assertFileExists home-files/.config/fish/themes/dummy-theme-plugin.theme
+        assertFileContent home-files/.config/fish/themes/dummy-theme-plugin.theme ${copied-theme}
+      '';
+    };
+  };
+}


### PR DESCRIPTION
### Description

Link theme files from installed plugins so that they may be properly loaded with `fish_config theme choose <theme>`

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

No maintainers so reaching out to people with most recent changes:
@natsukium @a-kenji 

[#3724](https://github.com/nix-community/home-manager/issues/3724)