### PR TITLE
pls: fixed perm argument to pass via pls

### DIFF
--- a/modules/programs/pls.nix
+++ b/modules/programs/pls.nix
@@ -9,7 +9,7 @@ let
   aliases = {
     ls = "${cfg.package}/bin/pls";
     ll =
-      "${cfg.package}/bin/pls -d perms -d user -d group -d size -d mtime -d git";
+      "${cfg.package}/bin/pls -d perm -d user -d group -d size -d mtime -d git";
   };
 
 in {

--- a/tests/modules/programs/pls/bash.nix
+++ b/tests/modules/programs/pls/bash.nix
@@ -23,7 +23,7 @@ with lib;
         "alias ls=@pls@/bin/pls"
       assertFileContains \
         home-files/.bashrc \
-        "alias ll='@pls@/bin/pls -d perms -d user -d group -d size -d mtime -d git'"
+        "alias ll='@pls@/bin/pls -d perm -d user -d group -d size -d mtime -d git'"
     '';
   };
 }

--- a/tests/modules/programs/pls/fish.nix
+++ b/tests/modules/programs/pls/fish.nix
@@ -27,7 +27,7 @@ with lib;
         "alias ls @pls@/bin/pls"
       assertFileContains \
         home-files/.config/fish/config.fish \
-        "alias ll '@pls@/bin/pls -d perms -d user -d group -d size -d mtime -d git'"
+        "alias ll '@pls@/bin/pls -d perm -d user -d group -d size -d mtime -d git'"
     '';
   };
 }

--- a/tests/modules/programs/pls/zsh.nix
+++ b/tests/modules/programs/pls/zsh.nix
@@ -26,7 +26,7 @@ with lib;
         "alias -- ls=@pls@/bin/pls"
       assertFileContains \
         home-files/.zshrc \
-        "alias -- ll='@pls@/bin/pls -d perms -d user -d group -d size -d mtime -d git'"
+        "alias -- ll='@pls@/bin/pls -d perm -d user -d group -d size -d mtime -d git'"
     '';
   };
 }


### PR DESCRIPTION
The argument should be perm not perms

### Description

The argument should be `perm` instead of `perms`. 

<img width="1114" alt="Screenshot 2024-09-28 at 5 15 08 PM" src="https://github.com/user-attachments/assets/7d891efc-0eba-4206-8db8-1c70044a3631">

<!--

Please provide a brief description of your change.

-->

I changed the argument from `perms` to `perm`. Just a little typo. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
  - [x] Test cases run successfully.
  - [x] No errors or warnings encountered during testing.

- [] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  - [] Coverage for edge cases considered.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@arjan-s 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
