### PR TITLE
zsh: add programs.zsh.autosuggestions.strategy option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -398,6 +398,22 @@ in
             {manpage}`zshzle(1)` for syntax.
           '';
         };
+
+        strategy = mkOption {
+          type = types.listOf (types.enum [ "history" "completion" "match_prev_cmd" ]);
+          default = [ "history" ];
+          description = ''
+            `ZSH_AUTOSUGGEST_STRATEGY` is an array that specifies how suggestions should be generated.
+            The strategies in the array are tried successively until a suggestion is found.
+            There are currently three built-in strategies to choose from:
+
+            - `history`: Chooses the most recent match from history.
+            - `completion`: Chooses a suggestion based on what tab-completion would suggest. (requires `zpty` module)
+            - `match_prev_cmd`: Like `history`, but chooses the most recent match whose preceding history item matches
+                the most recently executed command. Note that this strategy won't work as expected with ZSH options that
+                don't preserve the history order such as `HIST_IGNORE_ALL_DUPS` or `HIST_EXPIRE_DUPS_FIRST`.
+          '';
+        };
       };
 
       history = mkOption {
@@ -610,6 +626,7 @@ in
 
         (optionalString cfg.autosuggestion.enable ''
           source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+          ZSH_AUTOSUGGEST_STRATEGY=(${concatStringsSep " " cfg.autosuggestion.strategy})
         '')
         (optionalString (cfg.autosuggestion.enable && cfg.autosuggestion.highlight != null) ''
           ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="${cfg.autosuggestion.highlight}"


### PR DESCRIPTION
### Description

zsh: add programs.zsh.autosuggestions.strategy option like in nixpkgs.
The option defaults to history.

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

