### PR TITLE
{gtk, dunst}: replace `pkgs.gnome.adwaita-icon-theme` with `pkgs.adwaita-icon-theme` in the examples

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -53,7 +53,7 @@ let
       package = mkOption {
         type = types.nullOr types.package;
         default = null;
-        example = literalExpression "pkgs.gnome.adwaita-icon-theme";
+        example = literalExpression "pkgs.adwaita-icon-theme";
         description = ''
           Package providing the icon theme. This package will be installed
           to your profile. If `null` then the theme

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -25,7 +25,7 @@ let
     options = {
       package = mkOption {
         type = types.package;
-        example = literalExpression "pkgs.gnome.adwaita-icon-theme";
+        example = literalExpression "pkgs.adwaita-icon-theme";
         description = "Package providing the theme.";
       };
 


### PR DESCRIPTION
`adwaita-icon-theme` has been moved out of the `gnome` scope and into the top level with https://github.com/NixOS/nixpkgs/pull/319659.

### Description
Replaces every instance of `pkgs.gnome.adwaita-icon-theme` with `gnome.adwaita-icon-theme` in the `options.package.examples` for `gtk` and `dunst`. Doing so prevents an evaluation warning about the scope change to top-level.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
