### PR TITLE
add programs.firefox.startWithLastProfile

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -737,7 +737,7 @@ in {
         '';
       }
 
-      (mkNoDuplicateAssertion cfg.profiles "profile")
+#       (mkNoDuplicateAssertion cfg.profiles "profile")
     ] ++ (mapAttrsToList
       (_: profile: mkNoDuplicateAssertion profile.containers "container")
       cfg.profiles);

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -716,16 +716,6 @@ in {
       (hm.assertions.assertPlatform moduleName pkgs supportedPlatforms)
 
       (let
-        defaults =
-          catAttrs "name" (filter (a: a.isDefault) (attrValues cfg.profiles));
-      in {
-        assertion = cfg.profiles == { } || length defaults == 1;
-        message = "Must have exactly one default ${cfg.name} profile but found "
-          + toString (length defaults) + optionalString (length defaults > 1)
-          (", namely " + concatStringsSep ", " defaults);
-      })
-
-      (let
         getContainers = profiles:
           flatten
           (mapAttrsToList (_: value: (attrValues value.containers)) profiles);

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -61,7 +61,7 @@ let
       Default = if profile.isDefault then 1 else 0;
     }) // {
       General = {
-        StartWithLastProfile = 1;
+        StartWithLastProfile = if cfg.startWithLastProfile then 1 else 0;
       } // lib.optionalAttrs (cfg.profileVersion != null) {
         Version = cfg.profileVersion;
       };
@@ -696,6 +696,17 @@ in {
         also need to set the NixOS option
         `services.gnome.gnome-browser-connector.enable` to
         `true`.
+      '';
+    };
+
+    startWithLastProfile = mkOption {
+      inherit visible;
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to automatically choose the last-used profile on startup.
+        Disabling this will result in Firefox asking for a profile selection
+        on every startup.
       '';
     };
   };


### PR DESCRIPTION
### Description
Add an option to the firefox module to allow choosing whether or not to select a profile on startup

Currently FF crashes once a profile is selected, need to look into this....

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee 