### PR TITLE
fish: source event handling functions on shell init

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -228,6 +228,15 @@ let
       echo "end"
       echo "setup_hm_session_vars") > $out
     '';
+  sourceHandlersStr = let
+    handlerAttrs =
+      [ "onJobExit" "onProcessExit" "onVariable" "onSignal" "onEvent" ];
+    isHandler = name: def:
+      isAttrs def && any (attr: hasAttr attr def) handlerAttrs;
+    handlerFunctions = filterAttrs isHandler cfg.functions;
+    sourceFunction = name: def:
+      "source ${config.xdg.configHome}/fish/functions/${name}.fish";
+  in concatStringsSep "\n" (mapAttrsToList sourceFunction handlerFunctions);
 
 in {
   imports = [
@@ -474,6 +483,9 @@ in {
         set -g __fish_home_manager_config_sourced 1
 
         source ${translatedSessionVariables}
+
+        # Source handler functions
+        ${sourceHandlersStr}
 
         ${cfg.shellInit}
 

--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -3,5 +3,6 @@
   fish-format-scripts = ./format-scripts.nix;
   fish-functions = ./functions.nix;
   fish-no-functions = ./no-functions.nix;
+  fish-source-handlers = ./source-handlers.nix;
   fish-plugins = ./plugins.nix;
 }

--- a/tests/modules/programs/fish/source-handlers.nix
+++ b/tests/modules/programs/fish/source-handlers.nix
@@ -1,0 +1,43 @@
+{ config, lib, pkgs, ... }:
+
+with builtins; {
+  config = {
+    programs.fish = {
+      enable = true;
+
+      functions = {
+        normal-function = "";
+        event-handler = {
+          body = "";
+          onEvent = "test";
+        };
+        variable-handler = {
+          body = "";
+          onVariable = "test";
+        };
+        job-handler = {
+          body = "";
+          onJobExit = "10";
+        };
+        signal-handler = {
+          body = "";
+          onSignal = "10";
+        };
+        process-handler = {
+          body = "";
+          onProcessExit = "10";
+        };
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/fish/config.fish
+      assertFileContains home-files/.config/fish/config.fish "source /home/hm-user/.config/fish/functions/event-handler.fish"
+      assertFileContains home-files/.config/fish/config.fish "source /home/hm-user/.config/fish/functions/variable-handler.fish"
+      assertFileContains home-files/.config/fish/config.fish "source /home/hm-user/.config/fish/functions/job-handler.fish"
+      assertFileContains home-files/.config/fish/config.fish "source /home/hm-user/.config/fish/functions/signal-handler.fish"
+      assertFileContains home-files/.config/fish/config.fish "source /home/hm-user/.config/fish/functions/process-handler.fish"
+      assertFileNotRegex home-files/.config/fish/config.fish "source /home/hm-user/.config/fish/functions/normal-function.fish"
+    '';
+  };
+}


### PR DESCRIPTION
### Description

Functions that contain event handler switches should be sourced during init, otherwise they become active only after being called manually.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC