### PR TITLE
feh: add themes option

### DIFF
--- a/modules/programs/feh.nix
+++ b/modules/programs/feh.nix
@@ -8,6 +8,12 @@ let
 
   bindingsOf = t: with types; attrsOf (nullOr (either t (listOf t)));
 
+  renderThemes = options:
+    let
+      render =
+        mapAttrsToList (theme: options: "${theme} ${escapeShellArgs options}");
+    in concatStringsSep "\n" (render options);
+
   renderBindings = bindings:
     let
       enabled = filterAttrs (n: v: v != null) bindings;
@@ -41,7 +47,7 @@ in {
         Override feh's default mouse button mapping. If you want to disable an
         action, set its value to null. If you want to bind multiple buttons to
         an action, set its value to a list.
-        See <https://man.finalrewind.org/1/feh/#x425554544f4e53> for
+        See <https://man.finalrewind.org/1/feh/#BUTTONS_CONFIG_SYNTAX> for
         default bindings and available commands.
       '';
     };
@@ -58,10 +64,37 @@ in {
         Override feh's default keybindings. If you want to disable a keybinding
         set its value to null. If you want to bind multiple keys to an action,
         set its value to a list.
-        See <https://man.finalrewind.org/1/feh/#x4b455953> for
+        See <https://man.finalrewind.org/1/feh/#KEYS_CONFIG_SYNTAX> for
         default bindings and available commands.
       '';
     };
+
+    themes = mkOption {
+      default = { };
+      type = with types; attrsOf (listOf str);
+      example = {
+        feh = [ "--image-bg" "black" ];
+        webcam = [ "--multiwindow" "--reload" "20" ];
+        present = [ "--full-screen" "--sort" "name" "--hide-pointer" ];
+        booth = [ "--full-screen" "--hide-pointer" "--slideshow-delay" "20" ];
+        imagemap = [
+          "-rVq"
+          "--thumb-width"
+          "40"
+          "--thumb-height"
+          "30"
+          "--index-info"
+          "%n\\n%wx%h"
+        ];
+        example = [ "--info" "foo bar" ];
+      };
+      description = ''
+        Define themes for feh.
+        See <https://man.finalrewind.org/1/feh/#THEMES_CONFIG_SYNTAX> for
+        important guidelines and limitations related to theme configuration.
+      '';
+    };
+
   };
 
   config = mkIf cfg.enable {
@@ -79,5 +112,8 @@ in {
     xdg.configFile."feh/keys" = mkIf (cfg.keybindings != { }) {
       text = renderBindings cfg.keybindings + "\n";
     };
+
+    xdg.configFile."feh/themes" =
+      mkIf (cfg.themes != { }) { text = renderThemes cfg.themes + "\n"; };
   };
 }

--- a/tests/modules/programs/feh/default.nix
+++ b/tests/modules/programs/feh/default.nix
@@ -1,4 +1,5 @@
 {
   feh-empty-config = ./feh-empty-settings.nix;
   feh-bindings = ./feh-bindings.nix;
+  feh-themes = ./feh-themes.nix;
 }

--- a/tests/modules/programs/feh/feh-empty-settings.nix
+++ b/tests/modules/programs/feh/feh-empty-settings.nix
@@ -9,6 +9,7 @@
     nmt.script = ''
       assertPathNotExists home-files/.config/feh/buttons
       assertPathNotExists home-files/.config/feh/keys
+      assertPathNotExists home-files/.config/feh/themes
     '';
   };
 }

--- a/tests/modules/programs/feh/feh-themes-expected
+++ b/tests/modules/programs/feh/feh-themes-expected
@@ -1,0 +1,6 @@
+booth --full-screen --hide-pointer --slideshow-delay 20
+example --info 'foo bar'
+feh --image-bg black
+imagemap -rVq --thumb-width 40 --thumb-height 30 --index-info '%n\n%wx%h'
+present --full-screen --sort name --hide-pointer
+webcam --multiwindow --reload 20

--- a/tests/modules/programs/feh/feh-themes.nix
+++ b/tests/modules/programs/feh/feh-themes.nix
@@ -1,0 +1,32 @@
+{ pkgs, ... }:
+
+{
+  config = {
+    programs.feh.enable = true;
+
+    programs.feh.themes = {
+      feh = [ "--image-bg" "black" ];
+      webcam = [ "--multiwindow" "--reload" "20" ];
+      present = [ "--full-screen" "--sort" "name" "--hide-pointer" ];
+      booth = [ "--full-screen" "--hide-pointer" "--slideshow-delay" "20" ];
+      imagemap = [
+        "-rVq"
+        "--thumb-width"
+        "40"
+        "--thumb-height"
+        "30"
+        "--index-info"
+        "%n\\n%wx%h"
+      ];
+      example = [ "--info" "foo bar" ];
+    };
+
+    test.stubs.feh = { };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/feh/themes \
+        ${./feh-themes-expected}
+    '';
+  };
+}


### PR DESCRIPTION
### Description
- added themes option
- added themes test
- updated broken man page links


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
No `meta.maintainers` list for this module, so @-ing those who have last touched it.
@sumnerevans 
@ncfavier 
@rycee 