### PR TITLE
imapnotify: add `wait` option to imapnotify-accounts

### DIFF
--- a/modules/services/imapnotify-accounts.nix
+++ b/modules/services/imapnotify-accounts.nix
@@ -1,10 +1,8 @@
 { pkgs, lib, ... }:
-
-with lib;
-
-{
+let inherit (lib) mkOption types;
+in {
   options.imapnotify = {
-    enable = mkEnableOption "imapnotify";
+    enable = lib.mkEnableOption "imapnotify";
 
     onNotify = mkOption {
       type = with types; either str (attrsOf str);

--- a/modules/services/imapnotify-accounts.nix
+++ b/modules/services/imapnotify-accounts.nix
@@ -30,10 +30,16 @@ with lib;
       description = "IMAP folders to watch.";
     };
 
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "-wait 1" ];
+      description = "Extra arguments to pass to goimapnotify.";
+    };
+
     extraConfig = mkOption {
       type = let jsonFormat = pkgs.formats.json { }; in jsonFormat.type;
       default = { };
-      example = { wait = 10; };
       description = "Additional configuration to add for this account.";
     };
   };

--- a/modules/services/imapnotify.nix
+++ b/modules/services/imapnotify.nix
@@ -23,7 +23,10 @@ let
         Service = {
           # Use the nix store path for config to ensure service restarts when it changes
           ExecStart =
-            "${getExe cfg.package} -conf '${genAccountConfig account}'";
+            "${getExe cfg.package} -conf '${genAccountConfig account}'" + " ${
+               lib.optionalString (account.imapnotify.extraArgs != [ ])
+               (toString account.imapnotify.extraArgs)
+             }";
           Restart = "always";
           RestartSec = 30;
           Type = "simple";

--- a/tests/modules/services/imapnotify/imapnotify.nix
+++ b/tests/modules/services/imapnotify/imapnotify.nix
@@ -11,6 +11,7 @@
       imapnotify = {
         enable = true;
         boxes = [ "Inbox" ];
+        extraArgs = [ "--wait 1" ];
         onNotify = ''
           ${pkgs.notmuch}/bin/notmuch new
         '';

--- a/tests/modules/services/imapnotify/imapnotify.service
+++ b/tests/modules/services/imapnotify/imapnotify.service
@@ -4,7 +4,7 @@ WantedBy=default.target
 [Service]
 Environment=PATH=
 Environment=NOTMUCH_CONFIG=/home/hm-user/.config/notmuch/default/config
-ExecStart=@goimapnotify@/bin/goimapnotify -conf '/nix/store/00000000000000000000000000000000-imapnotify-hm-example.com-config.json'
+ExecStart=@goimapnotify@/bin/goimapnotify -conf '/nix/store/00000000000000000000000000000000-imapnotify-hm-example.com-config.json' --wait 1
 Restart=always
 RestartSec=30
 Type=simple


### PR DESCRIPTION
### Description

`wait` is no longer a part of the goimapnotify's config, but one of its
cli options.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@nickhu

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
