### PR TITLE
tmux: Disable tmux-sensible by Default (bug fix)

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -239,7 +239,7 @@ in {
 
       sensibleOnTop = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = ''
           Run the sensible plugin at the top of the configuration. It
           is possible to override the sensible settings using the

--- a/tests/modules/programs/tmux/default-shell.conf
+++ b/tests/modules/programs/tmux/default-shell.conf
@@ -1,8 +1,3 @@
-# ============================================= #
-# Start with defaults from the Sensible plugin  #
-# --------------------------------------------- #
-run-shell @sensible_rtp@
-# ============================================= #
 
 set  -g default-terminal "screen"
 set  -g base-index      0

--- a/tests/modules/programs/tmux/disable-confirmation-prompt.conf
+++ b/tests/modules/programs/tmux/disable-confirmation-prompt.conf
@@ -1,8 +1,3 @@
-# ============================================= #
-# Start with defaults from the Sensible plugin  #
-# --------------------------------------------- #
-run-shell @sensible_rtp@
-# ============================================= #
 
 set  -g default-terminal "screen"
 set  -g base-index      0

--- a/tests/modules/programs/tmux/emacs-with-plugins.conf
+++ b/tests/modules/programs/tmux/emacs-with-plugins.conf
@@ -1,8 +1,3 @@
-# ============================================= #
-# Start with defaults from the Sensible plugin  #
-# --------------------------------------------- #
-run-shell @tmuxplugin_sensible_rtp@
-# ============================================= #
 
 set  -g default-terminal "screen"
 set  -g base-index      0

--- a/tests/modules/programs/tmux/mouse-enabled.conf
+++ b/tests/modules/programs/tmux/mouse-enabled.conf
@@ -1,8 +1,3 @@
-# ============================================= #
-# Start with defaults from the Sensible plugin  #
-# --------------------------------------------- #
-run-shell @sensible_rtp@
-# ============================================= #
 
 set  -g default-terminal "screen"
 set  -g base-index      0

--- a/tests/modules/programs/tmux/prefix.conf
+++ b/tests/modules/programs/tmux/prefix.conf
@@ -1,8 +1,3 @@
-# ============================================= #
-# Start with defaults from the Sensible plugin  #
-# --------------------------------------------- #
-run-shell @sensible_rtp@
-# ============================================= #
 
 set  -g default-terminal "screen"
 set  -g base-index      0

--- a/tests/modules/programs/tmux/shortcut-without-prefix.conf
+++ b/tests/modules/programs/tmux/shortcut-without-prefix.conf
@@ -1,8 +1,3 @@
-# ============================================= #
-# Start with defaults from the Sensible plugin  #
-# --------------------------------------------- #
-run-shell @sensible_rtp@
-# ============================================= #
 
 set  -g default-terminal "screen"
 set  -g base-index      0

--- a/tests/modules/programs/tmux/vi-all-true.conf
+++ b/tests/modules/programs/tmux/vi-all-true.conf
@@ -1,8 +1,3 @@
-# ============================================= #
-# Start with defaults from the Sensible plugin  #
-# --------------------------------------------- #
-run-shell @sensible_rtp@
-# ============================================= #
 
 set  -g default-terminal "screen"
 set  -g base-index      0


### PR DESCRIPTION
### Description
In #5952, it was pointed out that tmux has changed how it handles shells, and because of this, the tmux.shell option doesn’t work properly unless tmux-sensible is turned off.

However, tmux-sensible hasn’t been updated for over two years, as mentioned [here](https://github.com/tmux-plugins/tmux-sensible/pull/70#issuecomment-2127666779). Since it’s no longer actively maintained, keeping it enabled by default is becoming more of a problem.

This PR suggests turning off tmux-sensible by default to avoid these issues and improve usability.

### Checklist
- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@rycee