### PR TITLE
wpaperd: add systemd user service

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -601,4 +601,12 @@
     keys =
       [{ fingerprint = "BC82 4BB5 1656 D144 285E  A0EC D382 C4AF EECE AA90"; }];
   };
+  ivandimitrov8080 = {
+    name = "Ivan Dimitrov";
+    email = "ivan@idimitrov.dev";
+    github = "ivandimitrov8080";
+    githubId = 80976541;
+    keys =
+      [{ fingerprint = "C565 2E79 2A7A 9110 DFA7  F77D 0BDA D4B2 11C4 9294"; }];
+  };
 }

--- a/modules/programs/wpaperd.nix
+++ b/modules/programs/wpaperd.nix
@@ -6,7 +6,7 @@ let
   cfg = config.programs.wpaperd;
   tomlFormat = pkgs.formats.toml { };
 in {
-  meta.maintainers = [ hm.maintainers.Avimitin ];
+  meta.maintainers = with hm.maintainers; [ Avimitin ivandimitrov8080 ];
 
   options.programs.wpaperd = {
     enable = mkEnableOption "wpaperd";
@@ -44,6 +44,15 @@ in {
       "wpaperd/wallpaper.toml" = mkIf (cfg.settings != { }) {
         source = tomlFormat.generate "wpaperd-wallpaper" cfg.settings;
       };
+    };
+    systemd.user.services.wpaperd = {
+      Unit = {
+        Description = "Modern wallpaper daemon for Wayland";
+        After = "graphical-session-pre.target";
+        PartOf = "graphical-session.target";
+      };
+      Install.WantedBy = [ "graphical-session.target" ];
+      Service.ExecStart = [ "${cfg.package}/bin/wpaperd" ];
     };
   };
 }

--- a/tests/modules/programs/wpaperd/wpaperd-example-settings.nix
+++ b/tests/modules/programs/wpaperd/wpaperd-example-settings.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ pkgs, ... }:
 
 {
   config = {
@@ -21,6 +21,25 @@
     nmt.script = ''
       assertFileContent home-files/.config/wpaperd/wallpaper.toml \
         ${./wpaperd-expected-settings.toml}
+
+      serviceFile=home-files/.config/systemd/user/wpaperd.service
+      assertFileExists $serviceFile
+      assertFileContent $serviceFile \
+        ${
+          pkgs.writeText "wpaperd-expected.service" ''
+            [Install]
+            WantedBy=graphical-session.target
+
+            [Service]
+            ExecStart=${pkgs.wpaperd}/bin/wpaperd
+
+            [Unit]
+            After=graphical-session-pre.target
+            Description=Modern wallpaper daemon for Wayland
+            PartOf=graphical-session.target
+          ''
+        }
+
     '';
   };
 }


### PR DESCRIPTION
### Description
This adds a wpaperd systemd user service.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@Avimitin 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
