### PR TITLE
treewide: remove with lib

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -16,12 +16,12 @@ let
 in runCommand "home-manager" {
   preferLocalBuild = true;
   nativeBuildInputs = [ gettext ];
-  meta = with lib; {
+  meta = {
     mainProgram = "home-manager";
     description = "A user environment configurator";
-    maintainers = [ maintainers.rycee ];
-    platforms = platforms.unix;
-    license = licenses.mit;
+    maintainers = [ lib.maintainers.rycee ];
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mit;
   };
 } ''
   install -v -D -m755  ${./home-manager} $out/bin/home-manager

--- a/modules/accounts/calendar.nix
+++ b/modules/accounts/calendar.nix
@@ -1,8 +1,6 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
-
+{ config, lib, ... }:
 let
+  inherit (lib) mkOption types;
 
   cfg = config.accounts.calendar;
 
@@ -70,7 +68,7 @@ let
     };
   };
 
-  calendarOpts = { name, config, ... }: {
+  calendarOpts = { name, ... }: {
     options = {
       name = mkOption {
         type = types.str;
@@ -125,7 +123,7 @@ in {
       type = types.str;
       example = ".calendar";
       apply = p:
-        if hasPrefix "/" p then p else "${config.home.homeDirectory}/${p}";
+        if lib.hasPrefix "/" p then p else "${config.home.homeDirectory}/${p}";
       description = ''
         The base directory in which to save calendars. May be a
         relative path, in which case it is relative the home
@@ -144,15 +142,15 @@ in {
       description = "List of calendars.";
     };
   };
-  config = mkIf (cfg.accounts != { }) {
+  config = lib.mkIf (cfg.accounts != { }) {
     assertions = let
-      primaries =
-        catAttrs "name" (filter (a: a.primary) (attrValues cfg.accounts));
+      primaries = lib.catAttrs "name"
+        (lib.filter (a: a.primary) (lib.attrValues cfg.accounts));
     in [{
-      assertion = length primaries <= 1;
+      assertion = lib.length primaries <= 1;
       message = "Must have at most one primary calendar account but found "
-        + toString (length primaries) + ", namely "
-        + concatStringsSep ", " primaries;
+        + toString (lib.length primaries) + ", namely "
+        + lib.concatStringsSep ", " primaries;
     }];
   };
 }

--- a/modules/accounts/contacts.nix
+++ b/modules/accounts/contacts.nix
@@ -1,8 +1,7 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, lib, ... }:
 
 let
+  inherit (lib) mkOption types;
 
   cfg = config.accounts.contact;
 
@@ -78,7 +77,7 @@ let
     };
   };
 
-  contactOpts = { name, config, ... }: {
+  contactOpts = { name, ... }: {
     options = {
       name = mkOption {
         type = types.str;
@@ -114,7 +113,7 @@ in {
     basePath = mkOption {
       type = types.str;
       apply = p:
-        if hasPrefix "/" p then p else "${config.home.homeDirectory}/${p}";
+        if lib.hasPrefix "/" p then p else "${config.home.homeDirectory}/${p}";
       description = ''
         The base directory in which to save contacts. May be a
         relative path, in which case it is relative the home

--- a/modules/accounts/email.nix
+++ b/modules/accounts/email.nix
@@ -1,8 +1,7 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, lib, ... }:
 
 let
+  inherit (lib) mkDefault mkIf mkOption types;
 
   cfg = config.accounts.email;
 
@@ -49,7 +48,7 @@ let
         default = ''
           --
         '';
-        example = literalExpression ''
+        example = lib.literalExpression ''
           ~*~*~*~*~*~*~*~*~*~*~*~
         '';
         description = ''
@@ -60,7 +59,7 @@ let
       command = mkOption {
         type = with types; nullOr path;
         default = null;
-        example = literalExpression ''
+        example = lib.literalExpression ''
           pkgs.writeScript "signature" "echo This is my signature"
         '';
         description = "A command that generates a signature.";
@@ -308,7 +307,7 @@ let
       passwordCommand = mkOption {
         type = types.nullOr (types.either types.str (types.listOf types.str));
         default = null;
-        apply = p: if isString p then splitString " " p else p;
+        apply = p: if lib.isString p then lib.splitString " " p else p;
         example = "secret-tool lookup email me@example.org";
         description = ''
           A command, which when run writes the account password on
@@ -407,10 +406,10 @@ let
       };
     };
 
-    config = mkMerge [
+    config = lib.mkMerge [
       {
         name = name;
-        maildir = mkOptionDefault { path = "${name}"; };
+        maildir = lib.mkOptionDefault { path = "${name}"; };
       }
 
       (mkIf (config.flavor == "yandex.com") {
@@ -526,7 +525,7 @@ in {
       default = "${config.home.homeDirectory}/Maildir";
       defaultText = "Maildir";
       apply = p:
-        if hasPrefix "/" p then p else "${config.home.homeDirectory}/${p}";
+        if lib.hasPrefix "/" p then p else "${config.home.homeDirectory}/${p}";
       description = ''
         The base directory for account maildir directories. May be a
         relative path (e.g. the user setting this value as "MyMaildir"),
@@ -545,13 +544,14 @@ in {
   config = mkIf (cfg.accounts != { }) {
     assertions = [
       (let
-        primaries =
-          catAttrs "name" (filter (a: a.primary) (attrValues cfg.accounts));
+        primaries = lib.catAttrs "name"
+          (lib.filter (a: a.primary) (lib.attrValues cfg.accounts));
       in {
-        assertion = length primaries == 1;
+        assertion = lib.length primaries == 1;
         message = "Must have exactly one primary mail account but found "
-          + toString (length primaries) + optionalString (length primaries > 1)
-          (", namely " + concatStringsSep ", " primaries);
+          + toString (lib.length primaries)
+          + lib.optionalString (lib.length primaries > 1)
+          (", namely " + lib.concatStringsSep ", " primaries);
       })
     ];
   };

--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -1,8 +1,7 @@
 { config, options, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkDefault mkEnableOption mkOption types;
 
   cfg = config.home.pointerCursor;
 
@@ -10,7 +9,7 @@ let
     options = {
       package = mkOption {
         type = types.package;
-        example = literalExpression "pkgs.vanilla-dmz";
+        example = lib.literalExpression "pkgs.vanilla-dmz";
         description = "Package providing the cursor theme.";
       };
 
@@ -64,8 +63,9 @@ let
     };
   };
 
-  cursorPath = "${cfg.package}/share/icons/${escapeShellArg cfg.name}/cursors/${
-      escapeShellArg cfg.x11.defaultCursor
+  cursorPath =
+    "${cfg.package}/share/icons/${lib.escapeShellArg cfg.name}/cursors/${
+      lib.escapeShellArg cfg.x11.defaultCursor
     }";
 
   defaultIndexThemePackage = pkgs.writeTextFile {
@@ -83,25 +83,25 @@ let
   };
 
 in {
-  meta.maintainers = [ maintainers.league ];
+  meta.maintainers = [ lib.maintainers.league ];
 
   imports = [
-    (mkAliasOptionModule [ "xsession" "pointerCursor" "package" ] [
+    (lib.mkAliasOptionModule [ "xsession" "pointerCursor" "package" ] [
       "home"
       "pointerCursor"
       "package"
     ])
-    (mkAliasOptionModule [ "xsession" "pointerCursor" "name" ] [
+    (lib.mkAliasOptionModule [ "xsession" "pointerCursor" "name" ] [
       "home"
       "pointerCursor"
       "name"
     ])
-    (mkAliasOptionModule [ "xsession" "pointerCursor" "size" ] [
+    (lib.mkAliasOptionModule [ "xsession" "pointerCursor" "size" ] [
       "home"
       "pointerCursor"
       "size"
     ])
-    (mkAliasOptionModule [ "xsession" "pointerCursor" "defaultCursor" ] [
+    (lib.mkAliasOptionModule [ "xsession" "pointerCursor" "defaultCursor" ] [
       "home"
       "pointerCursor"
       "x11"
@@ -109,8 +109,8 @@ in {
     ])
 
     ({ ... }: {
-      warnings = optional (any (x:
-        getAttrFromPath
+      warnings = lib.optional (lib.any (x:
+        lib.getAttrFromPath
         ([ "xsession" "pointerCursor" ] ++ [ x ] ++ [ "isDefined" ])
         options) [ "package" "name" "size" "defaultCursor" ]) ''
           The option `xsession.pointerCursor` has been merged into `home.pointerCursor` and will be removed
@@ -144,10 +144,11 @@ in {
     };
   };
 
-  config = mkIf (cfg != null) (mkMerge [
+  config = lib.mkIf (cfg != null) (lib.mkMerge [
     {
       assertions = [
-        (hm.assertions.assertPlatform "home.pointerCursor" pkgs platforms.linux)
+        (lib.hm.assertions.assertPlatform "home.pointerCursor" pkgs
+          lib.platforms.linux)
       ];
 
       home.packages = [ cfg.package defaultIndexThemePackage ];
@@ -178,7 +179,7 @@ in {
         "${cfg.package}/share/icons/${cfg.name}";
     }
 
-    (mkIf cfg.x11.enable {
+    (lib.mkIf cfg.x11.enable {
       xsession.profileExtra = ''
         ${pkgs.xorg.xsetroot}/bin/xsetroot -xcf ${cursorPath} ${
           toString cfg.size
@@ -191,11 +192,11 @@ in {
       };
     })
 
-    (mkIf cfg.gtk.enable {
+    (lib.mkIf cfg.gtk.enable {
       gtk.cursorTheme = mkDefault { inherit (cfg) package name size; };
     })
 
-    (mkIf cfg.hyprcursor.enable {
+    (lib.mkIf cfg.hyprcursor.enable {
       home.sessionVariables = {
         HYPRCURSOR_THEME = cfg.name;
         HYPRCURSOR_SIZE =
@@ -203,7 +204,7 @@ in {
       };
     })
 
-    (mkIf cfg.sway.enable {
+    (lib.mkIf cfg.sway.enable {
       wayland.windowManager.sway = {
         config = {
           seat = {

--- a/modules/config/i18n.nix
+++ b/modules/config/i18n.nix
@@ -17,8 +17,6 @@
 
 { lib, pkgs, config, ... }:
 
-with lib;
-
 let
   inherit (config.i18n) glibcLocales;
 
@@ -27,19 +25,19 @@ let
   archivePath = "${glibcLocales}/lib/locale/locale-archive";
 
   # lookup the version of glibcLocales and set the appropriate environment vars
-  localeVars = if versionAtLeast version "2.27" then {
+  localeVars = if lib.versionAtLeast version "2.27" then {
     LOCALE_ARCHIVE_2_27 = archivePath;
-  } else if versionAtLeast version "2.11" then {
+  } else if lib.versionAtLeast version "2.11" then {
     LOCALE_ARCHIVE_2_11 = archivePath;
   } else
     { };
 
 in {
-  meta.maintainers = with maintainers; [ midchildan ];
+  meta.maintainers = with lib.maintainers; [ midchildan ];
 
   options = {
-    i18n.glibcLocales = mkOption {
-      type = types.path;
+    i18n.glibcLocales = lib.mkOption {
+      type = lib.types.path;
       description = ''
         Customized `glibcLocales` package providing
         the `LOCALE_ARCHIVE_*` environment variable.
@@ -50,7 +48,7 @@ in {
         will be set to {var}`i18n.glibcLocales` from the
         system configuration.
       '';
-      example = literalExpression ''
+      example = lib.literalExpression ''
         pkgs.glibcLocales.override {
           allLocales = false;
           locales = [ "en_US.UTF-8/UTF-8" ];
@@ -58,11 +56,11 @@ in {
       '';
       # NB. See nixos/default.nix for NixOS default.
       default = pkgs.glibcLocales;
-      defaultText = literalExpression "pkgs.glibcLocales";
+      defaultText = lib.literalExpression "pkgs.glibcLocales";
     };
   };
 
-  config = mkIf pkgs.stdenv.hostPlatform.isLinux {
+  config = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     # For shell sessions.
     home.sessionVariables = localeVars;
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -5,16 +5,14 @@
   # Extra arguments passed to specialArgs.
 , extraSpecialArgs ? { } }:
 
-with lib;
-
 let
 
   collectFailed = cfg:
-    map (x: x.message) (filter (x: !x.assertion) cfg.assertions);
+    map (x: x.message) (lib.filter (x: !x.assertion) cfg.assertions);
 
   showWarnings = res:
     let f = w: x: builtins.trace "[1;31mwarning: ${w}[0m" x;
-    in fold f res res.config.warnings;
+    in lib.fold f res res.config.warnings;
 
   extendedLib = import ./lib/stdlib-extended.nix lib;
 
@@ -32,7 +30,7 @@ let
   moduleChecks = raw:
     showWarnings (let
       failed = collectFailed raw.config;
-      failedStr = concatStringsSep "\n" (map (x: "- ${x}") failed);
+      failedStr = lib.concatStringsSep "\n" (map (x: "- ${x}") failed);
     in if failed == [ ] then
       raw
     else
@@ -52,8 +50,8 @@ let
       activation-script = module.config.home.activationPackage;
 
       newsDisplay = rawModule.config.news.display;
-      newsEntries = sort (a: b: a.time > b.time)
-        (filter (a: a.condition) rawModule.config.news.entries);
+      newsEntries = lib.sort (a: b: a.time > b.time)
+        (lib.filter (a: a.condition) rawModule.config.news.entries);
 
       inherit (module._module.args) pkgs;
 

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -1,10 +1,8 @@
 { pkgs, config, lib, ... }:
 
-with lib;
-
 let
 
-  cfg = filterAttrs (n: f: f.enable) config.home.file;
+  cfg = lib.filterAttrs (n: f: f.enable) config.home.file;
 
   homeDirectory = config.home.homeDirectory;
 
@@ -25,14 +23,14 @@ in
 
 {
   options = {
-    home.file = mkOption {
+    home.file = lib.mkOption {
       description = "Attribute set of files to link into the user home.";
       default = {};
       type = fileType "home.file" "{env}`HOME`" homeDirectory;
     };
 
-    home-files = mkOption {
-      type = types.package;
+    home-files = lib.mkOption {
+      type = lib.types.package;
       internal = true;
       description = "Package to contain all home files";
     };
@@ -42,11 +40,11 @@ in
     assertions = [(
       let
         dups =
-          attrNames
-            (filterAttrs (n: v: v > 1)
-            (foldAttrs (acc: v: acc + v) 0
-            (mapAttrsToList (n: v: { ${v.target} = 1; }) cfg)));
-        dupsStr = concatStringsSep ", " dups;
+          lib.attrNames
+            (lib.filterAttrs (n: v: v > 1)
+            (lib.foldAttrs (acc: v: acc + v) 0
+            (lib.mapAttrsToList (n: v: { ${v.target} = 1; }) cfg)));
+        dupsStr = lib.concatStringsSep ", " dups;
       in {
         assertion = dups == [];
         message = ''
@@ -64,22 +62,22 @@ in
     lib.file.mkOutOfStoreSymlink = path:
       let
         pathStr = toString path;
-        name = hm.strings.storeFileName (baseNameOf pathStr);
+        name = lib.hm.strings.storeFileName (baseNameOf pathStr);
       in
-        pkgs.runCommandLocal name {} ''ln -s ${escapeShellArg pathStr} $out'';
+        pkgs.runCommandLocal name {} ''ln -s ${lib.escapeShellArg pathStr} $out'';
 
     # This verifies that the links we are about to create will not
     # overwrite an existing file.
-    home.activation.checkLinkTargets = hm.dag.entryBefore ["writeBoundary"] (
+    home.activation.checkLinkTargets = lib.hm.dag.entryBefore ["writeBoundary"] (
       let
         # Paths that should be forcibly overwritten by Home Manager.
         # Caveat emptor!
         forcedPaths =
-          concatMapStringsSep " " (p: ''"$HOME"/${escapeShellArg p}'')
-            (mapAttrsToList (n: v: v.target)
-            (filterAttrs (n: v: v.force) cfg));
+          lib.concatMapStringsSep " " (p: ''"$HOME"/${lib.escapeShellArg p}'')
+            (lib.mapAttrsToList (n: v: v.target)
+            (lib.filterAttrs (n: v: v.force) cfg));
 
-        storeDir = escapeShellArg builtins.storeDir;
+        storeDir = lib.escapeShellArg builtins.storeDir;
 
         check = pkgs.substituteAll {
           src = ./files/check-link-targets.sh;
@@ -118,7 +116,7 @@ in
     # and a failure during the intermediate state FA ∩ FB will not
     # result in lost links because this set of links are in both the
     # source and target generation.
-    home.activation.linkGeneration = hm.dag.entryAfter ["writeBoundary"] (
+    home.activation.linkGeneration = lib.hm.dag.entryAfter ["writeBoundary"] (
       let
         link = pkgs.writeShellScript "link" ''
           ${config.lib.bash.initHomeManagerLib}
@@ -151,7 +149,7 @@ in
 
           # A symbolic link whose target path matches this pattern will be
           # considered part of a Home Manager generation.
-          homeFilePattern="$(readlink -e ${escapeShellArg builtins.storeDir})/*-home-manager-files/*"
+          homeFilePattern="$(readlink -e ${lib.escapeShellArg builtins.storeDir})/*-home-manager-files/*"
 
           newGenFiles="$1"
           shift 1
@@ -216,9 +214,9 @@ in
         ''
     );
 
-    home.activation.checkFilesChanged = hm.dag.entryBefore ["linkGeneration"] (
+    home.activation.checkFilesChanged = lib.hm.dag.entryBefore ["linkGeneration"] (
       let
-        homeDirArg = escapeShellArg homeDirectory;
+        homeDirArg = lib.escapeShellArg homeDirectory;
       in ''
         function _cmp() {
           if [[ -d $1 && -d $2 ]]; then
@@ -228,31 +226,31 @@ in
           fi
         }
         declare -A changedFiles
-      '' + concatMapStrings (v:
+      '' + lib.concatMapStrings (v:
         let
-          sourceArg = escapeShellArg (sourceStorePath v);
-          targetArg = escapeShellArg v.target;
+          sourceArg = lib.escapeShellArg (sourceStorePath v);
+          targetArg = lib.escapeShellArg v.target;
         in ''
           _cmp ${sourceArg} ${homeDirArg}/${targetArg} \
             && changedFiles[${targetArg}]=0 \
             || changedFiles[${targetArg}]=1
-        '') (filter (v: v.onChange != "") (attrValues cfg))
+        '') (lib.filter (v: v.onChange != "") (lib.attrValues cfg))
       + ''
         unset -f _cmp
       ''
     );
 
-    home.activation.onFilesChange = hm.dag.entryAfter ["linkGeneration"] (
-      concatMapStrings (v: ''
-        if (( ''${changedFiles[${escapeShellArg v.target}]} == 1 )); then
+    home.activation.onFilesChange = lib.hm.dag.entryAfter ["linkGeneration"] (
+      lib.concatMapStrings (v: ''
+        if (( ''${changedFiles[${lib.escapeShellArg v.target}]} == 1 )); then
           if [[ -v DRY_RUN || -v VERBOSE ]]; then
-            echo "Running onChange hook for" ${escapeShellArg v.target}
+            echo "Running onChange hook for" ${lib.escapeShellArg v.target}
           fi
           if [[ ! -v DRY_RUN ]]; then
             ${v.onChange}
           fi
         fi
-      '') (filter (v: v.onChange != "") (attrValues cfg))
+      '') (lib.filter (v: v.onChange != "") (lib.attrValues cfg))
     );
 
     # Symlink directories and files that have the right execute bit.
@@ -324,10 +322,10 @@ in
             fi
           fi
         }
-      '' + concatStrings (
-        mapAttrsToList (n: v: ''
+      '' + lib.concatStrings (
+        lib.mapAttrsToList (n: v: ''
           insertFile ${
-            escapeShellArgs [
+            lib.escapeShellArgs [
               (sourceStorePath v)
               v.target
               (if v.executable == null

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -1,8 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) literalExpression mkOption types;
 
   inherit (config.home) stateVersion;
 
@@ -114,7 +113,7 @@ let
       layout = mkOption {
         type = with types; nullOr str;
         default =
-          if versionAtLeast config.home.stateVersion "19.09"
+          if lib.versionAtLeast config.home.stateVersion "19.09"
           then null
           else "us";
         defaultText = literalExpression "null";
@@ -148,7 +147,7 @@ let
       variant = mkOption {
         type = with types; nullOr str;
         default =
-          if versionAtLeast config.home.stateVersion "19.09"
+          if lib.versionAtLeast config.home.stateVersion "19.09"
           then null
           else "";
         defaultText = literalExpression "null";
@@ -167,10 +166,10 @@ let
 in
 
 {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = [ lib.maintainers.rycee ];
 
   imports = [
-    (mkRemovedOptionModule [ "home" "sessionVariableSetter" ] ''
+    (lib.mkRemovedOptionModule [ "home" "sessionVariableSetter" ] ''
       Session variables are now always set through the shell. This is
       done automatically if the shell configuration is managed by Home
       Manager. If not, then you must source the
@@ -223,7 +222,7 @@ in
 
     home.keyboard = mkOption {
       type = types.nullOr keyboardSubModule;
-      default = if versionAtLeast stateVersion "21.11" then null else { };
+      default = if lib.versionAtLeast stateVersion "21.11" then null else { };
       defaultText = literalExpression ''
         "{ }"  for state version < 21.11,
         "null" for state version ≥ 21.11
@@ -355,7 +354,7 @@ in
     home.emptyActivationPath = mkOption {
       internal = true;
       type = types.bool;
-      default = versionAtLeast stateVersion "22.11";
+      default = lib.versionAtLeast stateVersion "22.11";
       defaultText = literalExpression ''
         false   for state version < 22.11,
         true    for state version ≥ 22.11
@@ -370,7 +369,7 @@ in
     };
 
     home.activation = mkOption {
-      type = hm.types.dagOf types.str;
+      type = lib.hm.types.dagOf types.str;
       default = {};
       example = literalExpression ''
         {
@@ -475,7 +474,7 @@ in
       '';
     };
 
-    home.preferXdgDirectories = mkEnableOption "" // {
+    home.preferXdgDirectories = lib.mkEnableOption "" // {
       description = ''
         Whether to make programs use XDG directories whenever supported.
       '';
@@ -502,7 +501,7 @@ in
           config.home.enableNixpkgsReleaseCheck
           && hmRelease != nixpkgsRelease;
       in
-        optional releaseMismatch ''
+        lib.optional releaseMismatch ''
           You are using
 
             Home Manager version ${hmRelease} and
@@ -520,11 +519,11 @@ in
         '';
 
     home.username =
-      mkIf (versionOlder config.home.stateVersion "20.09")
-        (mkDefault (builtins.getEnv "USER"));
+      lib.mkIf (lib.versionOlder config.home.stateVersion "20.09")
+        (lib.mkDefault (builtins.getEnv "USER"));
     home.homeDirectory =
-      mkIf (versionOlder config.home.stateVersion "20.09")
-        (mkDefault (builtins.getEnv "HOME"));
+      lib.mkIf (lib.versionOlder config.home.stateVersion "20.09")
+        (lib.mkDefault (builtins.getEnv "HOME"));
 
     home.profileDirectory =
       if config.submoduleSupport.enable
@@ -540,7 +539,7 @@ in
 
     home.sessionVariables =
       let
-        maybeSet = n: v: optionalAttrs (v != null) { ${n} = v; };
+        maybeSet = n: v: lib.optionalAttrs (v != null) { ${n} = v; };
       in
         (maybeSet "LANG" cfg.language.base)
         //
@@ -577,7 +576,7 @@ in
 
         ${config.lib.shell.exportAll cfg.sessionVariables}
       '' + lib.optionalString (cfg.sessionPath != [ ]) ''
-        export PATH="$PATH''${PATH:+:}${concatStringsSep ":" cfg.sessionPath}"
+        export PATH="$PATH''${PATH:+:}${lib.concatStringsSep ":" cfg.sessionPath}"
       '' + cfg.sessionVariablesExtra;
     };
 
@@ -586,7 +585,7 @@ in
     # The entry acting as a boundary between the activation script's "check" and
     # the "write" phases. This is where we commit to attempting to actually
     # activate the configuration.
-    home.activation.writeBoundary = hm.dag.entryAnywhere ''
+    home.activation.writeBoundary = lib.hm.dag.entryAnywhere ''
       if [[ ! -v oldGenPath || "$oldGenPath" != "$newGenPath" ]] ; then
         _i "Creating new profile generation"
         run nix-env $VERBOSE_ARG --profile "$genProfilePath" --set "$newGenPath"
@@ -610,7 +609,7 @@ in
     # In case the user has moved from a user-install of Home Manager
     # to a submodule managed one we attempt to uninstall the
     # `home-manager-path` package if it is installed.
-    home.activation.installPackages = hm.dag.entryAfter ["writeBoundary"] (
+    home.activation.installPackages = lib.hm.dag.entryAfter ["writeBoundary"] (
       if config.submoduleSupport.externalPackageInstall
       then
         ''
@@ -676,10 +675,10 @@ in
             _iNote "Activating %s" "${res.name}"
             ${res.data}
           '';
-        sortedCommands = hm.dag.topoSort cfg.activation;
+        sortedCommands = lib.hm.dag.topoSort cfg.activation;
         activationCmds =
           if sortedCommands ? result then
-            concatStringsSep "\n" (map mkCmd sortedCommands.result)
+            lib.concatStringsSep "\n" (map mkCmd sortedCommands.result)
           else
             abort ("Dependency cycle in activation script: "
               + builtins.toJSON sortedCommands);
@@ -708,7 +707,7 @@ in
           else
             ":$(${pkgs.coreutils}/bin/dirname $(${pkgs.coreutils}/bin/readlink -m $(type -p nix-env)))"
         )
-        + optionalString (!cfg.emptyActivationPath) "\${PATH:+:}$PATH";
+        + lib.optionalString (!cfg.emptyActivationPath) "\${PATH:+:}$PATH";
 
         activationScript = pkgs.writeShellScript "activation-script" ''
           set -eu
@@ -722,8 +721,8 @@ in
           ${builtins.readFile ./lib-bash/activation-init.sh}
 
           if [[ ! -v SKIP_SANITY_CHECKS ]]; then
-            checkUsername ${escapeShellArg config.home.username}
-            checkHomeDirectory ${escapeShellArg config.home.homeDirectory}
+            checkUsername ${lib.escapeShellArg config.home.username}
+            checkHomeDirectory ${lib.escapeShellArg config.home.homeDirectory}
           fi
 
           # Create a temporary GC root to prevent collection during activation.
@@ -732,7 +731,7 @@ in
 
           ${activationCmds}
 
-          ${optionalString (!config.uninstall) ''
+          ${lib.optionalString (!config.uninstall) ''
             # Create the "current generation" GC root.
             run --silence nix-store --realise "$newGenPath" --add-root "$currentGenGcPath"
 

--- a/modules/i18n/input-method/default.nix
+++ b/modules/i18n/input-method/default.nix
@@ -1,6 +1,5 @@
 { config, pkgs, lib, ... }:
 
-with lib;
 let
 
   cfg = config.i18n.inputMethod;
@@ -26,9 +25,9 @@ in {
 
   options.i18n = {
     inputMethod = {
-      enabled = mkOption {
-        type = types.nullOr
-          (types.enum [ "fcitx" "fcitx5" "nabi" "uim" "hime" "kime" ]);
+      enabled = lib.mkOption {
+        type = lib.types.nullOr
+          (lib.types.enum [ "fcitx" "fcitx5" "nabi" "uim" "hime" "kime" ]);
         default = null;
         example = "fcitx5";
         description = ''
@@ -61,9 +60,9 @@ in {
         '';
       };
 
-      package = mkOption {
+      package = lib.mkOption {
         internal = true;
-        type = types.nullOr types.path;
+        type = lib.types.nullOr lib.types.path;
         default = null;
         description = ''
           The input method method package.
@@ -72,9 +71,10 @@ in {
     };
   };
 
-  config = mkIf (cfg.enabled != null) {
+  config = lib.mkIf (cfg.enabled != null) {
     assertions = [
-      (hm.assertions.assertPlatform "i18n.inputMethod" pkgs platforms.linux)
+      (lib.hm.assertions.assertPlatform "i18n.inputMethod" pkgs
+        lib.platforms.linux)
       {
         assertion = cfg.enabled != "fcitx";
         message = "fcitx has been removed, please use fcitx5 instead";
@@ -84,5 +84,5 @@ in {
     home.packages = [ cfg.package gtk2Cache gtk3Cache ];
   };
 
-  meta.maintainers = with lib; [ hm.maintainers.kranzes ];
+  meta.maintainers = [ lib.hm.maintainers.kranzes ];
 }

--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -1,7 +1,5 @@
 { config, pkgs, lib, ... }:
 
-with lib;
-
 let
   im = config.i18n.inputMethod;
   cfg = im.fcitx5;
@@ -9,25 +7,25 @@ let
 in {
   options = {
     i18n.inputMethod.fcitx5 = {
-      fcitx5-with-addons = mkOption {
-        type = types.package;
+      fcitx5-with-addons = lib.mkOption {
+        type = lib.types.package;
         default = pkgs.libsForQt5.fcitx5-with-addons;
-        example = literalExpression "pkgs.kdePackages.fcitx5-with-addons";
+        example = lib.literalExpression "pkgs.kdePackages.fcitx5-with-addons";
         description = ''
           The fcitx5 package to use.
         '';
       };
-      addons = mkOption {
-        type = with types; listOf package;
+      addons = lib.mkOption {
+        type = with lib.types; listOf package;
         default = [ ];
-        example = literalExpression "with pkgs; [ fcitx5-rime ]";
+        example = lib.literalExpression "with pkgs; [ fcitx5-rime ]";
         description = ''
           Enabled Fcitx5 addons.
         '';
       };
 
-      waylandFrontend = mkOption {
-        type = types.bool;
+      waylandFrontend = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Use the Wayland input method frontend.
@@ -37,7 +35,7 @@ in {
     };
   };
 
-  config = mkIf (im.enabled == "fcitx5") {
+  config = lib.mkIf (im.enabled == "fcitx5") {
     i18n.inputMethod.package = fcitx5Package;
 
     home.sessionVariables = {

--- a/modules/i18n/input-method/hime.nix
+++ b/modules/i18n/input-method/hime.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, ... }:
 
-with lib; {
-  config = mkIf (config.i18n.inputMethod.enabled == "hime") {
+{
+  config = lib.mkIf (config.i18n.inputMethod.enabled == "hime") {
     i18n.inputMethod.package = pkgs.hime;
 
     home.sessionVariables = {

--- a/modules/i18n/input-method/nabi.nix
+++ b/modules/i18n/input-method/nabi.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, ... }:
 
-with lib; {
-  config = mkIf (config.i18n.inputMethod.enabled == "nabi") {
+{
+  config = lib.mkIf (config.i18n.inputMethod.enabled == "nabi") {
     i18n.inputMethod.package = pkgs.nabi;
 
     home.sessionVariables = {

--- a/modules/i18n/input-method/uim.nix
+++ b/modules/i18n/input-method/uim.nix
@@ -1,14 +1,13 @@
 { config, pkgs, lib, ... }:
 
-with lib;
-
 let cfg = config.i18n.inputMethod.uim;
 in {
   options = {
 
     i18n.inputMethod.uim = {
-      toolbar = mkOption {
-        type = types.enum [ "gtk" "gtk3" "gtk-systray" "gtk3-systray" "qt4" ];
+      toolbar = lib.mkOption {
+        type =
+          lib.types.enum [ "gtk" "gtk3" "gtk-systray" "gtk3-systray" "qt4" ];
         default = "gtk";
         example = "gtk-systray";
         description = ''
@@ -19,7 +18,7 @@ in {
 
   };
 
-  config = mkIf (config.i18n.inputMethod.enabled == "uim") {
+  config = lib.mkIf (config.i18n.inputMethod.enabled == "uim") {
     i18n.inputMethod.package = pkgs.uim;
 
     home.sessionVariables = {

--- a/modules/manual.nix
+++ b/modules/manual.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
   cfg = config.manual;
@@ -13,8 +11,8 @@ let
 
 in {
   options = {
-    manual.html.enable = mkOption {
-      type = types.bool;
+    manual.html.enable = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Whether to install the HTML manual. This also installs the
@@ -23,8 +21,8 @@ in {
       '';
     };
 
-    manual.manpages.enable = mkOption {
-      type = types.bool;
+    manual.manpages.enable = lib.mkOption {
+      type = lib.types.bool;
       default = true;
       example = false;
       description = ''
@@ -37,8 +35,8 @@ in {
       '';
     };
 
-    manual.json.enable = mkOption {
-      type = types.bool;
+    manual.json.enable = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       example = true;
       description = ''
@@ -52,10 +50,10 @@ in {
   };
 
   config = {
-    home.packages = mkMerge [
-      (mkIf cfg.html.enable [ docs.manual.html docs.manual.htmlOpenTool ])
-      (mkIf cfg.manpages.enable [ docs.manPages ])
-      (mkIf cfg.json.enable [ docs.options.json ])
+    home.packages = lib.mkMerge [
+      (lib.mkIf cfg.html.enable [ docs.manual.html docs.manual.htmlOpenTool ])
+      (lib.mkIf cfg.manpages.enable [ docs.manPages ])
+      (lib.mkIf cfg.json.enable [ docs.options.json ])
     ];
   };
 

--- a/modules/misc/debug.nix
+++ b/modules/misc/debug.nix
@@ -1,10 +1,8 @@
-{ config, pkgs, lib, ... }:
-
-with lib;
+{ config, lib, ... }:
 
 {
   options.home = {
-    enableDebugInfo = mkEnableOption "" // {
+    enableDebugInfo = lib.mkEnableOption "" // {
       description = ''
         Some Nix packages provide debug symbols for
         {command}`gdb` in the `debug` output.
@@ -15,7 +13,7 @@ with lib;
     };
   };
 
-  config = mkIf config.home.enableDebugInfo {
+  config = lib.mkIf config.home.enableDebugInfo {
     home.extraOutputsToInstall = [ "debug" ];
 
     home.sessionVariables = {

--- a/modules/misc/editorconfig.nix
+++ b/modules/misc/editorconfig.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
   cfg = config.editorconfig;
@@ -9,12 +7,12 @@ let
   iniFormat = pkgs.formats.ini { };
 
 in {
-  meta.maintainers = with maintainers; [ loicreynier ];
+  meta.maintainers = with lib.maintainers; [ loicreynier ];
 
   options.editorconfig = {
-    enable = mkEnableOption "EditorConfig home configuration file";
+    enable = lib.mkEnableOption "EditorConfig home configuration file";
 
-    settings = mkOption {
+    settings = lib.mkOption {
       type = iniFormat.type;
       default = { };
       description = ''
@@ -23,7 +21,7 @@ in {
         it must not be added here.
         See <https://editorconfig.org> for documentation.
       '';
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           "*" = {
             charset = "utf-8";
@@ -39,9 +37,9 @@ in {
     };
   };
 
-  config = mkIf (cfg.enable && cfg.settings != { }) {
+  config = lib.mkIf (cfg.enable && cfg.settings != { }) {
     home.file.".editorconfig".text = let
-      renderedSettings = generators.toINIWithGlobalSection { } {
+      renderedSettings = lib.generators.toINIWithGlobalSection { } {
         globalSection = { root = true; };
         sections = cfg.settings;
       };

--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -4,8 +4,6 @@
 
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
   cfg = config.fonts.fontconfig;
@@ -13,10 +11,10 @@ let
   profileDirectory = config.home.profileDirectory;
 
 in {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = [ lib.maintainers.rycee ];
 
   imports = [
-    (mkRenamedOptionModule [ "fonts" "fontconfig" "enableProfileFonts" ] [
+    (lib.mkRenamedOptionModule [ "fonts" "fontconfig" "enableProfileFonts" ] [
       "fonts"
       "fontconfig"
       "enable"
@@ -25,8 +23,8 @@ in {
 
   options = {
     fonts.fontconfig = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to enable fontconfig configuration. This will, for
@@ -38,8 +36,8 @@ in {
       };
 
       defaultFonts = {
-        monospace = mkOption {
-          type = with types; listOf str;
+        monospace = lib.mkOption {
+          type = with lib.types; listOf str;
           default = [ ];
           description = ''
             Per-user default monospace font(s). Multiple fonts may be listed in
@@ -47,8 +45,8 @@ in {
           '';
         };
 
-        sansSerif = mkOption {
-          type = with types; listOf str;
+        sansSerif = lib.mkOption {
+          type = with lib.types; listOf str;
           default = [ ];
           description = ''
             Per-user default sans serif font(s). Multiple fonts may be listed
@@ -56,8 +54,8 @@ in {
           '';
         };
 
-        serif = mkOption {
-          type = with types; listOf str;
+        serif = lib.mkOption {
+          type = with lib.types; listOf str;
           default = [ ];
           description = ''
             Per-user default serif font(s). Multiple fonts may be listed in
@@ -65,8 +63,8 @@ in {
           '';
         };
 
-        emoji = mkOption {
-          type = with types; listOf str;
+        emoji = lib.mkOption {
+          type = with lib.types; listOf str;
           default = [ ];
           description = ''
             Per-user default emoji font(s). Multiple fonts may be listed in
@@ -83,7 +81,7 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     home.packages = [
       # Make sure that buildEnv creates a real directory path so that we avoid
       # trying to write to a read-only location.
@@ -105,7 +103,7 @@ in {
       </fontconfig>
       EOF
 
-        ${getBin pkgs.fontconfig}/bin/fc-cache -f
+        ${lib.getBin pkgs.fontconfig}/bin/fc-cache -f
         rm -f $out/lib/fontconfig/cache/CACHEDIR.TAG
         rmdir --ignore-fail-on-non-empty -p $out/lib/fontconfig/cache
 
@@ -147,12 +145,12 @@ in {
 
       "fontconfig/conf.d/52-hm-default-fonts.conf".text = let
         genDefault = fonts: name:
-          optionalString (fonts != [ ]) ''
+          lib.optionalString (fonts != [ ]) ''
             <alias binding="same">
               <family>${name}</family>
               <prefer>
               ${
-                concatStringsSep "" (map (font: ''
+                lib.concatStringsSep "" (map (font: ''
                   <family>${font}</family>
                 '') fonts)
               }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -1,6 +1,8 @@
-{ config, lib, options, pkgs, ... }:
-with lib;
+{ config, lib, pkgs, ... }:
+
 let
+  inherit (lib) mkOption types;
+
   cfg = config.news;
 
   hostPlatform = pkgs.stdenv.hostPlatform;
@@ -39,10 +41,12 @@ let
       };
     };
 
-    config = { id = mkDefault (builtins.hashString "sha256" config.message); };
+    config = {
+      id = lib.mkDefault (builtins.hashString "sha256" config.message);
+    };
   });
 in {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = [ lib.maintainers.rycee ];
 
   options = {
     news = {
@@ -1891,8 +1895,8 @@ in {
       {
         time = "2024-12-08T17:22:13+00:00";
         condition = let
-          usingMbsync = any (a: a.mbsync.enable)
-            (attrValues config.accounts.email.accounts);
+          usingMbsync = lib.any (a: a.mbsync.enable)
+            (lib.attrValues config.accounts.email.accounts);
         in usingMbsync;
         message = ''
           isync/mbsync 1.5.0 has changed several things.

--- a/modules/misc/nixpkgs-disabled.nix
+++ b/modules/misc/nixpkgs-disabled.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
   cfg = config.nixpkgs;
@@ -17,28 +15,28 @@ let
     let
       lhs = optCall lhs_ { inherit pkgs; };
       rhs = optCall rhs_ { inherit pkgs; };
-    in lhs // rhs // optionalAttrs (lhs ? packageOverrides) {
+    in lhs // rhs // lib.optionalAttrs (lhs ? packageOverrides) {
       packageOverrides = pkgs:
         optCall lhs.packageOverrides pkgs
-        // optCall (attrByPath [ "packageOverrides" ] ({ }) rhs) pkgs;
-    } // optionalAttrs (lhs ? perlPackageOverrides) {
+        // optCall (lib.attrByPath [ "packageOverrides" ] { } rhs) pkgs;
+    } // lib.optionalAttrs (lhs ? perlPackageOverrides) {
       perlPackageOverrides = pkgs:
         optCall lhs.perlPackageOverrides pkgs
-        // optCall (attrByPath [ "perlPackageOverrides" ] ({ }) rhs) pkgs;
+        // optCall (lib.attrByPath [ "perlPackageOverrides" ] { } rhs) pkgs;
     };
 
   # Copied from nixpkgs.nix.
-  configType = mkOptionType {
+  configType = lib.mkOptionType {
     name = "nixpkgs-config";
     description = "nixpkgs config";
     check = x:
       let traceXIfNot = c: if c x then true else lib.traceSeqN 1 x false;
       in traceXIfNot isConfig;
-    merge = args: fold (def: mergeConfig def.value) { };
+    merge = args: lib.fold (def: mergeConfig def.value) { };
   };
 
   # Copied from nixpkgs.nix.
-  overlayType = mkOptionType {
+  overlayType = lib.mkOptionType {
     name = "nixpkgs-overlay";
     description = "nixpkgs overlay";
     check = builtins.isFunction;
@@ -46,18 +44,18 @@ let
   };
 
 in {
-  meta.maintainers = with maintainers; [ thiagokokada ];
+  meta.maintainers = with lib.maintainers; [ thiagokokada ];
 
   options.nixpkgs = {
-    config = mkOption {
+    config = lib.mkOption {
       default = null;
-      type = types.nullOr configType;
+      type = lib.types.nullOr configType;
       visible = false;
     };
 
-    overlays = mkOption {
+    overlays = lib.mkOption {
       default = null;
-      type = types.nullOr (types.listOf overlayType);
+      type = lib.types.nullOr (lib.types.listOf overlayType);
       visible = false;
     };
   };
@@ -73,7 +71,7 @@ in {
       }
     ];
 
-    warnings = optional ((cfg.config != null) || (cfg.overlays != null)) ''
+    warnings = lib.optional ((cfg.config != null) || (cfg.overlays != null)) ''
       You have set either `nixpkgs.config` or `nixpkgs.overlays` while using `home-manager.useGlobalPkgs`.
       This will soon not be possible. Please remove all `nixpkgs` options when using `home-manager.useGlobalPkgs`.
     '';

--- a/modules/misc/numlock.nix
+++ b/modules/misc/numlock.nix
@@ -1,19 +1,18 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
   cfg = config.xsession.numlock;
 
 in {
-  meta.maintainers = [ maintainers.evanjs ];
+  meta.maintainers = [ lib.maintainers.evanjs ];
 
-  options = { xsession.numlock.enable = mkEnableOption "Num Lock"; };
+  options = { xsession.numlock.enable = lib.mkEnableOption "Num Lock"; };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
-      (hm.assertions.assertPlatform "xsession.numlock" pkgs platforms.linux)
+      (lib.hm.assertions.assertPlatform "xsession.numlock" pkgs
+        lib.platforms.linux)
     ];
 
     systemd.user.services.numlockx = {

--- a/modules/misc/pam.nix
+++ b/modules/misc/pam.nix
@@ -1,18 +1,16 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, lib, ... }:
 
 let
 
   cfg = config.pam;
 
 in {
-  meta.maintainers = with maintainers; [ rycee veehaitch ];
+  meta.maintainers = with lib.maintainers; [ rycee veehaitch ];
 
   options = {
-    pam.sessionVariables = mkOption {
+    pam.sessionVariables = lib.mkOption {
       default = { };
-      type = types.attrs;
+      type = lib.types.attrs;
       example = { EDITOR = "vim"; };
       description = ''
         Environment variables that will be set for the PAM session.
@@ -25,10 +23,10 @@ in {
     };
 
     pam.yubico.authorizedYubiKeys = {
-      ids = mkOption {
-        type = with types;
+      ids = lib.mkOption {
+        type = with lib.types;
           let
-            yubiKeyId = addCheck str (s: stringLength s == 12) // {
+            yubiKeyId = addCheck str (s: lib.stringLength s == 12) // {
               name = "yubiKeyId";
               description = "string of length 12";
             };
@@ -41,8 +39,8 @@ in {
         '';
       };
 
-      path = mkOption {
-        type = types.str;
+      path = lib.mkOption {
+        type = lib.types.str;
         default = ".yubico/authorized_yubikeys";
         description = ''
           File path to write the authorized YubiKeys,
@@ -52,16 +50,16 @@ in {
     };
   };
 
-  config = mkMerge [
-    (mkIf (cfg.sessionVariables != { }) {
-      home.file.".pam_environment".text = concatStringsSep "\n"
-        (mapAttrsToList (n: v: ''${n} OVERRIDE="${toString v}"'')
+  config = lib.mkMerge [
+    (lib.mkIf (cfg.sessionVariables != { }) {
+      home.file.".pam_environment".text = lib.concatStringsSep "\n"
+        (lib.mapAttrsToList (n: v: ''${n} OVERRIDE="${toString v}"'')
           cfg.sessionVariables) + "\n";
     })
 
-    (mkIf (cfg.yubico.authorizedYubiKeys.ids != [ ]) {
+    (lib.mkIf (cfg.yubico.authorizedYubiKeys.ids != [ ]) {
       home.file.${cfg.yubico.authorizedYubiKeys.path}.text =
-        concatStringsSep ":"
+        lib.concatStringsSep ":"
         ([ config.home.username ] ++ cfg.yubico.authorizedYubiKeys.ids);
     })
   ];

--- a/modules/misc/specialisation.nix
+++ b/modules/misc/specialisation.nix
@@ -1,27 +1,25 @@
 { config, name, extendModules, lib, ... }:
 
-with lib;
-
 {
   imports =
-    [ (mkRenamedOptionModule [ "specialization" ] [ "specialisation" ]) ];
+    [ (lib.mkRenamedOptionModule [ "specialization" ] [ "specialisation" ]) ];
 
-  options.specialisation = mkOption {
-    type = types.attrsOf (types.submodule {
+  options.specialisation = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule {
       options = {
-        configuration = mkOption {
+        configuration = lib.mkOption {
           type = let
             extended = extendModules {
               modules = [{
                 # Prevent infinite recursion
-                specialisation = mkOverride 0 { };
+                specialisation = lib.mkOverride 0 { };
 
                 # If used inside the NixOS/nix-darwin module, we get conflicting definitions
                 # of `name` inside the specialisation: one is the user name coming from the
                 # NixOS module definition and the other is `configuration`, the name of this
                 # option. Thus we need to explicitly wire the former into the module arguments.
                 # See discussion at https://github.com/nix-community/home-manager/issues/3716
-                _module.args.name = mkForce name;
+                _module.args.name = lib.mkForce name;
               }];
             };
           in extended.type;
@@ -70,20 +68,21 @@ with lib;
     '';
   };
 
-  config = mkIf (config.specialisation != { }) {
+  config = lib.mkIf (config.specialisation != { }) {
     assertions = map (n: {
       assertion = !lib.hasInfix "/" n;
       message =
         "<name> in specialisation.<name> cannot contain a forward slash.";
-    }) (attrNames config.specialisation);
+    }) (lib.attrNames config.specialisation);
 
     home.extraBuilderCommands = let
       link = n: v:
         let pkg = v.configuration.home.activationPackage;
-        in "ln -s ${pkg} $out/specialisation/${escapeShellArg n}";
+        in "ln -s ${pkg} $out/specialisation/${lib.escapeShellArg n}";
     in ''
       mkdir $out/specialisation
-      ${concatStringsSep "\n" (mapAttrsToList link config.specialisation)}
+      ${lib.concatStringsSep "\n"
+      (lib.mapAttrsToList link config.specialisation)}
     '';
   };
 }

--- a/modules/misc/submodule-support.nix
+++ b/modules/misc/submodule-support.nix
@@ -1,13 +1,11 @@
 { lib, ... }:
 
-with lib;
-
 {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = [ lib.maintainers.rycee ];
 
   options.submoduleSupport = {
-    enable = mkOption {
-      type = types.bool;
+    enable = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       internal = true;
       description = ''
@@ -16,8 +14,8 @@ with lib;
       '';
     };
 
-    externalPackageInstall = mkOption {
-      type = types.bool;
+    externalPackageInstall = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       internal = true;
       description = ''
@@ -39,9 +37,9 @@ with lib;
     # module system can not inform modules about their non-existence; see
     # https://github.com/NixOS/nixpkgs/issues/311709#issuecomment-2110861842
     _module.args = {
-      osConfig = mkDefault null;
-      nixosConfig = mkDefault null;
-      darwinConfig = mkDefault null;
+      osConfig = lib.mkDefault null;
+      nixosConfig = lib.mkDefault null;
+      darwinConfig = lib.mkDefault null;
     };
   };
 }

--- a/modules/misc/tmpfiles.nix
+++ b/modules/misc/tmpfiles.nix
@@ -1,16 +1,14 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
   cfg = config.systemd.user.tmpfiles;
 
 in {
-  meta.maintainers = [ maintainers.dawidsowa ];
+  meta.maintainers = [ lib.maintainers.dawidsowa ];
 
-  options.systemd.user.tmpfiles.rules = mkOption {
-    type = types.listOf types.str;
+  options.systemd.user.tmpfiles.rules = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
     default = [ ];
     example = [ "L /home/user/Documents - - - - /mnt/data/Documents" ];
     description = ''
@@ -21,10 +19,10 @@ in {
     '';
   };
 
-  config = mkIf (cfg.rules != [ ]) {
+  config = lib.mkIf (cfg.rules != [ ]) {
     assertions = [
-      (hm.assertions.assertPlatform "systemd.user.tmpfiles" pkgs
-        platforms.linux)
+      (lib.hm.assertions.assertPlatform "systemd.user.tmpfiles" pkgs
+        lib.platforms.linux)
     ];
 
     xdg.configFile = {
@@ -32,7 +30,7 @@ in {
         text = ''
           # This file is created automatically and should not be modified.
           # Please change the option ‘systemd.user.tmpfiles.rules’ instead.
-          ${concatStringsSep "\n" cfg.rules}
+          ${lib.concatStringsSep "\n" cfg.rules}
         '';
         onChange = "${pkgs.systemd}/bin/systemd-tmpfiles --user --create";
       };

--- a/modules/misc/uninstall.nix
+++ b/modules/misc/uninstall.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 
 let
 

--- a/modules/misc/version.nix
+++ b/modules/misc/version.nix
@@ -1,12 +1,13 @@
 { config, lib, ... }:
 
-with lib;
+let
+  inherit (lib) types;
 
-let releaseInfo = lib.importJSON ../../release.json;
+  releaseInfo = lib.importJSON ../../release.json;
 
 in {
   options = {
-    home.stateVersion = mkOption {
+    home.stateVersion = lib.mkOption {
       type = types.enum [
         "18.09"
         "19.03"
@@ -39,20 +40,20 @@ in {
     };
 
     home.version = {
-      full = mkOption {
+      full = lib.mkOption {
         internal = true;
         readOnly = true;
         type = types.str;
         default = let
           inherit (config.home.version) release revision;
-          suffix =
-            optionalString (revision != null) "+${substring 0 8 revision}";
+          suffix = lib.optionalString (revision != null)
+            "+${lib.substring 0 8 revision}";
         in "${release}${suffix}";
         example = "22.11+213a0629";
         description = "The full Home Manager version.";
       };
 
-      release = mkOption {
+      release = lib.mkOption {
         internal = true;
         readOnly = true;
         type = types.str;
@@ -61,7 +62,7 @@ in {
         description = "The Home Manager release.";
       };
 
-      isReleaseBranch = mkOption {
+      isReleaseBranch = lib.mkOption {
         internal = true;
         readOnly = true;
         type = types.bool;
@@ -72,11 +73,14 @@ in {
         '';
       };
 
-      revision = mkOption {
+      revision = lib.mkOption {
         internal = true;
         type = types.nullOr types.str;
         default = let gitRepo = "${toString ./../..}/.git";
-        in if pathIsGitRepo gitRepo then commitIdFromGitRepo gitRepo else null;
+        in if lib.pathIsGitRepo gitRepo then
+          lib.commitIdFromGitRepo gitRepo
+        else
+          null;
         description = ''
           The Git revision from which this Home Manager configuration was built.
         '';

--- a/modules/misc/vte.nix
+++ b/modules/misc/vte.nix
@@ -1,9 +1,7 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = [ lib.maintainers.rycee ];
 
   options.programs = let
     description = ''
@@ -12,13 +10,17 @@ with lib;
       directory.
     '';
   in {
-    bash.enableVteIntegration = mkEnableOption "" // { inherit description; };
+    bash.enableVteIntegration = lib.mkEnableOption "" // {
+      inherit description;
+    };
 
-    zsh.enableVteIntegration = mkEnableOption "" // { inherit description; };
+    zsh.enableVteIntegration = lib.mkEnableOption "" // {
+      inherit description;
+    };
   };
 
-  config = mkMerge [
-    (mkIf config.programs.bash.enableVteIntegration {
+  config = lib.mkMerge [
+    (lib.mkIf config.programs.bash.enableVteIntegration {
       # Unfortunately we have to do a little dance here to fix two
       # problems with the upstream vte.sh file:
       #
@@ -42,7 +44,7 @@ with lib;
       '';
     })
 
-    (mkIf config.programs.zsh.enableVteIntegration {
+    (lib.mkIf config.programs.zsh.enableVteIntegration {
       programs.zsh.initExtra = ''
         . ${pkgs.vte}/etc/profile.d/vte.sh
       '';

--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -1,13 +1,13 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) literalExpression mkOption types;
+
   desktopEntry = {
     imports = [
-      (mkRemovedOptionModule [ "extraConfig" ]
+      (lib.mkRemovedOptionModule [ "extraConfig" ]
         "The `extraConfig` option of `xdg.desktopEntries` has been removed following a change in Nixpkgs.")
-      (mkRemovedOptionModule [ "fileValidation" ]
+      (lib.mkRemovedOptionModule [ "fileValidation" ]
         "Validation of the desktop file is always enabled.")
     ];
     options = {
@@ -172,12 +172,12 @@ let
         type exec icon comment terminal genericName startupNotify noDisplay
         prefersNonDefaultGPU actions;
       desktopName = config.name;
-      mimeTypes = optionals (config.mimeType != null) config.mimeType;
-      categories = optionals (config.categories != null) config.categories;
+      mimeTypes = lib.optionals (config.mimeType != null) config.mimeType;
+      categories = lib.optionals (config.categories != null) config.categories;
       extraConfig = config.settings;
     };
 in {
-  meta.maintainers = [ hm.maintainers.cwyc ];
+  meta.maintainers = [ lib.hm.maintainers.cwyc ];
 
   options.xdg.desktopEntries = mkOption {
     description = ''
@@ -203,13 +203,16 @@ in {
     '';
   };
 
-  config = mkIf (config.xdg.desktopEntries != { }) {
+  config = lib.mkIf (config.xdg.desktopEntries != { }) {
     assertions = [
-      (hm.assertions.assertPlatform "xdg.desktopEntries" pkgs platforms.linux)
-    ] ++ flatten (catAttrs "assertions" (attrValues config.xdg.desktopEntries));
+      (lib.hm.assertions.assertPlatform "xdg.desktopEntries" pkgs
+        lib.platforms.linux)
+    ] ++ lib.flatten
+      (lib.catAttrs "assertions" (lib.attrValues config.xdg.desktopEntries));
 
-    home.packages = (map hiPrio # we need hiPrio to override existing entries
-      (attrsets.mapAttrsToList makeFile config.xdg.desktopEntries));
+    home.packages =
+      (map lib.hiPrio # we need hiPrio to override existing entries
+        (lib.attrsets.mapAttrsToList makeFile config.xdg.desktopEntries));
   };
 
 }

--- a/modules/misc/xdg-mime-apps.nix
+++ b/modules/misc/xdg-mime-apps.nix
@@ -1,16 +1,15 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkOption types;
 
   cfg = config.xdg.mimeApps;
 
   strListOrSingleton = with types;
-    coercedTo (either (listOf str) str) toList (listOf str);
+    coercedTo (either (listOf str) str) lib.toList (listOf str);
 
 in {
-  meta.maintainers = with maintainers; [ euxane ];
+  meta.maintainers = with lib.maintainers; [ euxane ];
 
   options.xdg.mimeApps = {
     enable = mkOption {
@@ -29,7 +28,7 @@ in {
     associations.added = mkOption {
       type = types.attrsOf strListOrSingleton;
       default = { };
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           "mimetype1" = [ "foo1.desktop" "foo2.desktop" "foo3.desktop" ];
           "mimetype2" = "foo4.desktop";
@@ -56,7 +55,7 @@ in {
     defaultApplications = mkOption {
       type = types.attrsOf strListOrSingleton;
       default = { };
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           "mimetype1" = [ "default1.desktop" "default2.desktop" ];
         }
@@ -71,22 +70,22 @@ in {
     };
   };
 
-  config = mkMerge [
+  config = lib.mkMerge [
     {
       # Given a package that installs .desktop files in the usual location,
       # return a mapping from mime types to lists of desktop file names. This is
       # suitable for use with `xdg.mimeApps.defaultApplications`.
       lib.xdg.mimeAssociations = let
         processLines = str:
-          zipAttrs
-          (filter (e: e != null) (map processLine (splitString "\n" str)));
+          lib.zipAttrs (lib.filter (e: e != null)
+            (map processLine (lib.splitString "\n" str)));
 
         processLine = str:
           let
-            entry = splitString ";" str;
-            k = elemAt entry 0;
-            v = elemAt entry 1;
-          in if length entry == 2 then { ${k} = v; } else null;
+            entry = lib.splitString ";" str;
+            k = lib.elemAt entry 0;
+            v = lib.elemAt entry 1;
+          in if lib.length entry == 2 then { ${k} = v; } else null;
 
         associations = ps:
           pkgs.runCommand "mime-assoc" { inherit ps; } ''
@@ -100,17 +99,19 @@ in {
       in p: processLines (builtins.readFile (associations p));
     }
 
-    (mkIf cfg.enable {
-      assertions =
-        [ (hm.assertions.assertPlatform "xdg.mimeApps" pkgs platforms.linux) ];
+    (lib.mkIf cfg.enable {
+      assertions = [
+        (lib.hm.assertions.assertPlatform "xdg.mimeApps" pkgs
+          lib.platforms.linux)
+      ];
 
       # Deprecated but still used by some applications.
       xdg.dataFile."applications/mimeapps.list".source =
         config.xdg.configFile."mimeapps.list".source;
 
       xdg.configFile."mimeapps.list".text =
-        let joinValues = mapAttrs (n: concatStringsSep ";");
-        in generators.toINI { } {
+        let joinValues = lib.mapAttrs (n: lib.concatStringsSep ";");
+        in lib.generators.toINI { } {
           "Added Associations" = joinValues cfg.associations.added;
           "Removed Associations" = joinValues cfg.associations.removed;
           "Default Applications" = joinValues cfg.defaultApplications;

--- a/modules/misc/xdg-mime.nix
+++ b/modules/misc/xdg-mime.nix
@@ -1,11 +1,10 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
   cfg = config.xdg.mime;
-  inherit (lib) getExe getExe';
+
+  inherit (lib) getExe getExe' mkOption types;
 
 in {
   options = {
@@ -13,8 +12,8 @@ in {
       enable = mkOption {
         type = types.bool;
         default = pkgs.stdenv.hostPlatform.isLinux;
-        defaultText =
-          literalExpression "true if host platform is Linux, false otherwise";
+        defaultText = lib.literalExpression
+          "true if host platform is Linux, false otherwise";
         description = ''
           Whether to install programs and files to support the
           XDG Shared MIME-info specification and XDG MIME Applications
@@ -29,22 +28,23 @@ in {
       sharedMimeInfoPackage = mkOption {
         type = types.package;
         default = pkgs.shared-mime-info;
-        defaultText = literalExpression "pkgs.shared-mime-info";
+        defaultText = lib.literalExpression "pkgs.shared-mime-info";
         description = "The package to use when running update-mime-database.";
       };
 
       desktopFileUtilsPackage = mkOption {
         type = types.package;
         default = pkgs.desktop-file-utils;
-        defaultText = literalExpression "pkgs.desktop-file-utils";
+        defaultText = lib.literalExpression "pkgs.desktop-file-utils";
         description =
           "The package to use when running update-desktop-database.";
       };
     };
   };
-  config = mkIf cfg.enable {
-    assertions =
-      [ (hm.assertions.assertPlatform "xdg.mime" pkgs platforms.linux) ];
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "xdg.mime" pkgs lib.platforms.linux)
+    ];
 
     home.packages = [
       # Explicitly install package to provide basic mime types.

--- a/modules/misc/xdg-system-dirs.nix
+++ b/modules/misc/xdg-system-dirs.nix
@@ -1,33 +1,32 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) types;
 
   cfg = config.xdg.systemDirs;
 
-  configDirs = concatStringsSep ":" cfg.config;
+  configDirs = lib.concatStringsSep ":" cfg.config;
 
-  dataDirs = concatStringsSep ":" cfg.data;
+  dataDirs = lib.concatStringsSep ":" cfg.data;
 
 in {
-  meta.maintainers = with maintainers; [ tadfisher ];
+  meta.maintainers = with lib.maintainers; [ tadfisher ];
 
   options.xdg.systemDirs = {
-    config = mkOption {
+    config = lib.mkOption {
       type = types.listOf types.str;
       default = [ ];
-      example = literalExpression ''[ "/etc/xdg" ]'';
+      example = lib.literalExpression ''[ "/etc/xdg" ]'';
       description = ''
         Directory names to add to {env}`XDG_CONFIG_DIRS`
         in the user session.
       '';
     };
 
-    data = mkOption {
+    data = lib.mkOption {
       type = types.listOf types.str;
       default = [ ];
-      example = literalExpression ''[ "/usr/share" "/usr/local/share" ]'';
+      example = lib.literalExpression ''[ "/usr/share" "/usr/local/share" ]'';
       description = ''
         Directory names to add to {env}`XDG_DATA_DIRS`
         in the user session.
@@ -35,14 +34,15 @@ in {
     };
   };
 
-  config = mkMerge [
-    (mkIf (cfg.config != [ ] || cfg.data != [ ]) {
+  config = lib.mkMerge [
+    (lib.mkIf (cfg.config != [ ] || cfg.data != [ ]) {
       assertions = [
-        (hm.assertions.assertPlatform "xdg.systemDirs" pkgs platforms.linux)
+        (lib.hm.assertions.assertPlatform "xdg.systemDirs" pkgs
+          lib.platforms.linux)
       ];
     })
 
-    (mkIf (cfg.config != [ ]) {
+    (lib.mkIf (cfg.config != [ ]) {
       home.sessionVariables.XDG_CONFIG_DIRS =
         "${configDirs}\${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}";
 
@@ -50,7 +50,7 @@ in {
         "${configDirs}\${XDG_CONFIG_DIRS:+:$XDG_CONFIG_DIRS}";
     })
 
-    (mkIf (cfg.data != [ ]) {
+    (lib.mkIf (cfg.data != [ ]) {
       home.sessionVariables.XDG_DATA_DIRS =
         "${dataDirs}\${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}";
 

--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -1,8 +1,7 @@
-{ options, config, lib, pkgs, ... }:
-
-with lib;
+{ config, lib, pkgs, ... }:
 
 let
+  inherit (lib) mkOptionDefault mkIf mkOption types;
 
   cfg = config.xdg;
 
@@ -22,7 +21,7 @@ let
 
 in {
   options.xdg = {
-    enable = mkEnableOption "management of XDG base directories";
+    enable = lib.mkEnableOption "management of XDG base directories";
 
     cacheFile = mkOption {
       type = fileType "xdg.cacheFile" "{var}`xdg.cacheHome`" cfg.cacheHome;
@@ -107,7 +106,7 @@ in {
     };
   };
 
-  config = mkMerge [
+  config = lib.mkMerge [
     (let
       variables = {
         XDG_CACHE_HOME = cfg.cacheHome;
@@ -127,7 +126,7 @@ in {
     })
 
     # Legacy non-deterministic setup.
-    (mkIf (!cfg.enable && versionOlder config.home.stateVersion "20.09") {
+    (mkIf (!cfg.enable && lib.versionOlder config.home.stateVersion "20.09") {
       xdg.cacheHome =
         mkOptionDefault (getEnvFallback "XDG_CACHE_HOME" defaultCacheHome);
       xdg.configHome =
@@ -139,7 +138,7 @@ in {
     })
 
     # "Modern" deterministic setup.
-    (mkIf (!cfg.enable && versionAtLeast config.home.stateVersion "20.09") {
+    (mkIf (!cfg.enable && lib.versionAtLeast config.home.stateVersion "20.09") {
       xdg.cacheHome = mkOptionDefault defaultCacheHome;
       xdg.configHome = mkOptionDefault defaultConfigHome;
       xdg.dataHome = mkOptionDefault defaultDataHome;
@@ -147,14 +146,18 @@ in {
     })
 
     {
-      home.file = mkMerge [
-        (mapAttrs' (name: file: nameValuePair "${cfg.cacheHome}/${name}" file)
+      home.file = lib.mkMerge [
+        (lib.mapAttrs'
+          (name: file: lib.nameValuePair "${cfg.cacheHome}/${name}" file)
           cfg.cacheFile)
-        (mapAttrs' (name: file: nameValuePair "${cfg.configHome}/${name}" file)
+        (lib.mapAttrs'
+          (name: file: lib.nameValuePair "${cfg.configHome}/${name}" file)
           cfg.configFile)
-        (mapAttrs' (name: file: nameValuePair "${cfg.dataHome}/${name}" file)
+        (lib.mapAttrs'
+          (name: file: lib.nameValuePair "${cfg.dataHome}/${name}" file)
           cfg.dataFile)
-        (mapAttrs' (name: file: nameValuePair "${cfg.stateHome}/${name}" file)
+        (lib.mapAttrs'
+          (name: file: lib.nameValuePair "${cfg.stateHome}/${name}" file)
           cfg.stateFile)
         { "${cfg.cacheHome}/.keep".text = ""; }
         { "${cfg.stateHome}/.keep".text = ""; }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -9,8 +9,6 @@
   # If disabled, the pkgs attribute passed to this function is used instead.
 , useNixpkgsModule ? true }:
 
-with lib;
-
 let
 
   modules = [
@@ -442,28 +440,28 @@ let
     (pkgs.path + "/nixos/modules/misc/assertions.nix")
     (pkgs.path + "/nixos/modules/misc/meta.nix")
 
-    (mkRemovedOptionModule [ "services" "password-store-sync" ] ''
+    (lib.mkRemovedOptionModule [ "services" "password-store-sync" ] ''
       Use services.git-sync instead.
     '')
-    (mkRemovedOptionModule [ "services" "keepassx" ] ''
+    (lib.mkRemovedOptionModule [ "services" "keepassx" ] ''
       KeePassX is no longer maintained.
     '')
-  ] ++ optional useNixpkgsModule ./misc/nixpkgs.nix
-    ++ optional (!useNixpkgsModule) ./misc/nixpkgs-disabled.nix;
+  ] ++ lib.optional useNixpkgsModule ./misc/nixpkgs.nix
+    ++ lib.optional (!useNixpkgsModule) ./misc/nixpkgs-disabled.nix;
 
   pkgsModule = { config, ... }: {
     config = {
       _module.args.baseModules = modules;
       _module.args.pkgsPath = lib.mkDefault
-        (if versionAtLeast config.home.stateVersion "20.09" then
+        (if lib.versionAtLeast config.home.stateVersion "20.09" then
           pkgs.path
         else
           <nixpkgs>);
       _module.args.pkgs = lib.mkDefault pkgs;
       _module.check = check;
       lib = lib.hm;
-    } // optionalAttrs useNixpkgsModule {
-      nixpkgs.system = mkDefault pkgs.stdenv.hostPlatform.system;
+    } // lib.optionalAttrs useNixpkgsModule {
+      nixpkgs.system = lib.mkDefault pkgs.stdenv.hostPlatform.system;
     };
   };
 

--- a/modules/targets/darwin/fonts.nix
+++ b/modules/targets/darwin/fonts.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   homeDir = config.home.homeDirectory;
   fontsEnv = pkgs.buildEnv {
@@ -13,13 +11,13 @@ let
   installDir = "${homeDir}/Library/Fonts/HomeManager";
 in {
   # macOS won't recognize symlinked fonts
-  config = mkIf pkgs.stdenv.hostPlatform.isDarwin {
+  config = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     home.file."Library/Fonts/.home-manager-fonts-version" = {
       text = "${fontsEnv}";
       onChange = ''
-        run mkdir -p ${escapeShellArg installDir}
+        run mkdir -p ${lib.escapeShellArg installDir}
         run ${pkgs.rsync}/bin/rsync $VERBOSE_ARG -acL --chmod=u+w --delete \
-          ${escapeShellArgs [ "${fonts}/" installDir ]}
+          ${lib.escapeShellArgs [ "${fonts}/" installDir ]}
       '';
     };
   };

--- a/modules/targets/darwin/keybindings.nix
+++ b/modules/targets/darwin/keybindings.nix
@@ -1,15 +1,13 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.targets.darwin;
   homeDir = config.home.homeDirectory;
   confFile = pkgs.writeText "DefaultKeybinding.dict"
     (lib.generators.toPlist { } cfg.keybindings);
 in {
-  options.targets.darwin.keybindings = mkOption {
-    type = with types; attrsOf anything;
+  options.targets.darwin.keybindings = lib.mkOption {
+    type = with lib.types; attrsOf anything;
     default = { };
     example = {
       "^u" = "deleteToBeginningOfLine:";
@@ -28,15 +26,15 @@ in {
     '';
   };
 
-  config = mkIf (cfg.keybindings != { }) {
+  config = lib.mkIf (cfg.keybindings != { }) {
     assertions = [
-      (hm.assertions.assertPlatform "targets.darwin.keybindings" pkgs
-        platforms.darwin)
+      (lib.hm.assertions.assertPlatform "targets.darwin.keybindings" pkgs
+        lib.platforms.darwin)
     ];
 
     # NOTE: just copy the files because symlinks won't be recognized by macOS
     home.activation.setCocoaKeybindings =
-      hm.dag.entryAfter [ "writeBoundary" ] ''
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
         verboseEcho "Configuring keybindings for the Cocoa Text System"
         run install -Dm644 $VERBOSE_ARG \
           "${confFile}" "${homeDir}/Library/KeyBindings/DefaultKeyBinding.dict"

--- a/modules/targets/darwin/search.nix
+++ b/modules/targets/darwin/search.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.targets.darwin;
   searchEngines = {
@@ -11,18 +9,18 @@ let
     Google = "com.google.www";
     Yahoo = "com.yahoo.www";
   };
-  searchId = getAttr cfg.search searchEngines;
+  searchId = lib.getAttr cfg.search searchEngines;
 in {
-  options.targets.darwin.search = mkOption {
-    type = with types; nullOr (enum (attrNames searchEngines));
+  options.targets.darwin.search = lib.mkOption {
+    type = with lib.types; nullOr (enum (lib.attrNames searchEngines));
     default = null;
     description = "Default search engine.";
   };
 
-  config = mkIf (cfg.search != null) {
+  config = lib.mkIf (cfg.search != null) {
     assertions = [
-      (hm.assertions.assertPlatform "targets.darwin.search" pkgs
-        platforms.darwin)
+      (lib.hm.assertions.assertPlatform "targets.darwin.search" pkgs
+        lib.platforms.darwin)
     ];
 
     targets.darwin.defaults = {

--- a/modules/targets/darwin/user-defaults/opts-allhosts.nix
+++ b/modules/targets/darwin/user-defaults/opts-allhosts.nix
@@ -1,8 +1,8 @@
 { config, lib, ... }:
 
-with lib;
-
 let
+  inherit (lib) types;
+
   mkNullableOption = args:
     lib.mkOption (args // {
       type = types.nullOr args.type;
@@ -284,12 +284,12 @@ in {
   };
 
   config = {
-    "com.apple.Safari" = mkIf (safari.IncludeDevelopMenu != null) {
+    "com.apple.Safari" = lib.mkIf (safari.IncludeDevelopMenu != null) {
       WebKitDeveloperExtrasEnabledPreferenceKey = safari.IncludeDevelopMenu;
       "WebKitPreferences.developerExtrasEnabled" = safari.IncludeDevelopMenu;
     };
     "com.apple.Safari.SandboxBroker" =
-      mkIf (safari.IncludeDevelopMenu != null) {
+      lib.mkIf (safari.IncludeDevelopMenu != null) {
         ShowDevelopMenu = safari.IncludeDevelopMenu;
       };
   };

--- a/modules/targets/darwin/user-defaults/opts-currenthost.nix
+++ b/modules/targets/darwin/user-defaults/opts-currenthost.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
 let
   mkNullableOption = args:

--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
   cfg = config.targets.genericLinux;
@@ -12,7 +10,7 @@ let
 
 in {
   imports = [
-    (mkRenamedOptionModule [ "targets" "genericLinux" "extraXdgDataDirs" ] [
+    (lib.mkRenamedOptionModule [ "targets" "genericLinux" "extraXdgDataDirs" ] [
       "xdg"
       "systemDirs"
       "data"
@@ -20,7 +18,7 @@ in {
   ];
 
   options.targets.genericLinux = {
-    enable = mkEnableOption "" // {
+    enable = lib.mkEnableOption "" // {
       description = ''
         Whether to enable settings that make Home Manager work better on
         GNU/Linux distributions other than NixOS.
@@ -28,9 +26,10 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
-      (hm.assertions.assertPlatform "targets.genericLinux" pkgs platforms.linux)
+      (lib.hm.assertions.assertPlatform "targets.genericLinux" pkgs
+        lib.platforms.linux)
     ];
 
     xdg.systemDirs.data = [
@@ -49,11 +48,12 @@ in {
     # resolving to the Nix store.
     # https://github.com/nix-community/home-manager/pull/2891#issuecomment-1101064521
     home.sessionVariables = {
-      XCURSOR_PATH = "$XCURSOR_PATH\${XCURSOR_PATH:+:}" + concatStringsSep ":" [
-        "${config.home.profileDirectory}/share/icons"
-        "/usr/share/icons"
-        "/usr/share/pixmaps"
-      ];
+      XCURSOR_PATH = "$XCURSOR_PATH\${XCURSOR_PATH:+:}"
+        + lib.concatStringsSep ":" [
+          "${config.home.profileDirectory}/share/icons"
+          "/usr/share/icons"
+          "/usr/share/pixmaps"
+        ];
     };
 
     home.sessionVariablesExtra = ''
@@ -93,7 +93,7 @@ in {
       # https://salsa.debian.org/debian/ncurses/-/blob/master/debian/rules
       # https://src.fedoraproject.org/rpms/ncurses/blob/main/f/ncurses.spec
       # https://gitweb.gentoo.org/repo/gentoo.git/tree/sys-libs/ncurses/ncurses-6.2-r1.ebuild
-      distroTerminfoDirs = concatStringsSep ":" [
+      distroTerminfoDirs = lib.concatStringsSep ":" [
         "/etc/terminfo" # debian, fedora, gentoo
         "/lib/terminfo" # debian
         "/usr/share/terminfo" # package default, all distros

--- a/modules/xresources.nix
+++ b/modules/xresources.nix
@@ -1,24 +1,23 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib) mkOption types;
 
   cfg = config.xresources;
 
   formatLine = n: v:
     let
       formatList = x:
-        if isList x then
+        if lib.isList x then
           throw "can not convert 2-dimensional lists to Xresources format"
         else
           formatValue x;
 
       formatValue = v:
-        if isBool v then
+        if lib.isBool v then
           (if v then "true" else "false")
-        else if isList v then
-          concatMapStringsSep ", " formatList v
+        else if lib.isList v then
+          lib.concatMapStringsSep ", " formatList v
         else
           toString v;
     in "${n}: ${formatValue v}";
@@ -26,7 +25,7 @@ let
   xrdbMerge = "${pkgs.xorg.xrdb}/bin/xrdb -merge ${cfg.path}";
 
 in {
-  meta.maintainers = [ maintainers.rycee ];
+  meta.maintainers = [ lib.maintainers.rycee ];
 
   options = {
     xresources.properties = mkOption {
@@ -36,7 +35,7 @@ in {
           entry = either prim (listOf prim);
         in nullOr (attrsOf entry);
       default = null;
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           "Emacs*toolBar" = 0;
           "XTerm*faceName" = "dejavu sans mono";
@@ -58,7 +57,7 @@ in {
     xresources.extraConfig = mkOption {
       type = types.lines;
       default = "";
-      example = literalExpression ''
+      example = lib.literalExpression ''
         builtins.readFile (
             pkgs.fetchFromGitHub {
                 owner = "solarized";
@@ -85,13 +84,13 @@ in {
     };
   };
 
-  config = mkIf ((cfg.properties != null && cfg.properties != { })
+  config = lib.mkIf ((cfg.properties != null && cfg.properties != { })
     || cfg.extraConfig != "") {
       home.file.${cfg.path} = {
-        text = concatStringsSep "\n" ([ ]
-          ++ optional (cfg.extraConfig != "") cfg.extraConfig
-          ++ optionals (cfg.properties != null)
-          (mapAttrsToList formatLine cfg.properties)) + "\n";
+        text = lib.concatStringsSep "\n" ([ ]
+          ++ lib.optional (cfg.extraConfig != "") cfg.extraConfig
+          ++ lib.optionals (cfg.properties != null)
+          (lib.mapAttrsToList formatLine cfg.properties)) + "\n";
         onChange = ''
           if [[ -v DISPLAY ]]; then
             ${xrdbMerge}

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
   cfg = config.home-manager;
@@ -9,11 +7,11 @@ let
 in {
   imports = [ ../nixos/common.nix ];
 
-  config = mkMerge [
+  config = lib.mkMerge [
     { home-manager.extraSpecialArgs.darwinConfig = config; }
-    (mkIf (cfg.users != { }) {
-      system.activationScripts.postActivation.text = concatStringsSep "\n"
-        (mapAttrsToList (username: usercfg: ''
+    (lib.mkIf (cfg.users != { }) {
+      system.activationScripts.postActivation.text = lib.concatStringsSep "\n"
+        (lib.mapAttrsToList (username: usercfg: ''
           echo Activating home-manager configuration for ${username}
           sudo -u ${username} --set-home ${
             pkgs.writeShellScript "activation-${username}" ''

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -1,19 +1,17 @@
 { config, lib, pkgs, utils, ... }:
 
-with lib;
-
 let
 
   cfg = config.home-manager;
 
-  serviceEnvironment = optionalAttrs (cfg.backupFileExtension != null) {
+  serviceEnvironment = lib.optionalAttrs (cfg.backupFileExtension != null) {
     HOME_MANAGER_BACKUP_EXT = cfg.backupFileExtension;
-  } // optionalAttrs cfg.verbose { VERBOSE = "1"; };
+  } // lib.optionalAttrs cfg.verbose { VERBOSE = "1"; };
 
 in {
   imports = [ ./common.nix ];
 
-  config = mkMerge [
+  config = lib.mkMerge [
     {
       home-manager = {
         extraSpecialArgs.nixosConfig = config;
@@ -33,10 +31,11 @@ in {
         }];
       };
     }
-    (mkIf (cfg.users != { }) {
-      systemd.services = mapAttrs' (_: usercfg:
+    (lib.mkIf (cfg.users != { }) {
+      systemd.services = lib.mapAttrs' (_: usercfg:
         let username = usercfg.home.username;
-        in nameValuePair ("home-manager-${utils.escapeSystemdPath username}") {
+        in lib.nameValuePair
+        "home-manager-${utils.escapeSystemdPath username}" {
           description = "Home Manager environment for ${username}";
           wantedBy = [ "multi-user.target" ];
           wants = [ "nix-daemon.socket" ];
@@ -61,7 +60,7 @@ in {
 
               sed = "${pkgs.gnused}/bin/sed";
 
-              exportedSystemdVariables = concatStringsSep "|" [
+              exportedSystemdVariables = lib.concatStringsSep "|" [
                 "DBUS_SESSION_BUS_ADDRESS"
                 "DISPLAY"
                 "WAYLAND_DISPLAY"

--- a/tests/modules/programs/firefox/profiles/bookmarks/default.nix
+++ b/tests/modules/programs/firefox/profiles/bookmarks/default.nix
@@ -1,11 +1,9 @@
 modulePath:
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
-  cfg = getAttrFromPath modulePath config;
+  cfg = lib.getAttrFromPath modulePath config;
 
   firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
 
@@ -18,7 +16,7 @@ let
 in {
   imports = [ firefoxMockOverlay ];
 
-  config = mkIf config.test.enableBig (setAttrByPath modulePath {
+  config = lib.mkIf config.test.enableBig (lib.setAttrByPath modulePath {
     enable = true;
     profiles.bookmarks = {
       settings = { "general.smoothScroll" = false; };

--- a/tests/modules/programs/firefox/profiles/containers/default.nix
+++ b/tests/modules/programs/firefox/profiles/containers/default.nix
@@ -1,18 +1,15 @@
 modulePath:
-{ config, lib, pkgs, ... }:
-
-with lib;
-
+{ config, lib, ... }:
 let
 
-  cfg = getAttrFromPath modulePath config;
+  cfg = lib.getAttrFromPath modulePath config;
 
   firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
 
 in {
   imports = [ firefoxMockOverlay ];
 
-  config = mkIf config.test.enableBig (setAttrByPath modulePath {
+  config = lib.mkIf config.test.enableBig (lib.setAttrByPath modulePath {
     enable = true;
     profiles.containers = {
       containers = {

--- a/tests/modules/programs/firefox/profiles/containers/duplicate-ids.nix
+++ b/tests/modules/programs/firefox/profiles/containers/duplicate-ids.nix
@@ -1,22 +1,20 @@
 modulePath:
 { config, lib, ... }:
 
-with lib;
-
 let
 
-  cfg = getAttrFromPath modulePath config;
+  cfg = lib.getAttrFromPath modulePath config;
 
   firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
 
 in {
   imports = [ firefoxMockOverlay ];
 
-  config = mkIf config.test.enableBig ({
+  config = lib.mkIf config.test.enableBig ({
     test.asserts.assertions.expected = [''
       Must not have a ${cfg.name} container with an existing ID but
         - ID 9 is used by dangerous, shopping''];
-  } // setAttrByPath modulePath {
+  } // lib.setAttrByPath modulePath {
     enable = true;
 
     profiles = {

--- a/tests/modules/programs/firefox/profiles/containers/id-out-of-range.nix
+++ b/tests/modules/programs/firefox/profiles/containers/id-out-of-range.nix
@@ -1,8 +1,6 @@
 modulePath:
 { config, lib, ... }:
 
-with lib;
-
 let
 
   firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
@@ -10,10 +8,10 @@ let
 in {
   imports = [ firefoxMockOverlay ];
 
-  config = mkIf config.test.enableBig ({
+  config = lib.mkIf config.test.enableBig ({
     test.asserts.assertions.expected =
       [ "Container id must be smaller than 4294967294 (2^32 - 2)" ];
-  } // setAttrByPath modulePath {
+  } // lib.setAttrByPath modulePath {
     enable = true;
 
     profiles.my-profile = {

--- a/tests/modules/programs/firefox/profiles/duplicate-ids.nix
+++ b/tests/modules/programs/firefox/profiles/duplicate-ids.nix
@@ -1,22 +1,20 @@
 modulePath:
 { config, lib, ... }:
 
-with lib;
-
 let
 
-  cfg = getAttrFromPath modulePath config;
+  cfg = lib.getAttrFromPath modulePath config;
 
   firefoxMockOverlay = import ../setup-firefox-mock-overlay.nix modulePath;
 
 in {
   imports = [ firefoxMockOverlay ];
 
-  config = mkIf config.test.enableBig ({
+  config = lib.mkIf config.test.enableBig ({
     test.asserts.assertions.expected = [''
       Must not have a ${cfg.name} profile with an existing ID but
         - ID 1 is used by first, second''];
-  } // setAttrByPath modulePath {
+  } // lib.setAttrByPath modulePath {
     enable = true;
 
     profiles = {

--- a/tests/modules/programs/firefox/profiles/extensions/default.nix
+++ b/tests/modules/programs/firefox/profiles/extensions/default.nix
@@ -1,14 +1,14 @@
 modulePath:
 { config, lib, ... }:
-with lib;
+
 let
-  cfg = getAttrFromPath modulePath config;
+  cfg = lib.getAttrFromPath modulePath config;
 
   firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
 in {
   imports = [ firefoxMockOverlay ];
 
-  config = mkIf config.test.enableBig (setAttrByPath modulePath {
+  config = lib.mkIf config.test.enableBig (lib.setAttrByPath modulePath {
     enable = true;
     profiles.extensions = {
       extensions = {

--- a/tests/modules/programs/firefox/profiles/overwrite/default.nix
+++ b/tests/modules/programs/firefox/profiles/overwrite/default.nix
@@ -1,18 +1,16 @@
 modulePath:
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, lib, ... }:
 
 let
 
-  cfg = getAttrFromPath modulePath config;
+  cfg = lib.getAttrFromPath modulePath config;
 
   firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
 
 in {
   imports = [ firefoxMockOverlay ];
 
-  config = mkIf config.test.enableBig (setAttrByPath modulePath {
+  config = lib.mkIf config.test.enableBig (lib.setAttrByPath modulePath {
     enable = true;
     profiles = {
       basic.isDefault = true;

--- a/tests/modules/programs/firefox/profiles/search/default.nix
+++ b/tests/modules/programs/firefox/profiles/search/default.nix
@@ -1,11 +1,9 @@
 modulePath:
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
-  cfg = getAttrFromPath modulePath config;
+  cfg = lib.getAttrFromPath modulePath config;
 
   firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
 
@@ -18,7 +16,7 @@ let
 in {
   imports = [ firefoxMockOverlay ];
 
-  config = mkIf config.test.enableBig (setAttrByPath modulePath {
+  config = lib.mkIf config.test.enableBig (lib.setAttrByPath modulePath {
     enable = true;
     profiles = {
       search = {

--- a/tests/modules/programs/firefox/profiles/settings/default.nix
+++ b/tests/modules/programs/firefox/profiles/settings/default.nix
@@ -1,18 +1,16 @@
 modulePath:
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ config, lib, ... }:
 
 let
 
-  cfg = getAttrFromPath modulePath config;
+  cfg = lib.getAttrFromPath modulePath config;
 
   firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
 
 in {
   imports = [ firefoxMockOverlay ];
 
-  config = mkIf config.test.enableBig (setAttrByPath modulePath {
+  config = lib.mkIf config.test.enableBig (lib.setAttrByPath modulePath {
     enable = true;
     profiles = {
       basic.isDefault = true;

--- a/tests/modules/programs/firefox/profiles/shared-path.nix
+++ b/tests/modules/programs/firefox/profiles/shared-path.nix
@@ -1,13 +1,11 @@
 modulePath:
 { config, lib, ... }:
 
-with lib;
-
 let firefoxMockOverlay = import ../setup-firefox-mock-overlay.nix modulePath;
 in {
   imports = [ firefoxMockOverlay ];
 
-  config = mkIf config.test.enableBig (setAttrByPath modulePath {
+  config = lib.mkIf config.test.enableBig (lib.setAttrByPath modulePath {
     enable = true;
 
     profiles = {

--- a/tests/modules/services/screen-locker/moved-options.nix
+++ b/tests/modules/services/screen-locker/moved-options.nix
@@ -15,16 +15,15 @@
   nmt.script =
     (import ./basic-configuration.nix { inherit config pkgs; }).nmt.script;
 
-  test.asserts.warnings.expected = with lib;
-    let
-      renamed = {
-        xssLockExtraOptions = "xss-lock.extraOptions";
-        xautolockExtraOptions = "xautolock.extraOptions";
-        enableDetectSleep = "xautolock.detectSleep";
-      };
-    in mapAttrsToList (old: new:
-      builtins.replaceStrings [ "\n" ] [ " " ] ''
-        The option `services.screen-locker.${old}' defined in
-        ${showFiles options.services.screen-locker.${old}.files}
-        has been renamed to `services.screen-locker.${new}'.'') renamed;
+  test.asserts.warnings.expected = let
+    renamed = {
+      xssLockExtraOptions = "xss-lock.extraOptions";
+      xautolockExtraOptions = "xautolock.extraOptions";
+      enableDetectSleep = "xautolock.detectSleep";
+    };
+  in mapAttrsToList (old: new:
+    builtins.replaceStrings [ "\n" ] [ " " ] ''
+      The option `services.screen-locker.${old}' defined in
+      ${showFiles options.services.screen-locker.${old}.files}
+      has been renamed to `services.screen-locker.${new}'.'') renamed;
 }

--- a/tests/modules/services/screen-locker/moved-options.nix
+++ b/tests/modules/services/screen-locker/moved-options.nix
@@ -21,9 +21,9 @@
       xautolockExtraOptions = "xautolock.extraOptions";
       enableDetectSleep = "xautolock.detectSleep";
     };
-  in mapAttrsToList (old: new:
+  in lib.mapAttrsToList (old: new:
     builtins.replaceStrings [ "\n" ] [ " " ] ''
       The option `services.screen-locker.${old}' defined in
-      ${showFiles options.services.screen-locker.${old}.files}
+      ${lib.showFiles options.services.screen-locker.${old}.files}
       has been renamed to `services.screen-locker.${new}'.'') renamed;
 }


### PR DESCRIPTION
### Description
Continuation of https://github.com/nix-community/home-manager/pull/6511 Didn't handle the programs/services, yet. 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
