### PR TITLE
tldr-update: init

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -393,6 +393,7 @@ let
     ./services/taffybar.nix
     ./services/tahoe-lafs.nix
     ./services/taskwarrior-sync.nix
+    ./services/tldr-update.nix
     ./services/trayer.nix
     ./services/trayscale.nix
     ./services/twmn.nix

--- a/modules/programs/tealdeer.nix
+++ b/modules/programs/tealdeer.nix
@@ -80,6 +80,11 @@ in {
         See <https://tealdeer-rs.github.io/tealdeer/config.html> for more information.
       '';
     };
+
+    enableAutoUpdates = mkEnableOption "Auto updates" // {
+      default = true;
+      example = false;
+    };
   };
 
   config = mkIf cfg.enable {
@@ -89,5 +94,10 @@ in {
       mkIf (cfg.settings != null && cfg.settings != { }) {
         source = tomlFormat.generate "tealdeer-config" cfg.settings;
       };
+
+    services.tldr-update = mkIf cfg.enableAutoUpdates {
+      enable = true;
+      package = pkgs.tealdeer;
+    };
   };
 }

--- a/modules/services/tldr-update.nix
+++ b/modules/services/tldr-update.nix
@@ -1,0 +1,50 @@
+{ config, lib, pkgs, ... }:
+let cfg = config.services.tldr-update;
+in {
+  meta.maintainers = [ lib.maintainers.perchun ];
+
+  options.services.tldr-update = {
+    enable = lib.mkEnableOption ''
+      Automatic updates for the tldr CLI
+    '';
+
+    package = lib.mkPackageOption pkgs "tldr" { example = "tlrc"; };
+
+    period = lib.mkOption {
+      type = lib.types.str;
+      default = "weekly";
+      description = ''
+        Systemd timer period to create for scheduled {command}`tldr --update`.
+
+        The format is described in {manpage}`systemd.time(7)`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.user.services.tldr-update = {
+      Unit = {
+        Description = "Update tldr CLI cache";
+        Documentation = "https://tldr.sh/";
+      };
+
+      Service = {
+        Type = "oneshot";
+        ExecStart = ''
+          ${lib.getExe cfg.package} --update
+        '';
+      };
+    };
+
+    systemd.user.timers.tldr-update = {
+      Unit.Description = "Update tldr CLI cache";
+
+      Timer = {
+        OnCalendar = cfg.period;
+        Persistent = true;
+      };
+
+      Install.WantedBy = [ "timers.target" ];
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -296,6 +296,7 @@ in import nmtSrc {
     ./modules/services/swayosd
     ./modules/services/sxhkd
     ./modules/services/syncthing/linux
+    ./modules/services/tldr-update
     ./modules/services/trayer
     ./modules/services/trayscale
     ./modules/services/twmn

--- a/tests/modules/services/tldr-update/default.nix
+++ b/tests/modules/services/tldr-update/default.nix
@@ -1,0 +1,1 @@
+{ tldr-update = ./tldr-update.nix; }

--- a/tests/modules/services/tldr-update/tldr-update.nix
+++ b/tests/modules/services/tldr-update/tldr-update.nix
@@ -1,0 +1,21 @@
+{ config, ... }:
+
+{
+  config = {
+    home.stateVersion = "24.11";
+
+    services.tldr-update = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { outPath = "@tldr@"; };
+      period = "monthly";
+    };
+
+    nmt.script = ''
+      serviceFile=$(normalizeStorePaths home-files/.config/systemd/user/tldr-update.service)
+      assertFileContent "$serviceFile" ${./tldr-update.service}
+
+      timerFile=$(normalizeStorePaths home-files/.config/systemd/user/tldr-update.timer)
+      assertFileContent "$timerFile" ${./tldr-update.timer}
+    '';
+  };
+}

--- a/tests/modules/services/tldr-update/tldr-update.service
+++ b/tests/modules/services/tldr-update/tldr-update.service
@@ -1,0 +1,8 @@
+[Service]
+ExecStart=@tldr@/bin/dummy --update
+
+Type=oneshot
+
+[Unit]
+Description=Update tldr CLI cache
+Documentation=https://tldr.sh/

--- a/tests/modules/services/tldr-update/tldr-update.timer
+++ b/tests/modules/services/tldr-update/tldr-update.timer
@@ -1,0 +1,9 @@
+[Install]
+WantedBy=timers.target
+
+[Timer]
+OnCalendar=monthly
+Persistent=true
+
+[Unit]
+Description=Update tldr CLI cache


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a simple systemd timer to automatically run `tldr --update`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

CC @pedorich-n (maintainer of tealdeer module)