### PR TITLE
vscode: add profiles support

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -210,8 +210,8 @@ let
       };
     };
   };
-  defaultProfile = (filterAttrs (n: v: n == "default") cfg.profiles).default;
-  allProfilesExceptDefault = (removeAttrs cfg.profiles [ "default" ]);
+  defaultProfile = if cfg.profiles ? default then cfg.profiles.default else { };
+  allProfilesExceptDefault = removeAttrs cfg.profiles [ "default" ];
 in {
   imports = [
     (mkChangedOptionModule [ "programs" "vscode" "immutableExtensionsDir" ] [
@@ -297,7 +297,7 @@ in {
           file="${userDir}/globalStorage/storage.json"
 
           if [ -f "$file" ]; then
-            existing_profiles=$(jq '.userDataProfiles // [] | map({ (.name): .location }) | add // {}' $file)
+            existing_profiles=$(jq '.userDataProfiles // [] | map({ (.name): .location }) | add // {}' "$file")
             file_write=""
             profiles=(${
               escapeShellArgs
@@ -314,12 +314,12 @@ in {
               file_write="$file_write$([ "$file_write" != "" ] && echo "...")$profile"
             done
 
-            echo "{}" > $file
+            echo "{}" > "$file"
           fi
 
           if [ "$file_write" != "" ]; then
-            userDataProfiles=$(jq ".userDataProfiles += $(echo $file_write | jq -R 'split("...") | map({ name: ., location: . })')" $file)
-            echo $userDataProfiles > $file
+            userDataProfiles=$(jq ".userDataProfiles += $(echo $file_write | jq -R 'split("...") | map({ name: ., location: . })')" "$file")
+            echo $userDataProfiles > "$file"
           fi
         '';
     in modifyGlobalStorage.outPath);

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -253,18 +253,25 @@ in {
       example = false;
       description = ''
         Whether extensions can be installed or updated manually
-        or by Visual Studio Code. This option is effective only
-        when there is a single profile (i.e. default).
+        or by Visual Studio Code. Mutually exclusive to
+        programs.vscode.profiles.
       '';
     };
 
     profiles = mkOption {
       type = types.listOf (profileType true);
       default = [ ];
+      description = ''
+        A list of all VSCode profiles. Mutually exclusive
+        to programs.vscode.mutableExtensionsDir
+      '';
     };
     defaultProfile = mkOption {
       type = profileType false;
       default = { };
+      description = ''
+        The default VSCode profile.
+      '';
     };
   };
 

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -1,5 +1,7 @@
 { config, lib, pkgs, ... }:
 
+# TODO: Re-write tests to support profiles.
+
 with lib;
 
 let
@@ -30,28 +32,174 @@ let
   else
     "${config.xdg.configHome}/${configDir}/User";
 
-  configFilePath = "${userDir}/settings.json";
-  tasksFilePath = "${userDir}/tasks.json";
-  keybindingsFilePath = "${userDir}/keybindings.json";
+  configFilePath = name:
+    "${userDir}/${
+      optionalString (name != "default") "profiles/${name}/"
+    }settings.json";
+  tasksFilePath = name:
+    "${userDir}/${
+      optionalString (name != "default") "profiles/${name}/"
+    }tasks.json";
+  keybindingsFilePath = name:
+    "${userDir}/${
+      optionalString (name != "default") "profiles/${name}/"
+    }keybindings.json";
 
-  snippetDir = "${userDir}/snippets";
+  snippetDir = name:
+    "${userDir}/${
+      optionalString (name != "default") "profiles/${name}/"
+    }snippets";
 
   # TODO: On Darwin where are the extensions?
   extensionPath = ".${extensionDir}/extensions";
 
-  extensionJson = pkgs.vscode-utils.toExtensionJson cfg.extensions;
-  extensionJsonFile = pkgs.writeTextFile {
-    name = "extensions-json";
-    destination = "/share/vscode/extensions/extensions.json";
-    text = extensionJson;
-  };
+  extensionJson = ext: pkgs.vscode-utils.toExtensionJson ext;
+  extensionJsonFile = name: text:
+    pkgs.writeTextFile {
+      inherit text;
+      name = "extensions-json-${name}";
+      destination = "/share/vscode/extensions/extensions.json";
+    };
 
-  mergedUserSettings = cfg.userSettings
+  mergedUserSettings = userSettings:
+    userSettings
     // optionalAttrs (!cfg.enableUpdateCheck) { "update.mode" = "none"; }
     // optionalAttrs (!cfg.enableExtensionUpdateCheck) {
       "extensions.autoCheckUpdates" = false;
     };
+
+  profileType = default:
+    types.submodule {
+      options = {
+        userSettings = mkOption {
+          type = jsonFormat.type;
+          default = { };
+          example = literalExpression ''
+            {
+              "files.autoSave" = "off";
+              "[nix]"."editor.tabSize" = 2;
+            }
+          '';
+          description = ''
+            Configuration written to Visual Studio Code's
+            {file}`settings.json`.
+          '';
+        };
+
+        userTasks = mkOption {
+          type = jsonFormat.type;
+          default = { };
+          example = literalExpression ''
+            {
+              version = "2.0.0";
+              tasks = [
+                {
+                  type = "shell";
+                  label = "Hello task";
+                  command = "hello";
+                }
+              ];
+            }
+          '';
+          description = ''
+            Configuration written to Visual Studio Code's
+            {file}`tasks.json`.
+          '';
+        };
+
+        keybindings = mkOption {
+          type = types.listOf (types.submodule {
+            options = {
+              key = mkOption {
+                type = types.str;
+                example = "ctrl+c";
+                description = "The key or key-combination to bind.";
+              };
+
+              command = mkOption {
+                type = types.str;
+                example = "editor.action.clipboardCopyAction";
+                description = "The VS Code command to execute.";
+              };
+
+              when = mkOption {
+                type = types.nullOr (types.str);
+                default = null;
+                example = "textInputFocus";
+                description = "Optional context filter.";
+              };
+
+              # https://code.visualstudio.com/docs/getstarted/keybindings#_command-arguments
+              args = mkOption {
+                type = types.nullOr (jsonFormat.type);
+                default = null;
+                example = { direction = "up"; };
+                description = "Optional arguments for a command.";
+              };
+            };
+          });
+          default = [ ];
+          example = literalExpression ''
+            [
+              {
+                key = "ctrl+c";
+                command = "editor.action.clipboardCopyAction";
+                when = "textInputFocus";
+              }
+            ]
+          '';
+          description = ''
+            Keybindings written to Visual Studio Code's
+            {file}`keybindings.json`.
+          '';
+        };
+
+        extensions = mkOption {
+          type = types.listOf types.package;
+          default = [ ];
+          example = literalExpression "[ pkgs.vscode-extensions.bbenoist.nix ]";
+          description = ''
+            The extensions Visual Studio Code should be started with.
+          '';
+        };
+
+        languageSnippets = mkOption {
+          type = jsonFormat.type;
+          default = { };
+          example = {
+            haskell = {
+              fixme = {
+                prefix = [ "fixme" ];
+                body = [ "$LINE_COMMENT FIXME: $0" ];
+                description = "Insert a FIXME remark";
+              };
+            };
+          };
+          description = "Defines user snippets for different languages.";
+        };
+
+        globalSnippets = mkOption {
+          type = jsonFormat.type;
+          default = { };
+          example = {
+            fixme = {
+              prefix = [ "fixme" ];
+              body = [ "$LINE_COMMENT FIXME: $0" ];
+              description = "Insert a FIXME remark";
+            };
+          };
+          description = "Defines global user snippets.";
+        };
+      } // optionalAttrs default {
+        name = mkOption {
+          type = types.str;
+          description = "Visual Studio Code's Profile name.";
+        };
+      };
+    };
+  allProfiles = cfg.profiles ++ [ cfg.defaultProfile ];
 in {
+  # TODO: Backwards compatibility with old options.
   imports = [
     (mkChangedOptionModule [ "programs" "vscode" "immutableExtensionsDir" ] [
       "programs"
@@ -60,204 +208,134 @@ in {
     ] (config: !config.programs.vscode.immutableExtensionsDir))
   ];
 
-  options = {
-    programs.vscode = {
-      enable = mkEnableOption "Visual Studio Code";
+  options.programs.vscode = {
+    enable = mkEnableOption "Visual Studio Code";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.vscode;
-        defaultText = literalExpression "pkgs.vscode";
-        example = literalExpression "pkgs.vscodium";
-        description = ''
-          Version of Visual Studio Code to install.
-        '';
-      };
+    package = mkOption {
+      type = types.package;
+      default = pkgs.vscode;
+      defaultText = literalExpression "pkgs.vscode";
+      example = literalExpression "pkgs.vscodium";
+      description = ''
+        Version of Visual Studio Code to install.
+      '';
+    };
 
-      enableUpdateCheck = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to enable update checks/notifications.
-        '';
-      };
+    enableUpdateCheck = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to enable update checks/notifications.
+      '';
+    };
 
-      enableExtensionUpdateCheck = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          Whether to enable update notifications for extensions.
-        '';
-      };
+    enableExtensionUpdateCheck = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to enable update notifications for extensions.
+      '';
+    };
 
