### PR TITLE
nixos: always run home-manager on NixOS activation

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -48,7 +48,6 @@ in {
           serviceConfig = {
             User = usercfg.home.username;
             Type = "oneshot";
-            RemainAfterExit = "yes";
             TimeoutStartSec = "5m";
             SyslogIdentifier = "hm-activate-${username}";
 


### PR DESCRIPTION
### Description

Currently, the home-manager systemd service will only get restarted when the home-manager configuration changes. This can lead to issues in users' home directories not getting corrected for a while.

    $ rm ~/.zshrc
    $ sudo nixos-rebuild switch
    $ ls ~/.zshrc
    ls: cannot access '/home/enzime/.zshrc': No such file or directory

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

cc @rycee 