### PR TITLE
git: add diff-highlight diff pager option

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -214,6 +214,24 @@ in {
         };
       };
 
+      diff-highlight = {
+        enable = mkEnableOption "" // {
+          description = ''
+            Enable the contrib {command}`diff-highlight` syntax highlighter.
+            See <https://github.com/git/git/blob/master/contrib/diff-highlight/README>,
+          '';
+        };
+
+        pagerOpts = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          example = [ "--tabs=4" "-RFX" ];
+          description = ''
+            Arguments to be passed to {command}`less`.
+          '';
+        };
+      };
+
       difftastic = {
         enable = mkEnableOption "" // {
           description = ''
@@ -360,11 +378,15 @@ in {
       home.packages = [ cfg.package ];
       assertions = [{
         assertion = let
-          enabled =
-            [ cfg.delta.enable cfg.diff-so-fancy.enable cfg.difftastic.enable ];
+          enabled = [
+            cfg.delta.enable
+            cfg.diff-so-fancy.enable
+            cfg.difftastic.enable
+            cfg.diff-highlight.enable
+          ];
         in count id enabled <= 1;
         message =
-          "Only one of 'programs.git.delta.enable' or 'programs.git.difftastic.enable' or 'programs.git.diff-so-fancy.enable' can be set to true at the same time.";
+          "Only one of 'programs.git.delta.enable' or 'programs.git.difftastic.enable' or 'programs.git.diff-so-fancy.enable' or 'programs.git.diff-highlight' can be set to true at the same time.";
       }];
 
       programs.git.iniContent.user = {
@@ -477,6 +499,18 @@ in {
           smudge = concatStringsSep " "
             ([ "git-lfs" "smudge" ] ++ skipArg ++ [ "--" "%f" ]);
         };
+    })
+
+    (mkIf cfg.diff-highlight.enable {
+      programs.git.iniContent = let
+        dhCommand =
+          "${cfg.package}/share/git/contrib/diff-highlight/diff-highlight";
+      in {
+        core.pager = "${dhCommand} | ${getExe pkgs.less} ${
+            escapeShellArgs cfg.diff-highlight.pagerOpts
+          }";
+        interactive.diffFilter = dhCommand;
+      };
     })
 
     (mkIf cfg.difftastic.enable {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This adds a new diff-highlight option to make use of the simple included git diff highlighter that comes with canonical git. `diff-highlight` is a perl script that high lights the changes in changed lines. This makes it human-readable and easy to see changes in diffs.

For more info, see https://github.com/git/git/blob/master/contrib/diff-highlight/README

This was inspired by https://github.com/nix-community/home-manager/pull/2882 and https://github.com/nix-community/home-manager/pull/2850

Before:
<img width="556" alt="image" src="https://github.com/user-attachments/assets/e0be5c11-9df9-4681-b28f-2aa534039e73">

After:
<img width="552" alt="image" src="https://github.com/user-attachments/assets/686d02e1-f218-4edd-986c-090e4a337126">


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

CC/ @rycee @ncfavier
