### PR TITLE
rofi: modes option

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -132,6 +132,7 @@ let
     else
       cfg.theme;
 
+  modes = map (mode: if isString mode then mode else "${mode.name}:${mode.path}") cfg.modes;
 in
 {
   options.programs.rofi = {
@@ -254,11 +255,36 @@ in
       description = "Path where to put generated configuration file.";
     };
 
+    modes = mkOption {
+      default = [ ];
+      example = literalExpression ''
+        [
+          "drun"
+          "emoji"
+          "ssh"
+          {
+            name = "whatnot";
+            path = lib.getExe pkgs.rofi-whatnot;
+          }
+        ]
+      '';
+      type =
+        with types;
+        listOf (
+          either str (submodule {
+            options = {
+              name = mkOption { type = str; };
+              path = mkOption { type = str; };
+            };
+          })
+        );
+      description = "Modes to enable. For custom modes see `man 5 rofi-script`.";
+    };
+
     extraConfig = mkOption {
       default = { };
       example = literalExpression ''
         {
-          modi = "drun,emoji,ssh";
           kb-primary-paste = "Control+V,Shift+Insert";
           kb-secondary-paste = "Control+v,Insert";
         }
@@ -313,6 +339,7 @@ in
       toRasi {
         configuration = (
           {
+            inherit modes;
             font = cfg.font;
             terminal = cfg.terminal;
             cycle = cfg.cycle;

--- a/tests/modules/programs/rofi/custom-theme-config.rasi
+++ b/tests/modules/programs/rofi/custom-theme-config.rasi
@@ -1,5 +1,6 @@
 configuration {
 location: 0;
+modes: [  ];
 xoffset: 0;
 yoffset: 0;
 }

--- a/tests/modules/programs/rofi/valid-config-expected.rasi
+++ b/tests/modules/programs/rofi/valid-config-expected.rasi
@@ -4,7 +4,7 @@ font: "Droid Sans Mono 14";
 kb-primary-paste: "Control+V,Shift+Insert";
 kb-secondary-paste: "Control+v,Insert";
 location: 0;
-modi: "drun,emoji,ssh";
+modes: [ "drun","emoji","ssh","foo:bar" ];
 terminal: "/some/path";
 xoffset: 0;
 yoffset: 0;

--- a/tests/modules/programs/rofi/valid-config.nix
+++ b/tests/modules/programs/rofi/valid-config.nix
@@ -9,8 +9,16 @@
       border = "border";
       separator = "separator";
     };
+    modes = [
+      "drun"
+      "emoji"
+      "ssh"
+      {
+        name = "foo";
+        path = "bar";
+      }
+    ];
     extraConfig = {
-      modi = "drun,emoji,ssh";
       kb-primary-paste = "Control+V,Shift+Insert";
       kb-secondary-paste = "Control+v,Insert";
     };


### PR DESCRIPTION
### Description

Adds `programs.rofi.modes` option.
For the tiny convenience of supporting the custom mode syntax.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
