### PR TITLE
programs.gpg: fix hash of test

### DIFF
--- a/tests/modules/programs/gpg/immutable-keyfiles.nix
+++ b/tests/modules/programs/gpg/immutable-keyfiles.nix
@@ -12,7 +12,7 @@
         source = pkgs.fetchurl {
           url =
             "https://keys.openpgp.org/pks/lookup?op=get&options=mr&search=0x44CF42371ADF842E12F116EAA9D3F98FCCF5460B";
-          hash = "sha256-u01QTYEFSY1feJWX3JJjXB6thiVO4WOnrqNmzg6vIDs=";
+          hash = "sha256-bSluCZh6ijwppigk8iF2BwWKZgq1WDbIjyYQRK772dM=";
         };
         trust = 1; # "unknown"
       }


### PR DESCRIPTION
would fail on tests
with
```

trying https://www.rsync.net/resources/pubkey.txt
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1855  100  1855    0     0   5086      0 --:--:-- --:--:-- --:--:--  5082
100  2584  100  2584    0     0   3462      0 --:--:-- --:--:-- --:--:--  3459
error: hash mismatch in fixed-output derivation '/nix/store/vfb9lh1nqla2aym1pkngc7f85bsy2f7g-lookup?op=get-options=mr-search=0x44CF42371ADF842E12F116EAA9D3F98FCCF5460B.drv':
         specified: sha256-u01QTYEFSY1feJWX3JJjXB6thiVO4WOnrqNmzg6vIDs=
            got:    sha256-bSluCZh6ijwppigk8iF2BwWKZgq1WDbIjyYQRK772dM=
error: 1 dependencies of derivation '/nix/store/06y1mjj51ldssghilhk7vwsvfk8dhvzw-gpg-pubring.drv' failed to build
error: 1 dependencies of derivation '/nix/store/k4704qdmq7hxl817p9nwnz4fjzmnd92j-activation-script.drv' failed to build
error: 1 dependencies of derivation '/nix/store/6qc1daqfm7l95npa74gmv64ffa3z9iy5-home-manager-generation.drv' failed to build
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:34:12:
         ```
see  https://github.com/nix-community/home-manager/actions/runs/12285968518/job/34285136506?pr=6198#step:9:1813

@rycee you are the last one editing this (a while ago) so putting you as a reviewer 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
