### PR TITLE
papis: add `program.papis.package` option

### DIFF
--- a/modules/programs/papis.nix
+++ b/modules/programs/papis.nix
@@ -19,6 +19,8 @@ in {
   options.programs.papis = {
     enable = mkEnableOption "papis";
 
+    package = mkPackageOption pkgs "papis" { };
+
     settings = mkOption {
       type = with types; attrsOf (oneOf [ bool int str ]);
       default = { };
@@ -84,7 +86,7 @@ in {
         (", namely " + concatStringsSep "," defaultLibraries);
     }];
 
-    home.packages = [ pkgs.papis ];
+    home.packages = [ cfg.package ];
 
     xdg.configFile."papis/config" =
       mkIf (cfg.libraries != { }) { text = generators.toINI { } settingsIni; };


### PR DESCRIPTION
- Add `programs.papis.package` option to override default pkg used. This can be useful to track latest rev from repository via a flake.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~~If this PR adds a new module~~

  - [ ] ~~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~~

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@marsam 