### PR TITLE
mpv: fix package if wrapMpv not found

### DIFF
--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -55,8 +55,13 @@ let
 
   mpvPackage = if cfg.scripts == [ ] then
     cfg.package
+  else if hasAttr "wrapMpv" pkgs then
+    pkgs.wrapMpv pkgs.mpv-unwrapped { scripts = cfg.scripts; }
   else
-    pkgs.wrapMpv pkgs.mpv-unwrapped { scripts = cfg.scripts; };
+    pkgs.mpv-unwrapped.wrapper {
+      mpv = pkgs.mpv-unwrapped;
+      scripts = cfg.scripts;
+    };
 
 in {
   options = {

--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -58,10 +58,7 @@ let
   else if hasAttr "wrapMpv" pkgs then
     pkgs.wrapMpv pkgs.mpv-unwrapped { scripts = cfg.scripts; }
   else
-    pkgs.mpv-unwrapped.wrapper {
-      mpv = pkgs.mpv-unwrapped;
-      scripts = cfg.scripts;
-    };
+    pkgs.mpv.override { scripts = cfg.scripts; };
 
 in {
   options = {


### PR DESCRIPTION
### Description

`wrapMpv` was removed from nixpkgs since this PR: https://github.com/NixOS/nixpkgs/pull/304349

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
