### PR TITLE
launchd: wrap agents in .app bundles

### DIFF
--- a/modules/launchd/main.swift
+++ b/modules/launchd/main.swift
@@ -1,0 +1,58 @@
+import Foundation
+import ServiceManagement
+
+if CommandLine.arguments.count <= 3 {
+    print("Usage: \(CommandLine.arguments[0]) register|unregister|status agent|daemon <plist name>")
+    exit(2)
+}
+
+let command = CommandLine.arguments[1]
+let agentOrDaemon = CommandLine.arguments[2]
+let plistName = CommandLine.arguments[3]
+
+let service: SMAppService
+switch agentOrDaemon {
+case "agent":
+    service = SMAppService.agent(plistName: plistName)
+case "daemon":
+    service = SMAppService.daemon(plistName: plistName)
+default:
+    print("2nd argument must be one of: agent, daemon")
+    exit(2)
+}
+
+switch command {
+case "register":
+    do {
+        try service.register()
+        print("Successfully registered \(agentOrDaemon) \(plistName)")
+    } catch {
+        print("Unable to register \(agentOrDaemon) \(plistName) with error: \(error)")
+        exit(1)
+    }
+case "unregister":
+    do {
+        try service.unregister()
+        print("Successfully unregistered \(agentOrDaemon) \(plistName)")
+    } catch {
+        print("Unable to unregister \(agentOrDaemon) \(plistName) with error: \(error)")
+        exit(1)
+    }
+case "status":
+    switch service.status {
+    case .notRegistered:
+        // Confusingly, the docs say that this case can also happen when the service has been double-registered.
+        print("\(agentOrDaemon) \(plistName) is not yet registered")
+    case .enabled:
+        print("\(agentOrDaemon) \(plistName) has been registered")
+    case .requiresApproval:
+        print("\(agentOrDaemon) \(plistName) must be approved in System Preferences")
+    case .notFound:
+        print("\(agentOrDaemon) \(plistName) cannot be found")
+    @unknown default:
+        print("\(agentOrDaemon) \(plistName) is in an unknown state")
+    }
+default:
+    print("1st argument must be one of: register, unregister, status")
+    exit(2)
+}

--- a/modules/launchd/wrapperApp.nix
+++ b/modules/launchd/wrapperApp.nix
@@ -1,21 +1,19 @@
 { pkgs, name, agent }:
 
 let
-  staging-next-pkgs = import (builtins.fetchTarball { url = "https://github.com/NixOS/nixpkgs/archive/staging-next.tar.gz"; sha256 = "1qv0a78lrgdhic7qr4xvh2c5s0hch3k3ix08ja04pxs2090m0a6n"; }) { inherit (pkgs) system; };
-
   label = agent.config.Label;
 
-  mainExe = staging-next-pkgs.stdenv.mkDerivation {
+  mainExe = pkgs.stdenv.mkDerivation {
     pname = "agent-wrapper-main-executable";
     version = "0.1.0";
 
     dontUnpack = true;
 
-    nativeBuildInputs = [ staging-next-pkgs.swift ];
+    nativeBuildInputs = [ pkgs.swift ];
 
     buildInputs = [
-      staging-next-pkgs.apple-sdk_13
-      (staging-next-pkgs.darwinMinVersionHook "13.0")
+      pkgs.apple-sdk_13
+      (pkgs.darwinMinVersionHook "13.0")
     ];
 
     buildPhase = ''

--- a/modules/launchd/wrapperApp.nix
+++ b/modules/launchd/wrapperApp.nix
@@ -1,0 +1,79 @@
+{ pkgs, name, agent }:
+
+let
+  staging-next-pkgs = import (builtins.fetchTarball { url = "https://github.com/NixOS/nixpkgs/archive/staging-next.tar.gz"; sha256 = "1qv0a78lrgdhic7qr4xvh2c5s0hch3k3ix08ja04pxs2090m0a6n"; }) { inherit (pkgs) system; };
+
+  label = agent.config.Label;
+
+  mainExe = staging-next-pkgs.stdenv.mkDerivation {
+    pname = "agent-wrapper-main-executable";
+    version = "0.1.0";
+
+    dontUnpack = true;
+
+    nativeBuildInputs = [ staging-next-pkgs.swift ];
+
+    buildInputs = [
+      staging-next-pkgs.apple-sdk_13
+      (staging-next-pkgs.darwinMinVersionHook "13.0")
+    ];
+
+    buildPhase = ''
+      swiftc -o $out ${./main.swift}
+    '';
+  };
+
+  launchAgentPlist = pkgs.writeText "${label}.plist" (pkgs.lib.generators.toPlist {} (agent.config // {
+    BundleProgram = "Contents/Resources/LaunchAgent";
+  }));
+  # launchAgentExe = pkgs.writeShellScript "LaunchAgent" ''
+  #   /bin/wait4path /nix/store && exec ${if agent.config ? Program then agent.config.Program else (builtins.elemAt agent.config.ProgramArguments 0)}
+  # '';
+  launchAgentExe = pkgs.writeShellScript "LaunchAgent" ''
+    true
+  '';
+
+  infoPlist = pkgs.writeText "Info.plist" (pkgs.lib.generators.toPlist {} {
+    CFBundleDevelopmentRegion = "en";
+    CFBundleExecutable = "main";
+    CFBundleIdentifier = label;
+    CFBundleInfoDictionaryVersion = "6.0";
+    CFBundleName = name;
+    CFBundlePackageType = "APPL";
+    CFBundleShortVersionString = "1.0";
+    CFBundleSupportedPlatforms = [ "MacOSX" ];
+    CFBUndleVersion = "1";
+    # CFBundleIconFile = "Icon.icns"; # Apparently not a problem if you have this key but not the icon? Maybe should be optional anyway
+  });
+  wrapper-app = pkgs.runCommand "${name}-agent-wrapper.app" {} ''
+    echo "Creating app..."
+    APP_DIR="$out/Applications/${name}.app"
+
+    echo "Creating Contents/Library/LaunchAgents"
+    mkdir -p "$APP_DIR/Contents/Library/LaunchAgents"
+    echo "Copying LaunchAgent plist into app"
+    cp ${launchAgentPlist} "$APP_DIR/Contents/Library/LaunchAgents/${label}.plist"
+    echo "Creating Contents/MacOS"
+    mkdir -p "$APP_DIR/Contents/MacOS"
+    echo "Copying main executable into app"
+    cp ${mainExe} "$APP_DIR/Contents/MacOS/main"
+    echo "Creating Contents/Resources"
+    mkdir -p "$APP_DIR/Contents/Resources"
+    echo "Copying LaunchAgent executable into app"
+    cp ${launchAgentExe} "$APP_DIR/Contents/Resources/LaunchAgent"
+    echo "Copying Info.plist into app"
+    cp ${infoPlist} "$APP_DIR/Contents/Info.plist"
+
+    # cp icon "$APP_DIR/Contents/Resources/Icon.icns"
+
+    echo "App finished at $APP_DIR"
+
+    # I'm not sure if this is necessary but rcodesign was complaining before I did this
+    echo "chmod -R 777 -ing app"
+    chmod -R 777 "$APP_DIR"
+
+    echo "Codesigning app"
+    ${pkgs.rcodesign}/bin/rcodesign sign "$APP_DIR"
+  '';
+in
+  wrapper-app


### PR DESCRIPTION
This causes agents to appear in System Settings with a fancy name (and optionally icon), rather than the file name of the executable. This is particularly desirous when the "executable" is a shell script that waits for the Nix store to be available before running the true agent, because those show up in System Settings as `sh`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

