### PR TITLE
Fix gpg-agent sockets on darwin

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -358,7 +358,8 @@ in {
           enable = true;
           config = {
             # macOS doesn't like the "--supervised" option
-            ProgramArguments = [ "${gpgPkg}/bin/gpgconf" "--launch" "gpg-agent" ]
+            ProgramArguments =
+              [ "${gpgPkg}/bin/gpgconf" "--launch" "gpg-agent" ]
               ++ optionals cfg.verbose [ "--verbose" ];
             EnvironmentVariables = { GNUPGHOME = homedir; };
             KeepAlive = {

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -280,8 +280,11 @@ in {
           "pinentry-program ${lib.getExe cfg.pinentryPackage}"
           ++ [ cfg.extraConfig ]);
 
+      # Make sure we export GnuPG agent socket for SSH
+      # https://www.gnupg.org/documentation/manuals/gnupg/Agent-Examples.html#Agent-Examples
       home.sessionVariablesExtra = optionalString cfg.enableSshSupport ''
-        if [[ -z "$SSH_AUTH_SOCK" ]]; then
+        unset SSH_AGENT_PID
+        if [ "''${gnupg_SSH_AUTH_SOCK_by:-0}" -ne $$ ]; then
           export SSH_AUTH_SOCK="$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)"
         fi
       '';

--- a/tests/modules/services/gpg-agent/expected-agent.plist
+++ b/tests/modules/services/gpg-agent/expected-agent.plist
@@ -32,7 +32,7 @@
 			<key>SockPathMode</key>
 			<integer>384</integer>
 			<key>SockPathName</key>
-			<string>/private/var/run/org.nix-community.home.gpg-agent/d.wp4h7ks5zxy4dodqadgpbbpz/S.gpg-agent</string>
+			<string>/path/to/hash/d.wp4h7ks5zxy4dodqadgpbbpz/S.gpg-agent</string>
 			<key>SockType</key>
 			<string>stream</string>
 		</dict>

--- a/tests/modules/services/gpg-agent/expected-agent.plist
+++ b/tests/modules/services/gpg-agent/expected-agent.plist
@@ -20,8 +20,9 @@
 	<string>Background</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>@gpg@/bin/gpg-agent</string>
-		<string>--supervised</string>
+		<string>@gpg@/bin/gpgconf</string>
+		<string>--launch</string>
+		<string>gpg-agent</string>
 	</array>
 	<key>RunAtLoad</key>
 	<false/>


### PR DESCRIPTION
### Description

This fixes a couple of issues with https://github.com/nix-community/home-manager/pull/5786 that uses launchd on darwin to start the gpg-agent daemon and its sockets. In particular, the issues outlined by @cmacrae.

1. Always export `$SSH_AUTH_SOCK` when using gpg-agent as ssh agent.
2. Use canonical socket paths on darwin
3. Replace deprecated `--supervised` option with `--daemon` using `gpgconf --launch` on darwin

Fixes: https://github.com/nix-community/home-manager/issues/3864

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee