### PR TITLE
Move aliases after initializations in fish

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -471,11 +471,11 @@ in {
           # Abbreviations
           ${abbrsStr}
 
-          # Aliases
-          ${aliasesStr}
-
           # Interactive shell initialisation
           ${cfg.interactiveShellInit}
+
+          # Aliases
+          ${aliasesStr}
 
         end
 


### PR DESCRIPTION
### Description

Move the aliases declaration in fish configuration to appear after the initialization as some programs (like zoxide) may need initialization before being used in an alias.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

#### Maintainer CC

No maintainer @rycee ? If so I may apply (it would improve my `nix`)
