### PR TITLE
firefox: Enable userChrome in about:config

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -975,6 +975,10 @@ in
                 ]
               ) (lib.attrsToList config.extensions.settings))
               ++ config.bookmarks.assertions;
+
+              settings."toolkit.legacyUserProfileCustomizations.stylesheets" = mkIf (
+                config.userChrome != "" || config.userContent != ""
+              ) true;
             };
           }
         )

--- a/tests/modules/programs/firefox/profiles/userchrome/default.nix
+++ b/tests/modules/programs/firefox/profiles/userchrome/default.nix
@@ -62,6 +62,16 @@ in
           assertFileContent \
             "home-files/${cfg.profilesPath}/derivation-file/chrome/userChrome.css" \
             ${./chrome/userChrome.css}
+
+          assertFileContains \
+            "home-files/${cfg.profilesPath}/lines/user.js" \
+            'user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true)'
+          assertFileContains \
+            "home-files/${cfg.profilesPath}/file/user.js" \
+            'user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true)'
+          assertFileContains \
+            "home-files/${cfg.profilesPath}/derivation-file/user.js" \
+            'user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true)'
         '';
     }
   );


### PR DESCRIPTION
### Description

Enable "toolkit.legacyUserProfileCustomizations.stylesheets" in about:config if userChrome is not empty.
Resolves #5666

Change is not backwards compatible. It will break configs where `userChrome` is set to non-empty string and `settings."toolkit.legacyUserProfileCustomizations.stylesheets"` is set to false. It seems unlikely but I've added assertion nevertheless.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee @kira-bruneau 