### PR TITLE
xdg: create '$XDG_STATE_HOME'

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -143,6 +143,7 @@ in {
         (mapAttrs' (name: file: nameValuePair "${cfg.stateHome}/${name}" file)
           cfg.stateFile)
         { "${cfg.cacheHome}/.keep".text = ""; }
+        { "${cfg.stateHome}/.keep".text = ""; }
       ];
     }
   ];


### PR DESCRIPTION
### Description

Some programs (e.g: `less`) will not make use of `$XDG_STATE_HOME` if the directory does not exist (even if the variable is set).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee @teto (no `meta.maintainers`)
