### PR TITLE
direnv: work around nushell bug

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -141,12 +141,12 @@ in {
             | default []
             | append {||
                 let direnv = (
-                    try {
-                        ${getExe cfg.package} export json
-                    } catch {
-                        ""
-                    }
-                    | from json
+                    # We want to get the stdout from direnv even if it exits with non-zero,
+                    # because it will have the DIRENV_ internal variables defined.
+                    do { ${getExe cfg.package} export json }
+                    | complete
+                    | get stdout
+                    | from json --strict
                     | default {}
                 )
                 if ($direnv | is-empty) {

--- a/tests/modules/programs/direnv/nushell.nix
+++ b/tests/modules/programs/direnv/nushell.nix
@@ -13,7 +13,6 @@
       "home-files/.config/nushell/config.nu";
   in ''
     assertFileExists "${configFile}"
-    assertFileRegex "${configFile}" \
-      '^\s*/nix/store/.*direnv.*/bin/direnv export json$'
+    assertFileRegex "${configFile}" '/nix/store/.*direnv.*/bin/direnv export json'
   '';
 }


### PR DESCRIPTION
### Description

try/catch in a pipeline does not always work correctly in 0.98, so use `do | complete` instead.

Upstream issue: https://github.com/nushell/nushell/issues/13868

Fixes #5880.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
