### PR TITLE
firefox: correct lastUserContextId output from firefox containers

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -102,7 +102,8 @@ let
       ${builtins.toJSON {
         version = 4;
         lastUserContextId =
-          elemAt (mapAttrsToList (_: container: container.id) containers) 0;
+          foldlAttrs (acc: _: value: if value.id > acc then value.id else acc) 0
+          containers;
         identities = mapAttrsToList containerToIdentity containers ++ [
           {
             userContextId = 4294967294; # 2^32 - 2


### PR DESCRIPTION

### Description

lastUserContextId should match the highest context id from the containers set in a given profile.  mapAttrsToList uses the container name for sorting.  foldlAttrs ensures we get the largets commit id.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@brckd @rycee @kira-bruneau
