### PR TITLE
gnome-terminal: update package name

### DIFF
--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -316,7 +316,7 @@ in {
       })
     ];
 
-    home.packages = [ pkgs.gnome.gnome-terminal ];
+    home.packages = [ pkgs.gnome-terminal ];
 
     dconf.settings = let dconfPath = "org/gnome/terminal/legacy";
     in {

--- a/tests/modules/programs/gnome-terminal/bad-profile-name.nix
+++ b/tests/modules/programs/gnome-terminal/bad-profile-name.nix
@@ -13,9 +13,8 @@
     };
   };
 
-  nixpkgs.overlays = [
-    (self: super: { gnome.gnome-terminal = config.lib.test.mkStubPackage { }; })
-  ];
+  nixpkgs.overlays =
+    [ (self: super: { gnome-terminal = config.lib.test.mkStubPackage { }; }) ];
 
   test.stubs.dconf = { };
 

--- a/tests/modules/programs/gnome-terminal/gnome-terminal-1.nix
+++ b/tests/modules/programs/gnome-terminal/gnome-terminal-1.nix
@@ -49,9 +49,7 @@ with lib;
     };
 
     nixpkgs.overlays = [
-      (self: super: {
-        gnome.gnome-terminal = config.lib.test.mkStubPackage { };
-      })
+      (self: super: { gnome-terminal = config.lib.test.mkStubPackage { }; })
     ];
 
     test.stubs.dconf = { };


### PR DESCRIPTION


### Description

The ``pkgs.gnome.gnome-terminal`` package was moved to ``pkgs.gnome-terminal``. The former is now a deprecated alias that throws a warning whenever a configuration enabling the module is used:

```
The ‘gnome.gnome-terminal’ was moved to top-level. Please use
‘pkgs.gnome-terminal’ directly.
```

Related: https://github.com/NixOS/nixpkgs/pull/319659
Related: https://github.com/nix-community/home-manager/pull/5611

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] N/A ~~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~~

#### Maintainer CC

@kamadorueda, @rycee