### PR TITLE
thunderbird: set the correct SMTP server for aliases

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -71,6 +71,8 @@ let
       "mail.identity.id_${id}.openpgp_key_id" = account.gpg.key;
       "mail.identity.id_${id}.protectSubject" = true;
       "mail.identity.id_${id}.sign_mail" = account.gpg.signByDefault;
+    } // optionalAttrs (account.smtp != null) {
+      "mail.identity.id_${id}.smtpServer" = "smtp_${account.id}";
     } // account.thunderbird.perIdentitySettings id;
 
   toThunderbirdAccount = account: profile:
@@ -103,7 +105,6 @@ let
       "mail.server.server_${id}.type" = "imap";
       "mail.server.server_${id}.userName" = account.userName;
     } // optionalAttrs (account.smtp != null) {
-      "mail.identity.id_${id}.smtpServer" = "smtp_${id}";
       "mail.smtpserver.smtp_${id}.authMethod" = 3;
       "mail.smtpserver.smtp_${id}.hostname" = account.smtp.host;
       "mail.smtpserver.smtp_${id}.port" =

--- a/tests/modules/programs/thunderbird/thunderbird-expected-first.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-first.js
@@ -18,6 +18,7 @@ user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ec
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.openpgp_key_id", "ABC");
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.protectSubject", true);
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.sign_mail", false);
+user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.smtpServer", "smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f");
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.useremail", "home-manager@example.com");
 user_pref("mail.identity.id_8bbcff78f53202c0bfaa490a2068e3e5d6e36872144c659952ecc0ada47d7562.valid", true);
 user_pref("mail.identity.id_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.autoEncryptDrafts", false);


### PR DESCRIPTION
Previously, only the main identity of an account would get the proper SMTP server assigned. Identities corresponding to aliases would not get an SMTP server assigned at all, leading to a (Thunderbird-internal) fallback to the SMTP server associated to the primary account. This is obviously wrong for non-primary accounts having aliases associated to them. Fix it by specifying the SMTP server explicitly for all identities.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
