### PR TITLE
git-worktree-switcher: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -106,6 +106,7 @@ let
     ./programs/gh-dash.nix
     ./programs/git-cliff.nix
     ./programs/git-credential-oauth.nix
+    ./programs/git-worktree-switcher.nix
     ./programs/git.nix
     ./programs/gitui.nix
     ./programs/gnome-shell.nix

--- a/modules/programs/git-worktree-switcher.nix
+++ b/modules/programs/git-worktree-switcher.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+{
+  lib.meta.maintainers = with lib.maintainers; [ jiriks74 ];
+
+  options.programs.git-worktree-switcher = {
+    enable = lib.mkEnableOption
+      "git-worktree-switcher - Switch between git worktrees with speed.";
+  };
+
+  config = let
+    initScript = shell:
+      if (shell == "fish") then ''
+        ${lib.getExe pkgs.git-worktree-switcher} init ${shell} | source
+      '' else ''
+        eval "$(${lib.getExe pkgs.git-worktree-switcher} init ${shell})"
+      '';
+  in lib.mkIf config.programs.git-worktree-switcher.enable {
+    home.packages = [ pkgs.git-worktree-switcher ];
+
+    config.programs.bash.interactiveShellInit = initScript "bash";
+    config.programs.zsh.interactiveShellInit =
+      lib.optionalString config.programs.zsh.enable (initScript "zsh");
+    config.programs.fish.interactiveShellInit =
+      lib.optionalString config.programs.fish.enable (initScript "fish");
+  };
+}


### PR DESCRIPTION
### Description

Add `git-worktree-switcher` module to make setup with home-manager easier.

[`git worktree` documentation](https://git-scm.com/docs/git-worktree)
[`git-worktree-switcher` repository](https://github.com/mateusauler/git-worktree-switcher)

From the project's description:

> Switch between git worktrees with speed.

It's a wrapper script around `git worktree` making some switching between worktrees easier.

> [!Note]
> `git worktree` is a little known feature and adding QoL things can help
it's adoption as it's a considerable upgrade against the `git stash`
workflow.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
