### PR TITLE
kanshi: fix configuration example

### DIFF
--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -209,24 +209,26 @@ in {
         Attribute set of profiles.
       '';
       example = literalExpression ''
-        undocked = {
-          outputs = [
-            {
-              criteria = "eDP-1";
-            }
-          ];
-        };
-        docked = {
-          outputs = [
-            {
-              criteria = "eDP-1";
-            }
-            {
-              criteria = "Some Company ASDF 4242";
-              transform = "90";
-            }
-          ];
-        };
+        {
+          undocked = {
+            outputs = [
+              {
+                criteria = "eDP-1";
+              }
+            ];
+          };
+          docked = {
+            outputs = [
+              {
+                criteria = "eDP-1";
+              }
+              {
+                criteria = "Some Company ASDF 4242";
+                transform = "90";
+              }
+            ];
+          };
+        }
       '';
     };
 
@@ -247,28 +249,30 @@ in {
         See kanshi(5) for informations.
       '';
       example = literalExpression ''
-        { include = "path/to/included/files"; }
-        { output.criteria = "eDP-1";
-          output.scale = 2;
-        }
-        { profile.name = "undocked";
-          profile.outputs = [
-            {
-              criteria = "eDP-1";
-            }
-          ];
-        }
-        { profile.name = "docked";
-          profile.outputs = [
-            {
-              criteria = "eDP-1";
-            }
-            {
-              criteria = "Some Company ASDF 4242";
-              transform = "90";
-            }
-          ];
-        }
+        [
+          { include = "path/to/included/files"; }
+          { output.criteria = "eDP-1";
+            output.scale = 2;
+          }
+          { profile.name = "undocked";
+            profile.outputs = [
+              {
+                criteria = "eDP-1";
+              }
+            ];
+          }
+          { profile.name = "docked";
+            profile.outputs = [
+              {
+                criteria = "eDP-1";
+              }
+              {
+                criteria = "Some Company ASDF 4242";
+                transform = "90";
+              }
+            ];
+          }
+        ]
       '';
     };
 


### PR DESCRIPTION
### Description

Kanshi: Fix configuration examples by adding enclosing braces/brackets.

Somewhat closes https://github.com/nix-community/home-manager/issues/5443

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
