### PR TITLE
espanso: add sandboxing for systemd service

### DIFF
--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -124,6 +124,15 @@ in {
         Type = "exec";
         ExecStart = "${cfg.package}/bin/espanso daemon";
         Restart = "on-failure";
+
+        # Sandboxing.
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateUsers = true;
+        RestrictNamespaces = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "@system-service";
       };
       Install = { WantedBy = [ "default.target" ]; };
     };

--- a/tests/modules/services/espanso/basic-configuration.service
+++ b/tests/modules/services/espanso/basic-configuration.service
@@ -3,7 +3,14 @@ WantedBy=default.target
 
 [Service]
 ExecStart=@espanso@/bin/espanso daemon
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateUsers=true
 Restart=on-failure
+RestrictNamespaces=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
 Type=exec
 
 [Unit]


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

- Add sandboxing for systemd service

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@n8henrie @lucasew @liyangau 