### PR TITLE
neomutt: added missing sort options

### DIFF
--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -371,8 +371,9 @@ in {
 
       sort = mkOption {
         # allow users to choose any option from sortOptions, or any option prefixed with "reverse-"
-        type = types.enum
-          (sortOptions ++ (map (option: "reverse-" + option) sortOptions));
+        type = types.enum (options: prefix:
+          builtins.concatMap (_pre: map (_opt: _pre + _opt) options) prefix)
+          sortOptions [ "" "reverse-" "last-" "reverse-last-" ];
         default = "threads";
         description = "Sorting method on messages.";
       };

--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -371,9 +371,13 @@ in {
 
       sort = mkOption {
         # allow users to choose any option from sortOptions, or any option prefixed with "reverse-"
-        type = types.enum (options: prefix:
-          builtins.concatMap (_pre: map (_opt: _pre + _opt) options) prefix)
-          sortOptions [ "" "reverse-" "last-" "reverse-last-" ];
+        type = types.enum
+          (builtins.concatMap (_pre: map (_opt: _pre + _opt) sortOptions) [
+            ""
+            "reverse-"
+            "last-"
+            "reverse-last-"
+          ]);
         default = "threads";
         description = "Sorting method on messages.";
       };


### PR DESCRIPTION
### Description

The allowed entries for `programs.neomutt.sort` were missing the `last` prefix, as shown in the [documentation](https://neomutt.org/man/neomuttrc), under the `sort` entry.

Fixes #6263

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
