### PR TITLE
kanshi: do not quote criteria and fix testcases

### DIFF
--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -137,7 +137,7 @@ let
 
   outputStr =
     { criteria, status, mode, position, scale, transform, adaptiveSync, ... }:
-    ''output "${criteria}"'' + optionalString (status != null) " ${status}"
+    "output ${criteria}" + optionalString (status != null) " ${status}"
     + optionalString (mode != null) " mode ${mode}"
     + optionalString (position != null) " position ${position}"
     + optionalString (scale != null) " scale ${toString scale}"

--- a/tests/modules/services/kanshi/basic-configuration.conf
+++ b/tests/modules/services/kanshi/basic-configuration.conf
@@ -1,21 +1,21 @@
 profile backwardsCompat {
-  output "LVDS-1" enable
+  output LVDS-1 enable
   exec echo "7 eight 9"
 }
 
 profile desktop {
-  output "eDP-1" disable
-  output "Iiyama North America PLE2483H-DP" enable position 0,0
-  output "Iiyama North America PLE2483H-DP 1158765348486" enable mode 1920x1080 position 1920,0 scale 2.100000 transform flipped-270
+  output eDP-1 disable
+  output "Iiyama North America" PLE2483H-DP Unknown enable position 0,0
+  output "Iiyama North America" PLE2483H-DP 1158765348486 enable mode 1920x1080 position 1920,0 scale 2.100000 transform flipped-270
   exec echo "1 two 3"
   exec echo "4 five 6"
 }
 
 profile nomad {
-  output "eDP-1" enable
+  output eDP-1 enable
 }
 
 profile test {
-  output "*" enable
+  output * enable
 }
 

--- a/tests/modules/services/kanshi/basic-configuration.nix
+++ b/tests/modules/services/kanshi/basic-configuration.nix
@@ -18,12 +18,12 @@
               status = "disable";
             }
             {
-              criteria = "Iiyama North America PLE2483H-DP";
+              criteria = ''"Iiyama North America" PLE2483H-DP Unknown'';
               status = "enable";
               position = "0,0";
             }
             {
-              criteria = "Iiyama North America PLE2483H-DP 1158765348486";
+              criteria = ''"Iiyama North America" PLE2483H-DP 1158765348486'';
               status = "enable";
               position = "1920,0";
               scale = 2.1;
@@ -42,7 +42,7 @@
       };
       extraConfig = ''
         profile test {
-          output "*" enable
+          output * enable
         }
       '';
     };

--- a/tests/modules/services/kanshi/new-configuration.conf
+++ b/tests/modules/services/kanshi/new-configuration.conf
@@ -1,19 +1,19 @@
 include "path/to/included/file"
-output "*" enable
+output * enable
 profile nomad {
-  output "eDP-1" enable
+  output eDP-1 enable
 }
 
 profile desktop {
-  output "eDP-1" disable
-  output "Iiyama North America PLE2483H-DP" enable position 0,0
-  output "Iiyama North America PLE2483H-DP 1158765348486" enable mode 1920x1080 position 1920,0 scale 2.100000 transform flipped-270
+  output eDP-1 disable
+  output "Iiyama North America" PLE2483H-DP Unknown enable position 0,0
+  output "Iiyama North America" PLE2483H-DP 1158765348486 enable mode 1920x1080 position 1920,0 scale 2.100000 transform flipped-270
   exec echo "1 two 3"
   exec echo "4 five 6"
 }
 
 profile  {
-  output "LVDS-1" enable
+  output LVDS-1 enable
   exec echo "7 eight 9"
 }
 

--- a/tests/modules/services/kanshi/new-configuration.nix
+++ b/tests/modules/services/kanshi/new-configuration.nix
@@ -27,12 +27,12 @@
               status = "disable";
             }
             {
-              criteria = "Iiyama North America PLE2483H-DP";
+              criteria = ''"Iiyama North America" PLE2483H-DP Unknown'';
               status = "enable";
               position = "0,0";
             }
             {
-              criteria = "Iiyama North America PLE2483H-DP 1158765348486";
+              criteria = ''"Iiyama North America" PLE2483H-DP 1158765348486'';
               status = "enable";
               position = "1920,0";
               scale = 2.1;


### PR DESCRIPTION
### Description

kashi doesn't require the whole criteria string to be quoted. However, quoting everything makes it impossible to add the actually required quotes around manufacturer names with spaces.

This commit also fixes the test cases that use manufacturer and model without serial as criteria, as kanshi requires missing values like the serial to be replaced with "Unknown"

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible. (?) doesn't change the API, but the changed output _may_ break something

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@nurelin 