### PR TITLE
iamb: new module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -131,6 +131,7 @@ let
     ./programs/i3blocks.nix
     ./programs/i3status-rust.nix
     ./programs/i3status.nix
+    ./programs/iamb.nix
     ./programs/imv.nix
     ./programs/info.nix
     ./programs/ion.nix

--- a/modules/programs/iamb.nix
+++ b/modules/programs/iamb.nix
@@ -1,0 +1,53 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.iamb;
+  tomlFormat = pkgs.formats.toml { };
+in {
+  options.programs.iamb = {
+    enable = lib.mkEnableOption "iamb";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.iamb;
+      defaultText = lib.literalExpression "pkgs.iamb";
+      description = "The package to use for the iamb binary.";
+    };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          default_profile = "personal";
+          settings = {
+            notifications.enabled = true;
+            image_preview.protocol = {
+              type = "kitty";
+              size = {
+                height = 10;
+                width = 66;
+              };
+            };
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/iamb/config.toml`.
+
+        See <https://iamb.chat/configure.html> for the full list
+        of options.
+      '';
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."iamb/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "iamb-config" cfg.settings;
+    };
+  };
+}

--- a/modules/programs/iamb.nix
+++ b/modules/programs/iamb.nix
@@ -1,5 +1,4 @@
 { config, lib, pkgs, ... }:
-
 let
   cfg = config.programs.iamb;
   tomlFormat = pkgs.formats.toml { };
@@ -7,12 +6,7 @@ in {
   options.programs.iamb = {
     enable = lib.mkEnableOption "iamb";
 
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.iamb;
-      defaultText = lib.literalExpression "pkgs.iamb";
-      description = "The package to use for the iamb binary.";
-    };
+    package = lib.mkPackageOption pkgs "iamb" { nullable = true; };
 
     settings = lib.mkOption {
       type = tomlFormat.type;
@@ -44,7 +38,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."iamb/config.toml" = lib.mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "iamb-config" cfg.settings;


### PR DESCRIPTION
### Description
Add a new module for configuring iamb.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
