### PR TITLE
i3-sway: Allow providing order of other workspaces

### DIFF
--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -19,7 +19,14 @@ let
         terminal defaultWorkspace workspaceOutputAssign;
 
       keybindings = mkOption {
-        type = types.attrsOf (types.nullOr types.str);
+        type = let
+          withPriority = types.submodule {
+            options = {
+              priority = mkOption { type = types.int; };
+              value = mkOption { type = types.str; };
+            };
+          };
+        in types.attrsOf (types.nullOr (types.either types.str withPriority));
         default = mapAttrs (n: mkOptionDefault) {
           "${cfg.config.modifier}+Return" = "exec ${cfg.config.terminal}";
           "${cfg.config.modifier}+Shift+q" = "kill";
@@ -51,37 +58,87 @@ let
           "${cfg.config.modifier}+Shift+minus" = "move scratchpad";
           "${cfg.config.modifier}+minus" = "scratchpad show";
 
-          "${cfg.config.modifier}+1" = "workspace number 1";
-          "${cfg.config.modifier}+2" = "workspace number 2";
-          "${cfg.config.modifier}+3" = "workspace number 3";
-          "${cfg.config.modifier}+4" = "workspace number 4";
-          "${cfg.config.modifier}+5" = "workspace number 5";
-          "${cfg.config.modifier}+6" = "workspace number 6";
-          "${cfg.config.modifier}+7" = "workspace number 7";
-          "${cfg.config.modifier}+8" = "workspace number 8";
-          "${cfg.config.modifier}+9" = "workspace number 9";
-          "${cfg.config.modifier}+0" = "workspace number 10";
+          "${cfg.config.modifier}+1" = {
+            priority = 101;
+            value = "workspace number 1";
+          };
+          "${cfg.config.modifier}+2" = {
+            priority = 102;
+            value = "workspace number 2";
+          };
+          "${cfg.config.modifier}+3" = {
+            priority = 103;
+            value = "workspace number 3";
+          };
+          "${cfg.config.modifier}+4" = {
+            priority = 104;
+            value = "workspace number 4";
+          };
+          "${cfg.config.modifier}+5" = {
+            priority = 105;
+            value = "workspace number 5";
+          };
+          "${cfg.config.modifier}+6" = {
+            priority = 106;
+            value = "workspace number 6";
+          };
+          "${cfg.config.modifier}+7" = {
+            priority = 107;
+            value = "workspace number 7";
+          };
+          "${cfg.config.modifier}+8" = {
+            priority = 108;
+            value = "workspace number 8";
+          };
+          "${cfg.config.modifier}+9" = {
+            priority = 109;
+            value = "workspace number 9";
+          };
+          "${cfg.config.modifier}+0" = {
+            priority = 110;
+            value = "workspace number 10";
+          };
 
-          "${cfg.config.modifier}+Shift+1" =
-            "move container to workspace number 1";
-          "${cfg.config.modifier}+Shift+2" =
-            "move container to workspace number 2";
-          "${cfg.config.modifier}+Shift+3" =
-            "move container to workspace number 3";
-          "${cfg.config.modifier}+Shift+4" =
-            "move container to workspace number 4";
-          "${cfg.config.modifier}+Shift+5" =
-            "move container to workspace number 5";
-          "${cfg.config.modifier}+Shift+6" =
-            "move container to workspace number 6";
-          "${cfg.config.modifier}+Shift+7" =
-            "move container to workspace number 7";
-          "${cfg.config.modifier}+Shift+8" =
-            "move container to workspace number 8";
-          "${cfg.config.modifier}+Shift+9" =
-            "move container to workspace number 9";
-          "${cfg.config.modifier}+Shift+0" =
-            "move container to workspace number 10";
+          "${cfg.config.modifier}+Shift+1" = {
+            priority = 201;
+            value = "move container to workspace number 1";
+          };
+          "${cfg.config.modifier}+Shift+2" = {
+            priority = 202;
+            value = "move container to workspace number 2";
+          };
+          "${cfg.config.modifier}+Shift+3" = {
+            priority = 203;
+            value = "move container to workspace number 3";
+          };
+          "${cfg.config.modifier}+Shift+4" = {
+            priority = 204;
+            value = "move container to workspace number 4";
+          };
+          "${cfg.config.modifier}+Shift+5" = {
+            priority = 205;
+            value = "move container to workspace number 5";
+          };
+          "${cfg.config.modifier}+Shift+6" = {
+            priority = 206;
+            value = "move container to workspace number 6";
+          };
+          "${cfg.config.modifier}+Shift+7" = {
+            priority = 207;
+            value = "move container to workspace number 7";
+          };
+          "${cfg.config.modifier}+Shift+8" = {
+            priority = 208;
+            value = "move container to workspace number 8";
+          };
+          "${cfg.config.modifier}+Shift+9" = {
+            priority = 209;
+            value = "move container to workspace number 9";
+          };
+          "${cfg.config.modifier}+Shift+0" = {
+            priority = 210;
+            value = "move container to workspace number 10";
+          };
 
           "${cfg.config.modifier}+Shift+c" = "reload";
           "${cfg.config.modifier}+Shift+r" = "restart";
@@ -140,7 +197,7 @@ let
   inherit (commonFunctions)
     keybindingsStr keycodebindingsStr modeStr assignStr barStr gapsStr
     floatingCriteriaStr windowCommandsStr colorSetStr windowBorderString
-    fontConfigStr keybindingDefaultWorkspace keybindingsRest workspaceOutputStr;
+    fontConfigStr workspaceOutputStr;
 
   startupEntryStr = { command, always, notification, workspace, ... }:
     concatStringsSep " " [
@@ -174,8 +231,7 @@ let
         "client.urgent ${colorSetStr colors.urgent}"
         "client.placeholder ${colorSetStr colors.placeholder}"
         "client.background ${colors.background}"
-        (keybindingsStr { keybindings = keybindingDefaultWorkspace; })
-        (keybindingsStr { keybindings = keybindingsRest; })
+        keybindingsStr
         (keycodebindingsStr keycodebindings)
       ] ++ mapAttrsToList (modeStr false) modes
         ++ mapAttrsToList assignStr assigns ++ map barStr bars

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -899,6 +899,8 @@ in {
         if isSway then "sway" else "i3"
       } is launched.
       This must to correspond to the value of the keybinding of the default workspace.
+      Alternatively you can specify a priority for any keybinding, default
+      priority is 1000, keybinding matching defaultWorkspace priority is 100.
     '';
     example = "workspace number 9";
   };

--- a/tests/modules/services/window-managers/i3/i3-bar-focused-colors-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-bar-focused-colors-expected.conf
@@ -15,8 +15,6 @@ client.unfocused #333333 #222222 #888888 #292d2e #222222
 client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
-
-bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -26,11 +24,7 @@ bindsym Mod1+6 workspace number 6
 bindsym Mod1+7 workspace number 7
 bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
-bindsym Mod1+Down focus down
-bindsym Mod1+Left focus left
-bindsym Mod1+Return exec i3-sensible-terminal
-bindsym Mod1+Right focus right
-bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3
@@ -40,6 +34,11 @@ bindsym Mod1+Shift+6 move container to workspace number 6
 bindsym Mod1+Shift+7 move container to workspace number 7
 bindsym Mod1+Shift+8 move container to workspace number 8
 bindsym Mod1+Shift+9 move container to workspace number 9
+bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+Down focus down
+bindsym Mod1+Left focus left
+bindsym Mod1+Return exec i3-sensible-terminal
+bindsym Mod1+Right focus right
 bindsym Mod1+Shift+Down move down
 bindsym Mod1+Shift+Left move left
 bindsym Mod1+Shift+Right move right

--- a/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-followmouse-expected.conf
@@ -15,8 +15,6 @@ client.unfocused #333333 #222222 #888888 #292d2e #222222
 client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
-
-bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -26,11 +24,7 @@ bindsym Mod1+6 workspace number 6
 bindsym Mod1+7 workspace number 7
 bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
-bindsym Mod1+Down focus down
-bindsym Mod1+Left focus left
-bindsym Mod1+Return exec i3-sensible-terminal
-bindsym Mod1+Right focus right
-bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3
@@ -40,6 +34,11 @@ bindsym Mod1+Shift+6 move container to workspace number 6
 bindsym Mod1+Shift+7 move container to workspace number 7
 bindsym Mod1+Shift+8 move container to workspace number 8
 bindsym Mod1+Shift+9 move container to workspace number 9
+bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+Down focus down
+bindsym Mod1+Left focus left
+bindsym Mod1+Return exec i3-sensible-terminal
+bindsym Mod1+Right focus right
 bindsym Mod1+Shift+Down move down
 bindsym Mod1+Shift+Left move left
 bindsym Mod1+Shift+Right move right

--- a/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-fonts-expected.conf
@@ -15,8 +15,6 @@ client.unfocused #333333 #222222 #888888 #292d2e #222222
 client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
-
-bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -26,11 +24,7 @@ bindsym Mod1+6 workspace number 6
 bindsym Mod1+7 workspace number 7
 bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
-bindsym Mod1+Down focus down
-bindsym Mod1+Left focus left
-bindsym Mod1+Return exec i3-sensible-terminal
-bindsym Mod1+Right focus right
-bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3
@@ -40,6 +34,11 @@ bindsym Mod1+Shift+6 move container to workspace number 6
 bindsym Mod1+Shift+7 move container to workspace number 7
 bindsym Mod1+Shift+8 move container to workspace number 8
 bindsym Mod1+Shift+9 move container to workspace number 9
+bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+Down focus down
+bindsym Mod1+Left focus left
+bindsym Mod1+Return exec i3-sensible-terminal
+bindsym Mod1+Right focus right
 bindsym Mod1+Shift+Down move down
 bindsym Mod1+Shift+Left move left
 bindsym Mod1+Shift+Right move right

--- a/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-keybindings-expected.conf
@@ -15,23 +15,16 @@ client.unfocused #333333 #222222 #888888 #292d2e #222222
 client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
-
-bindsym Mod1+0 workspace number 10
+bindsym Mod1+5 workspace number 5
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
 bindsym Mod1+4 workspace number 4
-bindsym Mod1+5 workspace number 5
 bindsym Mod1+6 workspace number 6
 bindsym Mod1+7 workspace number 7
 bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
-bindsym Mod1+Down focus down
-bindsym Mod1+Invented invented-key-command
-bindsym Mod1+Left overridden-command
-bindsym Mod1+Return exec i3-sensible-terminal
-
-bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3
@@ -41,6 +34,12 @@ bindsym Mod1+Shift+6 move container to workspace number 6
 bindsym Mod1+Shift+7 move container to workspace number 7
 bindsym Mod1+Shift+8 move container to workspace number 8
 bindsym Mod1+Shift+9 move container to workspace number 9
+bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+Down focus down
+bindsym Mod1+Invented invented-key-command
+bindsym Mod1+Left overridden-command
+bindsym Mod1+Return exec i3-sensible-terminal
+
 bindsym Mod1+Shift+Down move down
 bindsym Mod1+Shift+Left move left
 bindsym Mod1+Shift+Right move right

--- a/tests/modules/services/window-managers/i3/i3-keybindings.nix
+++ b/tests/modules/services/window-managers/i3/i3-keybindings.nix
@@ -6,6 +6,7 @@
   xsession.windowManager.i3 = {
     enable = true;
 
+    config.defaultWorkspace = "workspace number 5";
     config.keybindings =
       let modifier = config.xsession.windowManager.i3.config.modifier;
       in lib.mkOptionDefault {

--- a/tests/modules/services/window-managers/i3/i3-workspace-default-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-workspace-default-expected.conf
@@ -16,7 +16,6 @@ client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
 bindsym Mod1+1 workspace number 1
-bindsym Mod1+0 workspace number 10
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
 bindsym Mod1+4 workspace number 4
@@ -25,11 +24,7 @@ bindsym Mod1+6 workspace number 6
 bindsym Mod1+7 workspace number 7
 bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
-bindsym Mod1+Down focus down
-bindsym Mod1+Left focus left
-bindsym Mod1+Return exec i3-sensible-terminal
-bindsym Mod1+Right focus right
-bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3
@@ -39,6 +34,11 @@ bindsym Mod1+Shift+6 move container to workspace number 6
 bindsym Mod1+Shift+7 move container to workspace number 7
 bindsym Mod1+Shift+8 move container to workspace number 8
 bindsym Mod1+Shift+9 move container to workspace number 9
+bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+Down focus down
+bindsym Mod1+Left focus left
+bindsym Mod1+Return exec i3-sensible-terminal
+bindsym Mod1+Right focus right
 bindsym Mod1+Shift+Down move down
 bindsym Mod1+Shift+Left move left
 bindsym Mod1+Shift+Right move right

--- a/tests/modules/services/window-managers/i3/i3-workspace-output-expected.conf
+++ b/tests/modules/services/window-managers/i3/i3-workspace-output-expected.conf
@@ -15,8 +15,6 @@ client.unfocused #333333 #222222 #888888 #292d2e #222222
 client.urgent #2f343a #900000 #ffffff #900000 #900000
 client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
 client.background #ffffff
-
-bindsym Mod1+0 workspace number 10
 bindsym Mod1+1 workspace number 1
 bindsym Mod1+2 workspace number 2
 bindsym Mod1+3 workspace number 3
@@ -26,11 +24,7 @@ bindsym Mod1+6 workspace number 6
 bindsym Mod1+7 workspace number 7
 bindsym Mod1+8 workspace number 8
 bindsym Mod1+9 workspace number 9
-bindsym Mod1+Down focus down
-bindsym Mod1+Left focus left
-bindsym Mod1+Return exec i3-sensible-terminal
-bindsym Mod1+Right focus right
-bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+0 workspace number 10
 bindsym Mod1+Shift+1 move container to workspace number 1
 bindsym Mod1+Shift+2 move container to workspace number 2
 bindsym Mod1+Shift+3 move container to workspace number 3
@@ -40,6 +34,11 @@ bindsym Mod1+Shift+6 move container to workspace number 6
 bindsym Mod1+Shift+7 move container to workspace number 7
 bindsym Mod1+Shift+8 move container to workspace number 8
 bindsym Mod1+Shift+9 move container to workspace number 9
+bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+Down focus down
+bindsym Mod1+Left focus left
+bindsym Mod1+Return exec i3-sensible-terminal
+bindsym Mod1+Right focus right
 bindsym Mod1+Shift+Down move down
 bindsym Mod1+Shift+Left move left
 bindsym Mod1+Shift+Right move right


### PR DESCRIPTION
I'm using i3, not sway.

For multi-monitor setups, I end up the second screen having workspace 10 (because it is bound to Mod4+0, so ordered before the other numbers).

Needs more testing, especially with sway/tweaking to get it to work with sway. But posting it here because it might be useful.

CC #6041

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible -- I tried to make it so by making `defaultWorkspace` have a priority of 100. But strictly speaking this isn't backwards compatible, because it makes workspace number 1 the default, not number 10. (See tests).

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

  This currently moves the workspace stuff next to eachother, because I thought it's neater, but it isn't necessary.

  Currently the sway tests are broken, because I haven't fixed sway up

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC
@sumnerevans 