### PR TITLE
firefox: add `policies` support on Darwin with high enough stateVersion

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -201,13 +201,13 @@ let
 
     in if package == null then
       null
-    else if isDarwin then
-      package
     else if versionAtLeast config.home.stateVersion "19.09" then
       package.override (old: {
-        cfg = old.cfg or { } // fcfg;
+        cfg = old.cfg or { } // (if isDarwin then { } else fcfg);
         extraPolicies = (old.extraPolicies or { }) // cfg.policies;
       })
+    else if isDarwin then
+      package
     else
       (pkgs.wrapFirefox.override { config = bcfg; }) package { };
 


### PR DESCRIPTION
### Description

On Darwin, adding FF policies through `policies` currently does nothing while not giving the user any notice at all about why it doesn't work. 

This PR changes only one thing: `extraPolicies` on `stateVersion` >= 19.09 is populated with the options from `policies.` I tested this with my `nix-darwin` configuration and it does in fact work, although you must use a custom package as `pkgs.firefox` does not build.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [NA] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@rycee @kira-bruneau 