### PR TITLE
stalonetray: move config file to `XDG_CONFIG_HOME`

### DIFF
--- a/modules/services/stalonetray.nix
+++ b/modules/services/stalonetray.nix
@@ -74,7 +74,7 @@ in {
     }
 
     (mkIf (cfg.config != { }) {
-      home.file.".stalonetrayrc".text = let
+      xdg.configFile."stalonetrayrc".text = let
         valueToString = v:
           if isBool v then
             (if v then "true" else "false")
@@ -88,7 +88,7 @@ in {
     })
 
     (mkIf (cfg.extraConfig != "") {
-      home.file.".stalonetrayrc".text = cfg.extraConfig;
+      xdg.configFile."stalonetrayrc".text = cfg.extraConfig;
     })
   ]);
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Move `$HOME/.stalonetrayrc` file to be symlinked to `$XDG_CONFIG_HOME/stalonetrayrc`.

See the [README](https://github.com/kolbusa/stalonetray?tab=readme-ov-file#description), and https://github.com/kolbusa/stalonetray/issues/1 for support details.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

For the most part, unless someone has external scripts that depends on the location of this file? I find it unlikely.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
