### PR TITLE
mise: enable nushell integration

### DIFF
--- a/modules/programs/mise.nix
+++ b/modules/programs/mise.nix
@@ -21,6 +21,7 @@ in {
     "enableBashIntegration"
     "enableZshIntegration"
     "enableFishIntegration"
+    "enableNushellIntegration"
     "settings"
   ];
 
@@ -38,6 +39,9 @@ in {
 
       enableZshIntegration =
         lib.hm.shell.mkZshIntegrationOption { inherit config; };
+
+      enableNushellIntegration =
+        lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
       globalConfig = mkOption {
         type = tomlFormat.type;
@@ -103,6 +107,16 @@ in {
       fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
         ${getExe cfg.package} activate fish | source
       '';
+
+      nushell = mkIf cfg.enableNushellIntegration {
+        extraEnv = ''
+          let mise_path = $nu.default-config-dir | path join mise.nu
+          ^mise activate nu | save $mise_path --force
+        '';
+        extraConfig = ''
+          use ($nu.default-config-dir | path join mise.nu)
+        '';
+      };
     };
   };
 }

--- a/tests/modules/programs/mise/default.nix
+++ b/tests/modules/programs/mise/default.nix
@@ -4,4 +4,5 @@
   mise-bash-integration = ./bash-integration.nix;
   mise-zsh-integration = ./zsh-integration.nix;
   mise-fish-integration = ./fish-integration.nix;
+  mise-nushell-integration = ./nushell-integration.nix;
 }

--- a/tests/modules/programs/mise/nushell-integration.nix
+++ b/tests/modules/programs/mise/nushell-integration.nix
@@ -1,0 +1,21 @@
+{ config, ... }: {
+  programs = {
+    mise = {
+      package = config.lib.test.mkStubPackage { name = "mise"; };
+      enable = true;
+      enableNushellIntegration = true;
+    };
+
+    nushell.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileContains home-files/.config/nushell/env.nu \
+      '
+      let mise_path = $nu.default-config-dir | path join mise.nu
+      ^mise activate nu | save $mise_path --force
+      '
+    assertFileContains home-files/.config/nushell/config.nu \
+      'use ($nu.default-config-dir | path join mise.nu)'
+  '';
+}


### PR DESCRIPTION
### Description
Enable `nushell` [integration](https://mise.jdx.dev/installing-mise.html#nushell) for `mise`.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
