### PR TITLE
ludusavi: create Ludusavi module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -590,6 +590,11 @@
     github = "pedorich-n";
     githubId = 15573098;
   };
+  PopeRigby = {
+    name = "PopeRigby";
+    github = "poperigby";
+    githubId = 20866468;
+  };
   liyangau = {
     name = "Li Yang";
     email = "d@aufomm.com";

--- a/modules/services/ludusavi.nix
+++ b/modules/services/ludusavi.nix
@@ -1,0 +1,93 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) getExe maintainers mkEnableOption mkIf mkOption;
+
+  inherit (lib.types) bool nullOr path;
+
+  cfg = config.services.ludusavi;
+  settingsFormat = pkgs.formats.yaml { };
+
+  configFile = if cfg.configFile == null then
+    settingsFormat.generate "config.yaml" cfg.settings
+  else
+    cfg.configFile;
+in {
+
+  options.services.ludusavi = {
+    enable = mkEnableOption "Ludusavi game backup tool";
+    configFile = mkOption {
+      type = nullOr path;
+      default = null;
+      description = ''
+        Path to a Ludusavi `config.yaml`. Mutually exclusive with the `settings` option.
+        See https://github.com/mtkennerly/ludusavi/blob/master/docs/help/configuration-file.md for available options.
+      '';
+    };
+    settings = mkOption {
+      type = settingsFormat.type;
+      default = {
+        manifest.url =
+          "https://raw.githubusercontent.com/mtkennerly/ludusavi-manifest/master/data/manifest.yaml";
+        roots = [ ];
+        backup.path = "$XDG_STATE_HOME/backups/ludusavi";
+        restore.path = "$XDG_STATE_HOME/backups/ludusavi";
+      };
+      example = {
+        language = "en-US";
+        theme = "light";
+        roots = [{
+          path = "~/.local/share/Steam";
+          store = "steam";
+        }];
+        backup.path = "~/.local/state/backups/ludusavi";
+        restore.path = "~/.local/state/backups/ludusavi";
+      };
+      description = ''
+        Ludusavi configuration as an attribute set. See
+        https://github.com/mtkennerly/ludusavi#configuration-file
+        for available options.
+      '';
+    };
+    backupNotification = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Send a notification message after a successful backup.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [{
+      assertion = (cfg.settings != { }) != (cfg.configFile != null);
+      message =
+        "The `settings` and `configFile` options are mutually exclusive.";
+    }];
+
+    systemd.user = {
+      services.ludusavi = {
+        Unit.Description = "Run a game save backup with Ludusavi";
+        Service = {
+          Type = "oneshot";
+          ExecStart = "${getExe pkgs.ludusavi} backup --force";
+        } // lib.optionalAttrs cfg.backupNotification {
+          ExecStartPost = "${
+              getExe pkgs.libnotify
+            } 'Ludusavi' 'Backup completed' -i ludusavi -a 'Ludusavi'";
+        };
+      };
+      timers.ludusavi = {
+        Unit.Description = "Run a game save backup with Ludusavi, daily";
+        Timer.OnCalendar = "daily";
+        Install.WantedBy = [ "timers.target" ];
+      };
+    };
+
+    xdg.configFile."ludusavi/config.yaml".source = configFile;
+
+    home.packages = [ pkgs.ludusavi ];
+  };
+
+  meta.maintainers = [ maintainers.PopeRigby ];
+}


### PR DESCRIPTION
### Description

This adds a module for Ludusavi, that runs it daily with a systemd service, and allows you to configure it using Nix.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).