### PR TITLE
zoxide: replace outdated flag in "options" example

### DIFF
--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -26,7 +26,7 @@ in {
     options = mkOption {
       type = types.listOf types.str;
       default = [ ];
-      example = [ "--no-aliases" ];
+      example = [ "--no-cmd" ];
       description = ''
         List of options to pass to zoxide.
       '';


### PR DESCRIPTION
Replace `--no-aliases` flag with `--no-cmd`

### Description

Simple update to the "options" example. There's currently only one example flag listed but it's no longer valid, since it was renamed back in 2021 ([0.8.1](https://github.com/ajeetdsouza/zoxide/blob/main/CHANGELOG.md#081---2021-04-23)).

### Checklist

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
