### PR TITLE
direnv: hopefully final nushell fix

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -130,46 +130,64 @@ in {
         ${getExe cfg.package} hook fish | source
       '');
 
-    programs.nushell.extraConfig = mkIf cfg.enableNushellIntegration (
+    programs.nushell.extraConfig = mkIf cfg.enableNushellIntegration (let
+      # We want to get the stdout from direnv even if it exits with non-zero,
+      # because it will have the DIRENV_ internal variables defined.
+      #
+      # However, nushell's current implementation of try-catch is subtly
+      # broken with external commands in pipelines[0].
+      #
+      # This means we don't have a good way to ignore the exit code
+      # without using do | complete, which has a side effect of also
+      # capturing stderr, which we don't want.
+      #
+      # So, as a workaround, we wrap nushell in a second script that
+      # just ignores the exit code and does nothing else, allowing
+      # nushell to capture our stdout, but letting stderr go through
+      # and not causing a spurious "command failed" message.
+      #
+      # [0]: https://github.com/nushell/nushell/issues/13868
+      #
+      # FIXME: remove the wrapper once the upstream issue is fixed
+
+      direnvWrapped = pkgs.writeShellScript "direnv-wrapped" ''
+        ${getExe cfg.package} export json || true
+      '';
       # Using mkAfter to make it more likely to appear after other
       # manipulations of the prompt.
-      mkAfter ''
-        $env.config = ($env.config? | default {})
-        $env.config.hooks = ($env.config.hooks? | default {})
-        $env.config.hooks.pre_prompt = (
-            $env.config.hooks.pre_prompt?
-            | default []
-            | append {||
-                let direnv = (
-                    # We want to get the stdout from direnv even if it exits with non-zero,
-                    # because it will have the DIRENV_ internal variables defined.
-                    do --ignore-program-errors { ${
-                      getExe cfg.package
-                    } export json }
-                    | from json --strict
-                    | default {}
-                )
-                if ($direnv | is-empty) {
-                    return
-                }
-                $direnv
-                | items {|key, value|
-                    {
-                        key: $key
-                        value: (do (
-                            $env.ENV_CONVERSIONS?
-                            | default {}
-                            | get -i $key
-                            | get -i from_string
-                            | default {|x| $x}
-                        ) $value)
-                    }
-                }
-                | transpose -ird
-                | load-env
-            }
-        )
-      '');
+    in mkAfter ''
+      $env.config = ($env.config? | default {})
+      $env.config.hooks = ($env.config.hooks? | default {})
+      $env.config.hooks.pre_prompt = (
+          $env.config.hooks.pre_prompt?
+          | default []
+          | append {||
+              let direnv = (
+                  ${direnvWrapped}
+                  | from json --strict
+                  | default {}
+              )
+              if ($direnv | is-empty) {
+                  return
+              }
+              $direnv
+              | items {|key, value|
+                  {
+                      key: $key
+                      value: (do (
+                          $env.ENV_CONVERSIONS?
+                          | default {}
+                          | get -i $key
+                          | get -i from_string
+                          | default {|x| $x}
+                      ) $value)
+                  }
+              }
+              | transpose -ird
+              | load-env
+          }
+      )
+    '');
 
     home.sessionVariables = lib.mkIf cfg.silent { DIRENV_LOG_FORMAT = ""; };
   };

--- a/tests/modules/programs/direnv/nushell.nix
+++ b/tests/modules/programs/direnv/nushell.nix
@@ -13,6 +13,6 @@
       "home-files/.config/nushell/config.nu";
   in ''
     assertFileExists "${configFile}"
-    assertFileRegex "${configFile}" '/nix/store/.*direnv.*/bin/direnv export json'
+    assertFileRegex "${configFile}" '/nix/store/.*direnv-wrapped'
   '';
 }


### PR DESCRIPTION
### Description

I hate this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
