### PR TITLE
home-manager: add repl subcommand

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -637,6 +637,28 @@ function doBuild() {
     presentNews
 }
 
+function doRepl() {
+    setFlakeAttribute
+    if [[ -v FLAKE_CONFIG_URI ]]; then
+        _i 'home-manager repl does not (yet) support flakes' >&2
+        return 1
+    fi
+
+    setConfigFile
+
+    extraArgs=()
+    for p in "${EXTRA_NIX_PATH[@]}"; do
+        extraArgs+=(-I "$p")
+    done
+
+    exec nix repl \
+        --file '<home-manager/home-manager/home-manager.nix>' \
+        "${extraArgs[@]}" \
+        "${PASSTHROUGH_OPTS[@]}" \
+        --argstr confPath "$HOME_MANAGER_CONFIG" \
+        --argstr confAttr "$HOME_MANAGER_CONFIG_ATTRIBUTE"
+}
+
 function doSwitch() {
     setWorkDir
 
@@ -941,6 +963,9 @@ function doHelp() {
     echo "      Remove indicated generations. Use 'generations' command to"
     echo "      find suitable generation numbers."
     echo
+    echo "  repl"
+    echo "      Opens the configuration in \`nix repl\`"
+    echo
     echo "  expire-generations TIMESTAMP"
     echo "      Remove generations older than TIMESTAMP where TIMESTAMP is"
     echo "      interpreted as in the -d argument of the date tool. For"
@@ -964,7 +989,7 @@ while [[ $# -gt 0 ]]; do
     opt="$1"
     shift
     case $opt in
-        build|init|instantiate|option|edit|expire-generations|generations|help|news|packages|remove-generations|switch|uninstall)
+        build|init|instantiate|option|edit|expire-generations|generations|help|news|packages|remove-generations|repl|switch|uninstall)
             COMMAND="$opt"
             ;;
         -A)
@@ -1108,6 +1133,9 @@ case $COMMAND in
         ;;
     packages)
         doListPackages
+        ;;
+    repl)
+        doRepl
         ;;
     news)
         doShowNews --all

--- a/home-manager/home-manager.nix
+++ b/home-manager/home-manager.nix
@@ -16,5 +16,10 @@ let
 
 in
 {
-  inherit (env) activationPackage config;
+  inherit (env)
+    activationPackage
+    config
+    pkgs
+    options
+    ;
 }


### PR DESCRIPTION
I keep finding myself wanting to inspect the computed result of my Home Manager config. NixOS has `nixos-rebuild repl`, which launches the REPL with the NixOS configuration already loaded; it's essentially a shortcut for `nix repl --file '<nixos/nixos>'`.  This PR adds similar function to `home-manager`.

No tests, as this is fundamentally an interactive user-facing tool command that doesn't lend itself well to automated testing. All the existing tests pass, except for the "Argument list too long" error I also saw in #5576, which (a) I'm confident isn't related and (b) I'm now investigating separately.

### Description

Similar to the `nixos-rebuild repl` command, `home-manager repl` will launch the Nix read-evaluate-print-loop environment with the Home Manager configuration loaded.

To make that more useful, also add the pkgs and options attributes from the generated Home Manager configuration to the environment.

This doesn't currently work with flakes, because I don't use them and I'm not confident I could safely test that function.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

No obvious maintainer, so tagging @rycee as the person whose name keeps coming up in the history logs.