### PR TITLE
Added declarative installation instructions

### DIFF
--- a/docs/manual/installation/nixos.md
+++ b/docs/manual/installation/nixos.md
@@ -34,6 +34,31 @@ to your system `configuration.nix` file, which will introduce a new
 NixOS option called `home-manager.users` whose type is an attribute set
 that maps user names to Home Manager configurations.
 
+Alternatively, home-manager installation can be done declaratively through configuration.nix using the following syntax:
+```nix
+{ config, pkgs, lib, ... }:
+
+let
+  home-manager = builtins.fetchTarball https://github.com/nix-community/home-manager/archive/release-24.11.tar.gz;
+in
+{
+  imports =
+    [
+      (import "${home-manager}/nixos")
+    ];
+
+  users.users.eve.isNormalUser = true;
+  home-manager.users.eve = { pkgs, ... }: {
+    home.packages = [ pkgs.atool pkgs.httpie ];
+    programs.bash.enable = true;
+  
+    # The state version is required and should stay at the version you
+    # originally installed.
+    home.stateVersion = "24.11";
+  };
+}
+```
+
 For example, a NixOS configuration may include the lines
 
 ``` nix
@@ -123,3 +148,4 @@ you create. This contains the system's NixOS configuration.
 
 Once installed you can see [Using Home Manager](#ch-usage) for a more detailed
 description of Home Manager and how to use it.
+


### PR DESCRIPTION
### Description
Added instructions for a different installation method for home manager on NixOS.

Excuse my removal of the other headings of the issue template, but they seemed arbitrary for a small code change)..