### PR TITLE
thunderbird: add message filters option

### DIFF
--- a/tests/modules/programs/thunderbird/thunderbird-expected-msgFilterRules.dat
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-msgFilterRules.dat
@@ -1,0 +1,8 @@
+version="9"
+logging="no"
+name="test filter"
+enabled="yes"
+type="32"
+action="ACTION_NAME"
+actionValue="//imap:"
+condition="AND "

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -6,6 +6,14 @@
       thunderbird = {
         enable = true;
         profiles = [ "first" ];
+        msgFilters = [{
+          name = "test filter";
+          enabled = true;
+          type = "32";
+          action = "ACTION_NAME";
+          actionValue = "//imap:";
+          condition = "AND ";
+        }];
       };
 
       aliases = [ "home-manager@example.com" ];
@@ -84,5 +92,13 @@
     assertFileExists home-files/.thunderbird/first/chrome/userContent.css
     assertFileContent home-files/.thunderbird/first/chrome/userContent.css \
       <(echo "* { color: red !important; }")
+
+    assertFileExists home-files/.thunderbird/first/ImapMail/${
+      builtins.hashString "sha256" "hm@example.com"
+    }/msgFilterRules.dat
+    assertFileContent home-files/.thunderbird/first/ImapMail/${
+      builtins.hashString "sha256" "hm@example.com"
+    }/msgFilterRules.dat \
+      ${./thunderbird-expected-msgFilterRules.dat}    
   '';
 }


### PR DESCRIPTION
### Description

This adds an option to the Thunderbird module which declares message filters to easily replicate filter settings on other machines.

To make it more easily usable I could either extend its documentation or I could create attrsets as enums for the `type` and `action` fields of a filter. What do you think?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@d-dervishi @ethorsoe
