### PR TITLE
syncthing: use package options

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -38,13 +38,13 @@ let
           device) folder.devices;
     }) (filterAttrs (_: folder: folder.enable) cfg.settings.folders);
 
-  jq = "${pkgs.jq}/bin/jq";
-  sleep = "${pkgs.coreutils}/bin/sleep";
-  printf = "${pkgs.coreutils}/bin/printf";
-  cat = "${pkgs.coreutils}/bin/cat";
-  curl = "${pkgs.curl}/bin/curl";
-  install = "${pkgs.coreutils}/bin/install";
-  syncthing = "${pkgs.syncthing}/bin/syncthing";
+  jq = lib.getExe pkgs.jq;
+  sleep = lib.getExe' pkgs.coreutils "sleep";
+  printf = lib.getExe' pkgs.coreutils "printf";
+  cat = lib.getExe' pkgs.coreutils "cat";
+  curl = lib.getExe pkgs.curl;
+  install = lib.getExe' pkgs.coreutils "install";
+  syncthing = lib.getExe cfg.package;
 
   updateConfig = pkgs.writers.writeBash "merge-syncthing-config" (''
     set -efu
@@ -606,7 +606,7 @@ in {
 
   config = mkMerge [
     (mkIf cfg.enable {
-      home.packages = [ (getOutput "man" pkgs.syncthing) ];
+      home.packages = [ (getOutput "man" cfg.package) ];
 
       systemd.user.services = {
         syncthing = {

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -1,13 +1,13 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
+  inherit (lib) literalExpression mkOption mkEnableOption mkPackageOption types;
 
   cfg = config.services.syncthing;
+
   settingsFormat = pkgs.formats.json { };
   cleanedConfig =
-    converge (filterAttrsRecursive (_: v: v != null && v != { })) cfg.settings;
+    lib.converge (lib.filterAttrsRecursive (_: v: v != null && v != { }))
+    cfg.settings;
 
   isUnixGui = (builtins.substring 0 1 cfg.guiAddress) == "/";
 
@@ -26,17 +26,17 @@ let
     else
       "${cfg.guiAddress}${path}";
 
-  devices = mapAttrsToList (_: device: device // { deviceID = device.id; })
+  devices = lib.mapAttrsToList (_: device: device // { deviceID = device.id; })
     cfg.settings.devices;
 
-  folders = mapAttrsToList (_: folder:
+  folders = lib.mapAttrsToList (_: folder:
     folder // {
       devices = map (device:
         if builtins.isString device then {
           deviceId = cfg.settings.devices.${device}.id;
         } else
           device) folder.devices;
-    }) (filterAttrs (_: folder: folder.enable) cfg.settings.folders);
+    }) (lib.filterAttrs (_: folder: folder.enable) cfg.settings.folders);
 
   jq = lib.getExe pkgs.jq;
   sleep = lib.getExe' pkgs.coreutils "sleep";
@@ -91,7 +91,7 @@ let
     } [
       # Now for each of these attributes, write the curl commands that are
       # identical to both folders and devices.
-      (mapAttrs (conf_type: s:
+      (lib.mapAttrs (conf_type: s:
         # We iterate the `conf` list now, and run a curl -X POST command for each, that
         # should update that device/folder only.
         lib.pipe s.conf [
@@ -167,9 +167,9 @@ let
 
   syncthingArgs = defaultSyncthingArgs ++ cfg.extraOptions;
 in {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = [ lib.maintainers.rycee ];
 
-  options = with types; {
+  options = {
     services.syncthing = {
       enable = mkEnableOption ''
         Syncthing, a self-hosted open-source alternative to Dropbox and Bittorrent Sync.
@@ -177,7 +177,7 @@ in {
       '';
 
       cert = mkOption {
-        type = nullOr str;
+        type = with types; nullOr str;
         default = null;
         description = ''
           Path to the `cert.pem` file, which will be copied into Syncthing's
@@ -186,7 +186,7 @@ in {
       };
 
       key = mkOption {
-        type = nullOr str;
+        type = with types; nullOr str;
         default = null;
         description = ''
           Path to the `key.pem` file, which will be copied into Syncthing's
@@ -195,7 +195,7 @@ in {
       };
 
       passwordFile = mkOption {
-        type = nullOr path;
+        type = with types; nullOr path;
         default = null;
         description = ''
           Path to the gui password file.
@@ -203,7 +203,7 @@ in {
       };
 
       overrideDevices = mkOption {
-        type = bool;
+        type = types.bool;
         default = true;
         description = ''
           Whether to delete the devices which are not configured via the
@@ -214,7 +214,7 @@ in {
       };
 
       overrideFolders = mkOption {
-        type = bool;
+        type = types.bool;
         default = true;
         description = ''
           Whether to delete the folders which are not configured via the
@@ -225,7 +225,7 @@ in {
       };
 
       settings = mkOption {
-        type = submodule {
+        type = types.submodule {
           freeformType = settingsFormat.type;
           options = {
             # global options
@@ -234,11 +234,11 @@ in {
               description = ''
                 The options element contains all other global configuration options
               '';
-              type = submodule ({ name, ... }: {
+              type = types.submodule {
                 freeformType = settingsFormat.type;
                 options = {
                   localAnnounceEnabled = mkOption {
-                    type = nullOr bool;
+                    type = with types; nullOr bool;
                     default = null;
                     description = ''
                       Whether to send announcements to the local LAN, also use such announcements to find other devices.
@@ -246,7 +246,7 @@ in {
                   };
 
                   localAnnouncePort = mkOption {
-                    type = nullOr int;
+                    type = with types; nullOr int;
                     default = null;
                     description = ''
                       The port on which to listen and send IPv4 broadcast announcements to.
@@ -254,7 +254,7 @@ in {
                   };
 
                   relaysEnabled = mkOption {
-                    type = nullOr bool;
+                    type = with types; nullOr bool;
                     default = null;
                     description = ''
                       When true, relays will be connected to and potentially used for device to device connections.
@@ -262,7 +262,7 @@ in {
                   };
 
                   urAccepted = mkOption {
-                    type = nullOr int;
+                    type = with types; nullOr int;
                     default = null;
                     description = ''
                       Whether the user has accepted to submit anonymous usage data.
@@ -272,7 +272,7 @@ in {
                   };
 
                   limitBandwidthInLan = mkOption {
-                    type = nullOr bool;
+                    type = with types; nullOr bool;
                     default = null;
                     description = ''
                       Whether to apply bandwidth limits to devices in the same broadcast domain as the local device.
@@ -280,7 +280,7 @@ in {
                   };
 
                   maxFolderConcurrency = mkOption {
-                    type = nullOr int;
+                    type = with types; nullOr int;
                     default = null;
                     description = ''
                       This option controls how many folders may concurrently be in I/O-intensive operations such as syncing or scanning.
@@ -288,7 +288,7 @@ in {
                     '';
                   };
                 };
-              });
+              };
             };
 
             # device settings
@@ -308,12 +308,12 @@ in {
                   addresses = [ "tcp://192.168.0.10:51820" ];
                 };
               };
-              type = attrsOf (submodule ({ name, ... }: {
+              type = types.attrsOf (types.submodule ({ name, ... }: {
                 freeformType = settingsFormat.type;
                 options = {
 
                   name = mkOption {
-                    type = str;
+                    type = types.str;
                     default = name;
                     description = ''
                       The name of the device.
@@ -321,14 +321,14 @@ in {
                   };
 
                   id = mkOption {
-                    type = str;
+                    type = types.str;
                     description = ''
                       The device ID. See <https://docs.syncthing.net/dev/device-ids.html>.
                     '';
                   };
 
                   autoAcceptFolders = mkOption {
-                    type = bool;
+                    type = types.bool;
                     default = false;
                     description = ''
                       Automatically create or share folders that this device advertises at the default path.
@@ -358,12 +358,12 @@ in {
                   };
                 }
               '';
-              type = attrsOf (submodule ({ name, ... }: {
+              type = types.attrsOf (types.submodule ({ name, ... }: {
                 freeformType = settingsFormat.type;
                 options = {
 
                   enable = mkOption {
-                    type = bool;
+                    type = types.bool;
                     default = true;
                     description = ''
                       Whether to share this folder.
@@ -373,11 +373,12 @@ in {
                   };
 
                   path = mkOption {
-                    type = str // {
+                    type = types.str // {
                       check = x:
-                        str.check x
-                        && (substring 0 1 x == "/" || substring 0 2 x == "~/");
-                      description = str.description + " starting with / or ~/";
+                        types.str.check x && (lib.substring 0 1 x == "/"
+                          || lib.substring 0 2 x == "~/");
+                      description = types.str.description
+                        + " starting with / or ~/";
                     };
                     default = name;
                     description = ''
@@ -388,7 +389,7 @@ in {
                   };
 
                   id = mkOption {
-                    type = str;
+                    type = types.str;
                     default = name;
                     description = ''
                       The ID of the folder. Must be the same on all devices.
@@ -396,7 +397,7 @@ in {
                   };
 
                   label = mkOption {
-                    type = str;
+                    type = types.str;
                     default = name;
                     description = ''
                       The label of the folder.
@@ -404,7 +405,7 @@ in {
                   };
 
                   type = mkOption {
-                    type = enum [
+                    type = types.enum [
                       "sendreceive"
                       "sendonly"
                       "receiveonly"
@@ -418,7 +419,7 @@ in {
                   };
 
                   devices = mkOption {
-                    type = listOf str;
+                    type = with types; listOf str;
                     default = [ ];
                     description = ''
                       The devices this folder should be shared with. Each device must
@@ -490,7 +491,7 @@ in {
                   };
 
                   copyOwnershipFromParent = mkOption {
-                    type = bool;
+                    type = types.bool;
                     default = false;
                     description = ''
                       On Unix systems, tries to copy file/folder ownership from
@@ -541,7 +542,7 @@ in {
       };
 
       guiAddress = mkOption {
-        type = str;
+        type = types.str;
         default = "127.0.0.1:8384";
         description = ''
           The address to serve the web interface at.
@@ -561,7 +562,7 @@ in {
       };
 
       extraOptions = mkOption {
-        type = listOf str;
+        type = with types; listOf str;
         default = [ ];
         example = [ "--reset-deltas" ];
         description = ''
@@ -604,9 +605,9 @@ in {
     };
   };
 
-  config = mkMerge [
-    (mkIf cfg.enable {
-      home.packages = [ (getOutput "man" cfg.package) ];
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      home.packages = [ (lib.getOutput "man" cfg.package) ];
 
       systemd.user.services = {
         syncthing = {
@@ -618,28 +619,28 @@ in {
           };
 
           Service = {
-            ExecStartPre = mkIf (cfg.cert != null || cfg.key != null) "+${
+            ExecStartPre = lib.mkIf (cfg.cert != null || cfg.key != null) "+${
                 pkgs.writers.writeBash "syncthing-copy-keys" ''
                   syncthing_dir="''${XDG_STATE_HOME:-$HOME/.local/state}/syncthing"
                   ${install} -dm700 "$syncthing_dir"
-                  ${optionalString (cfg.cert != null) ''
+                  ${lib.optionalString (cfg.cert != null) ''
                     ${install} -Dm400 ${
                       toString cfg.cert
                     } "$syncthing_dir/cert.pem"
                   ''}
-                  ${optionalString (cfg.key != null) ''
+                  ${lib.optionalString (cfg.key != null) ''
                     ${install} -Dm400 ${
                       toString cfg.key
                     } "$syncthing_dir/key.pem"
                   ''}
                 ''
               }";
-            ExecStart = escapeShellArgs syncthingArgs;
+            ExecStart = lib.escapeShellArgs syncthingArgs;
             Restart = "on-failure";
             SuccessExitStatus = [ 3 4 ];
             RestartForceExitStatus = [ 3 4 ];
             Environment =
-              mkIf (cfg.allProxy != null) { all_proxy = cfg.allProxy; };
+              lib.mkIf (cfg.allProxy != null) { all_proxy = cfg.allProxy; };
 
             # Sandboxing.
             LockPersonality = true;
@@ -654,7 +655,7 @@ in {
           Install = { WantedBy = [ "default.target" ]; };
         };
 
-        syncthing-init = mkIf (cleanedConfig != { }) {
+        syncthing-init = lib.mkIf (cleanedConfig != { }) {
           Unit = {
             Description = "Syncthing configuration updater";
             Requires = [ "syncthing.service" ];
@@ -685,10 +686,10 @@ in {
       };
     })
 
-    (mkIf (isAttrs cfg.tray && cfg.tray.enable) {
+    (lib.mkIf (lib.isAttrs cfg.tray && cfg.tray.enable) {
       assertions = [
-        (hm.assertions.assertPlatform "services.syncthing.tray" pkgs
-          platforms.linux)
+        (lib.hm.assertions.assertPlatform "services.syncthing.tray" pkgs
+          lib.platforms.linux)
       ];
 
       systemd.user.services = {
@@ -710,10 +711,10 @@ in {
     })
 
     # deprecated
-    (mkIf (isBool cfg.tray && cfg.tray) {
+    (lib.mkIf (lib.isBool cfg.tray && cfg.tray) {
       assertions = [
-        (hm.assertions.assertPlatform "services.syncthing.tray" pkgs
-          platforms.linux)
+        (lib.hm.assertions.assertPlatform "services.syncthing.tray" pkgs
+          lib.platforms.linux)
       ];
 
       systemd.user.services = {


### PR DESCRIPTION
Currently, all references are hardcoded even though we offer package options. Update to use package options.

### Description
Closes https://github.com/nix-community/home-manager/issues/6426
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
