### PR TITLE
home-manager: improve path handling when building news

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -791,8 +791,8 @@ function buildNews() {
     nix-instantiate \
         --no-build-output --strict \
         --eval '<home-manager/home-manager/build-news.nix>' \
-        --arg newsJsonFile "$newsJsonFile" \
-        --arg newsReadIdsFile "$readIdsFile" \
+        --arg newsJsonFile "\"$(escapeForNix "$newsJsonFile")\"" \
+        --arg newsReadIdsFile "\"$(escapeForNix "$readIdsFile")\"" \
         "${extraArgs[@]}" \
         > "$newsNixFile"
 }

--- a/tests/integration/default.nix
+++ b/tests/integration/default.nix
@@ -10,6 +10,7 @@ let
     };
 
   tests = {
+    home-with-symbols = runTest ./standalone/home-with-symbols.nix;
     kitty = runTest ./standalone/kitty.nix;
     nixos-basics = runTest ./nixos/basics.nix;
     standalone-flake-basics = runTest ./standalone/flake-basics.nix;

--- a/tests/integration/standalone/home-with-symbols-init.nix
+++ b/tests/integration/standalone/home-with-symbols-init.nix
@@ -1,0 +1,76 @@
+{ config, pkgs, ... }:
+
+{
+  # Home Manager needs a bit of information about you and the paths it should
+  # manage.
+  home.username = "alice";
+  home.homeDirectory = "/home/alice@home\\extra";
+
+  # This value determines the Home Manager release that your configuration is
+  # compatible with. This helps avoid breakage when a new Home Manager release
+  # introduces backwards incompatible changes.
+  #
+  # You should not change this value, even if you update Home Manager. If you do
+  # want to update the value, then make sure to first check the Home Manager
+  # release notes.
+  home.stateVersion = "24.11"; # Please read the comment before changing.
+
+  # The home.packages option allows you to install Nix packages into your
+  # environment.
+  home.packages = [
+    # # Adds the 'hello' command to your environment. It prints a friendly
+    # # "Hello, world!" when run.
+    # pkgs.hello
+
+    # # It is sometimes useful to fine-tune packages, for example, by applying
+    # # overrides. You can do that directly here, just don't forget the
+    # # parentheses. Maybe you want to install Nerd Fonts with a limited number of
+    # # fonts?
+    # (pkgs.nerdfonts.override { fonts = [ "FantasqueSansMono" ]; })
+
+    # # You can also create simple shell scripts directly inside your
+    # # configuration. For example, this adds a command 'my-hello' to your
+    # # environment:
+    # (pkgs.writeShellScriptBin "my-hello" ''
+    #   echo "Hello, ${config.home.username}!"
+    # '')
+  ];
+
+  # Home Manager is pretty good at managing dotfiles. The primary way to manage
+  # plain files is through 'home.file'.
+  home.file = {
+    # # Building this configuration will create a copy of 'dotfiles/screenrc' in
+    # # the Nix store. Activating the configuration will then make '~/.screenrc' a
+    # # symlink to the Nix store copy.
+    # ".screenrc".source = dotfiles/screenrc;
+
+    # # You can also set the file content immediately.
+    # ".gradle/gradle.properties".text = ''
+    #   org.gradle.console=verbose
+    #   org.gradle.daemon.idletimeout=3600000
+    # '';
+  };
+
+  # Home Manager can also manage your environment variables through
+  # 'home.sessionVariables'. These will be explicitly sourced when using a
+  # shell provided by Home Manager. If you don't want to manage your shell
+  # through Home Manager then you have to manually source 'hm-session-vars.sh'
+  # located at either
+  #
+  #  ~/.nix-profile/etc/profile.d/hm-session-vars.sh
+  #
+  # or
+  #
+  #  ~/.local/state/nix/profiles/profile/etc/profile.d/hm-session-vars.sh
+  #
+  # or
+  #
+  #  /etc/profiles/per-user/alice/etc/profile.d/hm-session-vars.sh
+  #
+  home.sessionVariables = {
+    # EDITOR = "emacs";
+  };
+
+  # Let Home Manager install and manage itself.
+  programs.home-manager.enable = true;
+}

--- a/tests/integration/standalone/home-with-symbols.nix
+++ b/tests/integration/standalone/home-with-symbols.nix
@@ -1,0 +1,80 @@
+{ pkgs, ... }:
+
+let
+
+  inherit (pkgs.lib) escapeShellArg;
+
+  nixHome = "/home/alice@home\\extra";
+  pyHome = "/home/alice@home\\\\extra";
+
+in {
+  name = "home-with-symbols";
+  meta.maintainers = [ pkgs.lib.maintainers.rycee ];
+
+  nodes.machine = { ... }: {
+    imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
+    virtualisation.memorySize = 2048;
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
+      home = nixHome;
+    };
+  };
+
+  testScript = ''
+    import shlex
+
+    start_all()
+    machine.wait_for_unit("network.target")
+    machine.wait_for_unit("multi-user.target")
+
+    home_manager = "${../../..}"
+
+    def login_as_alice():
+      machine.wait_until_tty_matches("1", "login: ")
+      machine.send_chars("alice\n")
+      machine.wait_until_tty_matches("1", "Password: ")
+      machine.send_chars("foobar\n")
+      machine.wait_until_tty_matches("1", "alice\\@machine")
+
+    def logout_alice():
+      machine.send_chars("exit\n")
+
+    def alice_cmd(cmd):
+      cmd = shlex.quote(f"export XDG_RUNTIME_DIR=/run/user/$UID ; {cmd}")
+      print(f"CMD: {cmd}")
+      return f"su -l alice --shell /bin/sh -c {cmd}"
+
+    def succeed_as_alice(cmd):
+      return machine.succeed(alice_cmd(cmd))
+
+    def fail_as_alice(cmd):
+      return machine.fail(alice_cmd(cmd))
+
+    # Create a persistent login so that Alice has a systemd session.
+    login_as_alice()
+
+    # Set up a home-manager channel.
+    succeed_as_alice(" ; ".join([
+      "mkdir -p '${pyHome}/.nix-defexpr/channels'",
+      f"ln -s {home_manager} '${pyHome}/.nix-defexpr/channels/home-manager'"
+    ]))
+
+    with subtest("Home Manager installation"):
+      succeed_as_alice("nix-shell \"<home-manager>\" -A install")
+
+      actual = machine.succeed("ls '${pyHome}/.config/home-manager'")
+      assert actual == "home.nix\n", \
+        f"unexpected content of ${pyHome}/.config/home-manager: {actual}"
+
+      machine.succeed("diff -u ${
+        ./home-with-symbols-init.nix
+      } '${pyHome}/.config/home-manager/home.nix'")
+
+      # The default configuration creates this link on activation.
+      machine.succeed("test -L '${pyHome}/.cache/.keep'")
+    succeed_as_alice("nix-shell \"<home-manager>\" -A install")
+  '';
+}


### PR DESCRIPTION
### Description

Fixes #6217

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```