### PR TITLE
nh: fix conditional for warning (when osConfig is null) and remove potential null variable config.nix.package

### DIFF
--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -74,8 +74,7 @@ in {
         Service = {
           Type = "oneshot";
           ExecStart =
-            "exec ${lib.getExe cfg.package} clean user ${cfg.clean.extraArgs}";
-          Environment = "PATH=$PATH:${config.nix.package}";
+            "${lib.getExe cfg.package} clean user ${cfg.clean.extraArgs}";
         };
       };
 

--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -52,8 +52,8 @@ in {
   };
 
   config = {
-    warnings = lib.optionals (!(cfg.clean.enable -> !osConfig.nix.gc.automatic))
-      [
+    warnings = lib.optionals
+      (osConfig != null && !(cfg.clean.enable -> !osConfig.nix.gc.automatic)) [
         "programs.nh.clean.enable and nix.gc.automatic (system-wide in configuration.nix) are both enabled. Please use one or the other to avoid conflict."
       ];
 


### PR DESCRIPTION
### Description

`nh.clean.enable = true;` on my home-manager standalone installation gave me two evaluation errors.

First because osConfig is `null` which breaks the warning (for when GC is enabled both in nh and in NixOS configuration).

Then because `config.nix.package` can't be added to the nh-clean systemd service if evaluates to `null` (which is the default value).

After testing I found that nix doesn't need to be on path for nh to run so I removed the addition to path. 

I actually found a few problems with the systemd service. 

* `exec` is not found when I run it (bash built-in)
* I don't think `$PATH` would evaluate in a unit file like this

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee 