### PR TITLE
misc/specialisation: escape specialisation name

### DIFF
--- a/modules/misc/specialisation.nix
+++ b/modules/misc/specialisation.nix
@@ -71,10 +71,16 @@ with lib;
   };
 
   config = mkIf (config.specialisation != { }) {
+    assertions = map (n: {
+      assertion = !lib.hasInfix "/" n;
+      message =
+        "<name> in specialisation.<name> cannot contain a forward slash.";
+    }) (attrNames config.specialisation);
+
     home.extraBuilderCommands = let
       link = n: v:
         let pkg = v.configuration.home.activationPackage;
-        in "ln -s ${pkg} $out/specialisation/${n}";
+        in "ln -s ${pkg} $out/specialisation/${escapeShellArg n}";
     in ''
       mkdir $out/specialisation
       ${concatStringsSep "\n" (mapAttrsToList link config.specialisation)}


### PR DESCRIPTION
The specialisation name is included in home.extraBuilderCommands without being properly escaped and checked. This commit fixes that.

### Description

The specialisation name is currently not escaped when included in the command to create the symlink in home.extraBuilderCommands. This PR properly escapes it and adds an assertion to ensure it does not contain a forward slash.

This PR, for example, prevents people from running commands through the specialisation name:
```nix
home-manager.users.tobor.specialisation."test && echo 'test' > $out/test.txt".configuration = { };
```
After rebuilding, the test.txt file is present in the built derivation:
```bash
❯ cat .local/state/home-manager/gcroots/current-home/test.txt
test
```

Note: specialisation.nix was probably implemented by copying how it works in nixpkgs, which currently has the same problem. I will probably submit a PR in nixpkgs later too.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
