### PR TITLE
systemd: don't try to restart templates

### DIFF
--- a/modules/systemd-activate.sh
+++ b/modules/systemd-activate.sh
@@ -34,7 +34,7 @@ function systemdPostReload() {
     touch "$oldServiceFiles"
   else
     find "$oldUserServicePath" \
-      -maxdepth 1 -name '*.service' -exec basename '{}' ';' \
+      -maxdepth 1 -name '*.service' \! -name '*@.service' -exec basename '{}' ';' \
       | sort \
       > "$oldServiceFiles"
   fi
@@ -43,7 +43,7 @@ function systemdPostReload() {
     touch "$newServiceFiles"
   else
     find "$newUserServicePath" \
-      -maxdepth 1 -name '*.service' -exec basename '{}' ';' \
+      -maxdepth 1 -name '*.service' \! -name '*@.service' -exec basename '{}' ';' \
       | sort \
       > "$newServiceFiles"
   fi


### PR DESCRIPTION
If the user has template services in their systemd configuration, these can't be restarted, and will produces warnings during the activation phase.  Avoid those warnings by skipping any uninstantiated templates when looking for services to start or stop.

### Description

If a user has template files in their systemd configuration `unit@.service` rather than `unit.service` or `unit@instance.service`, these will produce error messages during the Home Manager activation phase, as they can't be activated or queried; systemctl will only let you activate/query instances of those templates. Avoid this by ignoring such files when looking for units that might want to be stopped or started.

This is fundamentally only a cosmetic change; the warnings are benign, they're just also unnecessary and unhelpful. I'm seeing them because I'm migrating my config files into Home Manager gradually, and in the interim I have a bunch of template systemd units that are stored in a separate Git repository.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
