### PR TITLE
docs: add redirect from the previous options.html

### DIFF
--- a/docs/home-manager-manual.nix
+++ b/docs/home-manager-manual.nix
@@ -32,6 +32,8 @@ in stdenv.mkDerivation {
         OPTIONS_JSON \
         ${home-manager-options.nix-darwin}/share/doc/nixos/options.json
 
+    cp ${./options.html} out/options.html
+
     cp ${./static/style.css} out/style.css
 
     cp -r ${./release-notes} release-notes

--- a/docs/options.html
+++ b/docs/options.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Redirecting&hellip;</title>
+    <meta charset="utf-8">
+    <link rel="canonical" href="options.xhtml">
+    <noscript><meta http-equiv="refresh" content="0; url=options.xhtml"></noscript>
+  </head>
+  <body>
+    <h1>Redirecting&hellip;</h1>
+    <script>
+      window.location.href = "options.xhtml" + (window.location.search || "") + (window.location.hash || "");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION

### Description

After migrating to nixos-render-docs, the extension move to .xtml. Unfortunately, this broke links to the previous Options Page.

This patch provides a basic redirect support to the new Options Page.

Fixes https://github.com/nix-community/home-manager/issues/5002

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
