### PR TITLE
gpg-agent: no-allow-external-cache option

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -218,6 +218,21 @@ in {
         '';
       };
 
+      noAllowExternalCache = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Tell Pinentry not to enable features which use an external cache for
+          passphrases.
+
+          Some desktop environments prefer to unlock all credentials with one
+          master password and may have installed a Pinentry which employs an
+          additional external cache to implement such a policy. By using this
+          option the Pinentry is advised not to make use of such a cache and
+          instead always ask the user for the requested passphrase.
+        '';
+      };
+
       extraConfig = mkOption {
         type = types.lines;
         default = "";
@@ -269,6 +284,7 @@ in {
         (optional (cfg.enableSshSupport) "enable-ssh-support"
           ++ optional cfg.grabKeyboardAndMouse "grab"
           ++ optional (!cfg.enableScDaemon) "disable-scdaemon"
+          ++ optional (cfg.noAllowExternalCache) "no-allow-external-cache"
           ++ optional (cfg.defaultCacheTtl != null)
           "default-cache-ttl ${toString cfg.defaultCacheTtl}"
           ++ optional (cfg.defaultCacheTtlSsh != null)


### PR DESCRIPTION
### Description

This is a pretty common configuration option, and one that many people
will find useful to discover, specially if they're not using a desktop
environment.

I thought I would add it. It is also useful to have for
`pass-secret-service` in the future, since you'd likely want to avoid DE
keyrings.

Signed-off-by: Christina Sørensen <ces@fem.gg>

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee
