### PR TITLE
gtk: explicitly set default font size

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -221,10 +221,9 @@ in {
 
   config = mkIf cfg.enable (let
     gtkIni = optionalAttrs (cfg.font != null) {
-      gtk-font-name = let
-        fontSize =
-          optionalString (cfg.font.size != null) " ${toString cfg.font.size}";
-      in "${cfg.font.name}" + fontSize;
+      gtk-font-name =
+        let fontSize = if cfg.font.size != null then cfg.font.size else 10;
+        in "${cfg.font.name} ${toString fontSize}";
     } // optionalAttrs (cfg.theme != null) { gtk-theme-name = cfg.theme.name; }
       // optionalAttrs (cfg.iconTheme != null) {
         gtk-icon-theme-name = cfg.iconTheme.name;
@@ -245,10 +244,9 @@ in {
       '' + cfg4.extraCss;
 
     dconfIni = optionalAttrs (cfg.font != null) {
-      font-name = let
-        fontSize =
-          optionalString (cfg.font.size != null) " ${toString cfg.font.size}";
-      in "${cfg.font.name}" + fontSize;
+      font-name =
+        let fontSize = if cfg.font.size != null then cfg.font.size else 10;
+        in "${cfg.font.name} ${toString fontSize}";
     } // optionalAttrs (cfg.theme != null) { gtk-theme = cfg.theme.name; }
       // optionalAttrs (cfg.iconTheme != null) {
         icon-theme = cfg.iconTheme.name;


### PR DESCRIPTION
### Description

Fixes #5562

I originally thought about changing the default of `hm.types.fontType` to 10, but just decided to do a null check in the gtk module since the new default wouldn't apply outside of gtk.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee