### PR TITLE
flake: don't import modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,21 +6,21 @@
   outputs = { self, nixpkgs, ... }:
     {
       nixosModules = rec {
-        home-manager = import ./nixos;
+        home-manager = ./nixos;
         default = home-manager;
       };
       # deprecated in Nix 2.8
       nixosModule = self.nixosModules.default;
 
       darwinModules = rec {
-        home-manager = import ./nix-darwin;
+        home-manager = ./nix-darwin;
         default = home-manager;
       };
       # unofficial; deprecated in Nix 2.8
       darwinModule = self.darwinModules.default;
 
       flakeModules = rec {
-        home-manager = import ./flake-module.nix;
+        home-manager = ./flake-module.nix;
         default = home-manager;
       };
 


### PR DESCRIPTION
### Description

Since the `imports` attributes of modules allows for paths we can remove the `import` making the consumption of nixosModules, darwinModules and flakeModules cheaper

I'm currently on darwin, so i'm unable to run the tests. :p

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
