### PR TITLE
himalaya: make generated config compatible with himalaya 1.0

### DIFF
--- a/modules/programs/himalaya.nix
+++ b/modules/programs/himalaya.nix
@@ -52,31 +52,36 @@ let
         };
 
       imapConfig = lib.optionalAttrs imapEnabled (compactAttrs {
-        backend = "imap";
-        imap.host = account.imap.host;
-        imap.port = account.imap.port;
-        imap.encryption = mkEncryptionConfig account.imap.tls;
-        imap.login = account.userName;
-        imap.passwd.cmd = builtins.concatStringsSep " " account.passwordCommand;
+        backend.type = "imap";
+        backend.host = account.imap.host;
+        backend.port = account.imap.port;
+        backend.encryption.type = mkEncryptionConfig account.imap.tls;
+        backend.login = account.userName;
+        backend.auth.type = "password";
+        backend.auth.cmd =
+          builtins.concatStringsSep " " account.passwordCommand;
       });
 
       maildirConfig = lib.optionalAttrs maildirEnabled (compactAttrs {
-        backend = "maildir";
+        backend.type = "maildir";
         maildir.root-dir = account.maildir.absPath;
       });
 
       notmuchConfig = lib.optionalAttrs notmuchEnabled (compactAttrs {
-        backend = "notmuch";
+        backend.type = "notmuch";
         notmuch.database-path = maildirBasePath;
       });
 
       smtpConfig = lib.optionalAttrs (!isNull account.smtp) (compactAttrs {
-        message.send.backend = "smtp";
-        smtp.host = account.smtp.host;
-        smtp.port = account.smtp.port;
-        smtp.encryption = mkEncryptionConfig account.smtp.tls;
-        smtp.login = account.userName;
-        smtp.passwd.cmd = builtins.concatStringsSep " " account.passwordCommand;
+        message.send.backend.type = "smtp";
+        message.send.backend.host = account.smtp.host;
+        message.send.backend.port = account.smtp.port;
+        message.send.backend.encryption.type =
+          mkEncryptionConfig account.smtp.tls;
+        message.send.backend.auth.type = "password";
+        message.send.backend.login = account.userName;
+        message.send.backend.auth.cmd =
+          builtins.concatStringsSep " " account.passwordCommand;
       });
 
       sendmailConfig =

--- a/tests/modules/programs/himalaya/basic-expected.toml
+++ b/tests/modules/programs/himalaya/basic-expected.toml
@@ -1,8 +1,18 @@
 [accounts."hm@example.com"]
-backend = "imap"
 default = true
 display-name = "H. M. Test"
 email = "hm@example.com"
+[accounts."hm@example.com".backend]
+host = "imap.example.com"
+login = "home.manager"
+port = 993
+type = "imap"
+[accounts."hm@example.com".backend.auth]
+cmd = "password-command"
+type = "password"
+
+[accounts."hm@example.com".backend.encryption]
+type = "tls"
 
 [accounts."hm@example.com".folder.alias]
 drafts = "Drafts"
@@ -10,23 +20,14 @@ inbox = "Inbox"
 sent = "Sent"
 trash = "Trash"
 
-[accounts."hm@example.com".imap]
-encryption = "tls"
-host = "imap.example.com"
-login = "home.manager"
-port = 993
-
-[accounts."hm@example.com".imap.passwd]
-cmd = "password-command"
-
-[accounts."hm@example.com".message.send]
-backend = "smtp"
-
-[accounts."hm@example.com".smtp]
-encryption = "tls"
+[accounts."hm@example.com".message.send.backend]
 host = "smtp.example.com"
 login = "home.manager"
 port = 465
-
-[accounts."hm@example.com".smtp.passwd]
+type = "smtp"
+[accounts."hm@example.com".message.send.backend.auth]
 cmd = "password-command"
+type = "password"
+
+[accounts."hm@example.com".message.send.backend.encryption]
+type = "tls"


### PR DESCRIPTION
### Description

This change will allow the generated config to work with Himalaya 1.0

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.



#### Maintainer CC

@soywod 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
