### PR TITLE
tests: change quoting to match new Nixpkgs behavior

### DIFF
--- a/tests/modules/misc/xsession/basic-xprofile-expected.txt
+++ b/tests/modules/misc/xsession/basic-xprofile-expected.txt
@@ -9,7 +9,7 @@ fi
 # script starts up graphical-session.target.
 systemctl --user stop graphical-session.target graphical-session-pre.target
 
-systemctl --user import-environment 'DBUS_SESSION_BUS_ADDRESS' 'DISPLAY' 'SSH_AUTH_SOCK' 'XAUTHORITY' 'XDG_DATA_DIRS' 'XDG_RUNTIME_DIR' 'XDG_SESSION_ID' 'EXTRA_IMPORTED_VARIABLE'
+systemctl --user import-environment DBUS_SESSION_BUS_ADDRESS DISPLAY SSH_AUTH_SOCK XAUTHORITY XDG_DATA_DIRS XDG_RUNTIME_DIR XDG_SESSION_ID EXTRA_IMPORTED_VARIABLE
 
 profile extra commands
 

--- a/tests/modules/misc/xsession/basic-xsession-expected.txt
+++ b/tests/modules/misc/xsession/basic-xsession-expected.txt
@@ -17,4 +17,4 @@ while [ -n "$(systemctl --user --no-legend --state=deactivating list-units)" ]; 
   sleep 0.5
 done
 
-systemctl --user unset-environment 'DBUS_SESSION_BUS_ADDRESS' 'DISPLAY' 'SSH_AUTH_SOCK' 'XAUTHORITY' 'XDG_DATA_DIRS' 'XDG_RUNTIME_DIR' 'XDG_SESSION_ID' 'EXTRA_IMPORTED_VARIABLE'
+systemctl --user unset-environment DBUS_SESSION_BUS_ADDRESS DISPLAY SSH_AUTH_SOCK XAUTHORITY XDG_DATA_DIRS XDG_RUNTIME_DIR XDG_SESSION_ID EXTRA_IMPORTED_VARIABLE

--- a/tests/modules/programs/atuin/set-flags.nix
+++ b/tests/modules/programs/atuin/set-flags.nix
@@ -25,12 +25,12 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
-      "eval \"\$(@atuin@/bin/atuin init bash '--disable-ctrl-r' '--disable-up-arrow')\""
+      "eval \"\$(@atuin@/bin/atuin init bash --disable-ctrl-r --disable-up-arrow)\""
 
     assertFileExists home-files/.zshrc
     assertFileContains \
       home-files/.zshrc \
-      "eval \"\$(@atuin@/bin/atuin init zsh '--disable-ctrl-r' '--disable-up-arrow')\""
+      "eval \"\$(@atuin@/bin/atuin init zsh --disable-ctrl-r --disable-up-arrow)\""
     assertFileExists home-files/.config/fish/config.fish
     assertFileContains \
       home-files/.config/fish/config.fish \

--- a/tests/modules/programs/bat/bat.nix
+++ b/tests/modules/programs/bat/bat.nix
@@ -35,7 +35,7 @@ with lib;
           --map-syntax='*.jenkinsfile:Groovy'
           --map-syntax='*.props:Java Properties'
           --pager='less -FR'
-          --theme='TwoDark'
+          --theme=TwoDark
           --show-all
         ''
       }

--- a/tests/modules/programs/bat/deprecated-options.nix
+++ b/tests/modules/programs/bat/deprecated-options.nix
@@ -45,7 +45,7 @@ with lib;
           --map-syntax='*.jenkinsfile:Groovy'
           --map-syntax='*.props:Java Properties'
           --pager='less -FR'
-          --theme='TwoDark'
+          --theme=TwoDark
         ''
       }
 

--- a/tests/modules/programs/bemenu/basic-configuration.nix
+++ b/tests/modules/programs/bemenu/basic-configuration.nix
@@ -24,6 +24,6 @@
   nmt.script = ''
     assertFileExists home-path/etc/profile.d/hm-session-vars.sh
     assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
