### PR TITLE
i3/sway: support str type for font size

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -31,7 +31,7 @@ let
       };
 
       size = mkOption {
-        type = types.float;
+        type = types.either types.float types.str;
         default = 8.0;
         description = ''
           The font size to use for window titles.

--- a/tests/modules/services/window-managers/i3/i3-fonts-deprecated.nix
+++ b/tests/modules/services/window-managers/i3/i3-fonts-deprecated.nix
@@ -7,7 +7,10 @@
     enable = true;
 
     config = {
-      bars = [{ fonts = [ "FontAwesome" "Iosevka 11.500000" ]; }];
+      bars = [
+        { fonts = [ "FontAwesome" "Iosevka 11.500000" ]; }
+        { fonts = [ "FontAwesome" "Iosevka Bold Semi-Condensed 14px" ]; }
+      ];
       fonts = [ "DejaVuSansMono" "Terminus Bold Semi-Condensed 13.500000" ];
     };
   };
@@ -20,6 +23,7 @@
 
   test.asserts.warnings.expected = [
     "Specifying i3.config.fonts as a list is deprecated. Use the attrset version instead."
+    "Specifying i3.config.bars[].fonts as a list is deprecated. Use the attrset version instead."
     "Specifying i3.config.bars[].fonts as a list is deprecated. Use the attrset version instead."
   ];
 }

--- a/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
@@ -94,3 +94,25 @@ bar {
   }
 }
 
+bar {
+  font pango:FontAwesome, Iosevka Bold Semi-Condensed 14px
+  mode dock
+  hidden_state hide
+  position bottom
+  status_command @i3status@/bin/i3status
+  i3bar_command @i3@/bin/i3bar
+  workspace_buttons yes
+  strip_workspace_numbers no
+  tray_output primary
+  colors {
+    background #000000
+    statusline #ffffff
+    separator #666666
+    focused_workspace #4c7899 #285577 #ffffff
+    active_workspace #333333 #5f676a #ffffff
+    inactive_workspace #333333 #222222 #888888
+    urgent_workspace #2f343a #900000 #ffffff
+    binding_mode #2f343a #900000 #ffffff
+  }
+}
+

--- a/tests/modules/services/window-managers/i3/i3-fonts.nix
+++ b/tests/modules/services/window-managers/i3/i3-fonts.nix
@@ -7,12 +7,21 @@
     enable = true;
 
     config = {
-      bars = [{
-        fonts = {
-          names = [ "FontAwesome" "Iosevka" ];
-          size = 11.5;
-        };
-      }];
+      bars = [
+        {
+          fonts = {
+            names = [ "FontAwesome" "Iosevka" ];
+            size = 11.5;
+          };
+        }
+        {
+          fonts = {
+            names = [ "FontAwesome" "Iosevka" ];
+            style = "Bold Semi-Condensed";
+            size = "14px";
+          };
+        }
+      ];
       fonts = {
         names = [ "DejaVuSansMono" "Terminus" ];
         style = "Bold Semi-Condensed";


### PR DESCRIPTION
### Description

This PR adds support for i3/sway font size with `px` suffix (e.g. `10px`), which is supported both in i3 & sway (https://i3wm.org/docs/userguide.html#fonts).

Previously, the type is restricted to float and impossible to add such config.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@sumnerevans @Scrumplex @alexarice @oxalica 
