### PR TITLE
accounts.email: Add clarifying documentation

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -493,17 +493,14 @@ in {
     maildirBasePath = mkOption {
       type = types.str;
       default = "${config.home.homeDirectory}/Maildir";
-      defaultText = "$HOME/Maildir";
+      defaultText = "Maildir";
       apply = p:
         if hasPrefix "/" p then p else "${config.home.homeDirectory}/${p}";
       description = ''
         The base directory for account maildir directories. May be a
         relative path (e.g. the user setting this value as "MyMaildir"),
         in which case it is relative the home directory (e.g. resulting
-        in "~/MyMaildir"). Note that "$HOME/Maildir" being cited as the
-        default value is showing the result, and could be achieved by
-        the user setting this value as "Maildir". Using "$HOME/" will
-        not do any interpolation.
+        in "~/MyMaildir").
       '';
     };
 

--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -498,8 +498,12 @@ in {
         if hasPrefix "/" p then p else "${config.home.homeDirectory}/${p}";
       description = ''
         The base directory for account maildir directories. May be a
-        relative path, in which case it is relative the home
-        directory.
+        relative path (e.g. the user setting this value as "MyMaildir"),
+        in which case it is relative the home directory (e.g. resulting
+        in "~/MyMaildir"). Note that "$HOME/Maildir" being cited as the
+        default value is showing the result, and could be achieved by
+        the user setting this value as "Maildir". Using "$HOME/" will
+        not do any interpolation.
       '';
     };
 


### PR DESCRIPTION
Add clarifying documentation for maildirBasePath value.

### Description

Fixes #2946 in the documentation.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
