### PR TITLE
treewide: standardize Wayland graphical services

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -309,8 +309,9 @@ in {
           Description =
             "Highly customizable Wayland bar for Sway and Wlroots based compositors.";
           Documentation = "https://github.com/Alexays/Waybar/wiki";
-          PartOf = [ "graphical-session.target" ];
-          After = [ "graphical-session-pre.target" ];
+          PartOf = [ cfg.systemd.target ];
+          After = [ cfg.systemd.target ];
+          ConditionEnvironment = "WAYLAND_DISPLAY";
           X-Restart-Triggers = optional (settings != [ ])
             "${config.xdg.configFile."waybar/config".source}"
             ++ optional (cfg.style != null)

--- a/modules/services/avizo.nix
+++ b/modules/services/avizo.nix
@@ -41,6 +41,19 @@ in {
       '';
       description = "The `avizo` package to use.";
     };
+
+    systemd.target = mkOption {
+      type = types.str;
+      default = "graphical-session.target";
+      example = "sway-session.target";
+      description = ''
+        The systemd target that will automatically start the Waybar service.
+
+        When setting this value to `"sway-session.target"`,
+        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+        otherwise the service may never be started.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -57,8 +70,8 @@ in {
       services.avizo = {
         Unit = {
           Description = "Volume/backlight OSD indicator";
-          PartOf = [ "graphical-session.target" ];
-          After = [ "graphical-session.target" ];
+          PartOf = [ cfg.systemd.target ];
+          After = [ cfg.systemd.target ];
           ConditionEnvironment = "WAYLAND_DISPLAY";
           Documentation = "man:avizo(1)";
         };
@@ -69,7 +82,7 @@ in {
           Restart = "always";
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = { WantedBy = [ cfg.systemd.target ]; };
       };
     };
   };

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -124,6 +124,19 @@ in {
           };
         '';
       };
+
+      systemd.target = mkOption {
+        type = types.str;
+        default = "graphical-session.target";
+        example = "sway-session.target";
+        description = ''
+          The systemd target that will automatically start the Waybar service.
+
+          When setting this value to `"sway-session.target"`,
+          make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+          otherwise the service may never be started.
+        '';
+      };
     };
   };
 
