### PR TITLE
hyprland: use package stubs

### DIFF
--- a/tests/modules/services/window-managers/hyprland/hyprland-stubs.nix
+++ b/tests/modules/services/window-managers/hyprland/hyprland-stubs.nix
@@ -1,0 +1,18 @@
+{ config, lib, ... }: {
+  # Avoid unnecessary downloads in CI jobs and/or make out paths constant, i.e.,
+  # not containing hashes, version numbers etc.
+  test.stubs = {
+    hyprland = { };
+    xdg-desktop-portal-hyprland = { };
+    xdg-desktop-portal = { };
+    xwayland = { };
+  };
+
+  nixpkgs.overlays = [
+    (_final: _prev: {
+      dbus = config.lib.test.mkStubPackage { name = "dbus"; };
+      systemd =
+        lib.makeOverridable (_attrs: config.lib.test.mkStubPackage { }) { };
+    })
+  ];
+}

--- a/tests/modules/services/window-managers/hyprland/multiple-devices-config.nix
+++ b/tests/modules/services/window-managers/hyprland/multiple-devices-config.nix
@@ -1,10 +1,15 @@
 { config, lib, ... }:
 
 {
+  imports = [ ./hyprland-stubs.nix ];
+
   wayland.windowManager.hyprland = {
     enable = true;
     package = lib.makeOverridable
       (attrs: config.lib.test.mkStubPackage { name = "hyprland"; }) { };
+    portalPackage = lib.makeOverridable (_:
+      config.lib.test.mkStubPackage { name = "xdg-desktop-portal-hyprland"; })
+      { };
     plugins =
       [ "/path/to/plugin1" (config.lib.test.mkStubPackage { name = "foo"; }) ];
     settings = {

--- a/tests/modules/services/window-managers/hyprland/null-all-packages-config.nix
+++ b/tests/modules/services/window-managers/hyprland/null-all-packages-config.nix
@@ -1,4 +1,6 @@
 { ... }: {
+  imports = [ ./hyprland-stubs.nix ];
+
   wayland.windowManager.hyprland = {
     enable = true;
     package = null;

--- a/tests/modules/services/window-managers/hyprland/null-package-config.nix
+++ b/tests/modules/services/window-managers/hyprland/null-package-config.nix
@@ -1,7 +1,12 @@
-{ ... }: {
+{ config, lib, ... }: {
+  imports = [ ./hyprland-stubs.nix ];
+
   wayland.windowManager.hyprland = {
     enable = true;
     package = null;
+    portalPackage = lib.makeOverridable (_:
+      config.lib.test.mkStubPackage { name = "xdg-desktop-portal-hyprland"; })
+      { };
     settings = {
       cursor = {
         enable_hyprcursor = true;

--- a/tests/modules/services/window-managers/hyprland/null-portal-package-config.nix
+++ b/tests/modules/services/window-managers/hyprland/null-portal-package-config.nix
@@ -1,6 +1,11 @@
-{ ... }: {
+{ config, lib, ... }: {
+  imports = [ ./hyprland-stubs.nix ];
+
   wayland.windowManager.hyprland = {
     enable = true;
+
+    package = lib.makeOverridable
+      (_: config.lib.test.mkStubPackage { name = "hyprland"; }) { };
     portalPackage = null;
 
     settings = {

--- a/tests/modules/services/window-managers/hyprland/simple-config.nix
+++ b/tests/modules/services/window-managers/hyprland/simple-config.nix
@@ -1,10 +1,15 @@
 { config, lib, ... }:
 
 {
+  imports = [ ./hyprland-stubs.nix ];
+
   wayland.windowManager.hyprland = {
     enable = true;
     package = lib.makeOverridable
       (attrs: config.lib.test.mkStubPackage { name = "hyprland"; }) { };
+    portalPackage = lib.makeOverridable (_:
+      config.lib.test.mkStubPackage { name = "xdg-desktop-portal-hyprland"; })
+      { };
     plugins =
       [ "/path/to/plugin1" (config.lib.test.mkStubPackage { name = "foo"; }) ];
     settings = {

--- a/tests/modules/services/window-managers/hyprland/sourceFirst-false-config.nix
+++ b/tests/modules/services/window-managers/hyprland/sourceFirst-false-config.nix
@@ -1,10 +1,15 @@
 { config, lib, ... }:
 
 {
+  imports = [ ./hyprland-stubs.nix ];
+
   wayland.windowManager.hyprland = {
     enable = true;
     package = lib.makeOverridable
       (attrs: config.lib.test.mkStubPackage { name = "hyprland"; }) { };
+    portalPackage = lib.makeOverridable (_:
+      config.lib.test.mkStubPackage { name = "xdg-desktop-portal-hyprland"; })
+      { };
     settings = {
       source = [ "sourced.conf" ];
 


### PR DESCRIPTION
Reducing closure size for tests. Follow up to https://github.com/nix-community/home-manager/pull/6382#issuecomment-2625773798

1.2 GB -> 357 MB

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
