### PR TITLE
nh: change name of flake envvar for newer nh

### DIFF
--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -16,10 +16,11 @@ in {
       type = lib.types.nullOr lib.types.singleLineStr;
       default = null;
       description = ''
-        The path that will be used for the {env}`FLAKE` environment variable.
+        The path that will be used for the {env}`NH_FLAKE`
+        ({env}`FLAKE` if < 4.0.0-beta.1) environment variable.
 
-        {env}`FLAKE` is used by nh as the default flake for performing actions,
-        like {command}`nh os switch`.
+        {env}`NH_FLAKE` and {env}`FLAKE` are used by nh as the default flake for
+        performing actions, like {command}`nh os switch`.
       '';
     };
 
@@ -60,7 +61,15 @@ in {
 
     home = lib.mkIf cfg.enable {
       packages = [ cfg.package ];
-      sessionVariables = lib.mkIf (cfg.flake != null) { FLAKE = cfg.flake; };
+      sessionVariables = lib.mkIf (cfg.flake != null) {
+        # Includes 4.0.0 beta versions
+        ${
+          if lib.versionAtLeast cfg.package.version "4.0.0" then
+            "NH_FLAKE"
+          else
+            "FLAKE"
+        } = cfg.flake;
+      };
     };
 
     systemd.user = lib.mkIf cfg.clean.enable {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Environment variable is renamed upstream
To be merged after [4.0.0 release](https://github.com/viperML/nh/milestone/1)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

\<draft\>