### PR TITLE
jqp: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2094,6 +2094,15 @@ in {
           Dockerfile-like syntax for fast builds and simplicity.
         '';
       }
+
+      {
+        time = "2025-02-22T16:53:20+00:00";
+        message = ''
+          A new module is available: 'programs.jqp'.
+
+          A TUI playground for experimentingn with `jq`.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -140,6 +140,7 @@ let
     ./programs/java.nix
     ./programs/jetbrains-remote.nix
     ./programs/jq.nix
+    ./programs/jqp.nix
     ./programs/jujutsu.nix
     ./programs/joshuto.nix
     ./programs/joplin-desktop.nix

--- a/modules/programs/jqp.nix
+++ b/modules/programs/jqp.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.programs.jqp;
+
+  yamlFormat = pkgs.formats.yaml { };
+in {
+  options.programs.jqp = {
+    enable = lib.mkEnableOption "jqp, jq playground";
+
+    package = lib.mkPackageOption pkgs "jqp" { };
+
+    settings = lib.mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = {
+        theme = {
+          name = "monokai";
+          chromaStyleOverrides = { kc = "#009900 underline"; };
+        };
+      };
+      description = "Jqp configuration";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    home = {
+      packages = [ cfg.package ];
+
+      file.".jqp.yaml" = lib.mkIf (cfg.settings != { }) {
+        source = yamlFormat.generate "jqp-config" cfg.settings;
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -171,6 +171,7 @@ in import nmtSrc {
     ./modules/programs/irssi
     ./modules/programs/jujutsu
     ./modules/programs/joplin-desktop
+    ./modules/programs/jqp
     ./modules/programs/k9s
     ./modules/programs/kakoune
     ./modules/programs/khal

--- a/tests/modules/programs/jqp/basic-configuration.nix
+++ b/tests/modules/programs/jqp/basic-configuration.nix
@@ -1,0 +1,14 @@
+{
+  programs = {
+    jqp = {
+      enable = true;
+      settings = { theme.name = "catppuccin-frappe"; };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.jqp.yaml
+    assertFileContent home-files/.jqp.yaml \
+        ${./basic-configuration.yaml}
+  '';
+}

--- a/tests/modules/programs/jqp/basic-configuration.yaml
+++ b/tests/modules/programs/jqp/basic-configuration.yaml
@@ -1,0 +1,2 @@
+theme:
+  name: catppuccin-frappe

--- a/tests/modules/programs/jqp/default.nix
+++ b/tests/modules/programs/jqp/default.nix
@@ -1,0 +1,1 @@
+{ jqp-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

I added `jqp` module with the ability to set the `jqp` configuratin within nix. I have tested the module and it creates the `~/.jqp.yaml` file with the nix config settings

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes. (although it fails, please see below)

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->


#### Additional info

I added a test case based on the Polybar example mentioned above but still couldn't manage to get the test working after half a day. I only found in the Home Manager manual how to run them. Is there any documentation available on how to write these tests with comments? 