### PR TITLE
nix-darwin: use correct username in activation script

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -14,9 +14,9 @@ in {
     (mkIf (cfg.users != { }) {
       system.activationScripts.postActivation.text = concatStringsSep "\n"
         (mapAttrsToList (username: usercfg: ''
-          echo Activating home-manager configuration for ${username}
-          sudo -u ${username} --set-home ${
-            pkgs.writeShellScript "activation-${username}" ''
+          echo Activating home-manager configuration for ${usercfg.home.username}
+          sudo -u ${usercfg.home.username} --set-home ${
+            pkgs.writeShellScript "activation-${usercfg.home.username}" ''
               ${lib.optionalString (cfg.backupFileExtension != null)
               "export HOME_MANAGER_BACKUP_EXT=${
                 lib.escapeShellArg cfg.backupFileExtension


### PR DESCRIPTION
### Description

This pull request updates the nix-darwin activation script to use the correct username. This was previously not the case if the username didn't match the key in the users attribute set, e.g.:

```nix
{
  users.users.myUser = {
    name = "actual_name";
  };
}
```

In this case home-manager would try to run the activation script for "myUser" when it should run for "actual_name".

There's another pull-request that fixes this issue (#5881) but it got marked as stale.

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `./format`.
