### PR TITLE
hypridle: add `systemdTarget` option

### DIFF
--- a/modules/services/hypridle.nix
+++ b/modules/services/hypridle.nix
@@ -63,6 +63,19 @@ in {
         List of prefix of attributes to source at the top of the config.
       '';
     };
+
+    systemdTarget = lib.mkOption {
+      type = lib.types.str;
+      default = "graphical-session.target";
+      example = "hyprland-session.target";
+      description = ''
+        The systemd target that will automatically start the hypridle service.
+
+        When setting this value to `"hyprland-session.target"`,
+        make sure to also enable {option}`wayland.windowManager.hyprland.systemd.enable`,
+        otherwise the service may never be started.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -74,11 +87,12 @@ in {
     };
 
     systemd.user.services.hypridle = {
-      Install = { WantedBy = [ "graphical-session.target" ]; };
+      Install = { WantedBy = [ cfg.systemdTarget ]; };
 
       Unit = {
         ConditionEnvironment = "WAYLAND_DISPLAY";
         Description = "hypridle";
+        Documentation = "https://wiki.hyprland.org/Hypr-Ecosystem/hypridle/";
         After = [ "graphical-session-pre.target" ];
         PartOf = [ "graphical-session.target" ];
         X-Restart-Triggers =

--- a/tests/modules/services/hypridle/basic-configuration.nix
+++ b/tests/modules/services/hypridle/basic-configuration.nix
@@ -24,6 +24,8 @@
         }
       ];
     };
+
+    systemdTarget = "hyprland-session.target";
   };
 
   test.stubs.hypridle = { };
@@ -34,5 +36,11 @@
     assertFileExists $config
     assertFileExists $clientServiceFile
     assertFileContent $config ${./hypridle.conf}
+
+    serviceFile=$(normalizeStorePaths $clientServiceFile)
+    assertFileContent "$serviceFile" ${
+      ./systemd-with-graphical-session-target.service
+    }
+
   '';
 }

--- a/tests/modules/services/hypridle/systemd-with-graphical-session-target.service
+++ b/tests/modules/services/hypridle/systemd-with-graphical-session-target.service
@@ -1,0 +1,15 @@
+[Install]
+WantedBy=hyprland-session.target
+
+[Service]
+ExecStart=@hypridle@/bin/dummy
+Restart=always
+RestartSec=10
+
+[Unit]
+After=graphical-session-pre.target
+ConditionEnvironment=WAYLAND_DISPLAY
+Description=hypridle
+Documentation=https://wiki.hyprland.org/Hypr-Ecosystem/hypridle/
+PartOf=graphical-session.target
+X-Restart-Triggers=/nix/store/00000000000000000000000000000000-hm_hyprhypridle.conf


### PR DESCRIPTION
### Description
- added `systemdTarget` option
- updated test to include new option
- added documentation link to systemd service

### Checklist
- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@khaneliman 
@fufexan 
