### PR TITLE
k9s: remove katexochen as maintainer

### DIFF
--- a/modules/programs/k9s.nix
+++ b/modules/programs/k9s.nix
@@ -9,11 +9,7 @@ let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
 in {
-  meta.maintainers = with maintainers; [
-    katexochen
-    liyangau
-    hm.maintainers.LucasWagler
-  ];
+  meta.maintainers = with maintainers; [ liyangau hm.maintainers.LucasWagler ];
 
   imports = [
     (mkRenamedOptionModule [ "programs" "k9s" "skin" ] [


### PR DESCRIPTION
### Description

I haven't got the time to maintain this anymore, see https://github.com/nix-community/home-manager/pull/4662#issuecomment-2336640088

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
