### PR TITLE
nushell: Allow arbitrary env vars

### DIFF
--- a/tests/modules/programs/nushell/env-expected.nu
+++ b/tests/modules/programs/nushell/env-expected.nu
@@ -1,4 +1,4 @@
 $env.FOO = 'BAR'
 
 
-$env.BAR = $'(echo BAZ)'
+{"BAR":"$'(echo BAZ)'","BOOLEAN_VAR":true,"LIST_VAR":["elem1",2],"NUMERIC_VAR":4} | load-env

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -28,7 +28,12 @@
       "ll" = "ls -a";
     };
 
-    environmentVariables = { BAR = "$'(echo BAZ)'"; };
+    environmentVariables = {
+      BAR = "$'(echo BAZ)'";
+      BOOLEAN_VAR = true;
+      NUMERIC_VAR = 4;
+      LIST_VAR = [ "elem1" 2 ];
+    };
   };
 
   test.stubs.nushell = { };


### PR DESCRIPTION
### Description

This PR allows setting arbitrary values as nushell's environment variables.

This started as a fix for [some value assigments now requiring quotes](https://www.nushell.sh/blog/2024-08-20-nushell_0_97_1.html#more-consistent-parsing-of-assignment-toc) (including `$env.FOO = bar`, which now needs to be `$env.FOO = "bar"`). Allowing any JSON value is just a secondary effect :)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Philipp-M 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
