### PR TITLE
zathura: Fix the type for config options

### DIFF
--- a/modules/programs/zathura.nix
+++ b/modules/programs/zathura.nix
@@ -31,7 +31,7 @@ in {
 
     options = mkOption {
       default = { };
-      type = with types; attrsOf (either str (either bool (either float int)));
+      type = with types; attrsOf (oneOf [ str bool int float ]);
       description = ''
         Add {option}`:set` command options to zathura and make
         them permanent. See

--- a/modules/programs/zathura.nix
+++ b/modules/programs/zathura.nix
@@ -31,7 +31,7 @@ in {
 
     options = mkOption {
       default = { };
-      type = with types; attrsOf (either str (either bool int));
+      type = with types; attrsOf (either str (either bool (either float int)));
       description = ''
         Add {option}`:set` command options to zathura and make
         them permanent. See


### PR DESCRIPTION
### Description

Changed the type for `programs.zathura.options` to accept float values as well. You can check their man page (https://manpages.ubuntu.com/manpages/trusty/man5/zathurarc.5.html) as well. In the beginning, they mention:

```
  set - Changing options
       In  addition  to  the  build-in :set command zathura offers more options to be changed and
       makes those changes permanent. To overwrite  an  option  you  just  have  to  add  a  line
       structured like the following

          set <option> <new value>

       The option field has to be replaced with the name of the option that should be changed and
       the new value field has to be replaced with the new value the option should get. The  type
       of the value can be one of the following:

       • INT - An integer number

       • FLOAT - A floating point number

       • STRING - A character string

       • BOOL - A boolean value ("true" for true, "false" for false)
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@rprospero 
