### PR TITLE
ssh-agent: use POSIX-conform test for session variables

### DIFF
--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -20,7 +20,7 @@ in {
     ];
 
     home.sessionVariablesExtra = ''
-      if [[ -z "$SSH_AUTH_SOCK" ]]; then
+      if [ -z "$SSH_AUTH_SOCK" ]; then
         export SSH_AUTH_SOCK=$XDG_RUNTIME_DIR/ssh-agent
       fi
     '';


### PR DESCRIPTION
### Description

According to the documentation, hm-session-vars.sh may be sourced by POSIX compatible shells. Therefore, home.sessionVariablesExtra should only include code that conforms to POSIX.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.