### PR TITLE
Fix atuin daemon on darwin

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -211,6 +211,13 @@ in {
         };
       })
       (mkIf isDarwin {
+        programs.atuin.settings = {
+          daemon = {
+            socket_path =
+              lib.mkDefault "${config.xdg.dataHome}/atuin/daemon.sock";
+          };
+        };
+
         launchd.agents.atuin-daemon = {
           enable = true;
           config = {


### PR DESCRIPTION
### Description

With atuin 18.4.0, it looks for the socket file in `XDG_RUNTIME_DIR` by default. But the launchd daemon we run doesn't have access to that variable, so it is created at the default `socket_path` which is `XDG_DATA_HOME/atuin`.
To fix this, we provide a default value for the socket path which is `XDG_DATA_HOME/atuin/daemon.sock`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@hawkw @water-sucks 