### PR TITLE
thunderbird: remove Version = 2 from profiles

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -27,7 +27,6 @@ let
   profilesIni = foldl recursiveUpdate {
     General = {
       StartWithLastProfile = 1;
-      Version = 2;
     };
   } (flip map profilesWithId (profile: {
     "Profile${profile.id}" = {

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -231,7 +231,7 @@ in {
 
       darwinSetupWarning = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         example = false;
         visible = isDarwin;
         readOnly = !isDarwin;
@@ -324,17 +324,8 @@ in {
     ];
 
     warnings = optional (isDarwin && cfg.darwinSetupWarning) ''
-      Thunderbird packages are not yet supported on Darwin. You can still use
-      this module to manage your accounts and profiles by setting
-      'programs.thunderbird.package' to a dummy value, for example using
-      'pkgs.runCommand'.
-
-      Note that this module requires you to set the following environment
-      variables when using an installation of Thunderbird that is not provided
-      by Nix:
-
-          export MOZ_LEGACY_PROFILES=1
-          export MOZ_ALLOW_DOWNGRADE=1
+      Using programs.thunderbird.darwinSetupWarning is deprecated. The module
+      is now compatible with all thunderbird installations.
     '';
 
     home.packages = [ cfg.package ]

--- a/tests/modules/programs/thunderbird/thunderbird-expected-profiles.ini
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-profiles.ini
@@ -1,6 +1,5 @@
 [General]
 StartWithLastProfile=1
-Version=2
 
 [Profile0]
 Default=1


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This fixes app startup for (externally managed, via homebrew)
thunderbird on Darwin.

The fix is almost identical to the other patch for Firefox:
https://github.com/nix-community/home-manager/pull/5724

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

This failed for me with an error that doesn't seem to have anything to do with the patch:

```
trying http://dkolf.de/dkjson-lua/dkjson-2.8.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 17442  100 17442    0     0  24679      0 --:--:-- --:--:-- --:--:-- 24670
error: hash mismatch in fixed-output derivation '/nix/store/xqgil3af1ij234gj2cr3irsqs7ylc34f-dkjson-2.8.tar.gz.drv':
         specified: sha256-CfpgoEECteMiqwa51Zt6oPKcChnHVCFfikHzoWT5SUs=
            got:    sha256-JOjNO+uRwchh63uz+8m9QYu/+a1KpdBHGBYlgjajFTI=
```

This seems related to https://github.com/NixOS/nixpkgs/pull/333779 (should hm pick up a newer nixpkgs?)

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@d-dervishi @jkarlson
