### PR TITLE
thunderbird: add profileVersion

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -32,7 +32,8 @@ let
   profilesIni = foldl recursiveUpdate {
     General = {
       StartWithLastProfile = 1;
-      Version = 2;
+    } // lib.optionalAttrs (cfg.profileVersion != null) {
+      Version = cfg.profileVersion;
     };
   } (flip map profilesWithId (profile: {
     "Profile${profile.id}" = {
@@ -143,6 +144,13 @@ in {
         defaultText = literalExpression "pkgs.thunderbird";
         example = literalExpression "pkgs.thunderbird-91";
         description = "The Thunderbird package to use.";
+      };
+
+      profileVersion = mkOption {
+        internal = true;
+        type = types.nullOr types.ints.unsigned;
+        default = if isDarwin then null else 2;
+        description = "profile version, set null for nix-darwin";
       };
 
       profiles = mkOption {
@@ -360,13 +368,6 @@ in {
       this module to manage your accounts and profiles by setting
       'programs.thunderbird.package' to a dummy value, for example using
       'pkgs.runCommand'.
-
-      Note that this module requires you to set the following environment
-      variables when using an installation of Thunderbird that is not provided
-      by Nix:
-
-          export MOZ_LEGACY_PROFILES=1
-          export MOZ_ALLOW_DOWNGRADE=1
     '';
 
     home.packages = [ cfg.package ]


### PR DESCRIPTION
Similar to what we did for firefox for darwin support.

### Description
Follow up to https://github.com/nix-community/home-manager/pull/5723

Haven't been using the firefox module on my macbook and ran into the same issue. Using my fork so I can use thunderbird again. 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
