### PR TITLE
home-manager: support username with special chars

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -52,6 +52,11 @@ function hasFlakeSupport() {
             | grep -q nix-command
 }
 
+# Escape string for use in Nix files.
+function escapeForNix() {
+    printf %s "$1" | sed 's/["$\\]/\\\0/g'
+}
+
 # Attempts to set the HOME_MANAGER_CONFIG global variable.
 #
 # If no configuration file can be found then this function will print
@@ -201,7 +206,7 @@ function setFlakeAttribute() {
                 # Check FQDN, long, and short hostnames; long first to preserve
                 # pre-existing behaviour in case both happen to be defined.
                 for n in "$USER@$(hostname -f)" "$USER@$(hostname)" "$USER@$(hostname -s)"; do
-                    if [[ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$n\"")" == "true" ]]; then
+                    if [[ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$(escapeForNix "$n")\"")" == "true" ]]; then
                         name="$n"
                         if [[ -v VERBOSE ]]; then
                             echo "Using flake homeConfiguration for $name"
@@ -210,7 +215,7 @@ function setFlakeAttribute() {
                 done
                 ;;
         esac
-        export FLAKE_CONFIG_URI="$flake#homeConfigurations.\"$name\""
+        export FLAKE_CONFIG_URI="$flake#homeConfigurations.\"$(printf %s "$name" | jq -sRr @uri)\""
     fi
 }
 
@@ -349,8 +354,8 @@ function doInit() {
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.
-  home.username = "$USER";
-  home.homeDirectory = "$HOME";
+  home.username = "$(escapeForNix "$USER")";
+  home.homeDirectory = "$(escapeForNix "$HOME")";
 $xdgVars
   # This value determines the Home Manager release that your configuration is
   # compatible with. This helps avoid breakage when a new Home Manager release
@@ -439,7 +444,7 @@ EOF
             mkdir -p "$confDir"
             cat > "$flakeFile" <<EOF
 {
-  description = "Home Manager configuration of $USER";
+  description = "Home Manager configuration of $(escapeForNix "$USER")";
 
   inputs = {
     # Specify the source of Home Manager and Nixpkgs.
@@ -455,7 +460,7 @@ EOF
       system = "$nixSystem";
       pkgs = nixpkgs.legacyPackages.\${system};
     in {
-      homeConfigurations."$USER" = home-manager.lib.homeManagerConfiguration {
+      homeConfigurations."$(escapeForNix "$USER")" = home-manager.lib.homeManagerConfiguration {
         inherit pkgs;
 
         # Specify your home configuration modules here, for example,
@@ -855,8 +860,8 @@ function doUninstall() {
             cat > "$HOME_MANAGER_CONFIG" <<EOF
 {
   uninstall = true;
-  home.username = "$USER";
-  home.homeDirectory = "$HOME";
+  home.username = "$(escapeForNix "$USER")";
+  home.homeDirectory = "$(escapeForNix "$HOME")";
   home.stateVersion = "24.11";
 }
 EOF


### PR DESCRIPTION
### Description

The home manager script fails when `$USER` contains special characters.

For example, my work PC is managed by company's LDAP and username is `<COMPANY>\<user>`). When running `home-manager switch` I get the following error:

```
error: flake 'path:/home/<COMPANY>/<user>/.config/home-manager' does not provide attribute 'packages.x86_64-linux.homeConfigurations."<COMPANY>\<user>".activationPackage', 'legacyPackages.x86_64-linux.homeConfigurations."<COMPANY>\<user>".activationPackage' or 'homeConfigurations."<COMPANY>\<user>".activationPackage'
       Did you mean <COMPANY><user>?
```

There are two types of strings that need escaping:

- strings in Nix expressions (e.g. `home.nix` generated by `home-manager init`)
  they need backslashes before special chars 
- flake URI (passed to `nix build`)
  they need URI's percent encoding, luckily `jq` supports that

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
