### PR TITLE
swaylock: allow setting `package = null`

### DIFF
--- a/modules/programs/swaylock.nix
+++ b/modules/programs/swaylock.nix
@@ -33,7 +33,15 @@ in {
       '';
     };
 
-    package = mkPackageOption pkgs "swaylock" { };
+    package = mkOption {
+      type = with types; nullOr package;
+      default = pkgs.swaylock;
+      defaultText = literalExpression "pkgs.swaylock";
+      example = null;
+      description = ''
+        The swaylock package to install, or `null` to install no package.
+      '';
+    };
 
     settings = mkOption {
       type = with types; attrsOf (oneOf [ bool float int str ]);
@@ -59,7 +67,7 @@ in {
         lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."swaylock/config" = mkIf (cfg.settings != { }) {
       text = concatStrings (mapAttrsToList (n: v:


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This fixes #6090.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
