### PR TITLE
starship: fix type of settings to allow all valid value

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -24,14 +24,7 @@ in {
     };
 
     settings = mkOption {
-      type = with types;
-        let
-          prim = either bool (either int str);
-          primOrPrimAttrs = either prim (attrsOf prim);
-          entry = either prim (listOf primOrPrimAttrs);
-          entryOrAttrsOf = t: either entry (attrsOf t);
-          entries = entryOrAttrsOf (entryOrAttrsOf entry);
-        in attrsOf entries // { description = "Starship configuration"; };
+      type = tomlFormat.type;
       default = { };
       example = literalExpression ''
         {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
This PR will close https://github.com/nix-community/home-manager/issues/4786.

<details>
<summary>Original comment</summary>
<blockquote>
Type checking for `programs.starship.settings` is nearly a redundant, since:
- It can hardly prevent invalid options in advance, as we cannot copy the whole schema from starship.
- The settings will be passed to `tomlFormat.generate`, which does check the type.
- It can be incomplete and refuse some valid options, e.g., `listOf (listOf str)`.
Just keep the type check as simple as possible, and `starship` will emit warings/errors when it sees invalid options.
</blockquote>
</details>

Changes the original `type` to `tomlFormat.type`, so `programs.starship.settings` can accept all valid TOML-style values.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] (skipped) Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] (skipped) Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
