### PR TITLE
eww: fix confDir using missing attribute "types.isNull" and add test

### DIFF
--- a/modules/programs/eww.nix
+++ b/modules/programs/eww.nix
@@ -45,8 +45,7 @@ in {
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
-    xdg.configFile."eww".source =
-      mkIf (!types.isNull cfg.configDir) cfg.configDir;
+    xdg.configFile."eww".source = mkIf (cfg.configDir != null) cfg.configDir;
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       if [[ $TERM != "dumb" ]]; then

--- a/modules/programs/eww.nix
+++ b/modules/programs/eww.nix
@@ -45,7 +45,8 @@ in {
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
-    xdg.configFile."eww".source = mkIf (cfg.configDir != null) cfg.configDir;
+    xdg =
+      mkIf (cfg.configDir != null) { configFile."eww".source = cfg.configDir; };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
       if [[ $TERM != "dumb" ]]; then

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -282,6 +282,7 @@ in import nmtSrc {
     ./modules/programs/bemenu
     ./modules/programs/boxxy
     ./modules/programs/cavalier
+    ./modules/programs/eww
     ./modules/programs/firefox/firefox.nix
     ./modules/programs/firefox/floorp.nix
     ./modules/programs/foot

--- a/tests/modules/programs/eww/basic-config.nix
+++ b/tests/modules/programs/eww/basic-config.nix
@@ -1,0 +1,15 @@
+{ ... }: {
+  config = {
+    programs.eww = {
+      enable = true;
+      configDir = ./config-dir;
+    };
+
+    nmt.script = ''
+      yuckDir=home-files/.config/eww
+
+      assertFileExists $yuckDir/eww.yuck
+      assertFileExists $yuckDir/eww.scss
+    '';
+  };
+}

--- a/tests/modules/programs/eww/config-dir/eww.scss
+++ b/tests/modules/programs/eww/config-dir/eww.scss
@@ -1,0 +1,4 @@
+.powermenu {
+  padding: 10px 10px;
+  border-radius: 10px;
+}

--- a/tests/modules/programs/eww/config-dir/eww.yuck
+++ b/tests/modules/programs/eww/config-dir/eww.yuck
@@ -1,0 +1,58 @@
+(defwindow powermenu
+    :monitor 0
+    :geometry (geometry
+        :anchor "center"
+    )
+    ; Widgets
+    (box
+        :spacing 5
+        :class "powermenu"
+        :space-evenly true
+        :orientation "vertical"
+        :halign "left"
+        :valign "center"
+
+        ; Contents
+        (button
+            :onclick "eww open confirm-command --arg action=poweroff --arg command=poweroff"
+            "Poweroff"
+        )
+        (button
+            :onclick "eww open confirm-command --arg action=reboot --arg command=reboot"
+            "Reboot"
+        )
+        (button
+            :onclick "eww close powermenu"
+            "Cancel"
+        )
+    )
+)
+
+(defwindow confirm-command [action command]
+    :monitor 0
+    :geometry (geometry
+        :anchor "center"
+        :width "13%"
+        :height "8%"
+    )
+    ; Widgets
+    (box
+        :class "powermenu"
+        :orientation "vertical"
+        :halign "center"
+        :valign "center"
+        "Are you sure you want to ${action}"
+        (box
+            :orientation "horizontal"
+            :spacing 10
+            (button
+                :onclick "eww close confirm-command"
+                "No"
+            )
+            (button
+                :onclick command
+                "Yes"
+            )
+        )
+    )
+)

--- a/tests/modules/programs/eww/default.nix
+++ b/tests/modules/programs/eww/default.nix
@@ -1,1 +1,4 @@
-{ eww-basic-config = ./basic-config.nix; }
+{
+  eww-basic-config = ./basic-config.nix;
+  eww-null-config = ./null-config.nix;
+}

--- a/tests/modules/programs/eww/default.nix
+++ b/tests/modules/programs/eww/default.nix
@@ -1,0 +1,1 @@
+{ eww-basic-config = ./basic-config.nix; }

--- a/tests/modules/programs/eww/null-config.nix
+++ b/tests/modules/programs/eww/null-config.nix
@@ -1,0 +1,11 @@
+{ ... }: {
+  config = {
+    programs.eww = { enable = true; };
+
+    nmt.script = ''
+      yuckDir=home-files/.config/eww
+
+      assertPathNotExists  $yuckDir/eww.yuck
+    '';
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
The eww module does not evaluate because of a missing attribute `types.isNull` being used for the `confDir` option config.
I have replaced `!types.isNull` with `!= null` to fix this error.
I also added a test, as tests were missing.

Issue: #6435 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@mainrs 