### PR TITLE
htop: write-protect entire configuration directory

### DIFF
--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -166,7 +166,8 @@ in {
 
   config = mkIf cfg.enable {
     lib.htop = {
-      inherit fields modes leftMeters rightMeters bar text graph led blank;
+      inherit fields defaultFields modes leftMeters rightMeters bar text graph
+        led blank;
     };
 
     home.packages = [ cfg.package ];

--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -172,7 +172,7 @@ in {
 
     home.packages = [ cfg.package ];
 
-    xdg.configFile."htop/htoprc" = let
+    xdg.configFile."htop" = let
       defaults = {
         fields = if isDarwin then
           remove fields.M_SHARE defaultFields
@@ -189,9 +189,9 @@ in {
       formatOptions = mapAttrsToList formatOption;
 
     in mkIf (cfg.settings != { }) {
-      text =
-        concatStringsSep "\n" (formatOptions before ++ formatOptions settings)
-        + "\n";
+      source = pkgs.writeTextDir "htoprc"
+        (concatStringsSep "\n" (formatOptions before ++ formatOptions settings)
+          + "\n");
     };
   };
 }


### PR DESCRIPTION
### Description

As of https://github.com/htop-dev/htop/commit/5e8fc97a96dd2dea1aad8c6c4f2e872aede38ead, htop creates a new config file and renames it over home-manager's symlink. This PR works around this by moving the whole $XDG_CONFIG_HOME/htop directory into the nix store, preventing such overwrites.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible. (it isn't, activation will fail with `Existing file '$XDG_CONFIG_HOME/htop' is in the way of '/nix/store/...-home-manager-files/.config/htop'`)

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@bjpbakker