### PR TITLE
Qutebrowser: allow config to output Python dict

### DIFF
--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -47,6 +47,8 @@ let
   formatQuickmarks = n: s: "${n} ${s}";
 
 in {
+  meta.maintainers = with lib.maintainers; [ giodamelio ];
+
   options.programs.qutebrowser = {
     enable = mkEnableOption "qutebrowser";
 

--- a/tests/modules/programs/qutebrowser/settings.nix
+++ b/tests/modules/programs/qutebrowser/settings.nix
@@ -14,6 +14,25 @@
       };
       spellcheck.languages = [ "en-US" "sv-SE" ];
       tabs.tabs_are_windows = true;
+      tabs.padding = {
+        __isDict = true;
+        bottom = 1;
+        left = 5;
+        right = 5;
+        top = 1;
+      };
+    };
+
+    searchEngines = {
+      DEFAULT = "https://duckduckgo.com/?q={}";
+
+      # Nix stuff
+      nix-home-manager =
+        "https://home-manager-options.extranix.com/?query={}&release=master";
+      nix-options =
+        "https://search.nixos.org/options?channel=unstable&type=packages&query={}";
+      nix-packages =
+        "https://search.nixos.org/packages?channel=unstable&type=packages&query={}";
     };
 
     extraConfig = ''
@@ -38,7 +57,15 @@
           c.colors.hints.fg = "#ffffff"
           c.colors.tabs.bar.bg = "#000000"
           c.spellcheck.languages = ["en-US", "sv-SE"]
+          c.tabs.padding['bottom'] = 1
+          c.tabs.padding['left'] = 5
+          c.tabs.padding['right'] = 5
+          c.tabs.padding['top'] = 1
           c.tabs.tabs_are_windows = True
+          c.url.searchengines['DEFAULT'] = "https://duckduckgo.com/?q={}"
+          c.url.searchengines['nix-home-manager'] = "https://home-manager-options.extranix.com/?query={}&release=master"
+          c.url.searchengines['nix-options'] = "https://search.nixos.org/options?channel=unstable&type=packages&query={}"
+          c.url.searchengines['nix-packages'] = "https://search.nixos.org/packages?channel=unstable&type=packages&query={}"
           # Extra qutebrowser configuration.
         ''
       }


### PR DESCRIPTION
### Description

Add a new special `__isDict` attribute to the qutebrowser settings code to allow it to output Python dicts.

I am not sure I love the solution really, but it works and is backwards compatable.

I think it would be great to instead serilize the config to something like toml or yaml then write some Python config to load that, but that is non trivial.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

There are no maintainers in the meta @somasis and @rycee it looks like you are recent commiters.

I also went ahead and added myself as a maintainer.
