### PR TITLE
mpv: drop old wrapMpv compatibility

### DIFF
--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -55,10 +55,8 @@ let
 
   mpvPackage = if cfg.scripts == [ ] then
     cfg.package
-  else if hasAttr "wrapMpv" pkgs then
-    pkgs.wrapMpv pkgs.mpv-unwrapped { scripts = cfg.scripts; }
   else
-    pkgs.mpv.override { scripts = cfg.scripts; };
+    pkgs.mpv.override { inherit (cfg) scripts; };
 
 in {
   options = {
@@ -69,7 +67,7 @@ in {
         type = types.package;
         default = pkgs.mpv;
         example = literalExpression
-          "pkgs.wrapMpv (pkgs.mpv-unwrapped.override { vapoursynthSupport = true; }) { youtubeSupport = true; }";
+          "pkgs.mpv-unwrapped.wrapper { mpv = pkgs.mpv-unwrapped.override { vapoursynthSupport = true; }; youtubeSupport = true; }";
         description = ''
           Package providing mpv.
         '';


### PR DESCRIPTION
Closes https://github.com/nix-community/home-manager/issues/6234

### Description

wrapMpv doesn't exist anymore for a while.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
