### PR TITLE
nixpkgs-disabled: correct assertion

### DIFF
--- a/modules/misc/nixpkgs-disabled.nix
+++ b/modules/misc/nixpkgs-disabled.nix
@@ -64,7 +64,7 @@ in {
 
   config = {
     assertions = [{
-      assertion = cfg.config == null || cfg.overlays == null;
+      assertion = cfg.config == null && cfg.overlays == null;
       message = ''
         `nixpkgs` options are disabled when `home-manager.useGlobalPkgs` is enabled.
       '';


### PR DESCRIPTION
### Description

Should only pass if _both_ attributes are `null`.

I recently found myself in a confusing situation when I added my usual
`homeConfiguration` to a `nixosConfiguration` that had
`home-manager.useGlobalPackages = true`.

`nixos-rebuild` was just claiming that some attributes were missing from `pkgs`,
rather than asserting that my `nixpkgs.overlays` was set when it couldn’t be.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@thiagokokada