### PR TITLE
qt: add "kde6" to qt.platformTheme

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -13,6 +13,11 @@ let
       libsForQt5.plasma-integration
       libsForQt5.systemsettings
     ];
+    kde6 = [
+      kdePackages.kio
+      kdePackages.plasma-integration
+      kdePackages.systemsettings
+    ];
     lxqt = [ lxqt.lxqt-qtplugin lxqt.lxqt-config ];
     qtct = [ libsForQt5.qt5ct qt6Packages.qt6ct ];
   };
@@ -75,6 +80,8 @@ in {
               [ "libsForQt5" "qt5ct" ]
               [ "libsForQt5" "qtstyleplugins" ]
               [ "libsForQt5" "systemsettings" ]
+              [ "kdePackages" "plasma-integration" ]
+              [ "kdePackages" "systemsettings" ]
               [ "lxqt" "lxqt-config" ]
               [ "lxqt" "lxqt-qtplugin" ]
               [ "qt6Packages" "qt6ct" ]
@@ -114,7 +121,10 @@ in {
                 applications
 
               `kde`
-              : Use Qt settings from Plasma
+              : Use Qt settings from Plasma 5
+
+              `kde6`
+              : Use Qt settings from Plasma 6
             '';
           };
           package = lib.mkOption {
@@ -131,8 +141,8 @@ in {
         };
       in lib.mkOption {
         type = with lib.types;
-          nullOr
-          (either (enum [ "gtk" "gtk3" "gnome" "adwaita" "lxqt" "qtct" "kde" ])
+          nullOr (either
+            (enum [ "gtk" "gtk3" "gnome" "adwaita" "lxqt" "qtct" "kde" "kde6" ])
             (lib.types.submodule { options = newOption; }));
         default = null;
         description = ''


### PR DESCRIPTION
### Description
Fixes #5098
This adds the necessary qt packages for KDE Plasma 6, fixing various issues with using qt.platformTheme on KDE Plasma 6

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@rycee
@thiagokokada