### PR TITLE
thunderbird: support native messaging hosts (2nd attempt)

### DIFF
--- a/modules/misc/mozilla-messaging-hosts.nix
+++ b/modules/misc/mozilla-messaging-hosts.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   inherit (pkgs.stdenv) isDarwin;
 
@@ -22,22 +20,25 @@ let
   else
     ".mozilla/native-messaging-hosts";
 in {
-  meta.maintainers =
-    [ maintainers.booxter maintainers.rycee hm.maintainers.bricked ];
+  meta.maintainers = with lib.maintainers; [
+    booxter
+    rycee
+    lib.hm.maintainers.bricked
+  ];
 
   options.mozilla = {
-    firefoxNativeMessagingHosts = mkOption {
+    firefoxNativeMessagingHosts = lib.mkOption {
       internal = true;
-      type = with types; listOf package;
+      type = with lib.types; listOf package;
       default = [ ];
       description = ''
         List of Firefox native messaging hosts to configure.
       '';
     };
 
-    thunderbirdNativeMessagingHosts = mkOption {
+    thunderbirdNativeMessagingHosts = lib.mkOption {
       internal = true;
-      type = with types; listOf package;
+      type = with lib.types; listOf package;
       default = [ ];
       description = ''
         List of Thunderbird native messaging hosts to configure.
@@ -45,7 +46,7 @@ in {
     };
   };
 
-  config = mkIf (cfg.firefoxNativeMessagingHosts != [ ]
+  config = lib.mkIf (cfg.firefoxNativeMessagingHosts != [ ]
     || cfg.thunderbirdNativeMessagingHosts != [ ]) {
       home.file = if isDarwin then
         let
@@ -59,14 +60,14 @@ in {
           };
         in {
           "${thunderbirdNativeMessagingHostsPath}" =
-            mkIf (cfg.thunderbirdNativeMessagingHosts != [ ]) {
+            lib.mkIf (cfg.thunderbirdNativeMessagingHosts != [ ]) {
               source =
                 "${thunderbirdNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
               recursive = true;
             };
 
           "${firefoxNativeMessagingHostsPath}" =
-            mkIf (cfg.firefoxNativeMessagingHosts != [ ]) {
+            lib.mkIf (cfg.firefoxNativeMessagingHosts != [ ]) {
               source =
                 "${firefoxNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
               recursive = true;

--- a/modules/misc/mozilla-messaging-hosts.nix
+++ b/modules/misc/mozilla-messaging-hosts.nix
@@ -1,0 +1,89 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  inherit (pkgs.stdenv) isDarwin;
+
+  cfg = config.mozilla;
+
+  defaultPaths = [
+    # Link a .keep file to keep the directory around
+    (pkgs.writeTextDir "lib/mozilla/native-messaging-hosts/.keep" "")
+  ];
+
+  thunderbirdNativeMessagingHostsPath = if isDarwin then
+    "Library/Mozilla/NativeMessagingHosts"
+  else
+    ".mozilla/native-messaging-hosts";
+
+  firefoxNativeMessagingHostsPath = if isDarwin then
+    "Library/Application Support/Mozilla/NativeMessagingHosts"
+  else
+    ".mozilla/native-messaging-hosts";
+in {
+  meta.maintainers =
+    [ maintainers.booxter maintainers.rycee hm.maintainers.bricked ];
+
+  options.mozilla = {
+    firefoxNativeMessagingHosts = mkOption {
+      internal = true;
+      type = with types; listOf package;
+      default = [ ];
+      description = ''
+        List of Firefox native messaging hosts to configure.
+      '';
+    };
+
+    thunderbirdNativeMessagingHosts = mkOption {
+      internal = true;
+      type = with types; listOf package;
+      default = [ ];
+      description = ''
+        List of Thunderbird native messaging hosts to configure.
+      '';
+    };
+  };
+
+  config = mkIf (cfg.firefoxNativeMessagingHosts != [ ]
+    || cfg.thunderbirdNativeMessagingHosts != [ ]) {
+      home.file = if isDarwin then
+        let
+          firefoxNativeMessagingHostsJoined = pkgs.symlinkJoin {
+            name = "ff-native-messaging-hosts";
+            paths = defaultPaths ++ cfg.firefoxNativeMessagingHosts;
+          };
+          thunderbirdNativeMessagingHostsJoined = pkgs.symlinkJoin {
+            name = "th-native-messaging-hosts";
+            paths = defaultPaths ++ cfg.thunderbirdNativeMessagingHosts;
+          };
+        in {
+          "${thunderbirdNativeMessagingHostsPath}" = {
+            source =
+              "${thunderbirdNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
+            recursive = true;
+          };
+
+          "${firefoxNativeMessagingHostsPath}" = {
+            source =
+              "${firefoxNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
+            recursive = true;
+          };
+        }
+      else
+        let
+          nativeMessagingHostsJoined = pkgs.symlinkJoin {
+            name = "mozilla-native-messaging-hosts";
+            # on Linux, the directory is shared between Firefox and Thunderbird; merge both into one
+            paths = defaultPaths ++ cfg.firefoxNativeMessagingHosts
+              ++ cfg.thunderbirdNativeMessagingHosts;
+          };
+        in {
+          "${firefoxNativeMessagingHostsPath}" = {
+            source =
+              "${nativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
+            recursive = true;
+          };
+        };
+    };
+}

--- a/modules/misc/mozilla-messaging-hosts.nix
+++ b/modules/misc/mozilla-messaging-hosts.nix
@@ -58,17 +58,19 @@ in {
             paths = defaultPaths ++ cfg.thunderbirdNativeMessagingHosts;
           };
         in {
-          "${thunderbirdNativeMessagingHostsPath}" = {
-            source =
-              "${thunderbirdNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
-            recursive = true;
-          };
+          "${thunderbirdNativeMessagingHostsPath}" =
+            mkIf (cfg.thunderbirdNativeMessagingHosts != [ ]) {
+              source =
+                "${thunderbirdNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
+              recursive = true;
+            };
 
-          "${firefoxNativeMessagingHostsPath}" = {
-            source =
-              "${firefoxNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
-            recursive = true;
-          };
+          "${firefoxNativeMessagingHostsPath}" =
+            mkIf (cfg.firefoxNativeMessagingHosts != [ ]) {
+              source =
+                "${firefoxNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
+              recursive = true;
+            };
         }
       else
         let

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -30,6 +30,7 @@ let
     ./misc/fontconfig.nix
     ./misc/gtk.nix
     ./misc/lib.nix
+    ./misc/mozilla-messaging-hosts.nix
     ./misc/news.nix
     ./misc/nixgl.nix
     ./misc/numlock.nix

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -847,9 +847,9 @@ in {
 
     home.packages = lib.optional (cfg.finalPackage != null) cfg.finalPackage;
 
-    mozilla.firefoxNativeMessagingHosts = [
-      cfg.finalPackage # package configured native messaging hosts (entire browser actually)
-    ] ++ cfg.nativeMessagingHosts; # user configured native messaging hosts
+    mozilla.firefoxNativeMessagingHosts = cfg.nativeMessagingHosts
+      # package configured native messaging hosts (entire browser actually)
+      ++ (lib.optional (cfg.finalPackage != null) cfg.finalPackage);
 
     home.file = mkMerge ([{
       "${cfg.configPath}/profiles.ini" =

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -136,6 +136,24 @@ let
     '') prefs)}
     ${extraPrefs}
   '';
+
+  nativeMessagingHostsPath = if isDarwin then
+    "${cfg.vendorPath}/NativeMessagingHosts"
+  else
+    "${cfg.vendorPath}/native-messaging-hosts";
+
+  nativeMessagingHostsJoined = pkgs.symlinkJoin {
+    name = "th_native-messaging-hosts";
+    paths = [
+      # Link a .keep file to keep the directory around
+      (pkgs.writeTextDir "lib/mozilla/native-messaging-hosts/.keep" "")
+      # Link package configured native messaging hosts (entire mail app actually)
+      cfg.package
+    ]
+    # Link user configured native messaging hosts
+      ++ cfg.nativeMessagingHosts;
+  };
+
 in {
   meta.maintainers = with hm.maintainers; [ d-dervishi jkarlson ];
 
@@ -157,6 +175,29 @@ in {
         default = if isDarwin then null else 2;
         description = "profile version, set null for nix-darwin";
       };
+
+      vendorPath = mkOption {
+        internal = true;
+        type = with types; nullOr str;
+        # Thunderbird doesn't look in `Application Support` on macOS for user
+        # config (in contrast to global settings that are the same for Firefox
+        # and Thunderbird):
+        # https://developer.thunderbird.net/add-ons/mailextensions/supported-webextension-api
+        default = if isDarwin then "Library/Mozilla" else ".mozilla";
+        example = ".mozilla";
+        description =
+          "Directory containing the native messaging hosts directory.";
+      };
+
+      nativeMessagingHosts = optionalAttrs (cfg.vendorPath != null) (mkOption {
+        visible = true;
+        type = types.listOf types.package;
+        default = [ ];
+        description = ''
+          Additional packages containing native messaging hosts that should be
+          made available to Thunderbird extensions.
+        '';
+      });
 
       profiles = mkOption {
         type = with types;
@@ -403,7 +444,13 @@ in {
     home.file = mkMerge ([{
       "${thunderbirdConfigPath}/profiles.ini" =
         mkIf (cfg.profiles != { }) { text = generators.toINI { } profilesIni; };
-    }] ++ flip mapAttrsToList cfg.profiles (name: profile: {
+    }] ++ optional (cfg.vendorPath != null) {
+      "${nativeMessagingHostsPath}" = {
+        source =
+          "${nativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
+        recursive = true;
+      };
+    } ++ flip mapAttrsToList cfg.profiles (name: profile: {
       "${thunderbirdProfilesPath}/${name}/chrome/userChrome.css" =
         mkIf (profile.userChrome != "") { text = profile.userChrome; };
 

--- a/tests/modules/programs/firefox/common.nix
+++ b/tests/modules/programs/firefox/common.nix
@@ -1,6 +1,7 @@
 name:
 builtins.mapAttrs (test: module: import module [ "programs" name ]) {
   "${name}-deprecated-native-messenger" = ./deprecated-native-messenger.nix;
+  "${name}-null-package" = ./null-package.nix;
   "${name}-final-package" = ./final-package.nix;
   "${name}-policies" = ./policies.nix;
   "${name}-profiles-bookmarks" = ./profiles/bookmarks;

--- a/tests/modules/programs/firefox/null-package.nix
+++ b/tests/modules/programs/firefox/null-package.nix
@@ -1,0 +1,10 @@
+modulePath:
+{ config, lib, ... }:
+
+lib.mkIf config.test.enableBig (lib.setAttrByPath modulePath { enable = true; }
+  // {
+    programs.firefox = {
+      enable = true;
+      package = null;
+    };
+  })

--- a/tests/modules/programs/thunderbird/default.nix
+++ b/tests/modules/programs/thunderbird/default.nix
@@ -1,1 +1,4 @@
-{ thunderbird = ./thunderbird.nix; }
+{
+  thunderbird = ./thunderbird.nix;
+  thunderbird-with-firefox = ./thunderbird-with-firefox.nix;
+}

--- a/tests/modules/programs/thunderbird/default.nix
+++ b/tests/modules/programs/thunderbird/default.nix
@@ -1,4 +1,5 @@
 {
   thunderbird = ./thunderbird.nix;
   thunderbird-with-firefox = ./thunderbird-with-firefox.nix;
+  thunderbird-native-messaging-host = ./thunderbird-native-messaging-host.nix;
 }

--- a/tests/modules/programs/thunderbird/thunderbird-native-messaging-host.nix
+++ b/tests/modules/programs/thunderbird/thunderbird-native-messaging-host.nix
@@ -1,0 +1,25 @@
+# Confirm that both Firefox and Thunderbird can be configured at the same time.
+{ lib, realPkgs, ... }:
+lib.recursiveUpdate (import ./thunderbird.nix { inherit lib realPkgs; }) {
+  programs.thunderbird = {
+    nativeMessagingHosts = with realPkgs;
+      [
+        # NOTE: this is not a real Thunderbird native host module but Firefox; no
+        # native hosts are currently packaged for nixpkgs or elsewhere, so we
+        # have to improvise. Packaging wise, Firefox and Thunderbird native hosts
+        # are identical though. The test doesn't care if the host was meant for
+        # either as long as the right paths are present in the package.
+        browserpass
+      ];
+  };
+
+  nmt.script = let
+    isDarwin = realPkgs.stdenv.hostPlatform.isDarwin;
+    nativeHostsDir = if isDarwin then
+      "Library/Mozilla/NativeMessagingHosts"
+    else
+      ".mozilla/native-messaging-hosts";
+  in ''
+    assertFileExists home-files/${nativeHostsDir}/com.github.browserpass.native.json
+  '';
+}

--- a/tests/modules/programs/thunderbird/thunderbird-with-firefox.nix
+++ b/tests/modules/programs/thunderbird/thunderbird-with-firefox.nix
@@ -1,5 +1,9 @@
 # Confirm that both Firefox and Thunderbird can be configured at the same time.
 { lib, realPkgs, ... }:
 lib.recursiveUpdate (import ./thunderbird.nix { inherit lib realPkgs; }) {
-  programs.firefox.enable = true;
+  programs.firefox = {
+    enable = true;
+    # Darwin doesn't support wrapped Firefox, using unwrapped instead
+    package = realPkgs.firefox-unwrapped;
+  };
 }

--- a/tests/modules/programs/thunderbird/thunderbird-with-firefox.nix
+++ b/tests/modules/programs/thunderbird/thunderbird-with-firefox.nix
@@ -1,0 +1,5 @@
+# Confirm that both Firefox and Thunderbird can be configured at the same time.
+{ lib, realPkgs, ... }:
+lib.recursiveUpdate (import ./thunderbird.nix { inherit lib realPkgs; }) {
+  programs.firefox.enable = true;
+}

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -1,8 +1,6 @@
 { lib, realPkgs, ... }: {
   imports = [ ../../accounts/email-test-accounts.nix ];
 
-  _module.args.pkgs = lib.mkForce realPkgs;
-
   accounts.email.accounts = {
     "hm@example.com" = {
       thunderbird = {

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -37,9 +37,6 @@
     };
   };
 
-  # Confirm that both Firefox and Thunderbird can be configured at the same time.
-  programs.firefox = { enable = true; };
-
   programs.thunderbird = {
     enable = true;
 

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -37,14 +37,18 @@
     };
   };
 
+  # Confirm that both Firefox and Thunderbird can be configured at the same time.
+  programs.firefox = { enable = true; };
+
   programs.thunderbird = {
     enable = true;
 
     # Disable warning so that platforms' behavior is the same
     darwinSetupWarning = false;
 
-    # Darwin doesn't support wrapped Thunderbird, using unwrapped instead
-    package = realPkgs.thunderbird-unwrapped;
+    # Darwin doesn't support wrapped Thunderbird, using unwrapped instead;
+    # using -latest- because ESR is currently broken on Darwin
+    package = realPkgs.thunderbird-latest-unwrapped;
 
     profiles = {
       first = {

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -66,16 +66,6 @@
       };
     };
 
-    nativeMessagingHosts = with realPkgs;
-      [
-        # NOTE: this is not a real Thunderbird native host module but Firefox; no
-        # native hosts are currently packaged for nixpkgs or elsewhere, so we
-        # have to improvise. Packaging wise, Firefox and Thunderbird native hosts
-        # are identical though. The test doesn't care if the host was meant for
-        # either as long as the right paths are present in the package.
-        browserpass
-      ];
-
     settings = {
       "general.useragent.override" = "";
       "privacy.donottrackheader.enabled" = true;
@@ -86,10 +76,6 @@
     isDarwin = realPkgs.stdenv.hostPlatform.isDarwin;
     configDir = if isDarwin then "Library/Thunderbird" else ".thunderbird";
     profilesDir = if isDarwin then "${configDir}/Profiles" else "${configDir}";
-    nativeHostsDir = if isDarwin then
-      "Library/Mozilla/NativeMessagingHosts"
-    else
-      ".mozilla/native-messaging-hosts";
     platform = if isDarwin then "darwin" else "linux";
   in ''
     assertFileExists home-files/${configDir}/profiles.ini
@@ -111,7 +97,5 @@
     assertFileExists home-files/${profilesDir}/first/chrome/userContent.css
     assertFileContent home-files/${profilesDir}/first/chrome/userContent.css \
       <(echo "* { color: red !important; }")
-
-    assertFileExists home-files/${nativeHostsDir}/com.github.browserpass.native.json
   '';
 }


### PR DESCRIPTION
- **Reapply "thunderbird: add native host support (#6292)" (#6371)**
- **thunderbird, firefox: fix file conflict for native messaging hosts**

### Description

<!--

Please provide a brief description of your change.

-->

This is the second attempt to implement native messaging hosts for Thunderbird.
The previous attempt was reverted because it broke activation when both Firefox
and Thunderbird were installed. This happened because on Linux, both
applications use the same directory for native messaging hosts, and the module
did not handle this case correctly.

Note: I've added maintainers of the Firefox module to maintainers for the new
helper module since this is a relocated code that is now a dependency for the
main Firefox module.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
