### PR TITLE
nushell: plugin support

### DIFF
--- a/tests/modules/programs/nushell/default.nix
+++ b/tests/modules/programs/nushell/default.nix
@@ -1,1 +1,4 @@
-{ nushell-example-settings = ./example-settings.nix; }
+{
+  nushell-example-settings = ./example-settings.nix;
+  nushell-plugins = ./plugins.nix;
+}

--- a/tests/modules/programs/nushell/plugins.nix
+++ b/tests/modules/programs/nushell/plugins.nix
@@ -1,0 +1,22 @@
+{ pkgs, config, ... }:
+
+{
+  programs.nushell = {
+    enable = true;
+    plugins =
+      builtins.attrValues { inherit (pkgs.nushellPlugins) formats gstat; };
+  };
+
+  test.stubs."nushellPlugins.formats" = { };
+
+  nmt.script = let
+    configDir = if pkgs.stdenv.isDarwin && !config.xdg.enable then
+      "home-files/Library/Application Support/nushell"
+    else
+      "home-files/.config/nushell";
+    pluginFile = "${configDir}/plugin.msgpackz";
+
+  in ''
+    assertFileExists "${pluginFile}"
+  '';
+}


### PR DESCRIPTION
### Description

This PR adds plugin support via `programs.nushell.plugins`.

To achieve it, a barebones nushell instance is launched and then the plugins are registered. The updated plugin file is then linked to the default location.

The plugin file and commands needed to register them differs between nushell versions, so that's handled accordingly. For reference, the new `plugin add` commands work for nushell `>=0.93.0`, the version on `nixpkgs-24.05`. `nixpkgs-23.11` has nushell version `0.87.0`.

I still there are some questions to answer before this becomes mergeable:
- Does it makes sense to support older nushell versions? Mixing an older nixpkgs stable release with home-manager unstable is AFAIK not supported
- As per [the docs](https://www.nushell.sh/book/plugins.html#downloading-and-installing-a-plugin) the plugin installation workflow is subject to changes. Is it worth it to allow this feature now, only to break in the future?
    - Maybe we can keep the interface consistent, but update the implementation. It would require more checks for specific version ranges tho 🥲 
 - It's also possible to [configure plugins](https://www.nushell.sh/book/plugins.html#downloading-and-installing-a-plugin). So instead of a list maybe an attrset with fields like `enabled`, `package`, `settings`... might be a better option

Happy to hear/read your feedback!

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Philipp-M 

