### PR TITLE
git: Fix maintenance service

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -549,7 +549,7 @@ in {
           Type = "oneshot";
           ExecStart = let exe = lib.getExe cfg.package;
           in ''
-            "${exe}" --exec-path="${exe}" for-each-repo --config=maintenance.repo maintenance run --schedule=%i
+            "${exe}" for-each-repo --keep-going --config=maintenance.repo maintenance run --schedule=%i
           '';
           LockPersonality = "yes";
           MemoryDenyWriteExecute = "yes";


### PR DESCRIPTION
Call to git-maintenance in the systemd user service was using a eroneous value for exec-path flag. Removing the flag is fine.

### Description

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 