### PR TITLE
mu: run initialization command when personal addresses change

### DIFF
--- a/modules/programs/mu.nix
+++ b/modules/programs/mu.nix
@@ -9,17 +9,22 @@ let
   # Used to generate command line arguments that mu can operate with.
   genCmdMaildir = path: "--maildir=" + path;
 
-  # Takes the list of accounts with mu.enable = true, and generates a
-  # command-line flag for initializing the mu database.
-  myAddresses = let
+  # Sorted list of personal email addresses to register
+  sortedAddresses = let
     # Set of email account sets where mu.enable = true.
     muAccounts =
       filter (a: a.mu.enable) (attrValues config.accounts.email.accounts);
     addrs = map (a: a.address) muAccounts;
     # Construct list of lists containing email aliases, and flatten
     aliases = flatten (map (a: a.aliases) muAccounts);
-    # Prefix --my-address= to each account's address AND all defined aliases
-    addMyAddress = map (addr: "--my-address=" + addr) (addrs ++ aliases);
+    # Sort the list
+  in sort lessThan (addrs ++ aliases);
+
+  # Takes the list of accounts with mu.enable = true, and generates a
+  # command-line flag for initializing the mu database.
+  myAddresses = let
+    # Prefix --my-address= to each account's address and all defined aliases
+    addMyAddress = map (addr: "--my-address=" + addr) sortedAddresses;
   in concatStringsSep " " addMyAddress;
 
 in {
@@ -49,14 +54,19 @@ in {
     home.activation.runMuInit = let
       maildirOption = genCmdMaildir config.accounts.email.maildirBasePath;
       dbLocation = config.xdg.cacheHome + "/mu";
+      muExe = getExe cfg.package;
     in hm.dag.entryAfter [ "writeBoundary" ] ''
-      # If the database directory exists, then `mu init` should NOT be run.
+      # If the database directory exists and registered personal addresses remain the same,
+      # then `mu init` should NOT be run.
       # In theory, mu is the only thing that creates that directory, and it is
       # only created during the initial index.
-      if [[ ! -d "${dbLocation}" ]]; then
-        run ${
-          getExe cfg.package
-        } init ${maildirOption} ${myAddresses} $VERBOSE_ARG;
+      MU_SORTED_ADDRS=$((${muExe} info store | ${
+        getExe pkgs.gawk
+      } '/personal-address/{print $4}' | LC_ALL=C sort | paste -sd ' ') || exit 0)
+      if [[ ! -d "${dbLocation}" || ! "$MU_SORTED_ADDRS" = "${
+        concatStringsSep " " sortedAddresses
+      }" ]]; then
+        run ${muExe} init ${maildirOption} ${myAddresses} $VERBOSE_ARG;
       fi
     '';
   };

--- a/modules/programs/mu.nix
+++ b/modules/programs/mu.nix
@@ -55,14 +55,13 @@ in {
       maildirOption = genCmdMaildir config.accounts.email.maildirBasePath;
       dbLocation = config.xdg.cacheHome + "/mu";
       muExe = getExe cfg.package;
+      gawkExe = getExe pkgs.gawk;
     in hm.dag.entryAfter [ "writeBoundary" ] ''
       # If the database directory exists and registered personal addresses remain the same,
       # then `mu init` should NOT be run.
       # In theory, mu is the only thing that creates that directory, and it is
       # only created during the initial index.
-      MU_SORTED_ADDRS=$((${muExe} info store | ${
-        getExe pkgs.gawk
-      } '/personal-address/{print $4}' | LC_ALL=C sort | paste -sd ' ') || exit 0)
+      MU_SORTED_ADDRS=$((${muExe} info store | ${gawkExe} '/personal-address/{print $4}' | LC_ALL=C sort | paste -sd ' ') || exit 0)
       if [[ ! -d "${dbLocation}" || ! "$MU_SORTED_ADDRS" = "${
         concatStringsSep " " sortedAddresses
       }" ]]; then

--- a/tests/integration/default.nix
+++ b/tests/integration/default.nix
@@ -12,6 +12,7 @@ let
   tests = {
     home-with-symbols = runTest ./standalone/home-with-symbols.nix;
     kitty = runTest ./standalone/kitty.nix;
+    mu = runTest ./standalone/mu;
     nixos-basics = runTest ./nixos/basics.nix;
     standalone-flake-basics = runTest ./standalone/flake-basics.nix;
     standalone-standard-basics = runTest ./standalone/standard-basics.nix;

--- a/tests/integration/standalone/mu/config-account-without-mu.nix
+++ b/tests/integration/standalone/mu/config-account-without-mu.nix
@@ -1,0 +1,5 @@
+{ lib, ... }: {
+  imports = [ ./config-two-accounts.nix ];
+
+  accounts.email.accounts.example2.mu.enable = lib.mkForce false;
+}

--- a/tests/integration/standalone/mu/config-no-accounts.nix
+++ b/tests/integration/standalone/mu/config-no-accounts.nix
@@ -1,0 +1,9 @@
+{
+  home.username = "alice";
+  home.homeDirectory = "/home/alice";
+  home.stateVersion = "24.11";
+
+  programs.mu.enable = true;
+
+  programs.home-manager.enable = true;
+}

--- a/tests/integration/standalone/mu/config-one-account.nix
+++ b/tests/integration/standalone/mu/config-one-account.nix
@@ -1,0 +1,9 @@
+{
+  imports = [ ./config-no-accounts.nix ];
+
+  accounts.email.accounts.example = {
+    primary = true;
+    address = "alice@example.com";
+    mu.enable = true;
+  };
+}

--- a/tests/integration/standalone/mu/config-one-alias.nix
+++ b/tests/integration/standalone/mu/config-one-alias.nix
@@ -1,0 +1,5 @@
+{
+  imports = [ ./config-one-account.nix ];
+
+  accounts.email.accounts.example.aliases = [ "alias@example.com" ];
+}

--- a/tests/integration/standalone/mu/config-two-accounts.nix
+++ b/tests/integration/standalone/mu/config-two-accounts.nix
@@ -1,0 +1,8 @@
+{
+  imports = [ ./config-one-account.nix ];
+
+  accounts.email.accounts.example2 = {
+    address = "alice@example2.com";
+    mu.enable = true;
+  };
+}

--- a/tests/integration/standalone/mu/default.nix
+++ b/tests/integration/standalone/mu/default.nix
@@ -1,0 +1,117 @@
+{ pkgs, ... }: {
+  name = "mu-store-init";
+
+  nodes.machine = { ... }: {
+    imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
+    virtualisation.memorySize = 2048;
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("network.target")
+    machine.wait_for_unit("multi-user.target")
+
+    home_manager = "${../../../..}"
+    home_config = "/home/alice/.config/home-manager"
+
+    def login_as_alice():
+      machine.wait_until_tty_matches("1", "login: ")
+      machine.send_chars("alice\n")
+      machine.wait_until_tty_matches("1", "Password: ")
+      machine.send_chars("foobar\n")
+      machine.wait_until_tty_matches("1", "alice\\@machine")
+
+    def logout_alice():
+      machine.send_chars("exit\n")
+
+    def alice_cmd(cmd):
+      return f"su -l alice --shell /bin/sh -c $'export XDG_RUNTIME_DIR=/run/user/$UID ; {cmd}'"
+
+    def succeed_as_alice(cmd):
+      return machine.succeed(alice_cmd(cmd))
+
+    def fail_as_alice(cmd):
+      return machine.fail(alice_cmd(cmd))
+
+    def switch_to(config):
+      succeed_as_alice(f"cp {home_config}/{config}.nix {home_config}/home.nix")
+      return succeed_as_alice("home-manager switch")
+      # succeed_as_alice(". /home/alice/.nix-profile/etc/profile.d/hm-session-vars.sh")
+
+    # Create a persistent login so that Alice has a systemd session.
+    login_as_alice()
+
+    # Set up a home-manager channel.
+    succeed_as_alice(" ; ".join([
+      "mkdir -p /home/alice/.nix-defexpr/channels",
+      f"ln -s {home_manager} /home/alice/.nix-defexpr/channels/home-manager"
+    ]))
+
+    succeed_as_alice("nix-shell \"<home-manager>\" -A install")
+
+    succeed_as_alice(f"cp -t {home_config} ${./.}/config-*")
+
+    with subtest("Switch to empty profile"):
+      switch_to("config-no-accounts")
+      actual = succeed_as_alice("mu info store")
+      expected = "/home/alice/Maildir"
+      assert expected in actual, \
+        f"expected mu info store to contain {expected}, but got {actual}"
+      unexpected = "personal-address"
+      assert not unexpected in actual, \
+        f"expected mu info store not to contain {unexpected}, but got {actual}"
+
+    with subtest("Switch to profile with an account"):
+      switch_to("config-one-account")
+      actual = succeed_as_alice("mu info store")
+      expected = "alice@example.com"
+      assert expected in actual, \
+        f"expected mu info store to contain {expected}, but got {actual}"
+
+    with subtest("Switch to profile with two accounts"):
+      switch_to("config-two-accounts")
+      actual = succeed_as_alice("mu info store")
+      expected = "alice@example.com"
+      assert expected in actual, \
+        f"expected mu info store to contain {expected}, but got {actual}"
+      expected = "alice@example2.com"
+      assert expected in actual, \
+        f"expected mu info store to contain {expected}, but got {actual}"
+
+    with subtest("Switch back to profile with one account"):
+      switch_to("config-one-account")
+      actual = succeed_as_alice("mu info store")
+      expected = "alice@example.com"
+      assert expected in actual, \
+        f"expected mu info store to contain {expected}, but got {actual}"
+      unexpected = "alice@example2.com"
+      assert not unexpected in actual, \
+        f"expected mu info store not to contain {unexpected}, but got {actual}"
+
+    with subtest("Switch to profile with an alias"):
+      switch_to("config-one-alias")
+      actual = succeed_as_alice("mu info store")
+      expected = "alice@example.com"
+      assert expected in actual, \
+        f"expected mu info store to contain {expected}, but got {actual}"
+      expected = "alias@example.com"
+      assert expected in actual, \
+        f"expected mu info store to contain {expected}, but got {actual}"
+
+    with subtest("Switch to a profile with mu disabled for one account"):
+      switch_to("config-account-without-mu")
+      actual = succeed_as_alice("mu info store")
+      expected = "alice@example.com"
+      assert expected in actual, \
+        f"expected mu info store to contain {expected}, but got {actual}"
+      unexpected = "alice@example2.com"
+      assert not unexpected in actual, \
+        f"expected mu info store not to contain {unexpected}, but got {actual}"
+  '';
+}

--- a/tests/modules/programs/mu/basic-configuration.nix
+++ b/tests/modules/programs/mu/basic-configuration.nix
@@ -16,9 +16,9 @@
 
   nmt.script = ''
     assertFileContains activate \
-      'if [[ ! -d "/home/hm-user/.cache/mu" ]]; then'
+      'if [[ ! -d "/home/hm-user/.cache/mu" || ! "$MU_SORTED_ADDRS" = "foo@example.com hm@example.com" ]]; then'
 
     assertFileContains activate \
-      'run @mu@/bin/mu init --maildir=/home/hm-user/Mail --my-address=hm@example.com --my-address=foo@example.com $VERBOSE_ARG;'
+      'run @mu@/bin/mu init --maildir=/home/hm-user/Mail --my-address=foo@example.com --my-address=hm@example.com $VERBOSE_ARG;'
   '';
 }


### PR DESCRIPTION
### Description

When the user changes which addresses mu should consider 'personal', mu's store should be reinitialized.

After this change, the activation script parses the previously configured list of addresses and compares it with the new one. If they differ, it runs the init command even when the store has already been initialized.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@KarlJoad 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
