### PR TITLE
bacon: fix configuration file location on Darwin

### DIFF
--- a/modules/programs/bacon.nix
+++ b/modules/programs/bacon.nix
@@ -7,6 +7,12 @@ let
   cfg = config.programs.bacon;
 
   settingsFormat = pkgs.formats.toml { };
+
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Application Support/org.dystroy.bacon"
+  else
+    "${config.xdg.configHome}/bacon";
+
 in {
   meta.maintainers = [ hm.maintainers.shimunn ];
 
@@ -34,7 +40,8 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."bacon/prefs.toml".source =
-      settingsFormat.generate "prefs.toml" cfg.settings;
+    home.file."${configDir}/prefs.toml" = mkIf (cfg.settings != { }) {
+      source = settingsFormat.generate "prefs.toml" cfg.settings;
+    };
   };
 }

--- a/tests/modules/programs/bacon/bacon.nix
+++ b/tests/modules/programs/bacon/bacon.nix
@@ -1,4 +1,10 @@
-{ ... }: {
+{ pkgs, ... }:
+let
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Application Support/org.dystroy.bacon"
+  else
+    ".config/bacon";
+in {
   programs.bacon = {
     enable = true;
     settings = {
@@ -17,7 +23,7 @@
   };
   test.stubs.bacon = { };
   nmt.script = ''
-    assertFileExists home-files/.config/bacon/prefs.toml
-    assertFileContent home-files/.config/bacon/prefs.toml ${./expected.toml}
+    assertFileExists 'home-files/${configDir}/prefs.toml'
+    assertFileContent 'home-files/${configDir}/prefs.toml' ${./expected.toml}
   '';
 }

--- a/tests/modules/programs/bacon/default.nix
+++ b/tests/modules/programs/bacon/default.nix
@@ -1,1 +1,4 @@
-{ bacon-program = ./bacon.nix; }
+{
+  bacon-program = ./bacon.nix;
+  bacon-empty-config = ./empty-config.nix;
+}

--- a/tests/modules/programs/bacon/empty-config.nix
+++ b/tests/modules/programs/bacon/empty-config.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+let
+  configDir = if pkgs.stdenv.isDarwin then
+    "Library/Application Support/org.dystroy.bacon"
+  else
+    ".config/bacon";
+in {
+  programs.bacon.enable = true;
+
+  test.stubs.bacon = { };
+
+  nmt.script = ''
+    assertPathNotExists 'home-files/${configDir}/prefs.toml'
+  '';
+}


### PR DESCRIPTION
### Description

bacon reads its preferences from a different directory on Darwin. Fix the path to read out of:
~/Library/Application\ Support/org.dystroy.bacon/prefs.toml Linux behavior should be unchanged.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes. (the "bacon-*" tests succeeded, although there was an unrelated failure in "syncthing-extra-options")

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@shimunn
