### PR TITLE
kitty: allow float values in settings

### DIFF
--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -6,7 +6,7 @@ let
 
   cfg = config.programs.kitty;
 
-  eitherStrBoolInt = with types; either str (either bool int);
+  settingsValueType = with types; oneOf [ str bool int float ];
 
   optionalPackage = opt:
     optional (opt != null && opt.package != null) opt.package;
@@ -83,7 +83,7 @@ in {
     };
 
     settings = mkOption {
-      type = types.attrsOf eitherStrBoolInt;
+      type = types.attrsOf settingsValueType;
       default = { };
       example = literalExpression ''
         {

--- a/tests/modules/programs/kitty/example-settings-expected.conf
+++ b/tests/modules/programs/kitty/example-settings-expected.conf
@@ -7,6 +7,7 @@ font_size 8
 # Shell integration is sourced and configured manually
 shell_integration no-rc
 
+background_opacity 0.500000
 enable_audio_bell no
 scrollback_lines 10000
 update_check_interval 0

--- a/tests/modules/programs/kitty/example-settings.nix
+++ b/tests/modules/programs/kitty/example-settings.nix
@@ -17,6 +17,7 @@ with lib;
         scrollback_lines = 10000;
         enable_audio_bell = false;
         update_check_interval = 0;
+        background_opacity = 0.5;
       };
 
       font.name = "DejaVu Sans";


### PR DESCRIPTION
### Description

Extends the values allowed in kitty settings to also include floating-point values, as upstream allows this in some settings.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
