### PR TITLE
firefox: Avoid unnecessarily overriding package

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -799,12 +799,13 @@ in {
     finalPackage = wrapPackage cfg.package;
 
     policies = {
-      ExtensionSettings = listToAttrs (map (lang:
-        nameValuePair "langpack-${lang}@firefox.mozilla.org" {
-          installation_mode = "normal_installed";
-          install_url =
-            "https://releases.mozilla.org/pub/firefox/releases/${cfg.package.version}/linux-x86_64/xpi/${lang}.xpi";
-        }) cfg.languagePacks);
+      ExtensionSettings = lib.mkIf (cfg.languagePacks != [ ]) (listToAttrs (map
+        (lang:
+          nameValuePair "langpack-${lang}@firefox.mozilla.org" {
+            installation_mode = "normal_installed";
+            install_url =
+              "https://releases.mozilla.org/pub/firefox/releases/${cfg.package.version}/linux-x86_64/xpi/${lang}.xpi";
+          }) cfg.languagePacks));
     };
   });
 }

--- a/tests/modules/programs/firefox/common.nix
+++ b/tests/modules/programs/firefox/common.nix
@@ -1,6 +1,7 @@
 name:
 builtins.mapAttrs (test: module: import module [ "programs" name ]) {
   "${name}-deprecated-native-messenger" = ./deprecated-native-messenger.nix;
+  "${name}-final-package" = ./final-package.nix;
   "${name}-policies" = ./policies.nix;
   "${name}-profiles-bookmarks" = ./profiles/bookmarks;
   "${name}-profiles-containers" = ./profiles/containers;

--- a/tests/modules/programs/firefox/final-package.nix
+++ b/tests/modules/programs/firefox/final-package.nix
@@ -1,0 +1,25 @@
+modulePath:
+{ config, lib, pkgs, ... }:
+
+let
+
+  cfg = lib.getAttrFromPath modulePath config;
+
+  firefoxMockOverlay = import ./setup-firefox-mock-overlay.nix modulePath;
+
+in {
+  imports = [ firefoxMockOverlay ];
+
+  config = lib.mkIf config.test.enableBig
+    (lib.setAttrByPath modulePath { enable = true; } // {
+      home.stateVersion = "19.09";
+
+      nmt.script = ''
+        package=${cfg.package}
+        finalPackage=${cfg.finalPackage}
+        if [[ $package != $finalPackage ]]; then
+          fail "Expected finalPackage ($finalPackage) to equal package ($package)"
+        fi
+      '';
+    });
+}


### PR DESCRIPTION
When `cfg.package` is already wrapped, and wrapped without the `ExtensionSettings` key set, this would always add that key, even if its value was blank. This would result in `cfg.finalPackage` being a functionally-identical, but differently-input-addressed package. This is generally undesirable as it may result in multiple derivations being built, and also if the value of `cfg.package` is expected to be unchanged by the user (e.g. because they want it to be consistent between NixOS and HM configuration).

Add a test to ensure this does not regress in the default case. Only test on newish stateVersion since the logic for `isWrapped` differs on older versions.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee @brckd 
