### PR TITLE
Fish copy plugins

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -6,29 +6,6 @@ let
 
   cfg = config.programs.fish;
 
-  pluginModule = types.submodule ({ config, ... }: {
-    options = {
-      src = mkOption {
-        type = types.path;
-        description = ''
-          Path to the plugin folder.
-
-          Relevant pieces will be added to the fish function path and
-          the completion path. The {file}`init.fish` and
-          {file}`key_binding.fish` files are sourced if
-          they exist.
-        '';
-      };
-
-      name = mkOption {
-        type = types.str;
-        description = ''
-          The name of the plugin.
-        '';
-      };
-    };
-  });
-
   functionModule = types.submodule {
     options = {
       body = mkOption {
@@ -326,36 +303,36 @@ in {
     };
 
     programs.fish.plugins = mkOption {
-      type = types.listOf pluginModule;
+      type = types.listOf types.path;
       default = [ ];
       example = literalExpression ''
         [
-          {
-            name = "z";
-            src = pkgs.fetchFromGitHub {
-              owner = "jethrokuan";
-              repo = "z";
-              rev = "ddeb28a7b6a1f0ec6dae40c636e5ca4908ad160a";
-              sha256 = "0c5i7sdrsp0q3vbziqzdyqn4fmp235ax4mn4zslrswvn8g3fvdyh";
-            };
-          }
+          (pkgs.fetchFromGitHub {
+            owner = "jethrokuan";
+            repo = "z";
+            rev = "ddeb28a7b6a1f0ec6dae40c636e5ca4908ad160a";
+            sha256 = "0c5i7sdrsp0q3vbziqzdyqn4fmp235ax4mn4zslrswvn8g3fvdyh";
+          })
 
           # oh-my-fish plugins are stored in their own repositories, which
           # makes them simple to import into home-manager.
-          {
-            name = "fasd";
-            src = pkgs.fetchFromGitHub {
-              owner = "oh-my-fish";
-              repo = "plugin-fasd";
-              rev = "38a5b6b6011106092009549e52249c6d6f501fba";
-              sha256 = "06v37hqy5yrv5a6ssd1p3cjd9y3hnp19d3ab7dag56fs1qmgyhbs";
-            };
-          }
+          (pkgs.fetchFromGitHub {
+            owner = "oh-my-fish";
+            repo = "plugin-fasd";
+            rev = "38a5b6b6011106092009549e52249c6d6f501fba";
+            sha256 = "06v37hqy5yrv5a6ssd1p3cjd9y3hnp19d3ab7dag56fs1qmgyhbs";
+          });
+
+          pkgs.fishPlugins.tide.src
         ]
       '';
       description = ''
-        The plugins to source in
-        {file}`conf.d/99plugins.fish`.
+        The plugins to install.
+
+        It's important to pass the source files directly,
+        instead of the derivations in nixpkgs. You can still
+        use plugins from nixpkgs by accessing their `src` attribute,
+        as seen in the example.
       '';
     };
 
@@ -516,37 +493,20 @@ in {
     # Each plugin gets a corresponding conf.d/plugin-NAME.fish file to load
     # in the paths and any initialization scripts.
     (mkIf (length cfg.plugins > 0) {
-      xdg.configFile = mkMerge ((map (plugin: {
-        "fish/conf.d/plugin-${plugin.name}.fish".source =
-          fishIndent "${plugin.name}.fish" ''
-            # Plugin ${plugin.name}
-            set -l plugin_dir ${plugin.src}
-
-            # Set paths to import plugin components
-            if test -d $plugin_dir/functions
-              set fish_function_path $fish_function_path[1] $plugin_dir/functions $fish_function_path[2..-1]
-            end
-
-            if test -d $plugin_dir/completions
-              set fish_complete_path $fish_complete_path[1] $plugin_dir/completions $fish_complete_path[2..-1]
-            end
-
-            # Source initialization code if it exists.
-            if test -d $plugin_dir/conf.d
-              for f in $plugin_dir/conf.d/*.fish
-                source $f
-              end
-            end
-
-            if test -f $plugin_dir/key_bindings.fish
-              source $plugin_dir/key_bindings.fish
-            end
-
-            if test -f $plugin_dir/init.fish
-              source $plugin_dir/init.fish
-            end
-          '';
-      }) cfg.plugins));
+      xdg.configFile = mkMerge (flatten (map (src:
+        let
+          mkPluginConfig = src: dir:
+            let path = "${src}/${dir}";
+            in if pathExists path then
+              map (file: { "fish/${dir}/${file}".source = "${path}/${file}"; })
+              (attrNames (builtins.readDir path))
+            else
+              [ ];
+        in [
+          (mkPluginConfig src "functions")
+          (mkPluginConfig src "completions")
+          (mkPluginConfig src "conf.d")
+        ]) cfg.plugins));
     })
   ]);
 }

--- a/tests/modules/programs/fish/plugins.nix
+++ b/tests/modules/programs/fish/plugins.nix
@@ -1,49 +1,16 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ lib, pkgs, ... }:
 
 let
-
-  fooPluginSrc = pkgs.writeText "fooPluginSrc" "";
-
-  generatedConfdFile = pkgs.writeText "plugin-foo.fish" ''
-    # Plugin foo
-    set -l plugin_dir ${fooPluginSrc}
-
-    # Set paths to import plugin components
-    if test -d $plugin_dir/functions
-        set fish_function_path $fish_function_path[1] $plugin_dir/functions $fish_function_path[2..-1]
-    end
-
-    if test -d $plugin_dir/completions
-        set fish_complete_path $fish_complete_path[1] $plugin_dir/completions $fish_complete_path[2..-1]
-    end
-
-    # Source initialization code if it exists.
-    if test -d $plugin_dir/conf.d
-        for f in $plugin_dir/conf.d/*.fish
-            source $f
-        end
-    end
-
-    if test -f $plugin_dir/key_bindings.fish
-        source $plugin_dir/key_bindings.fish
-    end
-
-    if test -f $plugin_dir/init.fish
-        source $plugin_dir/init.fish
-    end
+  testPlugin = pkgs.runCommandLocal "fish-test-plugin" { } ''
+    mkdir -p $out/{functions,completions,conf.d}
+    touch $out/{functions/test.fish,completions/test.fish,conf.d/test.fish}
   '';
-
 in {
   config = {
     programs.fish = {
       enable = true;
 
-      plugins = [{
-        name = "foo";
-        src = fooPluginSrc;
-      }];
+      plugins = [ testPlugin ];
     };
 
     # Needed to avoid error with dummy fish package.
@@ -54,11 +21,10 @@ in {
       description =
         "if fish.plugins set, check conf.d file exists and contents match";
       script = ''
-        assertDirectoryExists home-files/.config/fish/conf.d
-        assertFileExists home-files/.config/fish/conf.d/plugin-foo.fish
-        assertFileContent home-files/.config/fish/conf.d/plugin-foo.fish ${generatedConfdFile}
+        assertFileExists home-files/.config/fish/functions/test.fish
+        assertFileExists home-files/.config/fish/completions/test.fish
+        assertFileExists home-files/.config/fish/conf.d/test.fish
       '';
-
     };
   };
 }


### PR DESCRIPTION
### Description

Fish plugin files are now installed directly into the config directory instead of being sourced. This is needed because sourcing breaks attaching event listeners using `functions --query`, which sponge requires for example.

Breaking changes:
- `programs.fish.plugins` not takes a list of `path`s, instead of a submodule, because the name is no longer needed, only the source
- init.fish and key_bindings.fish are no longer sourced. While there is no official plugin spec, they are not a part of the [fisher](https://github.com/jorgebucaran/fisher) spec, which is what everyone uses outside of Nix.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

Uhh no clue
