### PR TITLE
maintainers: remove ivar

### DIFF
--- a/modules/programs/sm64ex.nix
+++ b/modules/programs/sm64ex.nix
@@ -29,7 +29,7 @@ let
     in "${key} ${generatedValue}";
 
 in {
-  meta.maintainers = [ maintainers.ivar ];
+  meta.maintainers = [ ];
 
   options.programs.sm64ex = {
     enable = mkEnableOption "sm64ex";

--- a/modules/services/pbgopy.nix
+++ b/modules/services/pbgopy.nix
@@ -15,7 +15,7 @@ let
     "--basic-auth ${escapeShellArg cfg.httpAuth}");
 
 in {
-  meta.maintainers = [ maintainers.ivar ];
+  meta.maintainers = [ ];
 
   options.services.pbgopy = {
     enable = mkEnableOption "pbgopy";


### PR DESCRIPTION
### Description

ivar was removed as a maintainer from upstream nixpkgs due to inactivity: https://github.com/NixOS/nixpkgs/pull/322266

Signed-off-by: Sumner Evans <me@sumnerevans.com>

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
