### PR TITLE
maintainers: remove polykernel

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -67,7 +67,7 @@ let
   };
 
 in {
-  meta.maintainers = [ hm.maintainers.polykernel maintainers.league ];
+  meta.maintainers = [ maintainers.league ];
 
   imports = [
     (mkAliasOptionModule [ "xsession" "pointerCursor" "package" ] [

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -445,11 +445,6 @@
     github = "podocarp";
     githubId = 10473184;
   };
-  polykernel = {
-    github = "polykernel";
-    githubId = 81340136;
-    name = "polykernel";
-  };
   mainrs = {
     name = "mainrs";
     email = "5113257+mainrs@users.noreply.github.com";

--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -311,5 +311,5 @@ in {
     })
   ]);
 
-  meta.maintainers = [ lib.hm.maintainers.polykernel ];
+  meta.maintainers = [ ];
 }

--- a/modules/programs/bottom.nix
+++ b/modules/programs/bottom.nix
@@ -56,5 +56,5 @@ in {
     };
   };
 
-  meta.maintainers = [ hm.maintainers.polykernel ];
+  meta.maintainers = [ ];
 }

--- a/modules/programs/watson.nix
+++ b/modules/programs/watson.nix
@@ -14,7 +14,7 @@ let
     config.xdg.configHome;
 
 in {
-  meta.maintainers = [ hm.maintainers.polykernel ];
+  meta.maintainers = [ ];
 
   options.programs.watson = {
     enable = mkEnableOption "watson, a wonderful CLI to track your time";

--- a/modules/services/fnott.nix
+++ b/modules/services/fnott.nix
@@ -9,7 +9,7 @@ let
 
   iniFormat = pkgs.formats.ini { };
 in {
-  meta.maintainers = [ hm.maintainers.polykernel ];
+  meta.maintainers = [ ];
 
   options = {
     services.fnott = {

--- a/modules/services/window-managers/i3-sway/swaynag.nix
+++ b/modules/services/window-managers/i3-sway/swaynag.nix
@@ -14,7 +14,7 @@ let
       };
     in attrsOf confAtom;
 in {
-  meta.maintainers = [ hm.maintainers.polykernel ];
+  meta.maintainers = [ ];
 
   options = {
     wayland.windowManager.sway.swaynag = {


### PR DESCRIPTION
### Description

As per https://github.com/NixOS/nixpkgs/pull/328969, I don't have time to actively participate in the Nix ecosystem now and likely won't be able to in the foreseeable future. I am grateful for the things I learned over the years trying to help and improve Nixpkgs and home-manager, as insignificant as those efforts may be in the grand scheme of things. Thanks for opening my eyes to what is possible with declarative configuration management.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
