### PR TITLE
git: add option to override difftastic package

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -222,6 +222,8 @@ in {
           '';
         };
 
+        package = mkPackageOption pkgs "difftastic" { };
+
         background = mkOption {
           type = types.enum [ "light" "dark" ];
           default = "light";
@@ -478,11 +480,11 @@ in {
     })
 
     (mkIf cfg.difftastic.enable {
-      home.packages = [ pkgs.difftastic ];
+      home.packages = [ cfg.difftastic.package ];
 
       programs.git.iniContent = let
         difftCommand = concatStringsSep " " [
-          "${pkgs.difftastic}/bin/difft"
+          "${getExe cfg.difftastic.package}"
           "--color ${cfg.difftastic.color}"
           "--background ${cfg.difftastic.background}"
           "--display ${cfg.difftastic.display}"


### PR DESCRIPTION
### Description

Just adds an option to override difftastic package.  

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