@@ -180,8 +193,10 @@ in {
       systemd.user.services.dunst = {
         Unit = {
           Description = "Dunst notification daemon";
-          After = [ "graphical-session-pre.target" ];
-          PartOf = [ "graphical-session.target" ];
+          PartOf = [ cfg.systemd.target ];
+          After = [ cfg.systemd.target ];
+          ConditionEnvironment =
+            lib.mkIf (cfg.waylandDisplay != "") "WAYLAND_DISPLAY";
         };
 
         Service = {

--- a/modules/services/hypridle.nix
+++ b/modules/services/hypridle.nix
@@ -63,6 +63,19 @@ in {
         List of prefix of attributes to source at the top of the config.
       '';
     };
+
+    systemd.target = mkOption {
+      type = types.str;
+      default = "graphical-session.target";
+      example = "sway-session.target";
+      description = ''
+        The systemd target that will automatically start the Waybar service.
+
+        When setting this value to `"sway-session.target"`,
+        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+        otherwise the service may never be started.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -79,8 +92,8 @@ in {
       Unit = {
         ConditionEnvironment = "WAYLAND_DISPLAY";
         Description = "hypridle";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        After = [ cfg.systemd.target ];
+        PartOf = [ cfg.systemd.target ];
         X-Restart-Triggers = mkIf (cfg.settings != { })
           [ "${config.xdg.configFile."hypr/hypridle.conf".source}" ];
       };

--- a/modules/services/hyprpaper.nix
+++ b/modules/services/hyprpaper.nix
@@ -57,6 +57,19 @@ in {
         List of prefix of attributes to source at the top of the config.
       '';
     };
+
+    systemd.target = mkOption {
+      type = types.str;
+      default = "graphical-session.target";
+      example = "sway-session.target";
+      description = ''
+        The systemd target that will automatically start the Waybar service.
+
+        When setting this value to `"sway-session.target"`,
+        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+        otherwise the service may never be started.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -68,13 +81,13 @@ in {
     };
 
     systemd.user.services.hyprpaper = {
-      Install = { WantedBy = [ "graphical-session.target" ]; };
+      Install = { WantedBy = [ cfg.systemd.target ]; };
 
       Unit = {
         ConditionEnvironment = "WAYLAND_DISPLAY";
         Description = "hyprpaper";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        PartOf = [ cfg.systemd.target ];
+        After = [ cfg.systemd.target ];
         X-Restart-Triggers = mkIf (cfg.settings != { })
           [ "${config.xdg.configFile."hypr/hyprpaper.conf".source}" ];
       };

--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -340,6 +340,7 @@ in {
 
       systemd.user.services.kanshi = {
         Unit = {
+          ConditionEnvironment = "WAYLAND_DISPLAY";
           Description = "Dynamic output configuration";
           Documentation = "man:kanshi(1)";
           PartOf = cfg.systemdTarget;

--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -107,7 +107,8 @@ in {
         Description = "Idle manager for Wayland";
         Documentation = "man:swayidle(1)";
         ConditionEnvironment = "WAYLAND_DISPLAY";
-        PartOf = [ "graphical-session.target" ];
+        PartOf = [ cfg.systemdTarget ];
+        After = [ cfg.systemdTarget ];
       };
 
       Service = {

--- a/modules/services/swaync.nix
+++ b/modules/services/swaync.nix
@@ -73,6 +73,19 @@ in {
         for the documentation.
       '';
     };
+
+    systemd.target = lib.mkOption {
+      type = lib.types.str;
+      default = "graphical-session.target";
+      example = "sway-session.target";
+      description = ''
+        The systemd target that will automatically start the Waybar service.
+
+        When setting this value to `"sway-session.target"`,
+        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+        otherwise the service may never be started.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -95,8 +108,8 @@ in {
       Unit = {
         Description = "Swaync notification daemon";
         Documentation = "https://github.com/ErikReider/SwayNotificationCenter";
-        PartOf = [ "graphical-session.target" ];
-        After = [ "graphical-session-pre.target" ];
+        PartOf = [ cfg.systemd.target ];
+        After = [ cfg.systemd.target ];
         ConditionEnvironment = "WAYLAND_DISPLAY";
       };
 
@@ -107,7 +120,7 @@ in {
         Restart = "on-failure";
       };
 
-      Install.WantedBy = [ "graphical-session.target" ];
+      Install.WantedBy = [ cfg.systemd.target ];
     };
   };
 }

--- a/modules/services/swayosd.nix
+++ b/modules/services/swayosd.nix
@@ -43,6 +43,19 @@ in {
         X display to use.
       '';
     };
+
+    systemd.target = mkOption {
+      type = types.str;
+      default = "graphical-session.target";
+      example = "sway-session.target";
+      description = ''
+        The systemd target that will automatically start the Waybar service.
+
+        When setting this value to `"sway-session.target"`,
+        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+        otherwise the service may never be started.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -56,8 +69,8 @@ in {
       services.swayosd = {
         Unit = {
           Description = "Volume/backlight OSD indicator";
-          PartOf = [ "graphical-session.target" ];
-          After = [ "graphical-session.target" ];
+          PartOf = [ cfg.systemd.target ];
+          After = [ cfg.systemd.target ];
           ConditionEnvironment = "WAYLAND_DISPLAY";
           Documentation = "man:swayosd(1)";
           StartLimitBurst = 5;
@@ -76,7 +89,7 @@ in {
           RestartSec = "2s";
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = { WantedBy = [ cfg.systemd.target ]; };
       };
     };
   };

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -8,7 +8,8 @@ KillMode=mixed
 Restart=on-failure
 
 [Unit]
-After=graphical-session-pre.target
+After=sway-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
 Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
 Documentation=https://github.com/Alexays/Waybar/wiki
-PartOf=graphical-session.target
+PartOf=sway-session.target

--- a/tests/modules/services/swayidle/basic-configuration.nix
+++ b/tests/modules/services/swayidle/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, ... }:
 
 {
   services.swayidle = {
@@ -50,6 +50,7 @@
         Type=simple
 
         [Unit]
+        After=graphical-session.target
         ConditionEnvironment=WAYLAND_DISPLAY
         Description=Idle manager for Wayland
         Documentation=man:swayidle(1)

--- a/tests/modules/services/swaync/swaync.nix
+++ b/tests/modules/services/swaync/swaync.nix
@@ -24,7 +24,7 @@
           Type=dbus
 
           [Unit]
-          After=graphical-session-pre.target
+          After=graphical-session.target
           ConditionEnvironment=WAYLAND_DISPLAY
           Description=Swaync notification daemon
           Documentation=https://github.com/ErikReider/SwayNotificationCenter


### PR DESCRIPTION
### Description

Graphical services that are meant for Wayland environment are all over the place:
- Some set `After = [ "graphical-session-pre.target" ]`, that is almost always a mistake ([see](https://github.com/Vladimir-csp/uwsm/issues/40)), others set `After = [ "graphical-session.target" ]`
- Some have `systemd.target` (or `systemdTarget`) to allow changing the default target, some does not
- Some set `ConditionEnvironment = "WAYLAND_DISPLAY"`, some does not

This PR tries to standardize this by:
- Adding `systemd.target` to services missing it, and defaulting it to `graphical-session.target`
- Set `After`, `PartOf` and `Wanted` to `cfg.systemd.target` 
- Adding `ConditionEnvironment = "WAYLAND_DISPLAY"` for services missing it

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
