### PR TITLE
mpdscribble: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -310,6 +310,12 @@
     github = "mifom";
     githubId = 23462908;
   };
+  msyds = {
+    name = "Madeleine Sydney Ślaga";
+    email = "65362461+msyds@users.noreply.github.com";
+    github = "msyds";
+    githubId = 65362461;
+  };
   nikp123 = {
     name = "nikp123";
     email = "nikp123@users.noreply.github.com";

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2148,6 +2148,7 @@ in {
           under '$XDG_CONFIG_HOME/easyeffects/{input,output}/'.
         '';
       }
+
       {
         time = "2025-02-12T15:56:00+00:00";
         message = ''
@@ -2167,6 +2168,16 @@ in {
           - programs.zellij.enableBashIntegration
           - programs.zellij.enableFishIntegration
           - programs.zellij.enableZshIntegration
+        '';
+      }
+
+      {
+        time = "2025-01-02T11:21:19+00:00";
+        message = ''
+          A new module is available: 'services.mpdscribble'.
+
+          A MPD client which submits information about tracks being played to a
+          scrobbler (e.g. last.fm)
         '';
       }
     ];

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -361,6 +361,7 @@ let
     ./services/mopidy.nix
     ./services/mpd.nix
     ./services/mpdris2.nix
+    ./services/mpdscribble.nix
     ./services/mpd-discord-rpc.nix
     ./services/mpd-mpris.nix
     ./services/mpris-proxy.nix

--- a/modules/services/mpdscribble.nix
+++ b/modules/services/mpdscribble.nix
@@ -1,0 +1,219 @@
+{ config, lib, options, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.mpdscribble;
+  mpdCfg = config.services.mpd;
+  mpdOpt = options.services.mpd;
+
+  endpointUrls = {
+    "last.fm" = "http://post.audioscrobbler.com";
+    "libre.fm" = "http://turtle.libre.fm";
+    "jamendo" = "http://postaudioscrobbler.jamendo.com";
+    "listenbrainz" = "http://proxy.listenbrainz.org";
+  };
+
+  mkSection = secname: secCfg: ''
+    [${secname}]
+    url      = ${secCfg.url}
+    username = ${secCfg.username}
+    password = {{${secname}_PASSWORD}}
+    journal  = /var/lib/mpdscribble/${secname}.journal
+  '';
+
+  endpoints = concatStringsSep "\n" (mapAttrsToList mkSection cfg.endpoints);
+  cfgTemplate = pkgs.writeText "mpdscribble.conf" ''
+    ## This file was automatically genenrated by home-manager and will be
+    ## overwritten.  Do not edit. Edit your home-manager configuration instead.
+
+    ## mpdscribble - an audioscrobbler for the Music Player Daemon.
+    ## http://mpd.wikia.com/wiki/Client:mpdscribble
+
+    # HTTP proxy URL.
+    ${optionalString (cfg.proxy != null) "proxy = ${cfg.proxy}"}
+
+    # The location of the mpdscribble log file.  The special value
+    # "syslog" makes mpdscribble use the local syslog daemon.  On most
+    # systems, log messages will appear in /var/log/daemon.log then.
+    # "-" means log to stderr (the current terminal).
+    log = -
+
+    # How verbose mpdscribble's logging should be.  Default is 1.
+    verbose = ${toString cfg.verbose}
+
+    # How often should mpdscribble save the journal file? [seconds]
+    journal_interval = ${toString cfg.journalInterval}
+
+    # The host running MPD, possibly protected by a password
+    # ([PASSWORD@]HOSTNAME).
+    host = ${
+      (optionalString (cfg.passwordFile != null) "{{MPD_PASSWORD}}@") + cfg.host
+    }
+
+    # The port that the MPD listens on and mpdscribble should try to
+    # connect to.
+    port = ${toString cfg.port}
+
+    ${endpoints}
+  '';
+
+  configFile =
+    "\${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/mpdscribble/mpdscribble.conf";
+
+  replaceSecret = secretFile: placeholder: targetFile:
+    optionalString (secretFile != null) ''
+      ${pkgs.replace-secret}/bin/replace-secret '${placeholder}' '${secretFile}' "${targetFile}" '';
+
+  preStart = pkgs.writeShellApplication {
+    name = "mpdscribble-pre-start";
+    runtimeInputs = [ pkgs.replace-secret pkgs.coreutils ];
+    text = ''
+      configFile="${configFile}"
+      mkdir -p "$(dirname "$configFile")"
+      cp --no-preserve=mode,ownership -f "${cfgTemplate}" "$configFile"
+      ${replaceSecret cfg.passwordFile "{{MPD_PASSWORD}}" "$configFile"}
+      ${concatStringsSep "\n" (mapAttrsToList (secname: cfg:
+        replaceSecret cfg.passwordFile "{{${secname}_PASSWORD}}" "$configFile")
+        cfg.endpoints)}
+    '';
+  };
+
+  start = pkgs.writeShellScript "mpdscribble-start" ''
+    configFile="${configFile}"
+    exec ${pkgs.mpdscribble}/bin/mpdscribble --no-daemon --conf "$configFile"
+  '';
+
+  localMpd = (cfg.host == "localhost" || cfg.host == "127.0.0.1");
+
+in {
+  ###### interface
+
+  options.services.mpdscribble = {
+
+    enable = mkEnableOption ''
+      mpdscribble, an MPD client which submits info about tracks being played to
+      Last.fm (formerly AudioScrobbler)
+    '';
+
+    proxy = mkOption {
+      default = null;
+      type = types.nullOr types.str;
+      description = ''
+        HTTP proxy URL.
+      '';
+    };
+
+    verbose = mkOption {
+      default = 1;
+      type = types.int;
+      description = ''
+        Log level for the mpdscribble daemon.
+      '';
+    };
+
+    journalInterval = mkOption {
+      default = 600;
+      example = 60;
+      type = types.int;
+      description = ''
+        How often should mpdscribble save the journal file? [seconds]
+      '';
+    };
+
+    host = mkOption {
+      default = (if mpdCfg.network.listenAddress != "any" then
+        mpdCfg.network.listenAddress
+      else
+        "localhost");
+      defaultText = literalExpression ''
+        if config.${mpdOpt.network.listenAddress} != "any"
+        then config.${mpdOpt.network.listenAddress}
+        else "localhost"
+      '';
+      type = types.str;
+      description = ''
+        Host for the mpdscribble daemon to search for a mpd daemon on.
+      '';
+    };
+
+    passwordFile = mkOption {
+      default = null;
+      type = types.nullOr types.str;
+      description = ''
+        File containing the password for the mpd daemon.
+      '';
+    };
+
+    port = mkOption {
+      default = mpdCfg.network.port;
+      defaultText = literalExpression "config.${mpdOpt.network.port}";
+      type = types.port;
+      description = ''
+        Port for the mpdscribble daemon to search for a mpd daemon on.
+      '';
+    };
+
+    endpoints = mkOption {
+      type = (let
+        endpoint = { name, ... }: {
+          options = {
+            url = mkOption {
+              type = types.str;
+              default = endpointUrls.${name} or "";
+              description =
+                "The url endpoint where the scrobble API is listening.";
+            };
+            username = mkOption {
+              type = types.str;
+              description = ''
+                Username for the scrobble service.
+              '';
+            };
+            passwordFile = mkOption {
+              type = types.nullOr types.str;
+              description =
+                "File containing the password, either as MD5SUM or cleartext.";
+            };
+          };
+        };
+      in types.attrsOf (types.submodule endpoint));
+      default = { };
+      example = {
+        "last.fm" = {
+          username = "foo";
+          passwordFile = "/run/secrets/lastfm_password";
+        };
+      };
+      description = ''
+        Endpoints to scrobble to.
+        If the endpoint is one of "${
+          concatStringsSep ''", "'' (attrNames endpointUrls)
+        }" the url is set automatically.
+      '';
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    systemd.user.services.mpdscribble = {
+      Unit = {
+        Description = "mpdscribble mpd scrobble client";
+        After = [ "network.target" ] ++ optional localMpd "mpd.service";
+      };
+      Install.WantedBy = [ "default.target" ];
+      Service = {
+        StateDirectory = "mpdscribble";
+        RuntimeDirectory = "mpdscribble";
+        RuntimeDirectoryMode = "700";
+        # TODO use LoadCredential= instead of running preStart with full privileges?
+        ExecStartPre = "+${preStart}/bin/mpdscribble-pre-start";
+        ExecStart = "${start}";
+      };
+    };
+  };
+
+  meta.maintainers = [ lib.hm.maintainers.msyds ];
+}

--- a/modules/services/mpdscribble.nix
+++ b/modules/services/mpdscribble.nix
@@ -121,6 +121,10 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.mpdscribble" pkgs
+        lib.platforms.linux)
+    ];
     systemd.user.services.mpdscribble = let
       localMpd = (cfg.host == "localhost" || cfg.host == "127.0.0.1");
 

