### PR TITLE
programs.borgmatic: note Darwin platform support

### DIFF
--- a/modules/programs/borgmatic.nix
+++ b/modules/programs/borgmatic.nix
@@ -272,10 +272,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      (lib.hm.assertions.assertPlatform "programs.borgmatic" pkgs
-        lib.platforms.linux)
-    ] ++ (mapAttrsToList (backup: opts: {
+    assertions = (mapAttrsToList (backup: opts: {
       assertion = opts.location.sourceDirectories == null
         || opts.location.patterns == null;
       message = ''

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -60,6 +60,7 @@ in import nmtSrc {
     ./modules/programs/bacon
     ./modules/programs/bash
     ./modules/programs/bat
+    ./modules/programs/borgmatic
     ./modules/programs/bottom
     ./modules/programs/broot
     ./modules/programs/browserpass
@@ -189,7 +190,6 @@ in import nmtSrc {
     ./modules/programs/awscli
     ./modules/programs/beets # One test relies on services.mpd
     ./modules/programs/bemenu
-    ./modules/programs/borgmatic
     ./modules/programs/boxxy
     ./modules/programs/firefox/firefox.nix
     ./modules/programs/foot


### PR DESCRIPTION

### Description

The current borgmatic module works on Darwin as-is;
mark the platform as supported.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [N/A] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [N/A] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@DamienCassou 
