### PR TITLE
nix-gc: add `randomizedDelaySec` option

### DIFF
--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -81,6 +81,18 @@ in {
         '';
       };
 
+      randomizedDelaySec = lib.mkOption {
+        default = "0";
+        type = lib.types.singleLineStr;
+        example = "45min";
+        description = ''
+          Add a randomized delay before each garbage collection.
+          The delay will be chosen between zero and this value.
+          This value must be a time span in the format specified by
+          {manpage}`systemd.time(7)`
+        '';
+      };
+
       options = mkOption {
         type = types.nullOr types.str;
         default = null;
@@ -121,6 +133,7 @@ in {
         Unit = { Description = "Nix Garbage Collector"; };
         Timer = {
           OnCalendar = "${cfg.frequency}";
+          RandomizedDelaySec = cfg.randomizedDelaySec;
           Persistent = cfg.persistent;
           Unit = "nix-gc.service";
         };

--- a/tests/modules/services/nix-gc/basic.nix
+++ b/tests/modules/services/nix-gc/basic.nix
@@ -4,6 +4,7 @@
   nix.gc = {
     automatic = true;
     frequency = "monthly";
+    randomizedDelaySec = "42min";
     options = "--delete-older-than 30d --max-freed $((64 * 1024**3))";
   };
 

--- a/tests/modules/services/nix-gc/expected.timer
+++ b/tests/modules/services/nix-gc/expected.timer
@@ -4,6 +4,7 @@ WantedBy=timers.target
 [Timer]
 OnCalendar=monthly
 Persistent=true
+RandomizedDelaySec=42min
 Unit=nix-gc.service
 
 [Unit]


### PR DESCRIPTION
There's no launchd equivalent to this option, so this is a no-op on Darwin.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@shivaraj-bh 
