### PR TITLE
listenbrainz-mpd: change config example to accurate one

### DIFF
--- a/modules/services/listenbrainz-mpd.nix
+++ b/modules/services/listenbrainz-mpd.nix
@@ -24,7 +24,7 @@ in {
         Configuration for listenbrainz-mpd written to
         {file}`$XDG_CONFIG_HOME/listenbrainz-mpd/config.toml`.
       '';
-      example = { submission.tokenFile = "/run/secrets/listenbrainz-mpd"; };
+      example = { submission.token_file = "/run/secrets/listenbrainz-mpd"; };
     };
   };
 


### PR DESCRIPTION
### Description

The [option name](https://codeberg.org/elomatreb/listenbrainz-mpd/src/commit/e340e990c7bdb61f3646991c02adb091ce1bc727/config.toml.sample#L14) is actually `token_file`, not `tokenFile`, so it's useful to change the example here in case someone gets tripped up by this. 

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Scrumplex