### PR TITLE
swayidle: make -w optional

### DIFF
--- a/docs/release-notes/rl-2411.md
+++ b/docs/release-notes/rl-2411.md
@@ -7,7 +7,16 @@ is therefore not final.
 
 This release has the following notable changes:
 
-- No changes.
+- The swayidle module behavior has changed. Specifically, swayidle was
+  previously always called with a `-w` flag. This flag is now moved to
+  the default
+  [services.swayidle.extraArgs](#opt-services.swayidle.extraArgs)
+  value to make it optional.
+
+  Your configuration may break if you already set this option and also
+  rely on the flag being automatically added. To resolve this, please
+  add `-w` to your assignment of
+  [services.swayidle.extraArgs](#opt-services.swayidle.extraArgs).
 
 ## State Version Changes {#sec-release-24.11-state-version-changes}
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1734,6 +1734,20 @@ in {
           list of themes.
         '';
       }
+
+      {
+        time = "2024-09-20T07:48:08+00:00";
+        condition = hostPlatform.isLinux && config.services.swayidle.enable;
+        message = ''
+          The swayidle module behavior has changed. Specifically, swayidle was
+          previously always called with a `-w` flag. This flag is now moved to
+          the default `services.swayidle.extraArgs` value to make it optional.
+
+          Your configuration may break if you already set this option and also
+          rely on the flag being automatically added. To resolve this, please
+          add `-w` to your assignment of `services.swayidle.extraArgs`.
+        '';
+      }
     ];
   };
 }

--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -94,7 +94,7 @@ in {
 
     extraArgs = mkOption {
       type = with types; listOf str;
-      default = [ ];
+      default = [ "-w" ];
       description = "Extra arguments to pass to swayidle.";
     };
 
@@ -127,8 +127,7 @@ in {
         Restart = "always";
         # swayidle executes commands using "sh -c", so the PATH needs to contain a shell.
         Environment = [ "PATH=${makeBinPath [ pkgs.bash ]}" ];
-        ExecStart =
-          "${cfg.package}/bin/swayidle -w ${concatStringsSep " " args}";
+        ExecStart = "${cfg.package}/bin/swayidle ${concatStringsSep " " args}";
       };
 
       Install = { WantedBy = [ cfg.systemdTarget ]; };


### PR DESCRIPTION
### Description

The option -w causes swayidle to wait on timeouts/events to finish. This can cause problems with certain timeout/event commands (see https://github.com/swaywm/swaylock/issues/86#issuecomment-662702180).

This PR lets the user choose if he wants to use the option. It defaults to the current behavior.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
-> swayidle-basic-configuration: OK

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@c0deaddict 
