### PR TITLE
zed-editor: add installRemoteServer option

### DIFF
--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -80,6 +80,21 @@ in {
           Use the name of a repository in the [extension list](https://github.com/zed-industries/extensions/tree/main/extensions).
         '';
       };
+
+      installRemoteServer = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to symlink the Zed's remote server binary to the expected
+          location. This allows remotely connecting to this system from a
+          distant Zed client.
+
+          For more information, consult the
+          ["Remote Server" section](https://wiki.nixos.org/wiki/Zed#Remote_Server)
+          in the wiki.
+        '';
+      };
     };
   };
 
@@ -100,6 +115,15 @@ in {
       ]
     else
       [ cfg.package ];
+
+    home.file = mkIf (cfg.installRemoteServer && (cfg.package ? remote_server))
+      (let
+        inherit (cfg.package) version remote_server;
+        binaryName = "zed-remote-server-stable-${version}";
+      in {
+        ".zed_server/${binaryName}".source =
+          lib.getExe' remote_server binaryName;
+      });
 
     xdg.configFile."zed/settings.json" = (mkIf (mergedSettings != { }) {
       source = jsonFormat.generate "zed-user-settings" mergedSettings;

--- a/tests/modules/programs/zed-editor/default.nix
+++ b/tests/modules/programs/zed-editor/default.nix
@@ -1,5 +1,6 @@
 {
   zed-extensions = ./extensions.nix;
+  zed-install-remote-server = ./install-remote-server.nix;
   zed-keymap = ./keymap.nix;
   zed-settings = ./settings.nix;
 }

--- a/tests/modules/programs/zed-editor/install-remote-server.nix
+++ b/tests/modules/programs/zed-editor/install-remote-server.nix
@@ -1,0 +1,20 @@
+{ config, ... }:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { version = "57"; } // {
+      remote_server = config.lib.test.mkStubPackage {
+        buildScript = ''
+          mkdir -p $out/bin
+          touch $out/bin/zed-remote-server-stable-57
+        '';
+      };
+    };
+    installRemoteServer = true;
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/.zed_server/zed-remote-server-stable-57"
+  '';
+}


### PR DESCRIPTION
### Description

Building on top of https://github.com/NixOS/nixpkgs/pull/370017.
This option automatically symlinks the Zed remote server binary to the right location in the user's home directory.
It allows to connect to this host from a remote Zed instance.

See https://wiki.nixos.org/wiki/Zed#Remote_Server for more details.

cc @niklaskorz

**Note:** Requires https://github.com/NixOS/nixpkgs/pull/370017 to land on the unstable channels.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

cc @libewa
