### PR TITLE
Backport #6253 and #6332

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -414,6 +414,7 @@ let
     ./systemd.nix
     ./targets/darwin
     ./targets/generic-linux.nix
+    ./wayland.nix
     ./xresources.nix
     ./xsession.nix
     ./misc/nix.nix

--- a/modules/services/avizo.nix
+++ b/modules/services/avizo.nix
@@ -57,8 +57,8 @@ in {
       services.avizo = {
         Unit = {
           Description = "Volume/backlight OSD indicator";
-          PartOf = [ "graphical-session.target" ];
-          After = [ "graphical-session.target" ];
+          PartOf = [ config.wayland.systemd.target ];
+          After = [ config.wayland.systemd.target ];
           ConditionEnvironment = "WAYLAND_DISPLAY";
           Documentation = "man:avizo(1)";
         };
@@ -69,7 +69,7 @@ in {
           Restart = "always";
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = { WantedBy = [ config.wayland.systemd.target ]; };
       };
     };
   };

--- a/modules/services/clipman.nix
+++ b/modules/services/clipman.nix
@@ -11,7 +11,8 @@ in {
 
     systemdTarget = mkOption {
       type = types.str;
-      default = "graphical-session.target";
+      default = config.wayland.systemd.target;
+      defaultText = literalExpression "config.wayland.systemd.target";
       example = "sway-session.target";
       description = ''
         The systemd target that will automatically start the clipman service.
@@ -34,8 +35,9 @@ in {
     systemd.user.services.clipman = {
       Unit = {
         Description = "Clipboard management daemon";
-        PartOf = [ "graphical-session.target" ];
-        After = [ "graphical-session.target" ];
+        PartOf = [ cfg.systemdTarget ];
+        After = [ cfg.systemdTarget ];
+        ConditionEnvironment = "WAYLAND_DISPLAY";
       };
 
       Service = {

--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -180,8 +180,8 @@ in {
       systemd.user.services.dunst = {
         Unit = {
           Description = "Dunst notification daemon";
-          After = [ "graphical-session-pre.target" ];
-          PartOf = [ "graphical-session.target" ];
+          After = [ config.wayland.systemd.target ];
+          PartOf = [ config.wayland.systemd.target ];
         };
 
         Service = {

--- a/modules/services/fnott.nix
+++ b/modules/services/fnott.nix
@@ -88,8 +88,9 @@ in {
       Unit = {
         Description = "Fnott notification daemon";
         Documentation = "man:fnott(1)";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        After = [ config.wayland.systemd.target ];
+        PartOf = [ config.wayland.systemd.target ];
+        ConditionEnvironment = "WAYLAND_DISPLAY";
       };
 
       Service = {

--- a/modules/services/hypridle.nix
+++ b/modules/services/hypridle.nix
@@ -74,13 +74,13 @@ in {
     };
 
     systemd.user.services.hypridle = {
-      Install = { WantedBy = [ "graphical-session.target" ]; };
+      Install = { WantedBy = [ config.wayland.systemd.target ]; };
 
       Unit = {
         ConditionEnvironment = "WAYLAND_DISPLAY";
         Description = "hypridle";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        After = [ config.wayland.systemd.target ];
+        PartOf = [ config.wayland.systemd.target ];
         X-Restart-Triggers = mkIf (cfg.settings != { })
           [ "${config.xdg.configFile."hypr/hypridle.conf".source}" ];
       };

--- a/modules/services/hyprpaper.nix
+++ b/modules/services/hyprpaper.nix
@@ -68,13 +68,13 @@ in {
     };
 
     systemd.user.services.hyprpaper = {
-      Install = { WantedBy = [ "graphical-session.target" ]; };
+      Install = { WantedBy = [ config.wayland.systemd.target ]; };
 
       Unit = {
         ConditionEnvironment = "WAYLAND_DISPLAY";
         Description = "hyprpaper";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        After = [ config.wayland.systemd.target ];
+        PartOf = [ config.wayland.systemd.target ];
         X-Restart-Triggers = mkIf (cfg.settings != { })
           [ "${config.xdg.configFile."hypr/hyprpaper.conf".source}" ];
       };

--- a/modules/services/kanshi.nix
+++ b/modules/services/kanshi.nix
@@ -288,7 +288,8 @@ in {
 
     systemdTarget = mkOption {
       type = types.str;
-      default = "sway-session.target";
+      default = config.wayland.systemd.target;
+      defaultText = literalExpression "config.wayland.systemd.target";
       description = ''
         Systemd target to bind to.
       '';
@@ -342,6 +343,7 @@ in {
         Unit = {
           Description = "Dynamic output configuration";
           Documentation = "man:kanshi(1)";
+          ConditionEnvironment = "WAYLAND_DISPLAY";
           PartOf = cfg.systemdTarget;
           Requires = cfg.systemdTarget;
           After = cfg.systemdTarget;

--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -88,7 +88,8 @@ in {
 
     systemdTarget = mkOption {
       type = types.str;
-      default = "graphical-session.target";
+      default = config.wayland.systemd.target;
+      defaultText = literalExpression "config.wayland.systemd.target";
       example = "sway-session.target";
       description = ''
         Systemd target to bind to.
@@ -107,7 +108,8 @@ in {
         Description = "Idle manager for Wayland";
         Documentation = "man:swayidle(1)";
         ConditionEnvironment = "WAYLAND_DISPLAY";
-        PartOf = [ "graphical-session.target" ];
+        PartOf = [ cfg.systemdTarget ];
+        After = [ cfg.systemdTarget ];
       };
 
       Service = {

--- a/modules/services/swaync.nix
+++ b/modules/services/swaync.nix
@@ -95,8 +95,8 @@ in {
       Unit = {
         Description = "Swaync notification daemon";
         Documentation = "https://github.com/ErikReider/SwayNotificationCenter";
-        PartOf = [ "graphical-session.target" ];
-        After = [ "graphical-session-pre.target" ];
+        PartOf = [ config.wayland.systemd.target ];
+        After = [ config.wayland.systemd.target ];
         ConditionEnvironment = "WAYLAND_DISPLAY";
       };
 
@@ -107,7 +107,7 @@ in {
         Restart = "on-failure";
       };
 
-      Install.WantedBy = [ "graphical-session.target" ];
+      Install.WantedBy = [ config.wayland.systemd.target ];
     };
   };
 }

--- a/modules/services/swayosd.nix
+++ b/modules/services/swayosd.nix
@@ -56,8 +56,8 @@ in {
       services.swayosd = {
         Unit = {
           Description = "Volume/backlight OSD indicator";
-          PartOf = [ "graphical-session.target" ];
-          After = [ "graphical-session.target" ];
+          PartOf = [ config.wayland.systemd.target ];
+          After = [ config.wayland.systemd.target ];
           ConditionEnvironment = "WAYLAND_DISPLAY";
           Documentation = "man:swayosd(1)";
           StartLimitBurst = 5;
@@ -76,7 +76,7 @@ in {
           RestartSec = "2s";
         };
 
-        Install = { WantedBy = [ "graphical-session.target" ]; };
+        Install = { WantedBy = [ config.wayland.systemd.target ]; };
       };
     };
   };

--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -277,12 +277,5 @@ in {
           [ "xdg-desktop-autostart.target" ];
       };
     };
-
-    systemd.user.targets.tray = {
-      Unit = {
-        Description = "Home Manager System Tray";
-        Requires = [ "graphical-session-pre.target" ];
-      };
-    };
   };
 }

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -553,13 +553,6 @@ in {
             optional cfg.systemd.xdgAutostart "xdg-desktop-autostart.target";
         };
       };
-
-      systemd.user.targets.tray = {
-        Unit = {
-          Description = "Home Manager System Tray";
-          Requires = [ "graphical-session-pre.target" ];
-        };
-      };
     }
   ]);
 }

--- a/modules/services/window-managers/river.nix
+++ b/modules/services/window-managers/river.nix
@@ -201,12 +201,5 @@ in {
         After = [ "graphical-session-pre.target" ];
       };
     };
-
-    systemd.user.targets.tray = {
-      Unit = {
-        Description = "Home Manager System Tray";
-        Requires = [ "graphical-session-pre.target" ];
-      };
-    };
   };
 }

--- a/modules/services/wob.nix
+++ b/modules/services/wob.nix
@@ -50,8 +50,8 @@ in {
           Description =
             "A lightweight overlay volume/backlight/progress/anything bar for Wayland";
           Documentation = "man:wob(1)";
-          PartOf = "graphical-session.target";
-          After = "graphical-session.target";
+          PartOf = [ config.wayland.systemd.target ];
+          After = [ config.wayland.systemd.target ];
           ConditionEnvironment = "WAYLAND_DISPLAY";
         };
         Service = {
@@ -59,7 +59,7 @@ in {
           ExecStart = builtins.concatStringsSep " " ([ (getExe cfg.package) ]
             ++ optional (cfg.settings != { }) "--config ${configFile}");
         };
-        Install.WantedBy = [ "graphical-session.target" ];
+        Install.WantedBy = [ config.wayland.systemd.target ];
       };
 
       sockets.wob = {

--- a/modules/wayland.nix
+++ b/modules/wayland.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+
+{
+  meta.maintainers = [ lib.maintainers.thiagokokada ];
+
+  options = {
+    wayland = {
+      systemd.target = lib.mkOption {
+        type = lib.types.str;
+        default = "graphical-session.target";
+        example = "sway-session.target";
+        description = ''
+          The systemd target that will automatically start the graphical Wayland services.
+          This option is a generalization of individual `systemd.target` or `systemdTarget`,
+          and affect all Wayland services by default.
+
+          When setting this value to `"sway-session.target"`,
+          make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+          otherwise the service may never be started.
+        '';
+      };
+    };
+  };
+}

--- a/modules/wayland.nix
+++ b/modules/wayland.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 
 {
   meta.maintainers = [ lib.maintainers.thiagokokada ];
@@ -20,5 +20,9 @@
         '';
       };
     };
+  };
+
+  config = lib.mkIf (!config.xsession.enable) {
+    systemd.user.targets.tray = config.xsession.trayTarget;
   };
 }

--- a/modules/wayland.nix
+++ b/modules/wayland.nix
@@ -23,6 +23,6 @@
   };
 
   config = lib.mkIf (!config.xsession.enable) {
-    systemd.user.targets.tray = config.xsession.trayTarget;
+    systemd.user.targets.tray = lib.mkDefault config.xsession.trayTarget;
   };
 }

--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -13,6 +13,20 @@ in {
     xsession = {
       enable = mkEnableOption "X Session";
 
+      trayTarget = mkOption {
+        readOnly = true;
+        internal = true;
+        visible = false;
+        description = "Common tray.target for both xsession and wayland";
+        type = types.attrs;
+        default = {
+          Unit = {
+            Description = "Home Manager System Tray";
+            Requires = [ "graphical-session-pre.target" ];
+          };
+        };
+      };
+
       scriptPath = mkOption {
         type = types.str;
         default = ".xsession";
@@ -163,12 +177,7 @@ in {
           };
         };
 
-        tray = {
-          Unit = {
-            Description = "Home Manager System Tray";
-            Requires = [ "graphical-session-pre.target" ];
-          };
-        };
+        tray = cfg.trayTarget;
       };
     };
 

--- a/tests/modules/programs/waybar/deprecated-modules-option.nix
+++ b/tests/modules/programs/waybar/deprecated-modules-option.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/waybar/settings-complex.nix
+++ b/tests/modules/programs/waybar/settings-complex.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/waybar/settings-with-attrs.nix
+++ b/tests/modules/programs/waybar/settings-with-attrs.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 {
   config = {
     home.stateVersion = "21.11";

--- a/tests/modules/programs/waybar/styling.nix
+++ b/tests/modules/programs/waybar/styling.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -8,7 +8,8 @@ KillMode=mixed
 Restart=on-failure
 
 [Unit]
-After=graphical-session-pre.target
+After=sway-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
 Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
 Documentation=https://github.com/Alexays/Waybar/wiki
-PartOf=graphical-session.target
+PartOf=sway-session.target

--- a/tests/modules/services/clipman/clipman-sway-session-target.service
+++ b/tests/modules/services/clipman/clipman-sway-session-target.service
@@ -8,6 +8,7 @@ KillMode=mixed
 Restart=on-failure
 
 [Unit]
-After=graphical-session.target
+After=sway-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
 Description=Clipboard management daemon
-PartOf=graphical-session.target
+PartOf=sway-session.target

--- a/tests/modules/services/fnott/systemd-user-service-expected.service
+++ b/tests/modules/services/fnott/systemd-user-service-expected.service
@@ -4,7 +4,8 @@ ExecStart=@fnott@/bin/fnott -c /home/hm-user/.config/fnott/fnott.ini
 Type=dbus
 
 [Unit]
-After=graphical-session-pre.target
+After=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
 Description=Fnott notification daemon
 Documentation=man:fnott(1)
 PartOf=graphical-session.target

--- a/tests/modules/services/swayidle/basic-configuration.nix
+++ b/tests/modules/services/swayidle/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, ... }:
 
 {
   services.swayidle = {
@@ -50,6 +50,7 @@
         Type=simple
 
         [Unit]
+        After=graphical-session.target
         ConditionEnvironment=WAYLAND_DISPLAY
         Description=Idle manager for Wayland
         Documentation=man:swayidle(1)

--- a/tests/modules/services/swaync/swaync.nix
+++ b/tests/modules/services/swaync/swaync.nix
@@ -24,7 +24,7 @@
           Type=dbus
 
           [Unit]
-          After=graphical-session-pre.target
+          After=graphical-session.target
           ConditionEnvironment=WAYLAND_DISPLAY
           Description=Swaync notification daemon
           Documentation=https://github.com/ErikReider/SwayNotificationCenter


### PR DESCRIPTION
### Description

Backport of #6253 (standardize wayland graphical services) and #6332 (create tray.target if xsession is not enabled).

IMO this should be backported because it fixes a common activation failure, which impacted other activation steps like stylix.

The first PR was already backwards compatible, I merely removed a change for a module that isn't in stable.
The second PR wasn't initially backwards compatible, but I added `lib.mkDefault` to ensure that configurations with the workaround discussed in #2064 still work.

Feel free to reject it if you don't want this backported.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
