### PR TITLE
borgmatic: fix service permissions (#5749)

### DIFF
--- a/modules/services/borgmatic.nix
+++ b/modules/services/borgmatic.nix
@@ -46,7 +46,6 @@ in {
 
           # Lower CPU and I/O priority:
           Nice = 19;
-          CPUSchedulingPolicy = "batch";
           IOSchedulingClass = "best-effort";
           IOSchedulingPriority = 7;
           IOWeight = 100;

--- a/tests/modules/services/borgmatic/basic-configuration.service
+++ b/tests/modules/services/borgmatic/basic-configuration.service
@@ -1,5 +1,4 @@
 [Service]
-CPUSchedulingPolicy=batch
 ExecStart=/nix/store/00000000000000000000000000000000-systemd/bin/systemd-inhibit \
   --who="borgmatic" \
   --what="sleep:shutdown" \


### PR DESCRIPTION
### Description
This fixes the permissions of the borgmatic service. Please see #5749  for further info

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@DamienCassou 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
