### PR TITLE
podman: install package if enabled and create config files

### DIFF
--- a/modules/services/podman-linux/default.nix
+++ b/modules/services/podman-linux/default.nix
@@ -12,13 +12,13 @@ in {
     enable = lib.mkEnableOption "Podman, a daemonless container engine";
 
     config = {
-      containers.settings = lib.mkOption {
+      containers = lib.mkOption {
         type = toml.type;
         default = { };
         description = "containers.conf configuration";
       };
 
-      storage.settings = lib.mkOption {
+      storage = lib.mkOption {
         type = toml.type;
         description = "storage.conf configuration";
       };
@@ -77,7 +77,7 @@ in {
 
     home.packages = [ cfg.package ];
 
-    services.podman.config.storage.settings = {
+    services.podman.config.storage = {
       storage.driver = lib.mkDefault "overlay";
     };
 
@@ -91,9 +91,9 @@ in {
           lib.mapAttrs (n: v: { registries = v; }) cfg.config.registries;
       };
       "containers/storage.conf".source =
-        toml.generate "storage.conf" cfg.config.storage.settings;
+        toml.generate "storage.conf" cfg.config.storage;
       "containers/containers.conf".source =
-        toml.generate "containers.conf" cfg.config.containers.settings;
+        toml.generate "containers.conf" cfg.config.containers;
     };
   };
 }

--- a/modules/services/podman-linux/default.nix
+++ b/modules/services/podman-linux/default.nix
@@ -1,6 +1,8 @@
 { config, pkgs, lib, ... }:
-
-{
+let
+  cfg = config.services.podman;
+  toml = pkgs.formats.toml { };
+in {
   meta.maintainers = with lib.hm.maintainers; [ bamhm182 n-hass ];
 
   imports =
@@ -8,10 +10,87 @@
 
   options.services.podman = {
     enable = lib.mkEnableOption "Podman, a daemonless container engine";
+
+    containersConf.settings = lib.mkOption {
+      type = toml.type;
+      default = { };
+      description = "containers.conf configuration";
+    };
+
+    storage.settings = lib.mkOption {
+      type = toml.type;
+      description = "storage.conf configuration";
+    };
+
+    registries = {
+      search = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ "docker.io" ];
+        description = ''
+          List of repositories to search.
+        '';
+      };
+
+      insecure = lib.mkOption {
+        default = [ ];
+        type = lib.types.listOf lib.types.str;
+        description = ''
+          List of insecure repositories.
+        '';
+      };
+
+      block = lib.mkOption {
+        default = [ ];
+        type = lib.types.listOf lib.types.str;
+        description = ''
+          List of blocked repositories.
+        '';
+      };
+    };
+
+    policy = lib.mkOption {
+      default = { };
+      type = lib.types.attrs;
+      example = lib.literalExpression ''
+        {
+          default = [ { type = "insecureAcceptAnything"; } ];
+          transports = {
+            docker-daemon = {
+              "" = [ { type = "insecureAcceptAnything"; } ];
+            };
+          };
+        }
+      '';
+      description = ''
+        Signature verification policy file.
+        If this option is empty the default policy file from
+        `skopeo` will be used.
+      '';
+    };
   };
 
-  config = lib.mkIf config.services.podman.enable {
+  config = lib.mkIf cfg.enable {
     assertions =
       [ (lib.hm.assertions.assertPlatform "podman" pkgs lib.platforms.linux) ];
+
+    home.packages = [ cfg.package ];
+
+    services.podman.storage.settings = {
+      storage.driver = lib.mkDefault "overlay";
+    };
+
+    xdg.configFile = {
+      "containers/policy.json".source = if cfg.policy != { } then
+        pkgs.writeText "policy.json" (builtins.toJSON cfg.policy)
+      else
+        "${pkgs.skopeo.policy}/default-policy.json";
+      "containers/registries.conf".source = toml.generate "registries.conf" {
+        registries = lib.mapAttrs (n: v: { registries = v; }) cfg.registries;
+      };
+      "containers/storage.conf".source =
+        toml.generate "storage.conf" cfg.storage.settings;
+      "containers/containers.conf".source =
+        toml.generate "containers.conf" cfg.containersConf.settings;
+    };
   };
 }

--- a/modules/services/podman-linux/default.nix
+++ b/modules/services/podman-linux/default.nix
@@ -11,7 +11,7 @@ in {
   options.services.podman = {
     enable = lib.mkEnableOption "Podman, a daemonless container engine";
 
-    config = {
+    settings = {
       containers = lib.mkOption {
         type = toml.type;
         default = { };
@@ -77,23 +77,23 @@ in {
 
     home.packages = [ cfg.package ];
 
-    services.podman.config.storage = {
+    services.podman.settings.storage = {
       storage.driver = lib.mkDefault "overlay";
     };
 
     xdg.configFile = {
-      "containers/policy.json".source = if cfg.config.policy != { } then
-        pkgs.writeText "policy.json" (builtins.toJSON cfg.config.policy)
+      "containers/policy.json".source = if cfg.settings.policy != { } then
+        pkgs.writeText "policy.json" (builtins.toJSON cfg.settings.policy)
       else
         "${pkgs.skopeo.policy}/default-policy.json";
       "containers/registries.conf".source = toml.generate "registries.conf" {
         registries =
-          lib.mapAttrs (n: v: { registries = v; }) cfg.config.registries;
+          lib.mapAttrs (n: v: { registries = v; }) cfg.settings.registries;
       };
       "containers/storage.conf".source =
-        toml.generate "storage.conf" cfg.config.storage;
+        toml.generate "storage.conf" cfg.settings.storage;
       "containers/containers.conf".source =
-        toml.generate "containers.conf" cfg.config.containers;
+        toml.generate "containers.conf" cfg.settings.containers;
     };
   };
 }

--- a/tests/modules/services/podman-linux/configuration-containers-expected.conf
+++ b/tests/modules/services/podman-linux/configuration-containers-expected.conf
@@ -1,0 +1,10 @@
+[network]
+default_subnet = "172.16.10.0/24"
+
+[[network.default_subnet_pools]]
+base = "172.16.11.0/24"
+size = 24
+
+[[network.default_subnet_pools]]
+base = "172.16.12.0/24"
+size = 24

--- a/tests/modules/services/podman-linux/configuration-policy-expected.json
+++ b/tests/modules/services/podman-linux/configuration-policy-expected.json
@@ -1,0 +1,1 @@
+{"default":[{"type":"insecureAcceptAnything"}]}

--- a/tests/modules/services/podman-linux/configuration-registries-expected.conf
+++ b/tests/modules/services/podman-linux/configuration-registries-expected.conf
@@ -1,0 +1,8 @@
+[registries.block]
+registries = ["ghcr.io", "gallery.ecr.aws"]
+
+[registries.insecure]
+registries = ["quay.io"]
+
+[registries.search]
+registries = ["docker.io"]

--- a/tests/modules/services/podman-linux/configuration-storage-expected.conf
+++ b/tests/modules/services/podman-linux/configuration-storage-expected.conf
@@ -1,0 +1,4 @@
+[storage]
+driver = "overlay"
+graphroot = "$HOME/.containers/graphroot"
+runroot = "$HOME/.containers/runroot"

--- a/tests/modules/services/podman-linux/configuration.nix
+++ b/tests/modules/services/podman-linux/configuration.nix
@@ -3,33 +3,35 @@
 {
   services.podman = {
     enable = true;
-    containersConf.settings = {
-      network = {
-        default_subnet = "172.16.10.0/24";
-        default_subnet_pools = [
-          {
-            base = "172.16.11.0/24";
-            size = 24;
-          }
-          {
-            base = "172.16.12.0/24";
-            size = 24;
-          }
-        ];
+    config = {
+      containers.settings = {
+        network = {
+          default_subnet = "172.16.10.0/24";
+          default_subnet_pools = [
+            {
+              base = "172.16.11.0/24";
+              size = 24;
+            }
+            {
+              base = "172.16.12.0/24";
+              size = 24;
+            }
+          ];
+        };
       };
-    };
-    storage.settings = {
-      storage = {
-        runroot = "$HOME/.containers/runroot";
-        graphroot = "$HOME/.containers/graphroot";
+      storage.settings = {
+        storage = {
+          runroot = "$HOME/.containers/runroot";
+          graphroot = "$HOME/.containers/graphroot";
+        };
       };
+      registries = {
+        block = [ "ghcr.io" "gallery.ecr.aws" ];
+        insecure = [ "quay.io" ];
+        search = [ "docker.io" ];
+      };
+      policy = { default = [{ type = "insecureAcceptAnything"; }]; };
     };
-    registries = {
-      block = [ "ghcr.io" "gallery.ecr.aws" ];
-      insecure = [ "quay.io" ];
-      search = [ "docker.io" ];
-    };
-    policy = { default = [{ type = "insecureAcceptAnything"; }]; };
   };
 
   nmt.script = ''

--- a/tests/modules/services/podman-linux/configuration.nix
+++ b/tests/modules/services/podman-linux/configuration.nix
@@ -4,7 +4,7 @@
   services.podman = {
     enable = true;
     config = {
-      containers.settings = {
+      containers = {
         network = {
           default_subnet = "172.16.10.0/24";
           default_subnet_pools = [
@@ -19,7 +19,7 @@
           ];
         };
       };
-      storage.settings = {
+      storage = {
         storage = {
           runroot = "$HOME/.containers/runroot";
           graphroot = "$HOME/.containers/graphroot";

--- a/tests/modules/services/podman-linux/configuration.nix
+++ b/tests/modules/services/podman-linux/configuration.nix
@@ -1,0 +1,61 @@
+{ ... }:
+
+{
+  services.podman = {
+    enable = true;
+    containersConf.settings = {
+      network = {
+        default_subnet = "172.16.10.0/24";
+        default_subnet_pools = [
+          {
+            base = "172.16.11.0/24";
+            size = 24;
+          }
+          {
+            base = "172.16.12.0/24";
+            size = 24;
+          }
+        ];
+      };
+    };
+    storage.settings = {
+      storage = {
+        runroot = "$HOME/.containers/runroot";
+        graphroot = "$HOME/.containers/graphroot";
+      };
+    };
+    registries = {
+      block = [ "ghcr.io" "gallery.ecr.aws" ];
+      insecure = [ "quay.io" ];
+      search = [ "docker.io" ];
+    };
+    policy = { default = [{ type = "insecureAcceptAnything"; }]; };
+  };
+
+  nmt.script = ''
+    configPath=home-files/.config/containers
+    containersFile=$configPath/containers.conf
+    policyFile=$configPath/policy.json
+    registriesFile=$configPath/registries.conf
+    storageFile=$configPath/storage.conf
+
+    assertFileExists $containersFile
+    assertFileExists $policyFile
+    assertFileExists $registriesFile
+    assertFileExists $storageFile
+
+    containersFile=$(normalizeStorePaths $containersFile)
+    policyFile=$(normalizeStorePaths $policyFile)
+    registriesFile=$(normalizeStorePaths $registriesFile)
+    storageFile=$(normalizeStorePaths $storageFile)
+
+    assertFileContent $containersFile ${
+      ./configuration-containers-expected.conf
+    }
+    assertFileContent $policyFile ${./configuration-policy-expected.json}
+    assertFileContent $registriesFile ${
+      ./configuration-registries-expected.conf
+    }
+    assertFileContent $storageFile ${./configuration-storage-expected.conf}
+  '';
+}

--- a/tests/modules/services/podman-linux/configuration.nix
+++ b/tests/modules/services/podman-linux/configuration.nix
@@ -3,7 +3,7 @@
 {
   services.podman = {
     enable = true;
-    config = {
+    settings = {
       containers = {
         network = {
           default_subnet = "172.16.10.0/24";

--- a/tests/modules/services/podman-linux/default.nix
+++ b/tests/modules/services/podman-linux/default.nix
@@ -1,4 +1,5 @@
 {
+  podman-configuration = ./configuration.nix;
   podman-container = ./container.nix;
   podman-integration = ./integration.nix;
   podman-manifest = ./manifest.nix;


### PR DESCRIPTION
### Description

Copied some useful options from NixOS podman module and adapted the configuration to home-manager.

Also setting `services.podman.enable = true` will now add `podman` to `PATH`.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@bamhm182 @n-hass 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
