### PR TITLE
home-cursor: modernize

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -58,6 +58,14 @@ let
         '';
       };
 
+      dotIcons = {
+        enable = mkEnableOption ''
+          `.icons` config generation for {option}`home.pointerCursor`
+        '' // {
+          default = true;
+        };
+      };
+
       hyprcursor = {
         enable = mkEnableOption "hyprcursor config generation";
 
@@ -175,7 +183,9 @@ in {
           "${defaultIndexThemePackage}/share/icons/default/index.theme";
         xdg.dataFile."icons/${cfg.name}".source =
           "${cfg.package}/share/icons/${cfg.name}";
+      }
 
+      (mkIf cfg.dotIcons.enable {
         # Add symlink of cursor icon directory to $HOME/.icons, needed for
         # backwards compatibility with some applications. See:
         # https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s03.html
@@ -183,7 +193,7 @@ in {
           "${defaultIndexThemePackage}/share/icons/default/index.theme";
         home.file.".icons/${cfg.name}".source =
           "${cfg.package}/share/icons/${cfg.name}";
-      }
+      })
 
       (mkIf cfg.x11.enable {
         xsession.profileExtra = ''

--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -1,7 +1,9 @@
 { config, options, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkDefault mkEnableOption mkOption types;
+  inherit (lib)
+    mkEnableOption mkOption mkIf mkMerge mkDefault mkAliasOptionModule types
+    literalExpression escapeShellArg hm getAttrFromPath any optional;
 
   cfg = config.home.pointerCursor;
 
@@ -9,7 +11,7 @@ let
     options = {
       package = mkOption {
         type = types.package;
-        example = lib.literalExpression "pkgs.vanilla-dmz";
+        example = literalExpression "pkgs.vanilla-dmz";
         description = "Package providing the cursor theme.";
       };
 
@@ -64,8 +66,8 @@ let
   };
 
   cursorPath =
-    "${cfg.package}/share/icons/${lib.escapeShellArg cfg.name}/cursors/${
-      lib.escapeShellArg cfg.x11.defaultCursor
+    "${cfg.package}/share/icons/${escapeShellArg cfg.name}/cursors/${
+      escapeShellArg cfg.x11.defaultCursor
     }";
 
   defaultIndexThemePackage = pkgs.writeTextFile {
@@ -86,22 +88,22 @@ in {
   meta.maintainers = [ lib.maintainers.league ];
 
   imports = [
-    (lib.mkAliasOptionModule [ "xsession" "pointerCursor" "package" ] [
+    (mkAliasOptionModule [ "xsession" "pointerCursor" "package" ] [
       "home"
       "pointerCursor"
       "package"
     ])
-    (lib.mkAliasOptionModule [ "xsession" "pointerCursor" "name" ] [
+    (mkAliasOptionModule [ "xsession" "pointerCursor" "name" ] [
       "home"
       "pointerCursor"
       "name"
     ])
-    (lib.mkAliasOptionModule [ "xsession" "pointerCursor" "size" ] [
+    (mkAliasOptionModule [ "xsession" "pointerCursor" "size" ] [
       "home"
       "pointerCursor"
       "size"
     ])
-    (lib.mkAliasOptionModule [ "xsession" "pointerCursor" "defaultCursor" ] [
+    (mkAliasOptionModule [ "xsession" "pointerCursor" "defaultCursor" ] [
       "home"
       "pointerCursor"
       "x11"

--- a/tests/modules/config/home-cursor/default.nix
+++ b/tests/modules/config/home-cursor/default.nix
@@ -32,11 +32,11 @@
     config = {
       home.pointerCursor = null;
 
-      home.stateVersion = "25.05";
+      home.stateVersion = "24.11";
 
       test.asserts.warnings.expected = [''
         Setting home.pointerCursor to null is deprecated.
-        Please update your configuration so that
+        Please update your configuration to explicitly set:
 
           home.pointerCursor.enable = false;
       ''];

--- a/tests/modules/config/home-cursor/default.nix
+++ b/tests/modules/config/home-cursor/default.nix
@@ -32,7 +32,127 @@
     config = {
       home.pointerCursor = null;
 
+      home.stateVersion = "25.05";
+
+      test.asserts.warnings.expected = [''
+        Setting home.pointerCursor to null is deprecated.
+        Please update your configuration so that
+
+          home.pointerCursor.enable = false;
+      ''];
+
+      nmt.script = ''
+        assertPathNotExists home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme
+
+        hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
+        assertFileExists $hmEnvFile
+        assertFileNotRegex $hmEnvFile 'XCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileNotRegex $hmEnvFile 'XCURSOR_SIZE="32"'
+        assertFileNotRegex $hmEnvFile 'HYPRCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileNotRegex $hmEnvFile 'HYPRCURSOR_SIZE="32"'
+      '';
+    };
+  };
+
+  home-cursor-legacy-disabled-with-enable = { realPkgs, ... }: {
+    config = {
+      home.pointerCursor = {
+        enable = false;
+        package = realPkgs.catppuccin-cursors.macchiatoBlue;
+        name = "catppuccin-macchiato-blue-standard";
+        size = 64;
+        gtk.enable = true;
+        hyprcursor.enable = true;
+        x11.enable = true;
+      };
+
       home.stateVersion = "24.11";
+
+      nmt.script = ''
+        assertPathNotExists home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme
+
+        hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
+        assertFileExists $hmEnvFile
+        assertFileNotRegex $hmEnvFile 'XCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileNotRegex $hmEnvFile 'XCURSOR_SIZE="32"'
+        assertFileNotRegex $hmEnvFile 'HYPRCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileNotRegex $hmEnvFile 'HYPRCURSOR_SIZE="32"'
+      '';
+    };
+  };
+
+  home-cursor-legacy-enabled-with-enable = { realPkgs, ... }: {
+    config = {
+      home.pointerCursor = {
+        enable = true;
+        package = realPkgs.catppuccin-cursors.macchiatoBlue;
+        name = "catppuccin-macchiato-blue-standard";
+        size = 64;
+        gtk.enable = true;
+        hyprcursor.enable = true;
+        x11.enable = true;
+      };
+
+      home.stateVersion = "24.11";
+
+      nmt.script = ''
+        assertFileContent \
+          home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme \
+          ${./expected-index.theme}
+
+        hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
+        assertFileExists $hmEnvFile
+        assertFileRegex $hmEnvFile 'XCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileRegex $hmEnvFile 'XCURSOR_SIZE="64"'
+        assertFileRegex $hmEnvFile 'HYPRCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileRegex $hmEnvFile 'HYPRCURSOR_SIZE="64"'
+      '';
+
+    };
+  };
+
+  home-cursor = { realPkgs, ... }: {
+    config = {
+      home.pointerCursor = {
+        enable = true;
+        package = realPkgs.catppuccin-cursors.macchiatoBlue;
+        name = "catppuccin-macchiato-blue-standard";
+        size = 64;
+        gtk.enable = true;
+        hyprcursor.enable = true;
+        x11.enable = true;
+      };
+
+      home.stateVersion = "25.05";
+
+      nmt.script = ''
+        assertFileContent \
+          home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme \
+          ${./expected-index.theme}
+
+        hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
+        assertFileExists $hmEnvFile
+        assertFileRegex $hmEnvFile 'XCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileRegex $hmEnvFile 'XCURSOR_SIZE="64"'
+        assertFileRegex $hmEnvFile 'HYPRCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileRegex $hmEnvFile 'HYPRCURSOR_SIZE="64"'
+      '';
+    };
+  };
+
+  home-cursor-disabled = { realPkgs, ... }: {
+    config = {
+      home.pointerCursor = {
+        enable = false;
+        package = realPkgs.catppuccin-cursors.macchiatoBlue;
+        name = "catppuccin-macchiato-blue-standard";
+        size = 64;
+        gtk.enable = true;
+        hyprcursor.enable = true;
+        x11.enable = true;
+      };
+
+      home.stateVersion = "25.05";
 
       nmt.script = ''
         assertPathNotExists home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme


### PR DESCRIPTION
### Description

Added the `.enable` pattern to `home.pointerCursor` for the selfish reason that is https://github.com/catppuccin/nix/blob/24dac16e6babd41961d985eef3dce6a30dab2e91/modules/home-manager/cursors.nix#L26-L27.

And made the `.icons` directory "toggleable" via `home.pointerCursor.doticons.enable`. Which in my opinion is easier than writing:

```nix 
{
  lib,
  config,
  ...
}:
{
  home.file = lib.mkIf (config.home.pointerCursor != null) {
    ".icons/default/index.theme".enable = false;
    ".icons/${config.home.pointerCursor.name}".enable = false;
  };
}
```

partially addresses https://github.com/nix-community/home-manager/issues/6268

And removing the top-level `with lib`

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
