### PR TITLE
tmux: add 'focusEvents'

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -95,6 +95,7 @@ let
     ''}
 
     set  -g mouse             ${boolToStr cfg.mouse}
+    set  -g focus-events      ${boolToStr cfg.focusEvents}
     setw -g aggressive-resize ${boolToStr cfg.aggressiveResize}
     setw -g clock-mode-style  ${if cfg.clock24 then "24" else "12"}
     set  -s escape-time       ${toString cfg.escapeTime}
@@ -188,6 +189,15 @@ in {
         description = ''
           Additional configuration to add to
           {file}`tmux.conf`.
+        '';
+      };
+
+      focusEvents = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          On supported terminals, request focus events and pass them through to
+          applications running in tmux.
         '';
       };
 

--- a/tests/modules/programs/tmux/default-shell.conf
+++ b/tests/modules/programs/tmux/default-shell.conf
@@ -19,6 +19,7 @@ set -g mode-keys   emacs
 
 
 set  -g mouse             off
+set  -g focus-events      off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12
 set  -s escape-time       500

--- a/tests/modules/programs/tmux/disable-confirmation-prompt.conf
+++ b/tests/modules/programs/tmux/disable-confirmation-prompt.conf
@@ -19,6 +19,7 @@ bind-key -N "Kill the current pane" x kill-pane
 
 
 set  -g mouse             off
+set  -g focus-events      off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12
 set  -s escape-time       500

--- a/tests/modules/programs/tmux/emacs-with-plugins.conf
+++ b/tests/modules/programs/tmux/emacs-with-plugins.conf
@@ -19,6 +19,7 @@ set -g mode-keys   emacs
 
 
 set  -g mouse             off
+set  -g focus-events      off
 setw -g aggressive-resize on
 setw -g clock-mode-style  24
 set  -s escape-time       500

--- a/tests/modules/programs/tmux/mouse-enabled.conf
+++ b/tests/modules/programs/tmux/mouse-enabled.conf
@@ -17,6 +17,7 @@ set -g mode-keys   emacs
 
 
 set  -g mouse             on
+set  -g focus-events      off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12
 set  -s escape-time       500

--- a/tests/modules/programs/tmux/prefix.conf
+++ b/tests/modules/programs/tmux/prefix.conf
@@ -22,6 +22,7 @@ bind -N "Send the prefix key through to the application" \
 
 
 set  -g mouse             off
+set  -g focus-events      off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12
 set  -s escape-time       500

--- a/tests/modules/programs/tmux/shortcut-without-prefix.conf
+++ b/tests/modules/programs/tmux/shortcut-without-prefix.conf
@@ -23,6 +23,7 @@ bind C-a last-window
 
 
 set  -g mouse             off
+set  -g focus-events      off
 setw -g aggressive-resize off
 setw -g clock-mode-style  12
 set  -s escape-time       500

--- a/tests/modules/programs/tmux/vi-all-true.conf
+++ b/tests/modules/programs/tmux/vi-all-true.conf
@@ -19,6 +19,7 @@ set -g mode-keys   vi
 
 
 set  -g mouse             off
+set  -g focus-events      off
 setw -g aggressive-resize on
 setw -g clock-mode-style  24
 set  -s escape-time       500


### PR DESCRIPTION
With `tmux-sensible` being disabled by default (#6091), add an easy toggle to enable this functionality.

Disabled by default, as in upstream `tmux` (I _could_ see an argument for enabling it by default, as `sensibleOnTop` was enabled by default and enabled this option unconditionally, but historically that's not been the way default option values have been chosen for this module).

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 