### PR TITLE
submodule-support: add default values for top-level configs

### DIFF
--- a/modules/misc/submodule-support.nix
+++ b/modules/misc/submodule-support.nix
@@ -29,4 +29,19 @@ with lib;
       '';
     };
   };
+
+  config = {
+    # To make it easier for the end user to override the values in the
+    # configuration depending on the installation method, we set default values
+    # for the arguments that are defined in the NixOS/nix-darwin modules.
+    #
+    # Without these defaults, these attributes would simply not exist, and the
+    # module system can not inform modules about their non-existence; see
+    # https://github.com/NixOS/nixpkgs/issues/311709#issuecomment-2110861842
+    _module.args = {
+      osConfig = mkDefault null;
+      nixosConfig = mkDefault null;
+      darwinConfig = mkDefault null;
+    };
+  };
 }


### PR DESCRIPTION
This way the end user can easily check whether the home-manager configuration is part of the module or not. Example of use:

```nix
{ lib, nixosConfig, ... }:
let
  mkIfNixos = lib.mkIf nixosConfig != null;
in
{
  programs.foot.enable = mkIfNixos true;
}
```

related: https://github.com/NixOS/nixpkgs/issues/311709
many thanks to @roberth for the explanation

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
