### PR TITLE
Bash: move `bash.sessionVariables` into `.bashrc`

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -214,8 +214,6 @@ in {
     home.file.".profile".source = writeBashScript "profile" ''
       . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
-      ${sessionVarsStr}
-
       ${cfg.profileExtra}
     '';
 
@@ -224,6 +222,8 @@ in {
 
       # Commands that should be applied only for interactive shells.
       [[ $- == *i* ]] || return
+
+      ${sessionVarsStr}
 
       ${historyControlStr}
 

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -17,13 +17,21 @@ with lib;
     nmt.script = ''
       assertFileExists home-files/.profile
       assertFileContent \
+        home-files/.bashrc \
+        ${
+          builtins.toFile "session-variables-expected" ''
+
+            export V1="v1"
+            export V2="v2-v1"
+
+
+          ''
+        }
+      assertFileContent \
         home-files/.profile \
         ${
           builtins.toFile "session-variables-expected" ''
             . "/home/hm-user/.nix-profile/etc/profile.d/hm-session-vars.sh"
-
-            export V1="v1"
-            export V2="v2-v1"
 
 
           ''


### PR DESCRIPTION
# Tests are failing in the `master` branch, I can't be sure if my changes are correct.

When you set `home.sessionVariables` the variables go into `hm-session-vars.sh`, which is loaded by `.profile`.
When you set `bash.sessionVariables` the variables go directly into `.profile`, serving the same purpose as `home.sessionVariables`.

With that, we're left missing a way to set variables in `.bashrc`, or bash session variables. One would have to script them directly.

`bash.sessionVariables` should not go directly into `.profile`, but into `.bashrc`.

Closes #5474.

### Description

Moving `bash.sessionVariables` into `.bashrc`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ x ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@rycee
