### PR TITLE
mpd: specify dependency of service on socket

### DIFF
--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -171,10 +171,17 @@ in {
     ];
 
     systemd.user.services.mpd = {
-      Unit = {
-        After = [ "network.target" "sound.target" ];
-        Description = "Music Player Daemon";
-      };
+      Unit = mkMerge [
+        {
+          Description = "Music Player Daemon";
+          After = [ "network.target" "sound.target" ];
+        }
+
+        (mkIf cfg.network.startWhenNeeded {
+          Requires = [ "mpd.socket" ];
+          After = [ "mpd.socket" ];
+        })
+      ];
 
       Install = mkIf (!cfg.network.startWhenNeeded) {
         WantedBy = [ "default.target" ];

--- a/tests/modules/services/mpd/default.nix
+++ b/tests/modules/services/mpd/default.nix
@@ -1,5 +1,6 @@
 {
   mpd-basic-configuration = ./basic-configuration.nix;
   mpd-before-state-version-22_11 = ./before-state-version-22_11.nix;
+  mpd-start-when-needed = ./start-when-needed.nix;
   mpd-xdg-music-dir = ./xdg-music-dir.nix;
 }

--- a/tests/modules/services/mpd/start-when-needed.nix
+++ b/tests/modules/services/mpd/start-when-needed.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  services.mpd = {
+    enable = true;
+    musicDirectory = "/my/music/dir";
+    extraArgs = [ "--verbose" ];
+    network.startWhenNeeded = true;
+  };
+
+  home.stateVersion = "22.11";
+
+  test.stubs.mpd = { };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/mpd.service)
+    assertFileContent "$serviceFile" ${./start-when-needed.service}
+
+    socketFile=home-files/.config/systemd/user/mpd.socket
+    assertFileContent "$socketFile" ${./start-when-needed.socket}
+
+    confFile=$(grep -o \
+        '/nix/store/.*-mpd.conf' \
+        $TESTED/home-files/.config/systemd/user/mpd.service)
+    assertFileContent "$confFile" ${./basic-configuration.conf}
+  '';
+}

--- a/tests/modules/services/mpd/start-when-needed.service
+++ b/tests/modules/services/mpd/start-when-needed.service
@@ -1,0 +1,12 @@
+[Service]
+Environment=PATH=/home/hm-user/.nix-profile/bin
+ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf '--verbose'
+ExecStartPre=/nix/store/00000000000000000000000000000000-bash/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
+Type=notify
+
+[Unit]
+After=network.target
+After=sound.target
+After=mpd.socket
+Description=Music Player Daemon
+Requires=mpd.socket

--- a/tests/modules/services/mpd/start-when-needed.socket
+++ b/tests/modules/services/mpd/start-when-needed.socket
@@ -1,0 +1,8 @@
+[Install]
+WantedBy=sockets.target
+
+[Socket]
+Backlog=5
+KeepAlive=true
+ListenStream=127.0.0.1:6600
+ListenStream=%t/mpd/socket


### PR DESCRIPTION
### Description

This allows `systemctl --user restart mpd.socket` to work properly.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
