### PR TITLE
home-cursor: add hyprcursor support

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -45,6 +45,17 @@ let
           gtk config generation for {option}`home.pointerCursor`
         '';
       };
+
+      hyprcursor = {
+        enable = mkEnableOption "hyprcursor config generation";
+
+        size = mkOption {
+          type = types.nullOr types.int;
+          example = 32;
+          default = null;
+          description = "The cursor size for hyprcursor.";
+        };
+      };
     };
   };
 
@@ -177,6 +188,14 @@ in {
 
     (mkIf cfg.gtk.enable {
       gtk.cursorTheme = mkDefault { inherit (cfg) package name size; };
+    })
+
+    (mkIf cfg.hyprcursor.enable {
+      home.sessionVariables = {
+        HYPRCURSOR_THEME = cfg.name;
+        HYPRCURSOR_SIZE =
+          if cfg.hyprcursor.size != null then cfg.hyprcursor.size else cfg.size;
+      };
     })
   ]);
 }


### PR DESCRIPTION
add the option to enable hyprcursor support by setting the relevant environment variables

### Description

<!--

Please provide a brief description of your change.

-->

"hyprcursor is a new cursor theme format that has many advantages over the widely used xcursor." - https://wiki.hyprland.org/Hypr-Ecosystem/hyprcursor/

This pull request is for adding an option to home-cursor to set the two variables needed for hyprcursor to set a theme, `HYPRCURSOR_THEME` and `HYPRCURSOR_SIZE`

I think the specific size option should be included, as that is specifically one benefit of hyprcursors, since all sizes are supported and not just a few common ones like in xcursor, but if this is not desired I can just remove it (I also don't know if this is the best way to make the size optional so that if it is not set to just use the size from xcursor)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@league 
