### PR TITLE
ripgrep-all: Add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -226,6 +226,7 @@ let
     ./programs/readline.nix
     ./programs/rio.nix
     ./programs/ripgrep.nix
+    ./programs/ripgrep-all.nix
     ./programs/rofi-pass.nix
     ./programs/rofi.nix
     ./programs/rtorrent.nix

--- a/modules/programs/ripgrep-all.nix
+++ b/modules/programs/ripgrep-all.nix
@@ -1,0 +1,102 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.ripgrep-all;
+  configPath = if pkgs.stdenv.hostPlatform.isDarwin then
+    "Library/Application Support/ripgrep-all/config.jsonc"
+  else
+    "${config.xdg.configHome}/ripgrep-all/config.jsonc";
+  customAdapter = lib.types.submodule {
+    # Descriptions are largely copied from https://github.com/phiresky/ripgrep-all/blob/v1.0.0-alpha.5/src/adapters/custom.rs
+    options = {
+      name = lib.mkOption {
+        type = lib.types.str;
+        description =
+          "The unique identifier and name of this adapter; must only include a-z, 0-9, _";
+      };
+      version = lib.mkOption {
+        type = lib.types.int;
+        default = 1;
+        description =
+          "The version identifier used to key cache entries; change if the configuration or program changes";
+      };
+      description = lib.mkOption {
+        type = lib.types.str;
+        description = "A description of this adapter; shown in rga's help";
+      };
+      extensions = lib.mkOption {
+        type = with lib.types; listOf str;
+        description = "The file extensions this adapter supports";
+        example = [ "pdf" ];
+      };
+      mimetypes = lib.mkOption {
+        type = with lib.types; nullOr (listOf str);
+        default = null;
+        description =
+          "If not null and --rga-accurate is enabled, mime type matching is used instead of file name matching";
+        example = [ "application/pdf" ];
+      };
+      binary = lib.mkOption {
+        type = lib.types.path;
+        description = "The path of the binary to run";
+      };
+      args = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [ ];
+        description =
+          "The output path hint; the placeholders are the same as for rga's `args`";
+      };
+      disabled_by_default = lib.mkOption {
+        type = with lib.types; nullOr bool;
+        default = null;
+        description = "If true, the adapter will be disabled by default";
+      };
+      match_only_by_mime = lib.mkOption {
+        type = with lib.types; nullOr bool;
+        default = null;
+        description =
+          "if --rga-accurate, only match by mime types, ignore extensions completely";
+      };
+      output_path_hint = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description =
+          "Setting this is useful if the output format is not plain text (.txt) but instead some other format that should be passed to another adapter";
+        example = "$${input_virtual_path}.txt.asciipagebreaks";
+      };
+    };
+  };
+in {
+  meta.maintainers = with lib.maintainers; [ lafrenierejm ];
+
+  options = {
+    programs.ripgrep-all = {
+      enable = lib.mkEnableOption "ripgrep-all (rga)";
+
+      package = lib.mkPackageOption pkgs "ripgrep-all" { nullable = true; };
+
+      custom_adapters = lib.mkOption {
+        type = lib.types.listOf customAdapter;
+        default = [ ];
+        description = ''
+          Custom adapters that invoke external preprocessing scripts.
+          See <link xlink:href="https://github.com/phiresky/ripgrep-all/wiki#custom-adapters"/>.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home = {
+      packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+      file."${configPath}" = lib.mkIf (cfg.custom_adapters != [ ]) {
+        source = (pkgs.formats.json { }).generate "ripgrep-all" {
+          "$schema" = "./config.schema.json";
+          custom_adapters =
+            map (lib.filterAttrs (n: v: v != null)) cfg.custom_adapters;
+        };
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -379,6 +379,7 @@ in import nmtSrc {
     ./modules/programs/readline
     ./modules/programs/rio
     ./modules/programs/ripgrep
+    ./modules/programs/ripgrep-all
     ./modules/programs/ruff
     ./modules/programs/sagemath
     ./modules/programs/sapling

--- a/tests/modules/programs/ripgrep-all/custom-arguments.nix
+++ b/tests/modules/programs/ripgrep-all/custom-arguments.nix
@@ -1,0 +1,51 @@
+{ pkgs, config, ... }: {
+  config = {
+    programs.ripgrep-all = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { name = "ripgrep-all"; };
+      custom_adapters = [{
+        name = "gron";
+        version = 1;
+        description = "Transform JSON into discrete JS assignments";
+        extensions = [ "json" ];
+        mimetypes = [ "application/json" ];
+        binary = "/bin/gron";
+        disabled_by_default = false;
+        match_only_by_mime = false;
+      }];
+    };
+
+    nmt.script = let
+      configPath = if pkgs.stdenv.hostPlatform.isDarwin then
+        "Library/Application Support/ripgrep-all/config.jsonc"
+      else
+        ".config/ripgrep-all/config.jsonc";
+    in ''
+      assertFileExists "home-files/${configPath}"
+      assertFileContent "home-files/${configPath}" ${
+        pkgs.writeText "ripgrep-all.expected" ''
+          {
+            "$schema": "./config.schema.json",
+            "custom_adapters": [
+              {
+                "args": [],
+                "binary": "/bin/gron",
+                "description": "Transform JSON into discrete JS assignments",
+                "disabled_by_default": false,
+                "extensions": [
+                  "json"
+                ],
+                "match_only_by_mime": false,
+                "mimetypes": [
+                  "application/json"
+                ],
+                "name": "gron",
+                "version": 1
+              }
+            ]
+          }
+        ''
+      }
+    '';
+  };
+}

--- a/tests/modules/programs/ripgrep-all/default-arguments.nix
+++ b/tests/modules/programs/ripgrep-all/default-arguments.nix
@@ -1,0 +1,13 @@
+{ config, ... }: {
+  config = {
+    programs.ripgrep-all = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { name = "ripgrep-all"; };
+    };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/ripgrep-all/config.jsonc
+      assertPathNotExists 'home-files/Library/Application Support/ripgrep-all/config.jsonc'
+    '';
+  };
+}

--- a/tests/modules/programs/ripgrep-all/default.nix
+++ b/tests/modules/programs/ripgrep-all/default.nix
@@ -1,0 +1,4 @@
+{
+  ripgrep-all-default-arguments = ./default-arguments.nix;
+  ripgrep-all-custom-arguments = ./custom-arguments.nix;
+}


### PR DESCRIPTION
### Description

Add module for [ripgrep-all](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/text/ripgrep-all/default.nix).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
