### PR TITLE
rbw: fix url option examples

### DIFF
--- a/modules/programs/rbw.nix
+++ b/modules/programs/rbw.nix
@@ -19,7 +19,7 @@ let
         base_url = mkOption {
           type = with types; nullOr str;
           default = null;
-          example = "bitwarden.example.com";
+          example = "https://bitwarden.example.com/";
           description =
             "The base-url for a self-hosted bitwarden installation.";
         };
@@ -27,7 +27,7 @@ let
         identity_url = mkOption {
           type = with types; nullOr str;
           default = null;
-          example = "identity.example.com";
+          example = "https://identity.example.com/";
           description = "The identity url for your bitwarden installation.";
         };
 


### PR DESCRIPTION
### Description

rbw expects a protocol for its base_url setting. Otherwise fails with `rbw unlock: failed to parse base url: relative URL without a base`.

See [README.md#configuration](https://github.com/doy/rbw/blob/741a72cf0d7d45fcd32b0326b69f6238733e5a56/README.md#configuration).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@ambroisie 
