### PR TITLE
gpg-agent: use $TTY parameter in zsh intergration

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -18,6 +18,10 @@ let
     export GPG_TTY
   '' + optionalString cfg.enableSshSupport gpgSshSupportStr;
 
+  gpgZshInitStr = ''
+    export GPG_TTY=$TTY
+  '' + optionalString cfg.enableSshSupport gpgSshSupportStr;
+
   gpgFishInitStr = ''
     set -gx GPG_TTY (tty)
   '' + optionalString cfg.enableSshSupport gpgSshSupportStr;
@@ -287,7 +291,7 @@ in {
       '';
 
       programs.bash.initExtra = mkIf cfg.enableBashIntegration gpgInitStr;
-      programs.zsh.initExtra = mkIf cfg.enableZshIntegration gpgInitStr;
+      programs.zsh.initExtra = mkIf cfg.enableZshIntegration gpgZshInitStr;
       programs.fish.interactiveShellInit =
         mkIf cfg.enableFishIntegration gpgFishInitStr;
 


### PR DESCRIPTION
### Description
Under certain conditions, `$(tty)` placed in `programs.zsh.initExtra` evaluates to `not a tty` instead of `/dev/pts/*`, which breaks terminal-based pinentry. (see [here](https://unix.stackexchange.com/questions/608842/zshrc-export-gpg-tty-tty-says-not-a-tty) for more information). 

Fixed by using the [`TTY` parameter](https://zsh.sourceforge.io/Doc/Release/Parameters.html#index-TTY) set by Zsh instead.
<!--

Please provide a brief description of your change.

-->
likely fixes #5888 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
