### PR TITLE
zellij: `programs.zellij.settings` are serialized as kdl and not yaml from version 0.32.0 onwards

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -34,7 +34,10 @@ in {
       '';
       description = ''
         Configuration written to
-        {file}`$XDG_CONFIG_HOME/zellij/config.yaml`.
+        {file}`$XDG_CONFIG_HOME/zellij/config.kdl`.
+
+        If `programs.zellij.package.version` is older than 0.32.0, then
+        the configuration is written to {file}`$XDG_CONFIG_HOME/zellij/config.yaml`.
 
         See <https://zellij.dev/documentation> for the full
         list of options.


### PR DESCRIPTION
### Description

<!--

Version [0.32.0](https://github.com/zellij-org/zellij/releases/tag/v0.32.0) of [zellij](https://github.com/zellij-org/zellij) released October 25 2022, changed the configuration format from yaml to kdl. This PR changes the description of the option to reflect that.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

- @mainrs

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