-      "export BEMENU_OPTS=\"'--ab' '#1e1e2e' '--af' '#cdd6f4' '--fb' '#1e1e2e' '--ff' '#cdd6f4' '--hb' '#1e1e2e' '--hf' '#f9e2af' '--ignorecase' '--line-height' '28' '--nb' '#1e1e2e' '--nf' '#cdd6f4' '--prompt' 'open' '--tb' '#1e1e2e' '--tf' '#f38ba8' '--width-factor' '0.300000'\""
+      "export BEMENU_OPTS=\"--ab '#1e1e2e' --af '#cdd6f4' --fb '#1e1e2e' --ff '#cdd6f4' --hb '#1e1e2e' --hf '#f9e2af' --ignorecase --line-height 28 --nb '#1e1e2e' --nf '#cdd6f4' --prompt open --tb '#1e1e2e' --tf '#f38ba8' --width-factor 0.300000\""
   '';
 }

--- a/tests/modules/programs/gpg/immutable-keyfiles.nix
+++ b/tests/modules/programs/gpg/immutable-keyfiles.nix
@@ -27,7 +27,7 @@
   };
 
   nmt.script = ''
-    assertFileNotRegex activate "^export GNUPGHOME='/home/hm-user/.gnupg'$"
+    assertFileNotRegex activate "^export GNUPGHOME=/home/hm-user/.gnupg$"
 
     assertFileRegex activate \
       '^install -m 0700 /nix/store/[0-9a-z]*-gpg-pubring/trustdb.gpg "/home/hm-user/.gnupg/trustdb.gpg"$'

--- a/tests/modules/programs/gpg/mutable-keyfiles.nix
+++ b/tests/modules/programs/gpg/mutable-keyfiles.nix
@@ -17,7 +17,7 @@
   test.stubs.systemd = { }; # depends on gnupg.override
 
   nmt.script = ''
-    assertFileContains activate "export GNUPGHOME='/home/hm-user/.gnupg'"
+    assertFileContains activate "export GNUPGHOME=/home/hm-user/.gnupg"
 
     assertFileContains activate "unset GNUPGHOME QUIET_ARG keyId importTrust"
 

--- a/tests/modules/programs/mujmap/mujmap-defaults-expected.toml
+++ b/tests/modules/programs/mujmap/mujmap-defaults-expected.toml
@@ -1,6 +1,6 @@
 auto_create_new_mailboxes = true
 fqdn = "example.com"
-password_command = "'password-command'"
+password_command = "password-command"
 username = "home.manager"
 
 [tags]

--- a/tests/modules/programs/pls/bash.nix
+++ b/tests/modules/programs/pls/bash.nix
@@ -20,7 +20,7 @@ with lib;
       assertFileExists home-files/.bashrc
       assertFileContains \
         home-files/.bashrc \
-        "alias ls='@pls@/bin/pls'"
+        "alias ls=@pls@/bin/pls"
       assertFileContains \
         home-files/.bashrc \
         "alias ll='@pls@/bin/pls -d perms -d user -d group -d size -d mtime -d git'"

--- a/tests/modules/programs/pls/fish.nix
+++ b/tests/modules/programs/pls/fish.nix
@@ -24,7 +24,7 @@ with lib;
       assertFileExists home-files/.config/fish/config.fish
       assertFileContains \
         home-files/.config/fish/config.fish \
-        "alias ls '@pls@/bin/pls'"
+        "alias ls @pls@/bin/pls"
       assertFileContains \
         home-files/.config/fish/config.fish \
         "alias ll '@pls@/bin/pls -d perms -d user -d group -d size -d mtime -d git'"

--- a/tests/modules/programs/pls/zsh.nix
+++ b/tests/modules/programs/pls/zsh.nix
@@ -23,10 +23,10 @@ with lib;
       assertFileExists home-files/.zshrc
       assertFileContains \
         home-files/.zshrc \
-        "alias -- 'ls'='@pls@/bin/pls'"
+        "alias -- ls=@pls@/bin/pls"
       assertFileContains \
         home-files/.zshrc \
