### PR TITLE
nix-gc: add `persistent` option

### DIFF
--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -90,6 +90,18 @@ in {
           garbage collector is run automatically.
         '';
       };
+
+      persistent = mkOption {
+        type = types.bool;
+        default = true;
+        example = false;
+        description = ''
+          If true, the time when the service unit was last triggered is
+          stored on disk. When the timer is activated, the service unit is
+          triggered immediately if it would have been triggered at least once
+          during the time when the timer was inactive.
+        '';
+      };
     };
   };
 
@@ -107,6 +119,7 @@ in {
         Unit = { Description = "Nix Garbage Collector"; };
         Timer = {
           OnCalendar = "${cfg.frequency}";
+          Persistent = cfg.persistent;
           Unit = "nix-gc.service";
         };
         Install = { WantedBy = [ "timers.target" ]; };

--- a/tests/modules/services/nix-gc/expected.timer
+++ b/tests/modules/services/nix-gc/expected.timer
@@ -3,6 +3,7 @@ WantedBy=timers.target
 
 [Timer]
 OnCalendar=monthly
+Persistent=true
 Unit=nix-gc.service
 
 [Unit]


### PR DESCRIPTION
### Description

Closes: https://github.com/nix-community/home-manager/issues/5465
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
