### PR TITLE
librespot: init module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -327,6 +327,7 @@ let
     ./services/kdeconnect.nix
     ./services/keybase.nix
     ./services/keynav.nix
+    ./services/librespot.nix
     ./services/lieer.nix
     ./services/listenbrainz-mpd.nix
     ./services/lorri.nix

--- a/modules/services/librespot.nix
+++ b/modules/services/librespot.nix
@@ -1,0 +1,88 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) types;
+
+  # Like lib.mapAttrsToList, but concatenate the results
+  concatMapAttrsToList = f: attrs:
+    builtins.concatMap (name: f name attrs.${name}) (builtins.attrNames attrs);
+
+  cfg = config.services.librespot;
+in {
+  options.services.librespot = {
+    enable = lib.mkEnableOption "Librespot (Spotify Connect speaker daemon)";
+
+    package = lib.mkPackageOption pkgs "librespot" { };
+
+    settings = lib.mkOption {
+      description = ''
+        Command-line arguments to pass to librespot.
+
+        Boolean values render as a flag if true, and nothing if false.
+        Null values are ignored.
+        All other values are rendered as options with an argument.
+      '';
+      type = types.submodule {
+        freeformType = let t = types;
+        in t.attrsOf (t.nullOr (t.oneOf [ t.bool t.str t.int t.path ]));
+
+        options = {
+          cache = lib.mkOption {
+            default = "${config.xdg.cacheHome}/librespot";
+            defaultText = "$XDG_CACHE_HOME/librespot";
+            type = types.nullOr types.path;
+            description =
+              "Path to a directory where files will be cached after downloading.";
+          };
+
+          system-cache = lib.mkOption {
+            default = "${config.xdg.stateHome}/librespot";
+            defaultText = "$XDG_STATE_HOME/librespot";
+            type = types.nullOr types.path;
+            description =
+              "Path to a directory where system files (credentials, volume) will be cached.";
+          };
+        };
+      };
+      default = { };
+    };
+
+    args = lib.mkOption {
+      type = types.listOf types.str;
+      internal = true;
+      description = ''
+        Command-line arguments to pass to the service.
+
+        This is generated from {option}`services.librespot.settings`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.librespot = {
+      args = concatMapAttrsToList (k: v:
+        if v == null || v == false then
+          [ ]
+        else if v == true then
+          [ "--${k}" ]
+        else
+          [ "--${k}=${toString v}" ]) cfg.settings;
+    };
+
+    home.packages = [ cfg.package ];
+
+    systemd.user.services.librespot = {
+      Unit = { Description = "Librespot (an open source Spotify client)"; };
+
+      Install.WantedBy = [ "default.target" ];
+
+      Service = {
+        ExecStart = pkgs.writeShellScript "librespot" ''
+          exec '${cfg.package}/bin/librespot' ${lib.escapeShellArgs cfg.args}
+        '';
+        Restart = "always";
+        RestartSec = 12;
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Description

Librespot is a Spotify client. While there is already a module for spotifyd, which uses Librespot as a library, this adds one for the upstream frontend.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
