### PR TITLE
aerospace: fix workspace assignment config

### DIFF
--- a/modules/programs/aerospace.nix
+++ b/modules/programs/aerospace.nix
@@ -154,8 +154,9 @@ in {
               "Commands to run every time a new window is detected with optional conditions.";
           };
           workspace-to-monitor-force-assignment = mkOption {
-            type = with types; attrsOf (oneOf [ int str (listOf str) ]);
-            default = { };
+            type = with types;
+              nullOr (attrsOf (oneOf [ int str (listOf str) ]));
+            default = null;
             description = ''
               Map workspaces to specific monitors.
               Left-hand side is the workspace name, and right-hand side is the monitor pattern.

--- a/tests/modules/programs/aerospace/settings-expected.toml
+++ b/tests/modules/programs/aerospace/settings-expected.toml
@@ -25,5 +25,3 @@ alt-h = "focus left"
 alt-j = "focus down"
 alt-k = "focus up"
 alt-l = "focus right"
-
-[workspace-to-monitor-force-assignment]


### PR DESCRIPTION
### Description
with the default to `{}`, this TOML table is always set in the generated config. this change allows `null` for
`workspace-to-monitor-force-assignment` and sets the default to `null`.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
