### PR TITLE
[24.11 backport] isync/mbsync: update module for 1.5.0 changes

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1837,6 +1837,35 @@ in {
           output.
         '';
       }
+
+      {
+        time = "2024-12-08T17:22:13+00:00";
+        condition = let
+          usingMbsync = any (a: a.mbsync.enable)
+            (attrValues config.accounts.email.accounts);
+        in usingMbsync;
+        message = ''
+          isync/mbsync 1.5.0 has changed several things.
+
+          isync gained support for using $XDG_CONFIG_HOME, and now places
+          its config file in '$XDG_CONFIG_HOME/isyncrc'.
+
+          isync changed the configuration options SSLType and SSLVersion to
+          TLSType and TLSVersion respectively.
+
+          All instances of
+          'accounts.email.accounts.<account-name>.mbsync.extraConfig.account'
+          that use 'SSLType' or 'SSLVersion' should be replaced with 'TLSType'
+          or 'TLSVersion', respectively.
+
+          TLSType options are unchanged.
+
+          TLSVersions has a new syntax, requiring a change to the Nix syntax.
+          Old Syntax: SSLVersions = [ "TLSv1.3" "TLSv1.2" ];
+          New Syntax: TLSVersions = [ "+1.3" "+1.2" "-1.1" ];
+          NOTE: The minus symbol means to NOT use that particular TLS version.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/mbsync-accounts.nix
+++ b/modules/programs/mbsync-accounts.nix
@@ -225,6 +225,8 @@ in {
       default = { };
       example = literalExpression ''
         {
+          TLSType = "IMAP";
+          TLSVersions = [ "+1.3" "+1.2" "-1.1" ];
           PipelineDepth = 10;
           Timeout = 60;
         };

--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -30,7 +30,7 @@ let
 
   genTlsConfig = tls:
     {
-      SSLType = if !tls.enable then
+      TLSType = if !tls.enable then
         "None"
       else if tls.useStartTls then
         "STARTTLS"
@@ -267,7 +267,7 @@ in {
 
       programs.notmuch.new.ignore = [ ".uidvalidity" ".mbsyncstate" ];
 
-      home.file.".mbsyncrc".text = let
+      xdg.configFile."isyncrc".text = let
         accountsConfig = map genAccountConfig mbsyncAccounts;
         # Only generate this kind of Group configuration if there are ANY accounts
         # that do NOT have a per-account groups/channels option(s) specified.

--- a/tests/modules/programs/mbsync/mbsync-expected.conf
+++ b/tests/modules/programs/mbsync/mbsync-expected.conf
@@ -4,7 +4,7 @@ IMAPAccount hm-account
 CertificateFile /etc/ssl/certs/ca-certificates.crt
 Host imap.example.org
 PassCmd "password-command 2"
-SSLType IMAPS
+TLSType IMAPS
 User home.manager.jr
 
 IMAPStore hm-account-remote
@@ -56,8 +56,8 @@ IMAPAccount hm@example.com
 CertificateFile /etc/ssl/certs/ca-certificates.crt
 Host imap.example.com
 PassCmd password-command
-SSLType IMAPS
-SSLVersions TLSv1.3 TLSv1.2
+TLSType IMAPS
+TLSVersions +1.3 +1.2 -1.1
 User home.manager
 
 IMAPStore hm@example.com-remote

--- a/tests/modules/programs/mbsync/mbsync.nix
+++ b/tests/modules/programs/mbsync/mbsync.nix
@@ -21,7 +21,7 @@ with lib;
     accounts.email.accounts = {
       "hm@example.com".mbsync = {
         enable = true;
-        extraConfig.account.SSLVersions = [ "TLSv1.3" "TLSv1.2" ];
+        extraConfig.account.TLSVersions = [ "+1.3" "+1.2" "-1.1" ];
         groups.inboxes = {
           channels = {
             inbox1 = {
@@ -79,8 +79,8 @@ with lib;
     test.stubs.isync = { };
 
     nmt.script = ''
-      assertFileExists home-files/.mbsyncrc
-      assertFileContent home-files/.mbsyncrc ${./mbsync-expected.conf}
+      assertFileExists home-files/.config/isyncrc
+      assertFileContent home-files/.config/isyncrc ${./mbsync-expected.conf}
     '';
   };
 }


### PR DESCRIPTION


### Description

<!--

Please provide a brief description of your change.

-->

This is a backport of  #5918. `isync` was also updated in `nixos-24.11`, so the option deprecation warning appears there as well. I think this should be backwards compatible.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@KarlJoad 