### PR TITLE
fastfetch: update example for JsonConfig settings

### DIFF
--- a/modules/programs/fastfetch.nix
+++ b/modules/programs/fastfetch.nix
@@ -26,7 +26,9 @@ in {
             };
           };
           display = {
-            binaryPrefix = "si";
+            size = {
+              binaryPrefix = "si";
+            };
             color = "blue";
             separator = "  ";
           };


### PR DESCRIPTION
### Description

<!--
-->
Using the present version of the example, trows an error:
```
JsonConfig Error: `display.binaryPrefix` has been renamed to `display.size.binaryPrefix`. Sorry for another break change.
```

It occurs because of change in fastfetch 2.19 of JsonConfig - moving `display.binaryPrefix` to `display.size.binaryPrefix`

To not confuse the users, this commit changes the example to fit current standard

[link to fastfetch's changelog ](https://github.com/fastfetch-cli/fastfetch/blob/b3ac696312824cce12df76e398b5362973cde481/CHANGELOG.md?plain=1#L85)



### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@afresquet 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
