### PR TITLE
firefox, thunderbird: conditional search file

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -777,11 +777,12 @@ in {
           force = profile.containersForce;
         };
 
-      "${profilesPath}/${profile.path}/search.json.mozlz4" = {
-        enable = profile.search.enable;
-        force = profile.search.force;
-        source = profile.search.file;
-      };
+      "${profilesPath}/${profile.path}/search.json.mozlz4" =
+        mkIf (profile.search.enable) {
+          enable = profile.search.enable;
+          force = profile.search.force;
+          source = profile.search.file;
+        };
 
       "${profilesPath}/${profile.path}/extensions" =
         mkIf (profile.extensions != [ ]) {

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -408,11 +408,12 @@ in {
           profile.extraConfig;
       };
 
-      "${thunderbirdProfilesPath}/${name}/search.json.mozlz4" = {
-        enable = profile.search.enable;
-        force = profile.search.force;
-        source = profile.search.file;
-      };
+      "${thunderbirdProfilesPath}/${name}/search.json.mozlz4" =
+        mkIf (profile.search.enable) {
+          enable = profile.search.enable;
+          force = profile.search.force;
+          source = profile.search.file;
+        };
     }));
   };
 }

--- a/tests/modules/programs/firefox/common.nix
+++ b/tests/modules/programs/firefox/common.nix
@@ -12,4 +12,5 @@ builtins.mapAttrs (test: module: import module [ "programs" name ]) {
   "${name}-profiles-search" = ./profiles/search;
   "${name}-profiles-settings" = ./profiles/settings;
   "${name}-state-version-19_09" = ./state-version-19_09.nix;
+  "${name}-profiles-shared-path" = ./profiles/shared-path.nix;
 }

--- a/tests/modules/programs/firefox/profiles/shared-path.nix
+++ b/tests/modules/programs/firefox/profiles/shared-path.nix
@@ -1,0 +1,53 @@
+modulePath:
+{ config, lib, ... }:
+
+with lib;
+
+let firefoxMockOverlay = import ../setup-firefox-mock-overlay.nix modulePath;
+in {
+  imports = [ firefoxMockOverlay ];
+
+  config = mkIf config.test.enableBig (setAttrByPath modulePath {
+    enable = true;
+
+    profiles = {
+      main = {
+        isDefault = true;
+        id = 1;
+        bookmarks = [{
+          toolbar = true;
+          bookmarks = [{
+            name = "Home Manager";
+            url = "https://wiki.nixos.org/wiki/Home_Manager";
+          }];
+        }];
+        containers = {
+          "shopping" = {
+            icon = "circle";
+            color = "yellow";
+          };
+        };
+        search = {
+          force = true;
+          default = "Google";
+          privateDefault = "DuckDuckGo";
+          engines = {
+            "Bing".metaData.hidden = true;
+            "Google".metaData.alias = "@g";
+          };
+        };
+        settings = {
+          "general.smoothScroll" = false;
+          "browser.newtabpage.pinned" = [{
+            title = "NixOS";
+            url = "https://nixos.org";
+          }];
+        };
+      };
+      "dev-edition-default" = {
+        id = 2;
+        path = "main";
+      };
+    };
+  });
+}


### PR DESCRIPTION
### Description
When using multiple profiles that share the same path we still try to evaluate the file even when search customization isn't enabled. 
Follow up to https://github.com/nix-community/home-manager/pull/5697#issuecomment-2411177495 to only evaluate when the profile wants a search.json.mozlz4 file generated. 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@teto @rycee @kira-bruneau 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
