### PR TITLE
hyprpaper: fix service when no config file

### DIFF
--- a/modules/services/hyprpaper.nix
+++ b/modules/services/hyprpaper.nix
@@ -75,7 +75,7 @@ in {
         Description = "hyprpaper";
         After = [ "graphical-session-pre.target" ];
         PartOf = [ "graphical-session.target" ];
-        X-Restart-Triggers =
+        X-Restart-Triggers = mkIf (cfg.settings != { })
           [ "${config.xdg.configFile."hypr/hyprpaper.conf".source}" ];
       };
 

--- a/tests/modules/services/hyprpaper/default.nix
+++ b/tests/modules/services/hyprpaper/default.nix
@@ -1,1 +1,4 @@
-{ hyprpaper-basic-configuration = ./basic-configuration.nix; }
+{
+  hyprpaper-basic-configuration = ./basic-configuration.nix;
+  hyprpaper-no-configuration = ./no-configuration.nix;
+}

--- a/tests/modules/services/hyprpaper/no-configuration.nix
+++ b/tests/modules/services/hyprpaper/no-configuration.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+{
+  services.hyprpaper = {
+    enable = true;
+    settings = { };
+  };
+
+  test.stubs.hyprpaper = { };
+
+  nmt.script = ''
+    config=home-files/.config/hypr/hyprpaper.conf
+    clientServiceFile=home-files/.config/systemd/user/hyprpaper.service
+    assertPathNotExists $config
+    assertFileExists $clientServiceFile
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
> Applies the same fix here from <https://github.com/nix-community/home-manager/pull/6131>.

The the systemd user service depends on `config.xdg.configFile."hypr/hyprpaper.conf".source` for `X-Restart-Triggers`. When `cfg.settings` is the default `{}`, this causes failure since `config.xdg.configFile."hypr/hyprpaper.conf".source` will not exist.

Making the addition conditional on `cfg.settings` actually having content, which would mean `xdg.configFile."hypr/hyprpaper.conf"` does exist, avoids the error.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@fufexan
@khaneliman

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
