### PR TITLE
Allow multiple backups files

### DIFF
--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -33,12 +33,16 @@ for sourcePath in "$@" ; do
     elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
       # Next, try to move the file to a backup location if configured and possible
       backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
-      if [[ -e "$backup" ]]; then
-        errorEcho "Existing file '$backup' would be clobbered by backing up '$targetPath'"
-        collision=1
-      else
-        warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
-      fi
+
+      # Check for backup existence and iterate until finding an available filename
+      counter=1
+      while [[ -e "$backup" ]]; do
+        backup="$targetPath.$HOME_MANAGER_BACKUP_EXT.$counter"
+        counter=$((counter + 1))
+      done
+
+      warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
+      mv "$targetPath" "$backup"
     else
       # Fail if nothing else works
       errorEcho "Existing file '$targetPath' is in the way of '$sourcePath'"


### PR DESCRIPTION
…he backup file path

### Description

Allow multiple backup files -- avoid failing the "switch home manager configuration".

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
