### PR TITLE
yambar: add systemd service

### DIFF
--- a/modules/programs/yambar.nix
+++ b/modules/programs/yambar.nix
@@ -44,6 +44,23 @@ in
         See {manpage}`yambar(5)` for options.
       '';
     };
+
+    systemd = {
+      enable = lib.mkEnableOption "yambar systemd integration";
+
+      target = lib.mkOption {
+        type = lib.types.str;
+        default = config.wayland.systemd.target;
+        example = "sway-session.target";
+        description = ''
+          The systemd target that will automatically start the yambar service.
+
+          When setting this value to `"sway-session.target"`,
+          make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+          otherwise the service may never be started.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -55,6 +72,27 @@ in
 
     xdg.configFile."yambar/config.yml" = lib.mkIf (cfg.settings != { }) {
       source = yamlFormat.generate "config.yml" cfg.settings;
+    };
+
+    systemd.user.services.yambar = lib.mkIf cfg.systemd.enable {
+      Unit = {
+        Description = "Modular status panel for X11 and Wayland";
+        Documentation = "man:yambar";
+        PartOf = [ cfg.systemd.target ];
+        After = [ cfg.systemd.target ];
+      };
+
+      Service = {
+        ExecStart = "${cfg.package}/bin/yambar";
+        ExecReload = "${pkgs.coreutils}/bin/kill -SIGUSR2 $MAINPID";
+        Restart = "on-failure";
+        RestartSec = 3;
+        KillMode = "mixed";
+      };
+
+      Install = {
+        WantedBy = [ cfg.systemd.target ];
+      };
     };
   };
 }


### PR DESCRIPTION
### Description

As discussed in https://github.com/nix-community/home-manager/pull/3353 it would be nice to have a yambar systemd service. This PR provides one.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.