### PR TITLE
broot: allow multiple keyboard keys per verb

### DIFF
--- a/modules/programs/broot.nix
+++ b/modules/programs/broot.nix
@@ -15,7 +15,7 @@ let
       modal = mkEnableOption "modal (vim) mode";
 
       verbs = mkOption {
-        type = with types; listOf (attrsOf (either bool str));
+        type = with types; listOf (attrsOf (oneOf [ bool str (listOf str) ]));
         default = [ ];
         example = literalExpression ''
           [
@@ -45,6 +45,9 @@ let
 
           `key` (optional)
           : a keyboard key triggering execution
+
+          `keys` (optional)
+          : multiple keyboard keys each triggering execution
 
           `shortcut` (optional)
           : an alternate way to call the verb (without


### PR DESCRIPTION
### Description

To allow multiple keys the verb options need to accept `listOf str`.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [-] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef). (I don't think this applies)

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@aheaume  @dermetfan
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
