### PR TITLE
docs: add XDG_*_HOME mentions to xdg.*Home options

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -30,6 +30,8 @@ in {
       apply = toString;
       description = ''
         Absolute path to directory holding application caches.
+
+        Sets `XDG_CACHE_HOME` for the user if `xdg.enable` is set `true`.
       '';
     };
 
@@ -48,6 +50,8 @@ in {
       apply = toString;
       description = ''
         Absolute path to directory holding application configurations.
+
+        Sets `XDG_CONFIG_HOME` for the user if `xdg.enable` is set `true`.
       '';
     };
 
@@ -67,6 +71,8 @@ in {
       apply = toString;
       description = ''
         Absolute path to directory holding application data.
+
+        Sets `XDG_DATA_HOME` for the user if `xdg.enable` is set `true`.
       '';
     };
 
@@ -86,6 +92,8 @@ in {
       apply = toString;
       description = ''
         Absolute path to directory holding application states.
+
+        Sets `XDG_STATE_HOME` for the user if `xdg.enable` is set `true`.
       '';
     };
   };


### PR DESCRIPTION
### Description

Fixes https://github.com/nix-community/home-manager/issues/5849.

One thing that I'm not user I should include in the docs is when the XDG var is actually applied. I tried changing the env vars a few times in a GNOME Wayland VM and the majority of the time they are only applied after system reboot. I think there were a couple of times when they are applied after re-login.

### Checklist
- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
