### PR TITLE
starship: fix broken path with XDG dirs

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -8,7 +8,7 @@ let
 
   tomlFormat = pkgs.formats.toml { };
 
-  starshipCmd = "${config.home.profileDirectory}/bin/starship";
+  starshipCmd = lib.getExe cfg.package;
 
 in {
   meta.maintainers = [ ];


### PR DESCRIPTION
### Description

This fixes the issue described in https://github.com/nix-community/home-manager/issues/4807.
The starship modules uses the executable ```~/.nix-profile/bin/starship``` even when ```nix.use-xdg-base-directories = true;```. Now it just uses the absolute path.

I did a quick grep on the code base and I noticed the pattern ```"${config.home.profileDirectory}/bin/..."```
 does show up a few times and my guess is that they will also break when using XDG directories. Maybe this should be fixed in the future?
### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
