### PR TITLE
mangohud: add `extraConfig` option

### DIFF
--- a/modules/programs/mangohud.nix
+++ b/modules/programs/mangohud.nix
@@ -79,6 +79,44 @@ in {
           for the default configuration.
         '';
       };
+
+      extraConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = literalExpression ''
+          ### Time formatting examples
+          # time_format=%H:%M
+          # time_format=[ %T %F ]
+          # time_format=%X # locally formatted time, because of limited glyph range, missing characters may show as '?' (e.g. Japanese)
+
+          ### Display MangoHud version
+          # version
+
+          ### Display the current GPU information
+          gpu_stats
+          gpu_temp
+          gpu_core_clock
+          gpu_mem_clock
+          gpu_power
+          # gpu_text=GPU
+          # gpu_load_change
+          # gpu_load_value=60,90
+          # gpu_load_color=39F900,FDFD09,B22222
+
+          ### Display the current CPU information
+          cpu_stats
+          cpu_temp
+          cpu_power
+          # cpu_text=CPU
+          cpu_mhz
+          # cpu_load_change
+          # cpu_load_value=60,90
+          # cpu_load_color=39F900,FDFD09,B22222
+        '';
+        description = ''
+          Extra configuration lines to add to `$XDG_CONFIG_HOME/MangoHud/MangoHud.conf`.
+        '';
+      };
     };
   };
 
@@ -95,8 +133,9 @@ in {
     };
 
     xdg.configFile = {
-      "MangoHud/MangoHud.conf" =
-        mkIf (cfg.settings != { }) { text = renderSettings cfg.settings; };
+      "MangoHud/MangoHud.conf" = mkIf (cfg.settings != { }) {
+        text = (renderSettings cfg.settings) + cfg.extraConfig;
+      };
     } // mapAttrs'
       (n: v: nameValuePair "MangoHud/${n}.conf" { text = renderSettings v; })
       cfg.settingsPerApplication;

--- a/tests/modules/programs/mangohud/basic-configuration.conf
+++ b/tests/modules/programs/mangohud/basic-configuration.conf
@@ -11,3 +11,16 @@ media_player_name=spotify
 media_player_order=title,artist,album
 output_folder=/home/user/Documents/mangohud
 vsync=0
+
+### Display the current GPU information
+gpu_stats
+gpu_temp
+gpu_core_clock
+gpu_mem_clock
+gpu_power
+
+# gpu_text=GPU
+# gpu_load_change
+# gpu_load_value=60,90
+# gpu_load_color=39F900,FDFD09,B22222
+

--- a/tests/modules/programs/mangohud/basic-configuration.nix
+++ b/tests/modules/programs/mangohud/basic-configuration.nix
@@ -26,6 +26,21 @@
           no_display = true;
         };
       };
+      extraConfig = ''
+
+        ### Display the current GPU information
+        gpu_stats
+        gpu_temp
+        gpu_core_clock
+        gpu_mem_clock
+        gpu_power
+
+        # gpu_text=GPU
+        # gpu_load_change
+        # gpu_load_value=60,90
+        # gpu_load_color=39F900,FDFD09,B22222
+
+      '';
     };
 
     nmt.script = ''


### PR DESCRIPTION
### Description

Added `extraConfig` option to append raw lines to the end of the\
primary config.

This is a nice, simple addition to be able to add mainly comments,\
along with anything else you'd like.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@zeratax