### PR TITLE
Fix zellij settings parsing to KDL

### DIFF
--- a/modules/lib/generators.nix
+++ b/modules/lib/generators.nix
@@ -221,7 +221,7 @@
         lib.throwIf (name == "") "Directive must not be empty"
         (let vType = typeOf value;
         in if elem vType [ "int" "float" "bool" "string" ] then
-          "${name} ${literalValueToString value}"
+          "${name} ${literalValueToString value};"
         else if vType == "set" then
           convertAttrsToSCFG name value
         else if vType == "list" then

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -28,8 +28,37 @@ in {
       default = { };
       example = literalExpression ''
         {
-          theme = "custom";
-          themes.custom.fg = "#ffffff";
+          default_layout = "compact";
+          keybinds = {
+            _props = {
+              clear-defaults = true;
+            };
+            normal = {
+              _props = {
+                clear-defaults = true;
+              };
+              "bind \"Alt /\"" = {
+                NewPane = "Right";
+                SwitchToMode = "Normal";
+              };
+              "bind \"Alt \\\\\"" = {
+                NewPane = "Down";
+                SwitchToMode = "Normal";
+              };
+              "bind \"Ctrl h\"" = {
+                MoveFocusOrTab = "Left";
+              };
+              "bind \"Ctrl l\"" = {
+                MoveFocusOrTab = "Right";
+              };
+              "bind \"Ctrl j\"" = {
+                MoveFocus = "Down";
+              };
+              "bind \"Ctrl k\"" = {
+                MoveFocus = "Up";
+              };
+            };
+          };
         }
       '';
       description = ''


### PR DESCRIPTION
### Description

fixed zellij settings by adding required semicolons when parsing toKDL (semicolons are optional in [kdl spec](https://github.com/kdl-org/kdl/blob/main/SPEC.md#node) and a new line is enough however).
added a more helpful example for unintuitive essential use cases.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
