### PR TITLE
ci/labeler: upgrade to v5 format

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,36 +1,46 @@
 "mail":
-  - modules/programs/aerc*.nix
-  - modules/programs/alot*.nix
-  - tests/modules/programs/aerc/*
-  - tests/modules/programs/alot/*
-  - modules/programs/mujmap.nix
-  - tests/modules/programs/mujmap/*
-  - modules/programs/notmuch.nix
-  - modules/programs/neomutt*
-  - tests/modules/programs/neomutt/*
-  - modules/programs/getmail*
-  - modules/*/mbsync*
-  - tests/modules/programs/mbsync/*
-  - modules/programs/himalaya.nix
-  - tests/modules/programs/himalaya/*
-  - modules/programs/thunderbird.nix
-  - tests/modules/programs/thunderbird/*
-  - modules/services/imapnotify.nix
+- changed-files
+  - any-glob-to-any-file
+    - modules/programs/aerc*.nix
+    - modules/programs/alot*.nix
+    - tests/modules/programs/aerc/*
+    - tests/modules/programs/alot/*
+    - modules/programs/mujmap.nix
+    - tests/modules/programs/mujmap/*
+    - modules/programs/notmuch.nix
+    - modules/programs/neomutt*
+    - tests/modules/programs/neomutt/*
+    - modules/programs/getmail*
+    - modules/*/mbsync*
+    - tests/modules/programs/mbsync/*
+    - modules/programs/himalaya.nix
+    - tests/modules/programs/himalaya/*
+    - modules/programs/thunderbird.nix
+    - tests/modules/programs/thunderbird/*
+    - modules/services/imapnotify.nix
 
 "neovim":
-  - modules/programs/neovim.nix
-  - tests/modules/programs/neovim/**/*
+- changed-files
+  - any-glob-to-any-file
+    - modules/programs/neovim.nix
+    - tests/modules/programs/neovim/**/*
 
 "shell":
-  - modules/lib/zsh.nix
-  - modules/programs/zsh*
-  - modules/programs/bash*
-  - tests/modules/programs/zsh/**/*
+- changed-files
+  - any-glob-to-any-file
+    - modules/lib/zsh.nix
+    - modules/programs/zsh*
+    - modules/programs/bash*
+    - tests/modules/programs/zsh/**/*
 
 "calendar":
-  - modules/programs/khal*
-  - modules/*/vdirsyncer*
-  - modules/accounts/calendar.nix
+- changed-files
+  - any-glob-to-any-file
+    - modules/programs/khal*
+    - modules/*/vdirsyncer*
+    - modules/accounts/calendar.nix
 
 "contacts":
-  - modules/accounts/contacts.nix
+- changed-files
+  - any-glob-to-any-file
+    - modules/accounts/contacts.nix


### PR DESCRIPTION
### Description

actions/labeler@v5 had breaking changes that I failed to update for in https://github.com/nix-community/home-manager/pull/5496. This PR should hopefully fix it.

I was unfortunately not able to catch the issue because the labeler config seems to be based on whatever is in the `master` branch, so CI didn't catch it on the original PR.

I'm going to need @rycee to help bail me out here.

Signed-off-by: Sumner Evans <me@sumnerevans.com>

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
