### PR TITLE
cliphist: support multiple systemdTargets properly

### DIFF
--- a/tests/modules/services/cliphist/cliphist-multiple-session-targets.nix
+++ b/tests/modules/services/cliphist/cliphist-multiple-session-targets.nix
@@ -1,9 +1,10 @@
-{ lib, options, ... }:
+{ ... }:
 
 {
   services.cliphist = {
     enable = true;
-    systemdTarget = "sway-session.target";
+
+    systemdTargets = [ "sway-session.target" "hyprland-session.target" ];
   };
 
   test.stubs = {
@@ -14,12 +15,6 @@
   nmt.script = ''
     assertFileExists home-files/.config/systemd/user/cliphist.service
     assertFileExists home-files/.config/systemd/user/sway-session.target.wants/cliphist.service
+    assertFileExists home-files/.config/systemd/user/hyprland-session.target.wants/cliphist.service
   '';
-
-  test.asserts.warnings.expected = [
-    "The option `services.cliphist.systemdTarget' defined in ${
-      lib.showFiles options.services.cliphist.systemdTarget.files
-    } has been renamed to `services.cliphist.systemdTargets'."
-  ];
-
 }

--- a/tests/modules/services/cliphist/default.nix
+++ b/tests/modules/services/cliphist/default.nix
@@ -1,4 +1,5 @@
 {
   cliphist-sway-session-target = ./cliphist-sway-session-target.nix;
   cliphist-extra-options = ./cliphist-extra-options.nix;
+  cliphist-multiple-session-targets = ./cliphist-multiple-session-targets.nix;
 }


### PR DESCRIPTION
Using a space separated list of targets as a single string element in the list doesn't work properly. Change property to support list of targets and backwards compatibility with warning for single string.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
