### PR TITLE
home-manager: move tests into new test flake

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,8 @@ Also make sure to read the guidelines found at
 
 - [ ] Code formatted with `./format`.
 
-- [ ] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.
+- [ ] Code tested through `nix-shell --pure tests -A run.all`
+    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.
 
 - [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
 

--- a/docs/manual/contributing/tests.md
+++ b/docs/manual/contributing/tests.md
@@ -29,10 +29,16 @@ through
 $ nix-shell --pure tests -A run.alacritty-empty-settings
 ```
 
-However, those invocations will impurely source the system's nixpkgs,
-and may cause failures. To run against the nixpkgs from the flake.lock,
+However, those invocations will impurely source the system's Nixpkgs,
+and may cause failures. To run against the Nixpkgs from the `flake.lock` file,
 use instead e.g.
 
 ``` shell
-$ nix develop --ignore-environment .#all
+$ nix build --reference-lock-file flake.lock ./tests#test-all
+```
+
+or
+
+``` shell
+$ nix build --reference-lock-file flake.lock ./tests#test-alacritty-empty-settings
 ```

--- a/docs/release-notes/rl-2505.md
+++ b/docs/release-notes/rl-2505.md
@@ -17,6 +17,11 @@ This release has the following notable changes:
   The `"suggest"` alternative will remain for a while longer but may
   also be deprecated for removal in the future.
 
+- The Home Manager test suite has been removed from the main Nix Flake
+  since it caused unnecessary evaluations and downloads. Instead the
+  tests are available through a Nix Flake file inside the `tests`
+  directory. See [](#sec-tests) for example commands.
+
 ## State Version Changes {#sec-release-25.05-state-version-changes}
 
 The state version in this release includes the changes below. These

--- a/flake.nix
+++ b/flake.nix
@@ -89,12 +89,6 @@
     } // (let
       forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
     in {
-      devShells = forAllSystems (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          tests = import ./tests { inherit pkgs; };
-        in tests.run);
-
       formatter = forAllSystems (system:
         let pkgs = nixpkgs.legacyPackages.${system};
         in pkgs.linkFarm "format" [{
@@ -105,23 +99,12 @@
       packages = forAllSystems (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          lib = pkgs.lib;
           releaseInfo = nixpkgs.lib.importJSON ./release.json;
           docs = import ./docs {
             inherit pkgs;
             inherit (releaseInfo) release isReleaseBranch;
           };
           hmPkg = pkgs.callPackage ./home-manager { path = "${./.}"; };
-
-          testPackages = let
-            tests = import ./tests { inherit pkgs; };
-            renameTestPkg = n: lib.nameValuePair "test-${n}";
-          in lib.mapAttrs' renameTestPkg tests.build;
-
-          integrationTestPackages = let
-            tests = import ./tests/integration { inherit pkgs; };
-            renameTestPkg = n: lib.nameValuePair "integration-test-${n}";
-          in lib.mapAttrs' renameTestPkg tests;
         in {
           default = hmPkg;
           home-manager = hmPkg;
@@ -129,7 +112,7 @@
           docs-html = docs.manual.html;
           docs-json = docs.options.json;
           docs-manpages = docs.manPages;
-        } // testPackages // integrationTestPackages);
+        });
 
       defaultPackage = forAllSystems (system: self.packages.${system}.default);
     });

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -1,0 +1,45 @@
+# This is an internal Nix Flake intended for use when running tests.
+#
+# You can build all tests or specific tests by running
+#
+#   nix build --reference-lock-file flake.lock ./tests#test-all
+#   nix build --reference-lock-file flake.lock ./tests#test-alacritty-empty-settings
+#
+# in the Home Manager project root directory.
+#
+# Similarly for integration tests
+#
+#   nix build --reference-lock-file flake.lock ./tests#integration-test-all
+#   nix build --reference-lock-file flake.lock ./tests#integration-test-standalone-standard-basics
+
+{
+  description = "Tests of Home Manager for Nix";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs, ... }:
+    let forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
+    in {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          tests = import ./. { inherit pkgs; };
+        in tests.run);
+
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          lib = pkgs.lib;
+
+          testPackages = let
+            tests = import ./. { inherit pkgs; };
+            renameTestPkg = n: lib.nameValuePair "test-${n}";
+          in lib.mapAttrs' renameTestPkg tests.build;
+
+          integrationTestPackages = let
+            tests = import ./integration { inherit pkgs; };
+            renameTestPkg = n: lib.nameValuePair "integration-test-${n}";
+          in lib.mapAttrs' renameTestPkg tests;
+        in testPackages // integrationTestPackages);
+    };
+}

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -25,7 +25,7 @@ with lib;
       vimout=$(mktemp)
       echo "redir >> /dev/stdout | echo g:hmExtraConfig | echo g:hmPlugins | redir END" \
         | ${pkgs.neovim}/bin/nvim -es -u "$TESTED/home-files/.config/nvim/init.lua" \
-        > "$vimout"
+        > "$vimout" || true
       assertFileContains "$vimout" "HM_EXTRA_CONFIG"
       assertFileContains "$vimout" "HM_PLUGINS_CONFIG"
     '';


### PR DESCRIPTION
### Description

Having the tests available in the main Nix Flake introduces unnecessary evaluation for non-developer users and, worse, a dependency on the nmt library.

Fixes #6354

### Checklist


- [ ] Change is backwards compatible. _It is not backwards compatible, but should only affect people that develop Home Manager._

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```