### PR TITLE
git-credential-oauth: fix, add tests

### DIFF
--- a/modules/programs/git-credential-oauth.nix
+++ b/modules/programs/git-credential-oauth.nix
@@ -30,7 +30,8 @@ in {
     home.packages = [ cfg.package ];
 
     programs.git.extraConfig.credential.helper = [
-      ("${cfg.package}/bin/git-credential-oauth" + lib.mkIf cfg.extraFlags
+      ("${cfg.package}/bin/git-credential-oauth"
+        + lib.optionalString (cfg.extraFlags != [ ])
         " ${lib.strings.concatStringsSep " " cfg.extraFlags}")
     ];
   };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -81,6 +81,7 @@ in import nmtSrc {
     ./modules/programs/gh-dash
     ./modules/programs/git
     ./modules/programs/git-cliff
+    ./modules/programs/git-credential-oauth
     ./modules/programs/gpg
     ./modules/programs/gradle
     ./modules/programs/granted

--- a/tests/modules/programs/git-credential-oauth/basic.nix
+++ b/tests/modules/programs/git-credential-oauth/basic.nix
@@ -1,0 +1,16 @@
+{ config, pkgs, ... }:
+
+{
+  programs.git-credential-oauth = { enable = true; };
+
+  programs.git = { enable = true; };
+
+  test.stubs.git-credential-oauth = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContains \
+      home-files/.config/git/config \
+      "${config.programs.git-credential-oauth.package}/bin/git-credential-oauth"
+  '';
+}

--- a/tests/modules/programs/git-credential-oauth/default.nix
+++ b/tests/modules/programs/git-credential-oauth/default.nix
@@ -1,0 +1,4 @@
+{
+  git-credential-oauth-basic = ./basic.nix;
+  git-credential-oauth-extra-flags = ./extra-flags.nix;
+}

--- a/tests/modules/programs/git-credential-oauth/extra-flags.nix
+++ b/tests/modules/programs/git-credential-oauth/extra-flags.nix
@@ -1,0 +1,19 @@
+{ config, pkgs, ... }:
+
+{
+  programs.git-credential-oauth = {
+    enable = true;
+    extraFlags = [ "-device" ];
+  };
+
+  programs.git = { enable = true; };
+
+  test.stubs.git-credential-oauth = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContains \
+      home-files/.config/git/config \
+      "${config.programs.git-credential-oauth.package}/bin/git-credential-oauth -device"
+  '';
+}


### PR DESCRIPTION
### Description

* Fix #6005
* Add tests to prevent obvious bugs like the above from slipping through

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@tomodachi94 (no clue who this human is /lh)