### PR TITLE
easyeffects: add option to import presets

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2140,6 +2140,14 @@ in {
           you can use `lib.mkOrder` to specify the order of the content you want to insert.
         '';
       }
+      {
+        time = "2025-03-19T18:10:56+00:00";
+        condition = config.services.easyeffects.enable;
+        message = ''
+          The Easyeffects module now supports adding json formatted presets
+          under '$XDG_CONFIG_HOME/easyeffects/{input,output}/'.
+        '';
+      }
     ];
   };
 }

--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -54,7 +54,7 @@ let
     '';
   };
 in {
-  meta.maintainers = [ maintainers.fufexan ];
+  meta.maintainers = with maintainers; [ fufexan hausken ];
 
   options.services.easyeffects = {
     enable = mkEnableOption ''

--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -8,6 +8,51 @@ let
 
   presetOpts = optionalString (cfg.preset != "") "--load-preset ${cfg.preset}";
 
+  jsonFormat = pkgs.formats.json { };
+
+  presetType = let baseType = types.attrsOf jsonFormat.type;
+  in baseType // {
+    check = v:
+      baseType.check v && elem (head (attrNames v)) [ "input" "output" ];
+    description = "EasyEffects input or output JSON preset";
+  };
+
+  presetOptionType = mkOption {
+    type = types.nullOr (types.attrsOf presetType);
+    default = { };
+    description = ''
+      List of presets to import to easyeffects.
+      Presets are written to input and output folder in `$XDG_CONFIG_HOME/easyeffects`.
+      Top level block (input/output) determines the folder the file is written to.
+
+      See community presets at:
+      https://github.com/wwmm/easyeffects/wiki/Community-Presets
+    '';
+    example = literalExpression ''
+      {
+        my-preset = {
+          input = {
+            blocklist = [
+
+            ];
+            "plugins_order" = [
+              "rnnoise#0"
+            ];
+            "rnnoise#0" = {
+              bypass = false;
+              "enable-vad" = false;
+              "input-gain" = 0.0;
+              "model-path" = "";
+              "output-gain" = 0.0;
+              release = 20.0;
+              "vad-thres" = 50.0;
+              wet = 0.0;
+            };
+          };
+        };
+      };
+    '';
+  };
 in {
   meta.maintainers = [ maintainers.fufexan ];
 
@@ -35,6 +80,8 @@ in {
         Will likely need to launch easyeffects to initially create preset.
       '';
     };
+
+    extraPresets = presetOptionType;
   };
 
   config = mkIf cfg.enable {
@@ -46,6 +93,13 @@ in {
     # at-spi2-core is to minimize journalctl noise of:
     # "AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files"
     home.packages = with pkgs; [ cfg.package at-spi2-core ];
+
+    xdg.configFile = mkIf (cfg.extraPresets != { }) (lib.mapAttrs' (k: v:
+      # assuming only one of either input or output block is defined, having both in same file not seem to be supported by the application since it separates it by folder
+      let folder = builtins.head (builtins.attrNames v);
+      in lib.nameValuePair "easyeffects/${folder}/${k}.json" {
+        source = jsonFormat.generate "${folder}-${k}.json" v;
+      }) cfg.extraPresets);
 
     systemd.user.services.easyeffects = {
       Unit = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -487,6 +487,7 @@ in import nmtSrc {
     ./modules/services/darkman
     ./modules/services/devilspie2
     ./modules/services/dropbox
+    ./modules/services/easyeffects
     ./modules/services/emacs
     ./modules/services/espanso
     ./modules/services/flameshot

--- a/tests/modules/services/easyeffects/default.nix
+++ b/tests/modules/services/easyeffects/default.nix
@@ -1,0 +1,4 @@
+{
+  easyeffects-service = ./service.nix;
+  easyeffects-example-preset = ./example-preset.nix;
+}

--- a/tests/modules/services/easyeffects/example-preset.json
+++ b/tests/modules/services/easyeffects/example-preset.json
@@ -1,0 +1,18 @@
+{
+  "input": {
+    "blocklist": [],
+    "plugins_order": [
+      "rnnoise#0"
+    ],
+    "rnnoise#0": {
+      "bypass": false,
+      "enable-vad": false,
+      "input-gain": 0.0,
+      "model-path": "",
+      "output-gain": 0.0,
+      "release": 20.0,
+      "vad-thres": 50.0,
+      "wet": 0.0
+    }
+  }
+}

--- a/tests/modules/services/easyeffects/example-preset.nix
+++ b/tests/modules/services/easyeffects/example-preset.nix
@@ -1,0 +1,36 @@
+{ ... }:
+
+{
+  services.easyeffects = {
+    enable = true;
+    extraPresets = {
+      example-preset = {
+        input = {
+          blocklist = [
+
+          ];
+          "plugins_order" = [ "rnnoise#0" ];
+          "rnnoise#0" = {
+            bypass = false;
+            "enable-vad" = false;
+            "input-gain" = 0.0;
+            "model-path" = "";
+            "output-gain" = 0.0;
+            release = 20.0;
+            "vad-thres" = 50.0;
+            wet = 0.0;
+          };
+        };
+      };
+    };
+  };
+
+  test.stubs.easyeffects = { };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/easyeffects/input/example-preset.json "${
+        ./example-preset.json
+      }"
+  '';
+}

--- a/tests/modules/services/easyeffects/service.nix
+++ b/tests/modules/services/easyeffects/service.nix
@@ -1,0 +1,14 @@
+{ ... }:
+
+{
+  services.easyeffects = { enable = true; };
+
+  test.stubs.easyeffects = { };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/easyeffects.service
+
+    assertFileExists $serviceFile
+    assertFileRegex $serviceFile 'ExecStart=.*/bin/easyeffects'
+  '';
+}


### PR DESCRIPTION
### Description
- added options to import presets
- added tests
- added hausken as maintainer
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
(tested with `nix-shell --pure tests -A run.easyeffects-service` and `nix-shell --pure tests -A run.easyeffects-example-preset`)

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@fufexan 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
