### PR TITLE
programs.waybar: remove modules-* from defaults

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -69,8 +69,8 @@ let
         };
 
         modules-left = mkOption {
-          type = listOf str;
-          default = [ ];
+          type = nullOr (listOf str);
+          default = null;
           description = "Modules that will be displayed on the left.";
           example = literalExpression ''
             [ "sway/workspaces" "sway/mode" "wlr/taskbar" ]
@@ -78,8 +78,8 @@ let
         };
 
         modules-center = mkOption {
-          type = listOf str;
-          default = [ ];
+          type = nullOr (listOf str);
+          default = null;
           description = "Modules that will be displayed in the center.";
           example = literalExpression ''
             [ "sway/window" ]
@@ -87,8 +87,8 @@ let
         };
 
         modules-right = mkOption {
-          type = listOf str;
-          default = [ ];
+          type = nullOr (listOf str);
+          default = null;
           description = "Modules that will be displayed on the right.";
           example = literalExpression ''
             [ "mpd" "custom/mymodule#with-css-id" "temperature" ]

--- a/tests/modules/programs/waybar/deprecated-modules-option.nix
+++ b/tests/modules/programs/waybar/deprecated-modules-option.nix
@@ -31,8 +31,6 @@ with lib;
                   "modules-center": [
                     "test"
                   ],
-                  "modules-left": [],
-                  "modules-right": [],
                   "test": {}
                 }
               ]

--- a/tests/modules/programs/waybar/settings-complex-expected.json
+++ b/tests/modules/programs/waybar/settings-complex-expected.json
@@ -51,7 +51,6 @@
     "modules-left": [
       "sway/mode"
     ],
-    "modules-right": [],
     "output": [
       "!DP-1"
     ],


### PR DESCRIPTION
I prefer to handle modules-* imperatively for more flexibility, I do this via waybar "includes" (https://github.com/Alexays/Waybar/wiki/Configuration). Current HM defaults modules-* to `[]` instead of null for most other settings, so they get written to ~/.config/waybar/config even though I've configured nothing.

And they take precedence over the impartives ones because of how waybar's includes work:

====
Paths to additional configuration files.
Each file can contain a single object with any of the bar configuration options. In case of duplicate options, the first defined value takes precedence, i.e. including file -> first included file -> etc. Nested includes are permitted, but make sure to avoid circular imports. For a multi-bar config, the include directive affects only current bar configuration object. ====

Since the default is [], they dont bring naything so defaulting to null is a better choice here.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
