### PR TITLE
wayland: create tray.target if xsession is not enabled

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -277,12 +277,5 @@ in {
           [ "xdg-desktop-autostart.target" ];
       };
     };
-
-    systemd.user.targets.tray = {
-      Unit = {
-        Description = "Home Manager System Tray";
-        Requires = [ "graphical-session-pre.target" ];
-      };
-    };
   };
 }

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -553,13 +553,6 @@ in {
             optional cfg.systemd.xdgAutostart "xdg-desktop-autostart.target";
         };
       };
-
-      systemd.user.targets.tray = {
-        Unit = {
-          Description = "Home Manager System Tray";
-          Requires = [ "graphical-session-pre.target" ];
-        };
-      };
     }
   ]);
 }

--- a/modules/services/window-managers/river.nix
+++ b/modules/services/window-managers/river.nix
@@ -201,12 +201,5 @@ in {
         After = [ "graphical-session-pre.target" ];
       };
     };
-
-    systemd.user.targets.tray = {
-      Unit = {
-        Description = "Home Manager System Tray";
-        Requires = [ "graphical-session-pre.target" ];
-      };
-    };
   };
 }

--- a/modules/services/window-managers/wayfire.nix
+++ b/modules/services/window-managers/wayfire.nix
@@ -189,12 +189,5 @@
         After = [ "graphical-session-pre.target" ];
       };
     };
-
-    systemd.user.targets.tray = {
-      Unit = {
-        Description = "Home Manager System Tray";
-        Requires = [ "graphical-session-pre.target" ];
-      };
-    };
   };
 }

--- a/modules/wayland.nix
+++ b/modules/wayland.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 
 {
   meta.maintainers = [ lib.maintainers.thiagokokada ];
@@ -20,5 +20,9 @@
         '';
       };
     };
+  };
+
+  config = lib.mkIf (!config.xsession.enable) {
+    systemd.user.targets.tray = config.xsession.trayTarget;
   };
 }

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -13,6 +13,20 @@ in {
     xsession = {
       enable = mkEnableOption "X Session";
 
+      trayTarget = mkOption {
+        readOnly = true;
+        internal = true;
+        visible = false;
+        description = "Common tray.target for both xsession and wayland";
+        type = types.attrs;
+        default = {
+          Unit = {
+            Description = "Home Manager System Tray";
+            Requires = [ "graphical-session-pre.target" ];
+          };
+        };
+      };
+
       scriptPath = mkOption {
         type = types.str;
         default = ".xsession";
@@ -163,12 +177,7 @@ in {
           };
         };
 
-        tray = {
-          Unit = {
-            Description = "Home Manager System Tray";
-            Requires = [ "graphical-session-pre.target" ];
-          };
-        };
+        tray = cfg.trayTarget;
       };
     };
 


### PR DESCRIPTION
### Description

As it current stands, the tray target is only created if xsession is
enabled. This causes services that depend on it to fail on wayland
sessions on configurations that do not have `services.xsession.enable =
true;` or the workaround as the following:

```nix
{config, lib, ...}: {
  systemd.user.targets.tray = lib.mkIf (!config.xsession.enable) {
    Unit = {
      Description = "Home Manager System Tray";
      Requires = [ "graphical-session-pre.target" ];
    };
  };
}
```

This PR addresses [#6329](https://github.com/nix-community/home-manager/issues/6329) and
[#2064](https://github.com/nix-community/home-manager/issues/2064),
albeit I do not think it is the greatest solution, since it allows the
targets defined by the xsession and wayland modules to be kept out of
sync.

I'd recommend defining `tray.target` independently from either one of
those modules, since virtually every graphical session that requires a
system tray would need such target.


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible. May break config of non xsession enabled
users that do not use `mkForce` for the tray target definition.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
