### PR TITLE
nix-your-shell: Fix creating required directory in nushell

### DIFF
--- a/modules/programs/nix-your-shell.nix
+++ b/modules/programs/nix-your-shell.nix
@@ -39,6 +39,7 @@ in {
 
       nushell = mkIf cfg.enableNushellIntegration {
         extraEnv = ''
+          mkdir ${config.xdg.cacheHome}/nix-your-shell
           ${cfg.package}/bin/nix-your-shell nu | save --force ${config.xdg.cacheHome}/nix-your-shell/init.nu
         '';
 


### PR DESCRIPTION
Fixes https://github.com/nix-community/home-manager/issues/6161

### Description

Creates a directory required by the nushell integration of `programs.nix-your-shell`, which throws an error otherwise.

The `mkdir` should never fail because nushell always creates all parent directories.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@terlar 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
