### PR TITLE
go: add telemetry options

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -83,6 +83,7 @@ in import nmtSrc {
     ./modules/programs/git
     ./modules/programs/git-cliff
     ./modules/programs/git-credential-oauth
+    ./modules/programs/go
     ./modules/programs/gpg
     ./modules/programs/gradle
     ./modules/programs/granted

--- a/tests/modules/programs/go/default.nix
+++ b/tests/modules/programs/go/default.nix
@@ -1,0 +1,1 @@
+{ go-telemetry = ./go-telemetry.nix; }

--- a/tests/modules/programs/go/go-telemetry.nix
+++ b/tests/modules/programs/go/go-telemetry.nix
@@ -1,0 +1,25 @@
+{ pkgs, ... }:
+
+{
+  programs.go = {
+    enable = true;
+    telemetry = {
+      mode = "on";
+      date = "2006-01-02";
+    };
+  };
+
+  test.stubs.go = { };
+
+  nm.script = let
+    modeFileDir = if !pkgs.stdenv.isDarwin then
+      ".config/go/telemetry"
+    else
+      "Library/Application Support/go/telemetry";
+  in ''
+    assertFileExists "home-files/${modeFileDir}/mode"
+    assertFileContent \
+      "home-files/${modeFileDir}/mode" \
+      "on 2006-01-02"
+  '';
+}


### PR DESCRIPTION
### Description

This PR adds 2 options for `programs.go` to configure Go telemetry mode. This is the same as running `go telemetry <mode>` manually, with a pre-configured date.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rvolosatovs 