### PR TITLE
gpg-agent: use $TTY for zsh

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -13,8 +13,13 @@ let
     ${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye > /dev/null
   '';
 
-  gpgInitStr = ''
+  gpgBashInitStr = ''
     GPG_TTY="$(tty)"
+    export GPG_TTY
+  '' + optionalString cfg.enableSshSupport gpgSshSupportStr;
+
+  gpgZshInitStr = ''
+    GPG_TTY="$TTY"
     export GPG_TTY
   '' + optionalString cfg.enableSshSupport gpgSshSupportStr;
 
@@ -256,8 +261,8 @@ in {
         fi
       '';
 
-      programs.bash.initExtra = mkIf cfg.enableBashIntegration gpgInitStr;
-      programs.zsh.initExtra = mkIf cfg.enableZshIntegration gpgInitStr;
+      programs.bash.initExtra = mkIf cfg.enableBashIntegration gpgBashInitStr;
+      programs.zsh.initExtra = mkIf cfg.enableZshIntegration gpgZshInitStr;
       programs.fish.interactiveShellInit =
         mkIf cfg.enableFishIntegration gpgFishInitStr;
 


### PR DESCRIPTION
### Description
Setting `GPG_TTY` through `$(tty)` is not reliable when powerlevel10k's instant prompt is enabled (it often fails for me, which is annoying). As a alternative, use zsh's builtin variable `TTY` which is recommended by powerlevel10k's author (who also claims it to be faster).

See also:
- <https://zsh.sourceforge.io/Doc/Release/Parameters.html#index-TTY>
- <https://github.com/romkatv/powerlevel10k/?tab=readme-ov-file#how-do-i-export-gpg_tty-when-using-instant-prompt>

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 
