### PR TITLE
eza: fix fish completion

### DIFF
--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -93,6 +93,10 @@ with lib;
 
     programs.fish.shellAliases = optionsAlias
       // optionalAttrs cfg.enableFishIntegration aliases;
+    programs.fish.plugins = mkIf cfg.enableFishIntegration [{
+      name = "eza-remove-default-ls-completion";
+      src = pkgs.writeTextDir "completions/ls.fish" "";
+    }];
 
     programs.ion.shellAliases = optionsAlias
       // optionalAttrs cfg.enableIonIntegration aliases;


### PR DESCRIPTION
### Description

Currently, when using eza with `enableFishIntegration` set to true, ls is aliased to eza. eza's completions are also correctly added to ls. However, the builtin ls completions are currently *not* removed. This means that some flags, like `--dired`, are still suggested, even though they do not exist on eza.

This pull request introduces a small fix via `programs.fish.plugins` which disables the builtin ls completions if and only if  `enableFishIntegration` is true, leaving only the eza completions. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@cafkafk 