### PR TITLE
firefox: deprecate vendorPath

### DIFF
--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -18,12 +18,8 @@ in {
       unwrappedPackageName = "firefox-unwrapped";
       visible = true;
 
-      platforms.linux = rec {
-        vendorPath = ".mozilla";
-        configPath = "${vendorPath}/firefox";
-      };
+      platforms.linux = rec { configPath = ".mozilla/firefox"; };
       platforms.darwin = {
-        vendorPath = "Library/Application Support/Mozilla";
         configPath = "Library/Application Support/Firefox";
       };
     })

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -280,11 +280,7 @@ in {
     vendorPath = mkOption {
       internal = true;
       type = with types; nullOr str;
-      default = with platforms;
-        if isDarwin then
-          darwin.vendorPath or null
-        else
-          linux.vendorPath or null;
+      default = null;
       example = ".mozilla";
       description =
         "Directory containing the native messaging hosts directory.";
@@ -299,7 +295,7 @@ in {
       description = "Directory containing the ${appName} configuration files.";
     };
 
-    nativeMessagingHosts = optionalAttrs (cfg.vendorPath != null) (mkOption {
+    nativeMessagingHosts = mkOption {
       inherit visible;
       type = types.listOf types.package;
       default = [ ];
@@ -307,7 +303,7 @@ in {
         Additional packages containing native messaging hosts that should be
         made available to ${appName} extensions.
       '';
-    });
+    };
 
     finalPackage = mkOption {
       inherit visible;
@@ -852,6 +848,9 @@ in {
       will be removed in the future. Please change to overriding the package
       configuration using '${moduleName}.package' instead. You can refer to
       its example for how to do this.
+    '' ++ optional (cfg.vendorPath != null) ''
+      Using '${moduleName}.vendorPath' has been deprecated and
+      will be removed in the future. Native messaging hosts will function normally without specifying this path.
     '';
 
     home.packages = lib.optional (cfg.finalPackage != null) cfg.finalPackage;

--- a/modules/programs/floorp.nix
+++ b/modules/programs/floorp.nix
@@ -19,14 +19,8 @@ in {
       unwrappedPackageName = "floorp-unwrapped";
       visible = true;
 
-      platforms.linux = {
-        configPath = ".floorp";
-        vendorPath = ".mozilla";
-      };
-      platforms.darwin = {
-        configPath = "Library/Application Support/Floorp";
-        vendorPath = "Library/Application Support/Mozilla";
-      };
+      platforms.linux = { configPath = ".floorp"; };
+      platforms.darwin = { configPath = "Library/Application Support/Floorp"; };
     })
   ];
 }

--- a/modules/programs/librewolf.nix
+++ b/modules/programs/librewolf.nix
@@ -29,13 +29,9 @@ in {
       wrappedPackageName = "librewolf";
       unwrappedPackageName = "librewolf-unwrapped";
 
-      platforms.linux = {
-        configPath = ".librewolf";
-        vendorPath = ".mozilla";
-      };
+      platforms.linux = { configPath = ".librewolf"; };
       platforms.darwin = {
         configPath = "Library/Application Support/LibreWolf";
-        vendorPath = "Library/Application Support/Mozilla";
       };
 
       enableBookmarks = false;


### PR DESCRIPTION

### Description

<!--

Please provide a brief description of your change.

-->
This is a reaction to PR #6460


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@booxter @khaneliman @brckd 
