### PR TITLE
eza: add color option

### DIFF
--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -59,6 +59,14 @@ with lib;
       '';
     };
 
+    colors = mkOption {
+      type = types.enum [ null "auto" "always" "never" ];
+      default = null;
+      description = ''
+        Use terminal colors in output ({option}`--color` argument).
+      '';
+    };
+
     git = mkOption {
       type = types.bool;
       default = false;
@@ -80,8 +88,9 @@ with lib;
         cfg.icons;
     in optionals (v != null) [ "--icons" v ];
 
-    args = escapeShellArgs
-      (iconsOption ++ optional cfg.git "--git" ++ cfg.extraOptions);
+    args = escapeShellArgs (iconsOption
+      ++ optionals (cfg.colors != null) [ "--color" cfg.colors ]
+      ++ optional cfg.git "--git" ++ cfg.extraOptions);
 
     optionsAlias = optionalAttrs (args != "") { eza = "eza ${args}"; };
 


### PR DESCRIPTION
### Description

This adds an option for the `--color` flag.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@cafkafk 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
