### PR TITLE
Fix yazi keymap example to use "run"

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -70,15 +70,15 @@ in {
       example = literalExpression ''
         {
           input.keymap = [
-            { exec = "close"; on = [ "<C-q>" ]; }
-            { exec = "close --submit"; on = [ "<Enter>" ]; }
-            { exec = "escape"; on = [ "<Esc>" ]; }
-            { exec = "backspace"; on = [ "<Backspace>" ]; }
+            { on = [ "<C-q>" ]; run = "close"; }
+            { on = [ "<Enter>" ];  run = "close --submit"; }
+            { on = [ "<Esc>" ];  run = "escape"; }
+            { on = [ "<Backspace>" ]; run = "backspace"; }
           ];
           manager.keymap = [
-            { exec = "escape"; on = [ "<Esc>" ]; }
-            { exec = "quit"; on = [ "q" ]; }
-            { exec = "close"; on = [ "<C-q>" ]; }
+            {  on = [ "<Esc>" ]; run = "escape"; }
+            {  on = [ "q" ]; run = "quit"; }
+            {  on = [ "<C-q>" ]; run = "close"; }
           ];
         }
       '';

--- a/tests/modules/programs/yazi/keymap-expected.toml
+++ b/tests/modules/programs/yazi/keymap-expected.toml
@@ -1,27 +1,27 @@
 [[input.keymap]]
-exec = "close"
 on = ["<C-q>"]
+run = "close"
 
 [[input.keymap]]
-exec = "close --submit"
 on = ["<Enter>"]
+run = "close --submit"
 
 [[input.keymap]]
-exec = "escape"
 on = ["<Esc>"]
+run = "escape"
 
 [[input.keymap]]
-exec = "backspace"
 on = ["<Backspace>"]
+run = "backspace"
 
 [[manager.keymap]]
-exec = "escape"
 on = ["<Esc>"]
+run = "escape"
 
 [[manager.keymap]]
-exec = "quit"
 on = ["q"]
+run = "quit"
 
 [[manager.keymap]]
-exec = "close"
 on = ["<C-q>"]
+run = "close"

--- a/tests/modules/programs/yazi/settings.nix
+++ b/tests/modules/programs/yazi/settings.nix
@@ -7,34 +7,34 @@
     keymap = {
       input.keymap = [
         {
-          exec = "close";
           on = [ "<C-q>" ];
+          run = "close";
         }
         {
-          exec = "close --submit";
           on = [ "<Enter>" ];
+          run = "close --submit";
         }
         {
-          exec = "escape";
           on = [ "<Esc>" ];
+          run = "escape";
         }
         {
-          exec = "backspace";
           on = [ "<Backspace>" ];
+          run = "backspace";
         }
       ];
       manager.keymap = [
         {
-          exec = "escape";
           on = [ "<Esc>" ];
+          run = "escape";
         }
         {
-          exec = "quit";
           on = [ "q" ];
+          run = "quit";
         }
         {
-          exec = "close";
           on = [ "<C-q>" ];
+          run = "close";
         }
       ];
     };


### PR DESCRIPTION
### Description

Yazi now uses `run` instead of `exec` for commands. I just updated the example to reflect this. They will be removing "exec" in the near future.

#### Maintainer CC

@XYenon @eljamm 