### PR TITLE
bash: Make HISTFILESIZE and HISTSIZE nullable

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -51,7 +51,7 @@ in {
       };
 
       historySize = mkOption {
-        type = types.int;
+        type = types.nullOr types.int;
         default = 10000;
         description = "Number of history lines to keep in memory.";
       };
@@ -63,7 +63,7 @@ in {
       };
 
       historyFileSize = mkOption {
-        type = types.int;
+        type = types.nullOr types.int;
         default = 100000;
         description = "Number of history lines to keep on file.";
       };
@@ -181,16 +181,18 @@ in {
     sessionVarsStr = config.lib.shell.exportAll cfg.sessionVariables;
 
     historyControlStr = (concatStringsSep "\n"
-      (mapAttrsToList (n: v: "${n}=${v}") ({
-        HISTFILESIZE = toString cfg.historyFileSize;
-        HISTSIZE = toString cfg.historySize;
-      } // optionalAttrs (cfg.historyFile != null) {
-        HISTFILE = ''"${cfg.historyFile}"'';
-      } // optionalAttrs (cfg.historyControl != [ ]) {
-        HISTCONTROL = concatStringsSep ":" cfg.historyControl;
-      } // optionalAttrs (cfg.historyIgnore != [ ]) {
-        HISTIGNORE = escapeShellArg (concatStringsSep ":" cfg.historyIgnore);
-      }) ++ optional (cfg.historyFile != null)
+      (mapAttrsToList (n: v: "${n}=${v}")
+        (optionalAttrs (cfg.historyFileSize != null) {
+          HISTFILESIZE = toString cfg.historyFileSize;
+        } // optionalAttrs (cfg.historySize != null) {
+          HISTSIZE = toString cfg.historySize;
+        } // optionalAttrs (cfg.historyFile != null) {
+          HISTFILE = ''"${cfg.historyFile}"'';
+        } // optionalAttrs (cfg.historyControl != [ ]) {
+          HISTCONTROL = concatStringsSep ":" cfg.historyControl;
+        } // optionalAttrs (cfg.historyIgnore != [ ]) {
+          HISTIGNORE = escapeShellArg (concatStringsSep ":" cfg.historyIgnore);
+        }) ++ optional (cfg.historyFile != null)
         ''mkdir -p "$(dirname "$HISTFILE")"''));
   in mkIf cfg.enable {
     home.packages = [ cfg.package ];


### PR DESCRIPTION
I assume it's not necessary to extend the tests for this change, right?

### Description

I would like to not have HISTFILESIZE and HISTSIZE set in the generated .bashrc 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@rycee 