### PR TITLE
eza: Fix icons option

### DIFF
--- a/docs/release-notes/rl-2411.md
+++ b/docs/release-notes/rl-2411.md
@@ -18,6 +18,11 @@ This release has the following notable changes:
   add `-w` to your assignment of
   [services.swayidle.extraArgs](#opt-services.swayidle.extraArgs).
 
+- Support for Boolean values in the option
+  [programs.eza.icons](#opt-programs.eza.icons) is deprecated for
+  future removal. The new value for `true` is `"auto"`, and for
+  `false` it is `null`.
+
 ## State Version Changes {#sec-release-24.11-state-version-changes}
 
 The state version in this release includes the changes below. These


### PR DESCRIPTION


### Description

<!--

Please provide a brief description of your change.

-->
Fix icons option for eza which was breaking completion in zsh.

Fixes #5800.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@cafkafk 