### PR TITLE
yazi: use builtin cd

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -11,7 +11,7 @@ let
       local tmp="$(mktemp -t "yazi-cwd.XXXXX")"
       yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
-        cd -- "$cwd"
+        builtin cd -- "$cwd"
       fi
       rm -f -- "$tmp"
     }
@@ -22,7 +22,7 @@ let
       set tmp (mktemp -t "yazi-cwd.XXXXX")
       yazi $argv --cwd-file="$tmp"
       if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
-        cd -- "$cwd"
+        builtin cd -- "$cwd"
       end
       rm -f -- "$tmp"
     end

--- a/tests/modules/programs/yazi/bash-integration-enabled.nix
+++ b/tests/modules/programs/yazi/bash-integration-enabled.nix
@@ -6,7 +6,7 @@ let
       local tmp="$(mktemp -t "yazi-cwd.XXXXX")"
       yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
-        cd -- "$cwd"
+        builtin cd -- "$cwd"
       fi
       rm -f -- "$tmp"
     }

--- a/tests/modules/programs/yazi/fish-integration-enabled.nix
+++ b/tests/modules/programs/yazi/fish-integration-enabled.nix
@@ -6,7 +6,7 @@ let
       set tmp (mktemp -t "yazi-cwd.XXXXX")
       yazi $argv --cwd-file="$tmp"
       if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
-        cd -- "$cwd"
+        builtin cd -- "$cwd"
       end
       rm -f -- "$tmp"
     end

--- a/tests/modules/programs/yazi/zsh-integration-enabled.nix
+++ b/tests/modules/programs/yazi/zsh-integration-enabled.nix
@@ -6,7 +6,7 @@ let
       local tmp="$(mktemp -t "yazi-cwd.XXXXX")"
       yazi "$@" --cwd-file="$tmp"
       if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
-        cd -- "$cwd"
+        builtin cd -- "$cwd"
       fi
       rm -f -- "$tmp"
     }


### PR DESCRIPTION
cd conflicts with aliases that dont support -- syntax

### Description

Enabling the zoxide --cmd cd will break this alias. Need to use the builtin cd behavior. 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
