### PR TITLE
programs.texlive: extend documentation of options

### DIFF
--- a/modules/programs/texlive.nix
+++ b/modules/programs/texlive.nix
@@ -14,12 +14,25 @@ in {
 
   options = {
     programs.texlive = {
-      enable = mkEnableOption "TeX Live";
+      enable = mkEnableOption ''
+        TeX Live package customization.
+
+        This module allows you to select which texlive packages you want to install.
+        Start by exteding {option}`programs.texlive.extraPackages`.
+      '';
 
       packageSet = mkOption {
         default = pkgs.texlive;
-        defaultText = literalExpression "pkgs.texlive";
-        description = "TeX Live package set to use.";
+        defaultText = literalExpression ''
+          pkgs.texlive  # corresponds to packages in pkgs.texlivePackages
+        '';
+        description = ''
+          TeX Live package set to use.
+
+          This is used in the option {option}`programs.texlive.extraPackages`.
+          Normally you do not want to change this from the default
+          except if you want to use texlive packages from a different nixpkgs release than your config’s default.
+        '';
       };
 
       extraPackages = mkOption {
@@ -28,7 +41,15 @@ in {
         example = literalExpression ''
           tpkgs: { inherit (tpkgs) collection-fontsrecommended algorithms; }
         '';
-        description = "Extra packages available to TeX Live.";
+        description = ''
+          Extra packages which should be appended.
+
+          {option}`programs.texlive.packageSet` will be passed to this function.
+          In case you changed your `packageSet`,
+          you can find all available packages to select from
+          in nixpkgs under `pkgs.texlivePackages`,
+          see [here to search for them in the latest release](https://search.nixos.org/packages?type=packages&query=texlivePackages.).
+        '';
       };
 
       package = mkOption {


### PR DESCRIPTION
The options were barely documented until now, making it unnecessarily hard for people even somewhat familiar with other, similar modules to use this one. This is especially because, intuitively, `packageSet` & `extraPackages` can be misunderstood and neither of their descriptions described their advantages. The enable option did not explain the module‘s purpose. I heavily expanded the option’s descriptions which hopefully makes this module useable to newcomers without resorting to look into the Nix code of the module.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
