### PR TITLE
fcitx5: fix tests

### DIFF
--- a/tests/modules/i18n/input-method/fcitx5-stubs.nix
+++ b/tests/modules/i18n/input-method/fcitx5-stubs.nix
@@ -4,11 +4,15 @@
       version = "0";
       outPath = null;
       buildScript = ''
-        mkdir -p $out/bin $out/share/applications $out/etc/xdg/autostart
+        mkdir -p $out/bin $out/share/applications $out/share/dbus-1/services $out/etc/xdg/autostart
         touch $out/bin/fcitx5 \
               $out/bin/fcitx5-config-qt \
               $out/share/applications/org.fcitx.Fcitx5.desktop \
+              $out/share/dbus-1/services/org.fcitx.Fcitx5.service \
               $out/etc/xdg/autostart/org.fcitx.Fcitx5.desktop
+        # The grep usage of fcitx5-with-addons expects one of the files to match with the fcitx5.out
+        # https://github.com/NixOS/nixpkgs/blob/d2eb4be48705289791428c07aca8ff654c1422ba/pkgs/tools/inputmethods/fcitx5/with-addons.nix#L40-L44
+        echo $out >> $out/etc/xdg/autostart/org.fcitx.Fcitx5.desktop
         chmod +x $out/bin/fcitx5 \
                  $out/bin/fcitx5-config-qt
       '';


### PR DESCRIPTION

### Description
Since https://github.com/NixOS/nixpkgs/pull/308725, fcitx5-with-addons expects share/dbus-1/services/ to be present.
This patch updates the fcitx5 stub to reflect that.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
