### PR TITLE
home-cursor, xresources: use `profileExtra` instead of `initExtra`

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -174,7 +174,7 @@ in {
     }
 
     (mkIf cfg.x11.enable {
-      xsession.initExtra = ''
+      xsession.profileExtra = ''
         ${pkgs.xorg.xsetroot}/bin/xsetroot -xcf ${cursorPath} ${
           toString cfg.size
         }

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -99,6 +99,6 @@ in {
         '';
       };
 
-      xsession.initExtra = xrdbMerge;
+      xsession.profileExtra = xrdbMerge;
     };
 }


### PR DESCRIPTION
### Description

`xsession.initExtra` is executed after systemd graphical-session.target, which means graphical applications started by graphical-session.target can get these x settings.


### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee @polykernel @league