-        "alias -- 'll'='@pls@/bin/pls -d perms -d user -d group -d size -d mtime -d git'"
+        "alias -- ll='@pls@/bin/pls -d perms -d user -d group -d size -d mtime -d git'"
     '';
   };
 }

--- a/tests/modules/programs/thefuck/integration-enabled-instant.nix
+++ b/tests/modules/programs/thefuck/integration-enabled-instant.nix
@@ -16,11 +16,11 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
-      'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"' '"'"'--enable-experimental-instant-mode'"'"')"'
+      'eval "$(@thefuck@/bin/thefuck --alias --enable-experimental-instant-mode)"'
 
     assertFileExists home-files/.zshrc
     assertFileContains \
       home-files/.zshrc \
-      'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"' '"'"'--enable-experimental-instant-mode'"'"')"'
+      'eval "$(@thefuck@/bin/thefuck --alias --enable-experimental-instant-mode)"'
   '';
 }

--- a/tests/modules/programs/thefuck/integration-enabled.nix
+++ b/tests/modules/programs/thefuck/integration-enabled.nix
@@ -15,7 +15,7 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
-      'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"')"'
+      'eval "$(@thefuck@/bin/thefuck --alias)"'
 
     assertFileExists home-files/.config/fish/functions/fuck.fish
     assertFileContains \
@@ -33,7 +33,7 @@
     assertFileExists home-files/.zshrc
     assertFileContains \
       home-files/.zshrc \
-      'eval "$(@thefuck@/bin/thefuck '"'"'--alias'"'"')"'
+      'eval "$(@thefuck@/bin/thefuck --alias)"'
 
     assertFileExists home-files/.config/nushell/config.nu
     assertFileContains \

--- a/tests/modules/programs/zsh/syntax-highlighting.nix
+++ b/tests/modules/programs/zsh/syntax-highlighting.nix
@@ -19,8 +19,8 @@ with lib;
 
     nmt.script = ''
       assertFileContains home-files/.zshrc "source ${pkgs.hello}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
-      assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_HIGHLIGHTERS+=('brackets' 'pattern' 'cursor')"
-      assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_STYLES+=('comment' 'fg=#6c6c6c')"
+      assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_HIGHLIGHTERS+=(brackets pattern cursor)"
+      assertFileContains home-files/.zshrc "ZSH_HIGHLIGHT_STYLES+=(comment 'fg=#6c6c6c')"
     '';
   };
 }

--- a/tests/modules/programs/zsh/zsh-abbr.nix
+++ b/tests/modules/programs/zsh/zsh-abbr.nix
@@ -12,6 +12,6 @@
     abbreviations=home-files/.config/zsh-abbr/user-abbreviations
 
     assertFileExists $abbreviations
-    assertFileContains $abbreviations "abbr 'ga'='git add'"
+    assertFileContains $abbreviations "abbr ga='git add'"
   '';
 }

--- a/tests/modules/services/cachix-agent/basic-setup.nix
+++ b/tests/modules/services/cachix-agent/basic-setup.nix
@@ -20,7 +20,7 @@
           [Service]
           Environment=PATH=@nix@/bin
           EnvironmentFile=/home/hm-user/.config/cachix-agent.token
-          ExecStart='@cachix-agent@/bin/cachix' 'deploy' 'agent' 'test-agent' 'home-manager'
+          ExecStart=@cachix-agent@/bin/cachix deploy agent test-agent home-manager
           KillMode=process
           Restart=on-failure
 

--- a/tests/modules/services/cliphist/cliphist-extra-options.nix
+++ b/tests/modules/services/cliphist/cliphist-extra-options.nix
@@ -16,9 +16,9 @@
     assertFileExists $servicePath/cliphist.service
     assertFileExists $servicePath/cliphist-images.service
 
