### PR TITLE
nushell: allow installing plugins

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1890,6 +1890,15 @@ in {
           NOTE: The minus symbol means to NOT use that particular TLS version.
         '';
       }
+
+      {
+        time = "2024-12-10T22:20:10+00:00";
+        condition = config.programs.nushell.enable;
+        message = ''
+          The module 'programs.nushell' can now manage the Nushell plugin
+          registry with the option 'programs.nushell.plugins'.
+        '';
+      }
     ];
   };
 }

--- a/tests/modules/programs/nushell/example-settings.nix
+++ b/tests/modules/programs/nushell/example-settings.nix
@@ -23,6 +23,8 @@
       }
     '';
 
+    plugins = [ pkgs.nushellPlugins.formats ];
+
     shellAliases = {
       "lsname" = "(ls | get name)";
       "ll" = "ls -a";
@@ -41,8 +43,6 @@
     };
   };
 
-  test.stubs.nushell = { };
-
   nmt.script = let
     configDir = if pkgs.stdenv.isDarwin && !config.xdg.enable then
       "home-files/Library/Application Support/nushell"
@@ -58,5 +58,7 @@
     assertFileContent \
       "${configDir}/login.nu" \
       ${./login-expected.nu}
+    assertFileExists \
+      "${configDir}/plugin.msgpackz"
   '';
 }


### PR DESCRIPTION
### Description
When the version of Nushell or any Nushell plugin changes, the plugin registry must be regenerated.  This adds an option that takes a list of Nushell plugin derivations and recreates the plugin registry file (`~/.config/nushell/plugin.msgpackz`) on profile activation.

Thanks to @crabdancing for most of the work: https://github.com/nushell/nushell/discussions/12997#discussioncomment-9638977

I believe this is worth adding a news entry even though it is only adding an option, because this has been a significant pain point for anyone using plugins with Nushell managed by home-manager.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@Philipp-M @JoaquinTrinanes 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
