### PR TITLE
yazi: set default integration values for Nushell, Fish, and Zsh to true

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -56,13 +56,21 @@ in {
       '';
     };
 
-    enableBashIntegration = mkEnableOption "Bash integration";
+    enableBashIntegration = mkEnableOption "Bash integration" // {
+      default = true;
+    };
 
-    enableZshIntegration = mkEnableOption "Zsh integration";
+    enableZshIntegration = mkEnableOption "Zsh integration" // {
+      default = true;
+    };
 
-    enableFishIntegration = mkEnableOption "Fish integration";
+    enableFishIntegration = mkEnableOption "Fish integration" // {
+      default = true;
+    };
 
-    enableNushellIntegration = mkEnableOption "Nushell integration";
+    enableNushellIntegration = mkEnableOption "Nushell integration" // {
+      default = true;
+    };
 
     keymap = mkOption {
       type = tomlFormat.type;


### PR DESCRIPTION
The `programs.yazi.enableNushellIntegration`, `programs.yazi.enableFishIntegration`, and `programs.yazi.enableZshIntegration` options were previously set to `false` by default. 

I didn't find a clear convention, but most of the modules I reviewed set these options to `true` by default. Following this pattern, it seems more appropriate to enable these integrations by default to enhance the user experience.


### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
