### PR TITLE
sbt: allow irregular plugins to be configured

### DIFF
--- a/modules/programs/sbt.nix
+++ b/modules/programs/sbt.nix
@@ -130,6 +130,20 @@ in {
       '';
     };
 
+    pluginsExtra = mkOption {
+      type = types.listOf (types.str);
+      default = [ ];
+      example = literalExpression ''
+        [
+          "addDependencyTreePlugin"
+        ]
+      '';
+      description = ''
+        A list of extra commands to put in plugins conf file.
+        Use it in last resort when you can't use the `plugins` option.
+      '';
+    };
+
     credentials = mkOption {
       type = types.listOf (sbtTypes.credential);
       default = [ ];
@@ -183,9 +197,10 @@ in {
   config = mkIf cfg.enable (mkMerge [
     { home.packages = [ cfg.package ]; }
 
-    (mkIf (cfg.plugins != [ ]) {
+    (mkIf (cfg.plugins != [ ] || cfg.pluginsExtra != [ ]) {
       home.file."${cfg.baseUserConfigPath}/1.0/plugins/plugins.sbt".text =
-        concatStrings (map renderPlugin cfg.plugins);
+        concatStrings (map renderPlugin cfg.plugins)
+        + concatStringsSep "\n" cfg.pluginsExtra + "\n";
     })
 
     (mkIf (cfg.credentials != [ ]) {

--- a/tests/modules/programs/sbt/plugins.nix
+++ b/tests/modules/programs/sbt/plugins.nix
@@ -15,12 +15,14 @@ let
   };
 
   plugins = [ dependencyGraph projectGraph ];
+  pluginsExtra = [ "addDependencyTreePlugin" ];
 
   pluginsSbtPath = ".sbt/1.0/plugins/plugins.sbt";
 
   expectedPluginsSbt = pkgs.writeText "plugins.sbt" ''
     addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
     addSbtPlugin("com.dwijnand" % "sbt-project-graph" % "0.4.0")
+    addDependencyTreePlugin
   '';
 
 in {
@@ -28,6 +30,7 @@ in {
     programs.sbt = {
       enable = true;
       plugins = plugins;
+      pluginsExtra = pluginsExtra;
       package = pkgs.writeScriptBin "sbt" "";
     };
 


### PR DESCRIPTION
Sometimes plugins doesn't follow the form

```
addSbtPlugin("${plugin.org}" % "${plugin.artifact}" % "${plugin.version}")
```

for instance

```
addDependencyTreePlugin
```

This commit allow free form plugin dependency.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
  
Got a repetitive "core dump" error so I ran the sbt tests specifically:
```
❯ nix-shell --pure tests -A list | grep sbt
sbt-credentials
sbt-deprecated-options
sbt-plugins
sbt-repositories
sbt-user-config-path

❯ nix-shell --pure tests -A run.sbt-credentials run.sbt-deprecated-options 
error: getting status of '/home/jprudent/projects/home-manager/run.sbt-deprecated-options': No such file or directory

❯ nix-shell --pure tests -A run.sbt-deprecated-options
building '/nix/store/4hxh0dr4jc0pz3ms7fjmgyr1a0zcf0ib-assertions.expected.drv'...
building '/nix/store/83xax0iba92yjni7zlf41s6jbpgjqjcl-hm_assertsassertions.actual.drv'...
building '/nix/store/8vzaczk7bnff3idqnrvclmpky9gy5ws6-home-manager-path.drv'...
created 179 symlinks in user environment
building '/nix/store/gv32j41a0kxkkzf3pl0022qllpwk3qpx-home-manager-files.drv'...
building '/nix/store/9bsxm24cvl1gqr562pq71rlh40lnm742-activation-script.drv'...
building '/nix/store/vf218axjdy6afciss3ckjxy64gy9wg3a-home-manager-generation.drv'...
building '/nix/store/p2cfi1b7x4wq5hhqd43d5cam5mdvyylw-nmt-report-sbt-deprecated-options.drv'...
sbt-deprecated-options: OK

❯ nix-shell --pure tests -A run.sbt-credentials 
building '/nix/store/q59bf07qnnx24g0pxlhvppdi519imns2-credentials.sbt.drv'...
building '/nix/store/l5qk81wc7a2ivya39g2m1a5xglmxjra8-hm_.sbt1.0credentials.sbt.drv'...
building '/nix/store/laifaxndb33yh6b9i93r0y4p94fablfs-home-manager-files.drv'...
building '/nix/store/06mi3vmxnpxry6drjg85giad8jiphfx9-home-manager-generation.drv'...
building '/nix/store/qz1wcgkma5r8zdj9k83d6myrad4xbxd0-nmt-report-sbt-credentials.drv'...
sbt-credentials: OK

❯ nix-shell --pure tests -A run.sbt-plugins
sbt-plugins: OK

❯ nix-shell --pure tests -A run.sbt-repositories
building '/nix/store/fcpzkfv1qrx7hbfglmh3sk644baf7qdm-hm_.sbtrepositories.drv'...
building '/nix/store/73kygkq2r7yd7a397lslkigy2r185849-home-manager-files.drv'...
building '/nix/store/8nj248mwv8yfl24mcvvbg4h5k92ncdpg-home-manager-generation.drv'...
building '/nix/store/1h3pk8v6bds4d9blz32kz1cj9vlg14xg-nmt-report-sbt-repositories.drv'...
sbt-repositories: OK

❯ nix-shell --pure tests -A run.sbt-user-config-path
building '/nix/store/20a761mh5b7808p6wiv6y4indrgbxs7r-hm_.configsbt1.0credentials.sbt.drv'...
building '/nix/store/mzgdzvkjjkf7ay09mrpmdzlx9gfyq6vs-hm_.configsbt1.0pluginsplugins.sbt.drv'...
building '/nix/store/sk3giaj56sfkyalr374a54sjhnj1sla0-hm_.configsbtrepositories.drv'...
building '/nix/store/jcxbyjqhwr7jz7l9n3lvd8chkz0ldpfk-home-manager-files.drv'...
building '/nix/store/ayw7rs3zfzlmvccbgnrhrn41g88rlyam-home-manager-generation.drv'...
building '/nix/store/h1bq653r420c66p6rmw9mqb2y2lfpdgj-nmt-report-sbt-user-config-path.drv'...
sbt-user-config-path: OK

```
 

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@kubukoz 
