### PR TITLE
neovim: use `home.shellAliases` for the `vimdiffAlias` option

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -414,6 +414,8 @@ in {
 
     home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };
 
+    home.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
+
     xdg.configFile =
       let hasLuaConfig = hasAttr "lua" config.programs.neovim.generatedConfigs;
       in mkMerge (
@@ -443,9 +445,5 @@ in {
           + extraMakeWrapperLuaArgs;
         wrapRc = false;
       });
-
-    programs.bash.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
-    programs.fish.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
-    programs.zsh.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
   };
 }


### PR DESCRIPTION
Instead of manually adding it as an alias for each and every individual shell, which inevitably ends up missing some.

### Description

<!--

Previously the alias was added for each shell individually, which doesn't make much sense. The code even missed some pretty popular shells like nushell, for example.

It is my first time contributing to the project and since I'm not used to the process of adding new tests i decided not to do that.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
