### PR TITLE
home-manager: ignore hostname -f lookup errors

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -198,9 +198,19 @@ function setFlakeAttribute() {
                 ;;
             *)
                 local name="$USER"
+
+                local hostnameArray=()
+                # FQDN lookup can fail depending on the resolver.
+                local fqdn
+                fqdn="$(hostname -f 2> /dev/null)"
+                if [[ $? -eq 0 ]]; then
+                    hostnameArray+=( "$USER@$fqdn"  )
+                fi
                 # Check FQDN, long, and short hostnames; long first to preserve
                 # pre-existing behaviour in case both happen to be defined.
-                for n in "$USER@$(hostname -f)" "$USER@$(hostname)" "$USER@$(hostname -s)"; do
+                hostnameArray+=( "$USER@$(hostname)" "$USER@$(hostname -s)" )
+
+                for n in "${hostnameArray[@]}"; do
                     if [[ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$n\"")" == "true" ]]; then
                         name="$n"
                         if [[ -v VERBOSE ]]; then


### PR DESCRIPTION
### Description

`hostname -f` could fail depending on the resolver. Discard any stderr
and test for the exit status before using the value for flake attribute
lookup.

I was unable to repro the exact bad exit status in #5665.
With
  - nscd disabled,
  - nsswitch.conf pointing to 'files',
  - hostname entry removed from /etc/hosts
`hostname -f` from inetutils-2.5 fell back to showing just the nodename
from `uname(2)`. Injecting an empty string into the
`(struct utsname).nodename` field of `uname(2)` using strace still
exited with empty output and 0 exit-status.

Fixes #5665


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
