### PR TITLE
accounts/{calendar,contacts}: fix defaultText rendering

### DIFF
--- a/modules/accounts/calendar.nix
+++ b/modules/accounts/calendar.nix
@@ -12,7 +12,8 @@ let
         path = mkOption {
           type = types.str;
           default = "${cfg.basePath}/${name}";
-          defaultText = "‹accounts.calendar.basePath›/‹name›";
+          defaultText =
+            lib.literalExpression "‹accounts.calendar.basePath›/‹name›";
           description = "The path of the storage.";
         };
 

--- a/modules/accounts/contacts.nix
+++ b/modules/accounts/contacts.nix
@@ -12,7 +12,8 @@ let
         path = mkOption {
           type = types.str;
           default = "${cfg.basePath}/${name}";
-          defaultText = "‹accounts.contact.basePath›/‹name›";
+          defaultText =
+            lib.literalExpression "‹accounts.contact.basePath›/‹name›";
           description = "The path of the storage.";
         };
 


### PR DESCRIPTION
### Description

Fixes that the defaultText gets rendered as string at https://search.nüschtos.de/?query=.local.path&scope=Home%20Manager&option=home-manager.users.%3Cname%3E.accounts.calendar.accounts.%3Cname%3E.local.path

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
