### PR TITLE
Revert "home-manager: Use path: URI type for flake default"

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -191,7 +191,7 @@ function setFlakeAttribute() {
         fi
 
         if [[ -v configFlake ]]; then
-            FLAKE_ARG="path:$(dirname "$(readlink -f "$configFlake")")"
+            FLAKE_ARG="$(dirname "$(readlink -f "$configFlake")")"
         fi
     fi
 


### PR DESCRIPTION
From the discussions in https://github.com/nix-community/home-manager/issues/4198, it seems like folks prefer the default Nix behaviour, and there's been no progress on https://github.com/NixOS/nix/issues/8710

So let's revert https://github.com/nix-community/home-manager/pull/3646 (I was the original author)