### PR TITLE
zsh: correct syntax option to syntax-highlighting

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -738,7 +738,7 @@ in
           ZSH_HIGHLIGHT_HIGHLIGHTERS+=(${lib.concatStringsSep " " (map lib.escapeShellArg cfg.syntaxHighlighting.highlighters)})
           ${lib.concatStringsSep "\n" (
               lib.mapAttrsToList
-                (name: value: "ZSH_HIGHLIGHT_STYLES+=(${lib.escapeShellArg name} ${lib.escapeShellArg value})")
+		(name: value: "ZSH_HIGHLIGHT_STYLES[${lib.escapeShellArg name}]=${lib.escapeShellArg value}")
                 cfg.syntaxHighlighting.styles
           )}
           ${lib.concatStringsSep "\n" (

--- a/tests/modules/programs/zsh/syntax-highlighting.nix
+++ b/tests/modules/programs/zsh/syntax-highlighting.nix
@@ -15,6 +15,6 @@
   nmt.script = ''
     assertFileContains home-files/.zshrc "source ${pkgs.hello}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
     assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_HIGHLIGHTERS+=(brackets pattern cursor)"
-    assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_STYLES+=(comment 'fg=#6c6c6c')"
+    assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_STYLES[comment]='fg=#6c6c6c'"
   '';
 }


### PR DESCRIPTION
### Description

<!--
Please provide a brief description of your change.
-->

The current syntax of highlighting style is outdated and not working as well. So this pr aims to update it so follow `zsh-syntax-highlight` new syntax [example](https://github.com/zsh-users/zsh-syntax-highlighting/blob/e0165eaa730dd0fa321a6a6de74f092fe87630b0/highlighters/main/main-highlighter.zsh#L32). 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee 