### PR TITLE
mangohud: make `false` values actually disable

### DIFF
--- a/modules/programs/mangohud.nix
+++ b/modules/programs/mangohud.nix
@@ -13,7 +13,7 @@ let
       int = toString option;
       float = int;
       path = int;
-      bool = "false";
+      bool = "0"; # "on/off" opts are disabled with `=0`
       string = option;
       list = concatStringsSep "," (lists.forEach option (x: toString x));
     }.${builtins.typeOf option};

--- a/tests/modules/programs/mangohud/basic-configuration.conf
+++ b/tests/modules/programs/mangohud/basic-configuration.conf
@@ -6,7 +6,7 @@ cpu_stats
 cpu_temp
 cpu_text=CPU
 fps_limit=30,60
-legacy_layout=false
+legacy_layout=0
 media_player_name=spotify
 media_player_order=title,artist,album
 output_folder=/home/user/Documents/mangohud


### PR DESCRIPTION
### Description

mangohud: make `false` values actually disable

Currently the following, will produce `some_opt=false` in the rendered config:

```nix
programs.mangohud.settings = {
  some_opt = false;
};
```

With the intention being to disable the option, this would be incorrect, as per
the following stated at:
<https://github.com/flightlessmango/MangoHud/blob/0575c8eb1f61692a2e5ca152c4f8ed70bef55ee2/data/MangoHud.conf#L3C5-L4C1>

> Use some_parameter=0 to disable a parameter (only works with on/off
> parameters)

As such, I changed the rendering to follow this. This will be output instead: `some_opt=0`

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or
  `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See
  [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@zeratax
