### PR TITLE
swayosd: add systemdTarget option

### DIFF
--- a/modules/services/swayosd.nix
+++ b/modules/services/swayosd.nix
@@ -43,6 +43,15 @@ in {
         X display to use.
       '';
     };
+
+    systemdTarget = mkOption {
+      type = types.str;
+      default = "graphical-session.target";
+      example = "sway-session.target";
+      description = ''
+        Systemd target to bind to.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -56,8 +65,8 @@ in {
       services.swayosd = {
         Unit = {
           Description = "Volume/backlight OSD indicator";
-          PartOf = [ "graphical-session.target" ];
-          After = [ "graphical-session.target" ];
+          PartOf = [ cfg.systemdTarget ];
+          After = [ cfg.systemdTarget ];
           ConditionEnvironment = "WAYLAND_DISPLAY";
           Documentation = "man:swayosd(1)";
         };

--- a/tests/modules/services/swayosd/swayosd.nix
+++ b/tests/modules/services/swayosd/swayosd.nix
@@ -10,6 +10,7 @@
     display = "DISPLAY";
     stylePath = "/etc/xdg/swayosd/style.css";
     topMargin = 0.1;
+    systemdTarget = "test.target";
   };
 
   nmt.script = ''
@@ -26,11 +27,11 @@
           Type=simple
 
           [Unit]
-          After=graphical-session.target
+          After=test.target
           ConditionEnvironment=WAYLAND_DISPLAY
           Description=Volume/backlight OSD indicator
           Documentation=man:swayosd(1)
-          PartOf=graphical-session.target
+          PartOf=test.target
         ''
       }
   '';


### PR DESCRIPTION
### Description

Adds a `systemdTarget` option for swayosd matching swayidle, clipman, wlsunset, etc. Fixes #5506.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

CC @pltanton