### PR TITLE
zed-editor: fix always generating settings.json

### DIFF
--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -6,10 +6,11 @@ let
   cfg = config.programs.zed-editor;
   jsonFormat = pkgs.formats.json { };
 
-  mergedSettings = cfg.userSettings // {
-    # this part by @cmacrae
-    auto_install_extensions = lib.genAttrs cfg.extensions (_: true);
-  };
+  mergedSettings = cfg.userSettings
+    // (lib.optionalAttrs (builtins.length cfg.extensions > 0) {
+      # this part by @cmacrae
+      auto_install_extensions = lib.genAttrs cfg.extensions (_: true);
+    });
 in {
   meta.maintainers = [ hm.maintainers.libewa ];
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Makes it so settings.json no longer gets made by ensuring it can be empty as expected when there are no extensions or userSettings defined.

Previously settings.json would always be generated because even if there were no extensions defined an empty value would still be made.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@libewa 

Fixes #6193 