### PR TITLE
mpd: allow using urls for musicDirectory

### DIFF
--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -51,7 +51,8 @@ in {
       };
 
       musicDirectory = mkOption {
-        type = with types; either path str;
+        type = with types;
+          either path (strMatching "(http|https|nfs|smb)://.+");
         defaultText = literalExpression ''
           ''${home.homeDirectory}/music    if state version < 22.11
           ''${xdg.userDirs.music}          if xdg.userDirs.enable == true


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x ] Change is backwards compatible.

- [ x] Code formatted with `./format`.

- [x ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef). (none needed)

- [x ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rembo10 
@emilazy 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
