### PR TITLE
man: add mandoc and man-db options

### DIFF
--- a/modules/programs/man/man-db.nix
+++ b/modules/programs/man/man-db.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.programs.man;
+in {
+  options.programs.man.man-db.enable = mkOption {
+    type = types.bool;
+    default = true;
+    description = ''
+      Whether to enable man-db as the man page viewer.
+    '';
+  };
+
+  config = mkIf cfg.man-db.enable {
+    programs.man.package = mkDefault pkgs.man;
+
+    # This is mostly copy/pasted/adapted from NixOS' documentation.nix.
+    home.file = mkIf cfg.generateCaches {
+      ".manpath".text = let
+        # Generate a directory containing installed packages' manpages.
+        manualPages = pkgs.buildEnv {
+          name = "man-paths";
+          paths = config.home.packages;
+          pathsToLink = [ "/share/man" ];
+          extraOutputsToInstall = [ "man" ];
+          ignoreCollisions = true;
+        };
+
+        # Generate a database of all manpages in ${manualPages}.
+        manualCache = pkgs.runCommandLocal "man-cache" {
+          nativeBuildInputs = [ cfg.package ];
+        } ''
+          # Generate a temporary man.conf so mandb knows where to
+          # write cache files.
+          echo "MANDB_MAP ${manualPages}/share/man $out" > man.conf
+
+          # Run mandb to generate cache files:
+          mandb -C man.conf --no-straycats --create \
+            ${manualPages}/share/man
+        '';
+      in ''
+        MANDB_MAP ${config.home.profileDirectory}/share/man ${manualCache}
+      '';
+    };
+  };
+}

--- a/modules/programs/man/mandoc.nix
+++ b/modules/programs/man/mandoc.nix
@@ -1,0 +1,34 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.programs.man;
+in {
+  options.programs.man.mandoc.enable = mkOption {
+    type = types.bool;
+    default = false;
+    description = ''
+      Whether to enable mandoc as the man page viewer.
+    '';
+  };
+
+  config = mkIf cfg.mandoc.enable (mkMerge [
+    { programs.man.package = mkDefault pkgs.mandoc; }
+    (mkIf cfg.generateCaches {
+      home.activation.generateMandocDB = hm.dag.entryAfter [ "writeBoundary" ]
+        (let
+          makewhatis = "${getBin cfg.package}/bin/makewhatis";
+
+          manualPages = pkgs.buildEnv {
+            name = "man-paths";
+            paths = config.home.packages;
+            pathsToLink = [ "/share/man" ];
+            extraOutputsToInstall = [ "man" ];
+            ignoreCollisions = true;
+          };
+        in ''
+          ${makewhatis} ''${DRY_RUN:+-n} ''${VERBOSE:+-Dp} -T utf8 ${manualPages} 2>&1
+        '');
+    })
+  ]);
+}


### PR DESCRIPTION
### Description

This PR adds 2 additional options `programs.man.mandoc.enable` and `programs.man.man-db.enable`, affecting script run to generate the index of man pages. To keep the change backward compatible, `programs.man.package` is reused for both cases.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 