### PR TITLE
zsh: added HIST_SAVE_NO_DUPS and HIST_FIND_NO_DUPS options to zsh for…

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -104,6 +104,23 @@ let
         '';
       };
 
+      saveNoDups = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Do not write duplicate entries into the history file.
+        '';
+      };
+
+      findNoDups = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Do not display a line previously found in the history
+          file.
+        '';
+      };
+
       ignoreSpace = mkOption {
         type = types.bool;
         default = true;
@@ -693,6 +710,8 @@ in
         ${if cfg.history.append then "setopt" else "unsetopt"} APPEND_HISTORY
         ${if cfg.history.ignoreDups then "setopt" else "unsetopt"} HIST_IGNORE_DUPS
         ${if cfg.history.ignoreAllDups then "setopt" else "unsetopt"} HIST_IGNORE_ALL_DUPS
+        ${if cfg.history.saveNoDups then "setopt" else "unsetopt"} HIST_SAVE_NO_DUPS
+        ${if cfg.history.findNoDups then "setopt" else "unsetopt"} HIST_FIND_NO_DUPS
         ${if cfg.history.ignoreSpace then "setopt" else "unsetopt"} HIST_IGNORE_SPACE
         ${if cfg.history.expireDuplicatesFirst then "setopt" else "unsetopt"} HIST_EXPIRE_DUPS_FIRST
         ${if cfg.history.share then "setopt" else "unsetopt"} SHARE_HISTORY


### PR DESCRIPTION
… history configuration.

### Description

Added two new config options for zsh module:

- `saveNoDups`: Do not write duplicate entries into the history file (setting HIST_SAVE_NO_DUPS).
- `findNoDups`: Do not display a line previously found in the history file (setting HIST_FIND_NO_DUPS).

Default is to unset these variables.

This allows for more fine-grained configurability of zsh behavior in terms of preserving the shell history.


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
As the code is super obvious and I did not found test cases for other options like e.g. `ignoreAllDups` I assume that his would be fine - otherwise please let me know.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

Omitted long description, as there is nothing more to say.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
