### PR TITLE
treewide: use graphical-session.target for GUI services

### DIFF
--- a/modules/misc/numlock.nix
+++ b/modules/misc/numlock.nix
@@ -19,7 +19,7 @@ in {
     systemd.user.services.numlockx = {
       Unit = {
         Description = "NumLockX";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/amberol.nix
+++ b/modules/services/amberol.nix
@@ -54,7 +54,7 @@ in {
       Unit = {
         Description = "Amberol music player daemon";
         Requires = [ "dbus.service" ];
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/autorandr.nix
+++ b/modules/services/autorandr.nix
@@ -36,7 +36,7 @@ in {
     systemd.user.services.autorandr = {
       Unit = {
         Description = "autorandr";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/barrier.nix
+++ b/modules/services/barrier.nix
@@ -63,7 +63,7 @@ in {
     systemd.user.services.barrierc = {
       Unit = {
         Description = "Barrier Client daemon";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
       Install.WantedBy = [ "graphical-session.target" ];

--- a/modules/services/batsignal.nix
+++ b/modules/services/batsignal.nix
@@ -32,7 +32,7 @@ in {
     systemd.user.services.batsignal = {
       Unit = {
         Description = "batsignal - battery monitor daemon";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/blanket.nix
+++ b/modules/services/blanket.nix
@@ -24,7 +24,7 @@ in {
       Unit = {
         Description = "Blanket daemon";
         Requires = [ "dbus.service" ];
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" "pipewire.service" ];
       };
 

--- a/modules/services/blueman-applet.nix
+++ b/modules/services/blueman-applet.nix
@@ -30,7 +30,7 @@ with lib;
       Unit = {
         Description = "Blueman applet";
         Requires = [ "tray.target" ];
-        After = [ "graphical-session-pre.target" "tray.target" ];
+        After = [ "graphical-session.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/cbatticon.nix
+++ b/modules/services/cbatticon.nix
@@ -118,7 +118,7 @@ in {
       Unit = {
         Description = "cbatticon system tray battery icon";
         Requires = [ "tray.target" ];
-        After = [ "graphical-session-pre.target" "tray.target" ];
+        After = [ "graphical-session.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/devilspie2.nix
+++ b/modules/services/devilspie2.nix
@@ -36,7 +36,7 @@ in {
       Service.ExecStart = "${pkgs.devilspie2}/bin/devilspie2";
       Unit = {
         Description = "devilspie2";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
       Install.WantedBy = [ "graphical-session.target" ];

--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -51,7 +51,7 @@ in {
       Unit = {
         Description = "Easyeffects daemon";
         Requires = [ "dbus.service" ];
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" "pipewire.service" ];
       };
 

--- a/modules/services/flameshot.nix
+++ b/modules/services/flameshot.nix
@@ -56,7 +56,7 @@ in {
       Unit = {
         Description = "Flameshot screenshot tool";
         Requires = [ "tray.target" ];
-        After = [ "graphical-session-pre.target" "tray.target" ];
+        After = [ "graphical-session.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
         X-Restart-Triggers = mkIf (cfg.settings != { }) [ "${iniFile}" ];
       };

--- a/modules/services/fusuma.nix
+++ b/modules/services/fusuma.nix
@@ -119,7 +119,7 @@ in {
     systemd.user.services.fusuma = {
       Unit = {
         Description = "Fusuma services";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/grobi.nix
+++ b/modules/services/grobi.nix
@@ -79,7 +79,7 @@ in {
     systemd.user.services.grobi = {
       Unit = {
         Description = "grobi display auto config daemon";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/gromit-mpx.nix
+++ b/modules/services/gromit-mpx.nix
@@ -215,7 +215,7 @@ in {
     systemd.user.services.gromit-mpx = {
       Unit = {
         Description = "Gromit-MPX";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
         X-Restart-Triggers = [
           "${config.xdg.configFile."gromit-mpx.cfg".source}"

--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -40,7 +40,7 @@ in {
         Unit = {
           Description =
             "Adds communication between your desktop and your smartphone";
-          After = [ "graphical-session-pre.target" ];
+          After = [ "graphical-session.target" ];
           PartOf = [ "graphical-session.target" ];
         };
 
@@ -69,7 +69,7 @@ in {
         Unit = {
           Description = "kdeconnect-indicator";
           After = [
-            "graphical-session-pre.target"
+            "graphical-session.target"
             "polybar.service"
             "taffybar.service"
             "stalonetray.service"

--- a/modules/services/keynav.nix
+++ b/modules/services/keynav.nix
@@ -18,7 +18,7 @@ in {
     systemd.user.services.keynav = {
       Unit = {
         Description = "keynav";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/mpd-discord-rpc.nix
+++ b/modules/services/mpd-discord-rpc.nix
@@ -50,7 +50,7 @@ in {
       Unit = {
         Description = "Discord Rich Presence for MPD";
         Documentation = "https://github.com/JakeStanger/mpd-discord-rpc";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
       Service = {

--- a/modules/services/network-manager-applet.nix
+++ b/modules/services/network-manager-applet.nix
@@ -28,7 +28,7 @@ in {
       Unit = {
         Description = "Network Manager applet";
         Requires = [ "tray.target" ];
-        After = [ "graphical-session-pre.target" "tray.target" ];
+        After = [ "graphical-session.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/nextcloud-client.nix
+++ b/modules/services/nextcloud-client.nix
@@ -36,7 +36,7 @@ in {
     systemd.user.services.nextcloud-client = {
       Unit = {
         Description = "Nextcloud Client";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/notify-osd.nix
+++ b/modules/services/notify-osd.nix
@@ -33,7 +33,7 @@ in {
     systemd.user.services.notify-osd = {
       Unit = {
         Description = "notify-osd";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/opensnitch-ui.nix
+++ b/modules/services/opensnitch-ui.nix
@@ -23,7 +23,7 @@ in {
     systemd.user.services.opensnitch-ui = {
       Unit = {
         Description = "Opensnitch ui";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/owncloud-client.nix
+++ b/modules/services/owncloud-client.nix
@@ -24,7 +24,7 @@ in {
     systemd.user.services.owncloud-client = {
       Unit = {
         Description = "Owncloud Client";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/parcellite.nix
+++ b/modules/services/parcellite.nix
@@ -42,7 +42,7 @@ in {
       Unit = {
         Description = "Lightweight GTK+ clipboard manager";
         Requires = [ "tray.target" ];
-        After = [ "graphical-session-pre.target" "tray.target" ];
+        After = [ "graphical-session.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/pasystray.nix
+++ b/modules/services/pasystray.nix
@@ -30,7 +30,7 @@ in {
       Unit = {
         Description = "PulseAudio system tray";
         Requires = [ "tray.target" ];
-        After = [ "graphical-session-pre.target" "tray.target" ];
+        After = [ "graphical-session.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/pbgopy.nix
+++ b/modules/services/pbgopy.nix
@@ -60,7 +60,7 @@ in {
     systemd.user.services.pbgopy = {
       Unit = {
         Description = "pbgopy server for sharing the clipboard between devices";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
       Service = {

--- a/modules/services/picom.nix
+++ b/modules/services/picom.nix
@@ -310,7 +310,7 @@ in {
     systemd.user.services.picom = {
       Unit = {
         Description = "Picom X11 compositor";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/plex-mpv-shim.nix
+++ b/modules/services/plex-mpv-shim.nix
@@ -58,7 +58,7 @@ in {
     systemd.user.services.plex-mpv-shim = {
       Unit = {
         Description = "Plex mpv shim";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/poweralertd.nix
+++ b/modules/services/poweralertd.nix
@@ -44,7 +44,7 @@ in {
       Unit = {
         Description = "UPower-powered power alerter";
         Documentation = "man:poweralertd(1)";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/pulseeffects.nix
+++ b/modules/services/pulseeffects.nix
@@ -52,7 +52,7 @@ in {
       Unit = {
         Description = "Pulseeffects daemon";
         Requires = [ "dbus.service" ];
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" "pulseaudio.service" ];
       };
 

--- a/modules/services/random-background.nix
+++ b/modules/services/random-background.nix
@@ -76,7 +76,7 @@ in {
       systemd.user.services.random-background = {
         Unit = {
           Description = "Set random desktop background using feh";
-          After = [ "graphical-session-pre.target" ];
+          After = [ "graphical-session.target" ];
           PartOf = [ "graphical-session.target" ];
         };
 

--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -189,7 +189,7 @@ in {
       in {
         Description = "${programName} colour temperature adjuster";
         Documentation = serviceDocumentation;
-        After = [ "graphical-session-pre.target" ] ++ geoclueAgentService;
+        After = [ "graphical-session.target" ] ++ geoclueAgentService;
         Wants = geoclueAgentService;
         PartOf = [ "graphical-session.target" ];
       };

--- a/modules/services/remmina.nix
+++ b/modules/services/remmina.nix
@@ -39,7 +39,7 @@ in {
         Unit = {
           Description = "Remmina remote desktop client";
           Documentation = "man:remmina(1)";
-          Requires = [ "graphical-session-pre.target" ];
+          Requires = [ "graphical-session.target" ];
         };
 
         Service = {

--- a/modules/services/rsibreak.nix
+++ b/modules/services/rsibreak.nix
@@ -23,7 +23,7 @@ in {
     systemd.user.services.rsibreak = {
       Unit = {
         Description = "RSI break timer";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -117,7 +117,7 @@ in {
       systemd.user.services.xss-lock = {
         Unit = {
           Description = "xss-lock, session locker service";
-          After = [ "graphical-session-pre.target" ];
+          After = [ "graphical-session.target" ];
           PartOf = [ "graphical-session.target" ];
         };
 
@@ -140,7 +140,7 @@ in {
       systemd.user.services.xautolock-session = {
         Unit = {
           Description = "xautolock, session locker service";
-          After = [ "graphical-session-pre.target" ];
+          After = [ "graphical-session.target" ];
           PartOf = [ "graphical-session.target" ];
         };
 

--- a/modules/services/sctd.nix
+++ b/modules/services/sctd.nix
@@ -30,7 +30,7 @@ with lib;
       Unit = {
         Description =
           "Dynamically adjust the screen color temperature twice every minute";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -696,7 +696,7 @@ in {
           Unit = {
             Description = cfg.tray.package.pname;
             Requires = [ "tray.target" ];
-            After = [ "graphical-session-pre.target" "tray.target" ];
+            After = [ "graphical-session.target" "tray.target" ];
             PartOf = [ "graphical-session.target" ];
           };
 
@@ -721,7 +721,7 @@ in {
           Unit = {
             Description = "syncthingtray";
             Requires = [ "tray.target" ];
-            After = [ "graphical-session-pre.target" "tray.target" ];
+            After = [ "graphical-session.target" "tray.target" ];
             PartOf = [ "graphical-session.target" ];
           };
 

--- a/modules/services/trayscale.nix
+++ b/modules/services/trayscale.nix
@@ -28,7 +28,7 @@ in {
         Description =
           "An unofficial GUI wrapper around the Tailscale CLI client";
         Requires = [ "tray.target" ];
-        After = [ "graphical-session-pre.target" "tray.target" ];
+        After = [ "graphical-session.target" "tray.target" ];
         PartOf = [ "graphical-session.target" ];
       };
       Install = { WantedBy = [ "graphical-session.target" ]; };

--- a/modules/services/twmn.nix
+++ b/modules/services/twmn.nix
@@ -361,7 +361,7 @@ in {
     systemd.user.services.twmnd = {
       Unit = {
         Description = "twmn daemon";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
         X-Restart-Triggers =
           [ "${config.xdg.configFile."twmn/twmn.conf".source}" ];

--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -116,7 +116,7 @@ in {
       Unit = {
         Description = "udiskie mount daemon";
         Requires = lib.optional (cfg.tray != "never") "tray.target";
-        After = [ "graphical-session-pre.target" ]
+        After = [ "graphical-session.target" ]
           ++ lib.optional (cfg.tray != "never") "tray.target";
         PartOf = [ "graphical-session.target" ];
       };

--- a/modules/services/unclutter.nix
+++ b/modules/services/unclutter.nix
@@ -45,7 +45,7 @@ in {
     systemd.user.services.unclutter = {
       Unit = {
         Description = "unclutter";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -128,6 +128,7 @@ in {
     systemd.user.services.wlsunset = {
       Unit = {
         Description = "Day/night gamma adjustments for Wayland compositors.";
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/xcape.nix
+++ b/modules/services/xcape.nix
@@ -60,11 +60,11 @@ in {
       Unit = mkMerge [
         {
           Description = "xcape";
-          After = [ "graphical-session-pre.target" ];
+          After = [ "graphical-session.target" ];
           PartOf = [ "graphical-session.target" ];
         }
         (mkIf (config.home.keyboard != null && config.home.keyboard != { }) {
-          After = [ "graphical-session-pre.target" "setxkbmap.service" ];
+          After = [ "graphical-session.target" "setxkbmap.service" ];
         })
       ];
 

--- a/modules/services/xembed-sni-proxy.nix
+++ b/modules/services/xembed-sni-proxy.nix
@@ -34,7 +34,7 @@ in {
     systemd.user.services.xembed-sni-proxy = {
       Unit = {
         Description = "XEmbed SNI Proxy";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/modules/services/xscreensaver.nix
+++ b/modules/services/xscreensaver.nix
@@ -50,7 +50,7 @@ in {
     systemd.user.services.xscreensaver = {
       Unit = {
         Description = "XScreenSaver";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
 
         # Make sure the service is restarted if the settings change.

--- a/modules/services/xsuspender.nix
+++ b/modules/services/xsuspender.nix
@@ -183,7 +183,7 @@ in {
     systemd.user.services.xsuspender = {
       Unit = {
         Description = "XSuspender";
-        After = [ "graphical-session-pre.target" ];
+        After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
         X-Restart-Triggers =
           [ "${config.xdg.configFile."xsuspender.conf".source}" ];

--- a/tests/modules/services/blanket/basic-configuration.nix
+++ b/tests/modules/services/blanket/basic-configuration.nix
@@ -20,7 +20,7 @@
         RestartSec=5
 
         [Unit]
-        After=graphical-session-pre.target
+        After=graphical-session.target
         Description=Blanket daemon
         PartOf=graphical-session.target
         PartOf=pipewire.service

--- a/tests/modules/services/fusuma/expected-service.service
+++ b/tests/modules/services/fusuma/expected-service.service
@@ -6,6 +6,6 @@ Environment=PATH=@coreutils@/bin:@xdotool@/bin:@xorg.xprop@/bin
 ExecStart=@fusuma@/bin/fusuma
 
 [Unit]
-After=graphical-session-pre.target
+After=graphical-session.target
 Description=Fusuma services
 PartOf=graphical-session.target

--- a/tests/modules/services/parcellite/parcellite-expected.service
+++ b/tests/modules/services/parcellite/parcellite-expected.service
@@ -6,7 +6,7 @@ ExecStart=@parcellite@/bin/parcellite --no-icon
 Restart=on-abort
 
 [Unit]
-After=graphical-session-pre.target
+After=graphical-session.target
 After=tray.target
 Description=Lightweight GTK+ clipboard manager
 PartOf=graphical-session.target

--- a/tests/modules/services/pasystray/expected.service
+++ b/tests/modules/services/pasystray/expected.service
@@ -6,7 +6,7 @@ Environment=PATH=@paprefs@/bin:@pavucontrol@/bin
 ExecStart=@pasystray@/bin/pasystray -g
 
 [Unit]
-After=graphical-session-pre.target
+After=graphical-session.target
 After=tray.target
 Description=PulseAudio system tray
 PartOf=graphical-session.target

--- a/tests/modules/services/picom/picom-basic-configuration-expected.service
+++ b/tests/modules/services/picom/picom-basic-configuration-expected.service
@@ -7,6 +7,6 @@ Restart=always
 RestartSec=3
 
 [Unit]
-After=graphical-session-pre.target
+After=graphical-session.target
 Description=Picom X11 compositor
 PartOf=graphical-session.target

--- a/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-expected.service
@@ -7,7 +7,7 @@ Restart=on-failure
 RestartSec=3
 
 [Unit]
-After=graphical-session-pre.target
+After=graphical-session.target
 Description=Gammastep colour temperature adjuster
 Documentation=https://gitlab.com/chinstrap/gammastep/
 PartOf=graphical-session.target

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration-expected.service
@@ -7,7 +7,7 @@ Restart=on-failure
 RestartSec=3
 
 [Unit]
-After=graphical-session-pre.target
+After=graphical-session.target
 Description=Redshift colour temperature adjuster
 Documentation=http://jonls.dk/redshift/
 PartOf=graphical-session.target

--- a/tests/modules/services/wlsunset/wlsunset-service-expected.service
+++ b/tests/modules/services/wlsunset/wlsunset-service-expected.service
@@ -5,5 +5,6 @@ WantedBy=test.target
 ExecStart=@wlsunset@/bin/wlsunset -L 128.8 -T 6000 -g 0.6 -l 12.3 -t 3500
 
 [Unit]
+After=graphical-session.target
 Description=Day/night gamma adjustments for Wayland compositors.
 PartOf=graphical-session.target


### PR DESCRIPTION
### Description

As per systemd.special(7)[[0]] graphical-session-pre.target is strictly
for units that set up things for a graphical session. Most notably,
these are usually started *before* the compositor/session is actually
ready.

While Home Manager's current implementation of graphical-session.target
allows these units to work regardless of what systemd.special(7)
specifies, other setups like ones with uwsm[[1]] do not allow these units
to start properly.

[0]: https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#graphical-session-pre.target
[1]: https://github.com/Vladimir-csp/uwsm

Signed-off-by: Sefa Eyeoglu <contact@scrumplex.net>

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
