### PR TITLE
eza: add options

### DIFF
--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -64,14 +64,61 @@ with lib;
       '';
     };
 
+    all = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Show hidden and 'dot' files.
+      '';
+    };
+
+    long = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Display extended details and attributes.
+      '';
+    };
+
+    extended = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        List each file’s extended attributes and sizes.
+      '';
+    };
+
+    header = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Add a header row to each column.
+      '';
+    };
+
+    clasiffy = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Display type indicator by file names.
+      '';
+    };
     package = mkPackageOption pkgs "eza" { };
   };
 
   config = let
     cfg = config.programs.eza;
 
-    args = escapeShellArgs (optional cfg.icons "--icons"
-      ++ optional cfg.git "--git" ++ cfg.extraOptions);
+    args = escapeShellArgs (
+      optional cfg.icons "--icons"
+      ++ optional cfg.git "--git"
+      ++ optional cfg.all "--all"
+      ++ optional cfg.long "--long"
+      ++ optional cfg.extended "--extended"
+      ++ optional cfg.header "--header"
+      ++ optional cfg.clasiffy "--classify"
+      ++ cfg.extraOptions
+    );
 
     optionsAlias = optionalAttrs (args != "") { eza = "eza ${args}"; };
 


### PR DESCRIPTION
> Add more commonly use options

### Description

The following options were added:
1. --all
2. --ling
3. --extended
4. --header
5. --classify

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC
@cafkafk
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
