### PR TITLE
 nh: fixes and addition to warnings/assertions

### DIFF
--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -53,7 +53,7 @@ in {
 
   config = {
     warnings = (lib.optional
-      (osConfig != null && cfg.clean.enable && osConfig.nix.gc.automatic)
+      (cfg.clean.enable && osConfig != null && osConfig.nix.gc.automatic)
       "programs.nh.clean.enable and nix.gc.automatic (system-wide in configuration.nix) are both enabled. Please use one or the other to avoid conflict.")
       ++ (lib.optional (cfg.clean.enable && config.nix.gc.automatic)
         "programs.nh.clean.enable and nix.gc.automatic (Home-Manager) are both enabled. Please use one or the other to avoid conflict.");

--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -52,15 +52,11 @@ in {
   };
 
   config = {
-    warnings = lib.optionals
-      (osConfig != null && !(cfg.clean.enable -> !osConfig.nix.gc.automatic)) [
-        "programs.nh.clean.enable and nix.gc.automatic (system-wide in configuration.nix) are both enabled. Please use one or the other to avoid conflict."
-      ];
-
-    assertions = [{
-      assertion = (cfg.flake != null) -> !(lib.hasSuffix ".nix" cfg.flake);
-      message = "nh.flake must be a directory, not a nix file";
-    }];
+    warnings = (lib.optional
+      (osConfig != null && cfg.clean.enable && osConfig.nix.gc.automatic)
+      "programs.nh.clean.enable and nix.gc.automatic (system-wide in configuration.nix) are both enabled. Please use one or the other to avoid conflict.")
+      ++ (lib.optional (cfg.clean.enable && config.nix.gc.automatic)
+        "programs.nh.clean.enable and nix.gc.automatic (Home-Manager) are both enabled. Please use one or the other to avoid conflict.");
 
     home = lib.mkIf cfg.enable {
       packages = [ cfg.package ];


### PR DESCRIPTION
### Description

Cherry picked @pedorich-n's #6325 to get address:

- Remove flake path assertion
- Add warning when HM's `nix.gc.automatic` is enabled

That I missed in my PR (#6350), as per @Weathercold's suggestion.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- ~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~If this PR adds a new module~

  - ~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~

#### Maintainer CC

@JohnRTitor 