### PR TITLE
zsh: Add extraPackages option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -288,6 +288,13 @@ in
 
       package = mkPackageOption pkgs "zsh" { };
 
+      extraPackages = mkOption {
+        type = with types; listOf package;
+        example = literalExpression "with pkgs; [ libnotify ]";
+        description = "Extra packages available to zsh.";
+        default = [ ];
+      };
+
       autocd = mkOption {
         default = null;
         description = ''
@@ -593,6 +600,7 @@ in
 
     {
       home.packages = [ cfg.package ]
+        ++ cfg.extraPackages
         ++ optional cfg.enableCompletion pkgs.nix-zsh-completions
         ++ optional cfg.oh-my-zsh.enable cfg.oh-my-zsh.package;
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Certain plugins such as `bgnotify` expect certain binaries from system packages to be available on zsh's PATH. Add support for 'extraPackages' so additional packages can be added as needed.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@teto 