### PR TITLE
Fix jetbrains-remote - do not fail if files do not exist yet

### DIFF
--- a/modules/programs/jetbrains-remote.nix
+++ b/modules/programs/jetbrains-remote.nix
@@ -31,7 +31,7 @@ in {
         "${ide}/bin/${ide.meta.mainProgram}-remote-dev-server registerBackendLocationForGateway || true";
       lines = map mkLine cfg.ides;
       linesStr = ''
-        rm $HOME/.cache/JetBrains/RemoteDev/userProvidedDist/_nix_store*
+        rm $HOME/.cache/JetBrains/RemoteDev/userProvidedDist/_nix_store* || true
       '' + concatStringsSep "\n" lines;
     in hm.dag.entryAfter [ "writeBoundary" ] linesStr;
   };


### PR DESCRIPTION
### Description

If you use `programs.jetbrains-remote` for the first time, `rm` will fail, as there are nothing to delete yet. I've tested this on my machine and it fixed an issue with the module

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

<details>
  <summary>There is an issue with other module when running tests the easy way</summary>
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/ac5c4134-aca6-4212-b88b-980054d97e2c" />

</details>

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@GenericNerdyUsername
