### PR TITLE
treewide: standardize shell integration options

### DIFF
--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -1,6 +1,22 @@
 { lib }:
 
-rec {
+let
+
+  mkShellIntegrationOption = name:
+    { config, baseName ? name, extraDescription ? "" }:
+    let attrName = "enable${baseName}Integration";
+    in lib.mkOption {
+      default = config.home.shell.${attrName};
+      defaultText = lib.literalMD "[](#opt-home.shell.${attrName})";
+      example = false;
+      description = "Whether to enable ${name} integration.${
+          lib.optionalString (extraDescription != "")
+          ("\n\n" + extraDescription)
+        }";
+      type = lib.types.bool;
+    };
+
+in rec {
   # Produces a Bourne shell like variable export statement.
   export = n: v: ''export ${n}="${toString v}"'';
 
@@ -8,4 +24,10 @@ rec {
   # assignment, this function produces a string containing an export
   # statement for each set entry.
   exportAll = vars: lib.concatStringsSep "\n" (lib.mapAttrsToList export vars);
+
+  mkBashIntegrationOption = mkShellIntegrationOption "Bash";
+  mkFishIntegrationOption = mkShellIntegrationOption "Fish";
+  mkIonIntegrationOption = mkShellIntegrationOption "Ion";
+  mkNushellIntegrationOption = mkShellIntegrationOption "Nushell";
+  mkZshIntegrationOption = mkShellIntegrationOption "Zsh";
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2018,6 +2018,22 @@ in {
           systems.
         '';
       }
+
+      {
+        time = "2025-02-07T22:31:45+00:00";
+        message = ''
+          All 'programs.<PROGRAM>.enable<SHELL>Integration' values now default
+          to the new 'home.shell.enable<SHELL>Integration' options, which
+          inherit from the new the 'home.shell.enableShellIntegration' option.
+
+          The following inconsistent default values change from 'false' to
+          'true':
+
+          - programs.zellij.enableBashIntegration
+          - programs.zellij.enableFishIntegration
+          - programs.zellij.enableZshIntegration
+        '';
+      }
     ];
   };
 }

--- a/modules/misc/shell.nix
+++ b/modules/misc/shell.nix
@@ -1,0 +1,43 @@
+{ config, lib, ... }:
+
+{
+  options.home.shell = {
+    enableShellIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whether to globally enable shell integration for all supported shells.
+
+        Individual shell integrations can be overridden with their respective
+        `shell.enable<SHELL>Integration` option. For example, the following
+        declaration globally disables shell integration for Bash:
+
+        ```nix
+        home.shell.enableBashIntegration = false;
+        ```
+      '';
+    };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption {
+      inherit config;
+      baseName = "Shell";
+    };
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption {
+      inherit config;
+      baseName = "Shell";
+    };
+    enableIonIntegration = lib.hm.shell.mkIonIntegrationOption {
+      inherit config;
+      baseName = "Shell";
+    };
+    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption {
+      inherit config;
+      baseName = "Shell";
+    };
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption {
+      inherit config;
+      baseName = "Shell";
+    };
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -36,6 +36,7 @@ let
     ./misc/pam.nix
     ./misc/qt.nix
     ./misc/qt/kconfig.nix
+    ./misc/shell.nix
     ./misc/specialisation.nix
     ./misc/submodule-support.nix
     ./misc/tmpfiles.nix

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -23,33 +23,26 @@ in {
       description = "The package to use for atuin.";
     };
 
-    enableBashIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable Atuin's Bash integration. This will bind
-        `ctrl-r` to open the Atuin history.
-      '';
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption {
+      inherit config;
+      extraDescription =
+        "If enabled, this will bind `ctrl-r` to open the Atuin history.";
     };
 
-    enableZshIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable Atuin's Zsh integration.
-
-        If enabled, this will bind `ctrl-r` and the up-arrow
-        key to open the Atuin history.
-      '';
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption {
+      inherit config;
+      extraDescription =
+        "If enabled, this will bind the up-arrow key to open the Atuin history.";
     };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Atuin's Fish integration.
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-        If enabled, this will bind the up-arrow key to open the Atuin history.
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption {
+      inherit config;
+      extraDescription = ''
+        If enabled, this will bind `ctrl-r` and the up-arrow key to open the
+        Atuin history.
       '';
     };
 
@@ -86,14 +79,6 @@ in {
 
         See <https://atuin.sh/docs/config/> for the full list
         of options.
-      '';
-    };
-
-    enableNushellIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Nushell integration.
       '';
     };
 

