### PR TITLE
wluma: init module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2074,6 +2074,16 @@ in {
           See https://github.com/artemsen/swayimg for more.
         '';
       }
+
+      {
+        time = "2025-02-16T17:00:00+00:00";
+        message = ''
+          A new module is available: 'services.wluma'.
+
+          Wluma is a tool for Wayland compositors to automatically adjust
+          screen brightness based on the screen contents and amount of ambient light around you.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -420,6 +420,7 @@ let
     ./services/window-managers/wayfire.nix
     ./services/window-managers/xmonad.nix
     ./services/wlsunset.nix
+    ./services/wluma.nix
     ./services/wob.nix
     ./services/xcape.nix
     ./services/xembed-sni-proxy.nix

--- a/modules/services/wluma.nix
+++ b/modules/services/wluma.nix
@@ -1,0 +1,103 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.wluma;
+  format = pkgs.formats.toml { };
+  configFile = format.generate "config.toml" cfg.settings;
+in {
+  meta.maintainers = with lib.maintainers; [ _0x5a4 ];
+
+  options.services.wluma = {
+    enable = lib.mkEnableOption
+      "Enable wluma, a service for automatic brightness adjustment";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.wluma;
+      defaultText = lib.literalExpression "pkgs.wluma";
+      description = "Package providing {command}`wluma`.";
+    };
+
+    settings = lib.mkOption {
+      type = format.type;
+      default = { };
+      example = {
+        als.iio = {
+          path = "";
+          thresholds = {
+            "0" = "night";
+            "20" = "dark";
+            "80" = "dim";
+            "250" = "normal";
+            "500" = "bright";
+            "800" = "outdoors";
+          };
+        };
+      };
+      description = ''
+        Configuration to use for wluma. See
+        <https://github.com/maximbaz/wluma/blob/main/config.toml>
+        for available options.
+      '';
+    };
+
+    systemd.enable = lib.mkOption {
+      description = "Wluma systemd integration";
+      type = lib.types.bool;
+      default = true;
+    };
+
+    systemd.target = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = config.wayland.systemd.target;
+      defaultText = lib.literalExpression "config.wayland.systemd.target";
+      example = "sway-session.target";
+      description = ''
+        The systemd target that will automatically start the Wluma service.
+
+        When setting this value to `"sway-session.target"`,
+        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+        otherwise the service may never be started.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.wluma" pkgs
+        lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = lib.mkIf (cfg.settings != { }) {
+      "wluma/config.toml".source = configFile;
+    };
+
+    systemd.user.services.wluma = lib.mkIf cfg.systemd.enable {
+      Unit = {
+        Description =
+          "Automatic brightness adjustment based on screen contents and ALS ";
+        After = [ cfg.systemd.target ];
+        PartOf = [ cfg.systemd.target ];
+        ConditionEnvironment = "WAYLAND_DISPLAY";
+        X-Restart-Triggers = lib.mkIf (cfg.settings != { }) [ "${configFile}" ];
+      };
+
+      Install.WantedBy = [ cfg.systemd.target ];
+
+      Service = {
+        ExecStart = lib.getExe cfg.package;
+        Restart = "always";
+
+        # Sandboxing.
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateUsers = true;
+        RestrictNamespaces = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "@system-service";
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Description

Adds a module for wluma, a service for automatic screen brightness adjustment.

There was also #5811, which was closed for no obvious reason. I've taken that as a basis and applied some minor changes on top of it.

Related: #2420 #5811

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
