### PR TITLE
distrobox: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -24,6 +24,12 @@
     github = "afresquet";
     githubId = 29437693;
   };
+  aguirre-matteo = {
+    name = "aguirre-matteo";
+    email = "aguirre.matteo.nix@gmail.com";
+    github = "aguirre-matteo";
+    githubId = 158215792;
+  };
   amesgen = {
     name = "amesgen";
     email = "amesgen@amesgen.de";

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -24,12 +24,6 @@
     github = "afresquet";
     githubId = 29437693;
   };
-  aguirre-matteo = {
-    name = "aguirre-matteo";
-    email = "aguirre.matteo.nix@gmail.com";
-    github = "aguirre-matteo";
-    githubId = 158215792;
-  };
   amesgen = {
     name = "amesgen";
     email = "amesgen@amesgen.de";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -88,6 +88,7 @@ let
     ./programs/dircolors.nix
     ./programs/direnv.nix
     ./programs/discocss.nix
+    ./programs/distrobox.nix
     ./programs/earthly.nix
     ./programs/eclipse.nix
     ./programs/emacs.nix

--- a/modules/programs/distrobox.nix
+++ b/modules/programs/distrobox.nix
@@ -26,6 +26,8 @@ let
   getContainersConfig = set:
     (concatStringsSep "\n\n" (mapAttrsToList setToContainer set)) + "\n";
 in {
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
   options.programs.distrobox = {
     enable = mkEnableOption "distrobox";
 
@@ -65,9 +67,9 @@ in {
         }
       '';
       description = ''
-        A set of containers and all its respective configurations. Each option cat be either a 
+        A set of containers and all its respective configurations. Each option cat be either a
         bool, string or a list of strings. If passed a list, the option will be repeated for each element.
-        See common-debian in the example config. All the available options for the containers can be found 
+        See common-debian in the example config. All the available options for the containers can be found
         in the distrobox-assemble documentation at <https://github.com/89luca89/distrobox/blob/main/docs/usage/distrobox-assemble.md>.
       '';
     };
@@ -98,7 +100,7 @@ in {
 
         if [[ -f $prev_hash_file ]]; then
           prev_hash=$(cat $prev_hash_file)
-        else 
+        else
           prev_hash=0
         fi
 

--- a/modules/programs/distrobox.nix
+++ b/modules/programs/distrobox.nix
@@ -1,0 +1,114 @@
+{ lib, pkgs, config, ... }:
+let
+  inherit (lib)
+    types isBool isList boolToString concatStringsSep mapAttrsToList removeAttrs
+    mkIf mkEnableOption mkPackageOption mkOption literalExpression;
+
+  cfg = config.programs.distrobox;
+
+  attrToString = name: value:
+    let
+      newvalue = if (isBool value) then
+        [ (boolToString value) ]
+      else if (isList value) then
+        value
+      else
+        [ value ];
+    in concatStringsSep "\n" (map (value: "${name}=${value}") newvalue);
+
+  getFlags = set: concatStringsSep "\n" (mapAttrsToList attrToString set);
+
+  setToContainer = name: set:
+    ''
+      [${name}]
+    '' + (getFlags set);
+
+  getContainersConfig = set:
+    (concatStringsSep "\n\n" (mapAttrsToList setToContainer set)) + "\n";
+in {
+  options.programs.distrobox = {
+    enable = mkEnableOption "distrobox";
+
+    package = mkPackageOption pkgs "distrobox" { };
+
+    containers = mkOption {
+      type = with types; attrsOf (attrsOf (oneOf [ bool str (listOf str) ]));
+      default = { };
+      example = ''
+        {
+          python-project = {
+            image = "fedora:40";
+            additional_packages = "python3 git";
+            init_hooks = "pip3 install numpy pandas torch torchvision";
+          };
+
+          common-debian = {
+            image = "debian:13";
+            entry = true;
+            additional_packages = "git";
+            init_hooks = [
+              "ln -sf /usr/bin/distrobox-host-exec /usr/local/bin/docker"
+              "ln -sf /usr/bin/distrobox-host-exec /usr/local/bin/docker-compose"
+            ];
+          };
+
+          office = {
+            clone = "common-debian";
+            additional_packages = "libreoffice onlyoffice";
+            entry = true;
+          };
+
+          random-things = {
+            clone = "common-debian";
+            entry = false;
+          };
+        }
+      '';
+      description = ''
+        A set of containers and all its respective configurations. Each option cat be either a 
+        bool, string or a list of strings. If passed a list, the option will be repeated for each element.
+        See common-debian in the example config. All the available options for the containers can be found 
+        in the distrobox-assemble documentation at <https://github.com/89luca89/distrobox/blob/main/docs/usage/distrobox-assemble.md>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.distrobox" pkgs
+        lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."distrobox/containers.ini".source =
+      pkgs.writeText "containers.ini" (getContainersConfig cfg.containers);
+
+    systemd.user.services.distrobox-home-manager = {
+      Unit.Description =
+        "Build the containers declared in ~/.config/distrobox/containers.ini";
+      Install.WantedBy = [ "default.target" ];
+
+      Service.ExecStart = "${pkgs.writeShellScript "distrobox-home-manager" ''
+        PATH=/run/current-system/sw/bin:
+
+        containers_file=${config.xdg.configHome}/distrobox/containers.ini
+        prev_hash_file=${config.xdg.configHome}/distrobox/prev_hash
+        new_hash=$(sha256sum $containers_file | cut -f 1 -d " ")
+
+        if [[ -f $prev_hash_file ]]; then
+          prev_hash=$(cat $prev_hash_file)
+        else 
+          prev_hash=0
+        fi
+
+        if [[ $prev_hash != $new_hash ]]; then
+          rm -rf /tmp/storage-run-1000/containers
+          rm -rf /tmp/storage-run-1000/libpod/tmp
+          $HOME/.nix-profile/bin/distrobox-assemble create --file $containers_file
+          echo $new_hash > $prev_hash_file
+        fi
+      ''}";
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -294,7 +294,6 @@ in import nmtSrc {
     ./modules/programs/darcs
     ./modules/programs/dircolors
     ./modules/programs/direnv
-    ./modules/programs/distrobox
     ./modules/programs/earthly
     ./modules/programs/emacs
     ./modules/programs/fastfetch
@@ -438,6 +437,7 @@ in import nmtSrc {
     ./modules/programs/bemenu
     ./modules/programs/boxxy
     ./modules/programs/cavalier
+    ./modules/programs/distrobox
     ./modules/programs/eww
     ./modules/programs/firefox
     ./modules/programs/firefox/firefox.nix

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -294,6 +294,7 @@ in import nmtSrc {
     ./modules/programs/darcs
     ./modules/programs/dircolors
     ./modules/programs/direnv
+    ./modules/programs/distrobox
     ./modules/programs/earthly
     ./modules/programs/emacs
     ./modules/programs/fastfetch

--- a/tests/modules/programs/distrobox/default.nix
+++ b/tests/modules/programs/distrobox/default.nix
@@ -1,0 +1,1 @@
+{ distrobox-example-config = ./example-config.nix; }

--- a/tests/modules/programs/distrobox/example-config.ini
+++ b/tests/modules/programs/distrobox/example-config.ini
@@ -1,0 +1,20 @@
+[common-debian]
+additional_packages=git
+entry=true
+image=debian:13
+init_hooks=ln -sf /usr/bin/distrobox-host-exec /usr/local/bin/docker
+init_hooks=ln -sf /usr/bin/distrobox-host-exec /usr/local/bin/docker-compose
+
+[office]
+additional_packages=libreoffice onlyoffice
+clone=common-debian
+entry=true
+
+[python-project]
+additional_packages=python3 git
+image=fedora:40
+init_hooks=pip3 install numpy pandas torch torchvision
+
+[random-things]
+clone=common-debian
+entry=false

--- a/tests/modules/programs/distrobox/example-config.nix
+++ b/tests/modules/programs/distrobox/example-config.nix
@@ -1,0 +1,41 @@
+{
+  programs.distrobox = {
+    enable = true;
+    containers = {
+
+      python-project = {
+        image = "fedora:40";
+        additional_packages = "python3 git";
+        init_hooks = "pip3 install numpy pandas torch torchvision";
+      };
+
+      common-debian = {
+        image = "debian:13";
+        entry = true;
+        additional_packages = "git";
+        init_hooks = [
+          "ln -sf /usr/bin/distrobox-host-exec /usr/local/bin/docker"
+          "ln -sf /usr/bin/distrobox-host-exec /usr/local/bin/docker-compose"
+        ];
+      };
+
+      office = {
+        clone = "common-debian";
+        additional_packages = "libreoffice onlyoffice";
+        entry = true;
+      };
+
+      random-things = {
+        clone = "common-debian";
+        entry = false;
+      };
+
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/distrobox/containers.ini
+    assertFileContent home-files/.config/distrobox/containers.ini \
+      ${./example-config.ini}
+  '';
+}


### PR DESCRIPTION
### Description
Added programs/distrobox.nix module. It provides the option "programs.distrobox.containers", which makes it possible to declare a list of containers to be created. Since building those containers is not possible at build time (because none container backend is available at that time), I also added a Systemd Unit to build those containers after switching the configuration.

Ready to be merged!

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
