### PR TITLE
hyprland: make package nullable

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -56,7 +56,13 @@ in {
       '';
     };
 
-    package = lib.mkPackageOption pkgs "hyprland" { };
+    package = lib.mkPackageOption pkgs "hyprland" {
+      nullable = true;
+      extraDescription = ''
+        Set to `null` to not add the hyprland package to your path.
+        This should be done if you want to use the hyprland package from the NixOS module.
+      '';
+    };
 
     finalPackage = lib.mkOption {
       type = lib.types.package;

--- a/tests/modules/services/window-managers/hyprland/default.nix
+++ b/tests/modules/services/window-managers/hyprland/default.nix
@@ -3,4 +3,5 @@
   hyprland-multiple-devices-config = ./multiple-devices-config.nix;
   hyprland-sourceFirst-false-config = ./sourceFirst-false-config.nix;
   hyprland-inconsistent-config = ./inconsistent-config.nix;
+  hyprland-null-package = ./null-package.nix;
 }

--- a/tests/modules/services/window-managers/hyprland/null-package.nix
+++ b/tests/modules/services/window-managers/hyprland/null-package.nix
@@ -1,0 +1,13 @@
+{
+  wayland.windowManager.hyprland = {
+    enable = true;
+    package = null;
+    settings = { "$mod" = "SUPER"; };
+  };
+
+  nmt.script = ''
+    config=home-files/.config/hypr/hyprland.conf
+    assertFileExists "$config"
+    assertPathNotExists home-path/bin/hyprctl
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Allow setting `wayland.windowManager.hyprland.package` to null for standalone home-manager installations. The hyprland package is not needed if it's already installed via the NixOS module.

At some point, I let my package versions get out of sync and encountered some weirdness trying to invoke `hyprctl`. The module code already seems to check for null; this just fixes the following error:

```
   error: A definition for option `wayland.windowManager.hyprland.package' is not of type `package'. Definition values:
       - In `/nix/store/...': null
```


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@fufexan 