### PR TITLE
topgrade: update example config

### DIFF
--- a/modules/programs/topgrade.nix
+++ b/modules/programs/topgrade.nix
@@ -28,13 +28,15 @@ in {
       defaultText = literalExpression "{ }";
       example = literalExpression ''
         {
-          assume_yes = true;
-          disable = [
-            "flutter"
-            "node"
-          ];
-          set_title = false;
-          cleanup = true;
+          misc = {
+            assume_yes = true;
+            disable = [
+              "flutter"
+              "node"
+            ];
+            set_title = false;
+            cleanup = true;
+          };
           commands = {
             "Run garbage collection on Nix store" = "nix-collect-garbage";
           };

--- a/tests/modules/programs/topgrade/settings-expected.toml
+++ b/tests/modules/programs/topgrade/settings-expected.toml
@@ -1,8 +1,9 @@
+[commands]
+"Purge unused APT packages" = "sudo apt autoremove"
+
+[misc]
 cleanup = true
 disable = ["sdkman", "flutter", "node", "nix", "home_manager"]
 remote_topgrade_path = "bin/topgrade"
 remote_topgrades = ["backup", "ci"]
 set_title = false
-
-[commands]
-"Purge unused APT packages" = "sudo apt autoremove"

--- a/tests/modules/programs/topgrade/settings.nix
+++ b/tests/modules/programs/topgrade/settings.nix
@@ -6,17 +6,21 @@
 
     settings = lib.mkMerge [
       {
-        disable = [ "sdkman" "flutter" "node" "nix" "home_manager" ];
+        misc = {
+          disable = [ "sdkman" "flutter" "node" "nix" "home_manager" ];
 
-        remote_topgrades = [ "backup" "ci" ];
+          remote_topgrades = [ "backup" "ci" ];
 
-        remote_topgrade_path = "bin/topgrade";
+          remote_topgrade_path = "bin/topgrade";
+        };
       }
 
       {
-        set_title = false;
-        cleanup = true;
+        misc = {
+          set_title = false;
 
+          cleanup = true;
+        };
         commands = { "Purge unused APT packages" = "sudo apt autoremove"; };
       }
     ];


### PR DESCRIPTION
### Description
Topgrade config format changed to use misc and thus the example becomes invalid, topgrade tries to migrate it but since /nix is readonly it fails. So the correct example is this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.
	- [x] No, old version of topgrade cannot read the `[misc]` block.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
	- [x] This was taking too long, I ran `nix run #.test-topgrade-settings` 

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