-      userSettings = mkOption {
-        type = jsonFormat.type;
-        default = { };
-        example = literalExpression ''
-          {
-            "files.autoSave" = "off";
-            "[nix]"."editor.tabSize" = 2;
-          }
-        '';
-        description = ''
-          Configuration written to Visual Studio Code's
-          {file}`settings.json`.
-        '';
-      };
+    mutableExtensionsDir = mkOption {
+      type = types.bool;
+      default = cfg.profiles == [ ];
+      example = false;
+      description = ''
+        Whether extensions can be installed or updated manually
+        or by Visual Studio Code. This option is effective only
+        when there is a single profile (i.e. default).
+      '';
+    };
 
-      userTasks = mkOption {
-        type = jsonFormat.type;
-        default = { };
-        example = literalExpression ''
-          {
-            version = "2.0.0";
-            tasks = [
-              {
-                type = "shell";
-                label = "Hello task";
-                command = "hello";
-              }
-            ];
-          }
-        '';
-        description = ''
-          Configuration written to Visual Studio Code's
-          {file}`tasks.json`.
-        '';
-      };
-
-      keybindings = mkOption {
-        type = types.listOf (types.submodule {
-          options = {
-            key = mkOption {
-              type = types.str;
-              example = "ctrl+c";
-              description = "The key or key-combination to bind.";
-            };
-
-            command = mkOption {
-              type = types.str;
-              example = "editor.action.clipboardCopyAction";
-              description = "The VS Code command to execute.";
-            };
-
-            when = mkOption {
-              type = types.nullOr (types.str);
-              default = null;
-              example = "textInputFocus";
-              description = "Optional context filter.";
-            };
-
-            # https://code.visualstudio.com/docs/getstarted/keybindings#_command-arguments
-            args = mkOption {
-              type = types.nullOr (jsonFormat.type);
-              default = null;
-              example = { direction = "up"; };
-              description = "Optional arguments for a command.";
-            };
-          };
-        });
-        default = [ ];
-        example = literalExpression ''
-          [
-            {
-              key = "ctrl+c";
-              command = "editor.action.clipboardCopyAction";
-              when = "textInputFocus";
-            }
-          ]
-        '';
-        description = ''
-          Keybindings written to Visual Studio Code's
-          {file}`keybindings.json`.
-        '';
-      };
-
-      extensions = mkOption {
-        type = types.listOf types.package;
-        default = [ ];
-        example = literalExpression "[ pkgs.vscode-extensions.bbenoist.nix ]";
-        description = ''
-          The extensions Visual Studio Code should be started with.
-        '';
-      };
-
-      mutableExtensionsDir = mkOption {
-        type = types.bool;
-        default = true;
-        example = false;
-        description = ''
-          Whether extensions can be installed or updated manually
-          or by Visual Studio Code.
-        '';
-      };
-
-      languageSnippets = mkOption {
-        type = jsonFormat.type;
-        default = { };
-        example = {
-          haskell = {
-            fixme = {
-              prefix = [ "fixme" ];
-              body = [ "$LINE_COMMENT FIXME: $0" ];
-              description = "Insert a FIXME remark";
-            };
-          };
-        };
-        description = "Defines user snippets for different languages.";
-      };
-
-      globalSnippets = mkOption {
-        type = jsonFormat.type;
-        default = { };
-        example = {
-          fixme = {
-            prefix = [ "fixme" ];
-            body = [ "$LINE_COMMENT FIXME: $0" ];
-            description = "Insert a FIXME remark";
-          };
-        };
-        description = "Defines global user snippets.";
-      };
+    profiles = mkOption {
+      type = types.listOf (profileType true);
+      default = [ ];
+    };
+    defaultProfile = mkOption {
+      type = profileType false;
+      default = { };
     };
   };
 
   config = mkIf cfg.enable {
+    warnings = [
+      (mkIf (cfg.profiles != [ ] && cfg.mutableExtensionsDir)
+        "programs.vscode.mutableExtensionsDir can be used only if profiles is an empty list.")
+    ];
+
     home.packages = [ cfg.package ];
 
-    home.file = mkMerge [
-      (mkIf (mergedUserSettings != { }) {
-        "${configFilePath}".source =
-          jsonFormat.generate "vscode-user-settings" mergedUserSettings;
-      })
-      (mkIf (cfg.userTasks != { }) {
-        "${tasksFilePath}".source =
-          jsonFormat.generate "vscode-user-tasks" cfg.userTasks;
-      })
-      (mkIf (cfg.keybindings != [ ])
-        (let dropNullFields = filterAttrs (_: v: v != null);
-        in {
-          "${keybindingsFilePath}".source =
-            jsonFormat.generate "vscode-keybindings"
-            (map dropNullFields cfg.keybindings);
-        }))
-      (mkIf (cfg.extensions != [ ]) (let
-        subDir = "share/vscode/extensions";
+    /* *
+       TODO: Write a home.activation script for ${userDir}/globalStorage/storage.json, appending
+       every profile in the format `{ "name": <profile_name>, "location": <profile_name> }` to the
+       userDataProfiles array.
 
+       This file needs to mutable, and cannot be symlinked. This is because the file stores other data,
+       such as background themes, keybindingReferences, etc.
+    */
+
+    home.file = mkMerge (flatten [
+      (map (v:
+        let
+          # The default profile does not have the `name` key
+          name = if v ? name then v.name else "default";
+        in [
+          (mkIf ((mergedUserSettings v.userSettings) != { }) {
+            "${configFilePath name}".source =
+              jsonFormat.generate "vscode-user-settings"
+              (mergedUserSettings v.userSettings);
+          })
+
+          (mkIf (v.userTasks != { }) {
+            "${tasksFilePath name}".source =
+              jsonFormat.generate "vscode-user-tasks" v.userTasks;
+          })
+
+          (mkIf (v.keybindings != [ ]) {
+            "${keybindingsFilePath name}".source =
+              jsonFormat.generate "vscode-keybindings"
+              (map (filterAttrs (_: v: v != null)) v.keybindings);
+          })
+
+          (mkIf (v.languageSnippets != { }) (lib.mapAttrs' (language: snippet:
+            lib.nameValuePair "${snippetDir name}/${language}.json" {
+              source =
+                jsonFormat.generate "user-snippet-${language}.json" snippet;
+            }) v.languageSnippets))
+
+          (mkIf (v.globalSnippets != { }) {
+            "${snippetDir name}/global.code-snippets".source =
+              jsonFormat.generate "user-snippet-global.code-snippets"
+              v.globalSnippets;
+          })
+        ]) allProfiles)
+
+      # We write extensions.json for all profiles, except the default profile,
+      # since that is handled by code below.
+      (mkIf (cfg.profiles != [ ]) (listToAttrs (map (v:
+        nameValuePair "${userDir}/profiles/${v.name}/extensions.json" {
+          source = "${
+              extensionJsonFile v.name (extensionJson v.extensions)
+            }/share/vscode/extensions/extensions.json";
+        }) cfg.profiles)))
+
+      (mkIf ((filter (v: v.extensions != [ ]) allProfiles) != [ ]) (let
         # Adapted from https://discourse.nixos.org/t/vscode-extensions-setup/1801/2
+        subDir = "share/vscode/extensions";
         toPaths = ext:
           map (k: { "${extensionPath}/${k}".source = "${ext}/${subDir}/${k}"; })
           (if ext ? vscodeExtUniqueId then
             [ ext.vscodeExtUniqueId ]
           else
             builtins.attrNames (builtins.readDir (ext + "/${subDir}")));
-      in if cfg.mutableExtensionsDir then
-        mkMerge (concatMap toPaths cfg.extensions
+      in if (cfg.mutableExtensionsDir && cfg.profiles == [ ]) then
+        mkMerge (concatMap toPaths (flatten (map (v: v.extensions) allProfiles))
           ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0") {
             # Whenever our immutable extensions.json changes, force VSCode to regenerate
             # extensions.json with both mutable and immutable extensions.
             "${extensionPath}/.extensions-immutable.json" = {
-              text = extensionJson;
+              text = extensionJson cfg.defaultProfile.extensions;
               onChange = ''
                 run rm $VERBOSE_ARG -f ${extensionPath}/{extensions.json,.init-default-profile-extensions}
                 verboseEcho "Regenerating VSCode extensions.json"
@@ -269,25 +347,13 @@ in {
         "${extensionPath}".source = let
           combinedExtensionsDrv = pkgs.buildEnv {
             name = "vscode-extensions";
-            paths = cfg.extensions
-              ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0")
-              extensionJsonFile;
+            paths = flatten (map (v: v.extensions) allProfiles) ++ lib.optional
+              (lib.versionAtLeast vscodeVersion "1.74.0" && cfg.defaultProfile
+                != { }) (extensionJsonFile "default"
+                  (extensionJson cfg.defaultProfile.extensions));
           };
         in "${combinedExtensionsDrv}/${subDir}";
       }))
-
-      (mkIf (cfg.globalSnippets != { })
-        (let globalSnippets = "${snippetDir}/global.code-snippets";
-        in {
-          "${globalSnippets}".source =
-            jsonFormat.generate "user-snippet-global.code-snippets"
-            cfg.globalSnippets;
-        }))
-
-      (lib.mapAttrs' (language: snippet:
-        lib.nameValuePair "${snippetDir}/${language}.json" {
-          source = jsonFormat.generate "user-snippet-${language}.json" snippet;
-        }) cfg.languageSnippets)
-    ];
+    ]);
   };
 }

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -59,143 +59,159 @@ let
       destination = "/share/vscode/extensions/extensions.json";
     };
 
