### PR TITLE
waylogout: added configuration module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -708,4 +708,10 @@
     github = "ipsavitsky";
     githubId = 33558632;
   };
+  noodlez = {
+    name = "Nathaniel Barragan";
+    email = "contact@nathanielbarragan.xyz";
+    github = "Noodlez1232";
+    githubId = 12480453;
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -269,6 +269,7 @@ let
     ./programs/pywal.nix
     ./programs/rbenv.nix
     ./programs/watson.nix
+    ./programs/waylogout.nix
     ./programs/waybar.nix
     ./programs/wezterm.nix
     ./programs/wlogout.nix

--- a/modules/programs/waylogout.nix
+++ b/modules/programs/waylogout.nix
@@ -1,13 +1,10 @@
 { pkgs, config, lib, ... }:
-
-with lib;
-
 let cfg = config.programs.waylogout;
 in {
-  meta.maintainers = [ hm.maintainers.noodlez ];
+  meta.maintainers = [ lib.hm.maintainers.noodlez ];
 
   options.programs.waylogout = {
-    enable = mkOption {
+    enable = lib.mkOption {
       default = false;
       type = lib.types.bool;
       example = true;
@@ -16,10 +13,10 @@ in {
       '';
     };
 
-    package = mkPackageOption pkgs "waylogout" { };
+    package = lib.mkPackageOption pkgs "waylogout" { };
 
-    settings = mkOption {
-      type = with types; attrsOf (oneOf [ bool float int str ]);
+    settings = lib.mkOption {
+      type = with lib.types; attrsOf (oneOf [ bool float int str ]);
       default = { };
       description = ''
         Default arguments to {command}`waylogout`. An empty set
@@ -36,7 +33,7 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       (lib.hm.assertions.assertPlatform "programs.waylogout" pkgs
         lib.platforms.linux)
@@ -44,8 +41,8 @@ in {
 
     home.packages = [ cfg.package ];
 
-    xdg.configFile."waylogout/config" = mkIf (cfg.settings != { }) {
-      text = concatStrings (mapAttrsToList (n: v:
+    xdg.configFile."waylogout/config" = lib.mkIf (cfg.settings != { }) {
+      text = lib.concatStrings (lib.mapAttrsToList (n: v:
         if v == false then
           ""
         else

--- a/modules/programs/waylogout.nix
+++ b/modules/programs/waylogout.nix
@@ -16,7 +16,7 @@ in {
     package = lib.mkPackageOption pkgs "waylogout" { nullable = true; };
 
     settings = lib.mkOption {
-      type = with lib.types; attrsOf (oneOf [ bool float int str ]);
+      type = with lib.types; attrsOf (oneOf [ bool float int path str ]);
       default = { };
       description = ''
         Default arguments to {command}`waylogout`. An empty set

--- a/modules/programs/waylogout.nix
+++ b/modules/programs/waylogout.nix
@@ -13,7 +13,7 @@ in {
       '';
     };
 
-    package = lib.mkPackageOption pkgs "waylogout" { };
+    package = lib.mkPackageOption pkgs "waylogout" { nullable = true; };
 
     settings = lib.mkOption {
       type = with lib.types; attrsOf (oneOf [ bool float int str ]);
@@ -39,7 +39,7 @@ in {
         lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."waylogout/config" = lib.mkIf (cfg.settings != { }) {
       text = lib.concatStrings (lib.mapAttrsToList (n: v:

--- a/modules/programs/waylogout.nix
+++ b/modules/programs/waylogout.nix
@@ -1,0 +1,56 @@
+{ pkgs, config, lib, ... }:
+
+with lib;
+
+let cfg = config.programs.waylogout;
+in {
+  meta.maintainers = [ hm.maintainers.noodlez ];
+
+  options.programs.waylogout = {
+    enable = mkOption {
+      default = false;
+      type = lib.types.bool;
+      example = true;
+      description = ''
+        Whether or not to enable waylogout.
+      '';
+    };
+
+    package = mkPackageOption pkgs "waylogout" { };
+
+    settings = mkOption {
+      type = with types; attrsOf (oneOf [ bool float int str ]);
+      default = { };
+      description = ''
+        Default arguments to {command}`waylogout`. An empty set
+        disables configuration generation.
+      '';
+      example = {
+        color = "808080";
+        poweroff-command = "systemctl poweroff";
+        reboot-command = "systemctl reboot";
+        scaling = "fit";
+        effect-blur = "7x4";
+        screenshots = true;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.waylogout" pkgs
+        lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."waylogout/config" = mkIf (cfg.settings != { }) {
+      text = concatStrings (mapAttrsToList (n: v:
+        if v == false then
+          ""
+        else
+          (if v == true then n else n + "=" + builtins.toString v) + "\n")
+        cfg.settings);
+    };
+  };
+}


### PR DESCRIPTION
90% of the code is copied over from swaylock so thanks to the creator of that module!

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
