### PR TITLE
git: support not configuring signing.format

### DIFF
--- a/tests/modules/programs/gh/credential-helper.git.conf
+++ b/tests/modules/programs/gh/credential-helper.git.conf
@@ -1,6 +1,3 @@
-[commit]
-	gpgSign = false
-
 [credential "https://github.com"]
 	helper = "@gh@/bin/gh auth git-credential"
 
@@ -12,6 +9,3 @@
 
 [gpg "openpgp"]
 	program = "path-to-gpg"
-
-[tag]
-	gpgSign = false

--- a/tests/modules/programs/git/default.nix
+++ b/tests/modules/programs/git/default.nix
@@ -6,5 +6,6 @@
   git-with-signing-key-id-legacy = ./git-with-signing-key-id-legacy.nix;
   git-with-signing-key-id = ./git-with-signing-key-id.nix;
   git-without-signing-key-id = ./git-without-signing-key-id.nix;
+  git-without-signing = ./git-without-signing.nix;
   git-with-hooks = ./git-with-hooks.nix;
 }

--- a/tests/modules/programs/git/git-with-email-expected.conf
+++ b/tests/modules/programs/git/git-with-email-expected.conf
@@ -1,11 +1,8 @@
-[commit]
-	gpgSign = false
-
 [gpg]
 	format = "openpgp"
 
 [gpg "openpgp"]
-	program = "path-to-gpg"
+	program = "@gnupg@/bin/gpg"
 
 [sendemail "hm-account"]
 	from = "H. M. Test Jr. <hm@example.org>"
@@ -20,9 +17,6 @@
 	smtpServer = "smtp.example.com"
 	smtpSslCertPath = "/etc/ssl/certs/ca-certificates.crt"
 	smtpUser = "home.manager"
-
-[tag]
-	gpgSign = false
 
 [user]
 	email = "hm@example.com"

--- a/tests/modules/programs/git/git-with-email.nix
+++ b/tests/modules/programs/git/git-with-email.nix
@@ -8,7 +8,6 @@
 
   programs.git = {
     enable = true;
-    signing.signer = "path-to-gpg";
     userEmail = "hm@example.com";
     userName = "H. M. Test";
   };

--- a/tests/modules/programs/git/git-with-msmtp-expected.conf
+++ b/tests/modules/programs/git/git-with-msmtp-expected.conf
@@ -1,6 +1,3 @@
-[commit]
-	gpgSign = false
-
 [gpg]
 	format = "openpgp"
 
@@ -18,9 +15,6 @@
 	envelopeSender = "auto"
 	from = "H. M. Test <hm@example.com>"
 	smtpServer = "@msmtp@/bin/msmtp"
-
-[tag]
-	gpgSign = false
 
 [user]
 	email = "hm@example.com"

--- a/tests/modules/programs/git/git-with-str-extra-config-expected.conf
+++ b/tests/modules/programs/git/git-with-str-extra-config-expected.conf
@@ -1,16 +1,10 @@
 This can be anything.
 
-[commit]
-	gpgSign = false
-
 [gpg]
 	format = "openpgp"
 
 [gpg "openpgp"]
 	program = "path-to-gpg"
-
-[tag]
-	gpgSign = false
 
 [user]
 	email = "user@example.org"

--- a/tests/modules/programs/git/git-without-signing.conf
+++ b/tests/modules/programs/git/git-without-signing.conf
@@ -1,0 +1,3 @@
+[user]
+	email = "user@example.org"
+	name = "John Doe"

--- a/tests/modules/programs/git/git-without-signing.nix
+++ b/tests/modules/programs/git/git-without-signing.nix
@@ -1,0 +1,16 @@
+{
+  programs.git = {
+    enable = true;
+    userName = "John Doe";
+    userEmail = "user@example.org";
+  };
+
+  home.stateVersion = "25.05";
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContent home-files/.config/git/config ${
+      ./git-without-signing.conf
+    }
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Closes https://github.com/nix-community/home-manager/issues/6472
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
