### PR TITLE
swayidle: minor cleanups

### DIFF
--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -6,18 +6,6 @@ let
 
   cfg = config.services.swayidle;
 
-  mkTimeout = t:
-    [ "timeout" (toString t.timeout) (escapeShellArg t.command) ]
-    ++ optionals (t.resumeCommand != null) [
-      "resume"
-      (escapeShellArg t.resumeCommand)
-    ];
-
-  mkEvent = e: [ e.event (escapeShellArg e.command) ];
-
-  args = cfg.extraArgs ++ (concatMap mkTimeout cfg.timeouts)
-    ++ (concatMap mkEvent cfg.events);
-
 in {
   meta.maintainers = [ maintainers.c0deaddict ];
 
@@ -127,7 +115,16 @@ in {
         Restart = "always";
         # swayidle executes commands using "sh -c", so the PATH needs to contain a shell.
         Environment = [ "PATH=${makeBinPath [ pkgs.bash ]}" ];
-        ExecStart = "${cfg.package}/bin/swayidle ${concatStringsSep " " args}";
+        ExecStart = let
+          mkTimeout = t:
+            [ "timeout" (toString t.timeout) t.command ]
+            ++ optionals (t.resumeCommand != null) [ "resume" t.resumeCommand ];
+
+          mkEvent = e: [ e.event e.command ];
+
+          args = cfg.extraArgs ++ (concatMap mkTimeout cfg.timeouts)
+            ++ (concatMap mkEvent cfg.events);
+        in "${getExe cfg.package} ${escapeShellArgs args}";
       };
 
       Install = { WantedBy = [ cfg.systemdTarget ]; };


### PR DESCRIPTION
### Description

Mostly just code rearrangement, usage of `getExe`, and making the test more explicit.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@c0deaddict 
