### PR TITLE
fcitx5: add waylandFrontend option to not set env vars

### DIFF
--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -25,6 +25,15 @@ in {
           Enabled Fcitx5 addons.
         '';
       };
+
+      waylandFrontend = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Use the Wayland input method frontend.
+          See [Using Fcitx 5 on Wayland](https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland).
+        '';
+      };
     };
   };
 
@@ -33,11 +42,12 @@ in {
 
     home.sessionVariables = {
       GLFW_IM_MODULE = "ibus"; # IME support in kitty
-      GTK_IM_MODULE = "fcitx";
-      QT_IM_MODULE = "fcitx";
       XMODIFIERS = "@im=fcitx";
       QT_PLUGIN_PATH =
         "$QT_PLUGIN_PATH\${QT_PLUGIN_PATH:+:}${fcitx5Package}/${pkgs.qt6.qtbase.qtPluginPrefix}";
+    } // lib.optionalAttrs (!cfg.waylandFrontend) {
+      GTK_IM_MODULE = "fcitx";
+      QT_IM_MODULE = "fcitx";
     };
 
     systemd.user.services.fcitx5-daemon = {

--- a/tests/modules/i18n/input-method/fcitx5-configuration.nix
+++ b/tests/modules/i18n/input-method/fcitx5-configuration.nix
@@ -5,10 +5,12 @@
 
   i18n.inputMethod = {
     enabled = "fcitx5";
-    fcitx5.addons = [ pkgs.libsForQt5.fcitx5-chinese-addons ];
+    fcitx5.waylandFrontend = true;
   };
 
   nmt.script = ''
     assertFileExists home-files/.config/systemd/user/fcitx5-daemon.service
+    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'GTK_IM_MODULE'
+    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'QT_IM_MODULE'
   '';
 }


### PR DESCRIPTION
### Description

Fixes: https://github.com/nix-community/home-manager/issues/5264
This patch adds new option to the fcitx5, which allows to specify that user wishes to use it with wayland, so environment variables which are necessary for the X11, should not be automatically set.

The same change was already made for the nixos repo: https://github.com/NixOS/nixpkgs/pull/278765

I've confirmed on my machine, that with this change, fctix5 no longer sets  "GTK_IM_MODULE" and "QT_IM_MODULE" environment variables.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
