### PR TITLE
home-cursor: add sway support

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -56,6 +56,11 @@ let
           description = "The cursor size for hyprcursor.";
         };
       };
+
+      sway = {
+        enable = mkEnableOption
+          "sway config generation for {option}`home.pointerCursor`";
+      };
     };
   };
 
@@ -195,6 +200,19 @@ in {
         HYPRCURSOR_THEME = cfg.name;
         HYPRCURSOR_SIZE =
           if cfg.hyprcursor.size != null then cfg.hyprcursor.size else cfg.size;
+      };
+    })
+
+    (mkIf cfg.sway.enable {
+      wayland.windowManager.sway = {
+        config = {
+          seat = {
+            "*" = {
+              xcursor_theme =
+                "${cfg.name} ${toString config.gtk.cursorTheme.size}";
+            };
+          };
+        };
       };
     })
   ]);


### PR DESCRIPTION
### Description

Not sure if it should use `*` or `seat0` for the configuration, as I'm not sure what the difference in semantics would be.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Scrumplex @alexarice @sumnerevans @oxalica @league 