### PR TITLE
docs: home.sessionVariables clarification

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -280,8 +280,9 @@ in
         };
         ```
         may not work as expected. If you need to reference another
-        session variable, then do so inside Nix instead. The above
-        example then becomes
+        session variable (even if it is declared by using other options
+        like [](#opt-xdg.configHome)), then do so inside Nix instead.
+        The above example then becomes
         ```nix
         home.sessionVariables = {
           FOO = "Hello";


### PR DESCRIPTION
### Description

Closes: https://github.com/nix-community/home-manager/issues/6027


### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 