### PR TITLE
zed-editor: add userThemes option

### DIFF
--- a/tests/modules/programs/zed-editor/default.nix
+++ b/tests/modules/programs/zed-editor/default.nix
@@ -3,4 +3,5 @@
   zed-install-remote-server = ./install-remote-server.nix;
   zed-keymap = ./keymap.nix;
   zed-settings = ./settings.nix;
+  zed-themes = ./themes.nix;
 }

--- a/tests/modules/programs/zed-editor/settings.nix
+++ b/tests/modules/programs/zed-editor/settings.nix
@@ -1,7 +1,5 @@
-# Test custom keymap functionality
-{ config, ... }:
-
-{
+# Test custom settings functionality
+{ config, ... }: {
   programs.zed-editor = {
     enable = true;
     package = config.lib.test.mkStubPackage { };

--- a/tests/modules/programs/zed-editor/themes.nix
+++ b/tests/modules/programs/zed-editor/themes.nix
@@ -1,0 +1,71 @@
+# Test custom theme functionality
+{ config, ... }: {
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    userThemes = [{
+      name = "Test";
+      author = "user";
+      themes = [{
+        name = "Test Catppuccin";
+        appearance = "light";
+        style = {
+          editor = {
+            foreground = "#4c4f69";
+            background = "#eff1f5";
+            gutter.background = "#eff1f5";
+            subheader.background = "#e6e9ef";
+            active_line.background = "#4c4f690d";
+            highlighted_line.background = null;
+            line_number = "#8c8fa1";
+            active_line_number = "#8839ef";
+            invisible = "#7c7f9366";
+            wrap_guide = "#acb0be";
+          };
+        };
+      }];
+    }];
+  };
+
+  nmt.script = let
+    expectedContent = builtins.toFile "expected.json" ''
+      {
+        "author": "user",
+        "name": "test",
+        "themes": [
+          {
+            "appearance": "light",
+            "name": "Test Catppuccin",
+            "style": {
+              "editor": {
+                "active_line": {
+                  "background": "#4c4f690d"
+                },
+                "active_line_number": "#8839ef",
+                "background": "#eff1f5",
+                "foreground": "#4c4f69",
+                "gutter": {
+                  "background": "#eff1f5"
+                },
+                "highlighted_line": {
+                  "background": null
+                },
+                "invisible": "#7c7f9366",
+                "line_number": "#8c8fa1",
+                "subheader": {
+                  "background": "#e6e9ef"
+                },
+                "wrap_guide": "#acb0be"
+              }
+            }
+          }
+        ]
+      }
+    '';
+
+    testPath = ".config/zed/themes/test.json";
+  in ''
+    assertFileExists "home-files/${testPath}"
+    assertFileContent "home-files/${testPath}" "${expectedContent}"
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Added support for local custom themes, each of which are added separately to ~/.config/zed/themes. Allows for users to update Zed's theming via nix-colors on rebuild.

See https://zed.dev/docs/extensions/themes for more details.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
cc @libewa

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
