### PR TITLE
ollama: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -345,6 +345,7 @@ let
     ./services/nextcloud-client.nix
     ./services/nix-gc.nix
     ./services/notify-osd.nix
+    ./services/ollama.nix
     ./services/opensnitch-ui.nix
     ./services/osmscout-server.nix
     ./services/owncloud-client.nix

--- a/modules/services/ollama.nix
+++ b/modules/services/ollama.nix
@@ -1,0 +1,97 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.ollama;
+
+  ollamaPackage = if cfg.acceleration == null then
+    cfg.package
+  else
+    cfg.package.override { inherit (cfg) acceleration; };
+
+in {
+  meta.maintainers = [ maintainers.terlar ];
+
+  options = {
+    services.ollama = {
+      enable = mkEnableOption "ollama server for local large language models";
+
+      package = mkPackageOption pkgs "ollama" { };
+
+      host = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        example = "[::]";
+        description = ''
+          The host address which the ollama server HTTP interface listens to.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 11434;
+        example = 11111;
+        description = ''
+          Which port the ollama server listens to.
+        '';
+      };
+
+      acceleration = mkOption {
+        type = types.nullOr (types.enum [ false "rocm" "cuda" ]);
+        default = null;
+        example = "rocm";
+        description = ''
+          What interface to use for hardware acceleration.
+
+          - `null`: default behavior
+            - if `nixpkgs.config.rocmSupport` is enabled, uses `"rocm"`
+            - if `nixpkgs.config.cudaSupport` is enabled, uses `"cuda"`
+            - otherwise defaults to `false`
+          - `false`: disable GPU, only use CPU
+          - `"rocm"`: supported by most modern AMD GPUs
+            - may require overriding gpu type with `services.ollama.rocmOverrideGfx`
+              if rocm doesn't detect your AMD gpu
+          - `"cuda"`: supported by most modern NVIDIA GPUs
+        '';
+      };
+
+      environmentVariables = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        example = {
+          OLLAMA_LLM_LIBRARY = "cpu";
+          HIP_VISIBLE_DEVICES = "0,1";
+        };
+        description = ''
+          Set arbitrary environment variables for the ollama service.
+
+          Be aware that these are only seen by the ollama server (systemd service),
+          not normal invocations like `ollama run`.
+          Since `ollama run` is mostly a shell around the ollama server, this is usually sufficient.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.ollama = {
+      Unit = {
+        Description = "Server for local large language models";
+        After = [ "network.target" ];
+      };
+
+      Service = {
+        ExecStart = "${getExe ollamaPackage} serve";
+        Environment =
+          (mapAttrsToList (n: v: "${n}=${v}") cfg.environmentVariables)
+          ++ [ "OLLAMA_HOST=${cfg.host}:${toString cfg.port}" ];
+      };
+
+      Install = { WantedBy = [ "default.target" ]; };
+    };
+
+    home.packages = [ ollamaPackage ];
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -270,6 +270,7 @@ in import nmtSrc {
     ./modules/services/mpd-mpris
     ./modules/services/mpdris2
     ./modules/services/nix-gc
+    ./modules/services/ollama
     ./modules/services/osmscout-server
     ./modules/services/pantalaimon
     ./modules/services/parcellite

--- a/tests/modules/services/ollama/basic.nix
+++ b/tests/modules/services/ollama/basic.nix
@@ -1,0 +1,13 @@
+{
+  config = {
+    services.ollama.enable = true;
+
+    test.stubs.ollama = { };
+
+    nmt.script = ''
+      serviceFile="home-files/.config/systemd/user/ollama.service"
+      assertFileRegex "$serviceFile" 'After=network\.target'
+      assertFileRegex "$serviceFile" 'Environment=OLLAMA_HOST=127.0.0.1:11434'
+    '';
+  };
+}

--- a/tests/modules/services/ollama/default.nix
+++ b/tests/modules/services/ollama/default.nix
@@ -1,0 +1,4 @@
+{
+  ollama-basic = ./basic.nix;
+  ollama-set-environment-variables = ./set-environment-variables.nix;
+}

--- a/tests/modules/services/ollama/set-environment-variables.nix
+++ b/tests/modules/services/ollama/set-environment-variables.nix
@@ -1,0 +1,22 @@
+{
+  config = {
+    services.ollama = {
+      enable = true;
+      host = "localhost";
+      port = 11111;
+      environmentVariables = {
+        OLLAMA_LLM_LIBRARY = "cpu";
+        HIP_VISIBLE_DEVICES = "0,1";
+      };
+    };
+
+    test.stubs.ollama = { };
+
+    nmt.script = ''
+      serviceFile="home-files/.config/systemd/user/ollama.service"
+      assertFileRegex "$serviceFile" 'Environment=OLLAMA_HOST=localhost:11111'
+      assertFileRegex "$serviceFile" 'Environment=OLLAMA_LLM_LIBRARY=cpu'
+      assertFileRegex "$serviceFile" 'Environment=HIP_VISIBLE_DEVICES=0,1'
+    '';
+  };
+}


### PR DESCRIPTION
### Description

This adds the service ollama, based on the [corresponding NixOS module](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/misc/ollama.nix)

It skips some of the options that doesn't make sense for the user unit and of course work with the Home Manager `systemd.user.services` which is slightly different.

Fix #5152

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
