### PR TITLE
tests/home-cursor: init

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -266,6 +266,7 @@ in import nmtSrc {
     ./modules/services/yubikey-agent-darwin
     ./modules/targets-darwin
   ] ++ lib.optionals isLinux [
+    ./modules/config/home-cursor
     ./modules/config/i18n
     ./modules/i18n/input-method
     ./modules/misc/debug

--- a/tests/modules/config/home-cursor/default.nix
+++ b/tests/modules/config/home-cursor/default.nix
@@ -1,0 +1,49 @@
+{
+  # Ensure backwards compatibility with existing configs
+  home-cursor-legacy = { realPkgs, ... }: {
+    config = {
+      home.pointerCursor = {
+        package = realPkgs.catppuccin-cursors.macchiatoBlue;
+        name = "catppuccin-macchiato-blue-standard";
+        size = 64;
+        gtk.enable = true;
+        hyprcursor.enable = true;
+        x11.enable = true;
+      };
+
+      home.stateVersion = "24.11";
+
+      nmt.script = ''
+        assertFileContent \
+          home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme \
+          ${./expected-index.theme}
+
+        hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
+        assertFileExists $hmEnvFile
+        assertFileRegex $hmEnvFile 'XCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileRegex $hmEnvFile 'XCURSOR_SIZE="64"'
+        assertFileRegex $hmEnvFile 'HYPRCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileRegex $hmEnvFile 'HYPRCURSOR_SIZE="64"'
+      '';
+    };
+  };
+
+  home-cursor-legacy-disabled = { ... }: {
+    config = {
+      home.pointerCursor = null;
+
+      home.stateVersion = "24.11";
+
+      nmt.script = ''
+        assertPathNotExists home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme
+
+        hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
+        assertFileExists $hmEnvFile
+        assertFileNotRegex $hmEnvFile 'XCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileNotRegex $hmEnvFile 'XCURSOR_SIZE="32"'
+        assertFileNotRegex $hmEnvFile 'HYPRCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileNotRegex $hmEnvFile 'HYPRCURSOR_SIZE="32"'
+      '';
+    };
+  };
+}

--- a/tests/modules/config/home-cursor/expected-index.theme
+++ b/tests/modules/config/home-cursor/expected-index.theme
@@ -1,0 +1,3 @@
+[Icon Theme]
+Name=Catppuccin Macchiato Blue
+Comment=based on Volantes Cursors


### PR DESCRIPTION
Working on module and needed test to verify expected behavior.

Created to aid in confidence with #6492
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
