### PR TITLE
zsh: add plugins.*.completions paths to fpath

### DIFF
--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -6,6 +6,7 @@
   zsh-history-path-old-custom = ./history-path-old-custom.nix;
   zsh-history-ignore-pattern = ./history-ignore-pattern.nix;
   zsh-history-substring-search = ./history-substring-search.nix;
+  zsh-plugins = ./plugins.nix;
   zsh-prezto = ./prezto.nix;
   zsh-syntax-highlighting = ./syntax-highlighting.nix;
   zsh-abbr = ./zsh-abbr.nix;

--- a/tests/modules/programs/zsh/plugins.nix
+++ b/tests/modules/programs/zsh/plugins.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let mockZshPluginSrc = pkgs.writeText "mockZshPluginSrc" "echo example";
+in {
+  config = {
+    programs.zsh = {
+      enable = true;
+      plugins = [{
+        name = "mockPlugin";
+        file = "share/mockPlugin/mockPlugin.plugin.zsh";
+        src = mockZshPluginSrc;
+        completions =
+          [ "share/zsh/site-functions" "share/zsh/vendor-completions" ];
+      }];
+    };
+
+    test.stubs.zsh = { };
+
+    nmt.script = ''
+      assertFileRegex home-files/.zshrc '^path+="$HOME/.zsh/plugins/mockPlugin"$'
+      assertFileRegex home-files/.zshrc '^fpath+="$HOME/.zsh/plugins/mockPlugin"$'
+      assertFileRegex home-files/.zshrc '^fpath+=("$HOME/.zsh/plugins/mockPlugin/share/zsh/site-functions" "$HOME/.zsh/plugins/mockPlugin/share/zsh/vendor-completions")$'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

👋 This PR adds a `programs.zsh.plugins.*.completions` options that accepts paths to plugin directories containing additional scripts, such as completion scripts. This adds these paths to `fpath` before calling `zsh.completionInit` - the point that completions are set.

Similar fixes found in #2562 are applied here with the option to extend the files that are being sourced to whichever directories are needed.

### Reviewers

These changes can be tested with [the `wd` package](https://github.com/mfaerevaag/wd). I find this plugin showcases a bit of everything well!

```nix
{
  programs.zsh = {
    enable = true;
    plugins = [
      {
        name = "wd";
        src = pkgs.zsh-wd;
        file = "share/wd/wd.plugin.zsh";
        completions = [ "share/zsh/site-functions" ];
      }
    ];
  };
}
```

After switching to a setup with `wd` the following commands and completions should work:

```sh
# Confirm installation
$ wd --version
$ man wd

# Set a warp point
$ cd /tmp
$ wd add tmp
$ wd list

# Confirm warps work
$ cd
$ pwd
$ wd tmp
$ pwd
```

Also check that the `.zshrc` file includes this new option:

```sh
$ cat ~/.zshrc
...
path+="$HOME/.zsh/plugins/wd"
fpath+="$HOME/.zsh/plugins/wd"
fpath+=("$HOME/.zsh/plugins/wd/share/zsh/site-functions")
...
```

### Notes

For a bit more context, the `result` of a built `zsh-wd` has this structure:

```txt
result
| share/
  | man/
    | man1/
      - wd.1.gz
  | wd/
    - wd.plugin.zsh
    - wd.sh
  | zsh/
    | site-functions/
      - _wd.sh
```

And before this change, this snippet was needed to add completion scripts:
 
```nix
programs.zsh.initExtraBeforeCompInit = '' fpath+=("${pkgs.zsh-wd}"/share/zsh/site-functions) '';
```

Here's a bit of reference I found useful too: https://thevaluable.dev/zsh-completion-guide-examples/

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

  <details>
  <summary>
  Changes to this module pass tests but a failure happened when running all tests and seems unrelated
  </summary>

  ```
  error:
       … while calling the 'derivationStrict' builtin

         at /derivation-internal.nix:9:12:

            8|
            9|   strict = derivationStrict drvAttrs;
             |            ^
           10|

       … while evaluating derivation 'nmt-run-all-tests'
         whose name attribute is located at /nix/store/z71lmgd0ydfnax1b13zbrls5idf1y7ak-source/pkgs/stdenv/generic/make-derivation.nix:331:7

       … while evaluating attribute 'shellHook' of derivation 'nmt-run-all-tests'

         at /nix/store/fm1dwqb08lxr1gk02niyvb1j7v4181c0-source/default.nix:38:40:

           37|   runShellOnlyCommand = name: shellHook:
           38|     pkgs.runCommandLocal name { inherit shellHook; } ''
             |                                        ^
           39|       echo This derivation is only useful when run through nix-shell.

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: infinite recursion encountered

       at /nix/store/z71lmgd0ydfnax1b13zbrls5idf1y7ak-source/lib/modules.nix:1016:14:

         1015|     { _type = "override";
         1016|       inherit priority content;
             |              ^
         1017|     };
  ```
  </details>


- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

Not sure who to add but found y'all in surrounding commits, hope that's alright! 😄 

@dermetfan @infinisil @uvNikita @teto 
