### PR TITLE
feat(zsh): initExtraLast option

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -469,6 +469,12 @@ in
         description = "Commands that should be added to top of {file}`.zshrc`.";
       };
 
+      initExtraLast = mkOption {
+        default = "";
+        type = types.lines;
+        description = "Commands that should be added to bottom of {file}`.zshrc`.";
+      };
+
       envExtra = mkOption {
         default = "";
         type = types.lines;
@@ -738,6 +744,10 @@ in
           }
         '')
 
+        cfg.initExtraLast
+
+        # zprof must place last after everything else, since it
+        # benchmarks the shell initialization.
         (optionalString cfg.zprof.enable
         ''
           zprof


### PR DESCRIPTION
### Description

Fix #6140.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
