### PR TITLE
files: support overwriting backup files

### DIFF
--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -33,7 +33,7 @@ for sourcePath in "$@" ; do
     elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
       # Next, try to move the file to a backup location if configured and possible
       backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
-      if [[ -e "$backup" ]]; then
+      if [[ -e "$backup" && "${HOME_MANAGER_OVERWRITE_BACKUPS:-false}" != "true" ]]; then
         errorEcho "Existing file '$backup' would be clobbered by backing up '$targetPath'"
         collision=1
       else

--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -35,7 +35,7 @@ for sourcePath in "$@" ; do
       backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
       if [[ -e "$backup" && "${HOME_MANAGER_OVERWRITE_BACKUPS:-false}" != "true" ]]; then
         errorEcho "Existing file '$backup' would be clobbered by backing up '$targetPath'"
-        collision=1
+        backupcollision=1
       else
         warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
       fi
@@ -55,5 +55,14 @@ if [[ -v collision ]] ; then
 - When used as a NixOS or nix-darwin module, set
     'home-manager.backupFileExtension'
   to, for example, 'backup' and rebuild."
+  exit 1
+fi
+
+if [[ -v backupcollision ]] ; then
+  errorEcho "Please do one of the following:
+- Move or remove the above files and try again.
+- When used as a NixOS or nix-darwin module, set
+    'home-manager.overwriteBackups'
+  to 'true' and rebuild."
   exit 1
 fi

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -17,12 +17,16 @@ in {
           echo Activating home-manager configuration for ${username}
           sudo -u ${username} --set-home ${
             pkgs.writeShellScript "activation-${username}" ''
-              ${lib.optionalString (cfg.backupFileExtension != null)
-              "export HOME_MANAGER_BACKUP_EXT=${
-                lib.escapeShellArg cfg.backupFileExtension
-              }"}
-              ${lib.optionalString cfg.verbose "export VERBOSE=1"}
-              exec ${usercfg.home.activationPackage}/activate
+              ${lib.optionalString cfg.overwriteBackups
+              "export HOME_MANAGER_OVERWRITE_BACKUPS=true"}
+                ${
+                  lib.optionalString (cfg.backupFileExtension != null)
+                  "export HOME_MANAGER_BACKUP_EXT=${
+                    lib.escapeShellArg cfg.backupFileExtension
+                  }"
+                }
+                ${lib.optionalString cfg.verbose "export VERBOSE=1"}
+                exec ${usercfg.home.activationPackage}/activate
             ''
           }
         '') cfg.users);

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -71,6 +71,11 @@ in {
       '';
     };
 
+    overwriteBackups = mkEnableOption ''
+      overwriting existing backups when activating a new
+      generation and detecting an existing backup
+    '';
+
     extraSpecialArgs = mkOption {
       type = types.attrs;
       default = { };

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -6,7 +6,9 @@ let
 
   cfg = config.home-manager;
 
-  serviceEnvironment = optionalAttrs (cfg.backupFileExtension != null) {
+  serviceEnvironment = optionalAttrs cfg.overwriteBackups {
+    HOME_MANAGER_OVERWRITE_BACKUPS = "true";
+  } // optionalAttrs (cfg.backupFileExtension != null) {
     HOME_MANAGER_BACKUP_EXT = cfg.backupFileExtension;
   } // optionalAttrs cfg.verbose { VERBOSE = "1"; };
 


### PR DESCRIPTION
Files that have backups already will prevent activation, add option to support overwriting files so users don't have to constantly clear conflicts if they don't care. This can be helpful with configuration files that get overwritten by programs, such as firefox extension configurations.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@teto @rycee 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
