### PR TITLE
Fix git-sync crash when whitespace in path

### DIFF
--- a/modules/services/git-sync.nix
+++ b/modules/services/git-sync.nix
@@ -16,9 +16,9 @@ let
         "PATH=${
           lib.makeBinPath (with pkgs; [ openssh git ] ++ repo.extraPackages)
         }"
-        "GIT_SYNC_DIRECTORY=${repo.path}"
+        "GIT_SYNC_DIRECTORY=${strings.escapeShellArg repo.path}"
         "GIT_SYNC_COMMAND=${cfg.package}/bin/git-sync"
-        "GIT_SYNC_REPOSITORY=${repo.uri}"
+        "GIT_SYNC_REPOSITORY=${strings.escapeShellArg repo.uri}"
         "GIT_SYNC_INTERVAL=${toString repo.interval}"
       ];
       ExecStart = "${cfg.package}/bin/git-sync-on-inotify";

--- a/modules/services/git-sync.nix
+++ b/modules/services/git-sync.nix
@@ -112,6 +112,15 @@ in {
         description = ''
           The repositories that should be synchronized.
         '';
+        example = literalExpression ''
+          {
+            xyz = {
+              path = "''${config.home.homeDirectory}/foo/home-manager";
+              uri = "git@github.com:nix-community/home-manager.git";
+              interval = 1000;
+            };
+          }
+        '';
       };
     };
   };

--- a/tests/modules/services/git-sync/default.nix
+++ b/tests/modules/services/git-sync/default.nix
@@ -1,1 +1,4 @@
-{ git-sync = ./basic.nix; }
+{
+  git-sync = ./basic.nix;
+  git-sync-with-whitespace = ./whitespace.nix;
+}

--- a/tests/modules/services/git-sync/whitespace.nix
+++ b/tests/modules/services/git-sync/whitespace.nix
@@ -4,16 +4,18 @@
   services.git-sync = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@git-sync@"; };
-    repositories.test = {
-      path = "/a/path";
-      uri = "git+ssh://user@example.com:/~user/path/to/repo.git";
+    repositories = {
+      testWithWhitespace = {
+        path = "/a path";
+        uri = "git+ssh://user@example.com:/~user/path to/repo.git";
+      };
     };
   };
 
   test.stubs.openssh = { name = "openssh"; };
 
   nmt.script = ''
-    serviceFile=home-files/.config/systemd/user/git-sync-test.service
+    serviceFile=home-files/.config/systemd/user/git-sync-testWithWhitespace.service
 
     assertFileExists $serviceFile
 
@@ -25,15 +27,15 @@
 
         [Service]
         Environment=PATH=@openssh@/bin:/nix/store/00000000000000000000000000000000-git/bin
-        Environment=GIT_SYNC_DIRECTORY=/a/path
+        Environment=GIT_SYNC_DIRECTORY='/a path'
         Environment=GIT_SYNC_COMMAND=@git-sync@/bin/git-sync
-        Environment=GIT_SYNC_REPOSITORY='git+ssh://user@example.com:/~user/path/to/repo.git'
+        Environment=GIT_SYNC_REPOSITORY='git+ssh://user@example.com:/~user/path to/repo.git'
         Environment=GIT_SYNC_INTERVAL=500
         ExecStart=@git-sync@/bin/git-sync-on-inotify
         Restart=on-abort
 
         [Unit]
-        Description=Git Sync test
+        Description=Git Sync testWithWhitespace
       ''
     }
   '';


### PR DESCRIPTION
### Description

We fixed the home-manager git-sync to properly escape the arguments that get written into the users git-sync-\<name\>.service.

We additionally bumped the nixpkgs-unstable version to include our recently merged update PR for git-sync.
git-sync was 2 years out of date and also had a bug with repo paths containing whitespaces.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.(Excluding the four broken, non-related tests, in #6049)

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@colonelpanic8 @cab404 @ryane