### PR TITLE
accounts/email: provide realName option for alias

### DIFF
--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -268,10 +268,26 @@ let
       };
 
       aliases = mkOption {
-        type = types.listOf (types.strMatching ".*@.*");
+        description = "Alternative identities of this account.";
         default = [ ];
         example = [ "webmaster@example.org" "admin@example.org" ];
-        description = "Alternative email addresses of this account.";
+        type = types.listOf (types.oneOf [
+          (types.strMatching ".*@.*")
+          (types.submodule {
+            options = {
+              realName = mkOption {
+                type = types.str;
+                example = "Jane Doe";
+                description = "Name displayed when sending mails.";
+              };
+              address = mkOption {
+                type = types.strMatching ".*@.*";
+                example = "jane.doe@example.org";
+                description = "The email address of this identity.";
+              };
+            };
+          })
+        ]);
       };
 
       realName = mkOption {

--- a/modules/programs/mu.nix
+++ b/modules/programs/mu.nix
@@ -16,7 +16,8 @@ let
       filter (a: a.mu.enable) (attrValues config.accounts.email.accounts);
     addrs = map (a: a.address) muAccounts;
     # Construct list of lists containing email aliases, and flatten
-    aliases = flatten (map (a: a.aliases) muAccounts);
+    aliases = map (alias: alias.address or alias)
+      (flatten (map (a: a.aliases) muAccounts));
     # Sort the list
   in sort lessThan (addrs ++ aliases);
 

--- a/modules/programs/notmuch.nix
+++ b/modules/programs/notmuch.nix
@@ -37,8 +37,9 @@ let
     in {
       name = catAttrs "realName" primary;
       primary_email = catAttrs "address" primary;
-      other_email = catAttrs "aliases" primary ++ catAttrs "address" secondaries
-        ++ catAttrs "aliases" secondaries;
+      other_email = map (email: email.address or email) (flatten
+        (catAttrs "aliases" primary ++ catAttrs "address" secondaries
+          ++ catAttrs "aliases" secondaries));
     };
 
     search = { exclude_tags = cfg.search.excludeTags; };


### PR DESCRIPTION
### Description

Provide options for setting `realName` in `accounts.email.accounts.*.aliases`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@d-dervishi