### PR TITLE
activitywatch: reduce test closure

### DIFF
--- a/tests/modules/services/activitywatch/basic-setup.nix
+++ b/tests/modules/services/activitywatch/basic-setup.nix
@@ -5,6 +5,7 @@ let stubPackage = config.lib.test.mkStubPackage { };
 in {
   services.activitywatch = {
     enable = true;
+    package = stubPackage;
     settings = {
       port = 3012;
       custom_static = { custom-watcher = stubPackage; };


### PR DESCRIPTION
### Description

This also reduces test flakiness.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@foo-dogsquared 
