### PR TITLE
taskwarrior: support taskwarrior3 migration

### DIFF
--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -85,7 +85,8 @@ in {
         '';
       };
 
-      package = mkPackageOption pkgs "taskwarrior" { };
+      package =
+        mkPackageOption pkgs "taskwarrior" { example = "pkgs.taskwarrior3"; };
     };
   };
 

--- a/modules/services/taskwarrior-sync.nix
+++ b/modules/services/taskwarrior-sync.nix
@@ -12,7 +12,8 @@ in {
   options.services.taskwarrior-sync = {
     enable = mkEnableOption "Taskwarrior periodic sync";
 
-    package = mkPackageOption pkgs "taskwarrior" { };
+    package =
+      mkPackageOption pkgs "taskwarrior" { example = "pkgs.taskwarrior3"; };
 
     frequency = mkOption {
       type = types.str;

--- a/tests/modules/programs/taskwarrior/taskwarrior.nix
+++ b/tests/modules/programs/taskwarrior/taskwarrior.nix
@@ -6,6 +6,7 @@ with lib;
   config = {
     programs.taskwarrior = {
       enable = true;
+      package = pkgs.taskwarrior3;
       colorTheme = "dark-violets-256";
       dataLocation = "/some/data/location";
       config = {
@@ -18,7 +19,7 @@ with lib;
       '';
     };
 
-    test.stubs.taskwarrior = { };
+    test.stubs.taskwarrior3 = { };
 
     nmt.script = ''
       assertFileExists home-files/.config/task/home-manager-taskrc


### PR DESCRIPTION
### Description

Support taskwarrior3 migration, following the approach in https://github.com/NixOS/nixpkgs/pull/303632 to avoid breaking changes.

Closes: https://github.com/nix-community/home-manager/issues/5310

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

- `taskwarrior-sync.nix`
  - @minijackson
  - @pacien

- `taskwarrior.nix`
  - @Leixb
  - @x10an14
