### PR TITLE
poweralertd: Enable passing CLI args to the daemon

### DIFF
--- a/modules/services/poweralertd.nix
+++ b/modules/services/poweralertd.nix
@@ -7,8 +7,18 @@ let cfg = config.services.poweralertd;
 in {
   meta.maintainers = [ maintainers.thibautmarty ];
 
-  options.services.poweralertd.enable =
-    mkEnableOption "the Upower-powered power alertd";
+  options.services.poweralertd = {
+    enable = mkEnableOption "the Upower-powered power alertd";
+
+    extraArgs = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      example = [ "-s" "-S" ];
+      description = ''
+        Extra command line arguments to pass to poweralertd.
+      '';
+    };
+  };
 
   config = mkIf cfg.enable {
     assertions = [
@@ -28,7 +38,9 @@ in {
 
       Service = {
         Type = "simple";
-        ExecStart = "${pkgs.poweralertd}/bin/poweralertd";
+        ExecStart = "${pkgs.poweralertd}/bin/poweralertd ${
+            utils.escapeSystemdExecArgs cfg.extraArgs
+          }";
         Restart = "always";
       };
     };


### PR DESCRIPTION
### Description

Enable passing CLI args to poweralertd.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@thibautmarty