### PR TITLE
xdg: add option 'xdg.stateFile'

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -70,6 +70,16 @@ in {
       '';
     };
 
+    stateFile = mkOption {
+      type = fileType "xdg.stateFile" "<varname>xdg.stateHome</varname>"
+        cfg.stateHome;
+      default = { };
+      description = ''
+        Attribute set of files to link into the user's XDG
+        state home.
+      '';
+    };
+
     stateHome = mkOption {
       type = types.path;
       defaultText = "~/.local/state";
@@ -122,6 +132,8 @@ in {
           cfg.configFile)
         (mapAttrs' (name: file: nameValuePair "${cfg.dataHome}/${name}" file)
           cfg.dataFile)
+        (mapAttrs' (name: file: nameValuePair "${cfg.stateHome}/${name}" file)
+          cfg.stateFile)
         { "${cfg.cacheHome}/.keep".text = ""; }
       ];
     }

--- a/tests/modules/misc/xdg/file-gen.nix
+++ b/tests/modules/misc/xdg/file-gen.nix
@@ -11,8 +11,8 @@ with lib;
 
     xdg.configFile.test.text = "config";
     xdg.dataFile.test.text = "data";
+    xdg.stateFile.test.text = "state";
     home.file."${config.xdg.cacheHome}/test".text = "cache";
-    home.file."${config.xdg.stateHome}/test".text = "state";
 
     nmt.script = ''
       assertFileExists home-files/.dummy-config/test


### PR DESCRIPTION
### Description

Same motivation as `xdg.dataFile` (I don't see a use-case for an `xdg.cacheFile`, but for consistency we could add one as well...)

### Checklist


- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 