### PR TITLE
lutris: configuration init

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -153,6 +153,7 @@ let
     ./programs/lieer.nix
     ./programs/looking-glass-client.nix
     ./programs/lsd.nix
+    ./programs/lutris.nix
     ./programs/man.nix
     ./programs/mangohud.nix
     ./programs/matplotlib.nix

--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -1,0 +1,152 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.programs.lutris;
+
+  cemuConf = ''
+    cemu:
+      runner_executable: ${lib.getExe pkgs.cemu}
+  '';
+  dolphinConf = ''
+    dolphin:
+      runner_executable: ${lib.getExe cfg.runners.dolphin.package}
+  '';
+  duckstationConf = ''
+    duckstation:
+      runner_executable: ${lib.getExe pkgs.duckstation}
+  '';
+  pcsx2Conf = ''
+    pcsx2:
+      runner_executable: ${lib.getExe pkgs.pcsx2}
+      nogui: ${boolToString cfg.runners.pcsx2.noGui}
+      visible_in_side_panel: ${boolToString cfg.runners.pcsx2.visible}
+      full_boot: ${boolToString cfg.runners.pcsx2.fullBoot}
+      fullscreen: ${boolToString cfg.runners.pcsx2.fullscreen}
+  '';
+  ppssppConf = ''
+    ppsspp:
+      runner_executable: ${lib.getExe cfg.runners.ppsspp.package}
+  '';
+  rpcs3Conf = ''
+    rpcs3:
+      runner_executable: ${lib.getExe pkgs.rpcs3}
+      nogui: ${boolToString cfg.runners.rpcs3.noGui}
+      visible_in_side_panel: ${boolToString cfg.runners.rpcs3.visible}
+  '';
+
+in {
+  meta.maintainers = [ maintainers.rapiteanu ];
+
+  options = {
+    programs.lutris = {
+      enable = mkEnableOption "Open Source gaming platform for GNU/Linux";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.lutris;
+        defaultText = literalExpression "pkgs.lutris";
+        description = "The Lutris package to use.";
+      };
+
+      extraPackages = mkOption {
+        type = with types; listOf package;
+        default = [ ];
+        example =
+          literalExpression "[ pkgs.wineWowPackages.staging pkgs.winetricks ]";
+        description = "Packages that should be available to Lutris.";
+      };
+
+      runners = {
+        cemu.enable = mkEnableOption "cemu";
+
+        dolphin = {
+          enable = mkEnableOption "dolphin-emu";
+          package = mkOption {
+            type = types.package;
+            default = pkgs.dolphin-emu;
+            defaultText = literalExpression "pkgs.dolphin-emu";
+            description = "The Lutris Dolphin Emulator package to use.";
+          };
+        };
+
+        duckstation.enable = mkEnableOption "duckstation";
+
+        pcsx2 = {
+          enable = mkEnableOption "pcsx2";
+          noGui = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Run the PCSX2 application without a GUI.";
+          };
+          visible = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Set the PCSX2 visiblity in the side panel.";
+          };
+          fullBoot = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Don't skip the BIOS handover.";
+          };
+          fullscreen = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Run the RPCS3 application in fullscreen.";
+          };
+        };
+
+        ppsspp = {
+          enable = mkEnableOption "ppsspp";
+          package = mkOption {
+            type = types.package;
+            default = pkgs.ppsspp;
+            defaultText = literalExpression "pkgs.ppsspp";
+            description = "The Lutris PPSSPP package to use.";
+          };
+        };
+
+        rpcs3 = {
+          enable = mkEnableOption "rpcs3";
+          noGui = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Run the RPCS3 application without a GUI.";
+          };
+          visible = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Set the RPCS3 visiblity in the side panel.";
+          };
+        };
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages =
+      [ (cfg.package.override { extraPkgs = pkgs: cfg.extraPackages; }) ]
+      ++ optional cfg.runners.cemu.enable pkgs.cemu
+      ++ optional cfg.runners.dolphin.enable cfg.runners.dolphin.package
+      ++ optional cfg.runners.duckstation.enable pkgs.duckstation
+      ++ optional cfg.runners.pcsx2.enable pkgs.pcsx2
+      ++ optional cfg.runners.ppsspp.enable cfg.runners.ppsspp.package
+      ++ optional cfg.runners.rpcs3.enable pkgs.rpcs3;
+
+    xdg.dataFile = {
+      "lutris/runners/cemu.yml" =
+        mkIf (cfg.runners.cemu.enable) { text = cemuConf; };
+      "lutris/runners/dolphin.yml" =
+        mkIf (cfg.runners.dolphin.enable) { text = dolphinConf; };
+      "lutris/runners/duckstation.yml" =
+        mkIf (cfg.runners.duckstation.enable) { text = duckstationConf; };
+      "lutris/runners/pcsx2.yml" =
+        mkIf (cfg.runners.pcsx2.enable) { text = pcsx2Conf; };
+      "lutris/runners/ppsspp.yml" =
+        mkIf (cfg.runners.ppsspp.enable) { text = ppssppConf; };
+      "lutris/runners/rpcs3.yml" =
+        mkIf (cfg.runners.rpcs3.enable) { text = rpcs3Conf; };
+    };
+  };
+}


### PR DESCRIPTION
### Description

Initial work to bring home-manager configuration to Lutris.
Due to some limitation on how Lutris rewrites on runtime the .conf file, only the runners and the extra packages will be addressed in this patchset.
With this change, you can automatically configure Lutris to execute a number of runners using nixpkgs instead of relying on the Appimages.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
