### PR TITLE
zellij: Add additional options for shell integration

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -8,18 +8,39 @@ let
   yamlFormat = pkgs.formats.yaml { };
   zellijCmd = getExe cfg.package;
 
+  autostartOnShellStartModule = types.submodule {
+    options = {
+      enable = mkEnableOption "" // {
+        description = ''
+          Whether to autostart Zellij session on shell creation.
+        '';
+      };
+
+      attachExistingSession = mkEnableOption "" // {
+        description = ''
+          Whether to attach to the default session after being autostarted if a Zellij session already exists.
+        '';
+      };
+
+      exitShellOnExit = mkEnableOption "" // {
+        description = ''
+          Whether to exit the shell when Zellij exits after being autostarted.
+        '';
+      };
+    };
+  };
 in {
   meta.maintainers = [ hm.maintainers.mainrs ];
 
   options.programs.zellij = {
-    enable = mkEnableOption "zellij";
+    enable = mkEnableOption "Zellij";
 
     package = mkOption {
       type = types.package;
       default = pkgs.zellij;
       defaultText = literalExpression "pkgs.zellij";
       description = ''
-        The zellij package to install.
+        The Zellij package to install.
       '';
     };
 
@@ -41,6 +62,15 @@ in {
 
         See <https://zellij.dev/documentation> for the full
         list of options.
+      '';
+    };
+
+    autostartOnShellStart = mkOption {
+      type = types.nullOr autostartOnShellStartModule;
+      default = null;
+      description = ''
+        Options related to autostarting Zellij on shell creation.
+        Requires enable<Shell>Integration to apply to the respective <Shell>.
       '';
     };
 
@@ -69,17 +99,32 @@ in {
         text = lib.hm.generators.toKDL { } cfg.settings;
       };
 
-    programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkOrder 200 ''
-      eval "$(${zellijCmd} setup --generate-auto-start bash)"
-    '');
+    programs.zsh.initExtra = mkIf (cfg.enableZshIntegration)
+      (if cfg.autostartOnShellStart.enable then ''
+        eval "$(${zellijCmd} setup --generate-auto-start zsh)"
+      '' else
+        "");
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration (mkOrder 200 ''
-      eval "$(${zellijCmd} setup --generate-auto-start zsh)"
-    '');
-
-    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration
-      (mkOrder 200 ''
+    programs.fish.interactiveShellInit = mkIf (cfg.enableFishIntegration)
+      (if cfg.autostartOnShellStart.enable then ''
         eval (${zellijCmd} setup --generate-auto-start fish | string collect)
-      '');
+      '' else
+        "");
+
+    programs.bash.initExtra = mkIf (cfg.enableBashIntegration)
+      (if cfg.autostartOnShellStart.enable then ''
+        eval "$(${zellijCmd} setup --generate-auto-start bash)"
+      '' else
+        "");
+
+    home.sessionVariables = mkIf cfg.autostartOnShellStart.enable {
+      ZELLIJ_AUTO_ATTACH =
+        if cfg.autostartOnShellStart.attachExistingSession then
+          "true"
+        else
+          "false";
+      ZELLIJ_AUTO_EXIT =
+        if cfg.autostartOnShellStart.exitShellOnExit then "true" else "false";
+    };
   };
 }

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -3,32 +3,8 @@
 with lib;
 
 let
-
   cfg = config.programs.zellij;
   yamlFormat = pkgs.formats.yaml { };
