### PR TITLE
syncthing: expand declarative config to Darwin

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -687,15 +687,17 @@ in {
         };
       };
 
-      launchd.agents.syncthing = {
-        enable = true;
-        config = {
-          ProgramArguments = syncthingArgs;
-          KeepAlive = {
-            Crashed = true;
-            SuccessfulExit = false;
+      launchd.agents = {
+        syncthing = {
+          enable = true;
+          config = {
+            ProgramArguments = syncthingArgs;
+            KeepAlive = {
+              Crashed = true;
+              SuccessfulExit = false;
+            };
+            ProcessType = "Background";
           };
-          ProcessType = "Background";
         };
       };
     })

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -50,6 +50,7 @@ let
   cat = lib.getExe' pkgs.coreutils "cat";
   curl = lib.getExe pkgs.curl;
   install = lib.getExe' pkgs.coreutils "install";
+  mktemp = lib.getExe' pkgs.coreutils "mktemp";
   syncthing = lib.getExe cfg.package;
 
   copyKeys = pkgs.writers.writeBash "syncthing-copy-keys" ''
@@ -67,6 +68,10 @@ let
   '';
 
   curlShellFunction = ''
+    # systemd sets and creates RUNTIME_DIRECTORY on Linux
+    # on Darwin, we create it manually via mktemp
+    RUNTIME_DIRECTORY="''${RUNTIME_DIRECTORY:=$(${mktemp} -d)}"
+
     curl() {
         # get the api key by parsing the config.xml
         while

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -66,12 +66,7 @@ let
     ''}
   '';
 
-  updateConfig = pkgs.writers.writeBash "merge-syncthing-config" (''
-    set -efu
-
-    # be careful not to leak secrets in the filesystem or in process listings
-    umask 0077
-
+  curlShellFunction = ''
     curl() {
         # get the api key by parsing the config.xml
         while
@@ -85,6 +80,15 @@ let
             --retry 1000 --retry-delay 1 --retry-all-errors \
             "$@"
     }
+  '';
+
+  updateConfig = pkgs.writers.writeBash "merge-syncthing-config" (''
+    set -efu
+
+    # be careful not to leak secrets in the filesystem or in process listings
+    umask 0077
+
+    ${curlShellFunction}
   '' +
 
     /* Syncthing's rest API for the folders and devices is almost identical.

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -13,9 +13,9 @@ let
 
   # syncthing's configuration directory (see https://docs.syncthing.net/users/config.html)
   syncthing_dir = if pkgs.stdenv.isDarwin then
-      "$HOME/Library/Application Support/Syncthing"
-    else
-      "\${XDG_STATE_HOME:-$HOME/.local/state}/syncthing";
+    "$HOME/Library/Application Support/Syncthing"
+  else
+    "\${XDG_STATE_HOME:-$HOME/.local/state}/syncthing";
 
   # Syncthing supports serving the GUI over Unix sockets. If that happens, the
   # API is served over the Unix socket as well.  This function returns the correct
@@ -56,14 +56,10 @@ let
   copyKeys = pkgs.writers.writeBash "syncthing-copy-keys" ''
     ${install} -dm700 "${syncthing_dir}"
     ${lib.optionalString (cfg.cert != null) ''
-      ${install} -Dm400 ${
-        toString cfg.cert
-      } "${syncthing_dir}/cert.pem"
+      ${install} -Dm400 ${toString cfg.cert} "${syncthing_dir}/cert.pem"
     ''}
     ${lib.optionalString (cfg.key != null) ''
-      ${install} -Dm400 ${
-        toString cfg.key
-      } "${syncthing_dir}/key.pem"
+      ${install} -Dm400 ${toString cfg.key} "${syncthing_dir}/key.pem"
     ''}
   '';
 
@@ -647,7 +643,8 @@ in {
           };
 
           Service = {
-            ExecStartPre = lib.mkIf (cfg.cert != null || cfg.key != null) "+${copyKeys}";
+            ExecStartPre =
+              lib.mkIf (cfg.cert != null || cfg.key != null) "+${copyKeys}";
             ExecStart = lib.escapeShellArgs syncthingArgs;
             Restart = "on-failure";
             SuccessExitStatus = [ 3 4 ];
@@ -693,13 +690,13 @@ in {
         syncthing = {
           enable = true;
           config = {
-            ProgramArguments = [ "${
-              pkgs.writers.writeBash "syncthing-wrapper" ''
+            ProgramArguments = [
+              "${pkgs.writers.writeBash "syncthing-wrapper" ''
                 ${copyKeys}                               # simulate systemd's `syncthing-init.Service.ExecStartPre`
                 touch "${syncthing_dir}/${watch_file}"    # notify syncthing-init agent
                 exec ${lib.escapeShellArgs syncthingArgs}
-              ''
-            }" ];
+              ''}"
+            ];
             KeepAlive = {
               Crashed = true;
               SuccessfulExit = false;
@@ -712,7 +709,9 @@ in {
           enable = true;
           config = {
             ProgramArguments = [ "${updateConfig}" ];
-            WatchPaths = [ "${config.home.homeDirectory}/Library/Application Support/Syncthing/${watch_file}" ];
+            WatchPaths = [
+              "${config.home.homeDirectory}/Library/Application Support/Syncthing/${watch_file}"
+            ];
           };
         };
       };


### PR DESCRIPTION
### Description

This PRs extends the recently merged PR #5616, which expanded the Synching config to allow declarative settings under Linux, such that it also works under Darwin.

To simplify the review process, I left split the PR into several commits for now:
* The first five commits perform some minor refactoring tasks of the module code such that parts of it can be reused in the Darwin specific changes.
* Commit six implements the actual Darwin specific changes. It does the following:
  * Update the module's `syncthing` launchd agent to copy the synching key/certificate before starting syncthing, analogously to the systemd service from the above mentioned PR #5616.
  * Adds an `syncthing-init`launchd agent (analogously to the systemd service `synching-init` from the above mentioned PR #5616) that updates the configuration files. Since this must be run after the syncthing service started, we use a `WatchPath` to coordinate both launchd agents.
* The last commit just fixes the formatting according to HM's `format` tool.

There might be better ways to coordinate the two launchd agents I'm not aware of. But I have had this running flawlessly for over two months now (on four Darwin and two Linux machines sharing various folders).

Fixes #4049 for Darwin systems.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted (see commit 6; I'll squash the other commits into it after the review process)

#### Maintainer CC

@karaolidis (pinging as author of the original (linux-specific) PR #5616)
@rycee (maintainer)
