### PR TITLE
yazi: allow literal string for `initLua`

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -141,7 +141,7 @@ in {
     };
 
     initLua = mkOption {
-      type = with types; nullOr path;
+      type = with types; nullOr (either path lines);
       default = null;
       description = ''
         The init.lua for Yazi itself.
@@ -210,7 +210,12 @@ in {
       "yazi/theme.toml" = mkIf (cfg.theme != { }) {
         source = tomlFormat.generate "yazi-theme" cfg.theme;
       };
-      "yazi/init.lua" = mkIf (cfg.initLua != null) { source = cfg.initLua; };
+      "yazi/init.lua" = mkIf (cfg.initLua != null)
+        (if builtins.isPath cfg.initLua then {
+          source = cfg.initLua;
+        } else {
+          text = cfg.initLua;
+        });
     } // (mapAttrs' (name: value:
       nameValuePair "yazi/flavors/${name}.yazi" { source = value; })
       cfg.flavors) // (mapAttrs' (name: value:

--- a/tests/modules/programs/yazi/default.nix
+++ b/tests/modules/programs/yazi/default.nix
@@ -1,5 +1,6 @@
 {
   yazi-settings = ./settings.nix;
+  yazi-init-lua-string = ./init-lua-string.nix;
   yazi-bash-integration-enabled = ./bash-integration-enabled.nix;
   yazi-zsh-integration-enabled = ./zsh-integration-enabled.nix;
   yazi-fish-integration-enabled = ./fish-integration-enabled.nix;

--- a/tests/modules/programs/yazi/init-lua-string.nix
+++ b/tests/modules/programs/yazi/init-lua-string.nix
@@ -1,0 +1,14 @@
+{ ... }: {
+  programs.yazi = {
+    enable = true;
+
+    initLua = builtins.readFile ./init.lua;
+  };
+
+  test.stubs.yazi = { };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/yazi/init.lua \
+      ${./init.lua}
+  '';
+}


### PR DESCRIPTION
### Description

Currently `programs.yazi.initLua` only accepts a path/module which seems unnecessarily constraining and I doubt most users will be creating a separate file for what is likely very little lines of Lua code. This change makes the `initLua` option work for literal strings as well.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@eljamm @XYenon