### PR TITLE
home-manager: check FQDN for '--flake .' attribute

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -198,9 +198,9 @@ function setFlakeAttribute() {
                 ;;
             *)
                 local name="$USER"
-                # Check both long and short hostnames; long first to preserve
+                # Check FQDN, long, and short hostnames; long first to preserve
                 # pre-existing behaviour in case both happen to be defined.
-                for n in "$USER@$(hostname)" "$USER@$(hostname -s)"; do
+                for n in "$USER@$(hostname --fqdn)" "$USER@$(hostname)" "$USER@$(hostname -s)"; do
                     if [[ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$n\"")" == "true" ]]; then
                         name="$n"
                         if [[ -v VERBOSE ]]; then


### PR DESCRIPTION
### Description

Since nixpkgs commit 993baa587c4b82e791686f6ce711bcd4ee8ef933, `networking.hostName` is not allowed to be a FQDN.

Add `hostname --fqdn` to the default flake attribute names that are searched.

If

    netorking.hostname = "hostname";
    networking.domain = "example.com";

is set in the system NixOS configuration, this allows defining

    homeConfigurations."username@hostname.example.com" = ...

and still use

    home-manager switch --flake .

instead of having to type out

    home-manager switch --flake .#$(whoami)@$(hostname --fqdn)


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.
    - Technically no if someone happens to have both `homeConfigurations."username@hostname"` and `homeConfigurations."username@hostname.example.com"`.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
