### PR TITLE
treewide: add khaneliman maintainer 

### DIFF
--- a/modules/programs/bat.nix
+++ b/modules/programs/bat.nix
@@ -22,7 +22,7 @@ let
     in keyValuePairs + switches;
 
 in {
-  meta.maintainers = [ ];
+  meta.maintainers = with lib.maintainers; [ khaneliman ];
 
   options.programs.bat = {
     enable = mkEnableOption "bat, a cat clone with wings";

--- a/modules/programs/btop.nix
+++ b/modules/programs/btop.nix
@@ -25,7 +25,7 @@ let
   '';
 
 in {
-  meta.maintainers = [ hm.maintainers.GaetanLepage ];
+  meta.maintainers = with lib.maintainers; [ GaetanLepage khaneliman ];
 
   options.programs.btop = {
     enable = mkEnableOption "btop";

--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -19,7 +19,7 @@ in {
       "Flake support is now always enabled.")
   ];
 
-  meta.maintainers = [ lib.maintainers.rycee lib.maintainers.shikanime ];
+  meta.maintainers = with lib.maintainers; [ khaneliman rycee shikanime ];
 
   options.programs.direnv = {
     enable = mkEnableOption "direnv, the environment switcher";

--- a/modules/programs/fastfetch.nix
+++ b/modules/programs/fastfetch.nix
@@ -7,7 +7,8 @@ let
 
   jsonFormat = pkgs.formats.json { };
 in {
-  meta.maintainers = with lib.hm.maintainers; [ afresquet ];
+  meta.maintainers =
+    [ lib.hm.maintainers.afresquet lib.maintainers.khaneliman ];
 
   options.programs.fastfetch = {
     enable = mkEnableOption "Fastfetch";

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -45,6 +45,8 @@ in {
       "This option is no longer supported by fzf.")
   ];
 
+  meta.maintainers = with lib.maintainers; [ khaneliman ];
+
   options.programs.fzf = {
     enable = mkEnableOption "fzf - a command-line fuzzy finder";
 

--- a/modules/programs/ghostty.nix
+++ b/modules/programs/ghostty.nix
@@ -8,7 +8,7 @@ let
   };
   keyValue = pkgs.formats.keyValue keyValueSettings;
 in {
-  meta.maintainers = [ lib.maintainers.HeitorAugustoLN ];
+  meta.maintainers = with lib.maintainers; [ HeitorAugustoLN khaneliman ];
 
   options.programs.ghostty = {
     enable = lib.mkEnableOption "Ghostty";

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -97,7 +97,7 @@ let
   });
 
 in {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = with lib.maintainers; [ khaneliman rycee ];
 
   options = {
     programs.git = {

--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -76,6 +76,8 @@ in {
         null))
   ];
 
+  meta.maintainers = with lib.maintainers; [ khaneliman ];
+
   options.programs.kitty = {
     enable = mkEnableOption "Kitty terminal emulator";
 

--- a/modules/programs/lazygit.nix
+++ b/modules/programs/lazygit.nix
@@ -11,7 +11,7 @@ let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
 
 in {
-  meta.maintainers = [ hm.maintainers.kalhauge ];
+  meta.maintainers = [ lib.hm.maintainers.kalhauge lib.maintainers.khaneliman ];
 
   options.programs.lazygit = {
     enable = mkEnableOption "lazygit, a simple terminal UI for git commands";

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -95,6 +95,8 @@ in {
     '')
   ];
 
+  meta.maintainers = with lib.maintainers; [ khaneliman ];
+
   options = {
     programs.neovim = {
       enable = mkEnableOption "Neovim";

--- a/modules/programs/nix-index.nix
+++ b/modules/programs/nix-index.nix
@@ -1,7 +1,8 @@
 { config, lib, pkgs, ... }:
 let cfg = config.programs.nix-index;
 in {
-  meta.maintainers = with lib.hm.maintainers; [ ambroisie ];
+  meta.maintainers =
+    [ lib.hm.maintainers.ambroisie lib.maintainers.khaneliman ];
 
   options.programs.nix-index = with lib; {
     enable = mkEnableOption "nix-index, a file database for nixpkgs";

--- a/modules/programs/ripgrep.nix
+++ b/modules/programs/ripgrep.nix
@@ -6,7 +6,8 @@ let
   cfg = config.programs.ripgrep;
   configPath = "${config.xdg.configHome}/ripgrep/ripgreprc";
 in {
-  meta.maintainers = [ hm.maintainers.pedorich-n ];
+  meta.maintainers =
+    [ lib.maintainers.khaneliman lib.hm.maintainers.pedorich-n ];
 
   options = {
     programs.ripgrep = {

--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -143,7 +143,7 @@ let
       };
     };
 in {
-  meta.maintainers = with lib.maintainers; [ berbiche ];
+  meta.maintainers = with lib.maintainers; [ berbiche khaneliman ];
 
   options.programs.waybar = with lib.types; {
     enable = mkEnableOption "Waybar";

--- a/modules/programs/wezterm.nix
+++ b/modules/programs/wezterm.nix
@@ -12,7 +12,7 @@ let
   '';
 
 in {
-  meta.maintainers = [ hm.maintainers.blmhemu ];
+  meta.maintainers = [ lib.hm.maintainers.blmhemu lib.maintainers.khaneliman ];
 
   options.programs.wezterm = {
     enable = mkEnableOption "wezterm";

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -38,7 +38,7 @@ let
     }
   '';
 in {
-  meta.maintainers = with maintainers; [ xyenon eljamm ];
+  meta.maintainers = with lib.maintainers; [ eljamm khaneliman xyenon ];
 
   options.programs.yazi = {
     enable = mkEnableOption "yazi";

--- a/modules/services/cliphist.nix
+++ b/modules/services/cliphist.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 let cfg = config.services.cliphist;
 in {
-  meta.maintainers = [ lib.hm.maintainers.janik ];
+  meta.maintainers = [ lib.hm.maintainers.janik lib.maintainers.khaneliman ];
 
   imports = [
     (lib.mkRenamedOptionModule [ "services" "cliphist" "systemdTarget" ] [

--- a/modules/services/swaync.nix
+++ b/modules/services/swaync.nix
@@ -7,7 +7,8 @@ let
   jsonFormat = pkgs.formats.json { };
 
 in {
-  meta.maintainers = [ lib.hm.maintainers.abayomi185 ];
+  meta.maintainers =
+    [ lib.hm.maintainers.abayomi185 lib.maintainers.khaneliman ];
 
   options.services.swaync = {
     enable = lib.mkEnableOption "Swaync notification daemon";


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adding myself to modules I'm using and would like to maintain. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
