### PR TITLE
swayimg: add module

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2062,6 +2062,18 @@ in {
           See https://github.com/mateusauler/git-worktree-switcher for more.
         '';
       }
+
+      {
+        time = "2025-02-20T18:39:31+00:00";
+        condition = hostPlatform.isLinux;
+        message = ''
+          A new module is available: 'programs.swayimg'.
+
+          swayimg is a fully customizable and lightweight image viewer for
+          Wayland based display servers.
+          See https://github.com/artemsen/swayimg for more.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -236,6 +236,7 @@ let
     ./programs/sqls.nix
     ./programs/ssh.nix
     ./programs/starship.nix
+    ./programs/swayimg.nix
     ./programs/swaylock.nix
     ./programs/swayr.nix
     ./programs/taskwarrior.nix

--- a/modules/programs/swayimg.nix
+++ b/modules/programs/swayimg.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.programs.swayimg;
   iniFormat = pkgs.formats.ini { };
@@ -9,21 +7,21 @@ in {
   meta.maintainers = with lib.maintainers; [ dod-101 ];
 
   options.programs.swayimg = {
-    enable = mkEnableOption "swayimg";
-    package = mkOption {
-      type = types.package;
+    enable = lib.mkEnableOption "swayimg";
+    package = lib.mkOption {
+      type = lib.types.package;
       default = pkgs.swayimg;
-      defaultText = literalExpression "pkgs.swayimg";
+      defaultText = lib.literalExpression "pkgs.swayimg";
       description = "The swayimg package to install";
     };
-    settings = mkOption {
+    settings = lib.mkOption {
       type = iniFormat.type;
       default = { };
       description = ''
         Configuration written to
         {file}`$XDG_CONFIG_HOME/swayimg/config`. See <https://github.com/artemsen/swayimg/blob/master/extra/swayimgrc> for a list of available options.
       '';
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           viewer = {
             window = "#10000010";
@@ -40,14 +38,15 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
-      (hm.assertions.assertPlatform "programs.swayimg" pkgs platforms.linux)
+      (lib.hm.assertions.assertPlatform "programs.swayimg" pkgs
+        lib.platforms.linux)
     ];
 
     home.packages = [ cfg.package ];
 
-    xdg.configFile."swayimg/config" = mkIf (cfg.settings != { }) {
+    xdg.configFile."swayimg/config" = lib.mkIf (cfg.settings != { }) {
       source = iniFormat.generate "config" cfg.settings;
     };
   };

--- a/modules/programs/swayimg.nix
+++ b/modules/programs/swayimg.nix
@@ -1,0 +1,54 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.swayimg;
+  iniFormat = pkgs.formats.ini { };
+in {
+  meta.maintainers = with lib.maintainers; [ dod-101 ];
+
+  options.programs.swayimg = {
+    enable = mkEnableOption "swayimg";
+    package = mkOption {
+      type = types.package;
+      default = pkgs.swayimg;
+      defaultText = literalExpression "pkgs.swayimg";
+      description = "The swayimg package to install";
+    };
+    settings = mkOption {
+      type = iniFormat.type;
+      default = { };
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/swayimg/config`. See <https://github.com/artemsen/swayimg/blob/master/extra/swayimgrc> for a list of available options.
+      '';
+      example = literalExpression ''
+        {
+          viewer = {
+            window = "#10000010";
+            scale = "fill";
+          };
+          "info.viewer" = {
+            top_left = "+name,+format";
+          };
+          "keys.viewer" = {
+            "Shift+r" = "rand_file";
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (hm.assertions.assertPlatform "programs.swayimg" pkgs platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."swayimg/config" = mkIf (cfg.settings != { }) {
+      source = iniFormat.generate "config" cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -306,6 +306,7 @@ in import nmtSrc {
     ./modules/programs/rbw
     ./modules/programs/rofi
     ./modules/programs/rofi-pass
+    ./modules/programs/swayimg
     ./modules/programs/swaylock
     ./modules/programs/swayr
     ./modules/programs/terminator

--- a/tests/modules/programs/swayimg/default.nix
+++ b/tests/modules/programs/swayimg/default.nix
@@ -1,0 +1,4 @@
+{
+  swayimg-empty-settings = ./empty-settings.nix;
+  swayimg-example-settings = ./example-settings.nix;
+}

--- a/tests/modules/programs/swayimg/empty-settings.nix
+++ b/tests/modules/programs/swayimg/empty-settings.nix
@@ -1,0 +1,7 @@
+{
+  programs.swayimg.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/swayimg
+  '';
+}

--- a/tests/modules/programs/swayimg/example-settings-expected.ini
+++ b/tests/modules/programs/swayimg/example-settings-expected.ini
@@ -1,0 +1,9 @@
+[info.viewer]
+top_left=+name,+format
+
+[keys.viewer]
+Shift+r=rand_file
+
+[viewer]
+scale=fill
+window=#10000010

--- a/tests/modules/programs/swayimg/example-settings.nix
+++ b/tests/modules/programs/swayimg/example-settings.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+
+{
+  programs.swayimg = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    settings = {
+      viewer = {
+        window = "#10000010";
+        scale = "fill";
+      };
+      "info.viewer" = { top_left = "+name,+format"; };
+      "keys.viewer" = { "Shift+r" = "rand_file"; };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/swayimg/config \
+      ${./example-settings-expected.ini}
+  '';
+}


### PR DESCRIPTION
### Description

Added a module for [swayimg](https://github.com/artemsen/swayimg) and the ability to generate the `swayimgrc` (just called `config` on disk) file using hm.

Swayimg description (taken from their README): 

> Fully customizable and lightweight image viewer for Wayland based display servers.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
