### PR TITLE
psd: add missing module config options

### DIFF
--- a/modules/services/psd.nix
+++ b/modules/services/psd.nix
@@ -34,7 +34,7 @@ in {
     browsers = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
-      example = [ "chromium" "firefox" ];
+      example = [ "chromium" "google-chrome" "firefox" ];
       description = ''
         A list of browsers to sync. An empty list will enable all browsers to be managed by profile-sync-daemon.
 

--- a/modules/services/psd.nix
+++ b/modules/services/psd.nix
@@ -4,6 +4,14 @@ let
 
   cfg = config.services.psd;
 
+  configFile = ''
+    ${lib.optionalString (cfg.browsers != [ ]) ''
+      BROWSERS=(${lib.concatStringsSep " " cfg.browsers})
+    ''}
+
+    USE_BACKUP="${if cfg.useBackup then "yes" else "no"}"
+    BACKUP_LIMIT=${builtins.toString cfg.backupLimit}
+  '';
 in {
   meta.maintainers = [ lib.hm.maintainers.danjujan ];
 
@@ -22,6 +30,34 @@ in {
         defaults to seconds if omitted.
       '';
     };
+
+    browsers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "chromium" "firefox" ];
+      description = ''
+        A list of browsers to sync. An empty list will enable all browsers to be managed by profile-sync-daemon.
+
+        Available choices are:
+        chromium chromium-dev conkeror.mozdev.org epiphany falkon firefox firefox-trunk google-chrome google-chrome-beta google-chrome-unstable heftig-aurora icecat inox luakit midori opera opera-beta opera-developer opera-legacy otter-browser qupzilla qutebrowser palemoon rekonq seamonkey surf vivaldi vivaldi-snapshot
+      '';
+    };
+
+    useBackup = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to completly enable or disable the crash recovery feature.
+      '';
+    };
+
+    backupLimit = lib.mkOption {
+      type = lib.types.ints.unsigned;
+      default = 5;
+      description = ''
+        Maximum number of crash recovery snapshots to keep (the oldest ones are deleted first).
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -38,6 +74,10 @@ in {
           rsync
           kmod
           gawk
+          gnugrep
+          gnused
+          coreutils
+          findutils
           nettools
           util-linux
           profile-sync-daemon
@@ -84,5 +124,7 @@ in {
         Timer = { OnUnitActiveSec = cfg.resyncTimer; };
       };
     };
+
+    xdg.configFile."psd/psd.conf".text = configFile;
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This change adds configurable options to psd and creates the corresponding config file, it also adds missing packages to the envPath. 
Previously the config file would not be automatically created, which broke psd and made it not function like it should.

I added config options that I think are relevant. I deliberately left out options like `USE_OVERLAYFS` and `USE_SUSPSYNC` as they have additional dependencies that would need to have assertions to check if they are met.

Closes #5454 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@danjujan 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
