### PR TITLE
tex-fmt: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2148,6 +2148,15 @@ in {
           under '$XDG_CONFIG_HOME/easyeffects/{input,output}/'.
         '';
       }
+      {
+        time = "2025-02-12T15:56:00+00:00";
+        message = ''
+          A new module is available: 'programs.tex-fmt'.
+
+          tex-fmt is a LaTeX formatter written in Rust.
+          See https://github.com/WGUNDERWOOD/tex-fmt for more information.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -246,6 +246,7 @@ let
     ./programs/tealdeer.nix
     ./programs/terminator.nix
     ./programs/termite.nix
+    ./programs/tex-fmt.nix
     ./programs/texlive.nix
     ./programs/thefuck.nix
     ./programs/thunderbird.nix

--- a/modules/programs/tex-fmt.nix
+++ b/modules/programs/tex-fmt.nix
@@ -18,7 +18,7 @@ in {
   options.programs.tex-fmt = {
     enable = mkEnableOption "tex-fmt";
 
-    package = mkPackageOption pkgs "tex-fmt" { };
+    package = mkPackageOption pkgs "tex-fmt" { nullable = true; };
 
     settings = mkOption {
       type = tomlFormat.type;
@@ -43,7 +43,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file."${configDir}/tex-fmt/tex-fmt.toml" =
       lib.mkIf (cfg.settings != { }) {

--- a/modules/programs/tex-fmt.nix
+++ b/modules/programs/tex-fmt.nix
@@ -1,0 +1,53 @@
+{ pkgs, config, lib, ... }:
+
+let
+
+  inherit (lib) mkEnableOption mkPackageOption mkOption literalExpression;
+
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Application Support"
+  else
+    config.xdg.configHome;
+
+  tomlFormat = pkgs.formats.toml { };
+  cfg = config.programs.tex-fmt;
+
+in {
+  meta.maintainers = with lib.maintainers; [ mirkolenz wgunderwood ];
+
+  options.programs.tex-fmt = {
+    enable = mkEnableOption "tex-fmt";
+
+    package = mkPackageOption pkgs "tex-fmt" { };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          wrap = true;
+          tabsize = 2;
+          tabchar = "space";
+          lists = [];
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/tex-fmt/tex-fmt.toml` on Linux or
+        {file}`$HOME/Library/Application Support/tex-fmt/tex-fmt.toml` on Darwin.
+        See <https://github.com/WGUNDERWOOD/tex-fmt> and
+        <https://github.com/WGUNDERWOOD/tex-fmt/blob/master/tex-fmt.toml>
+        for more information.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.file."${configDir}/tex-fmt/tex-fmt.toml" =
+      lib.mkIf (cfg.settings != { }) {
+        source = tomlFormat.generate "tex-fmt-config" cfg.settings;
+      };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -384,6 +384,7 @@ in import nmtSrc {
     ./modules/programs/starship
     ./modules/programs/taskwarrior
     ./modules/programs/tealdeer
+    ./modules/programs/tex-fmt
     ./modules/programs/texlive
     ./modules/programs/thefuck
     ./modules/programs/thunderbird

--- a/tests/modules/programs/tex-fmt/custom-settings.nix
+++ b/tests/modules/programs/tex-fmt/custom-settings.nix
@@ -1,0 +1,31 @@
+{ config, pkgs, ... }: {
+  config = {
+    programs.tex-fmt = {
+      enable = true;
+      settings = {
+        wrap = true;
+        tabsize = 2;
+        tabchar = "space";
+        lists = [ ];
+      };
+    };
+
+    nmt.script = let
+      expectedConfDir = if pkgs.stdenv.isDarwin then
+        "Library/Application Support"
+      else
+        ".config";
+      expectedConfigPath = "home-files/${expectedConfDir}/tex-fmt/tex-fmt.toml";
+    in ''
+      assertFileExists "${expectedConfigPath}"
+      assertFileContent "${expectedConfigPath}" ${
+        pkgs.writeText "tex-fmt.config-custom.expected" ''
+          lists = []
+          tabchar = "space"
+          tabsize = 2
+          wrap = true
+        ''
+      }
+    '';
+  };
+}

--- a/tests/modules/programs/tex-fmt/default-settings.nix
+++ b/tests/modules/programs/tex-fmt/default-settings.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, ... }: {
+  config = {
+    programs.tex-fmt = { enable = true; };
+
+    nmt.script = let
+      expectedConfDir = if pkgs.stdenv.isDarwin then
+        "Library/Application Support"
+      else
+        ".config";
+      expectedConfigPath = "home-files/${expectedConfDir}/tex-fmt/tex-fmt.toml";
+    in ''
+      assertPathNotExists "${expectedConfigPath}"
+    '';
+  };
+}

--- a/tests/modules/programs/tex-fmt/default.nix
+++ b/tests/modules/programs/tex-fmt/default.nix
@@ -1,0 +1,4 @@
+{
+  tex-fmt-default-settings = ./default-settings.nix;
+  tex-fmt-custom-settings = ./custom-settings.nix;
+}


### PR DESCRIPTION
tex-fmt is a LaTeX source code formatter written in Rust, and uses a user configuration file in the .toml format.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
