### PR TITLE
treewide: standardize wayland graphical services

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -417,6 +417,7 @@ let
     ./systemd.nix
     ./targets/darwin
     ./targets/generic-linux.nix
+    ./wayland.nix
     ./xresources.nix
     ./xsession.nix
     ./misc/nix.nix

--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -199,7 +199,8 @@ in {
 
     systemd.target = mkOption {
       type = str;
-      default = "graphical-session.target";
+      default = config.wayland.systemd.target;
+      defaultText = literalExpression "config.wayland.systemd.target";
       example = "sway-session.target";
       description = ''
         The systemd target that will automatically start the Waybar service.
@@ -309,8 +310,9 @@ in {
           Description =
             "Highly customizable Wayland bar for Sway and Wlroots based compositors.";
           Documentation = "https://github.com/Alexays/Waybar/wiki";
-          PartOf = [ "graphical-session.target" ];
-          After = [ "graphical-session-pre.target" ];
+          PartOf = [ cfg.systemd.target ];
+          After = [ cfg.systemd.target ];
+          ConditionEnvironment = "WAYLAND_DISPLAY";
           X-Restart-Triggers = optional (settings != [ ])
             "${config.xdg.configFile."waybar/config".source}"
             ++ optional (cfg.style != null)

--- a/modules/services/avizo.nix
+++ b/modules/services/avizo.nix
@@ -57,8 +57,8 @@ in {
       services.avizo = {
         Unit = {
           Description = "Volume/backlight OSD indicator";
-          PartOf = [ "graphical-session.target" ];
-          After = [ "graphical-session.target" ];
+          PartOf = [ config.wayland.systemd.target ];
+          After = [ config.wayland.systemd.target ];
           ConditionEnvironment = "WAYLAND_DISPLAY";
           Documentation = "man:avizo(1)";
         };
@@ -69,7 +69,7 @@ in {
           Restart = "always";
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = { WantedBy = [ config.wayland.systemd.target ]; };
       };
     };
   };

--- a/modules/services/clipman.nix
+++ b/modules/services/clipman.nix
@@ -11,7 +11,8 @@ in {
 
     systemdTarget = mkOption {
       type = types.str;
-      default = "graphical-session.target";
+      default = config.wayland.systemd.target;
+      defaultText = literalExpression "config.wayland.systemd.target";
       example = "sway-session.target";
       description = ''
         The systemd target that will automatically start the clipman service.
@@ -34,8 +35,9 @@ in {
     systemd.user.services.clipman = {
       Unit = {
         Description = "Clipboard management daemon";
-        PartOf = [ "graphical-session.target" ];
-        After = [ "graphical-session.target" ];
+        PartOf = [ cfg.systemdTarget ];
+        After = [ cfg.systemdTarget ];
+        ConditionEnvironment = "WAYLAND_DISPLAY";
       };
 
       Service = {

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -180,8 +180,8 @@ in {
       systemd.user.services.dunst = {
         Unit = {
           Description = "Dunst notification daemon";
-          After = [ "graphical-session-pre.target" ];
-          PartOf = [ "graphical-session.target" ];
+          After = [ config.wayland.systemd.target ];
+          PartOf = [ config.wayland.systemd.target ];
         };
 
         Service = {

--- a/modules/services/fnott.nix
+++ b/modules/services/fnott.nix
@@ -88,8 +88,9 @@ in {
       Unit = {
         Description = "Fnott notification daemon";
         Documentation = "man:fnott(1)";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        After = [ config.wayland.systemd.target ];
+        PartOf = [ config.wayland.systemd.target ];
+        ConditionEnvironment = "WAYLAND_DISPLAY";
       };
 
       Service = {

--- a/modules/services/hypridle.nix
+++ b/modules/services/hypridle.nix
@@ -74,13 +74,13 @@ in {
     };
 
     systemd.user.services.hypridle = {
-      Install = { WantedBy = [ "graphical-session.target" ]; };
+      Install = { WantedBy = [ config.wayland.systemd.target ]; };
 
       Unit = {
         ConditionEnvironment = "WAYLAND_DISPLAY";
         Description = "hypridle";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        After = [ config.wayland.systemd.target ];
+        PartOf = [ config.wayland.systemd.target ];
         X-Restart-Triggers = mkIf (cfg.settings != { })
           [ "${config.xdg.configFile."hypr/hypridle.conf".source}" ];
       };

--- a/modules/services/hyprpaper.nix
+++ b/modules/services/hyprpaper.nix
@@ -68,13 +68,13 @@ in {
     };
 
     systemd.user.services.hyprpaper = {
-      Install = { WantedBy = [ "graphical-session.target" ]; };
+      Install = { WantedBy = [ config.wayland.systemd.target ]; };
 
       Unit = {
         ConditionEnvironment = "WAYLAND_DISPLAY";
         Description = "hyprpaper";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        After = [ config.wayland.systemd.target ];
+        PartOf = [ config.wayland.systemd.target ];
         X-Restart-Triggers = mkIf (cfg.settings != { })
           [ "${config.xdg.configFile."hypr/hyprpaper.conf".source}" ];
       };

--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -286,7 +286,8 @@ in {
 
     systemdTarget = mkOption {
       type = types.str;
-      default = "sway-session.target";
+      default = config.wayland.systemd.target;
+      defaultText = literalExpression "config.wayland.systemd.target";
       description = ''
         Systemd target to bind to.
       '';
@@ -342,6 +343,7 @@ in {
         Unit = {
           Description = "Dynamic output configuration";
           Documentation = "man:kanshi(1)";
+          ConditionEnvironment = "WAYLAND_DISPLAY";
           PartOf = cfg.systemdTarget;
           Requires = cfg.systemdTarget;
           After = cfg.systemdTarget;

--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -88,7 +88,8 @@ in {
 
     systemdTarget = mkOption {
       type = types.str;
-      default = "graphical-session.target";
+      default = config.wayland.systemd.target;
+      defaultText = literalExpression "config.wayland.systemd.target";
       example = "sway-session.target";
       description = ''
         Systemd target to bind to.
@@ -107,7 +108,8 @@ in {
         Description = "Idle manager for Wayland";
         Documentation = "man:swayidle(1)";
         ConditionEnvironment = "WAYLAND_DISPLAY";
-        PartOf = [ "graphical-session.target" ];
+        PartOf = [ cfg.systemdTarget ];
+        After = [ cfg.systemdTarget ];
       };
 
       Service = {

--- a/modules/services/swaync.nix
+++ b/modules/services/swaync.nix
@@ -95,8 +95,8 @@ in {
       Unit = {
         Description = "Swaync notification daemon";
         Documentation = "https://github.com/ErikReider/SwayNotificationCenter";
-        PartOf = [ "graphical-session.target" ];
-        After = [ "graphical-session-pre.target" ];
+        PartOf = [ config.wayland.systemd.target ];
+        After = [ config.wayland.systemd.target ];
         ConditionEnvironment = "WAYLAND_DISPLAY";
       };
 
@@ -107,7 +107,7 @@ in {
         Restart = "on-failure";
       };
 
-      Install.WantedBy = [ "graphical-session.target" ];
+      Install.WantedBy = [ config.wayland.systemd.target ];
     };
   };
 }

--- a/modules/services/swayosd.nix
+++ b/modules/services/swayosd.nix
@@ -56,8 +56,8 @@ in {
       services.swayosd = {
         Unit = {
           Description = "Volume/backlight OSD indicator";
-          PartOf = [ "graphical-session.target" ];
-          After = [ "graphical-session.target" ];
+          PartOf = [ config.wayland.systemd.target ];
+          After = [ config.wayland.systemd.target ];
           ConditionEnvironment = "WAYLAND_DISPLAY";
           Documentation = "man:swayosd(1)";
           StartLimitBurst = 5;
@@ -76,7 +76,7 @@ in {
           RestartSec = "2s";
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = { WantedBy = [ config.wayland.systemd.target ]; };
       };
     };
   };

--- a/modules/services/wob.nix
+++ b/modules/services/wob.nix
@@ -50,8 +50,8 @@ in {
           Description =
             "A lightweight overlay volume/backlight/progress/anything bar for Wayland";
           Documentation = "man:wob(1)";
-          PartOf = "graphical-session.target";
-          After = "graphical-session.target";
+          PartOf = [ config.wayland.systemd.target ];
+          After = [ config.wayland.systemd.target ];
           ConditionEnvironment = "WAYLAND_DISPLAY";
         };
         Service = {
@@ -59,7 +59,7 @@ in {
           ExecStart = builtins.concatStringsSep " " ([ (getExe cfg.package) ]
             ++ optional (cfg.settings != { }) "--config ${configFile}");
         };
-        Install.WantedBy = [ "graphical-session.target" ];
+        Install.WantedBy = [ config.wayland.systemd.target ];
       };
 
       sockets.wob = {

--- a/modules/wayland.nix
+++ b/modules/wayland.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+
+{
+  meta.maintainers = [ lib.maintainers.thiagokokada ];
+
+  options = {
+    wayland = {
+      systemd.target = lib.mkOption {
+        type = lib.types.str;
+        default = "graphical-session.target";
+        example = "sway-session.target";
+        description = ''
+          The systemd target that will automatically start the graphical Wayland services.
+          This option is a generalization of individual `systemd.target` or `systemdTarget`,
+          and affect all Wayland services by default.
+
+          When setting this value to `"sway-session.target"`,
+          make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+          otherwise the service may never be started.
+        '';
+      };
+    };
+  };
+}

--- a/tests/modules/programs/waybar/deprecated-modules-option.nix
+++ b/tests/modules/programs/waybar/deprecated-modules-option.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/waybar/settings-complex.nix
+++ b/tests/modules/programs/waybar/settings-complex.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/waybar/settings-with-attrs.nix
+++ b/tests/modules/programs/waybar/settings-with-attrs.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 {
   config = {
     home.stateVersion = "21.11";

--- a/tests/modules/programs/waybar/styling.nix
+++ b/tests/modules/programs/waybar/styling.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -8,7 +8,8 @@ KillMode=mixed
 Restart=on-failure
 
 [Unit]
-After=graphical-session-pre.target
+After=sway-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
 Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
 Documentation=https://github.com/Alexays/Waybar/wiki
-PartOf=graphical-session.target
+PartOf=sway-session.target

--- a/tests/modules/services/clipman/clipman-sway-session-target.service
+++ b/tests/modules/services/clipman/clipman-sway-session-target.service
@@ -8,6 +8,7 @@ KillMode=mixed
 Restart=on-failure
 
 [Unit]
-After=graphical-session.target
+After=sway-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
 Description=Clipboard management daemon
-PartOf=graphical-session.target
+PartOf=sway-session.target

--- a/tests/modules/services/fnott/systemd-user-service-expected.service
+++ b/tests/modules/services/fnott/systemd-user-service-expected.service
@@ -4,7 +4,8 @@ ExecStart=@fnott@/bin/fnott -c /home/hm-user/.config/fnott/fnott.ini
 Type=dbus
 
 [Unit]
-After=graphical-session-pre.target
+After=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
 Description=Fnott notification daemon
 Documentation=man:fnott(1)
 PartOf=graphical-session.target

--- a/tests/modules/services/swayidle/basic-configuration.nix
+++ b/tests/modules/services/swayidle/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, ... }:
 
 {
   services.swayidle = {
@@ -50,6 +50,7 @@
         Type=simple
 
         [Unit]
+        After=graphical-session.target
         ConditionEnvironment=WAYLAND_DISPLAY
         Description=Idle manager for Wayland
         Documentation=man:swayidle(1)

--- a/tests/modules/services/swaync/swaync.nix
+++ b/tests/modules/services/swaync/swaync.nix
@@ -24,7 +24,7 @@
           Type=dbus
 
           [Unit]
-          After=graphical-session-pre.target
+          After=graphical-session.target
           ConditionEnvironment=WAYLAND_DISPLAY
           Description=Swaync notification daemon
           Documentation=https://github.com/ErikReider/SwayNotificationCenter


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Second try of PR https://github.com/nix-community/home-manager/pull/6239.

Graphical services that are meant for Wayland environment are all over the place:
- Some set `After = [ "graphical-session-pre.target" ]`, that is almost always a mistake ([see](https://github.com/Vladimir-csp/uwsm/issues/40)), others set `After = [ "graphical-session.target" ]`
- Some have `systemd.target` (or `systemdTarget`) to allow changing the default target, some does not
- Some set `ConditionEnvironment = "WAYLAND_DISPLAY"`, some does not

This PR tries to standardize this by:
- Adding `wayland.systemd.target` that is a new option for the default systemd target for all Wayland services. Defaults to `graphical-session.target`
- Set `After`, `PartOf` and `Wanted` to `cfg.systemd.target` 
- Adding `ConditionEnvironment = "WAYLAND_DISPLAY"` for services missing it

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
