### PR TITLE
Improve Darwin story for firefox and thunderbird

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -18,7 +18,7 @@ let
   supportedPlatforms = flatten (attrVals (attrNames platforms) lib.platforms);
 
   isWrapped = versionAtLeast config.home.stateVersion "19.09"
-    && wrappedPackageName != null;
+    && wrappedPackageName != null && !isDarwin;
 
   defaultPackageName =
     if isWrapped then wrappedPackageName else unwrappedPackageName;

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -133,7 +133,8 @@ in {
 
       package = mkOption {
         type = with types; nullOr package;
-        default = pkgs.thunderbird;
+        default =
+          if isDarwin then pkgs.thunderbird-unwrapped else pkgs.thunderbird;
         defaultText = literalExpression "pkgs.thunderbird";
         example = literalExpression "pkgs.thunderbird";
         description =

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -135,7 +135,7 @@ in {
         type = types.package;
         default = pkgs.thunderbird;
         defaultText = literalExpression "pkgs.thunderbird";
-        example = literalExpression "pkgs.thunderbird-91";
+        example = literalExpression "pkgs.thunderbird";
         description = "The Thunderbird package to use.";
       };
 

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -132,11 +132,12 @@ in {
       enable = mkEnableOption "Thunderbird";
 
       package = mkOption {
-        type = types.package;
+        type = with types; nullOr package;
         default = pkgs.thunderbird;
         defaultText = literalExpression "pkgs.thunderbird";
         example = literalExpression "pkgs.thunderbird";
-        description = "The Thunderbird package to use.";
+        description =
+          "The Thunderbird package to use. Set to `null` to disable installing Thunderbird.";
       };
 
       profiles = mkOption {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

1. Allow to set null as package for thunderbird. (Common on Darwin when it's pulled from e.g. Homebrew. No need to build a dummy package.)
2. Use -unwrapped packages for Darwin where wrapped versions are not supported in nixpkgs.
3. While at it, fix example for thunderbird.package to list a package that actually exists (thunderbird-91 was removed a while ago).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

<!-- @rycee @bricked @d-dervishi @jkarlson -->