### PR TITLE
Add support for mise integration in direnv

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -19,7 +19,7 @@ in {
       "Flake support is now always enabled.")
   ];
 
-  meta.maintainers = [ lib.maintainers.rycee ];
+  meta.maintainers = [ lib.maintainers.rycee lib.maintainers.shikanime ];
 
   options.programs.direnv = {
     enable = mkEnableOption "direnv, the environment switcher";
@@ -95,6 +95,14 @@ in {
       package = mkPackageOption pkgs "nix-direnv" { };
     };
 
+    mise = {
+      enable = mkEnableOption ''
+        [mise](https://mise.jdx.dev/direnv.html),
+        integration of use_mise for direnv'';
+
+      package = mkPackageOption pkgs "mise" { };
+    };
+
     silent = mkEnableOption "silent mode, that is, disabling direnv logging";
   };
 
@@ -111,6 +119,12 @@ in {
 
     xdg.configFile."direnv/direnvrc" =
       lib.mkIf (cfg.stdlib != "") { text = cfg.stdlib; };
+
+    xdg.configFile."direnv/lib/hm-mise.sh" = mkIf cfg.mise.enable {
+      text = ''
+        eval "$(${getExe cfg.mise.package} direnv activate)"
+      '';
+    };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (
       # Using mkAfter to make it more likely to appear after other

--- a/tests/modules/programs/direnv/default.nix
+++ b/tests/modules/programs/direnv/default.nix
@@ -1,5 +1,6 @@
 {
   direnv-bash = ./bash.nix;
+  direnv-mise = ./mise.nix;
   direnv-nix-direnv = ./nix-direnv.nix;
   direnv-nushell = ./nushell.nix;
   direnv-stdlib = ./stdlib.nix;

--- a/tests/modules/programs/direnv/mise.nix
+++ b/tests/modules/programs/direnv/mise.nix
@@ -1,0 +1,17 @@
+{ config, ... }:
+
+{
+  programs.bash.enable = true;
+  programs.direnv = {
+    enable = true;
+    mise = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { name = "mise"; };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileExists home-files/.config/direnv/lib/hm-mise.sh
+  '';
+}


### PR DESCRIPTION
### Description

This patch is aim to add support for the already existing program `mise`.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
