### PR TITLE
sway: allow sway specific hideEdgeBorders options

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -421,7 +421,13 @@ in {
         };
 
         hideEdgeBorders = mkOption {
-          type = types.enum [ "none" "vertical" "horizontal" "both" "smart" ];
+          type = let
+            i3Options = [ "none" "vertical" "horizontal" "both" "smart" ];
+            swayOptions = i3Options ++ [ "smart_no_gaps" ];
+          in if isI3 then
+            types.enum i3Options
+          else
+            types.enum (swayOptions ++ (map (e: "--i3 ${e}") swayOptions));
           default = "none";
           description = "Hide window borders adjacent to the screen edges.";
         };


### PR DESCRIPTION
### Description

* allow using `--i3` for hideEdgeBorders
* add `smart_no_gaps` option

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Scrumplex 
@alexarice
@sumnerevans
@oxalica
