### PR TITLE
glance: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1692,6 +1692,17 @@ in {
           allows you to override this name.
         '';
       }
+
+      {
+        time = "2024-06-28T14:18:16+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.glance'.
+
+          Glance is a self-hosted dashboard that puts all your feeds in
+          one place. See https://github.com/glanceapp/glance for more.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -301,6 +301,7 @@ let
     ./services/fusuma.nix
     ./services/getmail.nix
     ./services/git-sync.nix
+    ./services/glance.nix
     ./services/gnome-keyring.nix
     ./services/gpg-agent.nix
     ./services/grobi.nix

--- a/modules/services/glance.nix
+++ b/modules/services/glance.nix
@@ -1,0 +1,77 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.glance;
+
+  inherit (lib) mkEnableOption mkPackageOption mkOption mkIf getExe;
+
+  settingsFormat = pkgs.formats.yaml { };
+
+  settingsFile = settingsFormat.generate "glance.yml" cfg.settings;
+
+  configFilePath = "${config.xdg.configHome}/glance/glance.yml";
+in {
+  meta.maintainers = [ pkgs.lib.maintainers.gepbird ];
+
+  options.services.glance = {
+    enable = mkEnableOption "glance";
+
+    package = mkPackageOption pkgs "glance" { };
+
+    settings = mkOption {
+      type = settingsFormat.type;
+      default = {
+        pages = [{
+          name = "Calendar";
+          columns = [{
+            size = "full";
+            widgets = [{ type = "calendar"; }];
+          }];
+        }];
+      };
+      example = {
+        server.port = 5678;
+        pages = [{
+          name = "Home";
+          columns = [{
+            size = "full";
+            widgets = [
+              { type = "calendar"; }
+              {
+                type = "weather";
+                location = "London, United Kingdom";
+              }
+            ];
+          }];
+        }];
+      };
+      description = ''
+        Configuration written to a yaml file that is read by glance. See
+        <https://github.com/glanceapp/glance/blob/main/docs/configuration.md>
+        for more.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.glance" pkgs
+        lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."glance/glance.yml".source = settingsFile;
+
+    systemd.user.services.glance = {
+      Unit = {
+        Description = "Glance feed dashboard server";
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install.WantedBy = [ "graphical-session.target" ];
+
+      Service.ExecStart = "${getExe cfg.package} --config ${configFilePath}";
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -241,6 +241,7 @@ in import nmtSrc {
     ./modules/services/fnott
     ./modules/services/fusuma
     ./modules/services/git-sync
+    ./modules/services/glance
     ./modules/services/gpg-agent
     ./modules/services/gromit-mpx
     ./modules/services/home-manager-auto-upgrade

--- a/tests/modules/services/glance/default-settings.nix
+++ b/tests/modules/services/glance/default-settings.nix
@@ -1,0 +1,15 @@
+{ ... }:
+
+{
+  services.glance.enable = true;
+
+  test.stubs.glance = { };
+
+  nmt.script = ''
+    configFile=home-files/.config/glance/glance.yml
+    serviceFile=home-files/.config/systemd/user/glance.service
+
+    assertFileContent $configFile ${./glance-default-config.yml}
+    assertFileContent $serviceFile ${./glance.service}
+  '';
+}

--- a/tests/modules/services/glance/default.nix
+++ b/tests/modules/services/glance/default.nix
@@ -1,0 +1,4 @@
+{
+  glance-default-settings = ./default-settings.nix;
+  glance-example-settings = ./example-settings.nix;
+}

--- a/tests/modules/services/glance/example-settings.nix
+++ b/tests/modules/services/glance/example-settings.nix
@@ -1,0 +1,33 @@
+{ ... }:
+
+{
+  services.glance = {
+    enable = true;
+    settings = {
+      server.port = 5678;
+      pages = [{
+        name = "Home";
+        columns = [{
+          size = "full";
+          widgets = [
+            { type = "calendar"; }
+            {
+              type = "weather";
+              location = "London, United Kingdom";
+            }
+          ];
+        }];
+      }];
+    };
+  };
+
+  test.stubs.glance = { };
+
+  nmt.script = ''
+    configFile=home-files/.config/glance/glance.yml
+    serviceFile=home-files/.config/systemd/user/glance.service
+
+    assertFileContent $configFile ${./glance-example-config.yml}
+    assertFileContent $serviceFile ${./glance.service}
+  '';
+}

--- a/tests/modules/services/glance/glance-default-config.yml
+++ b/tests/modules/services/glance/glance-default-config.yml
@@ -1,0 +1,6 @@
+pages:
+- columns:
+  - size: full
+    widgets:
+    - type: calendar
+  name: Calendar

--- a/tests/modules/services/glance/glance-example-config.yml
+++ b/tests/modules/services/glance/glance-example-config.yml
@@ -1,0 +1,10 @@
+pages:
+- columns:
+  - size: full
+    widgets:
+    - type: calendar
+    - location: London, United Kingdom
+      type: weather
+  name: Home
+server:
+  port: 5678

--- a/tests/modules/services/glance/glance.service
+++ b/tests/modules/services/glance/glance.service
@@ -1,0 +1,9 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@glance@/bin/dummy --config /home/hm-user/.config/glance/glance.yml
+
+[Unit]
+Description=Glance feed dashboard server
+PartOf=graphical-session.target


### PR DESCRIPTION
### Description

Adds module `services.glance` which is a self-hosted feed dashboard. Their repo: https://github.com/glanceapp/glance/.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
