### PR TITLE
home-manager/default.nix: improve package definition

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -17,16 +17,24 @@ let
     (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { });
 
 in stdenvNoCC.mkDerivation (finalAttrs: {
-  name = "home-manager";
+  pname = "home-manager";
+  name = finalAttrs.pname; # without `version`
   inherit src;
   preferLocalBuild = true;
   nativeBuildInputs = [ gettext installShellFiles ];
-  meta = with lib; {
+  meta = {
     mainProgram = "home-manager";
-    description = "A user environment configurator";
-    maintainers = [ maintainers.rycee ];
-    platforms = platforms.unix;
-    license = licenses.mit;
+    description = "Nix-based user environment configurator";
+    maintainers = [ lib.maintainers.rycee ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mit;
+    homepage = "https://nix-community.github.io/home-manager/";
+    longDescription = ''
+      The Home-Manager project provides a basic system for managing a user
+      environment using the Nix package manager together with the Nix libraries
+      found in Nixpkgs. It allows declarative configuration of user specific
+      (non global) packages and dotfiles.
+    '';
   };
 dontConfigure = true;
 dontBuild = true;

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -36,6 +36,21 @@ installPhase = ''
   install -v -D -m755 home-manager/home-manager $out/bin/home-manager
   install -v -D -m755 lib/bash/home-manager.sh $out/share/bash/home-manager.sh
 
+  installShellCompletion --cmd home-manager \
+    --bash home-manager/completion.bash \
+    --fish home-manager/completion.fish \
+    --zsh home-manager/completion.zsh
+
+  for pofile in home-manager/po/*.po; do
+    lang="''${pofile##*/}"
+    lang="''${lang%%.*}"
+    mkdir -p "$out/share/locale/$lang/LC_MESSAGES"
+    msgfmt -o "$out/share/locale/$lang/LC_MESSAGES/home-manager.mo" "$pofile"
+  done
+
+  runHook postInstall
+'';
+postFixup = ''
   substituteInPlace $out/bin/home-manager \
     --subst-var-by bash "${bash}" \
     --subst-var-by DEP_PATH "${
@@ -54,19 +69,5 @@ installPhase = ''
     --subst-var-by HOME_MANAGER_LIB "$out/share/bash/home-manager.sh" \
     --subst-var-by HOME_MANAGER_PATH "${pathStr}" \
     --subst-var-by OUT "$out"
-
-  installShellCompletion --cmd home-manager \
-    --bash home-manager/completion.bash \
-    --fish home-manager/completion.fish \
-    --zsh home-manager/completion.zsh
-
-  for pofile in home-manager/po/*.po; do
-    lang="''${pofile##*/}"
-    lang="''${lang%%.*}"
-    mkdir -p "$out/share/locale/$lang/LC_MESSAGES"
-    msgfmt -o "$out/share/locale/$lang/LC_MESSAGES/home-manager.mo" "$pofile"
-  done
-
-  runHook postInstall
 '';
 })

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -1,81 +1,105 @@
-{ stdenvNoCC, lib, bash, callPackage, coreutils, findutils, gettext, gnused, jq
-, less, ncurses, inetutils
-# used for pkgs.path for nixos-option
-, pkgs
+{ lib
+, bash
+, callPackage
+, coreutils
+, findutils
+, gettext
+, gnused
+, inetutils
 , installShellFiles
-
-# Path to use as the Home Manager channel.
-, path ? null }:
+, jq
+, less
+, ncurses
+, stdenvNoCC
+, pkgs # used for pkgs.path for nixos-option
+, path ? null # Path to use as the Home Manager channel.
+}:
 
 let
 
   src = ../.;
-  pathStr = if path == null then "" else
-    if path == pkgs.path /* `path` is not passed to `callPackage` */ then "${src}" else path;
+  pathStr = if path == null then
+    ""
+  else if path == pkgs.path # `path` is not passed to `callPackage`
+  then
+    "${src}"
+  else
+    path;
 
   nixos-option = pkgs.nixos-option or (callPackage
     (pkgs.path + "/nixos/modules/installer/tools/nixos-option") { });
 
