### PR TITLE
git: fix setting format on >=25.05

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -496,7 +496,7 @@ in {
           format = if (versionOlder config.home.stateVersion "25.05") then
             (mkOptionDefault "openpgp")
           else
-            null;
+            (mkOptionDefault null);
           signer = let
             defaultSigners = {
               openpgp = getExe config.programs.gpg.package;


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

With the following config:

```
programs.git = {
  enable = true;
  signing = {
    format = "ssh";
    key = "~/.ssh/id_ed25519";
    signByDefault = true;
  };
  userName = fullName;
  userEmail = userEmail;
};
```

on stateVersion 25.05, you get the following error:

```
The option `home-manager.users.timo.programs.git.signing.format` is defined both null and not null, in `/nix/store/ip7y1cxy95vwscjy8ll86m5ls9i5kiad-source/modules/programs/git.nix' and `<unknown-file>'.
```

This PR fixes this by using `setOptionDefault` instead of just setting it to `null`

**Workaround**

Use `lib.mkForce` when setting the format in your config.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
