### PR TITLE
swayosd: avoid restarting too quickly

### DIFF
--- a/modules/services/swayosd.nix
+++ b/modules/services/swayosd.nix
@@ -60,6 +60,8 @@ in {
           After = [ "graphical-session.target" ];
           ConditionEnvironment = "WAYLAND_DISPLAY";
           Documentation = "man:swayosd(1)";
+          StartLimitBurst = 5;
+          StartLimitIntervalSec = 10;
         };
 
         Service = {
@@ -71,6 +73,7 @@ in {
             + (optionalString (cfg.topMargin != null)
               " --top-margin ${toString cfg.topMargin}");
           Restart = "always";
+          RestartSec = "2s";
         };
 
         Install = { WantedBy = [ "graphical-session.target" ]; };

--- a/tests/modules/services/swayosd/swayosd.nix
+++ b/tests/modules/services/swayosd/swayosd.nix
@@ -23,6 +23,7 @@
           [Service]
           ExecStart=@swayosd@/bin/swayosd-server --display DISPLAY --style '/etc/xdg/swayosd/style.css' --top-margin 0.100000
           Restart=always
+          RestartSec=2s
           Type=simple
 
           [Unit]
@@ -31,6 +32,8 @@
           Description=Volume/backlight OSD indicator
           Documentation=man:swayosd(1)
           PartOf=graphical-session.target
+          StartLimitBurst=5
+          StartLimitIntervalSec=10
         ''
       }
   '';


### PR DESCRIPTION
### Description

Should fix an issue where swayosd.service would stop without starting again after restarting too quickly.

Triggered by ending a Hyprland session and logging in with tuigreet.

Related: https://github.com/nix-community/home-manager/pull/4316

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@pltanton 