### PR TITLE
firefox: fix languagepacks policy

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -813,15 +813,6 @@ in {
       its example for how to do this.
     '';
 
-    programs.firefox.policies = {
-      ExtensionSettings = listToAttrs (map (lang:
-        nameValuePair "langpack-${lang}@firefox.mozilla.org" {
-          installation_mode = "normal_installed";
-          install_url =
-            "https://releases.mozilla.org/pub/firefox/releases/${cfg.package.version}/linux-x86_64/xpi/${lang}.xpi";
-        }) cfg.languagePacks);
-    };
-
     home.packages = lib.optional (cfg.finalPackage != null) cfg.finalPackage;
 
     home.file = mkMerge ([{
@@ -1013,6 +1004,17 @@ in {
           force = true;
         };
     }));
-  } // setAttrByPath modulePath { finalPackage = wrapPackage cfg.package; });
+  } // setAttrByPath modulePath {
+    finalPackage = wrapPackage cfg.package;
+
+    policies = {
+      ExtensionSettings = listToAttrs (map (lang:
+        nameValuePair "langpack-${lang}@firefox.mozilla.org" {
+          installation_mode = "normal_installed";
+          install_url =
+            "https://releases.mozilla.org/pub/firefox/releases/${cfg.package.version}/linux-x86_64/xpi/${lang}.xpi";
+        }) cfg.languagePacks);
+    };
+  });
 }
 


### PR DESCRIPTION
### Description

Fixes #5820 and prevent `programs.firefox.policies` from being overriden by `setAttrByPath modulePath`. This also adds support for Firefox derivatives to use the `programs.firefox.languagePacks` option.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@rycee @kira-bruneau @brckd