-  zellijCmd = getExe cfg.package;
-
-  autostartOnShellStartModule = types.submodule {
-    options = {
-      enable = mkEnableOption "" // {
-        description = ''
-          Whether to autostart Zellij session on shell creation.
-        '';
-      };
-
-      attachExistingSession = mkEnableOption "" // {
-        description = ''
-          Whether to attach to the default session after being autostarted if a Zellij session already exists.
-        '';
-      };
-
-      exitShellOnExit = mkEnableOption "" // {
-        description = ''
-          Whether to exit the shell when Zellij exits after being autostarted.
-        '';
-      };
-    };
-  };
 in {
   meta.maintainers = [ hm.maintainers.mainrs ];
 
@@ -65,12 +41,23 @@ in {
       '';
     };
 
-    autostartOnShellStart = mkOption {
-      type = types.nullOr autostartOnShellStartModule;
-      default = null;
+    attachExistingSession = mkOption {
+      type = types.bool;
+      default = false;
       description = ''
-        Options related to autostarting Zellij on shell creation.
-        Requires enable<Shell>Integration to apply to the respective <Shell>.
+        Whether to attach to the default session after being autostarted if a Zellij session already exists.
+
+        Requires shell integration to be enabled to have effect.
+      '';
+    };
+
+    exitShellOnExit = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to exit the shell when Zellij exits after being autostarted.
+
+        Requires shell integration to be enabled to have effect.
       '';
     };
 
@@ -84,7 +71,10 @@ in {
       lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
-  config = mkIf cfg.enable {
+  config = let
+    shellIntegrationEnabled = (cfg.enableBashIntegration
+      || cfg.enableZshIntegration || cfg.enableFishIntegration);
+  in mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
     # Zellij switched from yaml to KDL in version 0.32.0:
@@ -99,32 +89,33 @@ in {
         text = lib.hm.generators.toKDL { } cfg.settings;
       };
 
-    programs.zsh.initExtra = mkIf (cfg.enableZshIntegration)
-      (if cfg.autostartOnShellStart.enable then ''
-        eval "$(${zellijCmd} setup --generate-auto-start zsh)"
-      '' else
-        "");
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
+      eval "$(${getExe cfg.package} setup --generate-auto-start bash)"
+    '';
 
-    programs.fish.interactiveShellInit = mkIf (cfg.enableFishIntegration)
-      (if cfg.autostartOnShellStart.enable then ''
-        eval (${zellijCmd} setup --generate-auto-start fish | string collect)
-      '' else
-        "");
+    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      eval "$(${getExe cfg.package} setup --generate-auto-start zsh)"
+    '';
 
-    programs.bash.initExtra = mkIf (cfg.enableBashIntegration)
-      (if cfg.autostartOnShellStart.enable then ''
-        eval "$(${zellijCmd} setup --generate-auto-start bash)"
-      '' else
-        "");
+    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
+      eval (${
+        getExe cfg.package
+      } setup --generate-auto-start fish | string collect)
+    '';
 
-    home.sessionVariables = mkIf cfg.autostartOnShellStart.enable {
+    home.sessionVariables = mkIf shellIntegrationEnabled {
       ZELLIJ_AUTO_ATTACH =
-        if cfg.autostartOnShellStart.attachExistingSession then
-          "true"
-        else
-          "false";
-      ZELLIJ_AUTO_EXIT =
-        if cfg.autostartOnShellStart.exitShellOnExit then "true" else "false";
+        if cfg.attachExistingSession then "true" else "false";
+      ZELLIJ_AUTO_EXIT = if cfg.exitShellOnExit then "true" else "false";
     };
+
+    warnings =
+      optional (cfg.attachExistingSession && !shellIntegrationEnabled) ''
+        You have enabled `programs.zellij.attachExistingSession`, but none of the shell integrations are enabled.
+        This option will have no effect.
+      '' ++ optional (cfg.exitShellOnExit && !shellIntegrationEnabled) ''
+        You have enabled `programs.zellij.exitShellOnExit`, but none of the shell integrations are enabled.
+        This option will have no effect.
+      '';
   };
 }

--- a/tests/modules/programs/zellij/enable-shells.nix
+++ b/tests/modules/programs/zellij/enable-shells.nix
@@ -4,9 +4,16 @@
   programs = {
     zellij = {
       enable = true;
-      enableBashIntegration = true;
+
+      autostartOnShellStart = {
+        enable = true;
+        attachExistingSession = true;
+        exitShellOnExit = true;
+      };
+
       enableZshIntegration = true;
       enableFishIntegration = true;
+      enableBashIntegration = true;
     };
     bash.enable = true;
     zsh.enable = true;
@@ -32,5 +39,13 @@
     assertFileContains \
       home-files/.config/fish/config.fish \
       'eval (@zellij@/bin/zellij setup --generate-auto-start fish | string collect)'
+
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileContains \
+      home-path/etc/profile.d/hm-session-vars.sh \
+      'export ZELLIJ_AUTO_ATTACH="true"'
+    assertFileContains \
+      home-path/etc/profile.d/hm-session-vars.sh \
+      'export ZELLIJ_AUTO_EXIT="true"'
   '';
 }

--- a/tests/modules/programs/zellij/enable-shells.nix
+++ b/tests/modules/programs/zellij/enable-shells.nix
@@ -5,11 +5,8 @@
     zellij = {
       enable = true;
 
-      autostartOnShellStart = {
-        enable = true;
-        attachExistingSession = true;
-        exitShellOnExit = true;
-      };
+      attachExistingSession = true;
+      exitShellOnExit = true;
 
       enableZshIntegration = true;
       enableFishIntegration = true;


### PR DESCRIPTION
### Description

This PR adds additional options for integrating Zellij with shells, namely:
1. autostarting Zellij on shell start.
2. automatically attaching to an existing session on Zellij autostart if such session exists.
3. automatically exiting the shell when the Zellij session is terminated.

The new Zellij configurations can look like this:
```nix
  programs.zellij = {
    enable = true;

    autostartOnShellStart = {
      enable = true;
      attachExistingSession = false;
      exitShellOnExit = true;
    };

    enableZshIntegration = true;
    enableFishIntegration = true;
    enableBashIntegration = true;
  };
``` 

Currently, the options are implemented such a single configuration, which can get applied to shells by using `enable<Shell>Integration`. This means that one cannot have one configuration for, Zsh, another for Bash, and completely different one for Fish.
- Would separate configurations for each shell be useful? For example, use autostart in one shell, but load completions only in another?

The PR is supposed to supersede #5333 as it implements the same integration with Fish, albeit with different options. Closes #5333.

I tested the PR primarily on Zsh and Bash. Everything works for Bash and Zsh as expected.

~~However, Fish seems to be having issues. Namely, the completions are loaded, but for each shell instance, one must manually activate completions on `zellij` command by pressing `Tab` to allow for the functions (such as `ze`, `zfr` etc.) to register and the completions to load. Autostart for Fish does not work at all, as it seems that the `interactiveShellInit` does not write to the config file at all. Needs further investigation. Maybe a similar workaround as for Zsh is needed?~~ 
Fish integration works well, too.

I need to perform some more testing on Fish shell. When this is completed, I will open the PR for merging. Nevertheless, I ask for a review for the PR now, especially regarding the possibility of allowing different configurations for each shell (basically just having `autostartOn<Shell>Start` module for each shell instead of a shared `autostartOnShellStart`). But then the `enable<Shell>Integration` seems kinda pointless.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@mainrs 