### PR TITLE
git-credential-oauth: fix ensure git extraConfig is last in list

### DIFF
--- a/modules/programs/git-credential-oauth.nix
+++ b/modules/programs/git-credential-oauth.nix
@@ -29,7 +29,7 @@ in {
   config = lib.mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    programs.git.extraConfig.credential.helper = [
+    programs.git.extraConfig.credential.helper = lib.mkAfter [
       ("${cfg.package}/bin/git-credential-oauth"
         + lib.optionalString (cfg.extraFlags != [ ])
         " ${lib.strings.concatStringsSep " " cfg.extraFlags}")


### PR DESCRIPTION

### Description

when adding storage helpers via git.extraConfig,
git-credential-oauth is not last is `.git/config`, which is the desired state: [ git-credential-oauth must be configured last](https://github.com/hickford/git-credential-oauth?tab=readme-ov-file#how-it-works).
without the correct order, the storage helper is never called.

<!--

Please provide a brief description of your change.

-->

added mkAfter in git.extraConfig to ensure our oauth is last, as required to work with additional helpers


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@tomodachi94 

