### PR TITLE
kanshi: add support for output aliases

### DIFF
--- a/tests/modules/services/kanshi/alias-assertion.nix
+++ b/tests/modules/services/kanshi/alias-assertion.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, ... }: {
+  config = {
+    services.kanshi = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { };
+      settings = [{
+        profile.name = "nomad";
+        profile.outputs = [{
+          criteria = "eDP-1";
+          alias = "test";
+        }];
+      }];
+    };
+
+    test.asserts.assertions.expected =
+      [ "Output kanshi.*.output.alias can only be defined on global scope" ];
+  };
+}

--- a/tests/modules/services/kanshi/default.nix
+++ b/tests/modules/services/kanshi/default.nix
@@ -1,4 +1,5 @@
 {
   kanshi-basic-configuration = ./basic-configuration.nix;
   kanshi-new-configuration = ./new-configuration.nix;
+  kanshi-alias-assertion = ./alias-assertion.nix;
 }

--- a/tests/modules/services/kanshi/new-configuration.conf
+++ b/tests/modules/services/kanshi/new-configuration.conf
@@ -1,12 +1,12 @@
 include "path/to/included/file"
-output "*" enable
+output "Iiyama North America PLE2483H-DP" alias $iiyama
 profile nomad {
   output "eDP-1" enable
 }
 
 profile desktop {
   output "eDP-1" disable
-  output "Iiyama North America PLE2483H-DP" enable position 0,0
+  output "$iiyama" enable position 0,0
   output "Iiyama North America PLE2483H-DP 1158765348486" enable mode 1920x1080 position 1920,0 scale 2.100000 transform flipped-270
   exec echo "1 two 3"
   exec echo "4 five 6"

--- a/tests/modules/services/kanshi/new-configuration.nix
+++ b/tests/modules/services/kanshi/new-configuration.nix
@@ -7,8 +7,8 @@
         { include = "path/to/included/file"; }
         {
           output = {
-            criteria = "*";
-            status = "enable";
+            criteria = "Iiyama North America PLE2483H-DP";
+            alias = "iiyama";
           };
         }
         {
@@ -27,7 +27,7 @@
               status = "disable";
             }
             {
-              criteria = "Iiyama North America PLE2483H-DP";
+              criteria = "$iiyama";
               status = "enable";
               position = "0,0";
             }


### PR DESCRIPTION
- Add `services.kanshi.profiles.<name>.outputs.*.alias` to support new alias directive from kanshi [1].
- Add relevant coverage by modifying the existing "new-configuration" test.

[1]: https://git.sr.ht/~emersion/kanshi/commit/1ed86ce523553240ceb81e9d466b88d3554a66bb

### Description

_Refer to the commit msg_

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@nurelin
