### PR TITLE
espanso: Don't run as `background` processtype on darwin

### DIFF
--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -137,7 +137,6 @@ in {
           Crashed = true;
           SuccessfulExit = false;
         };
-        ProcessType = "Background";
         RunAtLoad = true;
       };
     };

--- a/tests/modules/services/espanso-darwin/launchd.plist
+++ b/tests/modules/services/espanso-darwin/launchd.plist
@@ -16,8 +16,6 @@
 	</dict>
 	<key>Label</key>
 	<string>org.nix-community.home.espanso</string>
-	<key>ProcessType</key>
-	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>@espanso@/bin/espanso</string>


### PR DESCRIPTION
This leads to a considerably slower expansion time for snippets,
which severely degrades the user experience.

Also, the launchd plist from the source omits
this key:
https://github.com/espanso/espanso/blob/8daadcc949c35a7b7aa20b7f544fdcff83e2c5f7/espanso/src/res/macos/com.federicoterzi.espanso.plist

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
