### PR TITLE
snixembed: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1748,6 +1748,18 @@ in {
           add `-w` to your assignment of `services.swayidle.extraArgs`.
         '';
       }
+
+      {
+        time = "2024-10-09T06:16:23+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.snixembed'.
+
+          snixembed proxies StatusNotifierItems as XEmbedded systemtray-spec
+          icons. This is useful for some tools in some environments, e.g., Safe
+          Eyes in i3, lxde or mate.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -361,6 +361,7 @@ let
     ./services/screen-locker.nix
     ./services/sctd.nix
     ./services/signaturepdf.nix
+    ./services/snixembed.nix
     ./services/spotifyd.nix
     ./services/ssh-agent.nix
     ./services/stalonetray.nix

--- a/modules/services/snixembed.nix
+++ b/modules/services/snixembed.nix
@@ -1,0 +1,50 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let cfg = config.services.snixembed;
+in {
+  meta.maintainers = [ maintainers.DamienCassou ];
+
+  options = {
+    services.snixembed = {
+      enable = mkEnableOption
+        "snixembed: proxy StatusNotifierItems as XEmbedded systemtray-spec icons";
+
+      package = mkPackageOption pkgs "snixembed" { };
+
+      beforeUnits = mkOption {
+        type = with types; listOf str;
+        default = [ ];
+        example = [ "safeeyes.service" ];
+        description = ''
+          List of other units that should be started after snixembed.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "services.snixembed" pkgs platforms.linux)
+    ];
+
+    systemd.user.services.snixembed = {
+      Install.WantedBy = [ "graphical-session.target" ];
+
+      Unit = {
+        Description = "snixembed";
+        PartOf = [ "graphical-session.target" ];
+        StartLimitIntervalSec = 100;
+        StartLimitBurst = 10;
+        Before = cfg.beforeUnits;
+      };
+
+      Service = {
+        ExecStart = getExe pkgs.snixembed;
+        Restart = "on-failure";
+        RestartSec = 3;
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -270,6 +270,7 @@ in import nmtSrc {
     ./modules/services/remmina
     ./modules/services/screen-locker
     ./modules/services/signaturepdf
+    ./modules/services/snixembed
     ./modules/services/swayidle
     ./modules/services/swaync
     ./modules/services/swayosd

--- a/tests/modules/services/snixembed/basic-configuration.desktop
+++ b/tests/modules/services/snixembed/basic-configuration.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Exec=@xdg-utils@/bin/xdg-open http://localhost:9494
+Icon=/snixembed/share/snixembed/public/favicon.ico
+Name=Snixembed
+Terminal=false
+Type=Application
+Version=1.4

--- a/tests/modules/services/snixembed/basic-configuration.nix
+++ b/tests/modules/services/snixembed/basic-configuration.nix
@@ -1,0 +1,16 @@
+{ ... }:
+
+{
+  services.snixembed = {
+    enable = true;
+    beforeUnits = [ "safeeyes.service" ];
+  };
+
+  test.stubs = { snixembed = { outPath = "/snixembed"; }; };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/systemd/user/snixembed.service \
+      ${./basic-configuration.service}
+  '';
+}

--- a/tests/modules/services/snixembed/basic-configuration.service
+++ b/tests/modules/services/snixembed/basic-configuration.service
@@ -1,0 +1,14 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=/snixembed/bin/dummy
+Restart=on-failure
+RestartSec=3
+
+[Unit]
+Before=safeeyes.service
+Description=snixembed
+PartOf=graphical-session.target
+StartLimitBurst=10
+StartLimitIntervalSec=100

--- a/tests/modules/services/snixembed/default.nix
+++ b/tests/modules/services/snixembed/default.nix
@@ -1,0 +1,1 @@
+{ snixembed-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION

### Description

https://git.sr.ht/~steef/snixembed

This is used by SafeEyes (another home-manager) module to show a
systemtray icon.

This fixes issue #5728.


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->