### PR TITLE
tests: check that all firefox derivatives can be installed

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -286,6 +286,7 @@ in import nmtSrc {
     ./modules/programs/boxxy
     ./modules/programs/cavalier
     ./modules/programs/eww
+    ./modules/programs/firefox
     ./modules/programs/firefox/firefox.nix
     ./modules/programs/firefox/floorp.nix
     ./modules/programs/foot

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -289,6 +289,7 @@ in import nmtSrc {
     ./modules/programs/firefox
     ./modules/programs/firefox/firefox.nix
     ./modules/programs/firefox/floorp.nix
+    ./modules/programs/firefox/librewolf.nix
     ./modules/programs/foot
     ./modules/programs/freetube
     ./modules/programs/fuzzel

--- a/tests/modules/programs/firefox/default.nix
+++ b/tests/modules/programs/firefox/default.nix
@@ -1,0 +1,1 @@
+{ "firefox-multiple-derivatives" = ./multiple-derivatives.nix; }

--- a/tests/modules/programs/firefox/librewolf.nix
+++ b/tests/modules/programs/firefox/librewolf.nix
@@ -1,0 +1,1 @@
+import ./common.nix "librewolf"

--- a/tests/modules/programs/firefox/multiple-derivatives.nix
+++ b/tests/modules/programs/firefox/multiple-derivatives.nix
@@ -1,0 +1,16 @@
+{ config, lib, ... }:
+
+lib.mkIf config.test.enableBig {
+  programs.firefox = {
+    enable = true;
+    package = null;
+  };
+  programs.floorp = {
+    enable = true;
+    package = null;
+  };
+  programs.librewolf = {
+    enable = true;
+    package = null;
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
The issue itself was resolved with:
https://github.com/nix-community/home-manager/pull/6460

This patch only adds a test case to make sure we don't ever regress by
installing firefox and librewolf and floorp at the same time.

Closes: #6467

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
