### PR TITLE
Sbt credentials scoping to build rather than projects.

### DIFF
--- a/modules/programs/sbt.nix
+++ b/modules/programs/sbt.nix
@@ -25,7 +25,7 @@ let
     in
     ''
       lazy val ${symbol} = "${cred.passwordCommand}".!!.trim
-      credentials += Credentials("${cred.realm}", "${cred.host}", "${cred.user}", ${symbol})
+      ThisBuild / credentials += Credentials("${cred.realm}", "${cred.host}", "${cred.user}", ${symbol})
     '';
 
   renderCredentials = creds: ''

--- a/tests/modules/programs/sbt/credentials.nix
+++ b/tests/modules/programs/sbt/credentials.nix
@@ -18,9 +18,9 @@ let
   expectedCredentialsSbt = pkgs.writeText "credentials.sbt" ''
     import scala.sys.process._
     lazy val credential_0 = "echo password".!!.trim
-    credentials += Credentials("Sonatype Nexus Repository Manager", "example.com", "user", credential_0)
+    ThisBuild / credentials += Credentials("Sonatype Nexus Repository Manager", "example.com", "user", credential_0)
     lazy val credential_1 = "echo password1".!!.trim
-    credentials += Credentials("Sonatype Nexus Repository Manager X", "v2.example.com", "user1", credential_1)
+    ThisBuild / credentials += Credentials("Sonatype Nexus Repository Manager X", "v2.example.com", "user1", credential_1)
   '';
   credentialsSbtPath = ".sbt/1.0/credentials.sbt";
 in


### PR DESCRIPTION
### Description

In Sbt (prior to 2.0) a sbt key not scoped to `ThisBuild` will always be at the project level, rather than at the build level.
In order to do some things, like use a private repository configured by sbt with sbt-scalafix, we need the credentials scope to the build, otherwise the credentials show as non-existant.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@kubukoz