### PR TITLE
starship: add `enableInteractive` option for fish

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1847,6 +1847,20 @@ in {
           output.
         '';
       }
+
+      {
+        time = "2024-12-04T20:00:00+00:00";
+        condition = let
+          sCfg = config.programs.starship;
+          fCfg = config.programs.fish;
+        in sCfg.enable && sCfg.enableFishIntegration && fCfg.enable;
+        message = ''
+          A new option 'programs.starship.enableInteractive' is available for
+          the Fish shell that only enables starship if the shell is interactive.
+
+          Some plugins require this to be set to 'false' to function correctly.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -119,7 +119,7 @@ in {
 
     programs.fish.${initFish} = mkIf cfg.enableFishIntegration ''
       if test "$TERM" != "dumb"
-        eval (${starshipCmd} init fish)
+        ${starshipCmd} init fish | source
         ${lib.optionalString cfg.enableTransience "enable_transience"}
       end
     '';

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -10,6 +10,8 @@ let
 
   starshipCmd = "${config.home.profileDirectory}/bin/starship";
 
+  initFish =
+    if cfg.enableInteractive then "interactiveShellInit" else "shellInitLast";
 in {
   meta.maintainers = [ ];
 
@@ -71,6 +73,17 @@ in {
       default = true;
     };
 
+    enableInteractive = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Only enable starship when the shell is interactive. This option is only
+        valid for the Fish shell.
+
+        Some plugins require this to be set to `false` to function correctly.
+      '';
+    };
+
     enableTransience = mkOption {
       type = types.bool;
       default = false;
@@ -104,7 +117,7 @@ in {
       fi
     '';
 
-    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
+    programs.fish.${initFish} = mkIf cfg.enableFishIntegration ''
       if test "$TERM" != "dumb"
         eval (${starshipCmd} init fish)
         ${lib.optionalString cfg.enableTransience "enable_transience"}

--- a/tests/modules/programs/starship/default.nix
+++ b/tests/modules/programs/starship/default.nix
@@ -2,4 +2,6 @@
   starship-settings = ./settings.nix;
   starship-fish-with-transience = ./fish_with_transience.nix;
   starship-fish-without-transience = ./fish_without_transience.nix;
+  starship-fish-with-interactive = ./fish_with_interactive.nix;
+  starship-fish-without-interactive = ./fish_without_interactive.nix;
 }

--- a/tests/modules/programs/starship/fish_with_interactive.nix
+++ b/tests/modules/programs/starship/fish_with_interactive.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs = {
+      fish.enable = true;
+      starship.enable = true;
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/fish/config.fish
+
+      export GOT="$(tail -n 5 `_abs home-files/.config/fish/config.fish`)"
+      export NOT_EXPECTED="
+      if test \"\$TERM\" != dumb
+          /home/hm-user/.nix-profile/bin/starship init fish | source
+
+      end"
+
+      if [[ "$GOT" == "$NOT_EXPECTED" ]]; then
+        fail "Expected starship init to be inside the 'is-interactive' block but it wasn't."
+      fi
+    '';
+  };
+}

--- a/tests/modules/programs/starship/fish_without_interactive.nix
+++ b/tests/modules/programs/starship/fish_without_interactive.nix
@@ -19,7 +19,7 @@ with lib;
       export GOT="$(tail -n 5 `_abs home-files/.config/fish/config.fish`)"
       export EXPECTED="
       if test \"\$TERM\" != dumb
-          eval (/home/hm-user/.nix-profile/bin/starship init fish)
+          /home/hm-user/.nix-profile/bin/starship init fish | source
 
       end"
 

--- a/tests/modules/programs/starship/fish_without_interactive.nix
+++ b/tests/modules/programs/starship/fish_without_interactive.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs = {
+      fish.enable = true;
+
+      starship = {
+        enable = true;
+        enableInteractive = false;
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/fish/config.fish
+
+      export GOT="$(tail -n 5 `_abs home-files/.config/fish/config.fish`)"
+      export EXPECTED="
+      if test \"\$TERM\" != dumb
+          eval (/home/hm-user/.nix-profile/bin/starship init fish)
+
+      end"
+
+      export MESSAGE="
+      ==========
+       Expected
+      ==========
+      $EXPECTED
+      ==========
+         Got
+      ==========
+      $GOT
+      ==========
+      "
+
+      if [[ "$GOT" != "$EXPECTED" ]]; then
+        fail "$MESSAGE"
+      fi
+    '';
+  };
+}


### PR DESCRIPTION
### Description

- Some fish plugins such as [fish-async-prompt](https://github.com/acomagu/fish-async-prompt) require that starship be initialized as non-interactive.

When the `programs.starship.enableInteractive` option is enabled, starship is initialized at the end of the init script, outside the interactive block.

**Note:** Don't know if other shells need this, so I only added this for fish for now.

- Also changed the initialization method from `eval` to `source` as per the [starship installation](https://starship.rs/guide/#%F0%9F%9A%80-installation) guide.

Closes #5445 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
