### PR TITLE
sesh: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -732,4 +732,10 @@
     github = "Noodlez1232";
     githubId = 12480453;
   };
+  michaelvanstraten = {
+    name = "Michael van Straten";
+    email = "michael@vanstraten.de";
+    github = "michaelvanstraten";
+    githubId = 50352631;
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2180,6 +2180,17 @@ in {
           scrobbler (e.g. last.fm)
         '';
       }
+
+      {
+        time = "2025-03-29T11:16:07+00:00";
+        message = ''
+          A new module is available: 'programs.sesh'.
+
+          Sesh is a CLI that helps you create and manage tmux sessions quickly
+          and easily using zoxide. See https://github.com/joshmedeski/sesh for
+          more.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -237,6 +237,7 @@ let
     ./programs/scmpuff.nix
     ./programs/script-directory.nix
     ./programs/senpai.nix
+    ./programs/sesh.nix
     ./programs/sftpman.nix
     ./programs/sioyek.nix
     ./programs/skim.nix

--- a/modules/programs/sesh.nix
+++ b/modules/programs/sesh.nix
@@ -1,0 +1,86 @@
+{ pkgs, lib, config, ... }:
+
+let
+  inherit (lib) mkEnableOption mkIf mkMerge mkOption mkPackageOption types;
+
+  cfg = config.programs.sesh;
+  tomlFormat = pkgs.formats.toml { };
+in {
+  meta.maintainers = [ lib.hm.maintainers.michaelvanstraten ];
+
+  options.programs.sesh = {
+    enable = mkEnableOption "the sesh terminal session manager";
+
+    package = mkPackageOption pkgs "sesh" { };
+    fzfPackage = mkPackageOption pkgs "fzf" { nullable = true; };
+    zoxidePackage = mkPackageOption pkgs "zoxide" { nullable = true; };
+
+    settings = mkOption {
+      type = types.submodule { freeformType = tomlFormat.type; };
+      default = { };
+      description = ''
+        Configuration for sesh, written to `~/.config/sesh/sesh.toml`.
+
+        See the [sesh documentation](https://github.com/joshmedeski/sesh#configuration) for available options.
+      '';
+    };
+
+    enableAlias = mkOption {
+      type = types.bool;
+      default = true;
+      description =
+        "Whether to enable a shell alias `s` to quickly launch sessions.";
+    };
+
+    enableTmuxIntegration = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable Tmux integration with sesh.";
+    };
+
+    tmuxKey = mkOption {
+      type = types.str;
+      default = "s";
+      description = "Keybinding for invoking sesh in Tmux.";
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      home.packages = [ cfg.package ];
+      home.file.".config/sesh/sesh.toml".source =
+        tomlFormat.generate "sesh.toml" cfg.settings;
+    }
+
+    (mkIf cfg.enableAlias {
+      home.packages = lib.mkIf (cfg.fzfPackage != null) [ cfg.fzfPackage ];
+      home.shellAliases.s = "sesh connect $(sesh list | fzf)";
+    })
+
+    (mkIf cfg.enableTmuxIntegration {
+      assertions = [{
+        assertion = config.programs.fzf.tmux.enableShellIntegration;
+        message =
+          "To use Tmux integration with sesh, enable `programs.fzf.tmux.enableShellIntegration`.";
+      }];
+
+      home.packages =
+        lib.mkIf (cfg.zoxidePackage != null) [ cfg.zoxidePackage ];
+
+      programs.tmux.extraConfig = ''
+        bind-key "${cfg.tmuxKey}" run-shell "sesh connect \"$(
+          sesh list | fzf-tmux -p 55%,60% \
+            --no-sort --ansi --border-label ' sesh ' --prompt '⚡  ' \
+            --header '  ^a all ^t tmux ^g configs ^x zoxide ^d tmux kill ^f find' \
+            --bind 'tab:down,btab:up' \
+            --bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list)' \
+            --bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -t)' \
+            --bind 'ctrl-g:change-prompt(⚙️  )+reload(sesh list -c)' \
+            --bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -z)' \
+            --bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
+            --bind 'ctrl-d:execute(tmux kill-session -t {})+change-prompt(⚡  )+reload(sesh list)'
+        )\""
+      '';
+    })
+  ]);
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -386,6 +386,7 @@ in import nmtSrc {
     ./modules/programs/sbt
     ./modules/programs/scmpuff
     ./modules/programs/senpai
+    ./modules/programs/sesh
     ./modules/programs/sftpman
     ./modules/programs/sioyek
     ./modules/programs/sm64ex

--- a/tests/modules/programs/sesh/basic-configuration.nix
+++ b/tests/modules/programs/sesh/basic-configuration.nix
@@ -1,0 +1,33 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    programs.fzf.tmux.enableShellIntegration = true;
+
+    programs.sesh = {
+      enable = true;
+      package = pkgs.writeScriptBin "dummy-polybar" "";
+      settings = {
+        default_session.startup_command = "nvim -c ':Telescope find_files'";
+        session = [
+          {
+            name = "Downloads 📥";
+            path = "~/Downloads";
+            startup_command = "ls";
+          }
+          {
+            name = "tmux config";
+            path = "~/c/dotfiles/.config/tmux";
+            startup_command = "nvim tmux.conf";
+          }
+        ];
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/sesh/sesh.toml
+      assertFileContent home-files/.config/sesh/sesh.toml \
+          ${./basic-configuration.toml}
+    '';
+  };
+}

--- a/tests/modules/programs/sesh/basic-configuration.toml
+++ b/tests/modules/programs/sesh/basic-configuration.toml
@@ -1,0 +1,12 @@
+[default_session]
+startup_command = "nvim -c ':Telescope find_files'"
+
+[[session]]
+name = "Downloads 📥"
+path = "~/Downloads"
+startup_command = "ls"
+
+[[session]]
+name = "tmux config"
+path = "~/c/dotfiles/.config/tmux"
+startup_command = "nvim tmux.conf"

--- a/tests/modules/programs/sesh/default.nix
+++ b/tests/modules/programs/sesh/default.nix
@@ -1,0 +1,1 @@
+{ sesh-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

Sesh is a CLI that helps you create and manage tmux sessions quickly and easily using zoxide. See https://github.com/joshmedeski/sesh for more.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

 - [x] Added myself as module maintainer.