### PR TITLE
mako: add max-history option

### DIFF
--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -33,6 +33,15 @@ in {
         '';
       };
 
+      maxHistory = mkOption {
+        default = 5;
+        type = types.nullOr types.int;
+        description = ''
+          Set maximum number of expired notifications to keep in the history
+          buffer. Set 0 to disable history.
+        '';
+      };
+
       sort = mkOption {
         default = "-time";
         type =
@@ -315,6 +324,7 @@ in {
       '';
       text = ''
         ${optionalInteger "max-visible" cfg.maxVisible}
+        ${optionalInteger "max-history" cfg.maxHistory}
         ${optionalString "sort" cfg.sort}
         ${optionalString "output" cfg.output}
         ${optionalString "layer" cfg.layer}


### PR DESCRIPTION
### Description

Add `max-history` option for mako

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

  - If someone add `max-history` to extraConfig, then mako doesn't work because cannot parse the config, so this case can be ignored

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@onny 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
