### PR TITLE
ntfy-sh: Add client module

### DIFF
--- a/modules/programs/ntfy-sh.nix
+++ b/modules/programs/ntfy-sh.nix
@@ -1,0 +1,73 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+let
+  cfg = config.programs.ntfy-sh;
+  yamlFormat = pkgs.formats.yaml { };
+in
+with lib;
+{
+  options.programs.ntfy-sh = {
+    enable = mkEnableOption "ntfy-sh";
+    enableUserService = mkEnableOption "ntfy-sh user service";
+
+    package = mkPackageOption pkgs "ntfy-sh" { };
+
+    configFilePath = mkOption {
+      type = types.path;
+      default = "${config.xdg.configHome}/ntfy/client.yml";
+      defaultText = literalExpression ''"''${config.xdg.configHome}/ntfy/client.yml"'';
+      description = "Path where the configuration file is placed.";
+    };
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      description = "Configuration for the ntfy binary";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.settings != { };
+        message = ''
+          You must set `programs.ntfy-sh.settings`.
+        '';
+      }
+    ];
+
+    home.packages = [ cfg.package ];
+
+    home.file.ntfy-sh = {
+      enable = true;
+      target = cfg.configFilePath;
+
+      onChange = ''
+        ${pkgs.systemd}/bin/systemctl --user restart ntfy-sh-client
+      '';
+
+      source = mkIf (cfg.settings != { }) (yamlFormat.generate "ntfy-sh-config" cfg.settings);
+    };
+
+    systemd.user.services.ntfy-sh-client = mkIf cfg.enableUserService {
+      Unit.Description = "ntfy-sh client service";
+
+      Install.WantedBy = [ "default.target" ];
+
+      Service = {
+        Type = "simple";
+        Restart = "on-failure";
+        ExecStart = ''
+          ${cfg.package}/bin/ntfy subscribe --config ${cfg.configFilePath} --from-config
+        '';
+      };
+    };
+  };
+
+  meta.maintainers = [ maintainers.matthiasbeyer ];
+}


### PR DESCRIPTION
### Description

ntfy-sh user background service.

This is my first time adding a module to home-manager. I've been using this locally for a few days now and it seems to work as intended.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
