### PR TITLE
direnv: add silent option

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -95,6 +95,10 @@ in {
       package = mkPackageOption pkgs "nix-direnv" { };
     };
 
+    silent = mkEnableOption ''
+      the hiding of direnv logging
+    '';
+
   };
 
   config = mkIf cfg.enable {
@@ -163,5 +167,7 @@ in {
             }
         )
       '');
+
+    home.sessionVariables = lib.mkIf cfg.silent { DIRENV_LOG_FORMAT = ""; };
   };
 }


### PR DESCRIPTION
### Description
<!--

Please provide a brief description of your change.

-->
Adds a silent option to direnv.
Copied from nipkgs.
https://github.com/NixOS/nixpkgs/blob/2893f56de08021cffd9b6b6dfc70fd9ccd51eb60/nixos/modules/programs/direnv.nix#L31
Tests have not been updated because I don't know how to check for `sessionVariables`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@rycee 
