### PR TITLE
helix: update comments

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -75,7 +75,6 @@ in {
       default = { };
       example = literalExpression ''
         {
-          # the language-server option currently requires helix from the master branch at https://github.com/helix-editor/helix/
           language-server.typescript-language-server = with pkgs.nodePackages; {
             command = "''${typescript-language-server}/bin/typescript-language-server";
             args = [ "--stdio" "--tsserver-path=''${typescript}/lib/node_modules/typescript/lib" ];

--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -15,6 +15,7 @@ in {
       type = types.package;
       default = pkgs.helix;
       defaultText = literalExpression "pkgs.helix";
+      example = literalExpression "pkgs.evil-helix";
       description = "The package to use for helix.";
     };
 


### PR DESCRIPTION
### Description

Removes the outdated comment about the language-server option and adds an example for use with evil-helix

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@Philipp-M Here's the updated PR
