### PR TITLE
gpg-agent: add quietShellIntegration option

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -9,8 +9,10 @@ let
 
   homedir = config.programs.gpg.homedir;
 
+  gpgConnectAgentOpts = optionalString cfg.quietShellIntegration "--quiet";
+
   gpgSshSupportStr = ''
-    ${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye > /dev/null
+    ${gpgPkg}/bin/gpg-connect-agent ${gpgConnectAgentOpts} updatestartuptty /bye > /dev/null
   '';
 
   gpgInitStr = ''
@@ -25,7 +27,7 @@ let
   gpgNushellInitStr = ''
     $env.GPG_TTY = (tty)
   '' + optionalString cfg.enableSshSupport ''
-    ${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye | ignore
+    ${gpgPkg}/bin/gpg-connect-agent ${gpgConnectAgentOpts} updatestartuptty /bye | ignore
 
     $env.SSH_AUTH_SOCK = ($env.SSH_AUTH_SOCK? | default (${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket))
   '';
@@ -228,6 +230,14 @@ in {
 
       enableNushellIntegration = mkEnableOption "Nushell integration" // {
         default = true;
+      };
+
+      quietShellIntegration = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to pass the `--quiet` flag to gpg-connect-agent.
+        '';
       };
     };
   };


### PR DESCRIPTION
### Description

This adds an option to `services.gpg-agent`: `quietShellIntegration`.

**Rationale:** it is annoying to see the verbose output on every ssh connection attempt.

If enabled, this adds `--quiet` to `gpg-connect-agent` when it is invoked as per `enable<Shell>Integration`.

I have left it disabled by default to not modify any existing behavior. 

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] ~~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~~

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC
@rycee 