### PR TITLE
hyprlock: add bezier to importantPrefixes

### DIFF
--- a/modules/programs/hyprlock.nix
+++ b/modules/programs/hyprlock.nix
@@ -102,9 +102,9 @@ in {
 
     importantPrefixes = lib.mkOption {
       type = with lib.types; listOf str;
-      default = [ "$" "monitor" "size" ]
+      default = [ "$" "bezier" "monitor" "size" ]
         ++ lib.optionals cfg.sourceFirst [ "source" ];
-      example = [ "$" "monitor" "size" ];
+      example = [ "$" "bezier" "monitor" "size" ];
       description = ''
         List of prefix of attributes to source at the top of the config.
       '';

--- a/modules/programs/hyprlock.nix
+++ b/modules/programs/hyprlock.nix
@@ -1,16 +1,14 @@
 { config, pkgs, lib, ... }:
 
-with lib;
-
 let
 
   cfg = config.programs.hyprlock;
 
 in {
-  meta.maintainers = [ maintainers.khaneliman maintainers.fufexan ];
+  meta.maintainers = with lib.maintainers; [ khaneliman fufexan ];
 
   options.programs.hyprlock = {
-    enable = mkEnableOption "" // {
+    enable = lib.mkEnableOption "" // {
       description = ''
         Whether to enable Hyprlock, Hyprland's GPU-accelerated lock screen
         utility.
@@ -27,7 +25,7 @@ in {
       '';
     };
 
-    package = mkPackageOption pkgs "hyprlock" { };
+    package = lib.mkPackageOption pkgs "hyprlock" { };
 
     settings = lib.mkOption {
       type = with lib.types;
@@ -111,12 +109,12 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
     xdg.configFile."hypr/hyprlock.conf" =
       let shouldGenerate = cfg.extraConfig != "" || cfg.settings != { };
-      in mkIf shouldGenerate {
+      in lib.mkIf shouldGenerate {
         text = lib.optionalString (cfg.settings != { })
           (lib.hm.generators.toHyprconf {
             attrs = cfg.settings;


### PR DESCRIPTION
Since hyprwm/hyprlock@00d2cbf hyprlock supports the animation and bezier keywords from Hyprland. But, bezier needs to be defined before an animation can use it.

Closes https://github.com/nix-community/home-manager/issues/6316

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee @fufexan 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
