### PR TITLE
gpg-agent: fix GCR DBus package note

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -235,15 +235,12 @@ in {
         example = literalExpression "pkgs.pinentry-gnome3";
         default = null;
         description = ''
-          Which pinentry interface to use. If not
-          `null`, it sets
-          {option}`pinentry-program` in
-          {file}`gpg-agent.conf`. Beware that
-          `pinentry-gnome3` may not work on non-Gnome
-          systems. You can fix it by adding the following to your
-          system configuration:
+          Which pinentry interface to use. If not `null`, it sets
+          {option}`pinentry-program` in {file}`gpg-agent.conf`. Beware that
+          `pinentry-gnome3` may not work on non-GNOME systems. You can fix it by
+          adding the following to your configuration:
           ```nix
-          services.dbus.packages = [ pkgs.gcr ];
+          home.packages = [ pkgs.gcr ];
           ```
         '';
       };


### PR DESCRIPTION
### Description

D-Bus services are queried from Home Manager packages too. NixOS is not required.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
