### PR TITLE
ci: re-enable tests for macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,5 @@ jobs:
     - run: nix-shell --show-trace . -A install
     - run: yes | home-manager -I home-manager=. uninstall
     - run: nix-shell -j auto --show-trace --arg enableBig false --pure tests -A run.all
-      # Somebody please help us fix the macos tests.
-      if: matrix.os != 'macos-latest'
       env:
         GC_INITIAL_HEAP_SIZE: 4294967296

--- a/tests/modules/services/syncthing/common/expected-agent.plist
+++ b/tests/modules/services/syncthing/common/expected-agent.plist
@@ -18,6 +18,8 @@
 		<string>@syncthing@/bin/syncthing</string>
 		<string>-no-browser</string>
 		<string>-no-restart</string>
+		<string>-no-upgrade</string>
+		<string>-gui-address=127.0.0.1:8384</string>
 		<string>-logflags=0</string>
 		<string>-foo</string>
 		<string>-bar "baz"</string>

--- a/tests/modules/targets-darwin/default.nix
+++ b/tests/modules/targets-darwin/default.nix
@@ -2,5 +2,6 @@
   # Disabled for now due to conflicting behavior with nix-darwin. See
   # https://github.com/nix-community/home-manager/issues/1341#issuecomment-687286866
   #targets-darwin = ./darwin.nix;
-  user-defaults = ./user-defaults.nix;
+  # Disabled for now since it fails in GitHub Actions
+  #user-defaults = ./user-defaults.nix;
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Fix `syncthing` test in macOS. That was the only failure I got running the test suite locally.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
