### PR TITLE
[24.11] nixos/common: forward `nix.enable` from the OS configuration

### DIFF
--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -34,6 +34,14 @@ let
           home.username = config.users.users.${name}.name;
           home.homeDirectory = config.users.users.${name}.home;
 
+          # Forward `nix.enable` from the OS configuration. The
+          # conditional is to check whether nix-darwin is new enough
+          # to have the `nix.enable` option; it was previously a
+          # `mkRemovedOptionModule` error, which we can crudely detect
+          # by `visible` being set to `false`.
+          nix.enable =
+            mkIf (options.nix.enable.visible or true) config.nix.enable;
+
           # Make activation script use same version of Nix as system as a whole.
           # This avoids problems with Nix not being in PATH.
           nix.package = config.nix.package;


### PR DESCRIPTION
### Description

Backport of https://github.com/nix-community/home-manager/pull/6383.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible. *(same caveats as original PR)*

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes. *(failed in `user-defaults` test due to escaping changes but seems unrelated)*

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee