### PR TITLE
vivid: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -264,6 +264,7 @@ let
     ./programs/vim-vint.nix
     ./programs/vim.nix
     ./programs/vinegar.nix
+    ./programs/vivid.nix
     ./programs/vscode.nix
     ./programs/vscode/haskell.nix
     ./programs/pywal.nix

--- a/modules/programs/vivid.nix
+++ b/modules/programs/vivid.nix
@@ -1,0 +1,95 @@
+{ config, lib, pkgs, ... }:
+let yaml = pkgs.formats.yaml { };
+in with lib; {
+  meta.maintainers = with maintainers; [ arunoruto ];
+
+  options.programs.vivid = {
+    enable = mkEnableOption ''
+      vivid - A themeable LS_COLORS generator with a rich filetype database
+      <link xlink:href="https://github.com/sharkdp/vivid" />
+    '';
+
+    package = mkPackageOption pkgs "vivid" { };
+
+    theme = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      example = "molokai";
+      description = ''
+        Color theme to enable.
+        Run `vivid themes` for a list of available themes.
+      '';
+    };
+
+    filetypes = mkOption {
+      type = yaml.type;
+      default = { };
+      example = literalExpression ''
+        {
+          core = {
+            regular_file = [ "$fi" ];
+            directory = [ "$di" ];
+          };
+          text = {
+            readme = [ "README.md" ];
+            licenses = [ "LICENSE" ];
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        <filename>~/.config/vivid/filetypes.yml</filename>.
+        Visit <link xlink:href="https://github.com/sharkdp/vivid/tree/master/config/filetypes.yml" />
+        for a reference file.
+      '';
+    };
+
+    themes = mkOption {
+      type = types.attrsOf (yaml.type);
+      default = { };
+      example = literalExpression ''
+        {
+          mytheme = {
+            colors = {
+              blue = "0000ff";
+            };
+            core = {
+              directory = {
+                foreground = "blue";
+                font-style = "bold";
+              };
+            };
+          };
+        }
+      '';
+      description = ''
+        Theme files written to
+        <filename>~/.config/vivid/themes/<mytheme>.yml</filename>.
+        Visit <link xlink:href="https://github.com/sharkdp/vivid/tree/master/themes" />
+        for references.
+      '';
+    };
+  };
+
+  config = let
+    cfg = config.programs.vivid;
+    lsColors = builtins.readFile (pkgs.runCommand "vivid-ls-colors" { } ''
+      ${lib.getExe cfg.package} generate ${cfg.theme} > $out
+    '');
+  in mkIf cfg.enable {
+    home = {
+      packages = [ cfg.package ];
+      sessionVariables = { LS_COLORS = "${lsColors}"; };
+    };
+
+    xdg.configFile = {
+      "vivid/filetypes.yml" =
+        mkIf (builtins.length (builtins.attrNames cfg.filetypes) > 0) {
+          source = yaml.generate "filetypes.yml" cfg.filetypes;
+        };
+    } // mapAttrs' (name: value:
+      nameValuePair "vivid/themes/${name}.yml" {
+        source = yaml.generate "${name}.yml" value;
+      }) cfg.themes;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -246,6 +246,7 @@ in import nmtSrc {
     ./modules/programs/vifm
     ./modules/programs/vim-vint
     ./modules/programs/vinegar
+    ./modules/programs/vivid
     ./modules/programs/vscode
     ./modules/programs/watson
     ./modules/programs/wezterm

--- a/tests/modules/programs/vivid/default.nix
+++ b/tests/modules/programs/vivid/default.nix
@@ -1,0 +1,5 @@
+{
+  vivid-empty-settings = ./empty.nix;
+  vivid-filetypes = ./filetypes-example.nix;
+  vivid-themes = ./themes-example.nix;
+}

--- a/tests/modules/programs/vivid/empty.nix
+++ b/tests/modules/programs/vivid/empty.nix
@@ -1,0 +1,11 @@
+{
+  programs.vivid = {
+    enable = true;
+    theme = "test";
+  };
+  test.stubs.vivid = { };
+  nmt.script = ''
+    assertPathNotExists home-files/.config/vivid/filetypes.yaml
+    assertPathNotExists home-files/.config/vivid/themes
+  '';
+}

--- a/tests/modules/programs/vivid/filetypes-example.nix
+++ b/tests/modules/programs/vivid/filetypes-example.nix
@@ -1,0 +1,464 @@
+{ config, ... }: {
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/vivid/filetypes.yml \
+      ${./filetypes-expected.yml}
+  '';
+
+  programs.vivid = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    filetypes = {
+      "core" = {
+        "normal_text" = [ "$no" ];
+        "regular_file" = [ "$fi" ];
+        "reset_to_normal" = [ "$rs" ];
+        "directory" = [ "$di" ];
+        "symlink" = [ "$ln" ];
+        "multi_hard_link" = [ "$mh" ];
+        "fifo" = [ "$pi" ];
+        "socket" = [ "$so" ];
+        "door" = [ "$do" ];
+        "block_device" = [ "$bd" ];
+        "character_device" = [ "$cd" ];
+        "broken_symlink" = [ "$or" ];
+        "missing_symlink_target" = [ "$mi" ];
+        "setuid" = [ "$su" ];
+        "setgid" = [ "$sg" ];
+        "file_with_capability" = [ "$ca" ];
+        "sticky_other_writable" = [ "$tw" ];
+        "other_writable" = [ "$ow" ];
+        "sticky" = [ "$st" ];
+        "executable_file" = [ "$ex" ];
+      };
+      "text" = {
+        "special" = [
+          "CHANGELOG"
+          "CHANGELOG.md"
+          "CHANGELOG.txt"
+          "CODE_OF_CONDUCT"
+          "CODE_OF_CONDUCT.md"
+          "CODE_OF_CONDUCT.txt"
+          "CONTRIBUTING"
+          "CONTRIBUTING.md"
+          "CONTRIBUTING.txt"
+          "CONTRIBUTORS"
+          "CONTRIBUTORS.md"
+          "CONTRIBUTORS.txt"
+          "FAQ"
+          "INSTALL"
+          "INSTALL.md"
+          "INSTALL.txt"
+          "LEGACY"
+          "NOTICE"
+          "README"
+          "README.md"
+          "README.txt"
+          "VERSION"
+        ];
+        "todo" = [ "TODO" "TODO.md" "TODO.txt" ];
+        "licenses" = [
+          "COPYING"
+          "COPYRIGHT"
+          "LICENCE"
+          "LICENSE"
+          "LICENSE-APACHE"
+          "LICENSE-MIT"
+        ];
+        "configuration" = {
+          "generic" = [
+            ".cfg"
+            ".conf"
+            ".config"
+            ".ini"
+            ".json"
+            ".tml"
+            ".toml"
+            ".webmanifest"
+            ".yaml"
+            ".yml"
+          ];
+          "metadata" = [ ".xmp" ];
+          "bibtex" = [ ".bib" ".bst" ];
+          "dockerfile" = [ "Dockerfile" ];
+          "nix" = [ ".nix" ];
+          "qt" = [ ".ui" ];
+          "desktop" = [ ".desktop" ];
+          "system" = [ "passwd" "shadow" ];
+        };
+        "other" = [ ".txt" ];
+      };
+      "markup" = {
+        "web" = [ ".htm" ".html" ".shtml" ".xhtml" ];
+        "other" = [
+          ".1"
+          ".aseprite-brushes"
+          ".aseprite-keys"
+          ".csv"
+          ".markdown"
+          ".md"
+          ".mdown"
+          ".info"
+          ".org"
+          ".rst"
+          ".tsv"
+          ".typ"
+          ".xml"
+        ];
+      };
+      "programming" = {
+        "source" = {
+          "actionscript" = [ ".as" ];
+          "ada" = [ ".adb" ".ads" ];
+          "applescript" = [ ".applescript" ];
+          "asp" = [ ".asa" ];
+          "assembly" = [ ".asm" ];
+          "awk" = [ ".awk" ];
+          "basic" = [ ".vb" ];
+          "cabal" = [ ".cabal" ];
+          "clojure" = [ ".clj" ];
+          "crystal" = [ ".cr" ];
+          "csharp" = [ ".cs" ".csx" ];
+          "css" = [ ".css" ];
+          "cxx" = [
+            ".c"
+            ".cpp"
+            ".cc"
+            ".cp"
+            ".cxx"
+            ".c++"
+            ".h"
+            ".hh"
+            ".hpp"
+            ".hxx"
+            ".h++"
+            ".ino"
+            ".inc"
+            ".inl"
+            ".ipp"
+            ".def"
+          ];
+          "d" = [ ".d" ".di" ];
+          "dart" = [ ".dart" ];
+          "diff" = [ ".diff" ".patch" ];
+          "elixir" = [ ".ex" ".exs" ];
+          "emacs" = [ ".elc" ];
+          "elm" = [ ".elm" ];
+          "erlang" = [ ".erl" ];
+          "fsharp" = [ ".fs" ".fsi" ".fsx" ];
+          "gcode" = [ ".gcode" ];
+          "go" = [ ".go" ];
+          "graphviz" = [ ".dot" ".gv" ];
+          "groovy" = [ ".groovy" ".gvy" ".gradle" ];
+          "hack" = [ ".hack" ];
+          "hare" = [ ".ha" ];
+          "haskell" = [ ".hs" ];
+          "ipython" = [ ".ipynb" ];
+          "java" = [ ".java" ".bsh" ];
+          "javascript" = [ ".js" ".jsx" ".htc" ];
+          "julia" = [ ".jl" ];
+          "kotlin" = [ ".kt" ".kts" ];
+          "latex" = [ ".tex" ".ltx" ];
+          "less" = [ ".less" ];
+          "llvm" = [ ".ll" ".mir" ];
+          "lisp" = [ ".lisp" ".el" ];
+          "lua" = [ ".lua" ];
+          "mathematica" = [ ".nb" ];
+          "matlab" = [ ".matlab" ".m" ".mn" ];
+          "mojo" = [ ".mojo" ];
+          "nim" = [ ".nim" ".nims" ".nimble" ];
+          "ocaml" = [ ".ml" ".mli" ];
+          "openscad" = [ ".scad" ];
+          "pascal" = [ ".pas" ".p" ".dpr" ];
+          "perl" = [ ".pl" ".pm" ".pod" ".t" ".cgi" ];
+          "php" = [ ".php" ];
+          "powershell" = [ ".ps1" ".psm1" ".psd1" ];
+          "prql" = [ ".prql" ];
+          "puppet" = [ ".pp" ".epp" ];
+          "purescript" = [ ".purs" ];
+          "python" = [ ".py" ];
+          "r" = [ ".r" ];
+          "raku" = [ ".raku" ];
+          "ruby" = [ ".rb" ];
+          "rust" = [ ".rs" ];
+          "sass" = [ ".sass" ".scss" ];
+          "scala" = [ ".scala" ".sbt" ];
+          "shell" =
+            [ ".sh" ".bash" ".nu" ".bashrc" ".bash_profile" ".zsh" ".fish" ];
+          "sql" = [ ".sql" ];
+          "swift" = [ ".swift" ];
+          "tablegen" = [ ".td" ];
+          "tcl" = [ ".tcl" ];
+          "typescript" = [ ".ts" ".tsx" ];
+          "v" = [ ".v" ".vsh" ];
+          "viml" = [ ".vim" ];
+          "zig" = [ ".zig" ];
+        };
+        "tooling" = {
+          "vcs" = {
+            "git" = [
+              ".gitignore"
+              ".gitmodules"
+              ".gitattributes"
+              ".gitconfig"
+              ".mailmap"
+            ];
+            "hg" = [ ".hgrc" "hgrc" ];
+            "other" =
+              [ "CODEOWNERS" ".ignore" ".fdignore" ".rgignore" ".tfignore" ];
+          };
+          "build" = {
+            "cmake" = [ ".cmake" "CMakeLists.txt" ".cmake.in" ];
+            "make" = [ "Makefile" ".make" ".mk" ];
+            "automake" = [ "Makefile.am" ];
+            "configure" = [ "configure" "configure.ac" ];
+            "scons" = [ "SConscript" "SConstruct" ];
+            "pip" = [ "requirements.txt" ];
+          };
+          "packaging" = {
+            "go" = [ "go.mod" ];
+            "python" = [ "MANIFEST.in" "setup.py" "pyproject.toml" ];
+            "ruby" = [ ".gemspec" ];
+            "v" = [ "v.mod" ];
+          };
+          "code-style" = {
+            "python" = [ ".flake8" ];
+            "cxx" = [ ".clang-format" ];
+          };
+          "editors" = {
+            "editorconfig" = [ ".editorconfig" ];
+            "qt" = [ ".pro" ];
+            "kdevelop" = [ ".kdevelop" ];
+          };
+          "documentation" = { "doxygen" = [ "Doxyfile" ".dox" ]; };
+          "continuous-integration" = [
+            "appveyor.yml"
+            "azure-pipelines.yml"
+            ".cirrus.yml"
+            ".gitlab-ci.yml"
+            ".travis.yml"
+          ];
+        };
+      };
+      "media" = {
+        "image" = {
+          "application" = [ ".aseprite" ".ase" ".ai" ".kra" ".psd" ".xvf" ];
+          "bitmap" = [
+            ".avif"
+            ".bmp"
+            ".exr"
+            ".gif"
+            ".heif"
+            ".ico"
+            ".jpeg"
+            ".jpg"
+            ".jxl"
+            ".pbm"
+            ".pcx"
+            ".pgm"
+            ".png"
+            ".ppm"
+            ".qoi"
+            ".tga"
+            ".tif"
+            ".tiff"
+            ".webp"
+            ".xpm"
+          ];
+          "raw" = [
+            ".3fr"
+            ".ari"
+            ".arw"
+            ".bay"
+            ".braw"
+            ".cap"
+            ".cr2"
+            ".cr3"
+            ".crw"
+            ".data"
+            ".dcr"
+            ".dcs"
+            ".dng"
+            ".drf"
+            ".eip"
+            ".erf"
+            ".fff"
+            ".gpr"
+            ".iiq"
+            ".k25"
+            ".kdc"
+            ".mdc"
+            ".mef"
+            ".mos"
+            ".mrw"
+            ".nef"
+            ".nrw"
+            ".obm"
+            ".orf"
+            ".pef"
+            ".ptx"
+            ".pxn"
+            ".r3d"
+            ".raf"
+            ".raw"
+            ".rw2"
+            ".rwl"
+            ".rwz"
+            ".sr2"
+            ".srf"
+            ".srw"
+            ".x3f"
+          ];
+          "vector" = [ ".dxf" ".eps" ".svg" ];
+        };
+        "audio" = [
+          ".aif"
+          ".ape"
+          ".flac"
+          ".m3u"
+          ".m4a"
+          ".mid"
+          ".mp3"
+          ".ogg"
+          ".opus"
+          ".wav"
+          ".wma"
+          ".wv"
+        ];
+        "video" = [
+          ".avi"
+          ".flv"
+          ".h264"
+          ".m4v"
+          ".mkv"
+          ".mov"
+          ".mp4"
+          ".mpeg"
+          ".mpg"
+          ".ogv"
+          ".rm"
+          ".swf"
+          ".vob"
+          ".webm"
+          ".wmv"
+        ];
+        "fonts" = [ ".fnt" ".fon" ".otf" ".ttf" ".woff" ".woff2" ];
+        "3d" = {
+          "application" = [ ".blend" ".hda" ".hip" ".ma" ".mb" ".otl" ];
+          "mesh" = [
+            ".3ds"
+            ".3mf"
+            ".alembic"
+            ".amf"
+            ".dae"
+            ".fbx"
+            ".iges"
+            ".igs"
+            ".mtl"
+            ".obj"
+            ".step"
+            ".stl"
+            ".stp"
+            ".usd"
+            ".usda"
+            ".usdc"
+            ".usdz"
+            ".wrl"
+            ".x3d"
+          ];
+        };
+      };
+      "office" = {
+        "document" =
+          [ ".doc" ".docx" ".epub" ".odt" ".pdf" ".ps" ".rtf" ".sxw" ];
+        "spreadsheet" = [ ".xls" ".xlsx" ".ods" ".xlr" ];
+        "presentation" = [ ".ppt" ".pptx" ".odp" ".sxi" ".kex" ".pps" ];
+        "calendar" = [ ".ics" ];
+      };
+      "archives" = {
+        "packages" = [ ".apk" ".deb" ".msi" ".rpm" ".xbps" ];
+        "ros" = [ ".bag" ];
+        "images" = [ ".bin" ".dmg" ".img" ".iso" ".toast" ".vcd" ];
+        "other" = [
+          ".7z"
+          ".arj"
+          ".aseprite-extension"
+          ".bz"
+          ".bz2"
+          ".db"
+          ".gz"
+          ".jar"
+          ".paq8n"
+          ".paq8o"
+          ".pkg"
+          ".rar"
+          ".tar"
+          ".tbz"
+          ".tbz2"
+          ".tgz"
+          ".xz"
+          ".z"
+          ".zip"
+          ".zpaq"
+          ".zst"
+        ];
+      };
+      "executable" = {
+        "windows" = [ ".bat" ".com" ".exe" ];
+        "library" = [ ".so" ".a" ".dll" ".dylib" ];
+        "linux" = [ ".ko" ];
+      };
+      "unimportant" = {
+        "build_artifacts" = {
+          "cxx" = [ ".o" ".la" ".lo" ];
+          "cmake" = [ "CMakeCache.txt" ];
+          "automake" = [ "Makefile.in" ];
+          "rust" = [ ".rlib" ".rmeta" ];
+          "python" = [ ".pyc" ".pyd" ".pyo" ];
+          "haskell" = [ ".dyn_hi" ".dyn_o" ".cache" ".hi" ];
+          "java" = [ ".class" ];
+          "scons" = [ ".scons_opt" ".sconsign.dblite" ];
+          "latex" = [
+            ".aux"
+            ".bbl"
+            ".bcf"
+            ".blg"
+            ".fdb_latexmk"
+            ".fls"
+            ".idx"
+            ".ilg"
+            ".ind"
+            ".out"
+            ".sty"
+            ".synctex.gz"
+            ".toc"
+          ];
+          "llvm" = [ ".bc" ];
+        };
+        "macos" = [ ".CFUserTextEncoding" ".DS_Store" ".localized" "Icon\\r" ];
+        "other" = [
+          "~"
+          ".bak"
+          ".ctags"
+          ".git"
+          ".lock"
+          ".log"
+          ".orig"
+          ".pid"
+          ".swp"
+          ".swo"
+          ".swn"
+          ".timestamp"
+          ".tmp"
+          "stderr"
+          "stdin"
+          "stdout"
+          "bun.lockb"
+          "go.sum"
+          "package-lock.json"
+        ];
+      };
+    };
+  };
+}

--- a/tests/modules/programs/vivid/filetypes-expected.yml
+++ b/tests/modules/programs/vivid/filetypes-expected.yml
@@ -1,0 +1,670 @@
+archives:
+  images:
+  - .bin
+  - .dmg
+  - .img
+  - .iso
+  - .toast
+  - .vcd
+  other:
+  - .7z
+  - .arj
+  - .aseprite-extension
+  - .bz
+  - .bz2
+  - .db
+  - .gz
+  - .jar
+  - .paq8n
+  - .paq8o
+  - .pkg
+  - .rar
+  - .tar
+  - .tbz
+  - .tbz2
+  - .tgz
+  - .xz
+  - .z
+  - .zip
+  - .zpaq
+  - .zst
+  packages:
+  - .apk
+  - .deb
+  - .msi
+  - .rpm
+  - .xbps
+  ros:
+  - .bag
+core:
+  block_device:
+  - $bd
+  broken_symlink:
+  - $or
+  character_device:
+  - $cd
+  directory:
+  - $di
+  door:
+  - $do
+  executable_file:
+  - $ex
+  fifo:
+  - $pi
+  file_with_capability:
+  - $ca
+  missing_symlink_target:
+  - $mi
+  multi_hard_link:
+  - $mh
+  normal_text:
+  - $no
+  other_writable:
+  - $ow
+  regular_file:
+  - $fi
+  reset_to_normal:
+  - $rs
+  setgid:
+  - $sg
+  setuid:
+  - $su
+  socket:
+  - $so
+  sticky:
+  - $st
+  sticky_other_writable:
+  - $tw
+  symlink:
+  - $ln
+executable:
+  library:
+  - .so
+  - .a
+  - .dll
+  - .dylib
+  linux:
+  - .ko
+  windows:
+  - .bat
+  - .com
+  - .exe
+markup:
+  other:
+  - '.1'
+  - .aseprite-brushes
+  - .aseprite-keys
+  - .csv
+  - .markdown
+  - .md
+  - .mdown
+  - .info
+  - .org
+  - .rst
+  - .tsv
+  - .typ
+  - .xml
+  web:
+  - .htm
+  - .html
+  - .shtml
+  - .xhtml
+media:
+  3d:
+    application:
+    - .blend
+    - .hda
+    - .hip
+    - .ma
+    - .mb
+    - .otl
+    mesh:
+    - .3ds
+    - .3mf
+    - .alembic
+    - .amf
+    - .dae
+    - .fbx
+    - .iges
+    - .igs
+    - .mtl
+    - .obj
+    - .step
+    - .stl
+    - .stp
+    - .usd
+    - .usda
+    - .usdc
+    - .usdz
+    - .wrl
+    - .x3d
+  audio:
+  - .aif
+  - .ape
+  - .flac
+  - .m3u
+  - .m4a
+  - .mid
+  - .mp3
+  - .ogg
+  - .opus
+  - .wav
+  - .wma
+  - .wv
+  fonts:
+  - .fnt
+  - .fon
+  - .otf
+  - .ttf
+  - .woff
+  - .woff2
+  image:
+    application:
+    - .aseprite
+    - .ase
+    - .ai
+    - .kra
+    - .psd
+    - .xvf
+    bitmap:
+    - .avif
+    - .bmp
+    - .exr
+    - .gif
+    - .heif
+    - .ico
+    - .jpeg
+    - .jpg
+    - .jxl
+    - .pbm
+    - .pcx
+    - .pgm
+    - .png
+    - .ppm
+    - .qoi
+    - .tga
+    - .tif
+    - .tiff
+    - .webp
+    - .xpm
+    raw:
+    - .3fr
+    - .ari
+    - .arw
+    - .bay
+    - .braw
+    - .cap
+    - .cr2
+    - .cr3
+    - .crw
+    - .data
+    - .dcr
+    - .dcs
+    - .dng
+    - .drf
+    - .eip
+    - .erf
+    - .fff
+    - .gpr
+    - .iiq
+    - .k25
+    - .kdc
+    - .mdc
+    - .mef
+    - .mos
+    - .mrw
+    - .nef
+    - .nrw
+    - .obm
+    - .orf
+    - .pef
+    - .ptx
+    - .pxn
+    - .r3d
+    - .raf
+    - .raw
+    - .rw2
+    - .rwl
+    - .rwz
+    - .sr2
+    - .srf
+    - .srw
+    - .x3f
+    vector:
+    - .dxf
+    - .eps
+    - .svg
+  video:
+  - .avi
+  - .flv
+  - .h264
+  - .m4v
+  - .mkv
+  - .mov
+  - .mp4
+  - .mpeg
+  - .mpg
+  - .ogv
+  - .rm
+  - .swf
+  - .vob
+  - .webm
+  - .wmv
+office:
+  calendar:
+  - .ics
+  document:
+  - .doc
+  - .docx
+  - .epub
+  - .odt
+  - .pdf
+  - .ps
+  - .rtf
+  - .sxw
+  presentation:
+  - .ppt
+  - .pptx
+  - .odp
+  - .sxi
+  - .kex
+  - .pps
+  spreadsheet:
+  - .xls
+  - .xlsx
+  - .ods
+  - .xlr
+programming:
+  source:
+    actionscript:
+    - .as
+    ada:
+    - .adb
+    - .ads
+    applescript:
+    - .applescript
+    asp:
+    - .asa
+    assembly:
+    - .asm
+    awk:
+    - .awk
+    basic:
+    - .vb
+    cabal:
+    - .cabal
+    clojure:
+    - .clj
+    crystal:
+    - .cr
+    csharp:
+    - .cs
+    - .csx
+    css:
+    - .css
+    cxx:
+    - .c
+    - .cpp
+    - .cc
+    - .cp
+    - .cxx
+    - .c++
+    - .h
+    - .hh
+    - .hpp
+    - .hxx
+    - .h++
+    - .ino
+    - .inc
+    - .inl
+    - .ipp
+    - .def
+    d:
+    - .d
+    - .di
+    dart:
+    - .dart
+    diff:
+    - .diff
+    - .patch
+    elixir:
+    - .ex
+    - .exs
+    elm:
+    - .elm
+    emacs:
+    - .elc
+    erlang:
+    - .erl
+    fsharp:
+    - .fs
+    - .fsi
+    - .fsx
+    gcode:
+    - .gcode
+    go:
+    - .go
+    graphviz:
+    - .dot
+    - .gv
+    groovy:
+    - .groovy
+    - .gvy
+    - .gradle
+    hack:
+    - .hack
+    hare:
+    - .ha
+    haskell:
+    - .hs
+    ipython:
+    - .ipynb
+    java:
+    - .java
+    - .bsh
+    javascript:
+    - .js
+    - .jsx
+    - .htc
+    julia:
+    - .jl
+    kotlin:
+    - .kt
+    - .kts
+    latex:
+    - .tex
+    - .ltx
+    less:
+    - .less
+    lisp:
+    - .lisp
+    - .el
+    llvm:
+    - .ll
+    - .mir
+    lua:
+    - .lua
+    mathematica:
+    - .nb
+    matlab:
+    - .matlab
+    - .m
+    - .mn
+    mojo:
+    - .mojo
+    nim:
+    - .nim
+    - .nims
+    - .nimble
+    ocaml:
+    - .ml
+    - .mli
+    openscad:
+    - .scad
+    pascal:
+    - .pas
+    - .p
+    - .dpr
+    perl:
+    - .pl
+    - .pm
+    - .pod
+    - .t
+    - .cgi
+    php:
+    - .php
+    powershell:
+    - .ps1
+    - .psm1
+    - .psd1
+    prql:
+    - .prql
+    puppet:
+    - .pp
+    - .epp
+    purescript:
+    - .purs
+    python:
+    - .py
+    r:
+    - .r
+    raku:
+    - .raku
+    ruby:
+    - .rb
+    rust:
+    - .rs
+    sass:
+    - .sass
+    - .scss
+    scala:
+    - .scala
+    - .sbt
+    shell:
+    - .sh
+    - .bash
+    - .nu
+    - .bashrc
+    - .bash_profile
+    - .zsh
+    - .fish
+    sql:
+    - .sql
+    swift:
+    - .swift
+    tablegen:
+    - .td
+    tcl:
+    - .tcl
+    typescript:
+    - .ts
+    - .tsx
+    v:
+    - .v
+    - .vsh
+    viml:
+    - .vim
+    zig:
+    - .zig
+  tooling:
+    build:
+      automake:
+      - Makefile.am
+      cmake:
+      - .cmake
+      - CMakeLists.txt
+      - .cmake.in
+      configure:
+      - configure
+      - configure.ac
+      make:
+      - Makefile
+      - .make
+      - .mk
+      pip:
+      - requirements.txt
+      scons:
+      - SConscript
+      - SConstruct
+    code-style:
+      cxx:
+      - .clang-format
+      python:
+      - .flake8
+    continuous-integration:
+    - appveyor.yml
+    - azure-pipelines.yml
+    - .cirrus.yml
+    - .gitlab-ci.yml
+    - .travis.yml
+    documentation:
+      doxygen:
+      - Doxyfile
+      - .dox
+    editors:
+      editorconfig:
+      - .editorconfig
+      kdevelop:
+      - .kdevelop
+      qt:
+      - .pro
+    packaging:
+      go:
+      - go.mod
+      python:
+      - MANIFEST.in
+      - setup.py
+      - pyproject.toml
+      ruby:
+      - .gemspec
+      v:
+      - v.mod
+    vcs:
+      git:
+      - .gitignore
+      - .gitmodules
+      - .gitattributes
+      - .gitconfig
+      - .mailmap
+      hg:
+      - .hgrc
+      - hgrc
+      other:
+      - CODEOWNERS
+      - .ignore
+      - .fdignore
+      - .rgignore
+      - .tfignore
+text:
+  configuration:
+    bibtex:
+    - .bib
+    - .bst
+    desktop:
+    - .desktop
+    dockerfile:
+    - Dockerfile
+    generic:
+    - .cfg
+    - .conf
+    - .config
+    - .ini
+    - .json
+    - .tml
+    - .toml
+    - .webmanifest
+    - .yaml
+    - .yml
+    metadata:
+    - .xmp
+    nix:
+    - .nix
+    qt:
+    - .ui
+    system:
+    - passwd
+    - shadow
+  licenses:
+  - COPYING
+  - COPYRIGHT
+  - LICENCE
+  - LICENSE
+  - LICENSE-APACHE
+  - LICENSE-MIT
+  other:
+  - .txt
+  special:
+  - CHANGELOG
+  - CHANGELOG.md
+  - CHANGELOG.txt
+  - CODE_OF_CONDUCT
+  - CODE_OF_CONDUCT.md
+  - CODE_OF_CONDUCT.txt
+  - CONTRIBUTING
+  - CONTRIBUTING.md
+  - CONTRIBUTING.txt
+  - CONTRIBUTORS
+  - CONTRIBUTORS.md
+  - CONTRIBUTORS.txt
+  - FAQ
+  - INSTALL
+  - INSTALL.md
+  - INSTALL.txt
+  - LEGACY
+  - NOTICE
+  - README
+  - README.md
+  - README.txt
+  - VERSION
+  todo:
+  - TODO
+  - TODO.md
+  - TODO.txt
+unimportant:
+  build_artifacts:
+    automake:
+    - Makefile.in
+    cmake:
+    - CMakeCache.txt
+    cxx:
+    - .o
+    - .la
+    - .lo
+    haskell:
+    - .dyn_hi
+    - .dyn_o
+    - .cache
+    - .hi
+    java:
+    - .class
+    latex:
+    - .aux
+    - .bbl
+    - .bcf
+    - .blg
+    - .fdb_latexmk
+    - .fls
+    - .idx
+    - .ilg
+    - .ind
+    - .out
+    - .sty
+    - .synctex.gz
+    - .toc
+    llvm:
+    - .bc
+    python:
+    - .pyc
+    - .pyd
+    - .pyo
+    rust:
+    - .rlib
+    - .rmeta
+    scons:
+    - .scons_opt
+    - .sconsign.dblite
+  macos:
+  - .CFUserTextEncoding
+  - .DS_Store
+  - .localized
+  - Icon\r
+  other:
+  - '~'
+  - .bak
+  - .ctags
+  - .git
+  - .lock
+  - .log
+  - .orig
+  - .pid
+  - .swp
+  - .swo
+  - .swn
+  - .timestamp
+  - .tmp
+  - stderr
+  - stdin
+  - stdout
+  - bun.lockb
+  - go.sum
+  - package-lock.json

--- a/tests/modules/programs/vivid/themes-example.nix
+++ b/tests/modules/programs/vivid/themes-example.nix
@@ -1,0 +1,120 @@
+{ config, ... }: {
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/vivid/themes/my-awesome-theme.yml \
+      ${./themes-expected.yml}
+  '';
+
+  programs.vivid = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    themes = {
+      my-awesome-theme = {
+        colors = {
+          black = "#000000";
+          red = "#FF0000";
+          green = "#00FF00";
+          yellow = "#FFFF00";
+          blue = "#0000FF";
+          purple = "#FF00FF";
+          cyan = "#00FFFF";
+          orange = "#FFA500";
+          white = "#FFFFFF";
+          base01 = "#AAAAAA";
+        };
+        core = {
+          "normal_text" = { foreground = "white"; };
+          "regular_file" = { foreground = "white"; };
+          "reset_to_normal" = { foreground = "orange"; };
+          "directory" = { foreground = "purple"; };
+          "symlink" = { foreground = "cyan"; };
+          "multi_hard_link" = { };
+          "fifo" = {
+            foreground = "yellow";
+            background = "black";
+          };
+          "socket" = {
+            foreground = "blue";
+            background = "black";
+            font-style = "bold";
+          };
+          "door" = {
+            foreground = "blue";
+            background = "black";
+            font-style = "bold";
+          };
+          "block_device" = {
+            foreground = "yellow";
+            background = "black";
+            font-style = "bold";
+          };
+          "character_device" = {
+            foreground = "yellow";
+            background = "black";
+            font-style = "bold";
+          };
+          "broken_symlink" = {
+            foreground = "red";
+            background = "black";
+            font-style = "bold";
+          };
+          "missing_symlink_target" = {
+            foreground = "red";
+            background = "black";
+          };
+          "setuid" = {
+            foreground = "white";
+            background = "red";
+          };
+          "setgid" = {
+            foreground = "black";
+            background = "yellow";
+          };
+          "file_with_capability" = { };
+          "sticky_other_writable" = {
+            foreground = "black";
+            background = "green";
+          };
+          "other_writable" = {
+            foreground = "purple";
+            background = "green";
+          };
+          "sticky" = {
+            foreground = "white";
+            background = "purple";
+          };
+          "executable_file" = { foreground = "green"; };
+        };
+        text = {
+          "special" = { foreground = "orange"; };
+          "todo" = {
+            foreground = "orange";
+            font-style = "bold";
+          };
+          "licenses" = { foreground = "orange"; };
+          "configuration" = { foreground = "orange"; };
+          "other" = { foreground = "orange"; };
+        };
+        markup = { foreground = "orange"; };
+        programming = { foreground = "orange"; };
+        media = {
+          "image" = { foreground = "blue"; };
+          "audio" = { foreground = "cyan"; };
+          "video" = {
+            foreground = "orange";
+            font-style = "bold";
+          };
+          "fonts" = { foreground = "orange"; };
+          "3d" = { foreground = "blue"; };
+        };
+        office = { foreground = "orange"; };
+        archives = {
+          foreground = "red";
+          font-style = "bold";
+        };
+        executable = { foreground = "green"; };
+        unimportant = { foreground = "base01"; };
+      };
+    };
+  };
+}

--- a/tests/modules/programs/vivid/themes-expected.yml
+++ b/tests/modules/programs/vivid/themes-expected.yml
@@ -1,0 +1,104 @@
+archives:
+  font-style: bold
+  foreground: red
+colors:
+  base01: '#AAAAAA'
+  black: '#000000'
+  blue: '#0000FF'
+  cyan: '#00FFFF'
+  green: '#00FF00'
+  orange: '#FFA500'
+  purple: '#FF00FF'
+  red: '#FF0000'
+  white: '#FFFFFF'
+  yellow: '#FFFF00'
+core:
+  block_device:
+    background: black
+    font-style: bold
+    foreground: yellow
+  broken_symlink:
+    background: black
+    font-style: bold
+    foreground: red
+  character_device:
+    background: black
+    font-style: bold
+    foreground: yellow
+  directory:
+    foreground: purple
+  door:
+    background: black
+    font-style: bold
+    foreground: blue
+  executable_file:
+    foreground: green
+  fifo:
+    background: black
+    foreground: yellow
+  file_with_capability: {}
+  missing_symlink_target:
+    background: black
+    foreground: red
+  multi_hard_link: {}
+  normal_text:
+    foreground: white
+  other_writable:
+    background: green
+    foreground: purple
+  regular_file:
+    foreground: white
+  reset_to_normal:
+    foreground: orange
+  setgid:
+    background: yellow
+    foreground: black
+  setuid:
+    background: red
+    foreground: white
+  socket:
+    background: black
+    font-style: bold
+    foreground: blue
+  sticky:
+    background: purple
+    foreground: white
+  sticky_other_writable:
+    background: green
+    foreground: black
+  symlink:
+    foreground: cyan
+executable:
+  foreground: green
+markup:
+  foreground: orange
+media:
+  3d:
+    foreground: blue
+  audio:
+    foreground: cyan
+  fonts:
+    foreground: orange
+  image:
+    foreground: blue
+  video:
+    font-style: bold
+    foreground: orange
+office:
+  foreground: orange
+programming:
+  foreground: orange
+text:
+  configuration:
+    foreground: orange
+  licenses:
+    foreground: orange
+  other:
+    foreground: orange
+  special:
+    foreground: orange
+  todo:
+    font-style: bold
+    foreground: orange
+unimportant:
+  foreground: base01


### PR DESCRIPTION
### Description

Add module for https://github.com/sharkdp/vivid.
Previous PRs #2194 and #3705 addressed this, but never merged.

The `themes` and `filetypes` section were taken from #2194.
The shell integrations are used since the variable name `LS_COLORS` needs to be set to the output of the command `vivid generate <theme>`. One could utilize what #2194 used:
```nix
home.sessionVariables = mkIf (cfg.theme != null) {
    LS_COLORS = "$(${cfg.package}/bin/vivid generate ${cfg.theme})";
};
```
but this wouldn't work for `fish` and `nushell`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
