### PR TITLE
mopidy: restart service on config changes

### DIFF
--- a/modules/services/mopidy.nix
+++ b/modules/services/mopidy.nix
@@ -126,6 +126,8 @@ in {
         Description = "mopidy music player daemon";
         Documentation = [ "https://mopidy.com/" ];
         After = [ "network.target" "sound.target" ];
+        X-Restart-Triggers = mkIf (cfg.settings != { })
+          [ "${config.xdg.configFile."mopidy/mopidy.conf".source}" ];
       };
 
       Service = {

--- a/tests/modules/services/mopidy/basic-configuration.nix
+++ b/tests/modules/services/mopidy/basic-configuration.nix
@@ -29,7 +29,28 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/systemd/user/mopidy.service
+    serviceFile=home-files/.config/systemd/user/mopidy.service
+    assertFileExists $serviceFile
+    serviceFile=$(normalizeStorePaths $serviceFile)
+    assertFileContent $serviceFile \
+      ${
+        builtins.toFile "expected-mopidy.service" ''
+          [Install]
+          WantedBy=default.target
+
+          [Service]
+          ExecStart=/nix/store/00000000000000000000000000000000-mopidy-with-extensions/bin/mopidy --config /home/hm-user/.config/mopidy/mopidy.conf
+          Restart=on-failure
+
+          [Unit]
+          After=network.target
+          After=sound.target
+          Description=mopidy music player daemon
+          Documentation=https://mopidy.com/
+          X-Restart-Triggers=/nix/store/00000000000000000000000000000000-mopidy-hm-user
+        ''
+      }
+
     assertPathNotExists home-files/.config/systemd/user/mopidy-scan.service
 
     assertFileExists home-files/.config/mopidy/mopidy.conf


### PR DESCRIPTION
### Description

The Mopidy service is not restarted when the config changes.
This PR adds `X-Restart-Triggers` to the unit to ensure that the service is restarted on config file changes.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@foo-dogsquared