### PR TITLE
swaync: Add onChange

### DIFF
--- a/modules/services/swaync.nix
+++ b/modules/services/swaync.nix
@@ -83,13 +83,16 @@ in {
       lib.mkIf (cfg.package != null) [ cfg.package pkgs.at-spi2-core ];
 
     xdg.configFile = {
-      "swaync/config.json".source =
-        jsonFormat.generate "config.json" cfg.settings;
+      "swaync/config.json" = {
+        source = jsonFormat.generate "config.json" cfg.settings;
+        onChange = "${cfg.package}/bin/swaync-client --reload-config";
+      };
       "swaync/style.css" = lib.mkIf (cfg.style != null) {
         source = if builtins.isPath cfg.style || lib.isStorePath cfg.style then
           cfg.style
         else
           pkgs.writeText "swaync/style.css" cfg.style;
+        onChange = "${cfg.package}/bin/swaync-client --reload-css";
       };
     };
 


### PR DESCRIPTION
Calls swanyc-client with the argument reload-css/reload-config when config/CSS is changed.

### Description
I have simply added calls to `swaync --reload-css` and `swaync --reload-config` for when the config or CSS are changed, so that changes take effect immediately.
<!--

Please provide a brief description of your change.

-->

### Checklist
<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC
@abayomi185 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
