### PR TITLE
git: change stateVersion check for compatiblity

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -120,8 +120,8 @@ in {
         format = mkOption {
           type = types.enum [ "openpgp" "ssh" "x509" ];
           defaultText = literalExpression ''
-            "openpgp" for state version < 24.11,
-            undefined for state version ≥ 24.11
+            "openpgp" for state version < 25.05,
+            undefined for state version ≥ 25.05
           '';
           description = ''
             The signing method to use when signing commits and tags.
@@ -490,7 +490,7 @@ in {
     (mkIf (cfg.signing != { }) {
       programs.git = {
         signing = {
-          format = mkIf (versionOlder config.home.stateVersion "24.11")
+          format = mkIf (versionOlder config.home.stateVersion "25.05")
             (mkOptionDefault "openpgp");
           signer = mkIf (cfg.signing.format != null) (mkOptionDefault {
             openpgp = getExe config.programs.gpg.package;


### PR DESCRIPTION
Original change was created before 24.11 release. We are in 25.05 now.

Follow up to https://github.com/nix-community/home-manager/pull/5516

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
