### PR TITLE
river: reduce risk of large rebuilds in test

### DIFF
--- a/tests/modules/services/window-managers/river/configuration.nix
+++ b/tests/modules/services/window-managers/river/configuration.nix
@@ -79,7 +79,6 @@
   };
 
   test.stubs = {
-    dbus = { };
     river = { };
     xwayland = { };
   };

--- a/tests/modules/services/window-managers/river/init
+++ b/tests/modules/services/window-managers/river/init
@@ -62,6 +62,6 @@ extra config
 
 
 ### SYSTEMD INTEGRATION ###
-@dbus@/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP NIXOS_OZONE_WL XCURSOR_THEME XCURSOR_SIZE && systemctl --user stop river-session.target && systemctl --user start river-session.target
+/nix/store/00000000000000000000000000000000-dbus/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY XDG_CURRENT_DESKTOP NIXOS_OZONE_WL XCURSOR_THEME XCURSOR_SIZE && systemctl --user stop river-session.target && systemctl --user start river-session.target
 
 


### PR DESCRIPTION
### Description

Specifically, overriding the dbus package can cause rebuilds of many packages.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```