### PR TITLE
nixpkgs: lib.isFunction replaces builtins.isFunction in check for ove…

### DIFF
--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -36,7 +36,7 @@ let
   overlayType = mkOptionType {
     name = "nixpkgs-overlay";
     description = "nixpkgs overlay";
-    check = builtins.isFunction;
+    check = lib.isFunction;
     merge = lib.mergeOneOption;
   };
 


### PR DESCRIPTION
### Description
The nixpkgs overlayType uses lib.isFunction so functions that are made/set with setFunctionArgs can be seen as functions.
Homemanager had an identical type that used builtins.isFunction instead which causes these functions to not be loaded and instead you get an unhelpful module error
### Checklist

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```