### PR TITLE
atuin: configure daemon using systemd and launchd

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -145,11 +145,19 @@ in {
 
     (mkIf cfg.daemon.enable (mkMerge [
       {
-        assertions = [{
-          assertion = isLinux || isDarwin;
-          message =
-            "The atuin daemon can only be configured on either Linux or macOS.";
-        }];
+        assertions = [
+          {
+            assertion = versionAtLeast cfg.package.version "18.2.0";
+            message = ''
+              The atuin daemon requires at least version 18.2.0 or later.
+            '';
+          }
+          {
+            assertion = isLinux || isDarwin;
+            message =
+              "The atuin daemon can only be configured on either Linux or macOS.";
+          }
+        ];
 
         programs.atuin.settings = { daemon = { enabled = true; }; };
       }

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -149,13 +149,13 @@ in {
           {
             assertion = versionAtLeast cfg.package.version "18.2.0";
             message = ''
-              The atuin daemon requires at least version 18.2.0 or later.
+              The Atuin daemon requires at least version 18.2.0 or later.
             '';
           }
           {
             assertion = isLinux || isDarwin;
             message =
-              "The atuin daemon can only be configured on either Linux or macOS.";
+              "The Atuin daemon can only be configured on either Linux or macOS.";
           }
         ];
 
@@ -166,7 +166,7 @@ in {
 
         systemd.user.services.atuin-daemon = {
           Unit = {
-            Description = "atuin daemon";
+            Description = "Atuin daemon";
             Requires = [ "atuin-daemon.socket" ];
           };
           Install = {
@@ -183,7 +183,7 @@ in {
         };
 
         systemd.user.sockets.atuin-daemon = {
-          Unit = { Description = "atuin daemon socket"; };
+          Unit = { Description = "Atuin daemon socket"; };
           Install = { WantedBy = [ "sockets.target" ]; };
           Socket = {
             ListenStream = "%h/.local/share/atuin/atuin.sock";

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -10,7 +10,7 @@ let
 
   inherit (pkgs.stdenv) isLinux isDarwin;
 in {
-  meta.maintainers = [ maintainers.hawkw ];
+  meta.maintainers = [ maintainers.hawkw maintainers.water-sucks ];
 
   options.programs.atuin = {
     enable = mkEnableOption "atuin";


### PR DESCRIPTION
### Description

This configures the atuin daemon for Linux and Darwin systems using systemd and launchd, respectively. For systemd, a socket is also automatically configured to exist at atuin's default socket location.

I also added myself as a maintainer of this module.

Closes #5797.

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@hawkw