### PR TITLE
espanso: use `launcher` command on Linux

### DIFF
--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -121,9 +121,9 @@ in {
     systemd.user.services.espanso = {
       Unit = { Description = "Espanso: cross platform text expander in Rust"; };
       Service = {
-        Type = "exec";
-        ExecStart = "${cfg.package}/bin/espanso daemon";
+        ExecStart = "${cfg.package}/bin/espanso launcher";
         Restart = "on-failure";
+        RestartSec = 3;
       };
       Install = { WantedBy = [ "default.target" ]; };
     };

--- a/tests/modules/services/espanso/basic-configuration.service
+++ b/tests/modules/services/espanso/basic-configuration.service
@@ -2,9 +2,9 @@
 WantedBy=default.target
 
 [Service]
-ExecStart=@espanso@/bin/espanso daemon
+ExecStart=@espanso@/bin/espanso launcher
 Restart=on-failure
-Type=exec
+RestartSec=3
 
 [Unit]
 Description=Espanso: cross platform text expander in Rust


### PR DESCRIPTION


### Description

<!--

Please provide a brief description of your change.

-->

- Use `launcher` command instead of `daemon`. Additionally we remove `Type` and add `RestartSec` as defined in the source: https://github.com/espanso/espanso/blob/b421bcf73fa13506938d62425459d6c16c6a8d0a/espanso/src/res/linux/systemd.service#L5-L7C1

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@n8henrie @lucasew @liyangau 