### PR TITLE
nix: add nix.package to home.packages

### DIFF
--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -276,6 +276,8 @@ in {
   };
 
   config = mkIf cfg.enable (mkMerge [
+    (mkIf (cfg.package != null) { home.packages = [ cfg.package ]; })
+
     (mkIf (cfg.nixPath != [ ] && !cfg.keepOldNixPath) {
       home.sessionVariables.NIX_PATH = "${nixPath}";
     })


### PR DESCRIPTION
### Description

Add nix.package to home.packages if nix.package is not null.
This fixes the following use case:

- set `nix.package` to a version newer than the default system nix version
- `nix.settings` or `nix.extraOptions` contains some options which work for `nix.package` but not the older system nix version
- after creating a new home-manager generation nix commands fail because of the incompatible options 

In my opinion it makes sense to install the nix package compatible to the configuration settings.
However the change might not be backwards compatible because it potentially installs a new package to existing setups.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@polykernel 