### PR TITLE
starship: add option to use community presets

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -628,4 +628,10 @@
     keys =
       [{ fingerprint = "BC82 4BB5 1656 D144 285E  A0EC D382 C4AF EECE AA90"; }];
   };
+  kpbaks = {
+    name = "Kristoffer Plagborg Bak Sørensen";
+    email = "kristoffer.pbs@gmail.com";
+    github = "kpbaks";
+    githubId = 57013304;
+  };
 }

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -11,7 +11,7 @@ let
   starshipCmd = "${config.home.profileDirectory}/bin/starship";
 
 in {
-  meta.maintainers = [ ];
+  meta.maintainers = [ maintainers.kpbaks ];
 
   options.programs.starship = {
     enable = mkEnableOption "starship";
@@ -21,6 +21,34 @@ in {
       default = pkgs.starship;
       defaultText = literalExpression "pkgs.starship";
       description = "The package to use for the starship binary.";
+    };
+
+    preset = mkOption {
+      # generated with `starship preset --list`
+      type = types.enum [
+        null
+        "bracketed-segments"
+        "gruvbox-rainbow"
+        "jetpack"
+        "nerd-font-symbols"
+        "no-empty-icons"
+        "no-nerd-font"
+        "no-runtime-versions"
+        "pastel-powerline"
+        "plain-text-symbols"
+        "pure-preset"
+        "tokyo-night"
+      ];
+      default = null;
+      example = "jetpack";
+      description = ''
+        The community-submitted configuration preset to use.
+
+        See <https://starship.rs/presets/#presets> for previews
+        of each preset.
+
+        Mutually exclusive with programs.starship.settings
+      '';
     };
 
     settings = mkOption {
@@ -48,6 +76,8 @@ in {
 
         See <https://starship.rs/config/> for the full list
         of options.
+
+        Mutually exclusive with programs.starship.preset
       '';
     };
 
@@ -88,9 +118,25 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."starship.toml" = mkIf (cfg.settings != { }) {
+    warnings = lib.optional (cfg.preset != null && cfg.settings != { })
+      "programs.starship.settings has no effect when programs.starship.preset != null";
+
+    xdg.configFile."starship.toml" = if cfg.preset != null then
+      let
+        starshipGithub = pkgs.fetchFromGitHub {
+          owner = "starship";
+          repo = "starship";
+          rev = "61c860e1293d446d515203ac44055f7bef77d14a";
+          hash = "sha256-pl3aW4zCM6CcYOL0dUwE56aTC7BJdvdRyo/GudvX7fQ=";
+        };
+      in {
+        text = builtins.readFile
+          "${starshipGithub}/docs/public/presets/toml/${cfg.preset}.toml";
+      }
+    else if cfg.settings != { } then {
       source = tomlFormat.generate "starship-config" cfg.settings;
-    };
+    } else
+      { };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       if [[ $TERM != "dumb" ]]; then


### PR DESCRIPTION
### Description

Presets are community-submitted configurations for starship. See: https://starship.rs/presets/#presets.

This PR adds the option `programs.starship.preset` that can be set to the name of a preset. If `programs.starship.preset != null` it will have priority over `programs.starship.settings`.

The preset is fetched from starships [github repo](https://github.com/starship/starship) by using `pkgs.fetchFromGithub`. I do not think this implementation detail is ideal, as the version fetched from the repo can be out of sync with `programs.starship.package`. This can lead to a bad user experience where a user has seen a preset online and wants to use it, but cannot because the revision is out of date. I am not experienced enough with nix and nixpkgs to know of an alternative. You can get the TOML of the preset with `starship preset <name>` where `<name>` is one of the items in `starship preset --list`.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
