### PR TITLE
waybar: support enable inspect from service

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -211,6 +211,17 @@ in {
       '';
     };
 
+    systemd.enableInspect = mkOption {
+      type = bool;
+      default = false;
+      example = true;
+      description = ''
+        Inspect objects and find their CSS classes, experiment with live CSS styles, and lookup the current value of CSS properties.
+
+        See <https://developer.gnome.org/documentation/tools/inspector.html>
+      '';
+    };
+
     style = mkOption {
       type = nullOr (either path lines);
       default = null;
@@ -324,6 +335,8 @@ in {
           ExecReload = "${pkgs.coreutils}/bin/kill -SIGUSR2 $MAINPID";
           Restart = "on-failure";
           KillMode = "mixed";
+        } // optionalAttrs cfg.systemd.enableInspect {
+          Environment = [ "GTK_DEBUG=interactive" ];
         };
 
         Install.WantedBy =


### PR DESCRIPTION
### Description

Support for passing `GTK_DEBUG` in the service to enable inspect

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@berbiche
