### PR TITLE
ci: disable the tests for macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,5 @@ jobs:
     - run: nix-shell --show-trace . -A install
     - run: yes | home-manager -I home-manager=. uninstall
     - run: nix-shell --show-trace --arg enableBig false --pure tests -A run.all
+      # Somebody please help us fix the macos tests.
+      if: matrix.os != 'macos-latest'


### PR DESCRIPTION


### Description

They have been broken for a long time now and makes the PR flow quite cumbersome. Thus we disable them until somebody is able to get them to work again.

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```