### PR TITLE
Set MOZ_* session variables for firefox and thunderbird modules

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -209,5 +209,21 @@ in {
           setupLaunchAgents
         '';
     })
+
+    (mkIf isDarwin (let
+      launchctl-setenv = pkgs.writeShellScriptBin "launchctl-setenv"
+        (concatStringsSep "\n" (mapAttrsToList
+          (name: val: "/bin/launchctl setenv ${name} ${toString val}")
+          config.home.sessionVariables));
+    in {
+      launchd.agents.launchctl-setenv = {
+        enable = true;
+        config = {
+          ProgramArguments = [ "${launchctl-setenv}/bin/launchctl-setenv" ];
+          KeepAlive.SuccessfulExit = false;
+          RunAtLoad = true;
+        };
+      };
+    }))
   ];
 }

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -62,7 +62,7 @@ let
     }) // {
       General = {
         StartWithLastProfile = 1;
-      } // lib.optionalAttrs (cfg.profileVersion != null) {
+      } // lib.optionalAttrs (cfg.profileVersion == null) {
         Version = cfg.profileVersion;
       };
     };

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -62,8 +62,7 @@ let
     }) // {
       General = {
         StartWithLastProfile = 1;
-      } // lib.optionalAttrs (cfg.profileVersion == null) {
-        Version = cfg.profileVersion;
+        Version = 2;
       };
     };
 
@@ -343,13 +342,6 @@ in {
         BlockAboutConfig = true;
       };
     });
-
-    profileVersion = mkOption {
-      internal = true;
-      type = types.nullOr types.ints.unsigned;
-      default = if isDarwin then null else 2;
-      description = "profile version, set null for nix-darwin";
-    };
 
     profiles = mkOption {
       inherit visible;

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -799,6 +799,12 @@ in {
           force = true;
         };
     }));
+
+    # Mimic nixpkgs package environment for read-only profiles.ini management
+    home.sessionVariables = {
+      MOZ_LEGACY_PROFILES = 1;
+      MOZ_ALLOW_DOWNGRADE = 1;
+    };
   } // setAttrByPath modulePath {
     finalPackage = wrapPackage cfg.package;
 

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -299,11 +299,11 @@ in {
         type = types.bool;
         default = true;
         example = false;
-        visible = isDarwin;
+        visible = false;
         readOnly = !isDarwin;
         description = ''
-          Warn to set environment variables before using this module. Only
-          relevant on Darwin.
+          Using programs.thunderbird.darwinSetupWarning is deprecated. The
+          module is compatible with all Thunderbird installations.
         '';
       };
     };
@@ -389,13 +389,6 @@ in {
       })
     ];
 
-    warnings = optional (isDarwin && cfg.darwinSetupWarning) ''
-      Thunderbird packages are not yet supported on Darwin. You can still use
-      this module to manage your accounts and profiles by setting
-      'programs.thunderbird.package' to a dummy value, for example using
-      'pkgs.runCommand'.
-    '';
-
     home.packages = [ cfg.package ]
       ++ optional (any (p: p.withExternalGnupg) (attrValues cfg.profiles))
       pkgs.gpgme;
@@ -456,5 +449,11 @@ in {
           force = true;
         };
     }));
+
+    # Mimic nixpkgs package environment for read-only profiles.ini management
+    home.sessionVariables = {
+      MOZ_LEGACY_PROFILES = 1;
+      MOZ_ALLOW_DOWNGRADE = 1;
+    };
   };
 }

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -37,8 +37,7 @@ let
   profilesIni = foldl recursiveUpdate {
     General = {
       StartWithLastProfile = 1;
-    } // lib.optionalAttrs (cfg.profileVersion != null) {
-      Version = cfg.profileVersion;
+      Version = 2;
     };
   } (flip map profilesWithId (profile: {
     "Profile${profile.id}" = {
@@ -149,13 +148,6 @@ in {
         defaultText = literalExpression "pkgs.thunderbird";
         example = literalExpression "pkgs.thunderbird-91";
         description = "The Thunderbird package to use.";
-      };
-
-      profileVersion = mkOption {
-        internal = true;
-        type = types.nullOr types.ints.unsigned;
-        default = if isDarwin then null else 2;
-        description = "profile version, set null for nix-darwin";
       };
 
       profiles = mkOption {


### PR DESCRIPTION
- **thunderbird: set MOZ_* variables for legacy profiles.ini**
- **firefox: set MOZ_* variables for legacy profiles.ini**

### Description

<!--

Please provide a brief description of your change.

-->

This PR includes the following changes:

1. Make thunderbird set MOZ_* session variables same as in nixpkgs wrapped package;
2. Make firefox do the same;
3. Deprecate the darwin warning message from thunderbird module about the need to set the variables, since now it's happening automatically;
4. Introduce a launchd service that will apply the session variables to GUI session environment with `launchctl setenv`.
5. Now that non-nixpkgs firefox can now work with Version=2 in profiles.ini thanks to MOZ_* variables, revert patches that introduced a new special option for Darwin to unset Version in profiles config file.

Closes: #5717

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee @kira-bruneau @bricked @d-dervishi @jkarlson
