### PR TITLE
direnv: even better nushell fix

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -143,9 +143,9 @@ in {
                 let direnv = (
                     # We want to get the stdout from direnv even if it exits with non-zero,
                     # because it will have the DIRENV_ internal variables defined.
-                    do { ${getExe cfg.package} export json }
-                    | complete
-                    | get stdout
+                    do --ignore-program-errors { ${
+                      getExe cfg.package
+                    } export json }
                     | from json --strict
                     | default {}
                 )


### PR DESCRIPTION
### Description

Avoid do | complete, because it swallows stderr, which can contain direnv debug output.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
