### PR TITLE
install: allow customizing the shellHook

### DIFF
--- a/home-manager/install.nix
+++ b/home-manager/install.nix
@@ -1,4 +1,6 @@
-{ home-manager, runCommand }:
+{ home-manager, runCommand
+, shellHook ? "exec ${home-manager}/bin/home-manager init --switch --no-flake"
+}:
 
 let
 
@@ -8,16 +10,13 @@ let
     source ${home-manager}/share/bash/home-manager.sh
   '';
 
-in
-runCommand "home-manager-install"
-  {
-    propagatedBuildInputs = [ home-manager ];
-    preferLocalBuild = true;
-    shellHookOnly = true;
-    shellHook = "exec ${home-manager}/bin/home-manager init --switch --no-flake";
-  }
-  ''
-    ${hmBashLibInit}
-    _iError 'This derivation is not buildable, please run it using nix-shell.'
-    exit 1
-  ''
+in runCommand "home-manager-install" {
+  propagatedBuildInputs = [ home-manager ];
+  preferLocalBuild = true;
+  shellHookOnly = true;
+  inherit shellHook;
+} ''
+  ${hmBashLibInit}
+  _iError 'This derivation is not buildable, please run it using nix-shell.'
+  exit 1
+''

--- a/tests/integration/standalone/alice-home-dotprofile.nix
+++ b/tests/integration/standalone/alice-home-dotprofile.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, ... }:
+
+{
+  home.username = "alice";
+  home.homeDirectory = "/home/alice";
+  home.stateVersion = "24.11";
+  programs.home-manager.enable = true;
+
+  # Write .profile
+  home.file = {
+    ".profile".text = ''
+      echo sourcing dotprofile
+    '';
+  };
+}

--- a/tests/integration/standalone/override-install.nix
+++ b/tests/integration/standalone/override-install.nix
@@ -1,0 +1,6 @@
+{ hmInstall ? (import <home-manager> { }).install }:
+hmInstall.override {
+  shellHook = ''
+    exec home-manager init --switch --no-flake -b backup
+  '';
+}

--- a/tests/integration/standalone/standard-basics.nix
+++ b/tests/integration/standalone/standard-basics.nix
@@ -124,6 +124,16 @@
       machine.succeed("test ! -e /home/alice/.local/state/home-manager")
       machine.succeed("test ! -e /home/alice/.local/state/nix/profiles/home-manager")
 
+    with subtest("Home Manager Installation with preexisting dotfile"):
+      succeed_as_alice("touch /home/alice/.profile")
+
+      succeed_as_alice("cp ${
+        ./alice-home-dotprofile.nix
+      } /home/alice/.config/home-manager/home.nix")
+
+      succeed_as_alice("nix-shell ${./override-install.nix}")
+      succeed_as_alice("test -e /home/alice/.profile.backup")
+
     logout_alice()
   '';
 }


### PR DESCRIPTION
### Description

`nix-shell "<home-manager>" -A install` fails when a target path to be written by home-manager (eg `~/.profile`) already exists. This causes problems when I try to bootstrap non-nixos machines with home-manager.

There's currently no way to modify the install shellHook, which runs `exec home-manager init --switch --no-flake`. This PR allows customizing the shellHook with an override (for example, changing it to `exec home-manager init --switch --no-flake -b backup`).

I've also added an integration test for illustration, happy to remove if you think it's overkill.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added.

- [x] Commit messages are formatted.

**Maintainer CC**
@rycee 