### PR TITLE
flake-module: rename `homeModules` to `homeManagerModules`

### DIFF
--- a/docs/manual/nix-flakes/flake-parts.md
+++ b/docs/manual/nix-flakes/flake-parts.md
@@ -22,7 +22,7 @@ you may wish to import Home Manager's flake module,
         inputs.home-manager.flakeModules.home-manager
       ];
       flake = {
-        # Define `homeModules`, `homeConfigurations`,
+        # Define `homeManagerModules`, `homeConfigurations`,
         # `nixosConfigurations`, etc here
       };
       # See flake.parts for more features, such as `perSystem`
@@ -30,10 +30,10 @@ you may wish to import Home Manager's flake module,
 }
 ```
 
-The flake module defines the `flake.homeModules` and `flake.homeConfigurations`
+The flake module defines the `flake.homeManagerModules` and `flake.homeConfigurations`
 options, allowing them to be properly merged if they are defined in multiple
 modules.
 
-If you are only defining `homeModules` and/or `homeConfigurations` once in a
+If you are only defining `homeManagerModules` and/or `homeConfigurations` once in a
 single module, flake-parts should work fine without importing
 `flakeModules.home-manager`.

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -14,11 +14,11 @@ in {
           that you can reference them in this or another flake's `homeConfigurations`.
         '';
       };
-      homeModules = mkOption {
+      homeManagerModules = mkOption {
         type = types.lazyAttrsOf types.unspecified;
         default = { };
         apply = mapAttrs (k: v: {
-          _file = "${toString moduleLocation}#homeModules.${k}";
+          _file = "${toString moduleLocation}#homeManagerModules.${k}";
           imports = [ v ];
         });
         description = ''


### PR DESCRIPTION
### Description

Renamed flake.homeModules to flake.homeManagerModules. It is the most common way to define home-manager modules in a nix flake.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
