### PR TITLE
nix: skip check completely when checkConfig=false

### DIFF
--- a/modules/misc/nix/default.nix
+++ b/modules/misc/nix/default.nix
@@ -105,6 +105,7 @@ let
         ${mkKeyValuePairs cfg.settings}
         ${cfg.extraOptions}
       '';
+      passthru.doCheck = cfg.checkConfig;
       checkPhase =
         if pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform then
           ''
@@ -122,7 +123,8 @@ let
             NIX_CONF_DIR=$PWD \
               ${cfg.package}/bin/nix ${showCommand} ${optionalString (isNixAtLeast "2.3pre") "--no-net --option experimental-features nix-command"} \
               |& sed -e 's/^warning:/error:/' \
-              | (! grep '${if cfg.checkConfig then "^error:" else "^error: unknown setting"}')
+              | ${if cfg.allowUnknownSettings then "grep -v '^error: unknown setting'" else "cat"} \
+              | (! grep '^error:')
             set -o pipefail
           '';
     };
@@ -296,7 +298,16 @@ in
       default = true;
       description = ''
         If enabled (the default), checks for data type mismatches and that Nix
-        can parse the generated nix.conf.
+        can parse the generated {file}`nix.conf`.
+      '';
+    };
+
+    allowUnknownSettings = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If enabled, unknown setting errors will be allowed when checking the
+        generated {file}`nix.conf`. This has no effect if {option}`checkConfig` is false.
       '';
     };
 

--- a/tests/modules/misc/nix/allow-unknown-settings-expected.conf
+++ b/tests/modules/misc/nix/allow-unknown-settings-expected.conf
@@ -1,0 +1,6 @@
+# WARNING: this file is generated from the nix.settings option in
+# your Home Manager configuration at $XDG_CONFIG_HOME/nix/nix.conf.
+# Do not edit it!
+and-another-one = hello
+some-arbitrary-setting = true
+

--- a/tests/modules/misc/nix/allow-unknown-settings.nix
+++ b/tests/modules/misc/nix/allow-unknown-settings.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  nix = {
+    package = config.lib.test.mkStubPackage {
+      version = lib.getVersion pkgs.nixVersions.stable;
+      buildScript = ''
+        target=$out/bin/nix
+        mkdir -p "$(dirname "$target")"
+
+        echo -n "true" > "$target"
+
+        chmod +x "$target"
+      '';
+    };
+
+    settings = {
+      some-arbitrary-setting = true;
+      and-another-one = "hello";
+    };
+    checkConfig = false;
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/nix/nix.conf \
+      ${./allow-unknown-settings-expected.conf}
+  '';
+}

--- a/tests/modules/misc/nix/default.nix
+++ b/tests/modules/misc/nix/default.nix
@@ -6,6 +6,8 @@
   nix-example-channels = ./example-channels.nix;
   nix-example-channels-xdg = ./example-channels-xdg.nix;
   nix-use-xdg = ./use-xdg.nix;
+  nix-skip-check-settings = ./skip-check-settings.nix;
+  nix-allow-unknown-settings = ./allow-unknown-settings.nix;
 
   # remote-build
   nix-remote-build-empty = ./remote-build/empty-settings.nix;

--- a/tests/modules/misc/nix/skip-check-settings-expected.conf
+++ b/tests/modules/misc/nix/skip-check-settings-expected.conf
@@ -1,0 +1,7 @@
+# WARNING: this file is generated from the nix.settings option in
+# your Home Manager configuration at $XDG_CONFIG_HOME/nix/nix.conf.
+# Do not edit it!
+
+some! nonsense {
+  which should fail validation
+

--- a/tests/modules/misc/nix/skip-check-settings.nix
+++ b/tests/modules/misc/nix/skip-check-settings.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  nix = {
+    package = config.lib.test.mkStubPackage {
+      version = lib.getVersion pkgs.nixVersions.stable;
+      buildScript = ''
+        target=$out/bin/nix
+        mkdir -p "$(dirname "$target")"
+
+        echo -n "true" > "$target"
+
+        chmod +x "$target"
+      '';
+    };
+
+    extraOptions = ''
+      some! nonsense {
+        which should fail validation
+    '';
+    checkConfig = false;
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/nix/nix.conf \
+      ${./skip-check-settings-expected.conf}
+  '';
+}


### PR DESCRIPTION
Fixes #5753 

### Description

Also add an `allowUnknownSettings` option to enable checking everything except for unknown settings.

### Checklist

- [x] Change is backwards compatible.
   
    NOTE: the caveat here is that users who previously had `checkConfig = false` will now have less checks performed than they did previously, but frankly I'm not sure it was even checking anything useful, since "unknown settings" seem to be emitted much later vs other kind of errors. A config like this only errors on `keep-outputs` and doesn't complain about the unknown setting at all:
	```ini
	keep-outputs = 123
	some-other-setting = true
	```

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
   NOTE: just testing the new tests I added and other `nix.conf` related tests

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
