### PR TITLE
git: add config option for gpg.format

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -38,6 +38,17 @@ let
         defaultText = "\${pkgs.gnupg}/bin/gpg2";
         description = "Path to GnuPG binary to use.";
       };
+
+      gpgFormat = mkOption {
+        type = types.str;
+        default = "openpgp";
+        defaultText = "openpgp";
+        description = ''
+          Specifies which key format to use when signing with
+          --gpg-sign. Default is "openpgp". Other possible values
+          are "x509", "ssh".
+        '';
+      };
     };
   };
 
@@ -421,6 +432,7 @@ in {
         commit.gpgSign = mkDefault cfg.signing.signByDefault;
         tag.gpgSign = mkDefault cfg.signing.signByDefault;
         gpg.program = cfg.signing.gpgPath;
+        gpg.format = cfg.signing.gpgFormat;
       };
     })
 

--- a/tests/modules/programs/git/git-expected.conf
+++ b/tests/modules/programs/git/git-expected.conf
@@ -38,6 +38,7 @@
 	smudge = "git-lfs smudge -- %f"
 
 [gpg]
+	format = "ssh"
 	program = "path-to-gpg"
 
 [interactive]

--- a/tests/modules/programs/git/git.nix
+++ b/tests/modules/programs/git/git.nix
@@ -55,6 +55,7 @@ in {
           }
         ];
         signing = {
+          gpgFormat = "ssh";
           gpgPath = "path-to-gpg";
           key = "00112233445566778899AABBCCDDEEFF";
           signByDefault = true;


### PR DESCRIPTION
### Description

git provides three options for signing key format, openpgp(default), ssh, and x509. This commit provides the option to specify one of the other two available formats.

Motivation: currently, we already have signing.pgpPath and signing.Key, with the addition of signing.Format, we also have support for ssh signing, which most major git servers also support. 

see https://git-scm.com/docs/git-config#Documentation/git-config.txt-gpgformat

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes. **I ran `nix-shell --pure tests -A run.git-with-most-options`**

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee