### PR TITLE
firefox: Allow to add PKCS11 modules

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -207,6 +207,7 @@ let
       package.override (old: {
         cfg = old.cfg or { } // fcfg;
         extraPolicies = (old.extraPolicies or { }) // cfg.policies;
+        pkcs11Modules = (old.pkcs11Modules or [ ]) ++ cfg.pkcs11Modules;
       })
     else
       (pkgs.wrapFirefox.override { config = bcfg; }) package { };
@@ -780,6 +781,14 @@ in {
         also need to set the NixOS option
         `services.gnome.gnome-browser-connector.enable` to
         `true`.
+      '';
+    };
+
+    pkcs11Modules = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      description = ''
+        Additional packages to be loaded as PKCS #11 modules in Firefox.
       '';
     };
   };


### PR DESCRIPTION
### Description

Add a new option `programs.firefox.pkcs11Modules` to add PKCS11 modules to firefox directly.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee @kira-bruneau 
