### PR TITLE
lorri: fix ReadWritePaths for new gcroots behavior

### DIFF
--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -59,7 +59,6 @@ in {
             "%C/lorri"
             # Needs %C/nix/fetcher-cache-v1.sqlite
             "%C/nix"
-            "/nix/var/nix/gcroots/per-user/%u"
           ];
           CacheDirectory = [ "lorri" ];
           Restart = "on-failure";


### PR DESCRIPTION
### Description

Since https://github.com/nix-community/lorri/pull/128, lorri no longer uses this legacy path for gcroots, and instead delegates to the Nix daemon. Leaving the path here causes the service to fail to start if the directory does not exist on the user's system:

```
nov 28 11:49:14 meitan (lorri)[50058]: lorri.service: Failed to set up mount namespacing: /nix/var/nix/gcroots/per-user/kmicklas: No such file or directory
nov 28 11:49:14 meitan systemd[2265]: lorri.service: Main process exited, code=exited, status=226/NAMESPACE
nov 28 11:49:14 meitan systemd[2265]: lorri.service: Failed with result 'exit-code'.
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
