### PR TITLE
neovim: add `extraPrefixedPackages` option

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -65,8 +65,10 @@ let
   luaPackages = cfg.finalPackage.unwrapped.lua.pkgs;
   resolvedExtraLuaPackages = cfg.extraLuaPackages luaPackages;
 
-  extraMakeWrapperArgs = lib.optionalString (cfg.extraPackages != [ ])
-    ''--suffix PATH : "${lib.makeBinPath cfg.extraPackages}"'';
+  extraMakeWrapperArgs = lib.optionalString (cfg.extraPackages != [ ]) ''
+    --suffix PATH : "${lib.makeBinPath cfg.extraPackages}"
+    --prefix PATH : "${lib.makeBinPath cfg.extraPrefixedPackages}"
+  '';
   extraMakeWrapperLuaCArgs =
     lib.optionalString (resolvedExtraLuaPackages != [ ]) ''
       --suffix LUA_CPATH ";" "${
@@ -298,7 +300,18 @@ in {
         type = with types; listOf package;
         default = [ ];
         example = literalExpression "[ pkgs.shfmt ]";
-        description = "Extra packages available to nvim.";
+        description = "Extra packages available to {command}`nvim`.";
+      };
+
+      extraPrefixedPackages = mkOption {
+        type = with types; listOf package;
+        default = [ ];
+        example = literalExpression "[ pkgs.gcc ]";
+        description = ''
+          Extra packages available to {command}`nvim`. Packages are *prepended*
+          to the {env}`PATH` environment variable, whereas packages in
+          `extraPackages` are *appended*.
+        '';
       };
 
       plugins = mkOption {


### PR DESCRIPTION
### Description

`extraPackages` is nice to have, but there are scenarios where a package can already exist in `PATH` before it is wrapped in, so the `--suffix` option that `extraPackages` uses will have no effect. It used to use `--prefix`, and I'd like to bring back the option to choose that.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes. **Hanging on `building pubkey.txt: Warning: Problem : timeout` but I don't think this is related to me.**

- [ ] Test cases updated/added. **No previous tests existed for `extraPackages`, so I have not yet added any for `extraPrefixedPackages`, but am happy to add a test for both if needed.**

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

Missing?

@teto @misumisumi 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
