### PR TITLE
gpg: add dirmngrSettings and gpgsmSettings options + remove obsolete default values

### DIFF
--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -18,6 +18,16 @@ let
     listsAsDuplicateKeys = true;
   } cfg.scdaemonSettings;
 
+  dirmngrCfgText = generators.toKeyValue {
+    inherit mkKeyValue;
+    listsAsDuplicateKeys = true;
+  } cfg.dirmngrSettings;
+
+  gpgsmCfgText = generators.toKeyValue {
+    inherit mkKeyValue;
+    listsAsDuplicateKeys = true;
+  } cfg.gpgsmSettings;
+
   primitiveType = types.oneOf [ types.str types.bool ];
 
   publicKeyOpts = { config, ... }: {
@@ -187,6 +197,41 @@ in {
       '';
     };
 
+    dirmngrSettings = mkOption {
+      type =
+        types.attrsOf (types.either primitiveType (types.listOf types.str));
+      example = literalExpression ''
+        {
+          allow-version-check = true;
+          keyserver = "ldaps://ldap.example.com";
+        }
+      '';
+      description = ''
+        Dirmngr configuration options. Available options are described
+        in
+        [
+          {manpage}`dirmngr(1)`
+        ](https://www.gnupg.org/documentation/manuals/gnupg/Dirmngr-Options.html)
+      '';
+    };
+
+    gpgsmSettings = mkOption {
+      type =
+        types.attrsOf (types.either primitiveType (types.listOf types.str));
+      example = literalExpression ''
+        {
+          with-key-data = true;
+        }
+      '';
+      description = ''
+        GPGSM configuration options. Available options are described
+        in
+        [
+          {manpage}`gpgsm(1)`
+        ](https://www.gnupg.org/documentation/manuals/gnupg/GPGSM-Options.html)
+      '';
+    };
+
     homedir = mkOption {
       type = types.path;
       example = literalExpression ''"''${config.xdg.dataHome}/gnupg"'';
@@ -266,12 +311,24 @@ in {
       # no defaults for scdaemon
     };
 
+    programs.gpg.dirmngrSettings = {
+      # no defaults for dirmngr
+    };
+
+    programs.gpg.gpgsmSettings = {
+      # no defaults for gpgsm
+    };
+
     home.packages = [ cfg.package ];
     home.sessionVariables = { GNUPGHOME = cfg.homedir; };
 
     home.file."${cfg.homedir}/gpg.conf".text = cfgText;
 
     home.file."${cfg.homedir}/scdaemon.conf".text = scdaemonCfgText;
+
+    home.file."${cfg.homedir}/dirmngr.conf".text = dirmngrCfgText;
+
+    home.file."${cfg.homedir}/gpgsm.conf".text = gpgsmCfgText;
 
     # Link keyring if keys are not mutable
     home.file."${cfg.homedir}/pubring.kbx" =

--- a/modules/programs/gpg.nix
+++ b/modules/programs/gpg.nix
@@ -294,8 +294,7 @@ in {
       cert-digest-algo = mkDefault "SHA512";
       s2k-digest-algo = mkDefault "SHA512";
       s2k-cipher-algo = mkDefault "AES256";
-      charset = mkDefault "utf-8";
-      fixed-list-mode = mkDefault true;
+      display-charset = mkDefault "utf-8";
       no-comments = mkDefault true;
       no-emit-version = mkDefault true;
       keyid-format = mkDefault "0xlong";
@@ -304,7 +303,6 @@ in {
       with-fingerprint = mkDefault true;
       require-cross-certification = mkDefault true;
       no-symkey-cache = mkDefault true;
-      use-agent = mkDefault true;
     };
 
     programs.gpg.scdaemonSettings = {

--- a/tests/modules/programs/gpg/override-defaults-expected.conf
+++ b/tests/modules/programs/gpg/override-defaults-expected.conf
@@ -1,7 +1,6 @@
 cert-digest-algo SHA512
-charset utf-8
 default-preference-list SHA512 SHA384 SHA256 AES256 AES192 AES ZLIB BZIP2 ZIP Uncompressed
-fixed-list-mode
+display-charset utf-8
 keyid-format 0xlong
 list-options show-uid-validity
 
@@ -16,6 +15,5 @@ s2k-digest-algo SHA512
 throw-keyids
 trusted-key 0xXXXXXXXXXXXXX
 trusted-key 0xYYYYYYYYYYYYY
-use-agent
 verify-options show-uid-validity
 with-fingerprint


### PR DESCRIPTION
### Description

The PR adds additional options to manage `dirmngr.conf` and `gpgsm.conf` files. The option I'm most interested in is `keyserver`, which has been deprecated in `gpg.conf` and should now be set in `dirmngr.conf`.

While at it, I've also deleted some obsolete values from the default gpg settings. The reasons are listed in the 2nd commit message.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC