### PR TITLE
thunderbird: darwin cleanup

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -452,11 +452,11 @@ in
         type = types.bool;
         default = true;
         example = false;
-        visible = isDarwin;
+        visible = false;
         readOnly = !isDarwin;
         description = ''
-          Warn to set environment variables before using this module. Only
-          relevant on Darwin.
+          Using programs.thunderbird.darwinSetupWarning is deprecated. The
+          module is compatible with all Thunderbird installations.
         '';
       };
     };
@@ -611,6 +611,13 @@ in
   };
 
   config = mkIf cfg.enable {
+    warnings = lib.optionals (!cfg.darwinSetupWarning) [
+      ''
+        Using programs.thunderbird.darwinSetupWarning is deprecated and will be
+        removed in the future. Thunderbird is now supported on Darwin.
+      ''
+    ];
+
     assertions = [
       (
         let
@@ -641,13 +648,6 @@ in
         }
       )
     ];
-
-    warnings = lib.optional (isDarwin && cfg.darwinSetupWarning) ''
-      Thunderbird packages are not yet supported on Darwin. You can still use
-      this module to manage your accounts and profiles by setting
-      'programs.thunderbird.package' to a dummy value, for example using
-      'pkgs.runCommand'.
-    '';
 
     home.packages = [
       cfg.package

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -64,9 +64,6 @@
       name = "thunderbird";
     };
 
-    # Disable warning so that platforms' behavior is the same
-    darwinSetupWarning = false;
-
     profiles = {
       first = {
         isDefault = true;


### PR DESCRIPTION
- **thunderbird: deprecate darwinSetupWarning option**

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
