### PR TITLE
Addd custome config path config option

### DIFF
--- a/modules/programs/oh-my-posh.nix
+++ b/modules/programs/oh-my-posh.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 with lib;
 let
@@ -7,14 +12,18 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
-  configArgument = if cfg.settings != { } then
-    "--config ${config.xdg.configHome}/oh-my-posh/config.json"
-  else if cfg.useTheme != null then
-    "--config ${cfg.package}/share/oh-my-posh/themes/${cfg.useTheme}.omp.json"
-  else
-    "";
+  configArgument =
+    if cfg.settings != { } then
+      "--config ${config.xdg.configHome}/oh-my-posh/config.json"
+    else if cfg.useTheme != null then
+      "--config ${cfg.package}/share/oh-my-posh/themes/${cfg.useTheme}.omp.json"
+    else if cfg.configFile != null then
+      "--config ${cfg.configFile}"
+    else
+      "";
 
-in {
+in
+{
   meta.maintainers = [ maintainers.arjan-s ];
 
   options.programs.oh-my-posh = {
@@ -25,8 +34,7 @@ in {
     settings = mkOption {
       type = jsonFormat.type;
       default = { };
-      example = literalExpression ''
-        builtins.fromJSON (builtins.unsafeDiscardStringContext (builtins.readFile "''${pkgs.oh-my-posh}/share/oh-my-posh/themes/space.omp.json"))'';
+      example = literalExpression ''builtins.fromJSON (builtins.unsafeDiscardStringContext (builtins.readFile "''${pkgs.oh-my-posh}/share/oh-my-posh/themes/space.omp.json"))'';
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/oh-my-posh/config.json`. See
@@ -44,6 +52,14 @@ in {
         <https://ohmyposh.dev/docs/themes>. Because a theme
         is essentially a configuration file, this option is not used when a
         `configFile` is set.
+      '';
+    };
+
+    configFile = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Path to a custome config path, can be json, yaml or toml  
       '';
     };
 


### PR DESCRIPTION
### Description

<!--

Added an option to suply a path to a custom conifg which can be json,yaml or toml

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