--- a/modules/programs/autojump.nix
+++ b/modules/programs/autojump.nix
@@ -13,29 +13,14 @@ in {
   options.programs.autojump = {
     enable = mkEnableOption "autojump";
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/broot.nix
+++ b/modules/programs/broot.nix
@@ -154,37 +154,17 @@ in {
   options.programs.broot = {
     enable = mkEnableOption "Broot, a better way to navigate directories";
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-    enableNushellIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Nushell integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     package = mkOption {
       type = types.package;

--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -16,21 +16,17 @@ in {
 
     package = mkPackageOption pkgs "carapace" { };
 
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-    enableNushellIntegration = mkEnableOption "Nushell integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -19,29 +19,14 @@ in {
       '';
     };
 
-    enableBashIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     settings = mkOption {
       type = with types; attrsOf str;

--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -48,44 +48,32 @@ in {
       '';
     };
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption {
+      inherit config;
+      extraDescription = ''
+        Note, enabling the direnv module will always active its functionality
+        for Fish since the direnv package automatically gets loaded in Fish.
+        If this is not the case try adding
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      readOnly = true;
-      description = ''
-        Whether to enable Fish integration. Note, enabling the direnv module
-        will always active its functionality for Fish since the direnv package
-        automatically gets loaded in Fish. If this is not the case try adding
         ```nix
-          environment.pathsToLink = [ "/share/fish" ];
+        environment.pathsToLink = [ "/share/fish" ];
         ```
+
         to the system configuration.
       '';
+    } // {
+      default = true;
+      readOnly = true;
     };
 
-    enableNushellIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Nushell integration.
-      '';
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
+
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     nix-direnv = {
       enable = mkEnableOption ''

--- a/modules/programs/eww.nix
+++ b/modules/programs/eww.nix
@@ -32,17 +32,14 @@ in {
       '';
     };
 
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -21,23 +21,20 @@ with lib;
   options.programs.eza = {
     enable = mkEnableOption "eza, a modern replacement for {command}`ls`";
 
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
+    enableIonIntegration =
+      lib.hm.shell.mkIonIntegrationOption { inherit config; };
 
-    enableIonIntegration = mkEnableOption "Ion integration" // {
-      default = true;
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-    enableNushellIntegration = mkEnableOption "Nushell integration";
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     extraOptions = mkOption {
       type = types.listOf types.str;

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -158,29 +158,14 @@ in {
       };
     };
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/ghostty.nix
+++ b/modules/programs/ghostty.nix
@@ -10,7 +10,22 @@ let
 in {
   meta.maintainers = with lib.maintainers; [ HeitorAugustoLN khaneliman ];
 
-  options.programs.ghostty = {
+  options.programs.ghostty = let
+    mkShellIntegrationOption = option:
+      option // {
+        description = ''
+          ${option.description}
+
+          This ensures that shell integration works in more scenarios, such as
+          switching shells within Ghostty. But it is not needed to have shell
+          integration.
+
+          See
+          <https://ghostty.org/docs/features/shell-integration#manual-shell-integration-setup>
+          for more information.
+        '';
+      };
+  in {
     enable = lib.mkEnableOption "Ghostty";
 
     package = lib.mkPackageOption pkgs "ghostty" {
@@ -91,29 +106,14 @@ in {
           lib.literalMD "`true` if programs.ghostty.package is not null";
       };
 
-    enableBashIntegration = lib.mkEnableOption ''
-      bash shell integration.
+    enableBashIntegration = mkShellIntegrationOption
+      (lib.hm.shell.mkBashIntegrationOption { inherit config; });
 
-      This is ensures that shell integration works in more scenarios, such as switching shells within Ghostty.
-      But it is not needed to have shell integration.
-      See <https://ghostty.org/docs/features/shell-integration#manual-shell-integration-setup> for more information
-    '';
+    enableFishIntegration = mkShellIntegrationOption
+      (lib.hm.shell.mkFishIntegrationOption { inherit config; });
 
-    enableFishIntegration = lib.mkEnableOption ''
-      fish shell integration.
-
-      This is ensures that shell integration works in more scenarios, such as switching shells within Ghostty.
-      But it is not needed to have shell integration.
-      See <https://ghostty.org/docs/features/shell-integration#manual-shell-integration-setup> for more information
-    '';
-
-    enableZshIntegration = lib.mkEnableOption ''
-      zsh shell integration.
-
-      This is ensures that shell integration works in more scenarios, such as switching shells within Ghostty.
-      But it is not needed to have shell integration.
-      See <https://ghostty.org/docs/features/shell-integration#manual-shell-integration-setup> for more information
-    '';
+    enableZshIntegration = mkShellIntegrationOption
+      (lib.hm.shell.mkZshIntegrationOption { inherit config; });
   };
 
   config = lib.mkIf cfg.enable (lib.mkMerge [

--- a/modules/programs/granted.nix
+++ b/modules/programs/granted.nix
@@ -13,13 +13,8 @@ in {
   options.programs.granted = {
     enable = mkEnableOption "granted";
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/hstr.nix
+++ b/modules/programs/hstr.nix
@@ -16,13 +16,11 @@ in {
 
     package = mkPackageOption pkgs "hstr" { };
 
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -63,37 +63,17 @@ in {
       '';
     };
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-    enableNushellIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Nushell integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     enableXsessionIntegration = mkOption {
       default = true;

--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -50,13 +50,14 @@ let
     '';
   };
 
-  shellIntegrationDefaultOpt = {
-    default =
-      !(lib.elem "disabled" (lib.splitString " " cfg.shellIntegration.mode));
-    defaultText = literalExpression ''
-      !(elem "disabled" (splitString " " config.programs.kitty.shellIntegration.mode))
-    '';
-  };
+  mkShellIntegrationOption = option:
+    option // {
+      default =
+        !(lib.elem "disabled" (lib.splitString " " cfg.shellIntegration.mode));
+      defaultText = literalExpression ''
+        !(elem "disabled" (splitString " " config.programs.kitty.shellIntegration.mode))
+      '';
+    };
 in {
   imports = [
     (lib.mkChangedOptionModule [ "programs" "kitty" "theme" ] [
@@ -184,14 +185,14 @@ in {
         '';
       };
 
-      enableBashIntegration = mkEnableOption "Kitty Bash integration"
-        // shellIntegrationDefaultOpt;
+      enableBashIntegration = mkShellIntegrationOption
+        (lib.hm.shell.mkBashIntegrationOption { inherit config; });
 
-      enableFishIntegration = mkEnableOption "Kitty fish integration"
-        // shellIntegrationDefaultOpt;
+      enableFishIntegration = mkShellIntegrationOption
+        (lib.hm.shell.mkFishIntegrationOption { inherit config; });
 
-      enableZshIntegration = mkEnableOption "Kitty Z Shell integration"
-        // shellIntegrationDefaultOpt;
+      enableZshIntegration = mkShellIntegrationOption
+        (lib.hm.shell.mkZshIntegrationOption { inherit config; });
     };
 
     extraConfig = mkOption {

--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -109,29 +109,14 @@ in {
       '';
     };
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable (mkMerge [

--- a/modules/programs/mise.nix
+++ b/modules/programs/mise.nix
@@ -30,17 +30,14 @@ in {
 
       package = mkPackageOption pkgs "mise" { };
 
-      enableBashIntegration = mkEnableOption "Bash Integration" // {
-        default = true;
-      };
+      enableBashIntegration =
+        lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-      enableZshIntegration = mkEnableOption "Zsh Integration" // {
-        default = true;
-      };
+      enableFishIntegration =
+        lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-      enableFishIntegration = mkEnableOption "Fish Integration" // {
-        default = true;
-      };
+      enableZshIntegration =
+        lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
       globalConfig = mkOption {
         type = tomlFormat.type;

--- a/modules/programs/navi.nix
+++ b/modules/programs/navi.nix
@@ -47,17 +47,14 @@ in {
       '';
     };
 
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/nix-index.nix
+++ b/modules/programs/nix-index.nix
@@ -14,17 +14,14 @@ in {
       description = "Package providing the {command}`nix-index` tool.";
     };
 
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/programs/nix-your-shell.nix
+++ b/modules/programs/nix-your-shell.nix
@@ -16,17 +16,14 @@ in {
 
     package = mkPackageOption pkgs "nix-your-shell" { };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableNushellIntegration = mkEnableOption "Nushell integration" // {
-      default = true;
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/oh-my-posh.nix
+++ b/modules/programs/oh-my-posh.nix
@@ -47,37 +47,17 @@ in {
       '';
     };
 
-    enableBashIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-    enableNushellIntegration = mkOption {
-      type = types.bool;
-      default = true;
-      description = ''
-        Whether to enable Nushell integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/opam.nix
+++ b/modules/programs/opam.nix
@@ -19,29 +19,14 @@ in {
       description = "Opam package to install.";
     };
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/pay-respects.nix
+++ b/modules/programs/pay-respects.nix
@@ -12,21 +12,17 @@ in {
 
     package = mkPackageOption pkgs "pay-respects" { };
 
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-    enableNushellIntegration = mkEnableOption "Nushell integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/pazi.nix
+++ b/modules/programs/pazi.nix
@@ -12,29 +12,14 @@ in {
   options.programs.pazi = {
     enable = mkEnableOption "pazi";
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/pyenv.nix
+++ b/modules/programs/pyenv.nix
@@ -19,29 +19,14 @@ in {
       description = "The package to use for pyenv.";
     };
 
-    enableBashIntegration = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = ''
-        Whether to enable pyenv's Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = ''
-        Whether to enable pyenv's Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = ''
-        Whether to enable pyenv's Fish integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     rootDirectory = lib.mkOption {
       type = lib.types.path;

--- a/modules/programs/rbenv.nix
+++ b/modules/programs/rbenv.nix
@@ -55,17 +55,14 @@ in {
       '';
     };
 
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/scmpuff.nix
+++ b/modules/programs/scmpuff.nix
@@ -16,29 +16,14 @@ in {
       description = "Package providing the {command}`scmpuff` tool.";
     };
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable fish integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     enableAliases = mkOption {
       default = true;

--- a/modules/programs/skim.nix
+++ b/modules/programs/skim.nix
@@ -83,29 +83,14 @@ in {
       '';
     };
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -53,25 +53,20 @@ in {
       '';
     };
 
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
+    enableIonIntegration =
+      lib.hm.shell.mkIonIntegrationOption { inherit config; };
 
-    enableIonIntegration = mkEnableOption "Ion integration" // {
-      default = true;
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-    enableNushellIntegration = mkEnableOption "Nushell integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     enableInteractive = mkOption {
       type = types.bool;

--- a/modules/programs/thefuck.nix
+++ b/modules/programs/thefuck.nix
@@ -13,33 +13,17 @@ with lib;
 
     enableInstantMode = mkEnableOption "thefuck's experimental instant mode";
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-    enableNushellIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Nushell integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = let

--- a/modules/programs/watson.nix
+++ b/modules/programs/watson.nix
@@ -26,17 +26,14 @@ in {
       description = "Package providing the {command}`watson`.";
     };
 
-    enableBashIntegration = mkEnableOption "watson's bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "watson's zsh integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "watson's fish integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     settings = mkOption {
       type = iniFormat.type;

--- a/modules/programs/wezterm.nix
+++ b/modules/programs/wezterm.nix
@@ -82,13 +82,11 @@ in {
       '';
     };
 
-    enableBashIntegration = mkEnableOption "WezTerm's Bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "WezTerm's Zsh integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -54,21 +54,17 @@ in {
       '';
     };
 
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = true;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = true;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = true;
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-    enableNushellIntegration = mkEnableOption "Nushell integration" // {
-      default = true;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     keymap = mkOption {
       type = tomlFormat.type;

--- a/modules/programs/z-lua.nix
+++ b/modules/programs/z-lua.nix
@@ -29,29 +29,14 @@ in {
       '';
     };
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
 
     enableAliases = mkOption {
       default = false;

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -41,17 +41,14 @@ in {
       '';
     };
 
-    enableBashIntegration = mkEnableOption "Bash integration" // {
-      default = false;
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkEnableOption "Zsh integration" // {
-      default = false;
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkEnableOption "Fish integration" // {
-      default = false;
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -32,37 +32,17 @@ in {
       '';
     };
 
-    enableBashIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Bash integration.
-      '';
-    };
+    enableBashIntegration =
+      lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-    enableZshIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Zsh integration.
-      '';
-    };
+    enableFishIntegration =
+      lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-    enableFishIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Fish integration.
-      '';
-    };
+    enableNushellIntegration =
+      lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-    enableNushellIntegration = mkOption {
-      default = true;
-      type = types.bool;
-      description = ''
-        Whether to enable Nushell integration.
-      '';
-    };
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
   };
 
   config = mkIf cfg.enable {

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -260,21 +260,17 @@ in {
         '';
       };
 
-      enableBashIntegration = mkEnableOption "Bash integration" // {
-        default = true;
-      };
+      enableBashIntegration =
+        lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
-      enableZshIntegration = mkEnableOption "Zsh integration" // {
-        default = true;
-      };
+      enableFishIntegration =
+        lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
-      enableFishIntegration = mkEnableOption "Fish integration" // {
-        default = true;
-      };
+      enableNushellIntegration =
+        lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
-      enableNushellIntegration = mkEnableOption "Nushell integration" // {
-        default = true;
-      };
+      enableZshIntegration =
+        lib.hm.shell.mkZshIntegrationOption { inherit config; };
     };
   };
 


### PR DESCRIPTION
### Description

```
Standardize all 'programs.<PROGRAM>.enable<SHELL>Integration' options
with the following new functions:

- lib.hm.shell.mkBashIntegrationOption
- lib.hm.shell.mkFishIntegrationOption
- lib.hm.shell.mkIonIntegrationOption
- lib.hm.shell.mkNushellIntegrationOption
- lib.hm.shell.mkZshIntegrationOption

These functions should default to their corresponding global option:

- shell.enableBashIntegration
- shell.enableFishIntegration
- shell.enableIonIntegration
- shell.enableNushellIntegration
- shell.enableZshIntegration

All these global options default to the 'shell.enableShellIntegration'
value.

This hierarchy standardizes the shell integration and increases end-user
flexibility.

BREAKING CHANGE: This modifies the following inconsistent default values
from 'false' to 'true':

- programs.zellij.enableBashIntegration
- programs.zellij.enableFishIntegration
- programs.zellij.enableZshIntegration
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC