### PR TITLE
waybar: allow setting systemd.target to null

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -198,7 +198,7 @@ in {
     systemd.enable = mkEnableOption "Waybar systemd integration";
 
     systemd.target = mkOption {
-      type = str;
+      type = nullOr str;
       default = config.wayland.systemd.target;
       defaultText = literalExpression "config.wayland.systemd.target";
       example = "sway-session.target";
@@ -326,7 +326,8 @@ in {
           KillMode = "mixed";
         };
 
-        Install = { WantedBy = [ cfg.systemd.target ]; };
+        Install.WantedBy =
+          lib.optional (cfg.systemd.target != null) cfg.systemd.target;
       };
     })
   ]);


### PR DESCRIPTION
This allows making the systemd user unit appear without it autostarting, which is useful if you want to start it manually from a specific display manager config only.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@berbiche 
