### PR TITLE
nix-gc: call nix-gc in a shell script to match upstream behavior

### DIFF
--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -110,9 +110,10 @@ in {
       systemd.user.services.nix-gc = {
         Unit = { Description = "Nix Garbage Collector"; };
         Service = {
-          ExecStart = "${nixPackage}/bin/nix-collect-garbage ${
+          ExecStart = toString (pkgs.writeShellScript "nix-gc" ''
+            exec "${nixPackage}/bin/nix-collect-garbage ${
               lib.optionalString (cfg.options != null) cfg.options
-            }";
+            }"'');
         };
       };
       systemd.user.timers.nix-gc = {

--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -110,6 +110,7 @@ in {
       systemd.user.services.nix-gc = {
         Unit = { Description = "Nix Garbage Collector"; };
         Service = {
+          Type = "oneshot";
           ExecStart = toString (pkgs.writeShellScript "nix-gc" ''
             exec "${nixPackage}/bin/nix-collect-garbage ${
               lib.optionalString (cfg.options != null) cfg.options

--- a/tests/modules/services/nix-gc/basic.nix
+++ b/tests/modules/services/nix-gc/basic.nix
@@ -4,7 +4,7 @@
   nix.gc = {
     automatic = true;
     frequency = "monthly";
-    options = "--delete-older-than 30d";
+    options = "--delete-older-than 30d --max-freed $((64 * 1024**3))";
   };
 
   test.stubs.nix = { name = "nix"; };

--- a/tests/modules/services/nix-gc/expected.service
+++ b/tests/modules/services/nix-gc/expected.service
@@ -1,5 +1,6 @@
 [Service]
 ExecStart=/nix/store/00000000000000000000000000000000-nix-gc
+Type=oneshot
 
 [Unit]
 Description=Nix Garbage Collector

--- a/tests/modules/services/nix-gc/expected.service
+++ b/tests/modules/services/nix-gc/expected.service
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=@nix@/bin/nix-collect-garbage --delete-older-than 30d
+ExecStart=/nix/store/00000000000000000000000000000000-nix-gc
 
 [Unit]
 Description=Nix Garbage Collector


### PR DESCRIPTION
### Description

This will match the behavior in the upstream service which allows the user to set options to something that uses shell syntax.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@shivaraj-bh
