### PR TITLE
nixos: add `key` to shared module to allow disabling it

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -19,13 +19,17 @@ in {
         extraSpecialArgs.nixosConfig = config;
 
         sharedModules = [{
-          # The per-user directory inside /etc/profiles is not known by
-          # fontconfig by default.
-          fonts.fontconfig.enable = lib.mkDefault
-            (cfg.useUserPackages && config.fonts.fontconfig.enable);
+          key = "home-manager#nixos-shared-module";
 
-          # Inherit glibcLocales setting from NixOS.
-          i18n.glibcLocales = lib.mkDefault config.i18n.glibcLocales;
+          config = {
+            # The per-user directory inside /etc/profiles is not known by
+            # fontconfig by default.
+            fonts.fontconfig.enable = lib.mkDefault
+              (cfg.useUserPackages && config.fonts.fontconfig.enable);
+
+            # Inherit glibcLocales setting from NixOS.
+            i18n.glibcLocales = lib.mkDefault config.i18n.glibcLocales;
+          };
         }];
       };
     }


### PR DESCRIPTION
### Description

By adding `key`, this allows users to disable this shared module or they can choose to not disable this shared module (by filtering by key before disabling)

This means users can disable all shared modules if all modules are paths or attrsets with a key:

`configuration.nix`:

```nix
{ config, ... }:

{
  home-manager.users.enzime = { ... }: {
    disabledModules = config.home-manager.sharedModules;
  };
}
```

Or disabling just this module specifically:

```nix
{ ... }:

{
  home-manager.users.enzime = { ... }: {
    disabledModules = [ { key = "home-manager#nixos-shared-module"; } ];
  };
}
```

Or disabling all modules when you have modules you can't disable (like lambdas):

```nix
{ ... }:

{
  home-manager.users.enzime = { ... }: {
    disabledModules = lib.filter (v: lib.isString v || lib.isPath v || (lib.isAttrs v && v ? key)) config.home-manager.sharedModules;
  };
}
```


https://nixos.org/manual/nixos/unstable/#sec-replace-modules

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

cc @rycee 
