### PR TITLE
atuin: Do not hardcode daemon socket path

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -199,7 +199,7 @@ in {
           Unit = { Description = "Atuin daemon socket"; };
           Install = { WantedBy = [ "sockets.target" ]; };
           Socket = {
-            ListenStream = "%h/.local/share/atuin/atuin.sock";
+            ListenStream = "%D/atuin/atuin.sock";
             SocketMode = "0600";
             RemoveOnStop = true;
           };

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -195,11 +195,16 @@ in {
           };
         };
 
-        systemd.user.sockets.atuin-daemon = {
+        systemd.user.sockets.atuin-daemon = let
+          socket_dir = if versionAtLeast cfg.package.version "18.4.0" then
+            "%t"
+          else
+            "%D/atuin";
+        in {
           Unit = { Description = "Atuin daemon socket"; };
           Install = { WantedBy = [ "sockets.target" ]; };
           Socket = {
-            ListenStream = "%D/atuin/atuin.sock";
+            ListenStream = "${socket_dir}/atuin.sock";
             SocketMode = "0600";
             RemoveOnStop = true;
           };


### PR DESCRIPTION
### Description

Use systemd path specifiers for appropriate path prefixes instead of assuming paths. This PR is future compatible with 18.4.0 preferring XDG_RUNTIME_PATH over XDG_DATA_DIR.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@hawkw @water-sucks 
