### PR TITLE
eww: string based config

### DIFF
--- a/modules/programs/eww.nix
+++ b/modules/programs/eww.nix
@@ -22,18 +22,48 @@ in {
       '';
     };
 
-    configDir = mkOption {
-      type = types.path;
-      example = literalExpression "./eww-config-dir";
+    configYuck = mkOption {
+      type = types.lines;
+      example = literalExpression ''
+        (defwindow example
+             :monitor 0
+             :geometry (geometry :x "0%"
+                                 :y "20px"
+                                 :width "90%"
+                                 :height "30px"
+                                 :anchor "top center")
+             :stacking "fg"
+             :reserve (struts :distance "40px" :side "top")
+             :windowtype "dock"
+             :wm-ignore false
+          "example content")
+      '';
       description = ''
-        The directory that gets symlinked to
-        {file}`$XDG_CONFIG_HOME/eww`.
+        The content that gets symlinked to
+        {file} `$XDG_CONFIG_HOME/eww/eww.yuck`.
+      '';
+    };
+
+    configScss = mkOption {
+      type = types.lines;
+      example = literalExpression ''
+        window {
+          background: pink;
+        }
+      '';
+      description = ''
+        The content that gets symlinked to
+        {file} `$XDG_CONFIG_HOME/eww/eww.scss`
       '';
     };
   };
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
-    xdg.configFile."eww".source = cfg.configDir;
+    xdg.configFile = {
+      "eww/eww.yuck".text = cfg.configYuck;
+      "eww/eww.scss".text = cfg.configScss;
+    };
   };
 }
+

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -71,6 +71,7 @@ in import nmtSrc {
     ./modules/programs/dircolors
     ./modules/programs/direnv
     ./modules/programs/emacs
+    ./modules/programs/eww
     ./modules/programs/fastfetch
     ./modules/programs/feh
     ./modules/programs/fish

--- a/tests/modules/programs/eww/basic-config.nix
+++ b/tests/modules/programs/eww/basic-config.nix
@@ -1,0 +1,32 @@
+{ pkgs, ... }: {
+  config = {
+    programs.eww = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-eww" "";
+      configYuck = ''
+        (defwindow example
+             :monitor 0
+             :geometry (geometry :x "0%"
+                                 :y "20px"
+                                 :width "90%"
+                                 :height "30px"
+                                 :anchor "top center")
+             :stacking "fg"
+             :reserve (struts :distance "40px" :side "top")
+             :windowtype "dock"
+             :wm-ignore false
+          "example content")
+      '';
+      configScss = ''
+        window {
+          background: pink;
+        }
+      '';
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/eww/eww.yuck
+      assertFileExists home-files/.config/eww/eww.scss
+    '';
+  };
+}

--- a/tests/modules/programs/eww/default.nix
+++ b/tests/modules/programs/eww/default.nix
@@ -1,0 +1,1 @@
+{ eww-basic-configuration = ./basic-config.nix; }


### PR DESCRIPTION
### Description

change eww options to allow for configuration via nix. the current implementation sets the entire config directory from a source path which makes it so the entire config must be static files, and the config cannot be split up/appended to from other modules. setting the entire directory also makes it so that fixing this must break backwards compatibility (as far as i can tell). I dont know what the policy is for breaking changes, but im happy to update with any necessary changes

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@mainrs 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
