### PR TITLE
firefox: make NixOS wiki search engine icon visible

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -546,7 +546,7 @@ in {
 
                     "NixOS Wiki" = {
                       urls = [{ template = "https://wiki.nixos.org/index.php?search={searchTerms}"; }];
-                      iconUpdateURL = "https://wiki.nixos.org/favicon.png";
+                      iconUpdateURL = "https://wiki.nixos.org/nixos.png";
                       updateInterval = 24 * 60 * 60 * 1000; # every day
                       definedAliases = [ "@nw" ];
                     };


### PR DESCRIPTION
Before it was referencing: `https://wiki.nixos.org/favicon.png` which is not existing. 
Now both of the icons for NixOS packages and NixOS wiki have the same icon.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
Before:
![image](https://github.com/user-attachments/assets/c459cb74-59ca-4972-a224-74a095f15ebd)
After:
![image](https://github.com/user-attachments/assets/4bfb5b48-356e-4d10-80d4-9de0ba835f75)
