### PR TITLE
sway: indent sway configuration options

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -249,7 +249,7 @@ let
   moduleStr = moduleType: name: attrs: ''
     ${moduleType} "${name}" {
     ${concatStringsSep "\n"
-    (mapAttrsToList (name: value: "${name} ${value}") attrs)}
+    (mapAttrsToList (name: value: "  ${name} ${value}") attrs)}
     }
   '';
   inputStr = moduleStr "input";

--- a/tests/modules/services/window-managers/sway/sway-modules.conf
+++ b/tests/modules/services/window-managers/sway/sway-modules.conf
@@ -71,15 +71,15 @@ bindsym Mod1+v splitv
 bindsym Mod1+w layout tabbed
 
 input "*" {
-xkb_variant dvorak
+  xkb_variant dvorak
 }
 
 output "HDMI-A-2" {
-bg ~/path/to/background.png fill
+  bg ~/path/to/background.png fill
 }
 
 seat "*" {
-hide_cursor when-typing enable
+  hide_cursor when-typing enable
 }
 
 mode "resize" {


### PR DESCRIPTION
The sway configuration maps attrsets into configuration blocks in the sway configuration files (typically ~/.config/sway/config).

The options nested inside curly braces are usually indented with 2 spaces, like is the case for `mode` (see: `modeStr` in [modules/services/window-managers/i3-sway/lib/functions.nix](https://github.com/nix-community/home-manager/blob/master/modules/services/window-managers/i3-sway/lib/functions.nix#L49)).

Nonetheless, some other configuration blocks are not indented, so it results looking like this:

```
output "eDP-1" {
position 0 0
resolution 1536x960@120Hz
}
```

rather than:

```
output "eDP-1" {
  position 0 0
  resolution 1536x960@120Hz
}
```

This PR fixes the indentation for `input`, `output` and `seat`.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@SebTM @alexarice @rycee 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