-  mergedUserSettings = userSettings:
+  mergedUserSettings =
+    userSettings: enableUpdateCheck: enableExtensionUpdateCheck:
     userSettings
-    // optionalAttrs (!cfg.enableUpdateCheck) { "update.mode" = "none"; }
-    // optionalAttrs (!cfg.enableExtensionUpdateCheck) {
+    // optionalAttrs (enableUpdateCheck == false) { "update.mode" = "none"; }
+    // optionalAttrs (enableExtensionUpdateCheck == false) {
       "extensions.autoCheckUpdates" = false;
     };
 
-  profileType = default:
-    types.submodule {
-      options = {
-        userSettings = mkOption {
-          type = jsonFormat.type;
-          default = { };
-          example = literalExpression ''
-            {
-              "files.autoSave" = "off";
-              "[nix]"."editor.tabSize" = 2;
-            }
-          '';
-          description = ''
-            Configuration written to Visual Studio Code's
-            {file}`settings.json`.
-          '';
-        };
+  profileType = types.submodule {
+    options = {
+      userSettings = mkOption {
+        type = jsonFormat.type;
+        default = { };
+        example = literalExpression ''
+          {
+            "files.autoSave" = "off";
+            "[nix]"."editor.tabSize" = 2;
+          }
+        '';
+        description = ''
+          Configuration written to Visual Studio Code's
+          {file}`settings.json`.
+        '';
+      };
 
-        userTasks = mkOption {
-          type = jsonFormat.type;
-          default = { };
-          example = literalExpression ''
-            {
-              version = "2.0.0";
-              tasks = [
-                {
-                  type = "shell";
-                  label = "Hello task";
-                  command = "hello";
-                }
-              ];
-            }
-          '';
-          description = ''
-            Configuration written to Visual Studio Code's
-            {file}`tasks.json`.
-          '';
-        };
-
-        keybindings = mkOption {
-          type = types.listOf (types.submodule {
-            options = {
-              key = mkOption {
-                type = types.str;
-                example = "ctrl+c";
-                description = "The key or key-combination to bind.";
-              };
-
-              command = mkOption {
-                type = types.str;
-                example = "editor.action.clipboardCopyAction";
-                description = "The VS Code command to execute.";
-              };
-
-              when = mkOption {
-                type = types.nullOr (types.str);
-                default = null;
-                example = "textInputFocus";
-                description = "Optional context filter.";
-              };
-
-              # https://code.visualstudio.com/docs/getstarted/keybindings#_command-arguments
-              args = mkOption {
-                type = types.nullOr (jsonFormat.type);
-                default = null;
-                example = { direction = "up"; };
-                description = "Optional arguments for a command.";
-              };
-            };
-          });
-          default = [ ];
-          example = literalExpression ''
-            [
+      userTasks = mkOption {
+        type = jsonFormat.type;
+        default = { };
+        example = literalExpression ''
+          {
+            version = "2.0.0";
+            tasks = [
               {
-                key = "ctrl+c";
-                command = "editor.action.clipboardCopyAction";
-                when = "textInputFocus";
+                type = "shell";
+                label = "Hello task";
+                command = "hello";
               }
-            ]
-          '';
-          description = ''
-            Keybindings written to Visual Studio Code's
-            {file}`keybindings.json`.
-          '';
-        };
+            ];
+          }
+        '';
+        description = ''
+          Configuration written to Visual Studio Code's
+          {file}`tasks.json`.
+        '';
+      };
 
-        extensions = mkOption {
-          type = types.listOf types.package;
-          default = [ ];
-          example = literalExpression "[ pkgs.vscode-extensions.bbenoist.nix ]";
-          description = ''
-            The extensions Visual Studio Code should be started with.
-          '';
-        };
+      keybindings = mkOption {
+        type = types.listOf (types.submodule {
+          options = {
+            key = mkOption {
+              type = types.str;
+              example = "ctrl+c";
+              description = "The key or key-combination to bind.";
+            };
 
-        languageSnippets = mkOption {
-          type = jsonFormat.type;
-          default = { };
-          example = {
-            haskell = {
-              fixme = {
-                prefix = [ "fixme" ];
-                body = [ "$LINE_COMMENT FIXME: $0" ];
-                description = "Insert a FIXME remark";
-              };
+            command = mkOption {
+              type = types.str;
+              example = "editor.action.clipboardCopyAction";
+              description = "The VS Code command to execute.";
+            };
+
+            when = mkOption {
+              type = types.nullOr (types.str);
+              default = null;
+              example = "textInputFocus";
+              description = "Optional context filter.";
+            };
+
+            # https://code.visualstudio.com/docs/getstarted/keybindings#_command-arguments
+            args = mkOption {
+              type = types.nullOr (jsonFormat.type);
+              default = null;
+              example = { direction = "up"; };
+              description = "Optional arguments for a command.";
             };
           };
-          description = "Defines user snippets for different languages.";
-        };
+        });
+        default = [ ];
+        example = literalExpression ''
+          [
+            {
+              key = "ctrl+c";
+              command = "editor.action.clipboardCopyAction";
+              when = "textInputFocus";
+            }
+          ]
+        '';
+        description = ''
+          Keybindings written to Visual Studio Code's
+          {file}`keybindings.json`.
+        '';
+      };
 
-        globalSnippets = mkOption {
-          type = jsonFormat.type;
-          default = { };
-          example = {
+      extensions = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        example = literalExpression "[ pkgs.vscode-extensions.bbenoist.nix ]";
+        description = ''
+          The extensions Visual Studio Code should be started with.
+        '';
+      };
+
+      languageSnippets = mkOption {
+        type = jsonFormat.type;
+        default = { };
+        example = {
+          haskell = {
             fixme = {
               prefix = [ "fixme" ];
               body = [ "$LINE_COMMENT FIXME: $0" ];
               description = "Insert a FIXME remark";
             };
           };
-          description = "Defines global user snippets.";
         };
-      } // optionalAttrs default {
-        name = mkOption {
-          type = types.str;
-          description = "Visual Studio Code's Profile name.";
+        description = "Defines user snippets for different languages.";
+      };
+
+      globalSnippets = mkOption {
+        type = jsonFormat.type;
+        default = { };
+        example = {
+          fixme = {
+            prefix = [ "fixme" ];
+            body = [ "$LINE_COMMENT FIXME: $0" ];
+            description = "Insert a FIXME remark";
+          };
         };
+        description = "Defines global user snippets.";
+      };
+
+      enableUpdateCheck = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = ''
+          Whether to enable update checks/notifications.
+          Can only be set for the default profile, but
+          it applies to all profiles.
+        '';
+      };
+
+      enableExtensionUpdateCheck = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = ''
+          Whether to enable update notifications for extensions.
+          Can only be set for the default profile, but
+          it applies to all profiles.
+        '';
       };
     };
-  allProfiles = cfg.profiles ++ [ cfg.defaultProfile ];
+  };
+  defaultProfile = (filterAttrs (n: v: n == "default") cfg.profiles).default;
+  allProfilesExceptDefault = (removeAttrs cfg.profiles [ "default" ]);
 in {
   imports = [
     (mkChangedOptionModule [ "programs" "vscode" "immutableExtensionsDir" ] [
@@ -207,9 +223,12 @@ in {
     mkRenamedOptionModule [ "programs" "vscode" v ] [
       "programs"
       "vscode"
-      "defaultProfile"
+      "profiles"
+      "default"
       v
     ]) [
+      "enableUpdateCheck"
+      "enableExtensionUpdateCheck"
       "userSettings"
       "userTasks"
       "keybindings"
@@ -231,25 +250,9 @@ in {
       '';
     };
 
-    enableUpdateCheck = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable update checks/notifications.
-      '';
-    };
-
-    enableExtensionUpdateCheck = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable update notifications for extensions.
-      '';
-    };
-
     mutableExtensionsDir = mkOption {
       type = types.bool;
-      default = cfg.profiles == [ ];
+      default = allProfilesExceptDefault == { };
       example = false;
       description = ''
         Whether extensions can be installed or updated manually
@@ -259,30 +262,34 @@ in {
     };
 
     profiles = mkOption {
-      type = types.listOf (profileType true);
-      default = [ ];
+      type = types.attrsOf profileType;
+      default = { };
       description = ''
         A list of all VSCode profiles. Mutually exclusive
         to programs.vscode.mutableExtensionsDir
-      '';
-    };
-    defaultProfile = mkOption {
-      type = profileType false;
-      default = { };
-      description = ''
-        The default VSCode profile.
       '';
     };
   };
 
   config = mkIf cfg.enable {
     warnings = [
-      (mkIf (cfg.profiles != [ ] && cfg.mutableExtensionsDir)
-        "programs.vscode.mutableExtensionsDir can be used only if profiles is an empty list.")
+      (mkIf (allProfilesExceptDefault != { } && cfg.mutableExtensionsDir)
+        "programs.vscode.mutableExtensionsDir can be used only if no profiles apart from default are set.")
+      (mkIf ((filterAttrs (n: v:
+        (v ? enableExtensionUpdateCheck || v ? enableUpdateCheck)
+        && (v.enableExtensionUpdateCheck != null || v.enableUpdateCheck
+          != null)) allProfilesExceptDefault) != { })
+        "The option programs.vscode.profiles.*.enableExtensionUpdateCheck and option programs.vscode.profiles.*.enableUpdateCheck is invalid for all profiles except default.")
     ];
 
     home.packages = [ cfg.package ];
 
+    # The file `${userDir}/globalStorage/storage.json` needs to be writable by VSCode,
+    # since it contains other data, such as theme backgrounds, recently opened folders, etc.
+
+    # A caveat of adding profiles this way is, VSCode has to be closed
+    # when this file is being written, since the file is loaded into RAM
+    # and overwritten on closing VSCode.
     home.activation.vscodeProfiles = hm.dag.entryAfter [ "writeBoundary" ] (let
       modifyGlobalStorage =
         pkgs.writeShellScript "vscode-global-storage-modify" ''
@@ -292,7 +299,10 @@ in {
           if [ -f "$file" ]; then
             existing_profiles=$(jq '.userDataProfiles // [] | map({ (.name): .location }) | add // {}' $file)
             file_write=""
-            profiles=(${escapeShellArgs (map (v: v.name) cfg.profiles)})
+            profiles=(${
+              escapeShellArgs
+              (flatten (mapAttrsToList (n: v: n) allProfilesExceptDefault))
+            })
 
             for profile in "''${profiles[@]}"; do
               if [[ "$(echo $existing_profiles | jq --arg profile $profile 'has ($profile)')" != "true" ]] || [[ "$(echo $existing_profiles | jq --arg profile $profile 'has ($profile)')" == "true" && "$(echo $existing_profiles | jq --arg profile $profile '.[$profile]')" != "\"$profile\"" ]]; then
@@ -308,58 +318,56 @@ in {
           fi
 
           if [ "$file_write" != "" ]; then
-            userDataProfiles=$(jq ".userDataProfiles += $(echo $file_write | jq -R 'split(" ") | map({ name: ., location: . })')" $file)
+            userDataProfiles=$(jq ".userDataProfiles += $(echo $file_write | jq -R 'split("...") | map({ name: ., location: . })')" $file)
             echo $userDataProfiles > $file
           fi
         '';
     in modifyGlobalStorage.outPath);
 
     home.file = mkMerge (flatten [
-      (map (v:
-        let
-          # The default profile does not have the `name` key
-          name = if v ? name then v.name else "default";
-        in [
-          (mkIf ((mergedUserSettings v.userSettings) != { }) {
-            "${configFilePath name}".source =
+      (mapAttrsToList (n: v: [
+        (mkIf ((mergedUserSettings v.userSettings v.enableUpdateCheck
+          v.enableExtensionUpdateCheck) != { }) {
+            "${configFilePath n}".source =
               jsonFormat.generate "vscode-user-settings"
-              (mergedUserSettings v.userSettings);
+              (mergedUserSettings v.userSettings v.enableUpdateCheck
+                v.enableExtensionUpdateCheck);
           })
 
-          (mkIf (v.userTasks != { }) {
-            "${tasksFilePath name}".source =
-              jsonFormat.generate "vscode-user-tasks" v.userTasks;
-          })
+        (mkIf (v.userTasks != { }) {
+          "${tasksFilePath n}".source =
+            jsonFormat.generate "vscode-user-tasks" v.userTasks;
+        })
 
-          (mkIf (v.keybindings != [ ]) {
-            "${keybindingsFilePath name}".source =
-              jsonFormat.generate "vscode-keybindings"
-              (map (filterAttrs (_: v: v != null)) v.keybindings);
-          })
+        (mkIf (v.keybindings != [ ]) {
+          "${keybindingsFilePath n}".source =
+            jsonFormat.generate "vscode-keybindings"
+            (map (filterAttrs (_: v: v != null)) v.keybindings);
+        })
 
-          (mkIf (v.languageSnippets != { }) (lib.mapAttrs' (language: snippet:
-            lib.nameValuePair "${snippetDir name}/${language}.json" {
-              source =
-                jsonFormat.generate "user-snippet-${language}.json" snippet;
-            }) v.languageSnippets))
+        (mkIf (v.languageSnippets != { }) (mapAttrs' (language: snippet:
+          nameValuePair "${snippetDir n}/${language}.json" {
+            source =
+              jsonFormat.generate "user-snippet-${language}.json" snippet;
+          }) v.languageSnippets))
 
-          (mkIf (v.globalSnippets != { }) {
-            "${snippetDir name}/global.code-snippets".source =
-              jsonFormat.generate "user-snippet-global.code-snippets"
-              v.globalSnippets;
-          })
-        ]) allProfiles)
+        (mkIf (v.globalSnippets != { }) {
+          "${snippetDir n}/global.code-snippets".source =
+            jsonFormat.generate "user-snippet-global.code-snippets"
+            v.globalSnippets;
+        })
+      ]) cfg.profiles)
 
       # We write extensions.json for all profiles, except the default profile,
       # since that is handled by code below.
-      (mkIf (cfg.profiles != [ ]) (listToAttrs (map (v:
-        nameValuePair "${userDir}/profiles/${v.name}/extensions.json" {
+      (mkIf (allProfilesExceptDefault != { }) (mapAttrs' (n: v:
+        nameValuePair "${userDir}/profiles/${n}/extensions.json" {
           source = "${
-              extensionJsonFile v.name (extensionJson v.extensions)
+              extensionJsonFile n (extensionJson v.extensions)
             }/share/vscode/extensions/extensions.json";
-        }) cfg.profiles)))
+        }) allProfilesExceptDefault))
 
-      (mkIf ((filter (v: v.extensions != [ ]) allProfiles) != [ ]) (let
+      (mkIf (cfg.profiles != { }) (let
         # Adapted from https://discourse.nixos.org/t/vscode-extensions-setup/1801/2
         subDir = "share/vscode/extensions";
         toPaths = ext:
@@ -368,13 +376,19 @@ in {
             [ ext.vscodeExtUniqueId ]
           else
             builtins.attrNames (builtins.readDir (ext + "/${subDir}")));
-      in if (cfg.mutableExtensionsDir && cfg.profiles == [ ]) then
-        mkMerge (concatMap toPaths (flatten (map (v: v.extensions) allProfiles))
-          ++ lib.optional (lib.versionAtLeast vscodeVersion "1.74.0") {
+      in if (cfg.mutableExtensionsDir && allProfilesExceptDefault == { }) then
+      # Mutable extensions dir can only occur when only default profile is set.
+      # Force regenerating extensions.json using the below method,
+      # causes VSCode to create the extensions.json with all the extensions
+      # in the extension directory, which includes extensions from other profiles.
+        mkMerge (concatMap toPaths
+          (flatten (mapAttrsToList (n: v: v.extensions) cfg.profiles))
+          ++ optional
+          (versionAtLeast vscodeVersion "1.74.0" && defaultProfile != { }) {
             # Whenever our immutable extensions.json changes, force VSCode to regenerate
             # extensions.json with both mutable and immutable extensions.
             "${extensionPath}/.extensions-immutable.json" = {
-              text = extensionJson cfg.defaultProfile.extensions;
+              text = extensionJson defaultProfile.extensions;
               onChange = ''
                 run rm $VERBOSE_ARG -f ${extensionPath}/{extensions.json,.init-default-profile-extensions}
                 verboseEcho "Regenerating VSCode extensions.json"
@@ -386,10 +400,11 @@ in {
         "${extensionPath}".source = let
           combinedExtensionsDrv = pkgs.buildEnv {
             name = "vscode-extensions";
-            paths = flatten (map (v: v.extensions) allProfiles) ++ lib.optional
-              (lib.versionAtLeast vscodeVersion "1.74.0" && cfg.defaultProfile
-                != { }) (extensionJsonFile "default"
-                  (extensionJson cfg.defaultProfile.extensions));
+            paths = (flatten (mapAttrsToList (n: v: v.extensions) cfg.profiles))
+              ++ optional
+              (versionAtLeast vscodeVersion "1.74.0" && defaultProfile != { })
+              (extensionJsonFile "default"
+                (extensionJson defaultProfile.extensions));
           };
         in "${combinedExtensionsDrv}/${subDir}";
       }))

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -199,14 +199,26 @@ let
     };
   allProfiles = cfg.profiles ++ [ cfg.defaultProfile ];
 in {
-  # TODO: Backwards compatibility with old options.
   imports = [
     (mkChangedOptionModule [ "programs" "vscode" "immutableExtensionsDir" ] [
       "programs"
       "vscode"
       "mutableExtensionsDir"
     ] (config: !config.programs.vscode.immutableExtensionsDir))
-  ];
+  ] ++ map (v:
+    mkRenamedOptionModule [ "programs" "vscode" v ] [
+      "programs"
+      "vscode"
+      "defaultProfile"
+      v
+    ]) [
+      "userSettings"
+      "userTasks"
+      "keybindings"
+      "extensions"
+      "languageSnippets"
+      "globalSnippets"
+    ];
 
   options.programs.vscode = {
     enable = mkEnableOption "Visual Studio Code";

--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-# TODO: Re-write tests to support profiles.
-
 with lib;
 
 let

--- a/modules/programs/vscode/haskell.nix
+++ b/modules/programs/vscode/haskell.nix
@@ -52,12 +52,12 @@ in {
   };
 
   config = mkIf cfg.enable {
-    programs.vscode.userSettings = mkIf cfg.hie.enable {
+    programs.vscode.defaultProfile.userSettings = mkIf cfg.hie.enable {
       "languageServerHaskell.enableHIE" = true;
       "languageServerHaskell.hieExecutablePath" = cfg.hie.executablePath;
     };
 
-    programs.vscode.extensions =
+    programs.vscode.defaultProfile.extensions =
       [ pkgs.vscode-extensions.justusadam.language-haskell ]
       ++ lib.optional cfg.hie.enable
       pkgs.vscode-extensions.alanz.vscode-hie-server;

--- a/modules/programs/vscode/haskell.nix
+++ b/modules/programs/vscode/haskell.nix
@@ -52,12 +52,12 @@ in {
   };
 
   config = mkIf cfg.enable {
-    programs.vscode.defaultProfile.userSettings = mkIf cfg.hie.enable {
+    programs.vscode.profiles.default.userSettings = mkIf cfg.hie.enable {
       "languageServerHaskell.enableHIE" = true;
       "languageServerHaskell.hieExecutablePath" = cfg.hie.executablePath;
     };
 
-    programs.vscode.defaultProfile.extensions =
+    programs.vscode.profiles.default.extensions =
       [ pkgs.vscode-extensions.justusadam.language-haskell ]
       ++ lib.optional cfg.hie.enable
       pkgs.vscode-extensions.alanz.vscode-hie-server;

--- a/tests/modules/programs/vscode/keybindings.nix
+++ b/tests/modules/programs/vscode/keybindings.nix
@@ -1,5 +1,5 @@
 # Test that keybindings.json is created correctly.
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 let
   bindings = [
@@ -25,15 +25,25 @@ let
     }
   ];
 
-  keybindingsPath = if pkgs.stdenv.hostPlatform.isDarwin then
-    "Library/Application Support/Code/User/keybindings.json"
-  else
-    ".config/Code/User/keybindings.json";
+  keybindingsPath = name:
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/Code/User/${
+        lib.optionalString (name != "default") "profiles/${name}/"
+      }keybindings.json"
+    else
+      ".config/Code/User/${
+        lib.optionalString (name != "default") "profiles/${name}/"
+      }keybindings.json";
 
-  settingsPath = if pkgs.stdenv.hostPlatform.isDarwin then
-    "Library/Application Support/Code/User/settings.json"
-  else
-    ".config/Code/User/settings.json";
+  settingsPath = name:
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/Code/User/${
+        lib.optionalString (name != "default") "profiles/${name}/"
+      }settings.json"
+    else
+      ".config/Code/User/${
+        lib.optionalString (name != "default") "profiles/${name}/"
+      }settings.json";
 
   expectedKeybindings = pkgs.writeText "expected.json" ''
     [
@@ -65,14 +75,27 @@ let
 in {
   programs.vscode = {
     enable = true;
-    keybindings = bindings;
+    defaultProfile.keybindings = bindings;
+    profiles = [{
+      name = "test";
+      keybindings = bindings;
+    }];
     package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
   };
 
   nmt.script = ''
-    assertFileExists "home-files/${keybindingsPath}"
-    assertFileContent "home-files/${keybindingsPath}" "${expectedKeybindings}"
+    assertFileExists "home-files/${keybindingsPath "default"}"
+    assertFileContent "home-files/${
+      keybindingsPath "default"
+    }" "${expectedKeybindings}"
 
-    assertPathNotExists "home-files/${settingsPath}"
+    assertPathNotExists "home-files/${settingsPath "default"}"
+
+    assertFileExists "home-files/${keybindingsPath "test"}"
+    assertFileContent "home-files/${
+      keybindingsPath "test"
+    }" "${expectedKeybindings}"
+
+    assertPathNotExists "home-files/${settingsPath "test"}"
   '';
 }

--- a/tests/modules/programs/vscode/keybindings.nix
+++ b/tests/modules/programs/vscode/keybindings.nix
@@ -75,12 +75,14 @@ let
 in {
   programs.vscode = {
     enable = true;
-    defaultProfile.keybindings = bindings;
-    profiles = [{
-      name = "test";
-      keybindings = bindings;
-    }];
-    package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
+    profiles = {
+      default.keybindings = bindings;
+      test.keybindings = bindings;
+    };
+    package = pkgs.writeScriptBin "vscode" "" // {
+      pname = "vscode";
+      version = "1.75.0";
+    };
   };
 
   nmt.script = ''

--- a/tests/modules/programs/vscode/snippets.nix
+++ b/tests/modules/programs/vscode/snippets.nix
@@ -1,13 +1,18 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 let
 
-  snippetsDir = if pkgs.stdenv.hostPlatform.isDarwin then
-    "Library/Application Support/Code/User/snippets"
-  else
-    ".config/Code/User/snippets";
+  snippetsDir = name:
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/Code/User${
+        lib.optionalString (name != "default") "profiles/${name}/"
+      }/snippets"
+    else
+      ".config/Code/User/${
+        lib.optionalString (name != "default") "profiles/${name}/"
+      }snippets";
 
-  globalSnippetsPath = "${snippetsDir}/global.code-snippets";
+  globalSnippetsPath = name: "${snippetsDir name}/global.code-snippets";
 
   globalSnippetsExpectedContent = pkgs.writeText "global.code-snippet" ''
     {
@@ -23,7 +28,7 @@ let
     }
   '';
 
-  haskellSnippetsPath = "${snippetsDir}/haskell.json";
+  haskellSnippetsPath = name: "${snippetsDir name}/haskell.json";
 
   haskellSnippetsExpectedContent = pkgs.writeText "haskell.json" ''
     {
@@ -39,10 +44,7 @@ let
     }
   '';
 
-in {
-  programs.vscode = {
-    enable = true;
-    package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
+  snippets = {
     globalSnippets = {
       fixme = {
         prefix = [ "fixme" ];
@@ -61,11 +63,33 @@ in {
     };
   };
 
-  nmt.script = ''
-    assertFileExists "home-files/${globalSnippetsPath}"
-    assertFileContent "home-files/${globalSnippetsPath}" "${globalSnippetsExpectedContent}"
+in {
+  programs.vscode = {
+    enable = true;
+    package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
+    defaultProfile = snippets;
+    profiles = [ ({ name = "test"; } // snippets) ];
+  };
 
-    assertFileExists "home-files/${haskellSnippetsPath}"
-    assertFileContent "home-files/${haskellSnippetsPath}" "${haskellSnippetsExpectedContent}"
+  nmt.script = ''
+    assertFileExists "home-files/${globalSnippetsPath "default"}"
+    assertFileContent "home-files/${
+      globalSnippetsPath "default"
+    }" "${globalSnippetsExpectedContent}"
+
+    assertFileExists "home-files/${globalSnippetsPath "test"}"
+    assertFileContent "home-files/${
+      globalSnippetsPath "test"
+    }" "${globalSnippetsExpectedContent}"
+
+    assertFileExists "home-files/${haskellSnippetsPath "default"}"
+    assertFileContent "home-files/${
+      haskellSnippetsPath "default"
+    }" "${haskellSnippetsExpectedContent}"
+
+    assertFileExists "home-files/${haskellSnippetsPath "test"}"
+    assertFileContent "home-files/${
+      haskellSnippetsPath "test"
+    }" "${haskellSnippetsExpectedContent}"
   '';
 }

--- a/tests/modules/programs/vscode/snippets.nix
+++ b/tests/modules/programs/vscode/snippets.nix
@@ -66,9 +66,14 @@ let
 in {
   programs.vscode = {
     enable = true;
-    package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
-    defaultProfile = snippets;
-    profiles = [ ({ name = "test"; } // snippets) ];
+    package = pkgs.writeScriptBin "vscode" "" // {
+      pname = "vscode";
+      version = "1.75.0";
+    };
+    profiles = {
+      default = snippets;
+      test = snippets;
+    };
   };
 
   nmt.script = ''

--- a/tests/modules/programs/vscode/tasks.nix
+++ b/tests/modules/programs/vscode/tasks.nix
@@ -37,12 +37,14 @@ let
 in {
   programs.vscode = {
     enable = true;
-    package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
-    defaultProfile.userTasks = tasks;
-    profiles = [{
-      name = "test";
-      userTasks = tasks;
-    }];
+    package = pkgs.writeScriptBin "vscode" "" // {
+      pname = "vscode";
+      version = "1.75.0";
+    };
+    profiles = {
+      default.userTasks = tasks;
+      test.userTasks = tasks;
+    };
   };
 
   nmt.script = ''

--- a/tests/modules/programs/vscode/update-checks.nix
+++ b/tests/modules/programs/vscode/update-checks.nix
@@ -17,9 +17,14 @@ let
 in {
   programs.vscode = {
     enable = true;
-    package = pkgs.writeScriptBin "vscode" "" // { pname = "vscode"; };
-    enableUpdateCheck = false;
-    enableExtensionUpdateCheck = false;
+    package = pkgs.writeScriptBin "vscode" "" // {
+      pname = "vscode";
+      version = "1.75.0";
+    };
+    profiles.default = {
+      enableUpdateCheck = false;
+      enableExtensionUpdateCheck = false;
+    };
   };
 
   nmt.script = ''


### PR DESCRIPTION
### Description

This PR adds support for [VSCode Profiles](https://code.visualstudio.com/docs/editor/profiles), fixing #3822

Pending
- [x] Add tests.
- [x] Write a script for `home.activation`, to modify `~/.config/VSCodium/User/globalStorage/storage.json` (Reason documented).
- [x] Run tests.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
