### PR TITLE
vscode: fix extensions dir path

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -20,7 +20,8 @@ let
 
   extensionDir = {
     "vscode" = "vscode";
-    "vscode-insiders" = "vscode-insiders";
+    "vscode-insiders" =
+      if pkgs.stdenv.hostPlatform.isDarwin then "vscode" else "vscode-insiders";
     "vscodium" = "vscode-oss";
     "openvscode-server" = "openvscode-server";
   }.${vscodePname};


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

On macOS, vscode-insiders (via `pkgs.vscode.override { isInsiders = true; }`) reads extension configuration from (and write to) `.vscode/extensions/extensions.json`, not under the `.vscode-insiders` folder. This commit affects only macOS since the author doesn't know and has no device to test the behaviour on other platform like linux.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
