### PR TITLE
ssh: Allow forwardAgent to be set to null

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -351,7 +351,7 @@ in {
 
     forwardAgent = mkOption {
       default = false;
-      type = types.bool;
+      type = types.nullOr types.bool;
       description = ''
         Whether the connection to the authentication agent (if any)
         will be forwarded to the remote machine.
@@ -533,7 +533,10 @@ in {
         '') ++ (map (block: matchBlockStr block.name block.data) matchBlocks))}
 
       Host *
-        ForwardAgent ${lib.hm.booleans.yesNo cfg.forwardAgent}
+        ${
+          optionalString (cfg.forwardAgent != null)
+          "ForwardAgent ${lib.hm.booleans.yesNo cfg.forwardAgent}"
+        }
         AddKeysToAgent ${cfg.addKeysToAgent}
         Compression ${lib.hm.booleans.yesNo cfg.compression}
         ServerAliveInterval ${toString cfg.serverAliveInterval}
@@ -554,3 +557,4 @@ in {
         cfg.matchBlocks);
   };
 }
+

--- a/tests/modules/programs/ssh/default.nix
+++ b/tests/modules/programs/ssh/default.nix
@@ -3,6 +3,7 @@
   ssh-includes = ./includes.nix;
   ssh-match-blocks = ./match-blocks-attrs.nix;
   ssh-match-blocks-match-and-hosts = ./match-blocks-match-and-hosts.nix;
+  ssh-forwardAgent-null-config = ./forwardAgent-null-config.nix;
 
   ssh-forwards-dynamic-valid-bind-no-asserts =
     ./forwards-dynamic-valid-bind-no-asserts.nix;

--- a/tests/modules/programs/ssh/forwardAgent-null-config.nix
+++ b/tests/modules/programs/ssh/forwardAgent-null-config.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.ssh = {
+      enable = true;
+      forwardAgent = null;
+    };
+
+    home.file.assertions.text = builtins.toJSON
+      (map (a: a.message) (filter (a: !a.assertion) config.assertions));
+
+    nmt.script = ''
+      assertFileExists home-files/.ssh/config
+      assertFileContent home-files/.ssh/config ${
+        ./forwardAgent-null-expected.conf
+      }
+      assertFileContent home-files/assertions ${./no-assertions.json}
+    '';
+  };
+}

--- a/tests/modules/programs/ssh/forwardAgent-null-expected.conf
+++ b/tests/modules/programs/ssh/forwardAgent-null-expected.conf
@@ -1,0 +1,15 @@
+
+
+Host *
+
+  AddKeysToAgent no
+  Compression no
+  ServerAliveInterval 0
+  ServerAliveCountMax 3
+  HashKnownHosts no
+  UserKnownHostsFile ~/.ssh/known_hosts
+  ControlMaster no
+  ControlPath ~/.ssh/master-%r@%n:%p
+  ControlPersist no
+
+  


### PR DESCRIPTION
### Description

Allow setting the forwardAgent to `null` to prevent it from being set in `Host *`.

In situations where you use `CanonicalizeHostname` and `CanonicalDomains` the ssh config is parsed twice. THe first time a value is set, typically means it's the final value. This means that if `programs.ssh.forwardAgent` is set to `false` you cannot have `ForwardAgent = yes` apply to a canonical match (`Match canonical *.my.tld`) as `Host *` will be parsed first.

If we consider the config where `programs.ssh.forwardAgent = false;`:

```ssh_config
CanonicalizeHostanme yes
CanonicalizeDomains my.tld
CanonicalizeMaxDots 1

Match canonical Host *.my.tld
  ForwardAgent yes

Host *
  ForwardAgent no
```

`ssh myhost` will first pass through `Host *` and set `ForwardAgent no`, canonicalize the name to myhost.my.tld, then match `Match canonical *.my.tld` and try to set `ForwardAgent` to `yes` but since it's already `no` it will be ignored.

The same is a problem in reverse if `programs.ssh.forwardAgent = true;` and the canonical match is `ForwardAgent no`.

The default for `forwardAgent` is already `false` so there's not a need to always explicitly set it, we allow `forwardAgent = null` in match blocks, we can set it to `null` in the root as well.

#### Note

This does add a blank line if `forwardAgent` is set to null in the `Host *` block. Mabye not ideal, can probably fix it if it's really a problem.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
