### PR TITLE
zsh: make autosuggest strategy accept more options

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -427,6 +427,9 @@ in
             - `match_prev_cmd`: Like `history`, but chooses the most recent match whose preceding history item matches
                 the most recently executed command. Note that this strategy won't work as expected with ZSH options that
                 don't preserve the history order such as `HIST_IGNORE_ALL_DUPS` or `HIST_EXPIRE_DUPS_FIRST`.
+
+            Setting the option to an empty list `[]` will make ZSH_AUTOSUGGESTION_STRATEGY not be set automatically,
+            allowing the variable to be declared in {option}`programs.zsh.localVariables` or {option}`programs.zsh.sessionVariables`
           '';
         };
       };
@@ -641,7 +644,10 @@ in
 
         (optionalString cfg.autosuggestion.enable ''
           source ${pkgs.zsh-autosuggestions}/share/zsh-autosuggestions/zsh-autosuggestions.zsh
-          ZSH_AUTOSUGGEST_STRATEGY=(${concatStringsSep " " cfg.autosuggestion.strategy})
+          ${optionalString (cfg.autosuggestion.strategy != []) ''
+            ZSH_AUTOSUGGEST_STRATEGY=(${concatStringsSep " " cfg.autosuggestion.strategy})
+          ''
+          }
         '')
         (optionalString (cfg.autosuggestion.enable && cfg.autosuggestion.highlight != null) ''
           ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="${cfg.autosuggestion.highlight}"


### PR DESCRIPTION
### Description
~The current implementation completely overrides any declaration of ZSH_AUTOSUGGEST_STRATEGY, which can break some user's settings (in my case, breaks adding abbr's suggestion strategy). New implementation now allows for users to define more than just `history`, `completion`, and `match_prev_cmd` and will auto append the variable if there are existing declarations of ZSH_AUTOSUGGEST_STRATEGY in the user's zshrc; and if there isn't any existing declaration, then simply just set the variable. Additionally, it can be left to empty (`[  ]`) which would completely disable the accompanying code; allowing users to fully decide where they want to place ZSH_AUTOSUGGEST_STRATEGY. And finally, use `typeset -U` to remove any possible duplicate values in the variable.~ The original scope of this PR was a much broader and complicated approach; simplified to allow `programs.zsh.autosuggestion.strategies` to be set to empty (`[]`) and disable the code. This would still allow for the option to declare `ZSH_AUTOSUGGEST_STRATEGY` in any of the `*Variables` module options available in Home-Manager

Edit: I did test the change in my flake and found that it works without causing issues to other parts of Home-Manager

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@JohnRTitor 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
