### PR TITLE
yazi: Fix example option values for settings

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -109,7 +109,7 @@ in {
           };
           manager = {
             show_hidden = false;
-            sort_by = "modified";
+            sort_by = "mtime";
             sort_dir_first = true;
             sort_reverse = true;
           };
@@ -134,7 +134,7 @@ in {
               { fg = "#7AD9E5"; mime = "image/*"; }
               { fg = "#F3D398"; mime = "video/*"; }
               { fg = "#F3D398"; mime = "audio/*"; }
-              { fg = "#CD9EFC"; mime = "application/x-bzip"; }
+              { fg = "#CD9EFC"; mime = "application/bzip"; }
             ];
           };
         }

--- a/tests/modules/programs/yazi/settings-expected.toml
+++ b/tests/modules/programs/yazi/settings-expected.toml
@@ -3,6 +3,6 @@ enabled = false
 
 [manager]
 show_hidden = false
-sort_by = "modified"
+sort_by = "mtime"
 sort_dir_first = true
 sort_reverse = true

--- a/tests/modules/programs/yazi/settings.nix
+++ b/tests/modules/programs/yazi/settings.nix
@@ -42,7 +42,7 @@
       log = { enabled = false; };
       manager = {
         show_hidden = false;
-        sort_by = "modified";
+        sort_by = "mtime";
         sort_dir_first = true;
         sort_reverse = true;
       };
@@ -64,7 +64,7 @@
           }
           {
             fg = "#CD9EFC";
-            mime = "application/x-bzip";
+            mime = "application/bzip";
           }
         ];
       };

--- a/tests/modules/programs/yazi/theme-expected.toml
+++ b/tests/modules/programs/yazi/theme-expected.toml
@@ -12,4 +12,4 @@ mime = "audio/*"
 
 [[filetype.rules]]
 fg = "#CD9EFC"
-mime = "application/x-bzip"
+mime = "application/bzip"


### PR DESCRIPTION
### Description

Yazi changed the allowed values for:
- its [setting `manager.sort_by`](https://yazi-rs.github.io/docs/configuration/yazi/#manager.sort_by). Option `modified` is now called `mtime`.
- its [setting `theme.filetype.rules.mime-type`](https://yazi-rs.github.io/docs/configuration/theme#filetype) to no longer use `x-` prefix for mime types. For example, `application/x-bzip` is not called `appliation/bzip`.

This PR makes the settings suggested by hm to be fully compatible with Yazi 0.4.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible. 
  - It is not, but it is also only a change in the example for an option value. And users get a nice warning when the option "modified" is used.
- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x]  Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@XYenon @eljamm 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
