### PR TITLE
flake.nix: remove deprecations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,15 +9,11 @@
         home-manager = ./nixos;
         default = home-manager;
       };
-      # deprecated in Nix 2.8
-      nixosModule = self.nixosModules.default;
 
       darwinModules = rec {
         home-manager = ./nix-darwin;
         default = home-manager;
       };
-      # unofficial; deprecated in Nix 2.8
-      darwinModule = self.darwinModules.default;
 
       flakeModules = rec {
         home-manager = ./flake-module.nix;
@@ -25,10 +21,7 @@
       };
 
       templates = {
-        standalone = {
-          path = ./templates/standalone;
-          description = "Standalone setup";
-        };
+        default = self.templates.standalone;
         nixos = {
           path = ./templates/nixos;
           description = "Home Manager as a NixOS module,";
@@ -37,9 +30,11 @@
           path = ./templates/nix-darwin;
           description = "Home Manager as a nix-darwin module,";
         };
+        standalone = {
+          path = ./templates/standalone;
+          description = "Standalone setup";
+        };
       };
-
-      defaultTemplate = self.templates.standalone;
 
       lib = import ./lib { inherit (nixpkgs) lib; };
     } // (let
@@ -69,7 +64,5 @@
           docs-json = docs.options.json;
           docs-manpages = docs.manPages;
         });
-
-      defaultPackage = forAllSystems (system: self.packages.${system}.default);
     });
 }


### PR DESCRIPTION
Multiple stable releases removed from inception. Don't need to keep it around anymore.

https://nixos.org/blog/announcements/2022/nix-280/

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
