### PR TITLE
swww: add swww service module for swww-daemon

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -130,6 +130,14 @@
     githubId = "56848082";
     name = "Henri Sota";
   };
+  hey2022 = {
+    name = "Yiheng He";
+    email = "yiheng.he@proton.me";
+    matrix = "@hey2022:matrix.org";
+    github = "hey2022";
+    keys =
+      [{ fingerprint = "128E 09C0 6F73 D678 6BB5  E551 5EA5 3C75 F7BE 3EDE"; }];
+  };
   jack5079 = {
     name = "Jack W.";
     email = "nix@jack.cab";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -394,6 +394,7 @@ let
     ./services/swayidle.nix
     ./services/swaync.nix
     ./services/swayosd.nix
+    ./services/swww.nix
     ./services/sxhkd.nix
     ./services/syncthing.nix
     ./services/systembus-notify.nix

--- a/modules/services/swww.nix
+++ b/modules/services/swww.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+let cfg = config.services.swww;
+in {
+  meta.maintainers = with lib.hm.maintainers; [ hey2022 ];
+
+  options.services.swww = {
+    enable =
+      lib.mkEnableOption "swww, a Solution to your Wayland Wallpaper Woes";
+    package = lib.mkPackageOption pkgs "swww" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.swww" pkgs
+        lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    systemd.user.services.swww = {
+      Install = { WantedBy = [ config.wayland.systemd.target ]; };
+
+      Unit = {
+        ConditionEnvironment = "WAYLAND_DISPLAY";
+        Description = "swww-daemon";
+        After = [ config.wayland.systemd.target ];
+        PartOf = [ config.wayland.systemd.target ];
+      };
+
+      Service = {
+        ExecStart = "${lib.getExe' cfg.package "swww-daemon"}";
+        Restart = "always";
+        RestartSec = 10;
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -528,6 +528,7 @@ in import nmtSrc {
     ./modules/services/swayidle
     ./modules/services/swaync
     ./modules/services/swayosd
+    ./modules/services/swww
     ./modules/services/sxhkd
     ./modules/services/syncthing/linux
     ./modules/services/tldr-update

--- a/tests/modules/services/swww/default.nix
+++ b/tests/modules/services/swww/default.nix
@@ -1,0 +1,1 @@
+{ swww-graphical-session-target = ./swww-graphical-session-target.nix; }

--- a/tests/modules/services/swww/swww-graphical-session-target.nix
+++ b/tests/modules/services/swww/swww-graphical-session-target.nix
@@ -1,0 +1,11 @@
+{ config, ... }: {
+  services.swww = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@swww@"; };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/swww.service
+    assertFileContent $serviceFile ${./swww-graphical-session-target.service}
+  '';
+}

--- a/tests/modules/services/swww/swww-graphical-session-target.service
+++ b/tests/modules/services/swww/swww-graphical-session-target.service
@@ -1,0 +1,13 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@swww@/bin/swww-daemon
+Restart=always
+RestartSec=10
+
+[Unit]
+After=graphical-session.target
+ConditionEnvironment=WAYLAND_DISPLAY
+Description=swww-daemon
+PartOf=graphical-session.target


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds services/swww.nix module to start swww-daemon with a systemd service.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
