### PR TITLE
firefox: read the appName for search engine disclaimer from package

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -553,6 +553,7 @@ in {
                 inherit (args) config;
                 inherit lib pkgs;
                 appName = cfg.name;
+                package = cfg.finalPackage;
                 modulePath = modulePath ++ [ "profiles" name "search" ];
                 profilePath = config.path;
               });

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -232,6 +232,7 @@ in {
                     inherit (args) config;
                     inherit lib pkgs;
                     appName = "Thunderbird";
+                    package = cfg.package;
                     modulePath =
                       [ "programs" "thunderbird" "profiles" name "search" ];
                     profilePath = name;


### PR DESCRIPTION
### Description

Using a fixed application name in the salt for the search engine name hash can break with minor branding changes. For example, LibreWolf 127 used the application name "LibreWolf", but in version 128 it's "Firefox".

The proper name can be found in about:support -> Application Basics.

Because it doesn't have to be related to the product name visible in most of the browser (for example in the window title and help menus), we shouldn't rely on cfg.name for that.

The application name can be read from lib/*/application.ini and we can use that if the browser was installed via home-manager. If not, we can fall back to cfg.name.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee @brckd @kira-bruneau 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
