### PR TITLE
conky: update systemd exec path to config package

### DIFF
--- a/modules/services/conky.nix
+++ b/modules/services/conky.nix
@@ -41,7 +41,7 @@ in with lib; {
       Service = {
         Restart = "always";
         RestartSec = "3";
-        ExecStart = toString ([ "${pkgs.conky}/bin/conky" ]
+        ExecStart = toString ([ "${cfg.package}/bin/conky" ]
           ++ optional (cfg.extraConfig != "")
           "--config ${pkgs.writeText "conky.conf" cfg.extraConfig}");
       };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Currently systemd ExecStart uses pks.conky as executable path, this commit changes it to the package defined by services.conky.package

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@kaleocheng