### PR TITLE
gpg-agent: prevent nushell crashing on non-interactive sessions

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -23,7 +23,9 @@ let
   '' + optionalString cfg.enableSshSupport gpgSshSupportStr;
 
   gpgNushellInitStr = ''
-    $env.GPG_TTY = (tty)
+    if (is-terminal --stdin) {
+      $env.GPG_TTY = (tty)
+    }
   '' + optionalString cfg.enableSshSupport ''
     ${gpgPkg}/bin/gpg-connect-agent updatestartuptty /bye | ignore
 


### PR DESCRIPTION
### Description

This PR fixes nushell crashing when the session is not interactive.

This is usually not a problem, as non-interactive session don't source the config most of the time. But `nu --lsp` especifically _does_ source them, while not being interactive (and most importantly, not being attached to `stdin`).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 

