### PR TITLE
feat(bat): set it as MANPAGER

### DIFF
--- a/modules/programs/bat.nix
+++ b/modules/programs/bat.nix
@@ -136,6 +136,7 @@ in {
     })
     {
       home.packages = [ cfg.package ] ++ cfg.extraPackages;
+      home.sessionVariables = { MANPAGER = "bat -p -lman"; };
 
       xdg.configFile = lib.mkMerge ([{
         "bat/config" =

--- a/modules/programs/bat.nix
+++ b/modules/programs/bat.nix
@@ -136,7 +136,7 @@ in {
     })
     {
       home.packages = [ cfg.package ] ++ cfg.extraPackages;
-      home.sessionVariables = { MANPAGER = "bat -p -lman"; };
+      home.sessionVariables = { MANPAGER = lib.mkDefault "bat -p -lman"; };
 
       xdg.configFile = lib.mkMerge ([{
         "bat/config" =


### PR DESCRIPTION
On grounds of reason and probability (only), I claim that: this overwhelminly reflects what people who choose to enable bat expect

_Note: People who benefit from this might as well enjoy a supplementary integration with `batman`._

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
