### PR TITLE
granted:.assume-wrapped no longer present

### DIFF
--- a/modules/programs/granted.nix
+++ b/modules/programs/granted.nix
@@ -28,7 +28,7 @@ in {
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
       function assume() {
         export GRANTED_ALIAS_CONFIGURED="true"
-        source ${package}/bin/.assume-wrapped "$@"
+        source ${package}/bin/assume "$@"
         unset GRANTED_ALIAS_CONFIGURED
       }
     '';

--- a/tests/modules/programs/granted/integration-disabled.nix
+++ b/tests/modules/programs/granted/integration-disabled.nix
@@ -19,7 +19,7 @@
       'export GRANTED_ALIAS_CONFIGURED="true"'
     assertFileNotRegex \
       home-files/.zshrc \
-      'source @granted@/bin/.assume-wrapped "$@"'
+      'source @granted@/bin/assume "$@"'
     assertFileNotRegex \
       home-files/.zshrc \
       'unset GRANTED_ALIAS_CONFIGURED'

--- a/tests/modules/programs/granted/integration-enabled.nix
+++ b/tests/modules/programs/granted/integration-enabled.nix
@@ -18,7 +18,7 @@
       'export GRANTED_ALIAS_CONFIGURED="true"'
     assertFileContains \
       home-files/.zshrc \
-      'source @granted@/bin/.assume-wrapped "$@"'
+      'source @granted@/bin/assume "$@"'
     assertFileContains \
       home-files/.zshrc \
       'unset GRANTED_ALIAS_CONFIGURED'


### PR DESCRIPTION
.assume-wrapped is no longer present, use assume instead

### Description

.assume-wrapped is no longer present see error message:

`assume:source:2: no such file or directory: /nix/store/7gp6i2pdvyk7cc01g4w8wz1ymjpxgcqx-granted-0.34.1/bin/.assume-wrapped`

Using `assume` instead seems to work as intended.

As a small remark I'm not sure how backwards compatible this is, since this comes from an change in upstream packaging.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

It doesn't make sense that I review this alone, since I'm maintaining it. But adding myself anyways @wcarlsen 