-    assertFileRegex $servicePath/cliphist.service " '-max-dedupe-search' '10' "
-    assertFileRegex $servicePath/cliphist.service " '-max-items' '500' "
-    assertFileRegex $servicePath/cliphist-images.service " '-max-dedupe-search' '10' "
-    assertFileRegex $servicePath/cliphist-images.service " '-max-items' '500' "
+    assertFileRegex $servicePath/cliphist.service " -max-dedupe-search 10 "
+    assertFileRegex $servicePath/cliphist.service " -max-items 500 "
+    assertFileRegex $servicePath/cliphist-images.service " -max-dedupe-search 10 "
+    assertFileRegex $servicePath/cliphist-images.service " -max-items 500 "
   '';
 }

--- a/tests/modules/services/emacs/emacs-service-emacs-after-graphical-session-target.service
+++ b/tests/modules/services/emacs/emacs-service-emacs-after-graphical-session-target.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon '-f' 'exwm-enable'"
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon -f exwm-enable"
 Restart=on-failure
 SuccessExitStatus=15
 Type=notify

--- a/tests/modules/services/emacs/emacs-service-emacs.service
+++ b/tests/modules/services/emacs/emacs-service-emacs.service
@@ -2,7 +2,7 @@
 WantedBy=default.target
 
 [Service]
-ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon '-f' 'exwm-enable'"
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon -f exwm-enable"
 Restart=on-failure
 SuccessExitStatus=15
 Type=notify

--- a/tests/modules/services/emacs/emacs-socket-27-emacs.service
+++ b/tests/modules/services/emacs/emacs-socket-27-emacs.service
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon='%t/emacs/server' '-f' 'exwm-enable'"
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon=%t/emacs/server -f exwm-enable"
 ExecStartPost=@coreutils@/bin/chmod --changes -w %t/emacs
 ExecStopPost=@coreutils@/bin/chmod --changes +w %t/emacs
 Restart=on-failure

--- a/tests/modules/services/emacs/emacs-socket-28-emacs.service
+++ b/tests/modules/services/emacs/emacs-socket-28-emacs.service
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon='%t/emacs/server' '-f' 'exwm-enable'"
+ExecStart=@runtimeShell@ -l -c "@emacs@/bin/emacs --fg-daemon=%t/emacs/server -f exwm-enable"
 Restart=on-failure
 SuccessExitStatus=15
 Type=notify

--- a/tests/modules/services/fnott/systemd-user-service-expected.service
+++ b/tests/modules/services/fnott/systemd-user-service-expected.service
@@ -1,6 +1,6 @@
 [Service]
 BusName=org.freedesktop.Notifications
-ExecStart=@fnott@/bin/fnott -c '/home/hm-user/.config/fnott/fnott.ini'
+ExecStart=@fnott@/bin/fnott -c /home/hm-user/.config/fnott/fnott.ini
 Type=dbus
 
 [Unit]

--- a/tests/modules/services/imapnotify/imapnotify-config.json
+++ b/tests/modules/services/imapnotify/imapnotify-config.json
@@ -1,1 +1,1 @@
-{"boxes":["Inbox"],"host":"imap.example.com","onNewMail":"@notmuch@/bin/notmuch new\n","passwordCmd":"'password-command'","port":993,"tls":true,"tlsOptions":{"starttls":false},"username":"home.manager"}
+{"boxes":["Inbox"],"host":"imap.example.com","onNewMail":"@notmuch@/bin/notmuch new\n","passwordCmd":"password-command","port":993,"tls":true,"tlsOptions":{"starttls":false},"username":"home.manager"}

--- a/tests/modules/services/mpd-mpris/configuration-with-password.service
+++ b/tests/modules/services/mpd-mpris/configuration-with-password.service
@@ -2,7 +2,7 @@
 WantedBy=default.target
 
 [Service]
-ExecStart=@mpd-mpris@/bin/mpd-mpris -host 'example.com' -network 'tcp' -no-instance -port 1234 -pwd 'my_password'
+ExecStart=@mpd-mpris@/bin/mpd-mpris -host example.com -network tcp -no-instance -port 1234 -pwd my_password
 Restart=on-failure
 RestartSec=5s
 Type=simple

--- a/tests/modules/services/mpd/basic-configuration.service
+++ b/tests/modules/services/mpd/basic-configuration.service
@@ -3,7 +3,7 @@ WantedBy=default.target
 
 [Service]
 Environment=PATH=/home/hm-user/.nix-profile/bin
-ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf '--verbose'
+ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf --verbose
 ExecStartPre=/nix/store/00000000000000000000000000000000-bash/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
 Type=notify
 

--- a/tests/modules/services/mpd/start-when-needed.service
+++ b/tests/modules/services/mpd/start-when-needed.service
@@ -1,6 +1,6 @@
 [Service]
 Environment=PATH=/home/hm-user/.nix-profile/bin
-ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf '--verbose'
+ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf --verbose
 ExecStartPre=/nix/store/00000000000000000000000000000000-bash/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
 Type=notify
 

--- a/tests/modules/services/parcellite/parcellite-expected.service
+++ b/tests/modules/services/parcellite/parcellite-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@parcellite@/bin/parcellite '--no-icon'
+ExecStart=@parcellite@/bin/parcellite --no-icon
 Restart=on-abort
 
 [Unit]

--- a/tests/modules/services/pasystray/expected.service
+++ b/tests/modules/services/pasystray/expected.service
@@ -3,7 +3,7 @@ WantedBy=graphical-session.target
 
 [Service]
 Environment=PATH=@paprefs@/bin:@pavucontrol@/bin
-ExecStart='@pasystray@/bin/pasystray' '-g'
+ExecStart=@pasystray@/bin/pasystray -g
 
 [Unit]
 After=graphical-session-pre.target

--- a/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/gammastep-basic-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@gammastep@/bin/gammastep '-c' '/home/hm-user/.config/gammastep/config.ini'
+ExecStart=@gammastep@/bin/gammastep -c /home/hm-user/.config/gammastep/config.ini
 Restart=on-failure
 RestartSec=3
 

--- a/tests/modules/services/redshift-gammastep/redshift-basic-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/redshift-basic-configuration-expected.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@redshift@/bin/redshift '-c' '/home/hm-user/.config/redshift/redshift.conf'
+ExecStart=@redshift@/bin/redshift -c /home/hm-user/.config/redshift/redshift.conf
 Restart=on-failure
 RestartSec=3
 

--- a/tests/modules/services/remmina/basic-config.nix
+++ b/tests/modules/services/remmina/basic-config.nix
@@ -17,7 +17,7 @@
 
     assertFileExists $serviceFile
     assertFileRegex $serviceFile 'ExecStart=.*/bin/dummy'
-    assertFileRegex $serviceFile "dummy '--icon' '--enable-extra-hardening'"
+    assertFileRegex $serviceFile "dummy --icon --enable-extra-hardening"
 
     mimetypeFile='./home-files/.local/share/mime/packages/application-x-rdp.xml'
 

--- a/tests/modules/services/signaturepdf/basic-configuration.service
+++ b/tests/modules/services/signaturepdf/basic-configuration.service
@@ -2,7 +2,7 @@
 WantedBy=default.target
 
 [Service]
-ExecStart=/signaturepdf/bin/signaturepdf 9494 '-d' 'upload_max_filesize=24M'
+ExecStart=/signaturepdf/bin/signaturepdf 9494 -d 'upload_max_filesize=24M'
 
 [Unit]
 Description=signaturepdf; signing, organizing, editing metadatas or compressing PDFs

--- a/tests/modules/services/swayosd/swayosd.nix
+++ b/tests/modules/services/swayosd/swayosd.nix
@@ -21,7 +21,7 @@
           WantedBy=graphical-session.target
 
           [Service]
-          ExecStart=@swayosd@/bin/swayosd-server --display DISPLAY --style '/etc/xdg/swayosd/style.css' --top-margin 0.100000
+          ExecStart=@swayosd@/bin/swayosd-server --display DISPLAY --style /etc/xdg/swayosd/style.css --top-margin 0.100000
           Restart=always
           RestartSec=2s
           Type=simple

