### PR TITLE
linux-wallpaperengine: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -640,4 +640,10 @@
     github = "ALameLlama";
     githubId = 55490546;
   };
+  ckgxrg = {
+    name = "ckgxrg";
+    email = "ckgxrg@ckgxrg.io";
+    github = "ckgxrg-salt";
+    githubId = 165614491;
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1997,6 +1997,17 @@ in {
           See https://github.com/nikitabobko/AeroSpace for more.
         '';
       }
+
+      {
+        time = "2025-01-30T09:18:55+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'services.linux-wallpaperengine'.
+
+          Reproduce the background functionality of Wallpaper Engine on Linux
+          systems.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -332,6 +332,7 @@ let
     ./services/keybase.nix
     ./services/keynav.nix
     ./services/lieer.nix
+    ./services/linux-wallpaperengine.nix
     ./services/listenbrainz-mpd.nix
     ./services/lorri.nix
     ./services/mako.nix

--- a/modules/services/linux-wallpaperengine.nix
+++ b/modules/services/linux-wallpaperengine.nix
@@ -1,0 +1,121 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.linux-wallpaperengine;
+
+in {
+  meta.maintainers = [ hm.maintainers.ckgxrg ];
+
+  options.services.linux-wallpaperengine = {
+    enable = mkEnableOption
+      "linux-wallpaperengine, an implementation of Wallpaper Engine functionality";
+
+    package = mkPackageOption pkgs "linux-wallpaperengine" { };
+
+    assetsPath = mkOption {
+      type = types.path;
+      description = "Path to the assets directory.";
+    };
+
+    clamping = mkOption {
+      type = types.nullOr (types.enum [ "clamp" "border" "repeat" ]);
+      default = null;
+      description = "Clamping mode for all wallpapers.";
+    };
+
+    wallpapers = mkOption {
+      type = types.listOf (types.submodule {
+        options = {
+          monitor = mkOption {
+            type = types.str;
+            description = "Which monitor to display the wallpaper.";
+          };
+
+          wallpaperId = mkOption {
+            type = types.str;
+            description = "Wallpaper ID to be used.";
+          };
+
+          extraOptions = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            description =
+              "Extra arguments to pass to the linux-wallpaperengine command for this wallpaper.";
+          };
+
+          scaling = mkOption {
+            type =
+              types.nullOr (types.enum [ "stretch" "fit" "fill" "default" ]);
+            default = null;
+            description = "Scaling mode for this wallpaper.";
+          };
+
+          fps = mkOption {
+            type = types.nullOr types.int;
+            default = null;
+            description = "Limits the FPS to a given number.";
+          };
+
+          audio = {
+            silent = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Mutes all sound of the wallpaper.";
+            };
+
+            automute = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Automute when another app is playing sound.";
+            };
+
+            processing = mkOption {
+              type = types.bool;
+              default = true;
+              description = "Enables audio processing for background.";
+            };
+          };
+        };
+      });
+      default = [ ];
+      description = "Define wallpapers.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.linux-wallpaperengine" pkgs
+        lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    systemd.user.services."linux-wallpaperengine" = let
+      args = lists.forEach cfg.wallpapers (each:
+        concatStringsSep " " (cli.toGNUCommandLine { } {
+          screen-root = each.monitor;
+          inherit (each) scaling fps;
+          silent = each.audio.silent;
+          noautomute = !each.audio.automute;
+          no-audio-processing = !each.audio.processing;
+        } ++ each.extraOptions)
+        # This has to be the last argument in each group
+        + " --bg ${each.wallpaperId}");
+    in {
+      Unit = {
+        Description = "Implementation of Wallpaper Engine on Linux";
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+      Service = {
+        ExecStart = getExe cfg.package + " --assets-dir ${cfg.assetsPath} "
+          + "--clamping ${cfg.clamping} " + (strings.concatStringsSep " " args);
+        Restart = "on-failure";
+      };
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -267,6 +267,7 @@ in import nmtSrc {
     ./modules/services/imapnotify
     ./modules/services/kanshi
     ./modules/services/lieer
+    ./modules/services/linux-wallpaperengine
     ./modules/services/mopidy
     ./modules/services/mpd
     ./modules/services/mpd-mpris

--- a/tests/modules/services/linux-wallpaperengine/basic-configuration-expected.service
+++ b/tests/modules/services/linux-wallpaperengine/basic-configuration-expected.service
@@ -1,0 +1,11 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@linux-wallpaperengine@/bin/dummy --assets-dir /some/path/to/assets --clamping border --fps 6 --scaling fit --screen-root HDMI-1 --bg 12345678 --no-audio-processing --noautomute --screen-root DP-1 --silent --scaling fill --fps 12 --bg 87654321
+Restart=on-failure
+
+[Unit]
+After=graphical-session.target
+Description=Implementation of Wallpaper Engine on Linux
+PartOf=graphical-session.target

--- a/tests/modules/services/linux-wallpaperengine/basic-configuration.nix
+++ b/tests/modules/services/linux-wallpaperengine/basic-configuration.nix
@@ -1,0 +1,35 @@
+{ config, pkgs, ... }:
+
+{
+  services.linux-wallpaperengine = {
+    enable = true;
+    assetsPath = "/some/path/to/assets";
+    clamping = "border";
+    wallpapers = [
+      {
+        monitor = "HDMI-1";
+        wallpaperId = "12345678";
+        scaling = "fit";
+        fps = 6;
+      }
+      {
+        monitor = "DP-1";
+        wallpaperId = "87654321";
+        extraOptions = [ "--scaling fill" "--fps 12" ];
+        audio = {
+          silent = true;
+          automute = false;
+          processing = false;
+        };
+      }
+    ];
+  };
+
+  test.stubs.linux-wallpaperengine = { };
+
+  nmt.script = ''
+    assertFileContent \
+        home-files/.config/systemd/user/linux-wallpaperengine.service \
+        ${./basic-configuration-expected.service}
+  '';
+}

--- a/tests/modules/services/linux-wallpaperengine/default.nix
+++ b/tests/modules/services/linux-wallpaperengine/default.nix
@@ -1,0 +1,1 @@
+{ linux-wallpaperengine-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description
Adds the `linux-wallpaperengine` systemd service.
The original project is here: https://github.com/Almamu/linux-wallpaperengine.
It simply converts options into command-line arguments and provides a systemd service to run `linux-wallpaperengine` in the background.

### Checklist
- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC