### PR TITLE
kubecolor: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1837,6 +1837,16 @@ in {
           the same shell inside the new environment.
         '';
       }
+
+      {
+        time = "2024-12-01T19:34:04+00:00";
+        message = ''
+          A new module is available: 'programs.kubecolor'.
+
+          Kubecolor is a kubectl wrapper used to add colors to your kubectl
+          output.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -143,6 +143,7 @@ let
     ./programs/khard.nix
     ./programs/kitty.nix
     ./programs/kodi.nix
+    ./programs/kubecolor.nix
     ./programs/lazygit.nix
     ./programs/ledger.nix
     ./programs/less.nix

--- a/modules/programs/kubecolor.nix
+++ b/modules/programs/kubecolor.nix
@@ -1,0 +1,87 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.kubecolor;
+  yamlFormat = pkgs.formats.yaml { };
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+in {
+  meta.maintainers = with maintainers; [ ajgon ];
+
+  options.programs.kubecolor = {
+    enable = mkEnableOption "kubecolor - Colorize your kubectl output";
+
+    package = mkPackageOption pkgs "kubecolor" { };
+
+    enableAlias = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        When set to true, it will create an alias for kubectl pointing to
+        kubecolor, thus making kubecolor the default kubectl client.
+      '';
+    };
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = literalExpression ''
+        kubectl = lib.getExe pkgs.kubectl
+        preset = "dark";
+        paging = "auto";
+      '';
+      description = ''
+        Configuration written to {file}`~/.kube/color.yaml` (Linux)
+        or {file}`Library/Application Support/kube/color.yaml` (Darwin).
+        See <https://kubecolor.github.io/reference/config/> for supported
+        values.
+      '';
+    };
+  };
+
+  config = let
+    preferXdgDirectories = config.home.preferXdgDirectories
+      && (!isDarwin || config.xdg.enable);
+
+    # https://github.com/kubecolor/kubecolor/pull/145
+    configPathSuffix = if cfg.package.pname == "kubecolor"
+    && lib.strings.toInt (lib.versions.major cfg.package.version) == 0
+    && lib.strings.toInt (lib.versions.minor cfg.package.version) < 4 then
+      "kube/"
+    else
+      "kube/color.yaml";
+
+  in mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.sessionVariables = if preferXdgDirectories then {
+      KUBECOLOR_CONFIG = "${config.xdg.configHome}/${configPathSuffix}";
+    } else if isDarwin then {
+      KUBECOLOR_CONFIG =
+        "${config.home.homeDirectory}/Library/Application Support/${configPathSuffix}";
+    } else
+      { };
+
+    xdg.configFile = mkIf preferXdgDirectories {
+      "kube/color.yaml" = mkIf (cfg.settings != { }) {
+        source = yamlFormat.generate "kubecolor-settings" cfg.settings;
+      };
+    };
+
+    home.file = mkIf (!preferXdgDirectories) {
+      "Library/Application Support/kube/color.yaml" =
+        mkIf (isDarwin && cfg.settings != { }) {
+          source = yamlFormat.generate "kubecolor-settings" cfg.settings;
+        };
+      ".kube/color.yaml" = mkIf (!isDarwin && cfg.settings != { }) {
+        source = yamlFormat.generate "kubecolor-settings" cfg.settings;
+      };
+    };
+
+    home.shellAliases =
+      lib.mkIf cfg.enableAlias { kubectl = lib.getExe cfg.package; };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -98,6 +98,7 @@ in import nmtSrc {
     ./modules/programs/khal
     ./modules/programs/khard
     ./modules/programs/kitty
+    ./modules/programs/kubecolor
     ./modules/programs/ledger
     ./modules/programs/less
     ./modules/programs/lf

--- a/tests/modules/programs/kubecolor/default.nix
+++ b/tests/modules/programs/kubecolor/default.nix
@@ -1,0 +1,5 @@
+{
+  kubecolor-empty-config = ./empty-config.nix;
+  kubecolor-example-config-default-paths = ./example-config-default-paths.nix;
+  kubecolor-example-config-xdg-paths = ./example-config-xdg-paths.nix;
+}

--- a/tests/modules/programs/kubecolor/empty-config.nix
+++ b/tests/modules/programs/kubecolor/empty-config.nix
@@ -1,0 +1,20 @@
+{ pkgs, config, ... }:
+
+let
+  configDir =
+    if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+in {
+  programs.kubecolor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "kubecolor";
+      version = "0.4.0";
+    };
+  };
+
+  test.stubs.kubecolor = { };
+
+  nmt.script = ''
+    assertPathNotExists 'home-files/${configDir}/kube/color.yaml'
+  '';
+}

--- a/tests/modules/programs/kubecolor/example-config-default-paths.nix
+++ b/tests/modules/programs/kubecolor/example-config-default-paths.nix
@@ -1,0 +1,37 @@
+{ pkgs, config, ... }:
+
+let
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Application Support/kube"
+  else
+    ".kube";
+in {
+  programs.kubecolor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "kubecolor";
+      version = "0.4.0";
+    };
+    settings = {
+      kubectl = "kubectl";
+      preset = "dark";
+      objFreshThreshold = 0;
+      paging = "auto";
+      pager = "less";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists 'home-files/${configDir}/color.yaml'
+    assertFileContent 'home-files/${configDir}/color.yaml' \
+      ${
+        builtins.toFile "expected.yaml" ''
+          kubectl: kubectl
+          objFreshThreshold: 0
+          pager: less
+          paging: auto
+          preset: dark
+        ''
+      }
+  '';
+}

--- a/tests/modules/programs/kubecolor/example-config-xdg-paths.nix
+++ b/tests/modules/programs/kubecolor/example-config-xdg-paths.nix
@@ -1,0 +1,36 @@
+{ config, ... }:
+
+{
+  xdg.enable = true;
+  home.preferXdgDirectories = true;
+
+  programs.kubecolor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "kubecolor";
+      version = "0.4.0";
+    };
+    settings = {
+      kubectl = "kubectl";
+      preset = "dark";
+      objFreshThreshold = 0;
+      paging = "auto";
+      pager = "less";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists 'home-files/.config/kube/color.yaml'
+    assertFileContent 'home-files/.config/kube/color.yaml' \
+      ${
+        builtins.toFile "expected.yaml" ''
+          kubectl: kubectl
+          objFreshThreshold: 0
+          pager: less
+          paging: auto
+          preset: dark
+        ''
+      }
+  '';
+}
+


### PR DESCRIPTION
### Description

Add support for [kubecolor](https://github.com/kubecolor/kubecolor) program.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
