### PR TITLE
mbsync: use TLSType instead of deprecated SSLType

### DIFF
--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -30,7 +30,7 @@ let
 
   genTlsConfig = tls:
     {
-      SSLType = if !tls.enable then
+      TLSType = if !tls.enable then
         "None"
       else if tls.useStartTls then
         "STARTTLS"

--- a/tests/modules/programs/mbsync/mbsync-expected.conf
+++ b/tests/modules/programs/mbsync/mbsync-expected.conf
@@ -4,7 +4,7 @@ IMAPAccount hm-account
 CertificateFile /etc/ssl/certs/ca-certificates.crt
 Host imap.example.org
 PassCmd "password-command 2"
-SSLType IMAPS
+TLSType IMAPS
 User home.manager.jr
 
 IMAPStore hm-account-remote
@@ -56,8 +56,8 @@ IMAPAccount hm@example.com
 CertificateFile /etc/ssl/certs/ca-certificates.crt
 Host imap.example.com
 PassCmd password-command
-SSLType IMAPS
 SSLVersions TLSv1.3 TLSv1.2
+TLSType IMAPS
 User home.manager
 
 IMAPStore hm@example.com-remote


### PR DESCRIPTION
### Description

SSLType was deprecated in mbsync in favor of TLSType

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@KarlJoad Is this safe to add?
