### PR TITLE
starship: use direct derivation binary path instead of referencing ~/nix-profile

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -8,8 +8,7 @@ let
 
   tomlFormat = pkgs.formats.toml { };
 
-  starshipCmd = "${config.home.profileDirectory}/bin/starship";
-
+  starshipCmd = "${lib.getExe pkgs.starship}";
 in {
   meta.maintainers = [ ];
 


### PR DESCRIPTION
### Description

Using the lib.getExe path from starship is better in this case because if your nix settings specify the "use-xdg-directories" variable, the default `$HOME/.nix-profile` path that is supposed to exist in the starshipCmd variable. It seems to be working fine on my system

### Checklist

Honestly since this is a single line change I dont know if all this makes sense?

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```