### PR TITLE
docs: fix typo in 24.11 release notes

### DIFF
--- a/docs/release-notes/rl-2411.md
+++ b/docs/release-notes/rl-2411.md
@@ -1,6 +1,6 @@
 # Release 24.11 {#sec-release-24.11}
 
-The 24.05 release branch became stable in November, 2024.
+The 24.11 release branch became stable in November, 2024.
 
 ## Highlights {#sec-release-24.11-highlights}
 


### PR DESCRIPTION
### Description

Fix typo: 24.05 should be 24.11.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.


- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
