### PR TITLE
maintainers: updated username to midirhee12

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -67,12 +67,6 @@
     github = "considerate";
     githubId = 217918;
   };
-  cvoges12 = {
-    name = "Clayton Voges";
-    email = "38054771+cvoges12@users.noreply.github.com";
-    github = "cvoges12";
-    githubId = 38054771;
-  };
   danjujan = {
     name = "Jan Schmitz";
     email = "44864658+danjujan@users.noreply.github.com";

--- a/modules/services/network-manager-applet.nix
+++ b/modules/services/network-manager-applet.nix
@@ -7,7 +7,7 @@ let
   cfg = config.services.network-manager-applet;
 
 in {
-  meta.maintainers = [ maintainers.rycee hm.maintainers.cvoges12 ];
+  meta.maintainers = [ maintainers.rycee maintainers.midirhee12 ];
 
   options = {
     services.network-manager-applet = {


### PR DESCRIPTION
### Description

I changed the maintainer list to reflect my username and email changes.  Also, I updated any modules that had me as a maintainer in the modules' metadata to the one used in nixpkgs repo.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
