### PR TITLE
evil-helix: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -107,6 +107,12 @@
     githubId = 32838899;
     name = "Daniel Wagenknecht";
   };
+  gurevitch = {
+    name = "Chet Gurevitch";
+    email = "chet@gurevitch.net";
+    github = "chetgurevitch";
+    githubId = 25513187;
+  };
   henrisota = {
     email = "henrisota@users.noreply.github.com";
     github = "henrisota";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -85,6 +85,7 @@ let
     ./programs/discocss.nix
     ./programs/eclipse.nix
     ./programs/emacs.nix
+    ./programs/evil-helix.nix
     ./programs/eww.nix
     ./programs/eza.nix
     ./programs/fastfetch.nix

--- a/modules/programs/evil-helix.nix
+++ b/modules/programs/evil-helix.nix
@@ -3,19 +3,19 @@
 with lib;
 
 let
-  cfg = config.programs.helix;
+  cfg = config.programs.evil-helix;
   tomlFormat = pkgs.formats.toml { };
 in {
-  meta.maintainers = [ hm.maintainers.Philipp-M ];
+  meta.maintainers = [ hm.maintainers.gurevitch ];
 
-  options.programs.helix = {
-    enable = mkEnableOption "helix text editor";
+  options.programs.evil-helix = {
+    enable = mkEnableOption "evil-helix text editor";
 
     package = mkOption {
       type = types.package;
-      default = pkgs.helix;
-      defaultText = literalExpression "pkgs.helix";
-      description = "The package to use for helix.";
+      default = pkgs.evil-helix;
+      defaultText = literalExpression "pkgs.evil-helix";
+      description = "The package to use for evil-helix.";
     };
 
     extraPackages = mkOption {
@@ -69,7 +69,7 @@ in {
             It now generates the whole languages.toml file instead of just the language array in that file.
 
             Use
-            programs.helix.languages = { language = <languages list>; }
+            programs.evil-helix.languages = { language = <languages list>; }
             instead.
           '' { inherit language; }) (addCheck tomlFormat.type builtins.isAttrs);
       default = { };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -71,6 +71,7 @@ in import nmtSrc {
     ./modules/programs/dircolors
     ./modules/programs/direnv
     ./modules/programs/emacs
+    ./modules/programs/evil-helix
     ./modules/programs/fastfetch
     ./modules/programs/feh
     ./modules/programs/fish

--- a/tests/modules/programs/evil-helix/default.nix
+++ b/tests/modules/programs/evil-helix/default.nix
@@ -1,0 +1,1 @@
+{ evil-helix-example-settings = ./example-settings.nix; }

--- a/tests/modules/programs/evil-helix/example-settings.nix
+++ b/tests/modules/programs/evil-helix/example-settings.nix
@@ -1,0 +1,144 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.evil-helix = {
+      enable = true;
+
+      settings = {
+        theme = "base16";
+        editor = {
+          line-number = "relative";
+          lsp.display-messages = true;
+        };
+        keys.normal = {
+          space.space = "file_picker";
+          space.w = ":w";
+          space.q = ":q";
+          esc = [ "collapse_selection" "keep_primary_selection" ];
+        };
+      };
+
+      languages = {
+        language-server.typescript-language-server = let
+          typescript-language-server = config.lib.test.mkStubPackage {
+            outPath = "@typescript-language-server@";
+          };
+          typescript =
+            config.lib.test.mkStubPackage { outPath = "@typescript@"; };
+        in {
+          command =
+            "${typescript-language-server}/bin/typescript-language-server";
+          args = [
+            "--stdio"
+            "--tsserver-path=${typescript}/lib/node_modules/typescript/lib"
+          ];
+        };
+
+        language = [{
+          name = "rust";
+          auto-format = false;
+        }];
+      };
+
+      ignores = [ ".build/" "!.gitignore" ];
+
+      themes = {
+        base16 = let
+          transparent = "none";
+          gray = "#665c54";
+          dark-gray = "#3c3836";
+          white = "#fbf1c7";
+          black = "#282828";
+          red = "#fb4934";
+          green = "#b8bb26";
+          yellow = "#fabd2f";
+          orange = "#fe8019";
+          blue = "#83a598";
+          magenta = "#d3869b";
+          cyan = "#8ec07c";
+        in {
+          "ui.menu" = transparent;
+          "ui.menu.selected" = { modifiers = [ "reversed" ]; };
+          "ui.linenr" = {
+            fg = gray;
+            bg = dark-gray;
+          };
+          "ui.popup" = { modifiers = [ "reversed" ]; };
+          "ui.linenr.selected" = {
+            fg = white;
+            bg = black;
+            modifiers = [ "bold" ];
+          };
+          "ui.selection" = {
+            fg = black;
+            bg = blue;
+          };
+          "ui.selection.primary" = { modifiers = [ "reversed" ]; };
+          "comment" = { fg = gray; };
+          "ui.statusline" = {
+            fg = white;
+            bg = dark-gray;
+          };
+          "ui.statusline.inactive" = {
+            fg = dark-gray;
+            bg = white;
+          };
+          "ui.help" = {
+            fg = dark-gray;
+            bg = white;
+          };
+          "ui.cursor" = { modifiers = [ "reversed" ]; };
+          "variable" = red;
+          "variable.builtin" = orange;
+          "constant.numeric" = orange;
+          "constant" = orange;
+          "attributes" = yellow;
+          "type" = yellow;
+          "ui.cursor.match" = {
+            fg = yellow;
+            modifiers = [ "underlined" ];
+          };
+          "string" = green;
+          "variable.other.member" = red;
+          "constant.character.escape" = cyan;
+          "function" = blue;
+          "constructor" = blue;
+          "special" = blue;
+          "keyword" = magenta;
+          "label" = magenta;
+          "namespace" = blue;
+          "diff.plus" = green;
+          "diff.delta" = yellow;
+          "diff.minus" = red;
+          "diagnostic" = { modifiers = [ "underlined" ]; };
+          "ui.gutter" = { bg = black; };
+          "info" = blue;
+          "hint" = dark-gray;
+          "debug" = dark-gray;
+          "warning" = yellow;
+          "error" = red;
+        };
+      };
+    };
+
+    test.stubs.evil-helix = { };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/helix/config.toml \
+        ${./settings-expected.toml}
+      assertFileContent \
+        home-files/.config/helix/languages.toml \
+        ${./languages-expected.toml}
+      assertFileContent \
+        home-files/.config/helix/ignore \
+        ${./ignore-expected}
+      assertFileContent \
+        home-files/.config/helix/themes/base16.toml \
+        ${./theme-base16-expected.toml}
+    '';
+  };
+}

--- a/tests/modules/programs/evil-helix/ignore-expected
+++ b/tests/modules/programs/evil-helix/ignore-expected
@@ -1,0 +1,2 @@
+.build/
+!.gitignore

--- a/tests/modules/programs/evil-helix/languages-expected.toml
+++ b/tests/modules/programs/evil-helix/languages-expected.toml
@@ -1,0 +1,7 @@
+[[language]]
+auto-format = false
+name = "rust"
+
+[language-server.typescript-language-server]
+args = ["--stdio", "--tsserver-path=@typescript@/lib/node_modules/typescript/lib"]
+command = "@typescript-language-server@/bin/typescript-language-server"

--- a/tests/modules/programs/evil-helix/settings-expected.toml
+++ b/tests/modules/programs/evil-helix/settings-expected.toml
@@ -1,0 +1,14 @@
+theme = "base16"
+[editor]
+line-number = "relative"
+
+[editor.lsp]
+display-messages = true
+
+[keys.normal]
+esc = ["collapse_selection", "keep_primary_selection"]
+
+[keys.normal.space]
+q = ":q"
+space = "file_picker"
+w = ":w"

--- a/tests/modules/programs/evil-helix/theme-base16-expected.toml
+++ b/tests/modules/programs/evil-helix/theme-base16-expected.toml
@@ -1,0 +1,74 @@
+attributes = "#fabd2f"
+constant = "#fe8019"
+"constant.character.escape" = "#8ec07c"
+"constant.numeric" = "#fe8019"
+constructor = "#83a598"
+debug = "#3c3836"
+"diff.delta" = "#fabd2f"
+"diff.minus" = "#fb4934"
+"diff.plus" = "#b8bb26"
+error = "#fb4934"
+function = "#83a598"
+hint = "#3c3836"
+info = "#83a598"
+keyword = "#d3869b"
+label = "#d3869b"
+namespace = "#83a598"
+special = "#83a598"
+string = "#b8bb26"
+type = "#fabd2f"
+"ui.menu" = "none"
+variable = "#fb4934"
+"variable.builtin" = "#fe8019"
+"variable.other.member" = "#fb4934"
+warning = "#fabd2f"
+
+[comment]
+fg = "#665c54"
+
+[diagnostic]
+modifiers = ["underlined"]
+
+["ui.cursor"]
+modifiers = ["reversed"]
+
+["ui.cursor.match"]
+fg = "#fabd2f"
+modifiers = ["underlined"]
+
+["ui.gutter"]
+bg = "#282828"
+
+["ui.help"]
+bg = "#fbf1c7"
+fg = "#3c3836"
+
+["ui.linenr"]
+bg = "#3c3836"
+fg = "#665c54"
+
+["ui.linenr.selected"]
+bg = "#282828"
+fg = "#fbf1c7"
+modifiers = ["bold"]
+
+["ui.menu.selected"]
+modifiers = ["reversed"]
+
+["ui.popup"]
+modifiers = ["reversed"]
+
+["ui.selection"]
+bg = "#83a598"
+fg = "#282828"
+
+["ui.selection.primary"]
+modifiers = ["reversed"]
+
+["ui.statusline"]
+bg = "#3c3836"
+fg = "#fbf1c7"
+
+["ui.statusline.inactive"]
+bg = "#fbf1c7"
+fg = "#3c3836"


### PR DESCRIPTION
Copied from helix

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@Philipp-M This removes the comment about the language-server option requiring the master branch from the upstream helix module since it was released in 23.10