### PR TITLE
tests: bash -> bash-interactive

### DIFF
--- a/tests/modules/services/mpd/basic-configuration.service
+++ b/tests/modules/services/mpd/basic-configuration.service
@@ -4,7 +4,7 @@ WantedBy=default.target
 [Service]
 Environment=PATH=/home/hm-user/.nix-profile/bin
 ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf --verbose
-ExecStartPre=@bash@/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
+ExecStartPre=@bash-interactive@/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
 Type=notify
 
 [Unit]

--- a/tests/modules/services/mpd/start-when-needed.service
+++ b/tests/modules/services/mpd/start-when-needed.service
@@ -1,7 +1,7 @@
 [Service]
 Environment=PATH=/home/hm-user/.nix-profile/bin
 ExecStart=@mpd@/bin/mpd --no-daemon /nix/store/00000000000000000000000000000000-mpd.conf --verbose
-ExecStartPre=@bash@/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
+ExecStartPre=@bash-interactive@/bin/bash -c "/nix/store/00000000000000000000000000000000-coreutils/bin/mkdir -p '/home/hm-user/.local/share/mpd' '/home/hm-user/.local/share/mpd/playlists'"
 Type=notify
 
 [Unit]

--- a/tests/modules/services/swayidle/basic-configuration.nix
+++ b/tests/modules/services/swayidle/basic-configuration.nix
@@ -44,7 +44,7 @@
         WantedBy=graphical-session.target
 
         [Service]
-        Environment=PATH=@bash@/bin
+        Environment=PATH=@bash-interactive@/bin
         ExecStart=@swayidle@/bin/dummy -w timeout 50 'notify-send -t 10000 -- "Screen lock in 10 seconds"' timeout 60 'swaylock -fF' timeout 300 'swaymsg "output * dpms off"' resume 'swaymsg "output * dpms on"' before-sleep 'swaylock -fF' lock 'swaylock -fF'
         Restart=always
         Type=simple


### PR DESCRIPTION
### Description
Apparently, bash was changed to bashInteractive by default https://github.com/NixOS/nixpkgs/pull/379368

Updating tests to reflect change to unblock CI. 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
