### PR TITLE
jq: add object keys color

### DIFF
--- a/modules/programs/jq.nix
+++ b/modules/programs/jq.nix
@@ -22,6 +22,7 @@ let
       strings = colorType;
       arrays = colorType;
       objects = colorType;
+      objectKeys = colorType;
     };
   };
 
@@ -41,19 +42,20 @@ in {
         description = ''
           The colors used in colored JSON output.
 
-          See the [Colors section](https://jqlang.github.io/jq/manual/#Colors)
+          See the [Colors section](https://jqlang.github.io/jq/manual/#colors)
           of the jq manual.
         '';
 
         example = literalExpression ''
           {
-            null    = "1;30";
-            false   = "0;31";
-            true    = "0;32";
-            numbers = "0;36";
-            strings = "0;33";
-            arrays  = "1;35";
-            objects = "1;37";
+            null       = "1;30";
+            false      = "0;31";
+            true       = "0;32";
+            numbers    = "0;36";
+            strings    = "0;33";
+            arrays     = "1;35";
+            objects    = "1;37";
+            objectKeys = "1;34";
           }
         '';
 
@@ -65,6 +67,7 @@ in {
           strings = "0;32";
           arrays = "1;37";
           objects = "1;37";
+          objectKeys = "1;34";
         };
 
         type = colorsType;
@@ -78,7 +81,7 @@ in {
     home.sessionVariables = let c = cfg.colors;
     in {
       JQ_COLORS =
-        "${c.null}:${c.false}:${c.true}:${c.numbers}:${c.strings}:${c.arrays}:${c.objects}";
+        "${c.null}:${c.false}:${c.true}:${c.numbers}:${c.strings}:${c.arrays}:${c.objects}:${c.objectKeys}";
     };
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

jq 1.7 added `object keys` color option. ([docs](https://jqlang.github.io/jq/manual/#colors), and [jq/docs/content/manual/v1.7/manual.yml](https://github.com/jqlang/jq/blob/7be6870751c2ab3f49365a955c51ce5ba1f1b752/docs/content/manual/v1.7/manual.yml#L3670-L3677))

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@bb010g @liff
