### PR TITLE
yazi: improve fish integration

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1960,6 +1960,19 @@ in {
           as well as wf-shell.
         '';
       }
+
+      {
+        time = "2025-01-21T17:28:13+00:00";
+        condition = with config.programs.yazi; enable && enableFishIntegration;
+        message = ''
+          Yazi's fish shell integration wrapper now calls the 'yazi' executable
+          directly, ignoring any shell aliases with the same name.
+
+          Your configuration may break if you rely on the wrapper calling a
+          'yazi' alias.
+        '';
+      }
     ];
   };
 }
+

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -18,14 +18,12 @@ let
   '';
 
   fishIntegration = ''
-    function ${cfg.shellWrapperName}
-      set tmp (mktemp -t "yazi-cwd.XXXXX")
-      yazi $argv --cwd-file="$tmp"
-      if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
-        builtin cd -- "$cwd"
-      end
-      rm -f -- "$tmp"
+    set -l tmp (mktemp -t "yazi-cwd.XXXXX")
+    command yazi $argv --cwd-file="$tmp"
+    if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
+      builtin cd -- "$cwd"
     end
+    rm -f -- "$tmp"
   '';
 
   nushellIntegration = ''
@@ -202,7 +200,7 @@ in {
 
     programs.zsh.initExtra = mkIf cfg.enableZshIntegration bashIntegration;
 
-    programs.fish.interactiveShellInit =
+    programs.fish.functions.${cfg.shellWrapperName} =
       mkIf cfg.enableFishIntegration fishIntegration;
 
     programs.nushell.extraConfig =

--- a/tests/modules/programs/yazi/fish-integration-enabled.nix
+++ b/tests/modules/programs/yazi/fish-integration-enabled.nix
@@ -1,27 +1,18 @@
-{ ... }:
+{ config, ... }:
 
-let
-  shellIntegration = ''
-    function yy
-      set tmp (mktemp -t "yazi-cwd.XXXXX")
-      yazi $argv --cwd-file="$tmp"
-      if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
-        builtin cd -- "$cwd"
-      end
-      rm -f -- "$tmp"
-    end
-  '';
-in {
+{
   programs.fish.enable = true;
 
   programs.yazi = {
     enable = true;
+    shellWrapperName = "yy";
     enableFishIntegration = true;
   };
 
   test.stubs.yazi = { };
 
   nmt.script = ''
-    assertFileContains home-files/.config/fish/config.fish '${shellIntegration}'
+    assertFileContent home-files/.config/fish/functions/${config.programs.yazi.shellWrapperName}.fish \
+      ${./fish-integration-expected.fish}
   '';
 }

--- a/tests/modules/programs/yazi/fish-integration-expected.fish
+++ b/tests/modules/programs/yazi/fish-integration-expected.fish
@@ -1,0 +1,8 @@
+function yy
+    set -l tmp (mktemp -t "yazi-cwd.XXXXX")
+    command yazi $argv --cwd-file="$tmp"
+    if set cwd (cat -- "$tmp"); and [ -n "$cwd" ]; and [ "$cwd" != "$PWD" ]
+        builtin cd -- "$cwd"
+    end
+    rm -f -- "$tmp"
+end


### PR DESCRIPTION
### Description

Improve yazi fish integration:

Calls yazi as `command yazi`, allowing to use "yazi" as `shellWrapperName` without infinite recursion. This could be backward-incompatible for users who have an alias named "yazi" and expect this shell wrapper to call that alias instead of the yazi executable directly.

Also defines the wrapper with `programs.fish.functions` instead of `interactiveShellInit`, which seems to be the preferred way.

### Checklist

- [x] Change is backwards compatible. (with one exception, see above)

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@XYenon @eljamm 