### PR TITLE
eza: add support for fish abbreviations

### DIFF
--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -91,8 +91,17 @@ with lib;
     programs.zsh.shellAliases = optionsAlias
       // optionalAttrs cfg.enableZshIntegration aliases;
 
-    programs.fish.shellAliases = optionsAlias
-      // optionalAttrs cfg.enableFishIntegration aliases;
+    programs.fish = mkMerge [
+      (mkIf (!config.programs.fish.preferAbbrs) {
+        shellAliases = optionsAlias
+          // optionalAttrs cfg.enableFishIntegration aliases;
+      })
+
+      (mkIf config.programs.fish.preferAbbrs {
+        shellAliases = optionsAlias;
+        shellAbbrs = optionalAttrs cfg.enableFishIntegration aliases;
+      })
+    ];
 
     programs.ion.shellAliases = optionsAlias
       // optionalAttrs cfg.enableIonIntegration aliases;

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -288,6 +288,16 @@ in {
         '';
       };
 
+      preferAbbrs = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          If enabled, abbreviations will be preferred over aliases when
+          other modules define aliases for fish.
+        '';
+      };
+
       shellInit = mkOption {
         type = types.lines;
         default = "";


### PR DESCRIPTION
### Description

Added support for fish abbreviations instead of aliases in `enableFishIntegration`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@cafkafk 
