### PR TITLE
eww: add terminal integration options

### DIFF
--- a/modules/programs/eww.nix
+++ b/modules/programs/eww.nix
@@ -5,6 +5,7 @@ with lib;
 let
 
   cfg = config.programs.eww;
+  ewwCmd = "${cfg.package}/bin/eww";
 
 in {
   meta.maintainers = [ hm.maintainers.mainrs ];
@@ -30,10 +31,40 @@ in {
         {file}`$XDG_CONFIG_HOME/eww`.
       '';
     };
+
+    enableBashIntegration = mkEnableOption "Bash integration" // {
+      default = true;
+    };
+
+    enableZshIntegration = mkEnableOption "Zsh integration" // {
+      default = true;
+    };
+
+    enableFishIntegration = mkEnableOption "Fish integration" // {
+      default = true;
+    };
   };
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
     xdg.configFile."eww".source = cfg.configDir;
+
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
+      if [[ $TERM != "dumb" ]]; then
+        eval "$(${ewwCmd} shell-completions --shell bash)"
+      fi
+    '';
+
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      if [[ $TERM != "dumb" ]]; then
+        eval "$(${ewwCmd} shell-completions --shell zsh)"
+      fi
+    '';
+
+    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
+      if test "$TERM" != "dumb"
+        eval "$(${ewwCmd} shell-completions --shell fish)"
+      end
+    '';
   };
 }


### PR DESCRIPTION
### Description

Use eww's shell-completions command to generate completions for bash, zsh and fish.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@mainrs