### PR TITLE
Enable nix-direnv option in direnv by default

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -8,7 +8,8 @@ let
 
   tomlFormat = pkgs.formats.toml { };
 
-in {
+in
+{
   imports = [
     (mkRenamedOptionModule [
       "programs"
@@ -88,9 +89,14 @@ in {
     };
 
     nix-direnv = {
-      enable = mkEnableOption ''
-        [nix-direnv](https://github.com/nix-community/nix-direnv),
-        a fast, persistent use_nix implementation for direnv'';
+      enable = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          [nix-direnv](https://github.com/nix-community/nix-direnv),
+          a fast, persistent use_nix implementation for direnv
+        '';
+      };
 
       package = mkPackageOption pkgs "nix-direnv" { };
     };


### PR DESCRIPTION
### Description

Enabling this option does speed up the usage of nix flakes together with direnv a lot.
I think it should be enabled by default as things don't change and it's just faster than the builtin `use flake`.
Most users probably just want it to be fast out of the box, without digging in and finding this option and enabling it manually.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.


#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@rycee 