### PR TITLE
git-worktree-switcher: init module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -258,6 +258,14 @@
     github = "LucasWagler";
     githubId = 32136449;
   };
+  mateusauler = {
+    name = "Mateus Auler";
+    email = "mateus@auler.dev";
+    github = "mateusauler";
+    githubId = 24767687;
+    keys =
+      [{ fingerprint = "A09D C093 3C37 4BFC 2B5A  269F 80A5 D62F 6EB7 D9F0"; }];
+  };
   matrss = {
     name = "Matthias Riße";
     email = "matrss@users.noreply.github.com";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1899,6 +1899,17 @@ in {
           registry with the option 'programs.nushell.plugins'.
         '';
       }
+
+      {
+        time = "2024-12-14T20:35:07+00:00";
+        message = ''
+          A new module is available: 'programs.git-worktree-switcher'.
+
+          git-worktree-switcher allows you to quickly switch git worktrees.
+          It includes shell completions for Bash, Fish and Zsh.
+          See https://github.com/mateusauler/git-worktree-switcher for more.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -105,6 +105,7 @@ let
     ./programs/gh-dash.nix
     ./programs/git-cliff.nix
     ./programs/git-credential-oauth.nix
+    ./programs/git-worktree-switcher.nix
     ./programs/git.nix
     ./programs/gitui.nix
     ./programs/gnome-shell.nix

--- a/modules/programs/git-worktree-switcher.nix
+++ b/modules/programs/git-worktree-switcher.nix
@@ -1,0 +1,52 @@
+{ pkgs, config, lib, ... }:
+
+let
+  inherit (lib) mkEnableOption mkOption mkPackageOption optionalString;
+
+  cfg = config.programs.git-worktree-switcher;
+
+  initScript = shell:
+    if (shell == "fish") then ''
+      ${lib.getExe pkgs.git-worktree-switcher} init ${shell} | source
+    '' else ''
+      eval "$(${lib.getExe pkgs.git-worktree-switcher} init ${shell})"
+    '';
+in {
+  meta.maintainers = [ lib.maintainers.mateusauler ];
+
+  options.programs.git-worktree-switcher = {
+    enable = mkEnableOption "git-worktree-switcher";
+    package = mkPackageOption pkgs "git-worktree-switcher" { };
+    enableBashIntegration = mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to enable git-worktree-switcher's Bash integration.
+      '';
+    };
+    enableFishIntegration = mkOption {
+      type = lib.types.bool;
+      default = config.programs.fish.enable;
+      description = ''
+        Whether to enable git-worktree-switcher's Fish integration.
+      '';
+    };
+    enableZshIntegration = mkOption {
+      type = lib.types.bool;
+      default = config.programs.zsh.enable;
+      description = ''
+        Whether to enable git-worktree-switcher's Zsh integration.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    programs.bash.initExtra =
+      optionalString cfg.enableBashIntegration (initScript "bash");
+    programs.fish.interactiveShellInit =
+      optionalString cfg.enableFishIntegration (initScript "fish");
+    programs.zsh.initExtra =
+      optionalString cfg.enableZshIntegration (initScript "zsh");
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -82,6 +82,7 @@ in import nmtSrc {
     ./modules/programs/git
     ./modules/programs/git-cliff
     ./modules/programs/git-credential-oauth
+    ./modules/programs/git-worktree-switcher
     ./modules/programs/gpg
     ./modules/programs/gradle
     ./modules/programs/granted

--- a/tests/modules/programs/git-worktree-switcher/bash.nix
+++ b/tests/modules/programs/git-worktree-switcher/bash.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs = {
+    bash.enable = true;
+    git-worktree-switcher.enable = true;
+  };
+
+  test.stubs.git-worktree-switcher = { name = "git-worktree-switcher"; };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileContains \
+      home-files/.bashrc \
+      'eval "$(@git-worktree-switcher@/bin/git-worktree-switcher init bash)"'
+  '';
+}

--- a/tests/modules/programs/git-worktree-switcher/default.nix
+++ b/tests/modules/programs/git-worktree-switcher/default.nix
@@ -1,0 +1,5 @@
+{
+  git-worktree-switcher-bash = ./bash.nix;
+  git-worktree-switcher-fish = ./fish.nix;
+  git-worktree-switcher-zsh = ./zsh.nix;
+}

--- a/tests/modules/programs/git-worktree-switcher/fish.nix
+++ b/tests/modules/programs/git-worktree-switcher/fish.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs = {
+    fish.enable = true;
+    git-worktree-switcher.enable = true;
+  };
+
+  test.stubs.git-worktree-switcher = { name = "git-worktree-switcher"; };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      '@git-worktree-switcher@/bin/git-worktree-switcher init fish | source'
+  '';
+}

--- a/tests/modules/programs/git-worktree-switcher/zsh.nix
+++ b/tests/modules/programs/git-worktree-switcher/zsh.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs = {
+    zsh.enable = true;
+    git-worktree-switcher.enable = true;
+  };
+
+  test.stubs.git-worktree-switcher = { name = "git-worktree-switcher"; };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+    assertFileContains \
+      home-files/.zshrc \
+      'eval "$(@git-worktree-switcher@/bin/git-worktree-switcher init zsh)"'
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Create new module for [git-worktree-switcher](https://github.com/mateusauler/git-worktree-switcher).

Note: I'm the upstream maintainer.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
