### PR TITLE
yubikey-agent: init service module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -424,6 +424,7 @@ let
     ./services/xscreensaver.nix
     ./services/xsettingsd.nix
     ./services/xsuspender.nix
+    ./services/yubikey-agent.nix
     ./systemd.nix
     ./targets/darwin
     ./targets/generic-linux.nix

--- a/modules/services/yubikey-agent.nix
+++ b/modules/services/yubikey-agent.nix
@@ -1,0 +1,92 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkIf;
+  cfg = config.services.yubikey-agent;
+
+in {
+  meta.maintainers = [ lib.maintainers.cmacrae ];
+
+  options.services.yubikey-agent = {
+    enable = lib.mkEnableOption "Seamless ssh-agent for YubiKeys";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.yubikey-agent;
+      defaultText = lib.literalExpression "pkgs.yubikey-agent";
+      description = "The yubikey-agent package to use.";
+    };
+  };
+
+  config = mkIf cfg.enable (lib.mkMerge [
+    { home.packages = [ cfg.package ]; }
+
+    (mkIf pkgs.stdenv.isLinux {
+      systemd.user.services.yubikey-agent = {
+        Unit = {
+          Description = "Seamless ssh-agent for YubiKeys";
+          Documentation = "https://github.com/FiloSottile/yubikey-agent";
+          Requires = "yubikey-agent.socket";
+          After = "yubikey-agent.socket";
+          RefuseManualStart = true;
+        };
+
+        Service = {
+          ExecStart =
+            "${cfg.package}/bin/yubikey-agent -l %t/yubikey-agent/yubikey-agent.sock";
+          Type = "simple";
+          # /run/user/$UID for the socket
+          ReadWritePaths = [ "%t" ];
+        };
+      };
+
+      systemd.user.sockets.yubikey-agent = {
+        Unit = {
+          Description = "Unix domain socket for Yubikey SSH agent";
+          Documentation = "https://github.com/FiloSottile/yubikey-agent";
+        };
+
+        Socket = {
+          ListenStream = "%t/yubikey-agent/yubikey-agent.sock";
+          RuntimeDirectory = "yubikey-agent";
+          SocketMode = "0600";
+          DirectoryMode = "0700";
+        };
+
+        Install = { WantedBy = [ "sockets.target" ]; };
+      };
+
+      home.sessionVariables = {
+        SSH_AUTH_SOCK =
+          "\${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-agent/yubikey-agent.sock";
+      };
+    })
+
+    (mkIf pkgs.stdenv.isDarwin {
+      launchd.agents.yubikey-agent = {
+        enable = true;
+        config = {
+          ProgramArguments = [
+            "${cfg.package}/bin/yubikey-agent"
+            "-l"
+            "/tmp/yubikey-agent.sock"
+          ];
+
+          KeepAlive = {
+            Crashed = true;
+            SuccessfulExit = false;
+          };
+          ProcessType = "Background";
+          Sockets = {
+            Listener = {
+              SockPathName = "/tmp/yubikey-agent.sock";
+              SockPathMode = 384; # 0600 in decimal
+            };
+          };
+        };
+      };
+
+      home.sessionVariables = { SSH_AUTH_SOCK = "/tmp/yubikey-agent.sock"; };
+    })
+  ]);
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -263,6 +263,7 @@ in import nmtSrc {
     ./modules/services/imapnotify-darwin
     ./modules/services/nix-gc-darwin
     ./modules/services/ollama/darwin
+    ./modules/services/yubikey-agent-darwin
     ./modules/targets-darwin
   ] ++ lib.optionals isLinux [
     ./modules/config/i18n
@@ -389,6 +390,7 @@ in import nmtSrc {
     ./modules/services/wlsunset
     ./modules/services/wob
     ./modules/services/xsettingsd
+    ./modules/services/yubikey-agent
     ./modules/systemd
     ./modules/targets-linux
   ]);

--- a/tests/modules/services/yubikey-agent-darwin/default.nix
+++ b/tests/modules/services/yubikey-agent-darwin/default.nix
@@ -1,0 +1,1 @@
+{ yubikey-agent-darwin = ./service.nix; }

--- a/tests/modules/services/yubikey-agent-darwin/service.nix
+++ b/tests/modules/services/yubikey-agent-darwin/service.nix
@@ -1,0 +1,50 @@
+{ config, ... }:
+
+{
+  services.yubikey-agent = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@yubikey-agent@"; };
+  };
+
+  nmt.script = ''
+    serviceFile=LaunchAgents/org.nix-community.home.yubikey-agent.plist
+    assertFileExists "$serviceFile"
+    assertFileContent "$serviceFile" ${
+      builtins.toFile "expected-agent.plist" ''
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+        	<key>KeepAlive</key>
+        	<dict>
+        		<key>Crashed</key>
+        		<true/>
+        		<key>SuccessfulExit</key>
+        		<false/>
+        	</dict>
+        	<key>Label</key>
+        	<string>org.nix-community.home.yubikey-agent</string>
+        	<key>ProcessType</key>
+        	<string>Background</string>
+        	<key>ProgramArguments</key>
+        	<array>
+                        <string>@yubikey-agent@/bin/yubikey-agent</string>
+        		<string>-l</string>
+        		<string>/tmp/yubikey-agent.sock</string>
+        	</array>
+        	<key>Sockets</key>
+        	<dict>
+        		<key>Listener</key>
+        		<dict>
+        			<key>SockPathMode</key>
+        			<integer>384</integer>
+        			<key>SockPathName</key>
+        			<string>/tmp/yubikey-agent.sock</string>
+        		</dict>
+        	</dict>
+        </dict>
+        </plist>
+      ''
+    }
+  '';
+}

--- a/tests/modules/services/yubikey-agent/default.nix
+++ b/tests/modules/services/yubikey-agent/default.nix
@@ -1,0 +1,1 @@
+{ yubikey-agent = ./service.nix; }

--- a/tests/modules/services/yubikey-agent/service.nix
+++ b/tests/modules/services/yubikey-agent/service.nix
@@ -1,0 +1,49 @@
+{ config, ... }:
+
+{
+  services.yubikey-agent = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@yubikey-agent@"; };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/yubikey-agent.service
+    socketFile=home-files/.config/systemd/user/yubikey-agent.socket
+
+    assertFileExists $serviceFile
+    assertFileExists $socketFile
+
+    assertFileContent $serviceFile ${
+      builtins.toFile "expected-service" ''
+        [Service]
+        ExecStart=@yubikey-agent@/bin/yubikey-agent -l %t/yubikey-agent/yubikey-agent.sock
+        ReadWritePaths=%t
+        Type=simple
+
+        [Unit]
+        After=yubikey-agent.socket
+        Description=Seamless ssh-agent for YubiKeys
+        Documentation=https://github.com/FiloSottile/yubikey-agent
+        RefuseManualStart=true
+        Requires=yubikey-agent.socket
+      ''
+    }
+
+    assertFileContent $socketFile ${
+      builtins.toFile "expected-socket" ''
+        [Install]
+        WantedBy=sockets.target
+
+        [Socket]
+        DirectoryMode=0700
+        ListenStream=%t/yubikey-agent/yubikey-agent.sock
+        RuntimeDirectory=yubikey-agent
+        SocketMode=0600
+
+        [Unit]
+        Description=Unix domain socket for Yubikey SSH agent
+        Documentation=https://github.com/FiloSottile/yubikey-agent
+      ''
+    }
+  '';
+}


### PR DESCRIPTION
### Description
[yubikey-agent](https://github.com/FiloSottile/yubikey-agent) socket-activated service module for Linux & Darwin - works nicely on both :)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).