### PR TITLE
profileDirectory: allow using xdg dir

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -530,7 +530,7 @@ in
       if config.submoduleSupport.enable
         && config.submoduleSupport.externalPackageInstall
       then "/etc/profiles/per-user/${cfg.username}"
-      else if config.nix.enable && (config.nix.settings.use-xdg-base-directories or false)
+      else if config.nix.enable || (config.nix.settings.use-xdg-base-directories or false)
       then "${config.xdg.stateHome}/nix/profile"
       else cfg.homeDirectory + "/.nix-profile";
 


### PR DESCRIPTION
### Description

`nix.enable` doesn't have to be a precondition to using xdg dirs for `profileDirectory`.
Remove that assumption to enable using xdg dirs for `profileDirectory`, even when nix is not managed through home-manager. 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible

- [x] Code formatted with `./format`.

- [] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

Fixes: #5805