### PR TITLE
xdg-mime type package options

### DIFF
--- a/modules/misc/xdg-mime.nix
+++ b/modules/misc/xdg-mime.nix
@@ -5,33 +5,50 @@ with lib;
 let
 
   cfg = config.xdg.mime;
+  inherit (lib) getExe getExe';
 
 in {
   options = {
-    xdg.mime.enable = mkOption {
-      type = types.bool;
-      default = pkgs.stdenv.hostPlatform.isLinux;
-      defaultText =
-        literalExpression "true if host platform is Linux, false otherwise";
-      description = ''
-        Whether to install programs and files to support the
-        XDG Shared MIME-info specification and XDG MIME Applications
-        specification at
-        <https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html>
-        and
-        <https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html>,
-        respectively.
-      '';
+    xdg.mime = {
+      enable = mkOption {
+        type = types.bool;
+        default = pkgs.stdenv.hostPlatform.isLinux;
+        defaultText =
+          literalExpression "true if host platform is Linux, false otherwise";
+        description = ''
+          Whether to install programs and files to support the
+          XDG Shared MIME-info specification and XDG MIME Applications
+          specification at
+          <https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html>
+          and
+          <https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html>,
+          respectively.
+        '';
+      };
+
+      sharedMimeInfoPackage = mkOption {
+        type = types.package;
+        default = pkgs.shared-mime-info;
+        defaultText = literalExpression "pkgs.shared-mime-info";
+        description = "The package to use when running update-mime-database.";
+      };
+
+      desktopFileUtilsPackage = mkOption {
+        type = types.package;
+        default = pkgs.desktop-file-utils;
+        defaultText = literalExpression "pkgs.desktop-file-utils";
+        description =
+          "The package to use when running update-desktop-database.";
+      };
     };
   };
-
-  config = mkIf config.xdg.mime.enable {
+  config = mkIf cfg.enable {
     assertions =
       [ (hm.assertions.assertPlatform "xdg.mime" pkgs platforms.linux) ];
 
     home.packages = [
       # Explicitly install package to provide basic mime types.
-      pkgs.shared-mime-info
+      cfg.sharedMimeInfoPackage
 
       # Make sure the target directories will be real directories.
       (pkgs.runCommandLocal "dummy-xdg-mime-dirs1" { } ''
@@ -46,12 +63,12 @@ in {
       if [[ -w $out/share/mime && -w $out/share/mime/packages && -d $out/share/mime/packages ]]; then
         XDG_DATA_DIRS=$out/share \
         PKGSYSTEM_ENABLE_FSYNC=0 \
-        ${pkgs.buildPackages.shared-mime-info}/bin/update-mime-database \
+        ${getExe cfg.sharedMimeInfoPackage} \
           -V $out/share/mime > /dev/null
       fi
 
       if [[ -w $out/share/applications ]]; then
-        ${pkgs.buildPackages.desktop-file-utils}/bin/update-desktop-database \
+        ${getExe' cfg.desktopFileUtilsPackage "update-desktop-database"} \
           $out/share/applications
       fi
     '';

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -6,4 +6,7 @@
   xdg-default-locations = ./default-locations.nix;
   xdg-user-dirs-null = ./user-dirs-null.nix;
   xdg-portal = ./portal.nix;
+  xdg-mime = ./mime.nix;
+  xdg-mime-disabled = ./mime-disabled.nix;
+  xdg-mime-package = ./mime-packages.nix;
 }

--- a/tests/modules/misc/xdg/mime-disabled.nix
+++ b/tests/modules/misc/xdg/mime-disabled.nix
@@ -1,0 +1,10 @@
+{ ... }: {
+  config = {
+    xdg.mime.enable = false;
+    nmt.script = ''
+      # assert that neither application is run
+      assertPathNotExists home-path/share/applications/mimeinfo.cache
+      assertPathNotExists home-path/share/applications/mime
+    '';
+  };
+}

--- a/tests/modules/misc/xdg/mime-expected.cache
+++ b/tests/modules/misc/xdg/mime-expected.cache
@@ -1,0 +1,3 @@
+[MIME Cache]
+text/html=mime-test.desktop;
+text/xml=mime-test.desktop;

--- a/tests/modules/misc/xdg/mime-packages.nix
+++ b/tests/modules/misc/xdg/mime-packages.nix
@@ -1,0 +1,38 @@
+{ config, ... }:
+let inherit (config.lib.test) mkStubPackage;
+in {
+  config = {
+    xdg.mime.enable = true;
+    xdg.mime.sharedMimeInfoPackage = mkStubPackage {
+      name = "update-mime-database";
+      buildScript = ''
+        mkdir -p $out/bin
+        echo '#!/bin/sh' > $out/bin/update-mime-database
+        echo 'mkdir -p $out/share/mime && touch $out/share/mime/mime.cache' >> $out/bin/update-mime-database
+        chmod +x $out/bin/update-mime-database
+      '';
+    };
+    xdg.mime.desktopFileUtilsPackage = mkStubPackage {
+      name = "desktop-file-utils";
+      buildScript = ''
+        mkdir -p $out/bin
+        echo '#!/bin/sh' > $out/bin/update-desktop-database
+        echo 'mkdir -p $out/share/applications/ && ln -s ${
+          ./mime-expected.cache
+        } $out/share/applications/mimeinfo.cache' >> $out/bin/update-desktop-database
+        chmod +x $out/bin/update-desktop-database
+      '';
+    };
+    nmt.script = ''
+      assertFileExists home-path/share/applications/mimeinfo.cache # Check that update-desktop-database created file
+      # Check that update-desktop-database file matches expected
+      assertFileContent \
+      home-path/share/applications/mimeinfo.cache \
+        ${./mime-expected.cache}
+
+      assertDirectoryExists home-path/share/mime # Check that update-mime-database created directory
+      assertFileExists home-path/share/mime/mime.cache # Check that update-mime-database created file
+
+    '';
+  };
+}

--- a/tests/modules/misc/xdg/mime.nix
+++ b/tests/modules/misc/xdg/mime.nix
@@ -1,0 +1,24 @@
+{ ... }: {
+  config = {
+    xdg.mime.enable = true;
+    xdg.desktopEntries = {
+      mime-test = { # mime info test
+        name = "mime-test";
+        mimeType = [ "text/html" "text/xml" ];
+      };
+
+    };
+
+    nmt.script = ''
+      assertFileExists home-path/share/applications/mimeinfo.cache # Check that update-desktop-database created file
+      # Check that update-desktop-database file matches expected
+      assertFileContent \
+        home-path/share/applications/mimeinfo.cache \
+        ${./mime-expected.cache}
+
+      assertDirectoryExists home-path/share/mime # Check that update-mime-database created directory
+      assertDirectoryNotEmpty home-path/share/mime # Check that update-mime-database created files
+
+    '';
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds package options for `shared-mime-info` and `desktop-file-utils` for the purpose of allowing users to override the version in nixpkgs. This with overridden version of `shared-mime-info` should  resolve #4955, #5102, #4682, and possibly #4941. I also added a couple basic tests for the module. An example of using the override can be found at notalltim/home-manager-config#4. I did not see a maintainer let me know if I missed one.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
