### PR TITLE
jujutsu: fix config file location on Darwin

### DIFF
--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -6,6 +6,10 @@ let
 
   cfg = config.programs.jujutsu;
   tomlFormat = pkgs.formats.toml { };
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Application Support"
+  else
+    config.xdg.configHome;
 
 in {
   meta.maintainers = [ maintainers.shikanime ];
@@ -51,7 +55,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."jj/config.toml" = mkIf (cfg.settings != { }) {
+    home.file."${configDir}/jj/config.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "jujutsu-config" (cfg.settings
         // optionalAttrs (cfg.ediff) (let
           emacsDiffScript = pkgs.writeShellScriptBin "emacs-ediff" ''

--- a/tests/modules/programs/jujutsu/empty-config.nix
+++ b/tests/modules/programs/jujutsu/empty-config.nix
@@ -7,5 +7,6 @@
 
   nmt.script = ''
     assertPathNotExists home-files/.config/jj/config.toml
+    assertPathNotExists "home-files/Library/Application Support/jj/config.toml"
   '';
 }

--- a/tests/modules/programs/jujutsu/example-config.nix
+++ b/tests/modules/programs/jujutsu/example-config.nix
@@ -1,6 +1,12 @@
-{ config, ... }:
+{ config, pkgs, ... }:
 
-{
+let
+  configFile = if pkgs.stdenv.isDarwin then
+    "home-files/Library/Application Support/jj/config.toml"
+  else
+    "home-files/.config/jj/config.toml";
+
+in {
   programs.jujutsu = {
     enable = true;
     package = config.lib.test.mkStubPackage { };
@@ -13,9 +19,9 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/jj/config.toml
+    assertFileExists "${configFile}"
     assertFileContent \
-      home-files/.config/jj/config.toml \
+      "${configFile}" \
       ${
         builtins.toFile "expected.toml" ''
           [user]


### PR DESCRIPTION
### Description

The `jj` tool loads its configuration from [a platform-dependent location](https://github.com/martinvonz/jj/blob/a9953b3fb0713b792541930bf880f6e0d93ede91/docs/config.md#user-config-file). On Darwin, it looks in `~/Library/Application Support/jj`. This revision updates the `programs.jujutsu` module to serialize the generated configuration to the correct location.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

Test system information:

```bash session
$ nix-shell -p nix-info --run "nix-info -m"
 - system: `"aarch64-darwin"`
 - host os: `Darwin 22.6.0, macOS 13.6.7`
 - multi-user?: `yes`
 - sandbox: `no`
 - version: `nix-env (Nix) 2.18.1`
 - channels(user): `""`
 - channels(root): `"nixpkgs-24.05"`
 - nixpkgs: `/nix/var/nix/profiles/per-user/root/channels/nixpkgs`
```


- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@shikanime