### PR TITLE
dconf: support configuring specific user databases

### DIFF
--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -13,10 +13,23 @@ let
   # The dconf keys managed by this configuration. We store this as part of the
   # generation state to be able to reset keys that become unmanaged during
   # switch.
-  stateDconfKeys = pkgs.writeText "dconf-keys.json" (builtins.toJSON
-    (concatLists (mapAttrsToList
-      (dir: entries: mapAttrsToList (key: _: "/${dir}/${key}") entries)
-      cfg.settings)));
+  mkStateDconfKeys = nameSuffix: settings:
+    pkgs.writeText "dconf-keys${nameSuffix}.json" (builtins.toJSON (concatLists
+      (mapAttrsToList
+        (dir: entries: mapAttrsToList (key: _: "/${dir}/${key}") entries)
+        settings)));
+
+  databases = optional (cfg.settings != { }) {
+    dconfProfile = null;
+    stateDconfKeys = mkStateDconfKeys "" cfg.settings;
+    inherit (cfg) settings;
+  } ++ mapAttrsToList (name: value: {
+    dconfProfile = pkgs.writeText "dconf-profile-${name}" ''
+      user-db:${name}
+    '';
+    stateDconfKeys = mkStateDconfKeys "-${name}" value;
+    settings = value;
+  }) cfg.databases;
 
 in {
   meta.maintainers = [ maintainers.rycee ];
@@ -72,65 +85,83 @@ in {
           to convert dconf database dumps into compatible Nix expression.
         '';
       };
+
+      databases = mkOption {
+        type = with types; attrsOf (attrsOf (attrsOf hm.types.gvariant));
+        default = { };
+        description = ''
+          Settings to write to specific dconf user databases.
+
+          See [](#opt-dconf.settings) for details.
+        '';
+      };
     };
   };
 
-  config = mkIf (cfg.enable && cfg.settings != { }) {
+  config = mkIf (cfg.enable && databases != [ ]) {
     # Make sure the dconf directory exists.
     xdg.configFile."dconf/.keep".source = builtins.toFile "keep" "";
 
     home.extraBuilderCommands = ''
       mkdir -p $out/state/
-      ln -s ${stateDconfKeys} $out/state/${stateDconfKeys.name}
-    '';
+    '' + concatMapStrings (db: ''
+      ln -s ${db.stateDconfKeys} $out/state/${db.stateDconfKeys.name}
+    '') databases;
 
-    home.activation.dconfSettings = hm.dag.entryAfter [ "installPackages" ] (let
-      iniFile = pkgs.writeText "hm-dconf.ini" (toDconfIni cfg.settings);
+    home.activation.dconfSettings = hm.dag.entryAfter [ "installPackages" ]
+      (concatMapStrings (db:
+        let
+          iniFile = pkgs.writeText "hm-dconf.ini" (toDconfIni db.settings);
 
-      statePath = "state/${stateDconfKeys.name}";
+          statePath = "state/${db.stateDconfKeys.name}";
 
-      cleanup = pkgs.writeShellScript "dconf-cleanup" ''
-        set -euo pipefail
+          cleanup = pkgs.writeShellScript "dconf-cleanup" ''
+            set -euo pipefail
 
-        ${config.lib.bash.initHomeManagerLib}
+            ${config.lib.bash.initHomeManagerLib}
 
-        PATH=${makeBinPath [ pkgs.dconf pkgs.jq ]}''${PATH:+:}$PATH
+            PATH=${makeBinPath [ pkgs.dconf pkgs.jq ]}''${PATH:+:}$PATH
 
-        oldState="$1"
-        newState="$2"
+            oldState="$1"
+            newState="$2"
 
-        # Can't do cleanup if we don't know the old state.
-        if [[ ! -f $oldState ]]; then
-          exit 0
-        fi
+            # Can't do cleanup if we don't know the old state.
+            if [[ ! -f $oldState ]]; then
+              exit 0
+            fi
 
-        # Reset all keys that are present in the old generation but not the new
-        # one.
-        jq -r -n \
-            --slurpfile old "$oldState" \
-            --slurpfile new "$newState" \
-            '($old[] - $new[])[]' \
-          | while read -r key; do
-              verboseEcho "Resetting dconf key \"$key\""
-              run $DCONF_DBUS_RUN_SESSION dconf reset "$key"
-            done
-      '';
-    in ''
-      if [[ -v DBUS_SESSION_BUS_ADDRESS ]]; then
-        export DCONF_DBUS_RUN_SESSION=""
-      else
-        export DCONF_DBUS_RUN_SESSION="${pkgs.dbus}/bin/dbus-run-session --dbus-daemon=${pkgs.dbus}/bin/dbus-daemon"
-      fi
+            # Reset all keys that are present in the old generation but not the new
+            # one.
+            jq -r -n \
+                --slurpfile old "$oldState" \
+                --slurpfile new "$newState" \
+                '($old[] - $new[])[]' \
+              | while read -r key; do
+                  verboseEcho "Resetting dconf key \"$key\""
+                  run $DCONF_DBUS_RUN_SESSION dconf reset "$key"
+                done
+          '';
 
-      if [[ -v oldGenPath ]]; then
-        ${cleanup} \
-          "$oldGenPath/${statePath}" \
-          "$newGenPath/${statePath}"
-      fi
+          envCommand = optionalString (db.dconfProfile != null)
+            "env DCONF_PROFILE=${db.dconfProfile}";
+        in ''
+          if [[ -v DBUS_SESSION_BUS_ADDRESS ]]; then
+            export DCONF_DBUS_RUN_SESSION="${envCommand}"
+          else
+            export DCONF_DBUS_RUN_SESSION="${pkgs.dbus}/bin/dbus-run-session --dbus-daemon=${pkgs.dbus}/bin/dbus-daemon ${envCommand}"
+          fi
 
-      run $DCONF_DBUS_RUN_SESSION ${pkgs.dconf}/bin/dconf load / < ${iniFile}
 
-      unset DCONF_DBUS_RUN_SESSION
-    '');
+
+          if [[ -v oldGenPath ]]; then
+            ${cleanup} \
+              "$oldGenPath/${statePath}" \
+              "$newGenPath/${statePath}"
+          fi
+
+          run $DCONF_DBUS_RUN_SESSION ${pkgs.dconf}/bin/dconf load / < ${iniFile}
+
+          unset DCONF_DBUS_RUN_SESSION
+        '') databases);
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

By default, dconf uses `$XDG_CONFIG_HOME/dconf/user` as the user database, but this can be changed by specifying `user-db:<name>` in a profile file and setting the `DCONF_PROFILE` environment variable to that profile. One may want to [use different user databases for different DE/WMs](https://wiki.archlinux.org/title/Hyprland#Separate_dconf_profile) to avoid collision.

Currently the module invokes dconf without touching `DCONF_PROFILE`, which means that 1) it is unable to configure multiple different user databases, and 2) the behavior of activation script will be affected by the `DCONF_PROFILE` environment variable when it is invoked, possibly leading to undesired results.

This PR adds a `dconf.databases` option, so that settings under `dconf.databases.<name>` will be written to `$XDG_CONFIG_HOME/dconf/<name>`. The old `dconf.settings` option is left as-is to avoid breaking compatibility.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee