### PR TITLE
keepassxc: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -152,6 +152,7 @@ let
       ./programs/just.nix
       ./programs/k9s.nix
       ./programs/kakoune.nix
+      ./programs/keepassxc.nix
       ./programs/keychain.nix
       ./programs/khal.nix
       ./programs/khard.nix

--- a/modules/programs/keepassxc.nix
+++ b/modules/programs/keepassxc.nix
@@ -1,0 +1,56 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.keepassxc;
+
+  iniFormat = pkgs.formats.ini { };
+in
+{
+  meta.maintainers = [ lib.maintainers.d-brasher ];
+
+  options.programs.keepassxc = {
+    enable = lib.mkEnableOption "keepassxc";
+
+    package = lib.mkPackageOption pkgs "keepassxc" { };
+
+    settings = lib.mkOption {
+      type = iniFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          Browser.Enabled = true;
+
+          GUI = {
+            AdvancedSettings = true;
+            ApplicationTheme = "dark";
+            CompactMode = true;
+            HidePasswords = true;
+          };
+
+          SSHAgent.Enabled = true;
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/keepassxc/keepassxc.ini`.
+
+        See <https://github.com/keepassxreboot/keepassxc/blob/647272e9c5542297d3fcf6502e6173c96f12a9a0/src/core/Config.cpp#L49-L223>
+        for the full list of options.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    xdg.configFile = {
+      "keepassxc/keepassxc.ini" = lib.mkIf (cfg.settings != { }) {
+        source = iniFormat.generate "keepassxc-settings" cfg.settings;
+      };
+    };
+  };
+}

--- a/modules/programs/keepassxc.nix
+++ b/modules/programs/keepassxc.nix
@@ -16,7 +16,7 @@ in
   options.programs.keepassxc = {
     enable = lib.mkEnableOption "keepassxc";
 
-    package = lib.mkPackageOption pkgs "keepassxc" { };
+    package = lib.mkPackageOption pkgs "keepassxc" { nullable = true; };
 
     settings = lib.mkOption {
       type = iniFormat.type;
@@ -46,7 +46,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
     xdg.configFile = {
       "keepassxc/keepassxc.ini" = lib.mkIf (cfg.settings != { }) {
         source = iniFormat.generate "keepassxc-settings" cfg.settings;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -385,6 +385,7 @@ import nmtSrc {
       ./modules/programs/jqp
       ./modules/programs/k9s
       ./modules/programs/kakoune
+      ./modules/programs/keepassxc
       ./modules/programs/khal
       ./modules/programs/khard
       ./modules/programs/kitty

--- a/tests/modules/programs/keepassxc/default-settings.nix
+++ b/tests/modules/programs/keepassxc/default-settings.nix
@@ -1,0 +1,13 @@
+{ ... }:
+
+{
+  programs.keepassxc = {
+    enable = true;
+  };
+
+  test.stubs.keepassxc = { };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/keepassxc/keepassxc.ini
+  '';
+}

--- a/tests/modules/programs/keepassxc/default.nix
+++ b/tests/modules/programs/keepassxc/default.nix
@@ -1,0 +1,4 @@
+{
+  keepassxc-default-settings = ./default-settings.nix;
+  keepassxc-example-settings = ./example-settings.nix;
+}

--- a/tests/modules/programs/keepassxc/example-settings.nix
+++ b/tests/modules/programs/keepassxc/example-settings.nix
@@ -1,0 +1,24 @@
+{ ... }:
+
+{
+  programs.keepassxc = {
+    enable = true;
+    settings = {
+      Browser.Enabled = true;
+      GUI = {
+        AdvancedSettings = true;
+        ApplicationTheme = "dark";
+        CompactMode = true;
+        HidePasswords = true;
+      };
+      SSHAgent.Enabled = true;
+    };
+  };
+
+  test.stubs.keepassxc = { };
+
+  nmt.script = ''
+    configFile=home-files/.config/keepassxc/keepassxc.ini
+    assertFileContent $configFile ${./keepassxc-example-config.ini}
+  '';
+}

--- a/tests/modules/programs/keepassxc/keepassxc-example-config.ini
+++ b/tests/modules/programs/keepassxc/keepassxc-example-config.ini
@@ -1,0 +1,11 @@
+[Browser]
+Enabled=true
+
+[GUI]
+AdvancedSettings=true
+ApplicationTheme=dark
+CompactMode=true
+HidePasswords=true
+
+[SSHAgent]
+Enabled=true

--- a/tests/modules/services/window-managers/labwc/autostart
+++ b/tests/modules/services/window-managers/labwc/autostart
@@ -1,4 +1,4 @@
-#!/nix/store/58br4vk3q5akf4g8lx0pqzfhn47k3j8d-bash-5.2p37/bin/bash
+#!/nix/store/00000000000000000000000000000000-bash/bin/bash
 ### This file was generated with Nix. Don't modify this file directly.
 
 ### AUTOSTART SERVICE ###

--- a/tests/modules/services/window-managers/labwc/labwc-autostart.nix
+++ b/tests/modules/services/window-managers/labwc/labwc-autostart.nix
@@ -13,6 +13,6 @@
     labwcAutostart=home-files/.config/labwc/autostart
 
     assertFileExists "$labwcAutostart"
-    assertFileContent "$labwcAutostart" "${./autostart}"
+    assertFileContent $(normalizeStorePaths "$labwcAutostart") "${./autostart}"
   '';
 }


### PR DESCRIPTION
### Description

Add module for [KeePassXC](https://keepassxc.org/), a popular password manager.

Implements handling of config file.

<!--

Add module for [KeepassXC](https://keepassxc.org/), an offline password manager with many features.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
