### PR TITLE
zsh-abbr: backport updated source path (#6109)

### DIFF
--- a/modules/programs/zsh/zsh-abbr.nix
+++ b/modules/programs/zsh/zsh-abbr.nix
@@ -28,7 +28,7 @@ in {
     programs.zsh.plugins = [{
       name = "zsh-abbr";
       src = pkgs.zsh-abbr;
-      file = "/share/zsh/zsh-abbr/abbr.plugin.zsh";
+      file = "share/zsh/zsh-abbr/zsh-abbr.plugin.zsh";
     }];
 
     xdg.configFile = {


### PR DESCRIPTION
### Description

Fixes 24.11 nixpkgs/home-manager mismatch for zsh-abbr plugin file path as described in #6109.

Closes #6109 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
