### PR TITLE
systemd: only set old units directory when available

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -335,7 +335,7 @@ in {
         in ''
           ${pkgs.sd-switch}/bin/sd-switch \
             ''${DRY_RUN:+--dry-run} $VERBOSE_ARG ${timeoutArg} \
-            ''${oldGenPath:+--old-units $oldGenPath/home-files/.config/systemd/user} \
+            ''${oldUnitsDir:+--old-units $oldUnitsDir} \
             --new-units "$newUnitsDir"
         '';
       };
@@ -354,6 +354,13 @@ in {
           warnEcho "Attempting to reload services anyway..."
         fi
 
+        if [[ -v oldGenPath ]]; then
+          oldUnitsDir="$oldGenPath/home-files/.config/systemd/user"
+          if [[ ! -e $oldUnitsDir ]]; then
+            oldUnitsDir=
+          fi
+        fi
+
         newUnitsDir="$newGenPath/home-files/.config/systemd/user"
         if [[ ! -e $newUnitsDir ]]; then
           newUnitsDir=${pkgs.emptyDirectory}
@@ -362,7 +369,7 @@ in {
         ${ensureRuntimeDir} \
           ${getAttr cfg.startServices cmd}
 
-        unset newUnitsDir
+        unset newUnitsDir oldUnitsDir
       else
         echo "User systemd daemon not running. Skipping reload."
       fi

--- a/tests/integration/nixos/basics.nix
+++ b/tests/integration/nixos/basics.nix
@@ -7,6 +7,8 @@
   nodes.machine = { ... }: {
     imports = [ ../../../nixos ]; # Import the HM NixOS module.
 
+    virtualisation.memorySize = 2048;
+
     users.users.alice = {
       isNormalUser = true;
       description = "Alice Foobar";

--- a/tests/integration/standalone/flake-basics.nix
+++ b/tests/integration/standalone/flake-basics.nix
@@ -6,7 +6,7 @@
 
   nodes.machine = { ... }: {
     imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-    virtualisation.memorySize = 2048;
+    virtualisation.memorySize = 3072;
     nix = {
       registry.home-manager.to = {
         type = "path";
@@ -88,7 +88,7 @@
       } /home/alice/.config/home-manager/home.nix")
 
       actual = succeed_as_alice("home-manager switch")
-      expected = "Started pueued.service - active"
+      expected = "Starting units: pueued.service"
       assert expected in actual, \
         f"expected home-manager switch to contain {expected}, but got {actual}"
 

--- a/tests/integration/standalone/standard-basics.nix
+++ b/tests/integration/standalone/standard-basics.nix
@@ -85,7 +85,7 @@
       } /home/alice/.config/home-manager/home.nix")
 
       actual = succeed_as_alice("home-manager switch")
-      expected = "Started pueued.service - active"
+      expected = "Starting units: pueued.service"
       assert expected in actual, \
         f"expected home-manager switch to contain {expected}, but got {actual}"
 


### PR DESCRIPTION
### Description

Avoid potential problems when we have an old generation but it does not contain any systemd units.

Also update integration tests to match recent changes in sd-switch behavior.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```