### PR TITLE
fcitx5: allow to set fcitx5-with-addons

### DIFF
--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -5,11 +5,18 @@ with lib;
 let
   im = config.i18n.inputMethod;
   cfg = im.fcitx5;
-  fcitx5Package =
-    pkgs.libsForQt5.fcitx5-with-addons.override { inherit (cfg) addons; };
+  fcitx5Package = cfg.fcitx5-with-addons.override { inherit (cfg) addons; };
 in {
   options = {
     i18n.inputMethod.fcitx5 = {
+      fcitx5-with-addons = mkOption {
+        type = types.package;
+        default = pkgs.libsForQt5.fcitx5-with-addons;
+        example = literalExpression "pkgs.kdePackages.fcitx5-with-addons";
+        description = ''
+          The fcitx5 package to use.
+        '';
+      };
       addons = mkOption {
         type = with types; listOf package;
         default = [ ];


### PR DESCRIPTION
### Description

Now there's `libsForQt5.fcitx5` and `kdePackages.fcitx5` in nixpkgs, we should allow user to choose which one to use.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Kranzes 
