### PR TITLE
Revert "firefox: correct vendorPath of firefox forks"

### DIFF
--- a/modules/programs/floorp.nix
+++ b/modules/programs/floorp.nix
@@ -21,12 +21,9 @@ in {
 
       platforms.linux = {
         configPath = ".floorp";
-        vendorPath = ".mozilla";
+        vendorPath = ".floorp";
       };
-      platforms.darwin = {
-        configPath = "Library/Application Support/Floorp";
-        vendorPath = "Library/Application Support/Mozilla";
-      };
+      platforms.darwin = { configPath = "Library/Application Support/Floorp"; };
     })
   ];
 }

--- a/modules/programs/librewolf.nix
+++ b/modules/programs/librewolf.nix
@@ -30,12 +30,12 @@ in {
       unwrappedPackageName = "librewolf-unwrapped";
 
       platforms.linux = {
+        vendorPath = ".librewolf";
         configPath = ".librewolf";
-        vendorPath = ".mozilla";
       };
       platforms.darwin = {
+        vendorPath = "Library/Application Support/LibreWolf";
         configPath = "Library/Application Support/LibreWolf";
-        vendorPath = "Library/Application Support/Mozilla";
       };
 
       enableBookmarks = false;


### PR DESCRIPTION
Reverts nix-community/home-manager#6421

It broke installations with multiple Firefox derivatives configured (e.g. LibreWolf and Firefox).

The complete fix will have to merge paths for all of them into a single directory.

Closes #6467