### PR TITLE
nixgl: forward override calls to wrapped package

### DIFF
--- a/modules/misc/nixgl.nix
+++ b/modules/misc/nixgl.nix
@@ -240,7 +240,15 @@ in {
 
             shopt -u nullglob # Revert nullglob back to its normal default state
           '';
-        }));
+        })) // {
+          # When the nixGL-wrapped package is given to a HM module, the module
+          # might want to override the package arguments, but our wrapper
+          # wouldn't know what to do with them. So, we rewrite the override
+          # function to instead forward the arguments to the package's own
+          # override function.
+          override = args:
+            makePackageWrapper vendor environment (pkg.override args);
+        };
 
     wrappers = {
       mesa = makePackageWrapper "Intel" { };


### PR DESCRIPTION
### Description

Currently, wrapping packages with `nixGL.wrap` will break any options in home manager modules that use `override` to modify the package.

This change overrides `override` on the wrapper package, such that it will instead forward the call to the internal package, and return a wrapped version of the result with the same arguments.

Tested via the `programs.chromium.commandLineArgs` option mentioned in #6016, with several other wrapped packages in my config to regression test.

Fixes #6016.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
