### PR TITLE
pay-respects: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -628,4 +628,10 @@
     keys =
       [{ fingerprint = "BC82 4BB5 1656 D144 285E  A0EC D382 C4AF EECE AA90"; }];
   };
+  ALameLlama = {
+    name = "Nicholas Ciechanowski";
+    email = "NicholasACiechanowski@gmail.com";
+    github = "ALameLlama";
+    githubId = 55490546;
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1899,6 +1899,16 @@ in {
           registry with the option 'programs.nushell.plugins'.
         '';
       }
+
+      {
+        time = "2024-12-21T17:07:49+00:00";
+        message = ''
+          A new module is available: 'programs.pay-respects'.
+
+          Pay Respects is a shell command suggestions tool and command-not-found
+          and thefuck replacement written in Rust.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -191,6 +191,7 @@ let
     ./programs/pandoc.nix
     ./programs/papis.nix
     ./programs/password-store.nix
+    ./programs/pay-respects.nix
     ./programs/pazi.nix
     ./programs/pet.nix
     ./programs/pidgin.nix

--- a/modules/programs/pay-respects.nix
+++ b/modules/programs/pay-respects.nix
@@ -1,0 +1,61 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib) mkEnableOption mkPackageOption getExe optionalString mkIf;
+
+  cfg = config.programs.pay-respects;
+  payRespectsCmd = getExe cfg.package;
+in {
+  meta.maintainers = [ lib.hm.maintainers.ALameLlama ];
+
+  options.programs.pay-respects = {
+    enable = mkEnableOption "pay-respects";
+
+    package = mkPackageOption pkgs "pay-respects" { };
+
+    enableBashIntegration = mkEnableOption "Bash integration" // {
+      default = true;
+    };
+
+    enableZshIntegration = mkEnableOption "Zsh integration" // {
+      default = true;
+    };
+
+    enableFishIntegration = mkEnableOption "Fish integration" // {
+      default = true;
+    };
+
+    enableNushellIntegration = mkEnableOption "Nushell integration" // {
+      default = true;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs = {
+      bash.initExtra = ''
+        ${optionalString cfg.enableBashIntegration ''
+          eval "$(${payRespectsCmd} bash --alias)"
+        ''}
+      '';
+
+      zsh.initExtra = ''
+        ${optionalString cfg.enableZshIntegration ''
+          eval "$(${payRespectsCmd} zsh --alias)"
+        ''}
+      '';
+
+      fish.interactiveShellInit = ''
+        ${optionalString cfg.enableFishIntegration ''
+          ${payRespectsCmd} fish --alias | source
+        ''}
+      '';
+
+      nushell.extraConfig = ''
+        ${optionalString cfg.enableNushellIntegration ''
+          ${payRespectsCmd} nushell --alias [<alias>]
+        ''}
+      '';
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -126,6 +126,7 @@ in import nmtSrc {
     ./modules/programs/openstackclient
     ./modules/programs/pandoc
     ./modules/programs/papis
+    ./modules/programs/pay-respects
     ./modules/programs/pet
     ./modules/programs/pistol
     ./modules/programs/pls

--- a/tests/modules/programs/pay-respects/default.nix
+++ b/tests/modules/programs/pay-respects/default.nix
@@ -1,0 +1,4 @@
+{
+  pay-respects-integration-enabled = ./integration-enabled.nix;
+  pay-respects-integration-disabled = ./integration-disabled.nix;
+}

--- a/tests/modules/programs/pay-respects/integration-disabled.nix
+++ b/tests/modules/programs/pay-respects/integration-disabled.nix
@@ -1,0 +1,22 @@
+{ ... }: {
+  programs = {
+    pay-respects.enable = true;
+    pay-respects.enableBashIntegration = false;
+    pay-respects.enableFishIntegration = false;
+    pay-respects.enableZshIntegration = false;
+    pay-respects.enableNushellIntegration = false;
+    bash.enable = true;
+    zsh.enable = true;
+    fish.enable = true;
+    nushell.enable = true;
+  };
+
+  test.stubs.pay-respects = { };
+
+  nmt.script = ''
+    assertFileNotRegex home-files/.bashrc '@pay-respects@/bin/dummy'
+    assertFileNotRegex home-files/.zshrc '@pay-respects@/bin/dummy'
+    assertFileNotRegex home-files/.config/fish/config.fish '@pay-respects@/bin/dummy'
+    assertFileNotRegex home-files/.config/nushell/config.nu '@pay-respects@/bin/dummy'
+  '';
+}

--- a/tests/modules/programs/pay-respects/integration-enabled.nix
+++ b/tests/modules/programs/pay-respects/integration-enabled.nix
@@ -1,0 +1,33 @@
+{ ... }: {
+  programs = {
+    pay-respects.enable = true;
+    bash.enable = true;
+    zsh.enable = true;
+    fish.enable = true;
+    nushell.enable = true;
+  };
+
+  test.stubs.pay-respects = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileContains \
+      home-files/.bashrc \
+      'eval "$(@pay-respects@/bin/dummy bash --alias)"'
+
+    assertFileExists home-files/.zshrc
+    assertFileContains \
+      home-files/.zshrc \
+      'eval "$(@pay-respects@/bin/dummy zsh --alias)"'
+
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      '@pay-respects@/bin/dummy fish --alias | source'
+
+    assertFileExists home-files/.config/nushell/config.nu
+    assertFileContains \
+      home-files/.config/nushell/config.nu \
+      '@pay-respects@/bin/dummy nushell --alias [<alias>]'
+  '';
+}


### PR DESCRIPTION
### Description
Add pay-respects module including shell integration support for bash, zsh, fish and nushell

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
