### PR TITLE
pqiv: add boolean support

### DIFF
--- a/modules/programs/pqiv.nix
+++ b/modules/programs/pqiv.nix
@@ -23,14 +23,13 @@ in {
       default = { };
       description = ''
         Configuration written to {file}`$XDG_CONFIG_HOME/pqivrc`. See
-        {manpage}`pqiv(1)` for a list of available options. To set a
-        boolean flag, set the value to 1.
+        {manpage}`pqiv(1)` for a list of available options.
       '';
       example = literalExpression ''
         {
           options = {
-            lazy-load = 1;
-            hide-info-box = 1;
+            lazy-load = true;
+            hide-info-box = true;
             background-pattern = "black";
             thumbnail-size = "256x256";
             command-1 = "thunar";
@@ -68,7 +67,15 @@ in {
     xdg.configFile."pqivrc" =
       mkIf (cfg.settings != { } && cfg.extraConfig != "") {
         text = lib.concatLines [
-          (generators.toINI { } cfg.settings)
+          (generators.toINI {
+            mkKeyValue = key: value:
+              let
+                value' = if isBool value then
+                  (if value then "1" else "0")
+                else
+                  toString value;
+              in "${key} = ${value'}";
+          } cfg.settings)
           cfg.extraConfig
         ];
       };

--- a/tests/modules/programs/pqiv/settings.nix
+++ b/tests/modules/programs/pqiv/settings.nix
@@ -6,7 +6,7 @@
     package = config.lib.test.mkStubPackage { name = "pqiv"; };
     settings = {
       options = {
-        hide-info-box = 1;
+        hide-info-box = true;
         thumbnail-size = "256x256";
       };
     };
@@ -21,8 +21,8 @@
     assertFileContent home-files/.config/pqivrc ${
       builtins.toFile "pqiv.expected" ''
         [options]
-        hide-info-box=1
-        thumbnail-size=256x256
+        hide-info-box = 1
+        thumbnail-size = 256x256
 
         [keybindings]
         t { montage_mode_enter() }


### PR DESCRIPTION
### Description

Now possible to use the pqiv module with `true` instead of `1`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@iynaix