### PR TITLE
gpg: immutable keyfile workaround

### DIFF
--- a/tests/modules/programs/gpg/immutable-keyfiles.nix
+++ b/tests/modules/programs/gpg/immutable-keyfiles.nix
@@ -8,23 +8,23 @@
     mutableKeys = false;
     mutableTrust = false;
 
-    publicKeys = [
-      {
-        source = realPkgs.fetchurl {
-          url =
-            "https://keys.openpgp.org/pks/lookup?op=get&options=mr&search=0x44CF42371ADF842E12F116EAA9D3F98FCCF5460B";
-          hash = "sha256-bSluCZh6ijwppigk8iF2BwWKZgq1WDbIjyYQRK772dM=";
-        };
-        trust = 1; # "unknown"
-      }
-      {
-        source = realPkgs.fetchurl {
-          url = "https://www.rsync.net/resources/pubkey.txt";
-          sha256 = "16nzqfb1kvsxjkq919hxsawx6ydvip3md3qyhdmw54qx6drnxckl";
-        };
-        trust = "never";
-      }
-    ];
+    publicKeys = [{
+      source = realPkgs.fetchurl {
+        url =
+          "https://keys.openpgp.org/pks/lookup?op=get&options=mr&search=0x44CF42371ADF842E12F116EAA9D3F98FCCF5460B";
+        hash = "sha256-bSluCZh6ijwppigk8iF2BwWKZgq1WDbIjyYQRK772dM=";
+      };
+      trust = 1; # "unknown"
+    }
+    # TODO: re-enable when site is stable
+    # {
+    #   source = realPkgs.fetchurl {
+    #     url = "https://www.rsync.net/resources/pubkey.txt";
+    #     sha256 = "16nzqfb1kvsxjkq919hxsawx6ydvip3md3qyhdmw54qx6drnxckl";
+    #   };
+    #   trust = "never";
+    # }
+      ];
   };
 
   nmt.script = ''
@@ -47,7 +47,7 @@
     assertFileRegex $WORKDIR/gpgtrust.txt \
       '^44CF42371ADF842E12F116EAA9D3F98FCCF5460B:2:$'
 
-    assertFileRegex $WORKDIR/gpgtrust.txt \
-      '^BB847B5A69EF343CEF511B29073C282D7D6F806C:3:$'
+    # assertFileRegex $WORKDIR/gpgtrust.txt \
+    #   '^BB847B5A69EF343CEF511B29073C282D7D6F806C:3:$'
   '';
 }


### PR DESCRIPTION
Rsync site is down and failing CI. Disabling fetching from resource, for now.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
