### PR TITLE
nixpkgs-disabled: warn instead of assert

### DIFF
--- a/modules/misc/nixpkgs-disabled.nix
+++ b/modules/misc/nixpkgs-disabled.nix
@@ -63,11 +63,19 @@ in {
   };
 
   config = {
-    assertions = [{
-      assertion = cfg.config == null && cfg.overlays == null;
-      message = ''
-        `nixpkgs` options are disabled when `home-manager.useGlobalPkgs` is enabled.
-      '';
-    }];
+    assertions = [
+      # TODO: Re-enable assertion after 25.05 (&&)
+      {
+        assertion = cfg.config == null || cfg.overlays == null;
+        message = ''
+          `nixpkgs` options are disabled when `home-manager.useGlobalPkgs` is enabled.
+        '';
+      }
+    ];
+
+    warnings = optional ((cfg.config != null) || (cfg.overlays != null)) ''
+      You have set either `nixpkgs.config` or `nixpkgs.overlays` while using `home-manager.useGlobalPkgs`.
+      This will soon not be possible. Please remove all `nixpkgs` options when using `home-manager.useGlobalPkgs`.
+    '';
   };
 }


### PR DESCRIPTION
Temporarily fixes backwards compatibility as issued in #6172.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@thiagokokada @justDeeevin 