### PR TITLE
hyprland: make package nullable

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -56,7 +56,11 @@ in {
       '';
     };
 
-    package = lib.mkPackageOption pkgs "hyprland" { };
+    package = lib.mkPackageOption pkgs "hyprland" {
+      nullable = true;
+      extraDescription =
+        "Set this to null if you use the NixOS module to install Hyprland.";
+    };
 
     portalPackage = lib.mkPackageOption pkgs "xdg-desktop-portal-hyprland" { };
 
@@ -234,10 +238,8 @@ in {
         "You have enabled hyprland.systemd.enable or listed plugins in hyprland.plugins but do not have any configuration in hyprland.settings or hyprland.extraConfig. This is almost certainly a mistake.";
     in lib.optional inconsistent warning;
 
-    home.packages = lib.concatLists [
-      (lib.optional (cfg.package != null) cfg.finalPackage)
-      (lib.optional (cfg.xwayland.enable) pkgs.xwayland)
-    ];
+    home.packages = lib.mkIf (cfg.package != null)
+      ([ cfg.finalPackage ] ++ lib.optional cfg.xwayland.enable pkgs.xwayland);
 
     xdg.configFile."hypr/hyprland.conf" = let
       shouldGenerate = cfg.systemd.enable || cfg.extraConfig != ""


### PR DESCRIPTION
### Description

Makes `wayland.windowManager.hyprland.package` nullable.

Should xwayland still be installed, if the package is null?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@fufexan 