### PR TITLE
uv: init module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -277,6 +277,7 @@ let
       ./programs/topgrade.nix
       ./programs/translate-shell.nix
       ./programs/urxvt.nix
+      ./programs/uv.nix
       ./programs/vdirsyncer.nix
       ./programs/vesktop.nix
       ./programs/vifm.nix

--- a/modules/programs/uv.nix
+++ b/modules/programs/uv.nix
@@ -1,0 +1,56 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+
+let
+
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    literalExpression
+    ;
+
+  tomlFormat = pkgs.formats.toml { };
+  cfg = config.programs.uv;
+
+in
+{
+  meta.maintainers = with lib.maintainers; [ mirkolenz ];
+
+  options.programs.uv = {
+    enable = mkEnableOption "uv";
+
+    package = mkPackageOption pkgs "uv" { };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          python-downloads = "never";
+          python-preference = "only-system";
+          pip.index-url = "https://test.pypi.org/simple";
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/uv/uv.toml`.
+        See <https://docs.astral.sh/uv/configuration/files/>
+        and <https://docs.astral.sh/uv/reference/settings/>
+        for more information.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."uv/uv.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "uv-config" cfg.settings;
+    };
+  };
+}

--- a/modules/programs/uv.nix
+++ b/modules/programs/uv.nix
@@ -24,7 +24,7 @@ in
   options.programs.uv = {
     enable = mkEnableOption "uv";
 
-    package = mkPackageOption pkgs "uv" { };
+    package = mkPackageOption pkgs "uv" { nullable = true; };
 
     settings = mkOption {
       type = tomlFormat.type;
@@ -47,7 +47,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."uv/uv.toml" = lib.mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "uv-config" cfg.settings;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -466,6 +466,7 @@ import nmtSrc {
       ./modules/programs/tmux
       ./modules/programs/topgrade
       ./modules/programs/translate-shell
+      ./modules/programs/uv
       ./modules/programs/vifm
       ./modules/programs/vim-vint
       ./modules/programs/vscode

--- a/tests/modules/programs/uv/default.nix
+++ b/tests/modules/programs/uv/default.nix
@@ -1,0 +1,4 @@
+{
+  uv-example-settings = ./example-settings.nix;
+  uv-no-settings = ./no-settings.nix;
+}

--- a/tests/modules/programs/uv/example-settings.nix
+++ b/tests/modules/programs/uv/example-settings.nix
@@ -1,0 +1,29 @@
+{ pkgs, ... }:
+
+{
+  programs.uv = {
+    enable = true;
+    settings = {
+      python-downloads = "never";
+      python-preference = "only-system";
+      pip.index-url = "https://test.pypi.org/simple";
+    };
+  };
+
+  test.stubs.uv = { };
+
+  nmt.script =
+    let
+      expectedConfigPath = "home-files/.config/uv/uv.toml";
+      expectedConfigContent = pkgs.writeText "uv.config-custom.expected" ''
+        python-downloads = "never"
+        python-preference = "only-system"
+        [pip]
+        index-url = "https://test.pypi.org/simple"
+      '';
+    in
+    ''
+      assertFileExists "${expectedConfigPath}"
+      assertFileContent "${expectedConfigPath}" "${expectedConfigContent}"
+    '';
+}

--- a/tests/modules/programs/uv/no-settings.nix
+++ b/tests/modules/programs/uv/no-settings.nix
@@ -1,0 +1,16 @@
+{ ... }:
+{
+  programs.uv = {
+    enable = true;
+  };
+
+  test.stubs.uv = { };
+
+  nmt.script =
+    let
+      expectedConfigPath = "home-files/.config/uv/uv.toml";
+    in
+    ''
+      assertPathNotExists "${expectedConfigPath}"
+    '';
+}


### PR DESCRIPTION
### Description

Fixes #5154 

Adds a new module for the python package manager uv. Includes support for writing settings to a config file and enabling shell integrations for bash/zsh/fish. I also added multiple tests (based on those for `atuin`).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
