### PR TITLE
hyprland: add xdg.portal configuration

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -58,6 +58,8 @@ in {
 
     package = lib.mkPackageOption pkgs "hyprland" { };
 
+    portalPackage = lib.mkPackageOption pkgs "xdg-desktop-portal-hyprland" { };
+
     finalPackage = lib.mkOption {
       type = lib.types.package;
       readOnly = true;
@@ -66,6 +68,18 @@ in {
         "`wayland.windowManager.hyprland.package` with applied configuration";
       description = ''
         The Hyprland package after applying configuration.
+      '';
+    };
+
+    finalPortalPackage = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+      default = cfg.portalPackage.override { hyprland = cfg.finalPackage; };
+      defaultText = lib.literalMD ''
+        `wayland.windowManager.hyprland.portalPackage` with
+                `wayland.windowManager.hyprland.finalPackage` override'';
+      description = ''
+        The xdg-desktop-portal-hyprland package after overriding its hyprland input.
       '';
     };
 
@@ -262,6 +276,12 @@ in {
           fi
         )
       '';
+    };
+
+    xdg.portal = {
+      enable = true;
+      extraPortals = [ cfg.finalPortalPackage ];
+      configPackages = lib.mkDefault [ cfg.finalPackage ];
     };
 
     systemd.user.targets.hyprland-session = lib.mkIf cfg.systemd.enable {


### PR DESCRIPTION
### Description

Adds integration with the `xdg.portal` options. Adds the `portalPackage` option, used to change the `xdg-desktop-portal-hyprland` package.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@khaneliman @rycee
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
