### PR TITLE
firefox: correct vendorPath of firefox forks

### DIFF
--- a/modules/programs/floorp.nix
+++ b/modules/programs/floorp.nix
@@ -21,9 +21,12 @@ in {
 
       platforms.linux = {
         configPath = ".floorp";
-        vendorPath = ".floorp";
+        vendorPath = ".mozilla";
       };
-      platforms.darwin = { configPath = "Library/Application Support/Floorp"; };
+      platforms.darwin = {
+        configPath = "Library/Application Support/Floorp";
+        vendorPash = "Library/Application Support/Mozilla";
+      };
     })
   ];
 }

--- a/modules/programs/floorp.nix
+++ b/modules/programs/floorp.nix
@@ -25,7 +25,7 @@ in {
       };
       platforms.darwin = {
         configPath = "Library/Application Support/Floorp";
-        vendorPash = "Library/Application Support/Mozilla";
+        vendorPath = "Library/Application Support/Mozilla";
       };
     })
   ];

--- a/modules/programs/librewolf.nix
+++ b/modules/programs/librewolf.nix
@@ -30,12 +30,12 @@ in {
       unwrappedPackageName = "librewolf-unwrapped";
 
       platforms.linux = {
-        vendorPath = ".librewolf";
         configPath = ".librewolf";
+        vendorPath = ".mozilla";
       };
       platforms.darwin = {
-        vendorPath = "Library/Application Support/LibreWolf";
         configPath = "Library/Application Support/LibreWolf";
+        vendorPash = "Library/Application Support/Mozilla";
       };
 
       enableBookmarks = false;

--- a/modules/programs/librewolf.nix
+++ b/modules/programs/librewolf.nix
@@ -35,7 +35,7 @@ in {
       };
       platforms.darwin = {
         configPath = "Library/Application Support/LibreWolf";
-        vendorPash = "Library/Application Support/Mozilla";
+        vendorPath = "Library/Application Support/Mozilla";
       };
 
       enableBookmarks = false;


### PR DESCRIPTION
### Description

The path for messaging hosts seems to have been
~/.mozilla/native-messaging-hosts/ all along.
This PR fixes that
Solves #5190


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@bricked

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
