### PR TITLE
kbfs: avoid using PrivateTmp for systemd service

### DIFF
--- a/modules/services/kbfs.nix
+++ b/modules/services/kbfs.nix
@@ -52,7 +52,6 @@ in {
           "${pkgs.kbfs}/bin/kbfsfuse ${toString cfg.extraFlags} ${mountPoint}";
         ExecStopPost = "/run/wrappers/bin/fusermount -u ${mountPoint}";
         Restart = "on-failure";
-        PrivateTmp = true;
       };
 
       Install.WantedBy = [ "default.target" ];


### PR DESCRIPTION
### Description

The kbfs service does not seem to actually work with a PrivateTmp. A
PrivateTmp seems as appropriate for kbfs as anything else, but the
upstream service does not use it either
<https://github.com/keybase/client/blob/master/packaging/linux/systemd/kbfs.service>

This PR sets `PrivateTmp` to false in the kbfs service definition, which at
least allows kbfs to run.

Closes #4722

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] ~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@tadfisher
