### PR TITLE
bash: Make sure HISTFILE's directory exists

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -180,7 +180,7 @@ in {
 
     sessionVarsStr = config.lib.shell.exportAll cfg.sessionVariables;
 
-    historyControlStr = concatStringsSep "\n"
+    historyControlStr = (concatStringsSep "\n"
       (mapAttrsToList (n: v: "${n}=${v}") ({
         HISTFILESIZE = toString cfg.historyFileSize;
         HISTSIZE = toString cfg.historySize;
@@ -190,7 +190,8 @@ in {
         HISTCONTROL = concatStringsSep ":" cfg.historyControl;
       } // optionalAttrs (cfg.historyIgnore != [ ]) {
         HISTIGNORE = escapeShellArg (concatStringsSep ":" cfg.historyIgnore);
-      }));
+      }) ++ optional (cfg.historyFile != null)
+        ''mkdir -p "$(dirname "$HISTFILE")"''));
   in mkIf cfg.enable {
     home.packages = [ cfg.package ];
 

--- a/tests/modules/programs/bash/bash-history-control-with-file.nix
+++ b/tests/modules/programs/bash/bash-history-control-with-file.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  config = {
+    programs.bash = {
+      enable = true;
+      historyControl = [ "erasedups" ];
+      historyFile = "/home/hm-user/foo/bash/history";
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.bashrc
+
+      assertFileRegex home-files/.bashrc \
+        '^mkdir -p "\$(dirname "\$HISTFILE")"'
+    '';
+  };
+}

--- a/tests/modules/programs/bash/default.nix
+++ b/tests/modules/programs/bash/default.nix
@@ -2,4 +2,5 @@
   bash-completion = ./completion.nix;
   bash-logout = ./logout.nix;
   bash-session-variables = ./session-variables.nix;
+  bash-history-control-with-file = ./bash-history-control-with-file.nix;
 }


### PR DESCRIPTION
-------

### Description

If HISTFILE's directory doesn't exist, bash history doesn't work. This PR fixes this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->