### PR TITLE
nix-your-shell: add nom (nix-output-monitor) support

### DIFF
--- a/modules/programs/nix-your-shell.nix
+++ b/modules/programs/nix-your-shell.nix
@@ -27,20 +27,29 @@ in {
     enableZshIntegration = mkEnableOption "Zsh integration" // {
       default = true;
     };
+
+    enableNom = mkEnableOption "nom (nix-output-monitor) integration";
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = [ cfg.package ]
+      ++ (optionals cfg.enableNom [ pkgs.nix-output-monitor ]);
 
-    programs = {
+    programs = let
+      argsForShell = shell:
+        concatStringsSep " "
+        ([ ] ++ (optional cfg.enableNom "--nom") ++ [ "${shell}" ]);
+    in {
       fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
-        ${cfg.package}/bin/nix-your-shell fish | source
+        ${cfg.package}/bin/nix-your-shell ${argsForShell "fish"} | source
       '';
 
       nushell = mkIf cfg.enableNushellIntegration {
         extraEnv = ''
           mkdir ${config.xdg.cacheHome}/nix-your-shell
-          ${cfg.package}/bin/nix-your-shell nu | save --force ${config.xdg.cacheHome}/nix-your-shell/init.nu
+          ${cfg.package}/bin/nix-your-shell ${
+            argsForShell "nu"
+          } | save --force ${config.xdg.cacheHome}/nix-your-shell/init.nu
         '';
 
         extraConfig = ''
@@ -49,7 +58,9 @@ in {
       };
 
       zsh.initExtra = mkIf cfg.enableZshIntegration ''
-        ${cfg.package}/bin/nix-your-shell zsh | source /dev/stdin
+        ${cfg.package}/bin/nix-your-shell ${
+          argsForShell "zsh"
+        } | source /dev/stdin
       '';
     };
   };

--- a/tests/modules/programs/nix-your-shell/default.nix
+++ b/tests/modules/programs/nix-your-shell/default.nix
@@ -1,1 +1,4 @@
-{ nix-your-shell-enable-shells = ./enable-shells.nix; }
+{
+  nix-your-shell-enable-shells = ./enable-shells.nix;
+  nix-your-shell-enable-nom = ./enable-nom.nix;
+}

--- a/tests/modules/programs/nix-your-shell/enable-nom.nix
+++ b/tests/modules/programs/nix-your-shell/enable-nom.nix
@@ -1,0 +1,49 @@
+{ pkgs, config, ... }:
+
+{
+  programs = {
+    nix-your-shell = {
+      enable = true;
+      enableFishIntegration = true;
+      enableNushellIntegration = true;
+      enableZshIntegration = true;
+      enableNom = true;
+    };
+    fish.enable = true;
+    nushell.enable = true;
+    zsh.enable = true;
+  };
+
+  test.stubs = {
+    nix-your-shell = { };
+    nushell = { };
+    zsh = { };
+  };
+
+  nmt.script = let
+    nushellConfigDir = if pkgs.stdenv.isDarwin && !config.xdg.enable then
+      "home-files/Library/Application Support/nushell"
+    else
+      "home-files/.config/nushell";
+  in ''
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      '@nix-your-shell@/bin/nix-your-shell --nom fish | source'
+
+    assertFileExists ${nushellConfigDir}/config.nu
+    assertFileContains \
+      ${nushellConfigDir}/config.nu \
+      'source ${config.xdg.cacheHome}/nix-your-shell/init.nu'
+
+    assertFileExists ${nushellConfigDir}/env.nu
+    assertFileContains \
+      ${nushellConfigDir}/env.nu \
+      '@nix-your-shell@/bin/nix-your-shell --nom nu | save --force ${config.xdg.cacheHome}/nix-your-shell/init.nu'
+
+    assertFileExists home-files/.zshrc
+    assertFileContains \
+      home-files/.zshrc \
+      '@nix-your-shell@/bin/nix-your-shell --nom zsh | source /dev/stdin'
+  '';
+}


### PR DESCRIPTION
### Description

`nix-your-shell` has a feature where you can pass `--nom` to it in order
to have it use `nix-output-monitor` monitor by default for `nix`
invocations. This commit adds support for that in the relevant module.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@terlar
