### PR TITLE
lazydocker: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -143,6 +143,7 @@ let
     ./programs/khard.nix
     ./programs/kitty.nix
     ./programs/kodi.nix
+    ./programs/lazydocker.nix
     ./programs/lazygit.nix
     ./programs/ledger.nix
     ./programs/less.nix

--- a/modules/programs/lazydocker.nix
+++ b/modules/programs/lazydocker.nix
@@ -1,0 +1,62 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.lazydocker;
+
+  yamlFormat = pkgs.formats.yaml { };
+
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+in {
+  meta.maintainers = [ maintainers.hausken ];
+
+  options.programs.lazydocker = {
+    enable = mkEnableOption
+      "lazydocker, a simple terminal UI for both docker and docker compose";
+
+    package = mkPackageOption pkgs "lazydocker" { };
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = {
+        commandTemplates.dockerCompose =
+          "docker compose"; # Lazydocker uses docker-compose by default which will not work
+      };
+      example = literalExpression ''
+        {
+          gui.theme = {
+            activeBorderColor = ["red" "bold"];
+            inactiveBorderColor = ["blue"];
+          };
+          commandTemplates.dockerCompose = "docker compose compose -f docker-compose.yml";
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/lazydocker/config.yml`
+        on Linux or on Darwin if [](#opt-xdg.enable) is set, otherwise
+        {file}`~/Library/Application Support/jesseduffield/lazydocker/config.yml`.
+        See
+        <https://github.com/jesseduffield/lazydocker/blob/master/docs/Config.md>
+        for supported values.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.file."Library/Application Support/jesseduffield/lazydocker/config.yml" =
+      mkIf (cfg.settings != { } && (isDarwin && !config.xdg.enable)) {
+        source = yamlFormat.generate "lazydocker-config" cfg.settings;
+      };
+
+    xdg.configFile."lazydocker/config.yml" =
+      mkIf (cfg.settings != { } && !(isDarwin && !config.xdg.enable)) {
+        source = yamlFormat.generate "lazydocker-config" cfg.settings;
+      };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -99,6 +99,7 @@ in import nmtSrc {
     ./modules/programs/khard
     ./modules/programs/kitty
     ./modules/programs/ledger
+    ./modules/programs/lazydocker
     ./modules/programs/less
     ./modules/programs/lf
     ./modules/programs/lsd

--- a/tests/modules/programs/lazydocker/custom-settings.nix
+++ b/tests/modules/programs/lazydocker/custom-settings.nix
@@ -1,0 +1,18 @@
+{ ... }: {
+  programs.lazydocker = {
+    enable = true;
+    settings = {
+      commandTemplates.dockerCompose = "docker compose";
+      gui.theme = {
+        activeBorderColor = [ "red" "bold" ];
+        inactiveBorderColor = [ "blue" ];
+      };
+    };
+  };
+  test.stubs.lazydocker = { };
+  nmt.script = ''
+    assertFileExists home-files/.config/lazydocker/config.yml
+    assertFileContent home-files/.config/lazydocker/config.yml \
+      ${./custom-settings.yml}
+  '';
+}

--- a/tests/modules/programs/lazydocker/custom-settings.yml
+++ b/tests/modules/programs/lazydocker/custom-settings.yml
@@ -1,0 +1,9 @@
+commandTemplates:
+  dockerCompose: docker compose
+gui:
+  theme:
+    activeBorderColor:
+    - red
+    - bold
+    inactiveBorderColor:
+    - blue

--- a/tests/modules/programs/lazydocker/default-settings.nix
+++ b/tests/modules/programs/lazydocker/default-settings.nix
@@ -1,0 +1,9 @@
+{ ... }: {
+  programs.lazydocker.enable = true;
+  test.stubs.lazydocker = { };
+  nmt.script = ''
+    assertFileExists home-files/.config/lazydocker/config.yml
+    assertFileContent home-files/.config/lazydocker/config.yml \
+      ${./default.yml}
+  '';
+}

--- a/tests/modules/programs/lazydocker/default.nix
+++ b/tests/modules/programs/lazydocker/default.nix
@@ -1,0 +1,5 @@
+{
+  lazydocker-default-settings = ./default-settings.nix;
+  lazydocker-custom-settings = ./custom-settings.nix;
+}
+

--- a/tests/modules/programs/lazydocker/default.yml
+++ b/tests/modules/programs/lazydocker/default.yml
@@ -1,0 +1,2 @@
+commandTemplates:
+  dockerCompose: docker compose


### PR DESCRIPTION
* Add lazydocker module
* maintainers: add hausken

Based on Lazygit home manager module, fixes #4924 
Note: Podman is not supported, you can set the DOCKER_HOST env var, but the experience is not good. 
Created a request in lazydocker repo https://github.com/jesseduffield/lazydocker/issues/556 for better podman support

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
