### PR TITLE
systemd: fully deprecate legacy switcher

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -183,7 +183,7 @@ in {
         default = "suggest";
         type = with types;
           either bool (enum [ "suggest" "legacy" "sd-switch" ]);
-        apply = p: if isBool p then if p then "legacy" else "suggest" else p;
+        apply = p: if isBool p then if p then "sd-switch" else "suggest" else p;
         description = ''
           Whether new or changed services that are wanted by active targets
           should be started. Additionally, stop obsolete services from the
@@ -196,17 +196,15 @@ in {
             {command}`systemctl` commands to run. You will have to
             manually run those commands after the switch.
 
-          `legacy` (or `true`)
+          `legacy`
           : Use a Ruby script to, in a more robust fashion, determine the
             necessary changes and automatically run the
-            {command}`systemctl` commands.
+            {command}`systemctl` commands. Note, this alternative will soon
+            be removed.
 
-          `sd-switch`
-          : Use sd-switch, a third party application, to perform the service
-            updates. This tool offers more features while having a small
-            closure size. Note, it requires a fully functional user D-Bus
-            session. Once tested and deemed sufficiently robust, this will
-            become the default.
+          `sd-switch` (or `true`)
+          : Use sd-switch, a tool that determines the necessary changes and
+            automatically apply them.
         '';
       };
 
@@ -298,6 +296,12 @@ in {
       assertion = pkgs.stdenv.isLinux;
       message = "This module is only available on Linux.";
     }];
+
+    warnings = lib.optional (cfg.startServices == "legacy") ''
+      Having 'systemd.user.startServices = "legacy"' is deprecated and will soon be removed.
+
+      Please change to 'systemd.user.startServices = true' to use the new systemd unit switcher (sd-switch).
+    '';
 
     xdg.configFile = mkMerge [
       (lib.listToAttrs ((buildServices "service" cfg.services)

--- a/tests/integration/nixos/basics.nix
+++ b/tests/integration/nixos/basics.nix
@@ -33,7 +33,7 @@
       machine.send_chars("alice\n")
       machine.wait_until_tty_matches("1", "Password: ")
       machine.send_chars("foobar\n")
-      machine.wait_until_tty_matches("1", "alice\@machine")
+      machine.wait_until_tty_matches("1", "alice\\@machine")
 
     def logout_alice():
       machine.send_chars("exit\n")

--- a/tests/integration/standalone/flake-basics.nix
+++ b/tests/integration/standalone/flake-basics.nix
@@ -32,7 +32,7 @@
       machine.send_chars("alice\n")
       machine.wait_until_tty_matches("1", "Password: ")
       machine.send_chars("foobar\n")
-      machine.wait_until_tty_matches("1", "alice\@machine")
+      machine.wait_until_tty_matches("1", "alice\\@machine")
 
     def logout_alice():
       machine.send_chars("exit\n")

--- a/tests/integration/standalone/standard-basics.nix
+++ b/tests/integration/standalone/standard-basics.nix
@@ -27,7 +27,7 @@
       machine.send_chars("alice\n")
       machine.wait_until_tty_matches("1", "Password: ")
       machine.send_chars("foobar\n")
-      machine.wait_until_tty_matches("1", "alice\@machine")
+      machine.wait_until_tty_matches("1", "alice\\@machine")
 
     def logout_alice():
       machine.send_chars("exit\n")


### PR DESCRIPTION
### Description

This switches `systemd.user.startServices = true` to be the same as `systemd.user.startServices = "sd-switch"`, previously it would use the "legacy" method. It also introduces a warning that triggers if the user explicitly have `systemd.user.startServices = "legacy"`.

See #5452

### Checklist

- [X] Change is backwards compatible. _Not fully backwards compatible since it changes the meaning of `true`_

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```