### PR TITLE
imapnotify: provide an option for setting PATH

### DIFF
--- a/modules/services/imapnotify.nix
+++ b/modules/services/imapnotify.nix
@@ -27,8 +27,8 @@ let
           Restart = "always";
           RestartSec = 30;
           Type = "simple";
-        } // optionalAttrs account.notmuch.enable {
-          Environment =
+          Environment = [ "PATH=${cfg.path}" ]
+            ++ optional account.notmuch.enable
             "NOTMUCH_CONFIG=${config.xdg.configHome}/notmuch/default/config";
         };
 
@@ -97,6 +97,17 @@ in {
         example = literalExpression "pkgs.imapnotify";
         description = "The imapnotify package to use";
       };
+
+      path = mkOption {
+        type = types.listOf types.package;
+        apply = lib.makeBinPath;
+        default = [ ];
+        description = ''
+          List of packages to provide in PATH for the imapnotify service.
+
+          Note, this does not apply to the Darwin launchd service.
+        '';
+      };
     };
 
     accounts.email.accounts = mkOption {
@@ -120,6 +131,12 @@ in {
       (checkAccounts (a: a.imap == null) "IMAP configuration")
       (checkAccounts (a: a.passwordCommand == null) "password command")
       (checkAccounts (a: a.userName == null) "username")
+    ];
+
+    services.imapnotify.path = lib.mkMerge [
+      (lib.mkIf config.programs.notmuch.enable [ pkgs.notmuch ])
+      (lib.mkIf config.programs.mbsync.enable
+        [ config.programs.mbsync.package ])
     ];
 
     systemd.user.services = listToAttrs (map genAccountUnit imapnotifyAccounts);

--- a/tests/modules/services/imapnotify/imapnotify.service
+++ b/tests/modules/services/imapnotify/imapnotify.service
@@ -2,6 +2,7 @@
 WantedBy=default.target
 
 [Service]
+Environment=PATH=
 Environment=NOTMUCH_CONFIG=/home/hm-user/.config/notmuch/default/config
 ExecStart=@goimapnotify@/bin/goimapnotify -conf '/nix/store/00000000000000000000000000000000-imapnotify-hm-example.com-config.json'
 Restart=always


### PR DESCRIPTION
### Description

Some tools are a bit too painful to get working without PATH.

This includes some useful presetting for notmuch and mbsync.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@NickHu 