### PR TITLE
xresources: allow floating point values

### DIFF
--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -32,7 +32,7 @@ in {
     xresources.properties = mkOption {
       type = with types;
         let
-          prim = either bool (either int str);
+          prim = oneOf [ bool int float str ];
           entry = either prim (listOf prim);
         in nullOr (attrsOf entry);
       default = null;

--- a/tests/modules/xresources/xresources-expected.conf
+++ b/tests/modules/xresources/xresources-expected.conf
@@ -1,5 +1,6 @@
 Test*boolean1: true
 Test*boolean2: false
+Test*float: 12.300000
 Test*int: 10
 Test*list: list-str, true, false, 10
 Test*string: test-string

--- a/tests/modules/xresources/xresources.nix
+++ b/tests/modules/xresources/xresources.nix
@@ -7,6 +7,7 @@
       "Test*boolean1" = true;
       "Test*boolean2" = false;
       "Test*int" = 10;
+      "Test*float" = 12.3;
       "Test*list" = [ "list-str" true false 10 ];
     };
   };


### PR DESCRIPTION
### Description

`.Xresources` contains properties such as `faceSize` which specifies the font's *pointsize*.

https://www.x.org/archive/X11R6.7.0/doc/xterm.1.html#:~:text=facesize%20(class%20facesize)

> faceSize (class FaceSize)
>     Specify the pointsize for fonts selected from the FreeType library if support for that library was compiled into xterm. The default is ``14.''

This means that floating point values should be allowed in the config.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
