### PR TITLE
fix(gnupg): console output when using ssh

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -10,7 +10,7 @@ let
   homedir = config.programs.gpg.homedir;
 
   gpgSshSupportStr = ''
-    ${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye > /dev/null
+    ${gpgPkg}/bin/gpg-connect-agent --quiet updatestartuptty /bye > /dev/null
   '';
 
   gpgInitStr = ''
@@ -25,7 +25,7 @@ let
   gpgNushellInitStr = ''
     $env.GPG_TTY = (tty)
   '' + optionalString cfg.enableSshSupport ''
-    ${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye | ignore
+    ${gpgPkg}/bin/gpg-connect-agent --quiet updatestartuptty /bye | ignore
 
     $env.SSH_AUTH_SOCK = ($env.SSH_AUTH_SOCK? | default (${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket))
   '';


### PR DESCRIPTION
I'm getting:

```
gpg-connect-agent: connection to the agent is in restricted mode
```

which I tracked to this invocation. Adding `--quiet` fixes it, and is probably a good idea.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
