### PR TITLE
emacs: get packages from local emacs

### DIFF
--- a/modules/programs/emacs.nix
+++ b/modules/programs/emacs.nix
@@ -14,15 +14,9 @@ let
 
   cfg = config.programs.emacs;
 
-  # Copied from all-packages.nix, with modifications to support
-  # overrides.
-  emacsPackages =
-    let
-      epkgs = pkgs.emacsPackagesFor cfg.package;
-    in
-    epkgs.overrideScope cfg.overrides;
-
-  emacsWithPackages = emacsPackages.emacsWithPackages;
+  # Get the packages from the supplied emacs rather than the nixpkgs to ensure a
+  # separate emacs pin also carries with it the packages from that pin.
+  inherit (cfg.package.pkgs.overrideScope cfg.overrides) emacsWithPackages;
 
   extraPackages =
     epkgs:


### PR DESCRIPTION
### Description
This fixes a problem I had locally where pinning an Emacs from a previous nixpkgs version in my config didn't also extend to pinning the packages.

I will admit I'm not 100% if I'm solving this the right way but it feels like this is what you'd want? And is this the right way to do so?

Whether this is backwards compatible depends on your interpretation of what the spec was in the first place; was this a bug or a feature?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
