### PR TITLE
git: apply sendmailCmd instead of smtpServer

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -450,7 +450,7 @@ in {
         genIdentity = name: account:
           with account;
           nameValuePair "sendemail.${name}" (if account.msmtp.enable then {
-            smtpServer = "${pkgs.msmtp}/bin/msmtp";
+            sendmailCmd = "${pkgs.msmtp}/bin/msmtp";
             envelopeSender = "auto";
             from = "${realName} <${address}>";
           } else

--- a/tests/modules/programs/git/git-with-msmtp-expected.conf
+++ b/tests/modules/programs/git/git-with-msmtp-expected.conf
@@ -8,7 +8,7 @@
 [sendemail "hm@example.com"]
 	envelopeSender = "auto"
 	from = "H. M. Test <hm@example.com>"
-	smtpServer = "@msmtp@/bin/msmtp"
+	sendmailCmd = "@msmtp@/bin/msmtp"
 
 [user]
 	email = "hm@example.com"

--- a/tests/modules/programs/git/git-with-msmtp.nix
+++ b/tests/modules/programs/git/git-with-msmtp.nix
@@ -30,7 +30,7 @@
 
     assertGitConfig "sendemail.hm@example.com.from" "H. M. Test <hm@example.com>"
     assertGitConfig "sendemail.hm-account.from" "H. M. Test Jr. <hm@example.org>"
-    assertGitConfig "sendemail.hm@example.com.smtpServer" "${pkgs.msmtp}/bin/msmtp"
+    assertGitConfig "sendemail.hm@example.com.sendmailCmd" "${pkgs.msmtp}/bin/msmtp"
     assertGitConfig "sendemail.hm@example.com.envelopeSender" "auto"
   '';
 }


### PR DESCRIPTION
### Description

In manpage of `git-send-email`,

> For backward compatibility, this option can also specify 
> full pathname of a sendmail-like program instead; the program
>  must support the -i option. This method does not support
> passing arguments or using plain command names. For those use
> cases, consider using --sendmail-cmd instead.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
