### PR TITLE
home-manager: fix early exit due to FQDN error

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -1,5 +1,5 @@
 { runCommand, lib, bash, callPackage, coreutils, findutils, gettext, gnused, jq
-, less, ncurses, unixtools
+, less, ncurses, inetutils
 # used for pkgs.path for nixos-option
 , pkgs
 
@@ -38,7 +38,7 @@ in runCommand "home-manager" {
         less
         ncurses
         nixos-option
-        unixtools.hostname
+        inetutils # for `hostname`
       ]
     }" \
     --subst-var-by HOME_MANAGER_LIB '${../lib/bash/home-manager.sh}' \

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -198,18 +198,9 @@ function setFlakeAttribute() {
                 ;;
             *)
                 local name="$USER"
-
-                local hostnameArray=()
-                # FQDN lookup can fail depending on the resolver.
-                local fqdn
-                if fqdn="$(hostname -f 2> /dev/null)"; then
-                    hostnameArray+=( "$USER@$fqdn"  )
-                fi
                 # Check FQDN, long, and short hostnames; long first to preserve
                 # pre-existing behaviour in case both happen to be defined.
-                hostnameArray+=( "$USER@$(hostname)" "$USER@$(hostname -s)" )
-
-                for n in "${hostnameArray[@]}"; do
+                for n in "$USER@$(hostname -f)" "$USER@$(hostname)" "$USER@$(hostname -s)"; do
                     if [[ "$(nix eval "$flake#homeConfigurations" --apply "x: x ? \"$n\"")" == "true" ]]; then
                         name="$n"
                         if [[ -v VERBOSE ]]; then

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -202,8 +202,7 @@ function setFlakeAttribute() {
                 local hostnameArray=()
                 # FQDN lookup can fail depending on the resolver.
                 local fqdn
-                fqdn="$(hostname -f 2> /dev/null)"
-                if [[ $? -eq 0 ]]; then
+                if fqdn="$(hostname -f 2> /dev/null)"; then
                     hostnameArray+=( "$USER@$fqdn"  )
                 fi
                 # Check FQDN, long, and short hostnames; long first to preserve


### PR DESCRIPTION
### Description

Closes #5711.

Since 89670e27e101b9b30f5900fc1eb6530258d316b1, FQDN lookup errors from `hostname -f` may cause an early exit of the whole program. This PR offers **two solutions** to the problem:

- The first commit fixes the issue at hand by absorbing the FQDN query inside the `if` statement.
- The second commit simply reverts back to the older simple logic, but now we pull in the GNU `inetutils` dependency whose `hostname` does not panic on failing FQDN queries. See: #5692.

@gauravjuvekar @rycee I am okay with either solution, feel free to pick one!

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
