### PR TITLE
waybar: add systemd restart triggers

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -2,7 +2,8 @@
 
 let
   inherit (lib)
-    all filterAttrs hasAttr isStorePath literalExpression optionalAttrs types;
+    all filterAttrs hasAttr isStorePath literalExpression optional optionalAttrs
+    types;
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.modules) mkIf mkMerge;
 
@@ -310,6 +311,10 @@ in {
           Documentation = "https://github.com/Alexays/Waybar/wiki";
           PartOf = [ "graphical-session.target" ];
           After = [ "graphical-session-pre.target" ];
+          X-Restart-Triggers = optional (settings != [ ])
+            "${config.xdg.configFile."waybar/config".source}"
+            ++ optional (cfg.style != null)
+            "${config.xdg.configFile."waybar/style.css".source}";
         };
 
         Service = {


### PR DESCRIPTION
### Description

Fixes #3186

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@berbiche