### PR TITLE
jujutsu: support darwin guidelines for config placement

### DIFF
--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -7,6 +7,11 @@ let
   cfg = config.programs.jujutsu;
   tomlFormat = pkgs.formats.toml { };
 
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Application Support"
+  else
+    config.xdg.configHome;
+
 in {
   meta.maintainers = [ maintainers.shikanime ];
 
@@ -51,7 +56,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."jj/config.toml" = mkIf (cfg.settings != { }) {
+    home.file."${configDir}/jj/config.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "jujutsu-config" (cfg.settings
         // optionalAttrs (cfg.ediff) (let
           emacsDiffScript = pkgs.writeShellScriptBin "emacs-ediff" ''

--- a/tests/modules/programs/jujutsu/empty-config.nix
+++ b/tests/modules/programs/jujutsu/empty-config.nix
@@ -1,11 +1,14 @@
-{ ... }:
+{ pkgs, ... }:
 
-{
+let
+  configDir =
+    if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+in {
   programs.jujutsu.enable = true;
 
   test.stubs.jujutsu = { };
 
   nmt.script = ''
-    assertPathNotExists home-files/.config/jj/config.toml
+    assertPathNotExists 'home-files/${configDir}/jj/config.toml'
   '';
 }

--- a/tests/modules/programs/jujutsu/example-config.nix
+++ b/tests/modules/programs/jujutsu/example-config.nix
@@ -1,6 +1,9 @@
-{ config, ... }:
+{ pkgs, config, ... }:
 
-{
+let
+  configDir =
+    if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+in {
   programs.jujutsu = {
     enable = true;
     package = config.lib.test.mkStubPackage { };
@@ -13,9 +16,8 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/jj/config.toml
-    assertFileContent \
-      home-files/.config/jj/config.toml \
+    assertFileExists 'home-files/${configDir}/jj/config.toml'
+    assertFileContent 'home-files/${configDir}/jj/config.toml' \
       ${
         builtins.toFile "expected.toml" ''
           [user]


### PR DESCRIPTION
Follow up to #5207, fixing jujutsu module on darwin targets.

Closes #5544 (duplicate)

### Description

If the module is evaluated on a Darwin platform, place config in `Library/Application Support` instead of unsupported XDG directory.

If someone could test it on Darwin, it would be great (e.g. @bnjmnt4n) :

```sh
nix develop --ignore-environment .#jujutsu-example-config
nix develop --ignore-environment .#jujutsu-empty-config
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@shikanime
