### PR TITLE
vscode: add windsurf directories

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -16,6 +16,7 @@ let
     "vscode-insiders" = "Code - Insiders";
     "vscodium" = "VSCodium";
     "openvscode-server" = "OpenVSCode Server";
+    "windsurf" = "Windsurf";
   }.${vscodePname};
 
   extensionDir = {
@@ -23,6 +24,7 @@ let
     "vscode-insiders" = "vscode-insiders";
     "vscodium" = "vscode-oss";
     "openvscode-server" = "openvscode-server";
+    "windsurf" = "windsurf";
   }.${vscodePname};
 
   userDir = if pkgs.stdenv.hostPlatform.isDarwin then


### PR DESCRIPTION
### Description

`windsurf` was added to `nixpkgs` recently. It is a drop-in replacement for VSCode. These directories are the defaults for config and extensions.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
