### PR TITLE
htop: use attrsOf type instead of attrs as the settings type

### DIFF
--- a/modules/programs/htop.nix
+++ b/modules/programs/htop.nix
@@ -113,7 +113,8 @@ in {
     enable = mkEnableOption "htop";
 
     settings = mkOption {
-      type = types.attrs;
+      type = with types;
+        attrsOf (oneOf [ bool int str (listOf (oneOf [ int str ])) ]);
       default = { };
       example = literalExpression ''
         {


### PR DESCRIPTION
### Description
Read https://github.com/NixOS/nixpkgs/issues/85508 for why it's a bad idea to use the attrs type.
I noticed this problem while trying to use `mkDefault` for one of the options, which did not work and instead failed with the unhelpful error message `error: cannot coerce a set to a string`.

The new type is a little more strict than the old type. I could have probably used something like `attrsOf anything` but making the type a little more explicit seems like a good idea. Let me know if 100% backwards compatibility is more important.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@bjpbakker @somasis 
