### PR TITLE
 volnoti: use cfg.package instead of pkgs

### DIFF
--- a/modules/services/volnoti.nix
+++ b/modules/services/volnoti.nix
@@ -37,7 +37,7 @@ in {
 
       Install = { WantedBy = [ "graphical-session.target" ]; };
 
-      Service = { ExecStart = "${pkgs.volnoti}/bin/volnoti -v -n"; };
+      Service = { ExecStart = "${lib.getExe cfg.package} -v -n"; };
     };
   };
 }

--- a/modules/services/volnoti.nix
+++ b/modules/services/volnoti.nix
@@ -7,7 +7,7 @@ let
   cfg = config.services.volnoti;
 
 in {
-  meta.maintainers = [ maintainers.imalison ];
+  meta.maintainers = with maintainers; [ imalison tomodachi94 ];
 
   options = {
     services.volnoti = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -287,6 +287,7 @@ in import nmtSrc {
     ./modules/services/trayscale
     ./modules/services/twmn
     ./modules/services/udiskie
+    ./modules/services/volnoti
     ./modules/services/window-managers/bspwm
     ./modules/services/window-managers/herbstluftwm
     ./modules/services/window-managers/hyprland

--- a/tests/modules/services/volnoti/default.nix
+++ b/tests/modules/services/volnoti/default.nix
@@ -1,0 +1,1 @@
+{ volnoti-package-option = ./package-option.nix; }

--- a/tests/modules/services/volnoti/package-option.nix
+++ b/tests/modules/services/volnoti/package-option.nix
@@ -1,0 +1,31 @@
+{ config, ... }:
+
+{
+  services.volnoti = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "volnoti";
+      outPath = "@volnoti@";
+    };
+  };
+
+  test.stubs.volnoti = { };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/volnoti.service
+    assertFileExists $serviceFile
+    assertFileContent $serviceFile \
+      ${
+        builtins.toFile "expected-volnoti.service" ''
+          [Install]
+          WantedBy=graphical-session.target
+
+          [Service]
+          ExecStart=@volnoti@/bin/volnoti -v -n
+
+          [Unit]
+          Description=volnoti
+        ''
+      }
+  '';
+}


### PR DESCRIPTION
### Description

The `services.volnoti.package` option was not used for the systemd user service. This PR fixes the issue, as well as adds myself to the module's maintainers and a test case.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@colonelpanic8