### PR TITLE
gpg-agent: fix usage of splitString

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -48,9 +48,8 @@ let
   hexStringToBase32 = let
     mod = a: b: a - a / b * b;
     pow2 = elemAt [ 1 2 4 8 16 32 64 128 256 ];
-    splitChars = s: init (tail (splitString "" s));
 
-    base32Alphabet = splitChars "ybndrfg8ejkmcpqxot1uwisza345h769";
+    base32Alphabet = stringToCharacters "ybndrfg8ejkmcpqxot1uwisza345h769";
     hexToIntTable = listToAttrs (genList (x: {
       name = toLower (toHexString x);
       value = x;
@@ -76,7 +75,7 @@ let
         buf = buf';
         bufBits = bufBits';
       };
-  in hexString: (foldl' go initState (splitChars hexString)).ret;
+  in hexString: (foldl' go initState (stringToCharacters hexString)).ret;
 
 in {
   meta.maintainers = [ maintainers.rycee ];


### PR DESCRIPTION
### Description

`splitString "" "some string"` would throw exception `error: invalid regular expression` on Darwin (or accurately, on Nix built against libc++). Refer to https://github.com/NixOS/nix/issues/7208 for details.

Before Nix handles that issue correctly, we should refrain from using `splitString ""`, and luckliy `lib.stringAsChars` can do the same thing. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee 
