### PR TITLE
qt: use kwriteconfig6 in qt.kde.settings and actually call the tool

### DIFF
--- a/modules/misc/qt/kconfig.nix
+++ b/modules/misc/qt/kconfig.nix
@@ -17,13 +17,13 @@ in {
       powermanagementprofilesrc.AC.HandleButtonEvents.lidAction = 32;
     };
     description = ''
-      A set of values to be modified by {command}`kwriteconfig5`.
+      A set of values to be modified by {command}`kwriteconfig6`.
 
       The example value would cause the following command to run in the
       activation script:
 
       ``` shell
-      kwriteconfig5 --file $XDG_CONFIG_HOME/powermanagementprofilesrc \
+      kwriteconfig6 --file $XDG_CONFIG_HOME/powermanagementprofilesrc \
                     --group AC \
                     --group HandleButtonEvents \
                     --group lidAction \
@@ -53,7 +53,7 @@ in {
             lib.mapAttrsToList
             (group: value: toLine file (path ++ [ group ]) value) value
           else
-            "run test -f '${configHome}/${file}' && run ${pkgs.libsForQt5.kconfig}/bin/kwriteconfig5 --file '${configHome}/${file}' ${
+            "run ${pkgs.kdePackages.kconfig}/bin/kwriteconfig6 --file '${configHome}/${file}' ${
               lib.concatMapStringsSep " " (x: "--group ${x}")
               (lib.lists.init path)
             } --key '${lib.lists.last path}' ${toValue value}";
@@ -62,7 +62,7 @@ in {
       in builtins.concatStringsSep "\n" lines}
 
       # TODO: some way to only call the dbus calls needed
-      run ${pkgs.libsForQt5.qttools.bin}/bin/qdbus org.kde.KWin /KWin reconfigure || echo "KWin reconfigure failed"
+      run ${pkgs.kdePackages.qttools}/bin/qdbus org.kde.KWin /KWin reconfigure || echo "KWin reconfigure failed"
       # the actual values are https://github.com/KDE/plasma-workspace/blob/c97dddf20df5702eb429b37a8c10b2c2d8199d4e/kcms/kcms-common_p.h#L13
       for changeType in {0..10}; do
         # even if one of those calls fails the others keep running


### PR DESCRIPTION
### Description

Update to configuration tool for plasma6.

Not sure why we had this `test -f` in the activation code?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

cc @tschai-yim @thiagokokada @JulianFP 