### PR TITLE
programs.gnome-shell: fix extensions' default

### DIFF
--- a/modules/programs/gnome-shell.nix
+++ b/modules/programs/gnome-shell.nix
@@ -17,7 +17,7 @@ let
 
       package = mkOption {
         type = types.package;
-        example = "pkgs.gnome.gnome-shell-extensions";
+        example = "pkgs.gnome-shell-extensions";
         description = ''
           Package providing a GNOME Shell extension in
           `$out/share/gnome-shell/extensions/''${id}`.
@@ -66,7 +66,7 @@ in {
           { package = pkgs.gnomeExtensions.dash-to-panel; }
           {
             id = "user-theme@gnome-shell-extensions.gcampax.github.com";
-            package = pkgs.gnome.gnome-shell-extensions;
+            package = pkgs.gnome-shell-extensions;
           }
         ]
       '';
@@ -106,7 +106,7 @@ in {
 
       programs.gnome-shell.extensions = [{
         id = "user-theme@gnome-shell-extensions.gcampax.github.com";
-        package = pkgs.gnome.gnome-shell-extensions;
+        package = pkgs.gnome-shell-extensions;
       }];
 
       home.packages = [ cfg.theme.package ];

--- a/tests/modules/programs/gnome-shell/gnome-shell.nix
+++ b/tests/modules/programs/gnome-shell/gnome-shell.nix
@@ -36,11 +36,7 @@ let
 
 in {
   nixpkgs.overlays = [
-    (self: super: {
-      gnome = super.gnome.overrideScope (gself: gsuper: {
-        gnome-shell-extensions = dummy-gnome-shell-extensions;
-      });
-    })
+    (final: prev: { gnome-shell-extensions = dummy-gnome-shell-extensions; })
   ];
 
   programs.gnome-shell.enable = true;


### PR DESCRIPTION
Else I get a
===

       … while calling the 'throw' builtin
         at /nix/store/afpmddfrmx5df3h16bdh00yy8i7db8w4-source/pkgs/desktops/gnome/default.nix:96:28:
           95|   gnome-shell = throw "The ‘gnome.gnome-shell’ was moved to top-level. Please use ‘pkgs.gnome-shell’ directly."; # Added on 2024-08-28.
           96|   gnome-shell-extensions = throw "The ‘gnome.gnome-shell-extensions’ was moved to top-level. Please use ‘pkgs.gnome-shell-extensions’ directly."; # Added on 2024-08-11.
             |                            ^
           97|   gnome-software = throw "The ‘gnome.gnome-software’ was moved to top-level. Please use ‘pkgs.gnome-software’ directly."; # Added on 2024-08-11.

       error: The ‘gnome.gnome-shell-extensions’ was moved to top-level. Please use ‘pkgs.gnome-shell-extensions’ directly.
===

on rebuild

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
