### PR TITLE
qt: install kio when qt.platformTheme = "kde"

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -8,7 +8,11 @@ let
     gnome = [ qgnomeplatform qgnomeplatform-qt6 ];
     adwaita = [ qadwaitadecorations qadwaitadecorations-qt6 ];
     gtk = [ libsForQt5.qtstyleplugins qt6Packages.qt6gtk2 ];
-    kde = [ libsForQt5.plasma-integration libsForQt5.systemsettings ];
+    kde = [
+      libsForQt5.kio
+      libsForQt5.plasma-integration
+      libsForQt5.systemsettings
+    ];
     lxqt = [ lxqt.lxqt-qtplugin lxqt.lxqt-config ];
     qtct = [ libsForQt5.qt5ct qt6Packages.qt6ct ];
   };


### PR DESCRIPTION
### Description

Following discussions at https://github.com/NixOS/nixpkgs/pull/362949, this PR fixes file dialogs when KDE is not installed but `qt.platformTheme = "kde"` (common for theming purposes). Without it, file dialogs fail to show files and folders. Only an issue when KDE is not installed, because KDE installs kio in its own module.

![image](https://github.com/user-attachments/assets/474d36f4-a65c-46e5-8f41-55e36a465187)


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee @thiagokokada
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
