### PR TITLE
atuin: use 'lib.getExe'

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -110,18 +110,18 @@ in {
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
         source "${pkgs.bash-preexec}/share/bash/bash-preexec.sh"
-        eval "$(${cfg.package}/bin/atuin init bash ${flagsStr})"
+        eval "$(${lib.getExe cfg.package} init bash ${flagsStr})"
       fi
     '';
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
       if [[ $options[zle] = on ]]; then
-        eval "$(${cfg.package}/bin/atuin init zsh ${flagsStr})"
+        eval "$(${lib.getExe cfg.package} init zsh ${flagsStr})"
       fi
     '';
 
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-      ${cfg.package}/bin/atuin init fish ${flagsStr} | source
+      ${lib.getExe cfg.package} init fish ${flagsStr} | source
     '';
 
     programs.nushell = mkIf cfg.enableNushellIntegration {
@@ -130,7 +130,9 @@ in {
         if not ($atuin_cache | path exists) {
           mkdir $atuin_cache
         }
-        ${cfg.package}/bin/atuin init nu ${flagsStr} | save --force ${config.xdg.cacheHome}/atuin/init.nu
+        ${
+          lib.getExe cfg.package
+        } init nu ${flagsStr} | save --force ${config.xdg.cacheHome}/atuin/init.nu
       '';
       extraConfig = ''
         source ${config.xdg.cacheHome}/atuin/init.nu


### PR DESCRIPTION
### Description



### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
