### PR TITLE
swayimg: add `programs.swayimg` module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1813,6 +1813,16 @@ in {
           systems" section in the Home Manager mantual for more.
         '';
       }
+      {
+        time = "2024-07-20T12:05:41+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'programs.swayimg'.
+
+          Swayimg is a lightweight image viewer for Wayland display servers.
+          See https://github.com/artemsen/swayimg for more.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -226,6 +226,7 @@ let
     ./programs/sqls.nix
     ./programs/ssh.nix
     ./programs/starship.nix
+    ./programs/swayimg.nix
     ./programs/swaylock.nix
     ./programs/swayr.nix
     ./programs/taskwarrior.nix

--- a/modules/programs/swayimg.nix
+++ b/modules/programs/swayimg.nix
@@ -1,0 +1,39 @@
+{ pkgs, config, lib, ... }:
+let
+  cfg = config.programs.swayimg;
+  iniFormat = pkgs.formats.ini { };
+in {
+  meta.maintainers = [ lib.maintainers.adtya ];
+
+  options.programs.swayimg = {
+    enable = lib.mkEnableOption "swayimg";
+    package = lib.mkPackageOption pkgs "swayimg" { };
+    settings = lib.mkOption {
+      type = iniFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          general = {
+            scale = "optimal";
+            fullscreen = "no";
+          };
+        };
+      '';
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/swayimg/config`. See
+        {manpage}`swayimgrc(5)` for a list of available options.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.swayimg" pkgs
+        lib.platforms.linux)
+    ];
+    home.packages = [ cfg.package ];
+    xdg.configFile."swayimg/config" = lib.mkIf (cfg.settings != { }) {
+      text = lib.generators.toINI { } cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -216,6 +216,7 @@ in import nmtSrc {
     ./modules/programs/rbw
     ./modules/programs/rofi
     ./modules/programs/rofi-pass
+    ./modules/programs/swayimg
     ./modules/programs/swaylock
     ./modules/programs/swayr
     ./modules/programs/terminator

--- a/tests/modules/programs/swayimg/config
+++ b/tests/modules/programs/swayimg/config
@@ -1,0 +1,12 @@
+[font]
+name=monospace
+size=14
+
+[general]
+antialiasing=no
+fixed=yes
+fullscreen=no
+position=parent
+scale=optimal
+size=parent
+transparency=grid

--- a/tests/modules/programs/swayimg/default.nix
+++ b/tests/modules/programs/swayimg/default.nix
@@ -1,0 +1,5 @@
+{
+  swayimg-disabled = import ./disabled.nix;
+  swayimg-enabled = import ./enabled.nix;
+  swayimg-settings = import ./settings.nix;
+}

--- a/tests/modules/programs/swayimg/disabled.nix
+++ b/tests/modules/programs/swayimg/disabled.nix
@@ -1,0 +1,6 @@
+{ ... }: {
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/swayimg/config
+  '';
+}

--- a/tests/modules/programs/swayimg/enabled.nix
+++ b/tests/modules/programs/swayimg/enabled.nix
@@ -1,0 +1,10 @@
+{ config, ... }: {
+  programs.swayimg = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/swayimg/config
+  '';
+}

--- a/tests/modules/programs/swayimg/settings.nix
+++ b/tests/modules/programs/swayimg/settings.nix
@@ -1,0 +1,27 @@
+{ config, ... }: {
+  programs.swayimg = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    settings = {
+      general = {
+        scale = "optimal";
+        fullscreen = "no";
+        antialiasing = "no";
+        fixed = "yes";
+        transparency = "grid";
+        position = "parent";
+        size = "parent";
+      };
+      font = {
+        name = "monospace";
+        size = 14;
+      };
+    };
+  };
+
+  nmt.script = let homeConfig = "home-files/.config/swayimg/config";
+  in ''
+    assertFileExists ${homeConfig}
+    assertFileContents ${homeConfig} ${./config}
+  '';
+}


### PR DESCRIPTION
### Description

Adds module `programs.swayimg` to enable and configure [swayimg](https://github.com/artemsen/swayimg)

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
