### PR TITLE
Nushell generator

### DIFF
--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -14,4 +14,5 @@ rec {
 
   shell = import ./shell.nix { inherit lib; };
   zsh = import ./zsh.nix { inherit lib; };
+  nushell = import ./nushell.nix { inherit lib; };
 }

--- a/modules/lib/nushell.nix
+++ b/modules/lib/nushell.nix
@@ -1,0 +1,65 @@
+{ lib }: rec {
+  mkNushellInline = expr: lib.setType "nushell-inline" { inherit expr; };
+
+  toNushell = { indent ? "", multiline ? true, asBindings ? false }@args:
+    v:
+    let
+      innerIndent = "${indent}    ";
+      introSpace = if multiline then ''
+
+        ${innerIndent}'' else
+        " ";
+      outroSpace = if multiline then ''
+
+        ${indent}'' else
+        " ";
+      innerArgs = args // {
+        indent = if asBindings then indent else innerIndent;
+        asBindings = false;
+      };
+      concatItems = lib.concatStringsSep introSpace;
+      isNushellInline = lib.isType "nushell-inline";
+
+      generatedBindings = assert lib.assertMsg (badVarNames == [ ])
+        "Bad Nushell variable names: ${
+          lib.generators.toPretty { } badVarNames
+        }";
+        lib.concatStrings (lib.mapAttrsToList (key: value: ''
+          ${indent}let ${key} = ${toNushell innerArgs value}
+        '') v);
+
+      isBadVarName = name:
+        # Extracted from https://github.com/nushell/nushell/blob/ebc7b80c23f777f70c5053cca428226b3fe00d30/crates/nu-parser/src/parser.rs#L33
+        # Variables with numeric or even empty names are allowed. The only requisite is not containing any of the following characters
+        let invalidVariableCharacters = ".[({+-*^/=!<>&|";
+        in lib.match "^[$]?[^${lib.escapeRegex invalidVariableCharacters}]+$"
+        name == null;
+      badVarNames = lib.filter isBadVarName (builtins.attrNames v);
+    in if asBindings then
+      generatedBindings
+    else if v == null then
+      "null"
+    else if lib.isInt v || lib.isFloat v || lib.isString v || lib.isBool v then
+      lib.strings.toJSON v
+    else if lib.isList v then
+      (if v == [ ] then
+        "[]"
+      else
+        "[${introSpace}${
+          concatItems (map (value: "${toNushell innerArgs value}") v)
+        }${outroSpace}]")
+    else if lib.isAttrs v then
+      (if isNushellInline v then
+        "(${v.expr})"
+      else if v == { } then
+        "{}"
+      else if lib.isDerivation v then
+        toString v
+      else
+        "{${introSpace}${
+          concatItems (lib.mapAttrsToList (key: value:
+            "${lib.strings.toJSON key}: ${toNushell innerArgs value}") v)
+        }${outroSpace}}")
+    else
+      abort "nushell.toNushell: type ${lib.typeOf v} is unsupported";
+}

--- a/modules/lib/types.nix
+++ b/modules/lib/types.nix
@@ -107,4 +107,27 @@ in rec {
         mergeDefaultOption loc defs;
   };
 
+  nushellValue = let
+    valueType = types.nullOr (types.oneOf [
+      (lib.mkOptionType {
+        name = "nushell";
+        description = "Nushell inline value";
+        descriptionClass = "name";
+        check = lib.isType "nushell-inline";
+      })
+      types.bool
+      types.int
+      types.float
+      types.str
+      types.path
+      (types.attrsOf valueType // {
+        description = "attribute set of Nushell values";
+        descriptionClass = "name";
+      })
+      (types.listOf valueType // {
+        description = "list of Nushell values";
+        descriptionClass = "name";
+      })
+    ]);
+  in valueType;
 }

