### PR TITLE
screen-locker: set Restart=always for all services

### DIFF
--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -127,6 +127,7 @@ in {
           ExecStart = concatStringsSep " "
             ([ "${cfg.xss-lock.package}/bin/xss-lock" "-s \${XDG_SESSION_ID}" ]
               ++ cfg.xss-lock.extraOptions ++ [ "-- ${cfg.lockCmd}" ]);
+          Restart = "always";
         };
       };
     }
@@ -153,6 +154,7 @@ in {
             "-locker '${pkgs.systemd}/bin/loginctl lock-session \${XDG_SESSION_ID}'"
           ] ++ optional cfg.xautolock.detectSleep "-detectsleep"
             ++ cfg.xautolock.extraOptions);
+          Restart = "always";
         };
       };
     })

--- a/tests/modules/services/screen-locker/basic-configuration.nix
+++ b/tests/modules/services/screen-locker/basic-configuration.nix
@@ -19,7 +19,9 @@
 
     assertFileExists $xssService
     assertFileRegex $xssService 'ExecStart=.*/bin/xss-lock.*-test.*i3lock -n -c AA0000'
+    assertFileRegex $xssService 'Restart=always'
     assertFileExists $xautolockService
     assertFileRegex $xautolockService 'ExecStart=.*/bin/xautolock.*-time 5.*-detectsleep.*-test.*'
+    assertFileRegex $xautolockService 'Restart=always'
   '';
 }


### PR DESCRIPTION
### Description

Set `Restart=always` for `xss-lock` and `xautolock` services. This is in line with NixOS counterparts.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
