### PR TITLE
dunst: fix warning for lib.cartesianProductOfSets

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -172,7 +172,7 @@ in {
 
         mkPath = { basePath, theme, category }:
           "${basePath}/share/icons/${theme.name}/${theme.size}/${category}";
-      in concatMapStringsSep ":" mkPath (cartesianProductOfSets {
+      in concatMapStringsSep ":" mkPath (cartesianProduct {
         basePath = basePaths;
         theme = themes;
         category = categories;


### PR DESCRIPTION
### Description

"lib.cartesianProductOfSets is a deprecated alias of lib.cartesianProduct."
Rename happened in nixpkgs commit `228621e42dc43f936b66e0ed042c90c511aa0535`.


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
