### PR TITLE
spotify-player: add support for actions

### DIFF
--- a/modules/programs/spotify-player.nix
+++ b/modules/programs/spotify-player.nix
@@ -1,12 +1,12 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib)
-    mkEnableOption mkPackageOption mkOption types literalExpression mkIf;
+  inherit (lib) mkEnableOption mkPackageOption mkOption literalExpression mkIf;
+  inherit (lib.types) listOf;
 
   cfg = config.programs.spotify-player;
   tomlFormat = pkgs.formats.toml { };
-
+  tomlType = tomlFormat.type;
 in {
   meta.maintainers = with lib.hm.maintainers; [ diniamo ];
 
@@ -16,7 +16,7 @@ in {
     package = mkPackageOption pkgs "spotify-player" { };
 
     settings = mkOption {
-      type = tomlFormat.type;
+      type = tomlType;
       default = { };
       example = literalExpression ''
         {
@@ -43,7 +43,7 @@ in {
     };
 
     themes = mkOption {
-      type = types.listOf tomlFormat.type;
+      type = listOf tomlType;
       default = [ ];
       example = literalExpression ''
         [
@@ -94,7 +94,7 @@ in {
     };
 
     keymaps = mkOption {
-      type = types.listOf tomlFormat.type;
+      type = listOf tomlType;
       default = [ ];
       example = literalExpression ''
         [
@@ -129,6 +129,36 @@ in {
         for the full list of options.
       '';
     };
+
+    actions = mkOption {
+      type = listOf tomlType;
+      default = [ ];
+      example = literalExpression ''
+        [
+          {
+            action = "GoToArtist";
+            key_sequence = "g A";
+          }
+          {
+            action = "GoToAlbum";
+            key_sequence = "g B";
+            target = "PlayingTrack";
+          }
+          {
+            action = "ToggleLiked";
+            key_sequence = "C-l";
+          }
+        ]
+      '';
+      description = ''
+        Configuration written to the `actions` field of
+        {file}`$XDG_CONFIG_HOME/spotify-player/keymap.toml`.
+
+        See
+        <https://github.com/aome510/spotify-player/blob/master/docs/config.md#actions>
+        for the full list of options.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -146,7 +176,7 @@ in {
 
       "spotify-player/keymap.toml" = mkIf (cfg.keymaps != [ ]) {
         source = tomlFormat.generate "spotify-player-keymap" {
-          inherit (cfg) keymaps;
+          inherit (cfg) keymaps actions;
         };
       };
     };

--- a/tests/modules/programs/spotify-player/keymap.toml
+++ b/tests/modules/programs/spotify-player/keymap.toml
@@ -1,3 +1,16 @@
+[[actions]]
+action = "GoToArtist"
+key_sequence = "g A"
+
+[[actions]]
+action = "GoToAlbum"
+key_sequence = "g B"
+target = "PlayingTrack"
+
+[[actions]]
+action = "ToggleLiked"
+key_sequence = "C-l"
+
 [[keymaps]]
 command = "NextTrack"
 key_sequence = "g n"

--- a/tests/modules/programs/spotify-player/settings.nix
+++ b/tests/modules/programs/spotify-player/settings.nix
@@ -87,6 +87,22 @@
         key_sequence = "q";
       }
     ];
+
+    actions = [
+      {
+        action = "GoToArtist";
+        key_sequence = "g A";
+      }
+      {
+        action = "GoToAlbum";
+        key_sequence = "g B";
+        target = "PlayingTrack";
+      }
+      {
+        action = "ToggleLiked";
+        key_sequence = "C-l";
+      }
+    ];
   };
 
   test.stubs.spotify-player = { };


### PR DESCRIPTION
### Description

Add support for configuring actions added in the new [v0.19.1](https://github.com/aome510/spotify-player/releases/tag/v0.19.1) release.

@repparw

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
