### PR TITLE
nix-gc: remove extraneous quotes from shell script

### DIFF
--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -111,10 +111,10 @@ in {
         Unit = { Description = "Nix Garbage Collector"; };
         Service = {
           Type = "oneshot";
-          ExecStart = toString (pkgs.writeShellScript "nix-gc" ''
-            exec "${nixPackage}/bin/nix-collect-garbage ${
+          ExecStart = toString (pkgs.writeShellScript "nix-gc"
+            "exec ${nixPackage}/bin/nix-collect-garbage ${
               lib.optionalString (cfg.options != null) cfg.options
-            }"'');
+            }");
         };
       };
       systemd.user.timers.nix-gc = {

--- a/tests/modules/services/nix-gc/basic.nix
+++ b/tests/modules/services/nix-gc/basic.nix
@@ -25,5 +25,16 @@
     timerFile=$(normalizeStorePaths $timerFile)
 
     assertFileContent $timerFile ${./expected.timer}
+
+    nixgcScriptFile=$(grep -o \
+      '/nix/store/.*-nix-gc' \
+      $TESTED/home-files/.config/systemd/user/nix-gc.service
+    )
+
+    assertFileExists $nixgcScriptFile
+
+    nixgcScriptFile=$(normalizeStorePaths $nixgcScriptFile)
+
+    assertFileContent $nixgcScriptFile ${./nix-gc-script-expected}
   '';
 }

--- a/tests/modules/services/nix-gc/nix-gc-script-expected
+++ b/tests/modules/services/nix-gc/nix-gc-script-expected
@@ -1,0 +1,2 @@
+#!/nix/store/00000000000000000000000000000000-bash/bin/bash
+exec @nix@/bin/nix-collect-garbage --delete-older-than 30d --max-freed $((64 * 1024**3))


### PR DESCRIPTION
### Description
Fixes small issue introduced by https://github.com/nix-community/home-manager/pull/5657. 

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 