### PR TITLE
Revert "thunderbird: add native host support (#6292)"

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -136,24 +136,6 @@ let
     '') prefs)}
     ${extraPrefs}
   '';
-
-  nativeMessagingHostsPath = if isDarwin then
-    "${cfg.vendorPath}/NativeMessagingHosts"
-  else
-    "${cfg.vendorPath}/native-messaging-hosts";
-
-  nativeMessagingHostsJoined = pkgs.symlinkJoin {
-    name = "th_native-messaging-hosts";
-    paths = [
-      # Link a .keep file to keep the directory around
-      (pkgs.writeTextDir "lib/mozilla/native-messaging-hosts/.keep" "")
-      # Link package configured native messaging hosts (entire mail app actually)
-      cfg.package
-    ]
-    # Link user configured native messaging hosts
-      ++ cfg.nativeMessagingHosts;
-  };
-
 in {
   meta.maintainers = with hm.maintainers; [ d-dervishi jkarlson ];
 
@@ -175,29 +157,6 @@ in {
         default = if isDarwin then null else 2;
         description = "profile version, set null for nix-darwin";
       };
-
-      vendorPath = mkOption {
-        internal = true;
-        type = with types; nullOr str;
-        # Thunderbird doesn't look in `Application Support` on macOS for user
-        # config (in contrast to global settings that are the same for Firefox
-        # and Thunderbird):
-        # https://developer.thunderbird.net/add-ons/mailextensions/supported-webextension-api
-        default = if isDarwin then "Library/Mozilla" else ".mozilla";
-        example = ".mozilla";
-        description =
-          "Directory containing the native messaging hosts directory.";
-      };
-
-      nativeMessagingHosts = optionalAttrs (cfg.vendorPath != null) (mkOption {
-        visible = true;
-        type = types.listOf types.package;
-        default = [ ];
-        description = ''
-          Additional packages containing native messaging hosts that should be
-          made available to Thunderbird extensions.
-        '';
-      });
 
       profiles = mkOption {
         type = with types;
@@ -444,13 +403,7 @@ in {
     home.file = mkMerge ([{
       "${thunderbirdConfigPath}/profiles.ini" =
         mkIf (cfg.profiles != { }) { text = generators.toINI { } profilesIni; };
-    }] ++ optional (cfg.vendorPath != null) {
-      "${nativeMessagingHostsPath}" = {
-        source =
-          "${nativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
-        recursive = true;
-      };
-    } ++ flip mapAttrsToList cfg.profiles (name: profile: {
+    }] ++ flip mapAttrsToList cfg.profiles (name: profile: {
       "${thunderbirdProfilesPath}/${name}/chrome/userChrome.css" =
         mkIf (profile.userChrome != "") { text = profile.userChrome; };
 

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -41,9 +41,6 @@
     # Disable warning so that platforms' behavior is the same
     darwinSetupWarning = false;
 
-    # Darwin doesn't support wrapped Thunderbird, using unwrapped instead
-    package = pkgs.thunderbird-unwrapped;
-
     profiles = {
       first = {
         isDefault = true;
@@ -65,31 +62,18 @@
       };
     };
 
-    nativeMessagingHosts = with pkgs;
-      [
-        # NOTE: this is not a real Thunderbird native host module but Firefox; no
-        # native hosts are currently packaged for nixpkgs or elsewhere, so we
-        # have to improvise. Packaging wise, Firefox and Thunderbird native hosts
-        # are identical though. Good news is that the test will still pass as
-        # long as we don't attempt to run the mail client itself with the host.
-        # (Which we don't.)
-        browserpass
-      ];
-
     settings = {
       "general.useragent.override" = "";
       "privacy.donottrackheader.enabled" = true;
     };
   };
 
+  test.stubs.thunderbird = { };
+
   nmt.script = let
     isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
     configDir = if isDarwin then "Library/Thunderbird" else ".thunderbird";
     profilesDir = if isDarwin then "${configDir}/Profiles" else "${configDir}";
-    nativeHostsDir = if isDarwin then
-      "Library/Mozilla/NativeMessagingHosts"
-    else
-      ".mozilla/native-messaging-hosts";
     platform = if isDarwin then "darwin" else "linux";
   in ''
     assertFileExists home-files/${configDir}/profiles.ini
@@ -111,7 +95,5 @@
     assertFileExists home-files/${profilesDir}/first/chrome/userContent.css
     assertFileContent home-files/${profilesDir}/first/chrome/userContent.css \
       <(echo "* { color: red !important; }")
-
-    assertFileExists home-files/${nativeHostsDir}/com.github.browserpass.native.json
   '';
 }


### PR DESCRIPTION
This reverts commit 608b26d16ee69384580b1b14ac947d81d0240beb.

Forgot to test with my config before merging... looks like we have 2 modules trying to write to the same location with different options. Reverting to fix the conflict, we can re-implement it. 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
