### PR TITLE
lapce: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -562,6 +562,13 @@
     githubId = 1545895;
     name = "Nicola Squartini";
   };
+  timon-schelling = {
+    name = "Timon Schelling";
+    email = "me@timon.zip";
+    github = "timon-schelling";
+    githubId = 36821505;
+    matrix = "@timon:beeper.com";
+  };
   toastal = {
     email = "toastal+nix@posteo.net";
     matrix = "@toastal:matrix.org";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1701,6 +1701,16 @@ in {
       }
 
       {
+        time = "2024-08-18T11:42:08+00:00";
+        message = ''
+          A new module is available: 'programs.lapce'.
+
+          Lightning-fast and Powerful Code Editor written in Rust.
+          See https://lapce.dev/ for more.
+        '';
+      }
+
+      {
         time = "2024-09-13T08:58:17+00:00";
         condition = hostPlatform.isLinux;
         message = ''

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -148,6 +148,7 @@ let
     ./programs/kitty.nix
     ./programs/kodi.nix
     ./programs/kubecolor.nix
+    ./programs/lapce.nix
     ./programs/lazygit.nix
     ./programs/ledger.nix
     ./programs/less.nix

--- a/modules/programs/lapce.nix
+++ b/modules/programs/lapce.nix
@@ -1,0 +1,187 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.lapce;
+
+  options = {
+    enable = mkEnableOption "lapce";
+    package = mkPackageOption pkgs "lapce" { };
+    channel = mkOption {
+      type = types.enum [ "stable" "nightly" ];
+      default = "stable";
+      description = ''
+        Lapce channel to configure.
+        Should correspond to the package channel.
+        This is used to determine the correct configuration and data directories.
+      '';
+    };
+    settings = mkOption {
+      type = settingsFormat.type;
+      default = { };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/lapce/settings.toml`.
+        See <https://github.com/lapce/lapce/blob/master/extra/schemas/settings.json> for schema.
+      '';
+      example = literalExpression ''
+        {
+          core = {
+            custom-titlebar = false;
+            color-theme = "Custom";
+            icon-theme = "Material Icons";
+          };
+          editor = {
+            font-family = "FiraCode Nerd Bold Font, monospace";
+            font-size = 22;
+            tab-width = 2;
+            cursor-surrounding-lines = 4;
+            render-whitespace = "all";
+            bracket-pair-colorization = true;
+            highlight-matching-brackets = true;
+          };
+          ui = {
+            font-size = 20;
+            open-editors-visible = false;
+          };
+          lapce-nix.lsp-path = "$\{pkgs.nil\}/bin/nil";
+        }
+      '';
+    };
+    plugins = mkOption {
+      type = types.listOf (types.submodule {
+        options = {
+          author = mkOption {
+            type = types.str;
+            description = ''
+              Author of the plugin.
+            '';
+          };
+          name = mkOption {
+            type = types.str;
+            description = ''
+              Name of the plugin.
+            '';
+          };
+          version = mkOption {
+            type = types.str;
+            description = ''
+              Version of the plugin.
+            '';
+          };
+          hash = mkOption {
+            type = types.str;
+            description = ''
+              Hash of the plugin tarball.
+              To find the hash leave this empty, rebuild and copy the hash from the error message.
+            '';
+            default = "";
+          };
+        };
+      });
+      default = [ ];
+      description = ''
+        Plugins to install.
+      '';
+      example = literalExpression ''
+        [
+          {
+            author = "MrFoxPro";
+            name = "lapce-nix";
+            version = "0.0.1";
+            hash = "sha256-...";
+          }
+          {
+            author = "dzhou121";
+            name = "lapce-rust";
+            version = "0.3.1932";
+            hash = "sha256-...";
+          }
+        ]
+      '';
+    };
+    keymaps = mkOption {
+      type = settingsFormat.type;
+      default = [ ];
+      description = ''
+        Keymaps written to {file}`$XDG_CONFIG_HOME/lapce/keymaps.toml`.
+        See <https://github.com/lapce/lapce/blob/master/defaults/keymaps-common.toml> for examples.
+      '';
+      example = literalExpression ''
+        [
+          {
+            command = "open_log_file";
+            key = "Ctrl+Shift+L";
+          }
+        ]
+      '';
+    };
+  };
+
+  settingsFormat = pkgs.formats.toml { };
+
+  fetchPluginTarballFromRegistry = { author, name, version, hash }:
+    pkgs.stdenvNoCC.mkDerivation (let
+      url =
+        "https://plugins.lapce.dev/api/v1/plugins/${author}/${name}/${version}/download";
+      file = "lapce-plugin-${author}-${name}-${version}.tar.zstd";
+    in {
+      name = file;
+      nativeBuildInputs = [ pkgs.curl pkgs.cacert ];
+      dontUnpack = true;
+      dontBuild = true;
+      installPhase = ''
+        runHook preInstall
+
+        url="$(curl ${url})"
+        curl -L "$url" -o "$out"
+
+        runHook postInstall
+      '';
+      outputHashAlgo = "sha256";
+      outputHashMode = "flat";
+      outputHash = hash;
+      inherit meta;
+    });
+  pluginFromRegistry = { author, name, version, hash }@args:
+    pkgs.stdenvNoCC.mkDerivation {
+      pname = "lapce-plugin-${author}-${name}";
+      inherit version;
+      src = fetchPluginTarballFromRegistry args;
+      nativeBuildInputs = [ pkgs.zstd ];
+      phases = [ "installPhase" ];
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        tar -C $out -xvf $src
+
+        runHook postInstall
+      '';
+    };
+  pluginsFromRegistry = plugins:
+    pkgs.linkFarm "lapce-plugins" (builtins.listToAttrs (builtins.map
+      ({ author, name, version, ... }@plugin: {
+        name = "${author}-${name}-${version}";
+        value = pluginFromRegistry plugin;
+      }) plugins));
+in {
+  meta.maintainers = [ hm.maintainers.timon-schelling ];
+
+  options.programs.lapce = options;
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg = let dir = "lapce-${cfg.channel}";
+    in {
+      configFile = {
+        "${dir}/settings.toml".source =
+          settingsFormat.generate "settings.toml" cfg.settings;
+        "${dir}/keymaps.toml".source =
+          settingsFormat.generate "keymaps.toml" { keymaps = cfg.keymaps; };
+      };
+      dataFile."${dir}/plugins".source = pluginsFromRegistry cfg.plugins;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -101,6 +101,7 @@ in import nmtSrc {
     ./modules/programs/khard
     ./modules/programs/kitty
     ./modules/programs/kubecolor
+    ./modules/programs/lapce
     ./modules/programs/ledger
     ./modules/programs/less
     ./modules/programs/lesspipe

--- a/tests/modules/programs/lapce/default.nix
+++ b/tests/modules/programs/lapce/default.nix
@@ -1,0 +1,4 @@
+{
+  lapce-example-keymaps = ./example-keymaps.nix;
+  lapce-example-settings = ./example-settings.nix;
+}

--- a/tests/modules/programs/lapce/example-keymaps-expected.toml
+++ b/tests/modules/programs/lapce/example-keymaps-expected.toml
@@ -1,0 +1,3 @@
+[[keymaps]]
+command = "open_log_file"
+key = "Ctrl+Shift+L"

--- a/tests/modules/programs/lapce/example-keymaps.nix
+++ b/tests/modules/programs/lapce/example-keymaps.nix
@@ -1,0 +1,18 @@
+{ config, ... }:
+
+{
+  programs.lapce = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    keymaps = [{
+      command = "open_log_file";
+      key = "Ctrl+Shift+L";
+    }];
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/lapce-stable/keymaps.toml \
+      ${./example-keymaps-expected.toml}
+  '';
+}

--- a/tests/modules/programs/lapce/example-settings-expected.toml
+++ b/tests/modules/programs/lapce/example-settings-expected.toml
@@ -1,0 +1,17 @@
+[core]
+color-theme = "Custom"
+custom-titlebar = false
+icon-theme = "Material Icons"
+
+[editor]
+bracket-pair-colorization = true
+cursor-surrounding-lines = 4
+font-family = "FiraCode Nerd Bold Font, monospace"
+font-size = 22
+highlight-matching-brackets = true
+render-whitespace = "all"
+tab-width = 2
+
+[ui]
+font-size = 20
+open-editors-visible = false

--- a/tests/modules/programs/lapce/example-settings.nix
+++ b/tests/modules/programs/lapce/example-settings.nix
@@ -1,0 +1,34 @@
+{ config, ... }:
+
+{
+  programs.lapce = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    settings = {
+      core = {
+        custom-titlebar = false;
+        color-theme = "Custom";
+        icon-theme = "Material Icons";
+      };
+      editor = {
+        font-family = "FiraCode Nerd Bold Font, monospace";
+        font-size = 22;
+        tab-width = 2;
+        cursor-surrounding-lines = 4;
+        render-whitespace = "all";
+        bracket-pair-colorization = true;
+        highlight-matching-brackets = true;
+      };
+      ui = {
+        font-size = 20;
+        open-editors-visible = false;
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/lapce-stable/settings.toml \
+      ${./example-settings-expected.toml}
+  '';
+}


### PR DESCRIPTION
### Description

Adds the 'programs.lapce' module for configuring lapce text editor.
Options for settings, plugins and keymaps are available. Idea #4541

Using the module would look something like this:

```
...
programs.lapce = {
  enable = true;
  package = pkgs.lapce;
  settings = {
    core = {
      custom-titlebar = false;
      color-theme = "Custom";
      icon-theme = "Material Icons";
    };
    editor = {
      font-family = "FiraCode Nerd Bold Font, monospace";
      font-size = 22;
      tab-width = 2;
      cursor-surrounding-lines = 4;
      render-whitespace = "all";
      bracket-pair-colorization = true;
      highlight-matching-brackets = true;
    };
    ui = {
      font-size = 20;
      open-editors-visible = false;
    };
    nushell-lsp = {
      path = "${pkgs.nushell}/bin/nu";
      args = [ "--lsp" ];
    };
    lapce-nix.lsp-path = "${pkgs.nil}/bin/nil";
  };
  plugins = [
    {
      author = "timon-schelling";
      name = "nushell-lsp";
      version = "0.1.0-rc2";
      hash = "sha256-/s982zGl85kxRoibwSpRiXxXD1Dgq6OUVvMXIUPP//4=";
    }
    {
      author = "MrFoxPro";
      name = "lapce-nix";
      version = "0.0.1";
      hash = "sha256-n+j8p6sB/Bxdp0iY6Gty9Zkpv9Rg34HjKsT1gUuGDzQ=";
    }
  ];
  keymaps = [
    {
      command = "open_log_file";
      key = "Ctrl+Shift+L";
    }
  ];
};
...
```

I'am allready using this in my nixos config via my fork. See [this](https://github.com/timon-schelling/timonos/blob/2ebda0730b5415e6abf7c3868e7cac02ae376f46/src/user/apps/editor/lapce/app.nix#L189) location.


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
