### PR TITLE
neovide: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -276,6 +276,12 @@
     github = "nilp0inter";
     githubId = 1224006;
   };
+  NitroSniper = {
+    name = "Nitro Sniper";
+    email = "nitro@ortin.dev";
+    github = "NitroSniper";
+    githubId = 44097331;
+  };
   seylerius = {
     email = "sable@seyleri.us";
     name = "Sable Seyler";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1703,6 +1703,15 @@ in {
           one place. See https://github.com/glanceapp/glance for more.
         '';
       }
+
+      {
+        time = "2024-08-26T18:41:20+00:00";
+        message = ''
+          A new module is available: 'programs.neovide'.
+
+          Neovide is a simple, no-nonsense, cross-platform graphical user interface for Neovim (an aggressively refactored and updated Vim editor).
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -167,6 +167,7 @@ let
     ./programs/ncspot.nix
     ./programs/ne.nix
     ./programs/neomutt.nix
+    ./programs/neovide.nix
     ./programs/neovim.nix
     ./programs/newsboat.nix
     ./programs/nheko.nix

--- a/modules/programs/neovide.nix
+++ b/modules/programs/neovide.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.programs.neovide;
+  settingsFormat = pkgs.formats.toml { };
+in {
+  meta.maintainers = [ lib.hm.maintainers.NitroSniper ];
+  options.programs.neovide = {
+
+    enable = lib.mkEnableOption "Neovide, No Nonsense Neovim Client in Rust";
+    package = lib.mkPackageOption pkgs "neovide" { };
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      example = lib.literalExpression ''
+        {
+          fork = false;
+          frame = "full";
+          idle = true;
+          maximized = false;
+          neovim-bin = "/usr/bin/nvim";
+          no-multigrid = false;
+          srgb = false;
+          tabs = true;
+          theme = "auto";
+          title-hidden = true;
+          vsync = true;
+          wsl = false;
+
+          font = {
+            normal = [];
+            size = 14.0;
+          };
+        }
+      '';
+      description = ''
+        Neovide configuration.
+        For available settings see <https://neovide.dev/config-file.html>.
+        For any option not found will need to be done in your neovim's config instead.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    xdg.configFile."neovide/config.toml".source =
+      settingsFormat.generate "config.toml" cfg.settings;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -110,6 +110,7 @@ in import nmtSrc {
     ./modules/programs/ncmpcpp
     ./modules/programs/ne
     ./modules/programs/neomutt
+    ./modules/programs/neovide
     ./modules/programs/neovim
     ./modules/programs/newsboat
     ./modules/programs/nheko

--- a/tests/modules/programs/neovide/default.nix
+++ b/tests/modules/programs/neovide/default.nix
@@ -1,0 +1,1 @@
+{ neovide-program = ./neovide.nix; }

--- a/tests/modules/programs/neovide/expected.toml
+++ b/tests/modules/programs/neovide/expected.toml
@@ -1,0 +1,15 @@
+fork = false
+frame = "full"
+idle = true
+maximized = false
+neovim-bin = "/usr/bin/nvim"
+no-multigrid = false
+srgb = false
+tabs = true
+theme = "auto"
+title-hidden = true
+vsync = true
+wsl = false
+[font]
+normal = []
+size = 14.0

--- a/tests/modules/programs/neovide/neovide.nix
+++ b/tests/modules/programs/neovide/neovide.nix
@@ -1,0 +1,34 @@
+{ ... }:
+
+{
+  programs.neovide = {
+    enable = true;
+
+    settings = {
+      fork = false;
+      frame = "full";
+      idle = true;
+      maximized = false;
+      neovim-bin = "/usr/bin/nvim";
+      no-multigrid = false;
+      srgb = false;
+      tabs = true;
+      theme = "auto";
+      title-hidden = true;
+      vsync = true;
+      wsl = false;
+
+      font = {
+        normal = [ ];
+        size = 14.0;
+      };
+    };
+  };
+
+  test.stubs.neovide = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/neovide/config.toml
+    assertFileContent home-files/.config/neovide/config.toml ${./expected.toml}
+  '';
+}


### PR DESCRIPTION
Neovide is a simple, no-nonsense, cross-platform graphical user interface for Neovim See <https://neovide.dev/>

Used ruff's module as reference during creation

### Description

Implemented a neovide module which can be used to generate its `config.toml`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
