### PR TITLE
programs.pqiv.nix: write configuration if either settings or extraConfig are set

### DIFF
--- a/modules/programs/pqiv.nix
+++ b/modules/programs/pqiv.nix
@@ -65,7 +65,7 @@ in {
     home.packages = [ cfg.package ];
 
     xdg.configFile."pqivrc" =
-      mkIf (cfg.settings != { } && cfg.extraConfig != "") {
+      mkIf (cfg.settings != { } || cfg.extraConfig != "") {
         text = lib.concatLines [
           (generators.toINI {
             mkKeyValue = key: value:


### PR DESCRIPTION
### Description

Issue: #6212

Due to flawed logic, configuration file for `programs.pqiv` was only written if both `settings` and `extraConfig` were set.

Desired behaviour is that either form of supplied configuration should trigger the creation of the config file. 

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@donovanglover @iynaix
