### PR TITLE
flake-module: fix naming

### DIFF
--- a/docs/manual/nix-flakes/flake-parts.md
+++ b/docs/manual/nix-flakes/flake-parts.md
@@ -1,7 +1,7 @@
 # flake-parts module {#sec-flakes-flake-parts-module}
 
 When using [flake-parts](https://flake.parts)
-you may wish to import home-manager's flake module,
+you may wish to import Home Manager's flake module,
 `flakeModules.home-manager`.
 
 ``` nix
@@ -37,4 +37,3 @@ modules.
 If you are only defining `homeModules` and/or `homeConfigurations` once in a
 single module, flake-parts should work fine without importing
 `flakeModules.home-manager`.
-

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -7,7 +7,7 @@ in {
         type = types.lazyAttrsOf types.raw;
         default = { };
         description = ''
-          Instantiated Home-Manager configurations.
+          Instantiated Home Manager configurations.
 
           `homeConfigurations` is for specific installations. If you want to expose
           reusable configurations, add them to `homeModules` in the form of modules, so
@@ -22,7 +22,7 @@ in {
           imports = [ v ];
         });
         description = ''
-          Home-Manager modules.
+          Home Manager modules.
 
           You may use this for reusable pieces of configuration, service modules, etc.
         '';


### PR DESCRIPTION
### Description

The naming was quite confused in #5229.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```