### PR TITLE
kdeconnect: Upgrade default version to Plasma6

### DIFF
--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -14,8 +14,8 @@ in {
       enable = mkEnableOption "KDE connect";
       package = mkOption {
         type = types.package;
-        default = pkgs.plasma5Packages.kdeconnect-kde;
-        example = literalExpression "pkgs.kdePackages.kdeconnect-kde";
+        default = pkgs.kdePackages.kdeconnect-kde;
+        example = literalExpression "pkgs.plasma5Packages.kdeconnect-kde";
         description = "The KDE connect package to use";
       };
 


### PR DESCRIPTION
Plasma6 has been out for a while now and the service still points to the old, incompatible version.

### Description

Upgrade the default version of kde-connect to use Plasma6.

The current one, based on Plasma5, is 23.08 and incompatible with Plasma6.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.(Kinda? It may break in Plasma5 setups)

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@adisbladis 
