### PR TITLE
mpv: support includes directives

### DIFF
--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -130,6 +130,19 @@ in {
         '';
       };
 
+      includes = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = literalExpression ''
+          [
+            "~/path/to/config.inc";
+            "~/path/to/conditional.inc";
+          ]
+        '';
+        description =
+          "List of configuration files to include at the end of mpv.conf.";
+      };
+
       profiles = mkOption {
         description = ''
           Sub-configuration options for specific profiles written to
@@ -207,6 +220,14 @@ in {
       home.packages = [ mpvPackage ];
       programs.mpv.finalPackage = mpvPackage;
     }
+
+    (mkIf (cfg.includes != [ ]) {
+      xdg.configFile."mpv/mpv.conf" = {
+        text = lib.mkAfter
+          (concatMapStringsSep "\n" (x: "include=${x}") cfg.includes);
+      };
+    })
+
     (mkIf (cfg.config != { } || cfg.profiles != { }) {
       xdg.configFile."mpv/mpv.conf".text = ''
         ${optionalString (cfg.defaultProfiles != [ ])

--- a/tests/modules/programs/mpv/mpv-example-settings-expected-config
+++ b/tests/modules/programs/mpv/mpv-example-settings-expected-config
@@ -11,3 +11,5 @@ vo=%5%vdpau
 alang=%2%en
 profile-desc=%26%profile for dvd:// streams
 
+
+include=manual.conf

--- a/tests/modules/programs/mpv/mpv-example-settings.nix
+++ b/tests/modules/programs/mpv/mpv-example-settings.nix
@@ -16,6 +16,8 @@
       #           script-binding uosc/video                   #! Video tracks
     '';
 
+    includes = [ "manual.conf" ];
+
     config = {
       force-window = true;
       ytdl-format = "bestvideo+bestaudio";


### PR DESCRIPTION
to allow mixing imperative and declarative config

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