--- a/modules/services/mpdscribble.nix
+++ b/modules/services/mpdscribble.nix
@@ -1,7 +1,5 @@
 { config, lib, options, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.services.mpdscribble;
   mpdCfg = config.services.mpd;
@@ -13,171 +11,98 @@ let
     "jamendo" = "http://postaudioscrobbler.jamendo.com";
     "listenbrainz" = "http://proxy.listenbrainz.org";
   };
-
-  mkSection = secname: secCfg: ''
-    [${secname}]
-    url      = ${secCfg.url}
-    username = ${secCfg.username}
-    password = {{${secname}_PASSWORD}}
-    journal  = /var/lib/mpdscribble/${secname}.journal
-  '';
-
-  endpoints = concatStringsSep "\n" (mapAttrsToList mkSection cfg.endpoints);
-  cfgTemplate = pkgs.writeText "mpdscribble.conf" ''
-    ## This file was automatically genenrated by home-manager and will be
-    ## overwritten.  Do not edit. Edit your home-manager configuration instead.
-
-    ## mpdscribble - an audioscrobbler for the Music Player Daemon.
-    ## http://mpd.wikia.com/wiki/Client:mpdscribble
-
-    # HTTP proxy URL.
-    ${optionalString (cfg.proxy != null) "proxy = ${cfg.proxy}"}
-
-    # The location of the mpdscribble log file.  The special value
-    # "syslog" makes mpdscribble use the local syslog daemon.  On most
-    # systems, log messages will appear in /var/log/daemon.log then.
-    # "-" means log to stderr (the current terminal).
-    log = -
-
-    # How verbose mpdscribble's logging should be.  Default is 1.
-    verbose = ${toString cfg.verbose}
-
-    # How often should mpdscribble save the journal file? [seconds]
-    journal_interval = ${toString cfg.journalInterval}
-
-    # The host running MPD, possibly protected by a password
-    # ([PASSWORD@]HOSTNAME).
-    host = ${
-      (optionalString (cfg.passwordFile != null) "{{MPD_PASSWORD}}@") + cfg.host
-    }
-
-    # The port that the MPD listens on and mpdscribble should try to
-    # connect to.
-    port = ${toString cfg.port}
-
-    ${endpoints}
-  '';
-
-  configFile =
-    "\${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/mpdscribble/mpdscribble.conf";
-
-  replaceSecret = secretFile: placeholder: targetFile:
-    optionalString (secretFile != null) ''
-      ${pkgs.replace-secret}/bin/replace-secret '${placeholder}' '${secretFile}' "${targetFile}" '';
-
-  preStart = pkgs.writeShellApplication {
-    name = "mpdscribble-pre-start";
-    runtimeInputs = [ pkgs.replace-secret pkgs.coreutils ];
-    text = ''
-      configFile="${configFile}"
-      mkdir -p "$(dirname "$configFile")"
-      cp --no-preserve=mode,ownership -f "${cfgTemplate}" "$configFile"
-      ${replaceSecret cfg.passwordFile "{{MPD_PASSWORD}}" "$configFile"}
-      ${concatStringsSep "\n" (mapAttrsToList (secname: cfg:
-        replaceSecret cfg.passwordFile "{{${secname}_PASSWORD}}" "$configFile")
-        cfg.endpoints)}
-    '';
-  };
-
-  start = pkgs.writeShellScript "mpdscribble-start" ''
-    configFile="${configFile}"
-    exec ${pkgs.mpdscribble}/bin/mpdscribble --no-daemon --conf "$configFile"
-  '';
-
-  localMpd = (cfg.host == "localhost" || cfg.host == "127.0.0.1");
-
 in {
-  ###### interface
-
   options.services.mpdscribble = {
 
-    enable = mkEnableOption ''
+    enable = lib.mkEnableOption ''
       mpdscribble, an MPD client which submits info about tracks being played to
       Last.fm (formerly AudioScrobbler)
     '';
 
-    proxy = mkOption {
+    proxy = lib.mkOption {
       default = null;
-      type = types.nullOr types.str;
+      type = lib.types.nullOr lib.types.str;
       description = ''
         HTTP proxy URL.
       '';
     };
 
-    verbose = mkOption {
+    verbose = lib.mkOption {
       default = 1;
-      type = types.int;
+      type = lib.types.int;
       description = ''
         Log level for the mpdscribble daemon.
       '';
     };
 
-    journalInterval = mkOption {
+    journalInterval = lib.mkOption {
       default = 600;
       example = 60;
-      type = types.int;
+      type = lib.types.int;
       description = ''
         How often should mpdscribble save the journal file? [seconds]
       '';
     };
 
-    host = mkOption {
+    host = lib.mkOption {
       default = (if mpdCfg.network.listenAddress != "any" then
         mpdCfg.network.listenAddress
       else
         "localhost");
-      defaultText = literalExpression ''
+      defaultText = lib.literalExpression ''
         if config.${mpdOpt.network.listenAddress} != "any"
         then config.${mpdOpt.network.listenAddress}
         else "localhost"
       '';
-      type = types.str;
+      type = lib.types.str;
       description = ''
         Host for the mpdscribble daemon to search for a mpd daemon on.
       '';
     };
 
-    passwordFile = mkOption {
+    package = lib.mkPackageOption pkgs "mpdscribble" { };
+
+    passwordFile = lib.mkOption {
       default = null;
-      type = types.nullOr types.str;
+      type = lib.types.nullOr lib.types.str;
       description = ''
         File containing the password for the mpd daemon.
       '';
     };
 
-    port = mkOption {
+    port = lib.mkOption {
       default = mpdCfg.network.port;
-      defaultText = literalExpression "config.${mpdOpt.network.port}";
-      type = types.port;
+      defaultText = lib.literalExpression "config.${mpdOpt.network.port}";
+      type = lib.types.port;
       description = ''
         Port for the mpdscribble daemon to search for a mpd daemon on.
       '';
     };
 
-    endpoints = mkOption {
-      type = (let
+    endpoints = lib.mkOption {
+      type = let
         endpoint = { name, ... }: {
           options = {
-            url = mkOption {
-              type = types.str;
+            url = lib.mkOption {
+              type = lib.types.str;
               default = endpointUrls.${name} or "";
               description =
                 "The url endpoint where the scrobble API is listening.";
             };
-            username = mkOption {
-              type = types.str;
+            username = lib.mkOption {
+              type = lib.types.str;
               description = ''
                 Username for the scrobble service.
               '';
             };
-            passwordFile = mkOption {
-              type = types.nullOr types.str;
+            passwordFile = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
               description =
                 "File containing the password, either as MD5SUM or cleartext.";
             };
           };
         };
-      in types.attrsOf (types.submodule endpoint));
+      in lib.types.attrsOf (lib.types.submodule endpoint);
       default = { };
       example = {
         "last.fm" = {
@@ -188,20 +113,94 @@ in {
       description = ''
         Endpoints to scrobble to.
         If the endpoint is one of "${
-          concatStringsSep ''", "'' (attrNames endpointUrls)
+          lib.concatStringsSep ''", "'' (builtins.attrNames endpointUrls)
         }" the url is set automatically.
       '';
     };
 
   };
 
-  ###### implementation
+  config = lib.mkIf cfg.enable {
+    systemd.user.services.mpdscribble = let
+      localMpd = (cfg.host == "localhost" || cfg.host == "127.0.0.1");
 
-  config = mkIf cfg.enable {
-    systemd.user.services.mpdscribble = {
+      mkSection = secname: secCfg: ''
+        [${secname}]
+        url      = ${secCfg.url}
+        username = ${secCfg.username}
+        password = {{${secname}_PASSWORD}}
+        journal  = /var/lib/mpdscribble/${secname}.journal
+      '';
+
+      endpoints =
+        lib.concatStringsSep "\n" (lib.mapAttrsToList mkSection cfg.endpoints);
+      cfgTemplate = pkgs.writeText "mpdscribble.conf" ''
+        ## This file was automatically genenrated by home-manager and will be
+        ## overwritten.  Do not edit. Edit your home-manager configuration instead.
+
+        ## mpdscribble - an audioscrobbler for the Music Player Daemon.
+        ## http://mpd.wikia.com/wiki/Client:mpdscribble
+
+        # HTTP proxy URL.
+        ${lib.optionalString (cfg.proxy != null) "proxy = ${cfg.proxy}"}
+
+        # The location of the mpdscribble log file.  The special value
+        # "syslog" makes mpdscribble use the local syslog daemon.  On most
+        # systems, log messages will appear in /var/log/daemon.log then.
+        # "-" means log to stderr (the current terminal).
+        log = -
+
+        # How verbose mpdscribble's logging should be.  Default is 1.
+        verbose = ${toString cfg.verbose}
+
+        # How often should mpdscribble save the journal file? [seconds]
+        journal_interval = ${toString cfg.journalInterval}
+
+        # The host running MPD, possibly protected by a password
+        # ([PASSWORD@]HOSTNAME).
+        host = ${
+          (lib.optionalString (cfg.passwordFile != null) "{{MPD_PASSWORD}}@")
+          + cfg.host
+        }
+
+        # The port that the MPD listens on and mpdscribble should try to
+        # connect to.
+        port = ${toString cfg.port}
+
+        ${endpoints}
+      '';
+
+      configFile =
+        "\${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/mpdscribble/mpdscribble.conf";
+
+      replaceSecret = secretFile: placeholder: targetFile:
+        lib.optionalString (secretFile != null) ''
+          ${pkgs.replace-secret}/bin/replace-secret '${placeholder}' '${secretFile}' "${targetFile}"
+        '';
+
+      preStart = pkgs.writeShellApplication {
+        name = "mpdscribble-pre-start";
+        runtimeInputs = [ pkgs.replace-secret pkgs.coreutils ];
+        text = ''
+          configFile="${configFile}"
+          mkdir -p "$(dirname "$configFile")"
+          cp --no-preserve=mode,ownership -f "${cfgTemplate}" "$configFile"
+          ${replaceSecret cfg.passwordFile "{{MPD_PASSWORD}}" "$configFile"}
+          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (secname: cfg:
+            replaceSecret cfg.passwordFile "{{${secname}_PASSWORD}}"
+            "$configFile") cfg.endpoints)}
+        '';
+      };
+
+      start = pkgs.writeShellScript "mpdscribble-start" ''
+        configFile="${configFile}"
+        exec "${lib.getExe cfg.package}" --no-daemon --conf "$configFile"
+      '';
+
+    in {
       Unit = {
         Description = "mpdscribble mpd scrobble client";
-        After = [ "network.target" ] ++ optional localMpd "mpd.service";
+        After = [ "network.target" ] ++ lib.optional localMpd "mpd.service";
       };
       Install.WantedBy = [ "default.target" ];
       Service = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -522,6 +522,7 @@ in import nmtSrc {
     ./modules/services/mpd
     ./modules/services/mpd-mpris
     ./modules/services/mpdris2
+    ./modules/services/mpdscribble
     ./modules/services/nix-gc
     ./modules/services/ollama/linux
     ./modules/services/osmscout-server

--- a/tests/modules/services/mpdscribble/basic-configuration.nix
+++ b/tests/modules/services/mpdscribble/basic-configuration.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  services.mpdscribble = {
+    enable = true;
+    endpoints = {
+      "libre.fm" = {
+        username = "musicfan1992";
+        passwordFile = toString ./password-file;
+      };
+      "https://music.com/" = {
+        username = "musicHATER1000";
+        passwordFile = toString ./password-file;
+      };
+    };
+  };
+
+  home.stateVersion = "22.11";
+
+  test.stubs.mpd = { };
+
+  nmt.script = ''
+    serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/mpdscribble.service)
+    assertFileContent "$serviceFile" ${./basic-configuration.service}
+  '';
+}

--- a/tests/modules/services/mpdscribble/basic-configuration.service
+++ b/tests/modules/services/mpdscribble/basic-configuration.service
@@ -1,0 +1,14 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=/nix/store/00000000000000000000000000000000-mpdscribble-start
+ExecStartPre=+/nix/store/00000000000000000000000000000000-mpdscribble-pre-start/bin/mpdscribble-pre-start
+RuntimeDirectory=mpdscribble
+RuntimeDirectoryMode=700
+StateDirectory=mpdscribble
+
+[Unit]
+After=network.target
+After=mpd.service
+Description=mpdscribble mpd scrobble client

--- a/tests/modules/services/mpdscribble/default.nix
+++ b/tests/modules/services/mpdscribble/default.nix
@@ -1,0 +1,1 @@
+{ mpdscribble-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

This PR adds the module `services.mpdscribble` based on the NixOS module of the same name.

Old feature request: #4963 

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).