### PR TITLE
gnome-keyring: update package

### DIFF
--- a/modules/services/gnome-keyring.nix
+++ b/modules/services/gnome-keyring.nix
@@ -49,7 +49,7 @@ in {
           args = concatStringsSep " " ([ "--start" "--foreground" ]
             ++ optional (cfg.components != [ ])
             ("--components=" + concatStringsSep "," cfg.components));
-        in "${pkgs.gnome.gnome-keyring}/bin/gnome-keyring-daemon ${args}";
+        in "${pkgs.gnome-keyring}/bin/gnome-keyring-daemon ${args}";
         Restart = "on-abort";
       };
 


### PR DESCRIPTION
### Description

`pkgs.gnome.gnome-keyring` has been moved to `pkgs.gnome-keyring` in nixpgkgs-unstable.
Change happened in https://github.com/NixOS/nixpkgs/commit/1369411184ce66bf812935ede91f52789252e1e5

### Checklist

- [x] Change is backwards compatible.
  :warning: I think ? I've seen a review commit from @rycee on [another PR](https://github.com/nix-community/home-manager/pull/5605) stating that home-manager is only targetting nixpkgs-unstable branch so I think we're good

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 