### PR TITLE
{lsd, pls, z-lua}: add support for fish abbreviations

### DIFF
--- a/modules/programs/lsd.nix
+++ b/modules/programs/lsd.nix
@@ -74,7 +74,15 @@ in {
 
     programs.zsh.shellAliases = mkIf cfg.enableAliases aliases;
 
-    programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
+    programs.fish = mkMerge [
+      (mkIf (!config.programs.fish.preferAbbrs) {
+        shellAliases = mkIf cfg.enableAliases aliases;
+      })
+
+      (mkIf config.programs.fish.preferAbbrs {
+        shellAbbrs = mkIf cfg.enableAliases aliases;
+      })
+    ];
 
     programs.lsd =
       mkIf (cfg.colors != { }) { settings.color.theme = "custom"; };

--- a/modules/programs/pls.nix
+++ b/modules/programs/pls.nix
@@ -28,7 +28,15 @@ in {
 
     programs.bash.shellAliases = mkIf cfg.enableAliases aliases;
 
-    programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
+    programs.fish = mkMerge [
+      (mkIf (!config.programs.fish.preferAbbrs) {
+        shellAliases = mkIf cfg.enableAliases aliases;
+      })
+
+      (mkIf config.programs.fish.preferAbbrs {
+        shellAbbrs = mkIf cfg.enableAliases aliases;
+      })
+    ];
 
     programs.zsh.shellAliases = mkIf cfg.enableAliases aliases;
   };

--- a/modules/programs/z-lua.nix
+++ b/modules/programs/z-lua.nix
@@ -77,16 +77,26 @@ in {
       })"
     '';
 
-    programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
-      source (${pkgs.z-lua}/bin/z --init fish ${
-        concatStringsSep " " cfg.options
-      } | psub)
-    '';
-
     programs.bash.shellAliases = mkIf cfg.enableAliases aliases;
 
     programs.zsh.shellAliases = mkIf cfg.enableAliases aliases;
 
-    programs.fish.shellAliases = mkIf cfg.enableAliases aliases;
+    programs.fish = mkMerge [
+      {
+        shellInit = mkIf cfg.enableFishIntegration ''
+          source (${pkgs.z-lua}/bin/z --init fish ${
+            concatStringsSep " " cfg.options
+          } | psub)
+        '';
+      }
+
+      (mkIf (!config.programs.fish.preferAbbrs) {
+        shellAliases = mkIf cfg.enableAliases aliases;
+      })
+
+      (mkIf config.programs.fish.preferAbbrs {
+        shellAbbrs = mkIf cfg.enableAliases aliases;
+      })
+    ];
   };
 }


### PR DESCRIPTION
### Description

Added support for enabling fish abbreviations for these modules if `preferAbbrs` is enabled

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@arjan-s 
