### PR TITLE
firefox: prevent extensions settings override

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -847,13 +847,11 @@ in {
           Using '${
             lib.showAttrPath
             (modulePath ++ [ "profiles" profileName "extensions" "settings" ])
-          }'
-          will override all previous extensions settings.
-          '${
+          }' will override all previous extensions settings.
+          Enable '${
             lib.showAttrPath
             (modulePath ++ [ "profiles" profileName "extensions" "force" ])
-          }'
-          needs to be enabled to acknowledge this.
+          }' to acknowledge this.
         '';
       }) cfg.profiles);
 


### PR DESCRIPTION
### Description

Prevents extensions settings from accidentally being overriden when using `profiles.<name>.extensions.settings`. Adds the `profiles.<name>.extensions.force` option to acknowledge the risk. See https://github.com/nix-community/home-manager/pull/6389#issuecomment-2666634695.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@khaneliman @rycee @brckd 
