### PR TITLE
fd: don't create shell aliases with empty args

### DIFF
--- a/modules/programs/fd.nix
+++ b/modules/programs/fd.nix
@@ -38,7 +38,7 @@ with lib; {
 
     args = escapeShellArgs (optional cfg.hidden "--hidden" ++ cfg.extraOptions);
 
-    optionsAlias = { fd = "fd ${args}"; };
+    optionsAlias = optionalAttrs (args != "") { fd = "fd ${args}"; };
   in mkIf cfg.enable {
     home.packages = [ cfg.package ];
 


### PR DESCRIPTION
### Description

Without this change a dummy alias `{ fd = "fd ";}` is created.

There are no tests for this module, so I tested it manually.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
