### PR TITLE
mu: allow option to set muhome

### DIFF
--- a/tests/modules/programs/mu/basic-configuration.nix
+++ b/tests/modules/programs/mu/basic-configuration.nix
@@ -19,6 +19,6 @@
       'if [[ ! -d "/home/hm-user/.cache/mu" || ! "$MU_SORTED_ADDRS" = "foo@example.com hm@example.com" ]]; then'
 
     assertFileContains activate \
-      'run @mu@/bin/mu init --maildir=/home/hm-user/Mail --my-address=foo@example.com --my-address=hm@example.com $VERBOSE_ARG;'
+      'run @mu@/bin/mu init --maildir=/home/hm-user/Mail --muhome "/home/hm-user/.cache/mu" --my-address=foo@example.com --my-address=hm@example.com $VERBOSE_ARG;'
   '';
 }

--- a/tests/modules/programs/mu/custom-configuration.nix
+++ b/tests/modules/programs/mu/custom-configuration.nix
@@ -1,0 +1,25 @@
+{ config, ... }: {
+  imports = [ ../../accounts/email-test-accounts.nix ];
+
+  accounts.email.accounts = {
+    "hm@example.com" = {
+      mu.enable = true;
+      aliases = [ "foo@example.com" ];
+    };
+  };
+
+  programs.mu = {
+    enable = true;
+    home = config.xdg.dataHome + "/mu";
+  };
+
+  test.stubs.mu = { name = "mu"; };
+
+  nmt.script = ''
+    assertFileContains activate \
+      'if [[ ! -d "/home/hm-user/.local/share/mu" || ! "$MU_SORTED_ADDRS" = "foo@example.com hm@example.com" ]]; then'
+
+    assertFileContains activate \
+      'run @mu@/bin/mu init --maildir=/home/hm-user/Mail --muhome "/home/hm-user/.local/share/mu" --my-address=foo@example.com --my-address=hm@example.com $VERBOSE_ARG;'
+  '';
+}

--- a/tests/modules/programs/mu/default.nix
+++ b/tests/modules/programs/mu/default.nix
@@ -1,1 +1,4 @@
-{ mu-basic-configuration = ./basic-configuration.nix; }
+{
+  mu-basic-configuration = ./basic-configuration.nix;
+  mu-custom-configuration = ./custom-configuration.nix;
+}


### PR DESCRIPTION
### Description
Supersedes and closes #5535
Allows for the database path for mu to be configured. Useful for keeping the maildir and mu xapian cache together without having to modify XDG_CACHE_HOME. Add test to check for custom home setting.
Fixes #5534

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@Karljo
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
