### PR TITLE
docs: reduce dependencies on user's configuration

### DIFF
--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -33,15 +33,18 @@ let
       modulesPath = builtins.toString ../modules;
     }
     // cfg.extraSpecialArgs;
+
     modules = [
       (
         { name, ... }:
         {
-          imports = import ../modules/modules.nix {
-            inherit pkgs;
-            lib = extendedLib;
-            useNixpkgsModule = !cfg.useGlobalPkgs;
-          };
+          imports =
+            import ../modules/modules.nix {
+              inherit pkgs;
+              lib = extendedLib;
+              useNixpkgsModule = !cfg.useGlobalPkgs;
+            }
+            ++ cfg.sharedModules;
 
           config = {
             submoduleSupport.enable = true;
@@ -63,8 +66,7 @@ let
           };
         }
       )
-    ]
-    ++ cfg.sharedModules;
+    ];
   };
 
 in


### PR DESCRIPTION
### Description

This fixes a few modules such that their documentation no longer depends on `config`. To reduce the risk of similar problems in the future this PR also introduces a "poison module" when building documentation. The poison module will abort the documentation build if a reference is made to any attribute inside `config` other than `_module`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```