### PR TITLE
gpg-agent: add launchd service agent and sockets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,6 @@ indent_style = tab
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.plist]
+insert_final_newline = false

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -162,6 +162,7 @@ in import nmtSrc {
     ./modules/programs/zk
     ./modules/programs/zplug
     ./modules/programs/zsh
+    ./modules/services/gpg-agent
     ./modules/services/syncthing/common
     ./modules/xresources
   ] ++ lib.optionals isDarwin [
@@ -242,7 +243,6 @@ in import nmtSrc {
     ./modules/services/fusuma
     ./modules/services/git-sync
     ./modules/services/glance
-    ./modules/services/gpg-agent
     ./modules/services/gromit-mpx
     ./modules/services/home-manager-auto-upgrade
     ./modules/services/hypridle

--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -2,7 +2,7 @@
 
 with lib;
 
-{
+mkIf pkgs.stdenv.isLinux {
   config = {
     services.gpg-agent.enable = true;
     services.gpg-agent.pinentryPackage = pkgs.pinentry-gnome3;

--- a/tests/modules/services/gpg-agent/expected-agent.plist
+++ b/tests/modules/services/gpg-agent/expected-agent.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>GNUPGHOME</key>
+		<string>/path/to/hash</string>
+	</dict>
+	<key>KeepAlive</key>
+	<dict>
+		<key>Crashed</key>
+		<true/>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>Label</key>
+	<string>org.nix-community.home.gpg-agent</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>@gpg@/bin/gpg-agent</string>
+		<string>--supervised</string>
+	</array>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>Sockets</key>
+	<dict>
+		<key>Agent</key>
+		<dict>
+			<key>SockPathMode</key>
+			<integer>384</integer>
+			<key>SockPathName</key>
+			<string>/private/var/run/org.nix-community.home.gpg-agent/d.wp4h7ks5zxy4dodqadgpbbpz/S.gpg-agent</string>
+			<key>SockType</key>
+			<string>stream</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/tests/modules/services/gpg-agent/override-homedir.nix
+++ b/tests/modules/services/gpg-agent/override-homedir.nix
@@ -2,19 +2,25 @@
 
 with lib;
 
-{
+let inherit (pkgs.stdenv) isDarwin;
+in {
   config = {
     services.gpg-agent.enable = true;
     services.gpg-agent.pinentryPackage = null; # Don't build pinentry package.
     programs.gpg = {
       enable = true;
       homedir = "/path/to/hash";
+      package = config.lib.test.mkStubPackage { outPath = "@gpg@"; };
     };
 
     test.stubs.gnupg = { };
     test.stubs.systemd = { }; # depends on gnupg.override
 
-    nmt.script = ''
+    nmt.script = if isDarwin then ''
+      serviceFile=LaunchAgents/org.nix-community.home.gpg-agent.plist
+      assertFileExists "$serviceFile"
+      assertFileContent "$serviceFile" ${./expected-agent.plist}
+    '' else ''
       in="${config.systemd.user.sockets.gpg-agent.Socket.ListenStream}"
       if [[ $in != "%t/gnupg/d.wp4h7ks5zxy4dodqadgpbbpz/S.gpg-agent" ]]
       then


### PR DESCRIPTION
### Description

This adds a Darwin Launchd agent along with its sockets to make gpg-agent starts at load or whenever the sockets are needed.

Fixes: https://github.com/nix-community/home-manager/issues/3864
Supersedes: https://github.com/nix-community/home-manager/pull/2964

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee