### PR TITLE
bash: add package option

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -29,6 +29,8 @@ in {
     programs.bash = {
       enable = mkEnableOption "GNU Bourne-Again SHell";
 
+      package = mkPackageOption pkgs "bash" { default = "bashInteractive"; };
+
       enableCompletion = mkOption {
         type = types.bool;
         default = true;
@@ -190,7 +192,7 @@ in {
         HISTIGNORE = escapeShellArg (concatStringsSep ":" cfg.historyIgnore);
       }));
   in mkIf cfg.enable {
-    home.packages = [ pkgs.bashInteractive ];
+    home.packages = [ cfg.package ];
 
     home.file.".bash_profile".source = writeBashScript "bash_profile" ''
       # include .profile if it exists


### PR DESCRIPTION
### Description

This PR adds the `programs.bash.package` option to allow specifying which `bash` package to install (default `pkgs.bashInteractive`). This brings `bash` to parity with `fish`, `zsh`, and `nushell`, which already have analogous options.

I found myself wanting this functionality when writing additional logic around my shell configuration (in particular, `exec`ing into the `nixpkgs` version of `bash`).

### Checklist

- [X] Change is backwards compatible.

    Default `package` is `pkgs.bashInteractive`, which was previously hard-coded. 

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@rycee 