### PR TITLE
files: show colliding files at bottom in checkLinkTargets

### DIFF
--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -34,26 +34,27 @@ for sourcePath in "$@" ; do
       # Next, try to move the file to a backup location if configured and possible
       backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
       if [[ -e "$backup" ]]; then
-        errorEcho "Existing file '$backup' would be clobbered by backing up '$targetPath'"
-        collision=1
+        collisionErrors+=("Existing file '$backup' would be clobbered by backing up '$targetPath'")
       else
         warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
       fi
     else
       # Fail if nothing else works
-      errorEcho "Existing file '$targetPath' is in the way of '$sourcePath'"
-      collision=1
+      collisionErrors+=("Existing file '$backup' would be clobbered by backing up '$targetPath'")
     fi
   fi
 done
 
-if [[ -v collision ]] ; then
+if [[ ${#collisionErrors[@]} -gt 0 ]] ; then
   errorEcho "Please do one of the following:
-- Move or remove the above files and try again.
+- Move or remove the files below and try again.
 - In standalone mode, use 'home-manager switch -b backup' to back up
   files automatically.
 - When used as a NixOS or nix-darwin module, set
     'home-manager.backupFileExtension'
   to, for example, 'backup' and rebuild."
+  for error in "${collisionErrors[@]}" ; do
+    errorEcho "$error"
+  done
   exit 1
 fi


### PR DESCRIPTION
### Description

The new error message created in f8e6694 truncates the actual colliding files error within the systemd log, leading to a lot of confusion from newer Nix users. This fix moves the colliding files to the end, making it visible again.

#### Before:

```
warning: the following units failed: home-manager-iynaix.service

× home-manager-iynaix.service - Home Manager environment for iynaix
     Loaded: loaded (/etc/systemd/system/home-manager-iynaix.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Tue 2024-06-04 08:46:52 +08; 52ms ago
   Duration: 46min 26.136s
    Process: 88527 ExecStart=/nix/store/7i0d80cp7l2f3kzphp2pgl75f8k9bqal-hm-setup-env /nix/store/zw7il0w4kc897jjm2mm4flvssm6s00hw-home-manager-generation (code=exited, status=1/FAILURE)
   Main PID: 88527 (code=exited, status=1/FAILURE)
         IP: 0B in, 0B out
        CPU: 163ms

Jun 04 08:46:52 iynaix-desktop hm-activate-iynaix[88633]: Please do one of the following:
Jun 04 08:46:52 iynaix-desktop hm-activate-iynaix[88633]: - Move or remove the above files and try again.
Jun 04 08:46:52 iynaix-desktop hm-activate-iynaix[88633]: - In standalone mode, use 'home-manager switch -b backup' to back up
Jun 04 08:46:52 iynaix-desktop hm-activate-iynaix[88633]:   files automatically.
Jun 04 08:46:52 iynaix-desktop hm-activate-iynaix[88633]: - When used as a NixOS or nix-darwin module, set
Jun 04 08:46:52 iynaix-desktop hm-activate-iynaix[88633]:     'home-manager.backupFileExtension'
Jun 04 08:46:52 iynaix-desktop hm-activate-iynaix[88633]:   to, for example, 'backup' and rebuild.
Jun 04 08:46:52 iynaix-desktop systemd[1]: home-manager-iynaix.service: Main process exited, code=exited, status=1/FAILURE
Jun 04 08:46:52 iynaix-desktop systemd[1]: home-manager-iynaix.service: Failed with result 'exit-code'.
Jun 04 08:46:52 iynaix-desktop systemd[1]: Failed to start Home Manager environment for iynaix.
warning: error(s) occurred while switching to the new configuration
```

#### After:

```
warning: the following units failed: home-manager-iynaix.service

× home-manager-iynaix.service - Home Manager environment for iynaix
     Loaded: loaded (/etc/systemd/system/home-manager-iynaix.service; enabled; preset: enabled)
     Active: failed (Result: exit-code) since Tue 2024-06-04 09:05:51 +08; 56ms ago
   Duration: 2min 28.327s
    Process: 135260 ExecStart=/nix/store/7i0d80cp7l2f3kzphp2pgl75f8k9bqal-hm-setup-env /nix/store/vv84s6k08nqsq52sqq76h48fadli5ms5-home-manager-generation (code=exited, status=1/FAILURE)
   Main PID: 135260 (code=exited, status=1/FAILURE)
         IP: 0B in, 0B out
        CPU: 158ms

Jun 04 09:05:51 iynaix-desktop hm-activate-iynaix[135365]: - Move or remove the files below and try again.
Jun 04 09:05:51 iynaix-desktop hm-activate-iynaix[135365]: - In standalone mode, use 'home-manager switch -b backup' to back up
Jun 04 09:05:51 iynaix-desktop hm-activate-iynaix[135365]:   files automatically.
Jun 04 09:05:51 iynaix-desktop hm-activate-iynaix[135365]: - When used as a NixOS or nix-darwin module, set
Jun 04 09:05:51 iynaix-desktop hm-activate-iynaix[135365]:     'home-manager.backupFileExtension'
Jun 04 09:05:51 iynaix-desktop hm-activate-iynaix[135365]:   to, for example, 'backup' and rebuild.
Jun 04 09:05:51 iynaix-desktop hm-activate-iynaix[135365]: Existing file '/home/iynaix/.config/gtk-3.0/settings.ini' is in the way of '/nix/store/yq4pz2g3953z6jr7hmxmikv205g8d0x6-home-manager-files/.config/gtk-3.0/settings.ini'
Jun 04 09:05:51 iynaix-desktop systemd[1]: home-manager-iynaix.service: Main process exited, code=exited, status=1/FAILURE
Jun 04 09:05:51 iynaix-desktop systemd[1]: home-manager-iynaix.service: Failed with result 'exit-code'.
Jun 04 09:05:51 iynaix-desktop systemd[1]: Failed to start Home Manager environment for iynaix.
warning: error(s) occurred while switching to the new configuration
```

Fixes #5522 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Lichthagel  @rycee

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
