### PR TITLE
mopidy: fix issues with building extensions

### DIFF
--- a/modules/services/mopidy.nix
+++ b/modules/services/mopidy.nix
@@ -23,7 +23,7 @@ let
     name = "mopidy-with-extensions-${pkgs.mopidy.version}";
     paths = closePropagation cfg.extensionPackages;
     pathsToLink = [ "/${pkgs.mopidyPackages.python.sitePackages}" ];
-    buildInputs = [ pkgs.makeWrapper ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
     postBuild = ''
       makeWrapper ${pkgs.mopidy}/bin/mopidy $out/bin/mopidy \
         --prefix PYTHONPATH : $out/${pkgs.mopidyPackages.python.sitePackages}

--- a/modules/services/mopidy.nix
+++ b/modules/services/mopidy.nix
@@ -24,6 +24,7 @@ let
     paths = closePropagation cfg.extensionPackages;
     pathsToLink = [ "/${pkgs.mopidyPackages.python.sitePackages}" ];
     nativeBuildInputs = [ pkgs.makeWrapper ];
+    ignoreCollisions = true;
     postBuild = ''
       makeWrapper ${pkgs.mopidy}/bin/mopidy $out/bin/mopidy \
         --prefix PYTHONPATH : $out/${pkgs.mopidyPackages.python.sitePackages}


### PR DESCRIPTION
### Description

Using Mopidy extensions is broken in multiple ways currently, which is apparent when cross building. The first issue is the error `error: makeWrapper/makeShellWrapper must be in nativeBuildInputs`, which has an obvious solution.

The other issue stems from Python dependency conflicts between Mopidy and any enabled extensions. This is an issue upstream in `nixpkgs`. See nixos/nixpkgs#297539. I've created a PR to fix the issue upstream in nixos/nixpkgs#354069.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@foo-dogsquared