### PR TITLE
espanso, spotify-player, alacritty: fix failing tests

### DIFF
--- a/tests/modules/programs/alacritty/settings-toml-expected.toml
+++ b/tests/modules/programs/alacritty/settings-toml-expected.toml
@@ -1,4 +1,3 @@
-[font]
 [font.bold]
 family = "SFMono"
 

--- a/tests/modules/programs/spotify-player/theme.toml
+++ b/tests/modules/programs/spotify-player/theme.toml
@@ -1,7 +1,6 @@
 [[themes]]
 name = "default2"
 
-[themes.component_style]
 [themes.component_style.block_title]
 fg = "Magenta"
 

--- a/tests/modules/services/espanso/basic-matches.yaml
+++ b/tests/modules/services/espanso/basic-matches.yaml
@@ -10,9 +10,7 @@ global_vars:
 matches:
 - replace: It's {{currentdate}} {{currenttime}}
   trigger: :now
-- replace: 'line1
-
-    line2'
+- replace: "line1\nline2"
   trigger: :hello
 - regex: :hi(?P<person>.*)\.
   replace: Hi {{person}}!


### PR DESCRIPTION
### Description


Those tests were failing.
It is necessary to double-check whether adapting the expected config files was a legitimate approach.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

- alacritty: ?
- espanso: cc @lucasew @bobvanderlinden @liyangau @n8henrie 
- spotify-player: cc  @diniamo 
