### PR TITLE
sd-switch: respect xdg directory specifications

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -100,10 +100,7 @@ let
       settingsFormat.generate "user.conf" cfg.settings;
   };
 
-  configHome = if (config.xdg.enable) then
-    lib.removePrefix config.home.homeDirectory config.xdg.configHome
-  else
-    "/.config";
+  configHome = lib.removePrefix config.home.homeDirectory config.xdg.configHome;
 
 in {
   meta.maintainers = [ lib.maintainers.rycee ];

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -100,6 +100,11 @@ let
       settingsFormat.generate "user.conf" cfg.settings;
   };
 
+  configHome = if (config.xdg.enable) then
+    lib.removePrefix config.home.homeDirectory config.xdg.configHome
+  else
+    "/.config";
+
 in {
   meta.maintainers = [ lib.maintainers.rycee ];
 
@@ -355,13 +360,13 @@ in {
         fi
 
         if [[ -v oldGenPath ]]; then
-          oldUnitsDir="$oldGenPath/home-files/.config/systemd/user"
+          oldUnitsDir="$oldGenPath/home-files${configHome}/systemd/user"
           if [[ ! -e $oldUnitsDir ]]; then
             oldUnitsDir=
           fi
         fi
 
-        newUnitsDir="$newGenPath/home-files/.config/systemd/user"
+        newUnitsDir="$newGenPath/home-files${configHome}/systemd/user"
         if [[ ! -e $newUnitsDir ]]; then
           newUnitsDir=${pkgs.emptyDirectory}
         fi


### PR DESCRIPTION
### Description

In the course of applying a workaround for #5552, I discovered that the `sd-switch` reload script assumes that systemd units are always located in `home-files/.config`. However, this is not necessarily the location of systemd user units, as a user wanting a tidier home folder may have `xdg.configHome` set.

Therefore, this PR seeks to update the `sd-switch` reload script to respect `xdg.configHome`. It does not seek to address a similar problem in the `legacy` or `suggest` reload scripts.

Note 1: In an ideal world, `xdg.configHome` would be relative to the user's home folder, so we could simply template it into the path used by the reload script. However: `xdg.configHome` is conventionally a string containing an absolute path. Therefore, we have to discover the expected subfolder for the XDG config home by stripping a leading `home.homeDirectory` prefix from it, so we can re-root under the directory for the new and old profiles.

Note 2: This patch is an improvement, but it is not perfect: it will not find old units if the user changes their `xdg.configHome` value. However, if they do change that value, they should probably log out and back in anyway.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee @kkoniuszy 
