### PR TITLE
bash: Add missing 'ignoreboth' to historyControl allowed values

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -67,8 +67,8 @@ in {
       };
 
       historyControl = mkOption {
-        type =
-          types.listOf (types.enum [ "erasedups" "ignoredups" "ignorespace" ]);
+        type = types.listOf
+          (types.enum [ "erasedups" "ignoredups" "ignorespace" "ignoreboth" ]);
         default = [ ];
         description = "Controlling how commands are saved on the history list.";
       };


### PR DESCRIPTION
reference: https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-HISTCONTROL

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ofc(:] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
