### PR TITLE
home-manager: set FLAKE_ARG with HOME_MANAGER_PATH

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -100,6 +100,10 @@ function setHomeManagerNixPath() {
     local path="@HOME_MANAGER_PATH@"
 
     if [[ -n "$path" ]] ; then
+        if [[ -e "$path/flake.nix" ]] ; then
+            # Set FLAKE_ARG if not set by --flake already
+            FLAKE_ARG=${FLAKE_ARG:-$path}
+        fi
         if [[ -e "$path" || "$path" =~ ^https?:// ]] ; then
             EXTRA_NIX_PATH+=("home-manager=$path")
             return


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

I use a flake setup with home-manager. Currently setting `programs.home-manager.path` will still result in:

```
No configuration file found. Please create one at ~/.config/home-manager/home.nix
```

And so I have to either `ln -s <dotfiles> ~/.config/home-manager` or each time do `home-manager switch --flake <dotfiles>` which kinda defeats the purpose of having `programs.home-manager.path`.

I think it makes sense for home-manager to set `FLAKE_ARG` automatically when both `programs.home-manager.path` and `$path/flake.nix` exist.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
