### PR TITLE
taskwarrior-sync: add package option

### DIFF
--- a/modules/services/taskwarrior-sync.nix
+++ b/modules/services/taskwarrior-sync.nix
@@ -12,6 +12,8 @@ in {
   options.services.taskwarrior-sync = {
     enable = mkEnableOption "Taskwarrior periodic sync";
 
+    package = mkPackageOption pkgs "taskwarrior" { };
+
     frequency = mkOption {
       type = types.str;
       default = "*:0/5";
@@ -36,7 +38,7 @@ in {
       Service = {
         CPUSchedulingPolicy = "idle";
         IOSchedulingClass = "idle";
-        ExecStart = "${pkgs.taskwarrior}/bin/task synchronize";
+        ExecStart = "${cfg.package}/bin/task synchronize";
       };
     };
 


### PR DESCRIPTION
### Description
Add option to change which package is used for taskwarrior-sync, to e.g. taskwarrior3.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@minijackson @pacien 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