--- a/tests/modules/services/syncthing/common/extra-options.nix
+++ b/tests/modules/services/syncthing/common/extra-options.nix
@@ -13,7 +13,7 @@ lib.mkMerge [
     nmt.script = ''
       assertFileExists home-files/.config/systemd/user/syncthing.service
       assertFileContains home-files/.config/systemd/user/syncthing.service \
-      "ExecStart='@syncthing@/bin/syncthing' '-no-browser' '-no-restart' '-logflags=0' '-foo' '-bar \"baz\"'"
+      "ExecStart=@syncthing@/bin/syncthing -no-browser -no-restart '-logflags=0' -foo '-bar \"baz\"'"
     '';
   })
   (lib.mkIf pkgs.stdenv.isDarwin {

--- a/tests/modules/services/window-managers/bspwm/bspwmrc
+++ b/tests/modules/services/window-managers/bspwm/bspwmrc
@@ -1,14 +1,14 @@
 extra config early
 
-if [[ $(bspc query --desktops --names --monitor 'focused') == Desktop ]]; then
-  bspc monitor 'focused' -d 'desktop 1' 'd'\''esk top'
+if [[ $(bspc query --desktops --names --monitor focused) == Desktop ]]; then
+  bspc monitor focused -d 'desktop 1' 'd'\''esk top'
 fi
 
-bspc config 'border_width' '2'
-bspc config 'external_rules_command' '/path/to/external rules command'
-bspc config 'gapless_monocle' 'on'
-bspc config 'ignore_ewmh_fullscreen' 'enter,exit'
-bspc config 'split_ratio' '0.520000'
+bspc config border_width 2
+bspc config external_rules_command '/path/to/external rules command'
+bspc config gapless_monocle on
+bspc config ignore_ewmh_fullscreen enter,exit
+bspc config split_ratio 0.520000
 
 bspc rule -r '*'
 bspc rule -a '*' 'center=off' 'desktop=d'\''esk top#next' 'split_dir=north' 'sticky=on' 'unknown_rule=42'

--- a/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config-autostart
+++ b/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config-autostart
@@ -15,18 +15,18 @@ herbstclient mouseunbind --all
 herbstclient unrule --all
 
 herbstclient set always_show_frame true
-herbstclient set default_frame_layout 'max'
+herbstclient set default_frame_layout max
 herbstclient set frame_bg_active_color '#000000'
-herbstclient set frame_gap '12'
-herbstclient set frame_padding '-12'
+herbstclient set frame_gap 12
+herbstclient set frame_padding -12
 
-for tag in '1' 'with space' 'wə1rd#ch@rs'\'''; do
+for tag in 1 'with space' 'wə1rd#ch@rs'\'''; do
   herbstclient add "$tag"
 done
 
 if @herbstluftwm@/bin/herbstclient object_tree tags.by-name.default &>/dev/null; then
-  herbstclient use '1'
-  herbstclient merge_tag default '1'
+  herbstclient use 1
+  herbstclient merge_tag default 1
 fi
 
 

--- a/tests/modules/services/wlsunset/wlsunset-service-expected.service
+++ b/tests/modules/services/wlsunset/wlsunset-service-expected.service
@@ -2,7 +2,7 @@
 WantedBy=test.target
 
 [Service]
-ExecStart=@wlsunset@/bin/wlsunset '-L' '128.8' '-T' '6000' '-g' '0.6' '-l' '12.3' '-t' '3500'
+ExecStart=@wlsunset@/bin/wlsunset -L 128.8 -T 6000 -g 0.6 -l 12.3 -t 3500
 
 [Unit]
 Description=Day/night gamma adjustments for Wayland compositors.

--- a/tests/modules/systemd/user-config.nix
+++ b/tests/modules/systemd/user-config.nix
@@ -17,7 +17,7 @@
       pkgs.writeText "expected" ''
         [Manager]
         DefaultCPUAccounting=true
-        DefaultEnvironment=PATH='/bin:/sbin:/some where' TEST='abc'
+        DefaultEnvironment=PATH='/bin:/sbin:/some where' TEST=abc
         LogLevel=debug
       ''
     }


### PR DESCRIPTION
### Description

Fixes tests that are affected by <https://github.com/NixOS/nixpkgs/pull/333744>.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```