### PR TITLE
home-manager: add lib support for non-flake users

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -24,6 +24,7 @@ in rec {
     pkgs.callPackage ./home-manager/install.nix { inherit home-manager; };
 
   nixos = import ./nixos;
+  lib = import ./lib { inherit (pkgs) lib; };
 
   inherit path;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -41,56 +41,7 @@
 
       defaultTemplate = self.templates.standalone;
 
-      lib = {
-        hm = (import ./modules/lib/stdlib-extended.nix nixpkgs.lib).hm;
-        homeManagerConfiguration = { modules ? [ ], pkgs, lib ? pkgs.lib
-          , extraSpecialArgs ? { }, check ? true
-            # Deprecated:
-          , configuration ? null, extraModules ? null, stateVersion ? null
-          , username ? null, homeDirectory ? null, system ? null }@args:
-          let
-            msgForRemovedArg = ''
-              The 'homeManagerConfiguration' arguments
-
-                - 'configuration',
-                - 'username',
-                - 'homeDirectory'
-                - 'stateVersion',
-                - 'extraModules', and
-                - 'system'
-
-              have been removed. Instead use the arguments 'pkgs' and
-              'modules'. See the 22.11 release notes for more: https://nix-community.github.io/home-manager/release-notes.xhtml#sec-release-22.11-highlights
-            '';
-
-            throwForRemovedArgs = v:
-              let
-                used = builtins.filter (n: (args.${n} or null) != null) [
-                  "configuration"
-                  "username"
-                  "homeDirectory"
-                  "stateVersion"
-                  "extraModules"
-                  "system"
-                ];
-                msg = msgForRemovedArg + ''
-
-
-                  Deprecated args passed: ''
-                  + builtins.concatStringsSep " " used;
-              in lib.throwIf (used != [ ]) msg v;
-
-          in throwForRemovedArgs (import ./modules {
-            inherit pkgs lib check extraSpecialArgs;
-            configuration = { ... }: {
-              imports = modules ++ [{ programs.home-manager.path = "${./.}"; }];
-              nixpkgs = {
-                config = nixpkgs.lib.mkDefault pkgs.config;
-                inherit (pkgs) overlays;
-              };
-            };
-          });
-      };
+      lib = import ./lib { inherit (nixpkgs) lib; };
     } // (let
       forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
     in {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,0 +1,49 @@
+{ lib }: {
+  hm = (import ../modules/lib/stdlib-extended.nix lib).hm;
+  homeManagerConfiguration = { modules ? [ ], pkgs, lib ? pkgs.lib
+    , extraSpecialArgs ? { }, check ? true
+      # Deprecated:
+    , configuration ? null, extraModules ? null, stateVersion ? null
+    , username ? null, homeDirectory ? null, system ? null }@args:
+    let
+      msgForRemovedArg = ''
+        The 'homeManagerConfiguration' arguments
+
+          - 'configuration',
+          - 'username',
+          - 'homeDirectory'
+          - 'stateVersion',
+          - 'extraModules', and
+          - 'system'
+
+        have been removed. Instead use the arguments 'pkgs' and
+        'modules'. See the 22.11 release notes for more: https://nix-community.github.io/home-manager/release-notes.xhtml#sec-release-22.11-highlights
+      '';
+
+      throwForRemovedArgs = v:
+        let
+          used = builtins.filter (n: (args.${n} or null) != null) [
+            "configuration"
+            "username"
+            "homeDirectory"
+            "stateVersion"
+            "extraModules"
+            "system"
+          ];
+          msg = msgForRemovedArg + ''
+
+
+            Deprecated args passed: '' + builtins.concatStringsSep " " used;
+        in lib.throwIf (used != [ ]) msg v;
+
+    in throwForRemovedArgs (import ../modules {
+      inherit pkgs lib check extraSpecialArgs;
+      configuration = { ... }: {
+        imports = modules ++ [{ programs.home-manager.path = "${../.}"; }];
+        nixpkgs = {
+          config = lib.mkDefault pkgs.config;
+          inherit (pkgs) overlays;
+        };
+      };
+    });
+}


### PR DESCRIPTION
### Description

This patch moves the lib functionality from the flake into a file and imports in both the `flake.nix` and `default.nix` which makes it accessible for non-flake users.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
