### PR TITLE
Add river.systemd.runInService option

### DIFF
--- a/tests/modules/services/window-managers/river/init
+++ b/tests/modules/services/window-managers/river/init
@@ -6,6 +6,9 @@ export BAR="bar"
 export FOO="foo"
 export FOURTY_TWO="42"
 
+### SYSTEMD INTEGRATION ###
+/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP NIXOS_OZONE_WL XCURSOR_THEME XCURSOR_SIZE && systemctl --user stop river-session.target && systemctl --user start river-session.target
+
 ### CONFIGURATION ###
 riverctl attach-mode bottom
 riverctl background-color 0x002b36
@@ -59,9 +62,5 @@ riverctl xcursor-theme someGreatTheme 12
 rivertile -view-padding 6 -outer-padding 6 &
 some
 extra config
-
-
-### SYSTEMD INTEGRATION ###
-/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP NIXOS_OZONE_WL XCURSOR_THEME XCURSOR_SIZE && systemctl --user stop river-session.target && systemctl --user start river-session.target
 
 


### PR DESCRIPTION
### Description

Add a systemd.inService option to run river in systemd (via `systemctl --user start river`). This means that start & STOP events work for river in systemd. Services that bind to `graphical-session.target` will get stopped when river stops or when the computer shutdown. Without this, services never stops, and it leads to a "Stop session timeout" when shutting down. Stopping & restarting river without this option also does not restart graphic services (and they still refer to the old DISPLAY/WAYLAND_DISPLAY vars).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@GaetanLepage 