### PR TITLE
inori: init module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -762,4 +762,10 @@
     github = "LesVu";
     githubId = 66196443;
   };
+  lunahd = {
+    name = "Miku B";
+    email = "lunab08@proton.me";
+    github = "miku4k";
+    githubId = 89653242;
+  };
 }

--- a/modules/misc/news/2025-04-18_10-58-18.nix
+++ b/modules/misc/news/2025-04-18_10-58-18.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-04-18T08:58:18+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.inori'.
+
+    inori is a client for the Music Player Daemon (MPD)
+  '';
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -140,6 +140,7 @@ let
       ./programs/iamb.nix
       ./programs/imv.nix
       ./programs/info.nix
+      ./programs/inori.nix
       ./programs/ion.nix
       ./programs/irssi.nix
       ./programs/java.nix

--- a/modules/programs/inori.nix
+++ b/modules/programs/inori.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    literalExpression
+    mkIf
+    hm
+    maintainers
+    ;
+
+  cfg = config.programs.inori;
+
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = [
+    hm.maintainers.lunahd
+    maintainers.stephen-huan
+  ];
+
+  options.programs.inori = {
+    enable = mkEnableOption "inori";
+
+    package = mkPackageOption pkgs "inori" { nullable = true; };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          seek_seconds = 10;
+          dvorak_keybindings = true;
+        }
+      '';
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/inori/config.toml`.
+
+        See <https://github.com/eshrh/inori/blob/master/CONFIGURATION.md> for available options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."inori/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "config.toml" cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -380,6 +380,7 @@ import nmtSrc {
       ./modules/programs/htop
       ./modules/programs/hyfetch
       ./modules/programs/i3status
+      ./modules/programs/inori
       ./modules/programs/irssi
       ./modules/programs/jujutsu
       ./modules/programs/joplin-desktop

--- a/tests/modules/programs/inori/default-config.nix
+++ b/tests/modules/programs/inori/default-config.nix
@@ -1,0 +1,9 @@
+{
+  config = {
+    programs.inori.enable = true;
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/inori/config.toml
+    '';
+  };
+}

--- a/tests/modules/programs/inori/default.nix
+++ b/tests/modules/programs/inori/default.nix
@@ -1,0 +1,4 @@
+{
+  inori-default-config = ./default-config.nix;
+  inori-full-config = ./full-config.nix;
+}

--- a/tests/modules/programs/inori/full-config.nix
+++ b/tests/modules/programs/inori/full-config.nix
@@ -1,0 +1,59 @@
+{
+  config = {
+    programs.inori = {
+      enable = true;
+      settings = {
+        seek_seconds = 10;
+        dvorak_keybindings = true;
+        keybindings = {
+          toggle_playpause = [
+            "p"
+            "<space>"
+          ];
+          next_song = [
+            ">"
+            "C-n"
+          ];
+          previous_song = [
+            "<"
+            "C-p"
+          ];
+          seek = "<right>";
+          seek_backwards = "<left>";
+
+          up = "k";
+          down = "j";
+          left = "h";
+          right = "l";
+          top = [
+            "g g"
+            "<home>"
+          ];
+          bottom = [
+            "G"
+            "<end>"
+          ];
+          quit = [
+            "<escape>"
+            "q"
+          ];
+        };
+        theme = {
+          status_artist.fg = "#fab387";
+          status_album.fg = "#89b4fa";
+          status_title = {
+            fg = "#cba6f7";
+            add_modifier = "BOLD";
+          };
+          album.fg = "#89b4fa";
+          playing.fg = "#a6e3a1";
+        };
+      };
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/inori/config.toml
+      assertFileContent home-files/.config/inori/config.toml ${./full-config.toml}
+    '';
+  };
+}

--- a/tests/modules/programs/inori/full-config.toml
+++ b/tests/modules/programs/inori/full-config.toml
@@ -1,0 +1,32 @@
+dvorak_keybindings = true
+seek_seconds = 10
+
+[keybindings]
+bottom = ["G", "<end>"]
+down = "j"
+left = "h"
+next_song = [">", "C-n"]
+previous_song = ["<", "C-p"]
+quit = ["<escape>", "q"]
+right = "l"
+seek = "<right>"
+seek_backwards = "<left>"
+toggle_playpause = ["p", "<space>"]
+top = ["g g", "<home>"]
+up = "k"
+
+[theme.album]
+fg = "#89b4fa"
+
+[theme.playing]
+fg = "#a6e3a1"
+
+[theme.status_album]
+fg = "#89b4fa"
+
+[theme.status_artist]
+fg = "#fab387"
+
+[theme.status_title]
+add_modifier = "BOLD"
+fg = "#cba6f7"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This adds a module to configure [Inori](https://github.com/eshrh/inori), a MPD client written in Rust.

This depends on NixOS/nixpkgs#371762 getting merged first. Tests are expected to fail since the package doesnt exist yet.

This also depends on features that are expected to come out in the upcoming 0.2.3 release (should be within the next few days).

CC: @eshrh @stephen-huan

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
