### PR TITLE
Minor refactoring

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -147,7 +147,7 @@ in {
       substitute \
         ${hmOptionsDocs.optionsJSON}/nix-support/hydra-build-products \
         $out/nix-support/hydra-build-products \
-        --replace \
+        --replace-fail \
           '${hmOptionsDocs.optionsJSON}/share/doc/nixos' \
           "$out/share/doc/home-manager"
     '';

--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -56,7 +56,7 @@ in {
           buildCommand = lib.concatStringsSep "\n" [
             prevAttrs.buildCommand
             # TODO: why is this needed? Is there a better way to retain escape sequences?
-            "substituteInPlace $out --replace '\\\\' '\\'"
+            "substituteInPlace $out --replace-quiet '\\\\' '\\'"
           ];
         });
     };

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -337,7 +337,7 @@ in {
           else
             "";
         in ''
-          ${pkgs.sd-switch}/bin/sd-switch \
+          ${lib.getExe pkgs.sd-switch} \
             ''${DRY_RUN:+--dry-run} $VERBOSE_ARG ${timeoutArg} \
             ''${oldUnitsDir:+--old-units $oldUnitsDir} \
             --new-units "$newUnitsDir"


### PR DESCRIPTION
### Description

Specifically

- systemd: use getExe for sd-switch
- systemd: unify handling of switch environment
- treewide: use non-deprecated substitute arguments

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```