### PR TITLE
window-managers: reduce closure sizes

### DIFF
--- a/tests/modules/services/window-managers/bspwm/bspwm-stubs.nix
+++ b/tests/modules/services/window-managers/bspwm/bspwm-stubs.nix
@@ -1,0 +1,13 @@
+{ config, lib, ... }: {
+  # Avoid unnecessary downloads in CI jobs and/or make out paths constant, i.e.,
+  # not containing hashes, version numbers etc.
+  test.stubs = { bspwm = { }; };
+
+  nixpkgs.overlays = [
+    (_final: _prev: {
+      dbus = config.lib.test.mkStubPackage { name = "dbus"; };
+      systemd =
+        lib.makeOverridable (_attrs: config.lib.test.mkStubPackage { }) { };
+    })
+  ];
+}

--- a/tests/modules/services/window-managers/bspwm/configuration.nix
+++ b/tests/modules/services/window-managers/bspwm/configuration.nix
@@ -1,6 +1,8 @@
 { pkgs, ... }:
 
 {
+  imports = [ ./bspwm-stubs.nix ];
+
   xsession.windowManager.bspwm = {
     enable = true;
     monitors.focused = [ "desktop 1" "d'esk top" ]; # pathological desktop names

--- a/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-no-tags.nix
+++ b/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-no-tags.nix
@@ -1,6 +1,8 @@
 { lib, pkgs, ... }:
 
 {
+  imports = [ ./herbstluftwm-stubs.nix ];
+
   xsession.windowManager.herbstluftwm = { enable = true; };
 
   test.stubs.herbstluftwm = { };

--- a/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config.nix
+++ b/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-simple-config.nix
@@ -1,6 +1,8 @@
 { lib, pkgs, ... }:
 
 {
+  imports = [ ./herbstluftwm-stubs.nix ];
+
   xsession.windowManager.herbstluftwm = {
     enable = true;
     settings = {

--- a/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-stubs.nix
+++ b/tests/modules/services/window-managers/herbstluftwm/herbstluftwm-stubs.nix
@@ -1,0 +1,13 @@
+{ config, lib, ... }: {
+  # Avoid unnecessary downloads in CI jobs and/or make out paths constant, i.e.,
+  # not containing hashes, version numbers etc.
+  test.stubs = { herbstluftwm = { }; };
+
+  nixpkgs.overlays = [
+    (_final: _prev: {
+      dbus = config.lib.test.mkStubPackage { name = "dbus"; };
+      systemd =
+        lib.makeOverridable (_attrs: config.lib.test.mkStubPackage { }) { };
+    })
+  ];
+}

--- a/tests/modules/services/window-managers/hyprland/hyprland-stubs.nix
+++ b/tests/modules/services/window-managers/hyprland/hyprland-stubs.nix
@@ -1,0 +1,21 @@
+{ config, lib, ... }: {
+  # Avoid unnecessary downloads in CI jobs and/or make out paths constant, i.e.,
+  # not containing hashes, version numbers etc.
+  test.stubs = {
+    xdg-desktop-portal = { };
+    xwayland = { };
+  };
+
+  nixpkgs.overlays = [
+    (_final: _prev: {
+      dbus = config.lib.test.mkStubPackage { name = "dbus"; };
+      hyprland = lib.makeOverridable
+        (attrs: config.lib.test.mkStubPackage { name = "hyprland"; }) { };
+      xdg-desktop-portal-hyprland = lib.makeOverridable (_:
+        config.lib.test.mkStubPackage { name = "xdg-desktop-portal-hyprland"; })
+        { };
+      systemd =
+        lib.makeOverridable (_attrs: config.lib.test.mkStubPackage { }) { };
+    })
+  ];
+}

--- a/tests/modules/services/window-managers/hyprland/inconsistent-config.nix
+++ b/tests/modules/services/window-managers/hyprland/inconsistent-config.nix
@@ -1,10 +1,6 @@
-{ config, lib, ... }:
-
-{
+{ config, ... }: {
   wayland.windowManager.hyprland = {
     enable = true;
-    package = lib.makeOverridable
-      (attrs: config.lib.test.mkStubPackage { name = "hyprland"; }) { };
     plugins =
       [ "/path/to/plugin1" (config.lib.test.mkStubPackage { name = "foo"; }) ];
   };

--- a/tests/modules/services/window-managers/hyprland/multiple-devices-config.nix
+++ b/tests/modules/services/window-managers/hyprland/multiple-devices-config.nix
@@ -1,10 +1,8 @@
-{ config, lib, ... }:
+{ config, ... }: {
+  imports = [ ./hyprland-stubs.nix ];
 
-{
   wayland.windowManager.hyprland = {
     enable = true;
-    package = lib.makeOverridable
-      (attrs: config.lib.test.mkStubPackage { name = "hyprland"; }) { };
     plugins =
       [ "/path/to/plugin1" (config.lib.test.mkStubPackage { name = "foo"; }) ];
     settings = {

--- a/tests/modules/services/window-managers/hyprland/null-all-packages-config.nix
+++ b/tests/modules/services/window-managers/hyprland/null-all-packages-config.nix
@@ -1,4 +1,6 @@
 { ... }: {
+  imports = [ ./hyprland-stubs.nix ];
+
   wayland.windowManager.hyprland = {
     enable = true;
     package = null;

--- a/tests/modules/services/window-managers/hyprland/null-package-config.nix
+++ b/tests/modules/services/window-managers/hyprland/null-package-config.nix
@@ -1,4 +1,6 @@
-{ ... }: {
+{
+  imports = [ ./hyprland-stubs.nix ];
+
   wayland.windowManager.hyprland = {
     enable = true;
     package = null;

--- a/tests/modules/services/window-managers/hyprland/null-portal-package-config.nix
+++ b/tests/modules/services/window-managers/hyprland/null-portal-package-config.nix
@@ -1,6 +1,9 @@
-{ ... }: {
+{
+  imports = [ ./hyprland-stubs.nix ];
+
   wayland.windowManager.hyprland = {
     enable = true;
+
     portalPackage = null;
 
     settings = {

--- a/tests/modules/services/window-managers/hyprland/simple-config.nix
+++ b/tests/modules/services/window-managers/hyprland/simple-config.nix
@@ -1,10 +1,8 @@
-{ config, lib, ... }:
+{ config, ... }: {
+  imports = [ ./hyprland-stubs.nix ];
 
-{
   wayland.windowManager.hyprland = {
     enable = true;
-    package = lib.makeOverridable
-      (attrs: config.lib.test.mkStubPackage { name = "hyprland"; }) { };
     plugins =
       [ "/path/to/plugin1" (config.lib.test.mkStubPackage { name = "foo"; }) ];
     settings = {

--- a/tests/modules/services/window-managers/hyprland/sourceFirst-false-config.nix
+++ b/tests/modules/services/window-managers/hyprland/sourceFirst-false-config.nix
@@ -1,10 +1,8 @@
-{ config, lib, ... }:
-
 {
+  imports = [ ./hyprland-stubs.nix ];
+
   wayland.windowManager.hyprland = {
     enable = true;
-    package = lib.makeOverridable
-      (attrs: config.lib.test.mkStubPackage { name = "hyprland"; }) { };
     settings = {
       source = [ "sourced.conf" ];
 

--- a/tests/modules/services/window-managers/i3/i3-stubs.nix
+++ b/tests/modules/services/window-managers/i3/i3-stubs.nix
@@ -1,4 +1,4 @@
-{
+{ config, lib, ... }: {
   # Avoid unnecessary downloads in CI jobs and/or make out paths constant, i.e.,
   # not containing hashes, version numbers etc.
   test.stubs = {
@@ -16,4 +16,12 @@
 
     i3status = { };
   };
+
+  nixpkgs.overlays = [
+    (_final: _prev: {
+      dbus = config.lib.test.mkStubPackage { name = "dbus"; };
+      systemd =
+        lib.makeOverridable (_attrs: config.lib.test.mkStubPackage { }) { };
+    })
+  ];
 }

--- a/tests/modules/services/window-managers/river/configuration.nix
+++ b/tests/modules/services/window-managers/river/configuration.nix
@@ -1,6 +1,8 @@
 { ... }:
 
 {
+  imports = [ ./river-stubs.nix ];
+
   wayland.windowManager.river = {
     enable = true;
     xwayland.enable = true;

--- a/tests/modules/services/window-managers/river/river-stubs.nix
+++ b/tests/modules/services/window-managers/river/river-stubs.nix
@@ -1,0 +1,13 @@
+{ config, lib, ... }: {
+  # Avoid unnecessary downloads in CI jobs and/or make out paths constant, i.e.,
+  # not containing hashes, version numbers etc.
+  test.stubs = { river = { }; };
+
+  nixpkgs.overlays = [
+    (_final: _prev: {
+      dbus = config.lib.test.mkStubPackage { name = "dbus"; };
+      systemd =
+        lib.makeOverridable (_attrs: config.lib.test.mkStubPackage { }) { };
+    })
+  ];
+}

--- a/tests/modules/services/window-managers/spectrwm/spectrwm-simple-config.nix
+++ b/tests/modules/services/window-managers/spectrwm/spectrwm-simple-config.nix
@@ -1,6 +1,8 @@
 { ... }:
 
 {
+  imports = [ ./spectrwm-stubs.nix ];
+
   xsession.windowManager.spectrwm = {
     enable = true;
     settings = {

--- a/tests/modules/services/window-managers/spectrwm/spectrwm-stubs.nix
+++ b/tests/modules/services/window-managers/spectrwm/spectrwm-stubs.nix
@@ -1,0 +1,13 @@
+{ config, lib, ... }: {
+  # Avoid unnecessary downloads in CI jobs and/or make out paths constant, i.e.,
+  # not containing hashes, version numbers etc.
+  test.stubs = { spectrwm = { }; };
+
+  nixpkgs.overlays = [
+    (_final: _prev: {
+      dbus = config.lib.test.mkStubPackage { name = "dbus"; };
+      systemd =
+        lib.makeOverridable (_attrs: config.lib.test.mkStubPackage { }) { };
+    })
+  ];
+}

--- a/tests/modules/services/window-managers/sway/sway-stubs.nix
+++ b/tests/modules/services/window-managers/sway/sway-stubs.nix
@@ -1,4 +1,4 @@
-{
+{ config, lib, ... }: {
   # Avoid unnecessary downloads in CI jobs and/or make out paths constant, i.e.,
   # not containing hashes, version numbers etc.
   test.stubs = {
@@ -10,4 +10,13 @@
     swaybg = { };
     xwayland = { };
   };
+
+  nixpkgs.overlays = [
+    (_final: _prev: {
+      procps = config.lib.test.mkStubPackage { name = "procps"; };
+      dbus = config.lib.test.mkStubPackage { name = "dbus"; };
+      systemd =
+        lib.makeOverridable (_attrs: config.lib.test.mkStubPackage { }) { };
+    })
+  ];
 }

--- a/tests/modules/services/window-managers/wayfire/configuration.nix
+++ b/tests/modules/services/window-managers/wayfire/configuration.nix
@@ -1,4 +1,6 @@
 { ... }: {
+  imports = [ ./wayfire-stubs.nix ];
+
   wayland.windowManager.wayfire = {
     enable = true;
     package = null;

--- a/tests/modules/services/window-managers/wayfire/wayfire-stubs.nix
+++ b/tests/modules/services/window-managers/wayfire/wayfire-stubs.nix
@@ -1,0 +1,13 @@
+{ config, lib, ... }: {
+  # Avoid unnecessary downloads in CI jobs and/or make out paths constant, i.e.,
+  # not containing hashes, version numbers etc.
+  test.stubs = { wayfire = { }; };
+
+  nixpkgs.overlays = [
+    (_final: _prev: {
+      dbus = config.lib.test.mkStubPackage { name = "dbus"; };
+      systemd =
+        lib.makeOverridable (_attrs: config.lib.test.mkStubPackage { }) { };
+    })
+  ];
+}

--- a/tests/modules/services/window-managers/wayfire/wf-shell.nix
+++ b/tests/modules/services/window-managers/wayfire/wf-shell.nix
@@ -1,4 +1,6 @@
 { pkgs, ... }: {
+  imports = [ ./wayfire-stubs.nix ];
+
   wayland.windowManager.wayfire = {
     enable = true;
     package = null;


### PR DESCRIPTION
### Description

Reduces closures from 500 -> 357 MB for most of them, Hyprland is a larger one of 1.2 GB -> 357 MB.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