--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -145,11 +145,24 @@ in {
     };
 
     environmentVariables = mkOption {
-      type = types.attrsOf types.str;
+      type = types.attrsOf hm.types.nushellValue;
       default = { };
-      example = { FOO = "BAR"; };
+      example = literalExpression ''
+        {
+          FOO = "BAR";
+          LIST_VALUE = [ "foo" "bar" ];
+          NU_LIB_DIRS = lib.concatStringsSep ":" [ ./scripts ];
+          PROMPT_COMMAND = lib.hm.nushell.mkNushellInline '''{|| "> "}''';
+          ENV_CONVERSIONS.PATH = {
+            from_string = lib.hm.nushell.mkNushellInline "{|s| $s | split row (char esep) }";
+            to_string = lib.hm.nushell.mkNushellInline "{|v| $v | str join (char esep) }";
+          };
+        }
+      '';
       description = ''
-        An attribute set that maps an environment variable to a shell interpreted string.
+        Environment variables to be set.
+
+        Inline values can be set with `lib.hm.nushell.mkNushellInline`.
       '';
     };
   };
@@ -173,9 +186,11 @@ in {
       })
 
       (let
-        envVarsStr = concatStringsSep "\n"
-          (mapAttrsToList (k: v: "$env.${k} = ${v}") cfg.environmentVariables);
-      in mkIf (cfg.envFile != null || cfg.extraEnv != "" || envVarsStr != "") {
+        hasEnvVars = cfg.environmentVariables != { };
+        envVarsStr = ''
+          load-env ${hm.nushell.toNushell { } cfg.environmentVariables}
+        '';
+      in mkIf (cfg.envFile != null || cfg.extraEnv != "" || hasEnvVars) {
         "${configDir}/env.nu".text = mkMerge [
           (mkIf (cfg.envFile != null) cfg.envFile.text)
           cfg.extraEnv

--- a/modules/programs/nushell.nix
+++ b/modules/programs/nushell.nix
@@ -39,7 +39,7 @@ let
       };
     });
 in {
-  meta.maintainers = [ maintainers.Philipp-M ];
+  meta.maintainers = [ maintainers.Philipp-M maintainers.joaquintrinanes ];
 
   imports = [
     (mkRemovedOptionModule [ "programs" "nushell" "settings" ] ''

--- a/tests/modules/programs/nushell/env-expected.nu
+++ b/tests/modules/programs/nushell/env-expected.nu
@@ -1,4 +1,17 @@
 $env.FOO = 'BAR'
 
 
-$env.BAR = $'(echo BAZ)'
+load-env {
+    "ENV_CONVERSIONS": {
+        "PATH": {
+            "from_string": ({|s| $s | split row (char esep) })
+            "to_string": ({|v| $v | str join (char esep) })
+        }
+    }
+    "FOO": "BAR"
+    "LIST_VALUE": [
+        "foo"
+        "bar"
+    ]
+    "PROMPT_COMMAND": ({|| "> "})
+}

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, ... }:
+{ pkgs, config, lib, ... }:
 
 {
   programs.nushell = {
@@ -28,7 +28,17 @@
       "ll" = "ls -a";
     };
 
-    environmentVariables = { BAR = "$'(echo BAZ)'"; };
+    environmentVariables = {
+      FOO = "BAR";
+      LIST_VALUE = [ "foo" "bar" ];
+      PROMPT_COMMAND = lib.hm.nushell.mkNushellInline ''{|| "> "}'';
+      ENV_CONVERSIONS.PATH = {
+        from_string =
+          lib.hm.nushell.mkNushellInline "{|s| $s | split row (char esep) }";
+        to_string =
+          lib.hm.nushell.mkNushellInline "{|v| $v | str join (char esep) }";
+      };
+    };
   };
 
   test.stubs.nushell = { };


### PR DESCRIPTION
### Description

This PR supersedes #5795.

It adds a nushell generator that works with basic primitive types, records and lists. It also adds a `nushell-inline` to allow generating nushell code instead of strings.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Philipp-M @rycee 
