### PR TITLE
nix-direnv: Override the `nix-direnv` package with `nix` from `config.nix.package`

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -92,7 +92,17 @@ in {
         [nix-direnv](https://github.com/nix-community/nix-direnv),
         a fast, persistent use_nix implementation for direnv'';
 
-      package = mkPackageOption pkgs "nix-direnv" { };
+      package = mkOption {
+        default = pkgs.nix-direnv.override {
+          nix =
+            if config.nix.package == null then pkgs.nix else config.nix.package;
+        };
+        defaultText = "pkgs.nix-direnv";
+        type = types.package;
+        description = ''
+          The nix-direnv package to use
+        '';
+      };
     };
 
     silent = mkEnableOption "silent mode, that is, disabling direnv logging";


### PR DESCRIPTION
### Description

Override the `nix-direnv` package with `nix` from `config.nix.package` to match the behaviour with upstream nixpkgs: https://github.com/NixOS/nixpkgs/blob/6a9d18e057c1dbd6acefa6fe094de8f3c68051a2/nixos/modules/programs/direnv.nix#L64
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
