### PR TITLE
copyq: add option to disable XWayland

### DIFF
--- a/modules/services/copyq.nix
+++ b/modules/services/copyq.nix
@@ -25,6 +25,13 @@ in {
         otherwise the service may never be started.
       '';
     };
+
+    forceXWayland = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = "Force the CopyQ to use the X backend on wayland";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -45,7 +52,7 @@ in {
       Service = {
         ExecStart = "${cfg.package}/bin/copyq";
         Restart = "on-failure";
-        Environment = [ "QT_QPA_PLATFORM=xcb" ];
+        Environment = lib.optional cfg.forceXWayland "QT_QPA_PLATFORM=xcb";
       };
 
       Install = { WantedBy = [ cfg.systemdTarget ]; };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -242,6 +242,7 @@ in import nmtSrc {
     ./modules/services/cliphist
     ./modules/services/clipman
     ./modules/services/comodoro
+    ./modules/services/copyq
     ./modules/services/conky
     ./modules/services/darkman
     ./modules/services/devilspie2

--- a/tests/modules/services/copyq/basic-configuration.nix
+++ b/tests/modules/services/copyq/basic-configuration.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  config = {
+    services.copyq = {
+      enable = true;
+      systemdTarget = "sway-session.target";
+    };
+
+    test.stubs.copyq = { };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/copyq.service
+      assertFileContent $serviceFile ${./basic-expected.service}
+    '';
+  };
+}

--- a/tests/modules/services/copyq/basic-expected.service
+++ b/tests/modules/services/copyq/basic-expected.service
@@ -1,0 +1,12 @@
+[Install]
+WantedBy=sway-session.target
+
+[Service]
+Environment=QT_QPA_PLATFORM=xcb
+ExecStart=@copyq@/bin/copyq
+Restart=on-failure
+
+[Unit]
+After=graphical-session.target
+Description=CopyQ clipboard management daemon
+PartOf=graphical-session.target

--- a/tests/modules/services/copyq/default.nix
+++ b/tests/modules/services/copyq/default.nix
@@ -1,0 +1,4 @@
+{
+  copyq-basic-configuration = ./basic-configuration.nix;
+  copyq-dont-force-x = ./dont-force-x-configuration.nix;
+}

--- a/tests/modules/services/copyq/dont-force-x-configuration.nix
+++ b/tests/modules/services/copyq/dont-force-x-configuration.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  config = {
+    services.copyq = {
+      enable = true;
+      forceXWayland = false;
+    };
+
+    test.stubs.copyq = { };
+
+    nmt.script = ''
+      serviceFile=home-files/.config/systemd/user/copyq.service
+      assertFileContent $serviceFile ${./dont-force-x-expected.service}
+    '';
+  };
+}

--- a/tests/modules/services/copyq/dont-force-x-expected.service
+++ b/tests/modules/services/copyq/dont-force-x-expected.service
@@ -1,0 +1,11 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@copyq@/bin/copyq
+Restart=on-failure
+
+[Unit]
+After=graphical-session.target
+Description=CopyQ clipboard management daemon
+PartOf=graphical-session.target


### PR DESCRIPTION
### Description

The current CopyQ service always forces the use of XWayland, this PR adds option to disable that.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@DamienCassou 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
