### PR TITLE
syncthing: have tray wait for bar to load

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -726,7 +726,7 @@ in {
           };
 
           Service = {
-            ExecStart = "${pkgs.syncthingtray-minimal}/bin/syncthingtray";
+            ExecStart = "${pkgs.syncthingtray-minimal}/bin/syncthingtray --wait";
           };
 
           Install = { WantedBy = [ "graphical-session.target" ]; };

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -726,7 +726,8 @@ in {
           };
 
           Service = {
-            ExecStart = "${pkgs.syncthingtray-minimal}/bin/syncthingtray --wait";
+            ExecStart =
+              "${pkgs.syncthingtray-minimal}/bin/syncthingtray --wait";
           };
 
           Install = { WantedBy = [ "graphical-session.target" ]; };


### PR DESCRIPTION
### Description

Add --wait flag to tray to avoid loading before bar. Attempts to fix #3416 per the comments. It appears that #4548 already has some work towards this, but that's been sitting stale so this present and trivial PR is a just to tide us over until that gets sorted out.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
