### PR TITLE
programs.wlr-which-key: init

### DIFF
--- a/modules/misc/news/2025-04-20_16-43-56.nix
+++ b/modules/misc/news/2025-04-20_16-43-56.nix
@@ -1,0 +1,12 @@
+{
+  time = "2025-04-20T21:43:56+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.wlr-which-key'.
+
+    wlr-which-key is a keymap manager for wlroots-based compositors,
+    inspired by which-key.nvim.
+
+    See https://github.com/MaxVerevkin/wlr-which-key for more.
+  '';
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -295,6 +295,7 @@ let
       ./programs/waybar.nix
       ./programs/wezterm.nix
       ./programs/wlogout.nix
+      ./programs/wlr-which-key.nix
       ./programs/wofi.nix
       ./programs/xmobar.nix
       ./programs/xplr.nix

--- a/modules/programs/wlr-which-key.nix
+++ b/modules/programs/wlr-which-key.nix
@@ -1,0 +1,104 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.wlr-which-key;
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    LilleAila
+    mightyiam
+    minijackson
+  ];
+
+  options.programs.wlr-which-key = {
+    enable = lib.mkEnableOption "wlr-which-key";
+
+    package = lib.mkPackageOption pkgs "wlr-which-key" { nullable = true; };
+
+    commonSettings = lib.mkOption {
+      type = lib.types.submodule { freeformType = yamlFormat.type; };
+
+      default = { };
+      example = {
+        anchor = "center";
+        background = "#282828d0";
+        border = "#8ec07c";
+        color = "#fbf1c7";
+      };
+
+      description = ''
+        Settings to be applied to every configuration under the `configs` option.
+      '';
+    };
+
+    configs = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          freeformType = yamlFormat.type;
+
+          options.menu = lib.mkOption {
+            description = "The various menus to display";
+            type = lib.types.attrs;
+          };
+
+          config = cfg.commonSettings;
+        }
+      );
+
+      default = { };
+      example.config = {
+        anchor = "center";
+        menu = {
+          p = {
+            desc = "Power";
+            submenu = {
+              o = {
+                cmd = "poweroff";
+                desc = "Off";
+              };
+              r = {
+                cmd = "reboot";
+                desc = "Reboot";
+              };
+              s = {
+                cmd = "systemctl suspend";
+                desc = "Sleep";
+              };
+            };
+          };
+        };
+      };
+
+      description = ''
+        Various configurations for wlr-which-key.
+
+        Each configuration `configs.''${name}` is installed into
+        `~/.config/wlr-which-key/''${name}.yaml`.
+
+        This enables you to run: `wlr-which-key ''${name}`.
+
+        To set the default menu, use `programs.wlr-which-key.configs.config`.
+
+        For more information on available options, see:
+        <https://github.com/MaxVerevkin/wlr-which-key/>
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile = lib.mapAttrs' (
+      name: value:
+      lib.nameValuePair "wlr-which-key/${name}.yaml" {
+        source = yamlFormat.generate "wlr-which-key-${name}.yaml" value;
+      }
+    ) cfg.configs;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -473,6 +473,7 @@ import nmtSrc {
       ./modules/programs/wallust
       ./modules/programs/watson
       ./modules/programs/wezterm
+      ./modules/programs/wlr-which-key
       ./modules/programs/yazi
       ./modules/programs/zed-editor
       ./modules/programs/zellij

--- a/tests/modules/programs/wlr-which-key/default.nix
+++ b/tests/modules/programs/wlr-which-key/default.nix
@@ -1,0 +1,1 @@
+{ wlr-which-key = ./wlr-which-key.nix; }

--- a/tests/modules/programs/wlr-which-key/expected-config.yaml
+++ b/tests/modules/programs/wlr-which-key/expected-config.yaml
@@ -1,0 +1,68 @@
+anchor: center
+background: '#282828d0'
+border: '#8ec07c'
+border_width: 2
+color: '#fbf1c7'
+corner_r: 10
+font: JetBrainsMono Nerd Font 12
+margin_bottom: 0
+margin_left: 0
+margin_right: 0
+margin_top: 0
+menu:
+  l:
+    desc: Laptop Screen
+    submenu:
+      s:
+        desc: Scale
+        submenu:
+          '1':
+            cmd: wlr-randr --output eDP-1 --scale 1
+            desc: Set Scale to 1.0
+          '2':
+            cmd: wlr-randr --output eDP-1 --scale 1.1
+            desc: Set Scale to 1.1
+          '3':
+            cmd: wlr-randr --output eDP-1 --scale 1.2
+            desc: Set Scale to 1.2
+          '4':
+            cmd: wlr-randr --output eDP-1 --scale 1.3
+            desc: Set Scale to 1.3
+      t:
+        cmd: toggle-laptop-display.sh
+        desc: Toggle On/Off
+  p:
+    desc: Power
+    submenu:
+      o:
+        cmd: poweroff
+        desc: 'Off'
+      r:
+        cmd: reboot
+        desc: Reboot
+      s:
+        cmd: systemctl suspend
+        desc: Sleep
+  t:
+    desc: Theme
+    submenu:
+      d:
+        cmd: dark-theme on
+        desc: Dark
+      l:
+        cmd: dark-theme off
+        desc: Light
+      t:
+        cmd: dark-theme toggle
+        desc: Toggle
+  w:
+    desc: WiFi
+    submenu:
+      c:
+        cmd: kitty --class nmtui-connect nmtui-connect
+        desc: Connections
+      t:
+        cmd: wifi_toggle.sh
+        desc: Toggle
+padding: 15
+separator: ' ➜ '

--- a/tests/modules/programs/wlr-which-key/expected-other.yaml
+++ b/tests/modules/programs/wlr-which-key/expected-other.yaml
@@ -1,0 +1,17 @@
+anchor: center
+background: '#282828d0'
+border: '#8ec07c'
+border_width: 2
+color: '#fbf1c7'
+corner_r: 10
+font: JetBrainsMono Nerd Font 12
+margin_bottom: 0
+margin_left: 0
+margin_right: 0
+margin_top: 0
+menu:
+  a:
+    cmd: echo aaah
+    desc: Say aaah
+padding: 15
+separator: ' ➜ '

--- a/tests/modules/programs/wlr-which-key/wlr-which-key.nix
+++ b/tests/modules/programs/wlr-which-key/wlr-which-key.nix
@@ -1,0 +1,119 @@
+{
+  programs.wlr-which-key = {
+    enable = true;
+
+    commonSettings = {
+      anchor = "center";
+      background = "#282828d0";
+      border = "#8ec07c";
+      border_width = 2;
+      color = "#fbf1c7";
+      corner_r = 10;
+      font = "JetBrainsMono Nerd Font 12";
+      margin_bottom = 0;
+      margin_left = 0;
+      margin_right = 0;
+      margin_top = 0;
+      padding = 15;
+      separator = " ➜ ";
+    };
+
+    # Example config in the README
+    configs.config = {
+      menu = {
+        l = {
+          desc = "Laptop Screen";
+          submenu = {
+            s = {
+              desc = "Scale";
+              submenu = {
+                "1" = {
+                  cmd = "wlr-randr --output eDP-1 --scale 1";
+                  desc = "Set Scale to 1.0";
+                };
+                "2" = {
+                  cmd = "wlr-randr --output eDP-1 --scale 1.1";
+                  desc = "Set Scale to 1.1";
+                };
+                "3" = {
+                  cmd = "wlr-randr --output eDP-1 --scale 1.2";
+                  desc = "Set Scale to 1.2";
+                };
+                "4" = {
+                  cmd = "wlr-randr --output eDP-1 --scale 1.3";
+                  desc = "Set Scale to 1.3";
+                };
+              };
+            };
+            t = {
+              cmd = "toggle-laptop-display.sh";
+              desc = "Toggle On/Off";
+            };
+          };
+        };
+        p = {
+          desc = "Power";
+          submenu = {
+            o = {
+              cmd = "poweroff";
+              desc = "Off";
+            };
+            r = {
+              cmd = "reboot";
+              desc = "Reboot";
+            };
+            s = {
+              cmd = "systemctl suspend";
+              desc = "Sleep";
+            };
+          };
+        };
+        t = {
+          desc = "Theme";
+          submenu = {
+            d = {
+              cmd = "dark-theme on";
+              desc = "Dark";
+            };
+            l = {
+              cmd = "dark-theme off";
+              desc = "Light";
+            };
+            t = {
+              cmd = "dark-theme toggle";
+              desc = "Toggle";
+            };
+          };
+        };
+        w = {
+          desc = "WiFi";
+          submenu = {
+            c = {
+              cmd = "kitty --class nmtui-connect nmtui-connect";
+              desc = "Connections";
+            };
+            t = {
+              cmd = "wifi_toggle.sh";
+              desc = "Toggle";
+            };
+          };
+        };
+      };
+    };
+
+    configs.other.menu.a = {
+      cmd = "echo aaah";
+      desc = "Say aaah";
+    };
+  };
+
+  test.stubs.wlr-which-key = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/wlr-which-key/config.yaml
+    assertFileContent home-files/.config/wlr-which-key/config.yaml ${./expected-config.yaml}
+
+    assertFileExists home-files/.config/wlr-which-key/other.yaml
+    assertFileContent home-files/.config/wlr-which-key/other.yaml ${./expected-other.yaml}
+  '';
+}


### PR DESCRIPTION
### Description

wlr-which-key is a keymap manager for wlroots-based compositors, inspired by which-key.nvim.

closes #4396

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@mightyiam, @hervyqa any of you interested in becoming co-maintainer of this module?
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
