### PR TITLE
hypridle: configurable systemd target

### DIFF
--- a/modules/services/hypridle.nix
+++ b/modules/services/hypridle.nix
@@ -11,6 +11,20 @@ in {
 
     package = mkPackageOption pkgs "hypridle" { };
 
+    systemd = {
+      enable = lib.mkEnableOption "Hypridle Systemd integration" // {
+        default = true;
+      };
+      target = lib.mkOption {
+        type = lib.types.str;
+        default = "graphical-session.target";
+        example = "hyprland-session.target";
+        description = ''
+          The systemd target that will automatically start the hypridle service.
+        '';
+      };
+    };
+
     settings = lib.mkOption {
       type = with lib.types;
         let
@@ -73,8 +87,8 @@ in {
       };
     };
 
-    systemd.user.services.hypridle = {
-      Install = { WantedBy = [ "graphical-session.target" ]; };
+    systemd.user.services.hypridle = mkIf cfg.systemd.enable {
+      Install = { WantedBy = [ cfg.systemd.target ]; };
 
       Unit = {
         ConditionEnvironment = "WAYLAND_DISPLAY";

--- a/tests/modules/services/hypridle/basic-configuration.nix
+++ b/tests/modules/services/hypridle/basic-configuration.nix
@@ -5,6 +5,8 @@
     enable = true;
     package = pkgs.hypridle;
 
+    systemd.target = "hyprland-session.target";
+
     settings = {
       general = {
         after_sleep_cmd = "hyprctl dispatch dpms on";
@@ -34,5 +36,6 @@
     assertFileExists $config
     assertFileExists $clientServiceFile
     assertFileContent $config ${./hypridle.conf}
+    assertFileContains $clientServiceFile "WantedBy=hyprland-session.target"
   '';
 }


### PR DESCRIPTION
### Description

Allows you to set the systemd target for hypridle. Also allows you to disable the service.
I set the service to default to true to preserve backward compatibility.
The options layout is based off waybar's.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

> [!NOTE]  
> this is based on `master`, which appears to have broken test `neovim-plugin-config`
> https://github.com/nix-community/home-manager/actions/runs/11422914607/job/31781473809

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@fufexan @khaneliman 
