### PR TITLE
sway: add PATH to systemd.variables

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -387,6 +387,7 @@ in {
           * {env}`NIXOS_OZONE_WL`
           * {env}`XCURSOR_THEME`
           * {env}`XCURSOR_SIZE`
+          * {env}`PATH`
           You can extend this list using the `systemd.variables` option.
         '';
       };
@@ -402,6 +403,7 @@ in {
           "NIXOS_OZONE_WL"
           "XCURSOR_THEME"
           "XCURSOR_SIZE"
+          "PATH"
         ];
         example = [ "-all" ];
         description = ''


### PR DESCRIPTION
### Description

Flatpak apps use xdg-desktop-portals to open e.g. links in the default browser.
For this to work, the xdg-desktop-portal user service needs the PATH environment variable to be set correctly.
See the following issue and especially the linked comment for details: https://github.com/NixOS/nixpkgs/issues/189851#issuecomment-1238907955
### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Scrumplex
@alexarice 
@sumnerevans 
@oxalica 