-in stdenvNoCC.mkDerivation (finalAttrs: {
+in
+
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "home-manager";
   name = finalAttrs.pname; # without `version`
+
   inherit src;
   preferLocalBuild = true;
-  nativeBuildInputs = [ gettext installShellFiles ];
+
+  nativeBuildInputs = [
+    gettext
+    installShellFiles
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -v -D -m755 home-manager/home-manager $out/bin/home-manager
+    install -v -D -m755 lib/bash/home-manager.sh $out/share/bash/home-manager.sh
+
+    installShellCompletion --cmd home-manager \
+      --bash home-manager/completion.bash \
+      --fish home-manager/completion.fish \
+      --zsh home-manager/completion.zsh
+
+    for pofile in home-manager/po/*.po; do
+      lang="''${pofile##*/}"
+      lang="''${lang%%.*}"
+      mkdir -p "$out/share/locale/$lang/LC_MESSAGES"
+      msgfmt -o "$out/share/locale/$lang/LC_MESSAGES/home-manager.mo" "$pofile"
+    done
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/bin/home-manager \
+      --subst-var-by bash "${bash}" \
+      --subst-var-by DEP_PATH "${
+        lib.makeBinPath [
+          coreutils
+          findutils
+          gettext
+          gnused
+          jq
+          less
+          ncurses
+          nixos-option
+          inetutils # for `hostname`
+        ]
+      }" \
+      --subst-var-by HOME_MANAGER_LIB "$out/share/bash/home-manager.sh" \
+      --subst-var-by HOME_MANAGER_PATH "${pathStr}" \
+      --subst-var-by OUT "$out"
+  '';
+
   meta = {
-    mainProgram = "home-manager";
-    description = "Nix-based user environment configurator";
-    maintainers = [ lib.maintainers.rycee ];
-    platforms = lib.platforms.unix;
-    license = lib.licenses.mit;
     homepage = "https://nix-community.github.io/home-manager/";
+    description = "Nix-based user environment configurator";
     longDescription = ''
       The Home-Manager project provides a basic system for managing a user
       environment using the Nix package manager together with the Nix libraries
       found in Nixpkgs. It allows declarative configuration of user specific
       (non global) packages and dotfiles.
     '';
+    license = lib.licenses.mit;
+    mainProgram = "home-manager";
+    maintainers = [ lib.maintainers.rycee ];
+    platforms = lib.platforms.unix;
   };
-dontConfigure = true;
-dontBuild = true;
-installPhase = ''
-  runHook preInstall
-
-  install -v -D -m755 home-manager/home-manager $out/bin/home-manager
-  install -v -D -m755 lib/bash/home-manager.sh $out/share/bash/home-manager.sh
-
-  installShellCompletion --cmd home-manager \
-    --bash home-manager/completion.bash \
-    --fish home-manager/completion.fish \
-    --zsh home-manager/completion.zsh
-
-  for pofile in home-manager/po/*.po; do
-    lang="''${pofile##*/}"
-    lang="''${lang%%.*}"
-    mkdir -p "$out/share/locale/$lang/LC_MESSAGES"
-    msgfmt -o "$out/share/locale/$lang/LC_MESSAGES/home-manager.mo" "$pofile"
-  done
-
-  runHook postInstall
-'';
-postFixup = ''
-  substituteInPlace $out/bin/home-manager \
-    --subst-var-by bash "${bash}" \
-    --subst-var-by DEP_PATH "${
-      lib.makeBinPath [
-        coreutils
-        findutils
-        gettext
-        gnused
-        jq
-        less
-        ncurses
-        nixos-option
-        inetutils # for `hostname`
-      ]
-    }" \
-    --subst-var-by HOME_MANAGER_LIB "$out/share/bash/home-manager.sh" \
-    --subst-var-by HOME_MANAGER_PATH "${pathStr}" \
-    --subst-var-by OUT "$out"
-'';
 })


### PR DESCRIPTION
### Description

This is **experimental** and **not fully tested**. Comments are welcomed!

This PR tries to clean up `home-manager/default.nix` in the hope that it may be more easily reused in nixpkgs in the future. The important changes are organized in the first few commits (with meaningful diffs) while the final commit is purely formatting.

Currently, the home-manager package is defined separately here and in nixpkgs:
- https://github.com/nix-community/home-manager/blob/master/home-manager/default.nix
- https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ho/home-manager/package.nix

These are two very different package definitions, and it's easy to develop inconsistencies between them; changes must be ported back and forth, which is somewhat inconvenient and prone to error. This happened for the recent change of `unixtools -> inetutils`, in which we need to create two PRs for the fix to work across the board:

- https://github.com/nix-community/home-manager/pull/5738
- https://github.com/NixOS/nixpkgs/pull/344341

This PR aims to reduce the future workload of syncing the package definitions. I have also added myself to the maintainers of the nixpkgs expression [there](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ho/home-manager/package.nix) so that I can help with this in the future. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`, **with manual fixes to mimic the style of nixpkgs.**

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
nixpkgs @AndersonTorres 
