### PR TITLE
xdg: add option 'xdg.cacheFile'

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -24,6 +24,15 @@ in {
   options.xdg = {
     enable = mkEnableOption "management of XDG base directories";
 
+    cacheFile = mkOption {
+      type = fileType "xdg.cacheFile" "{var}`xdg.cacheHome`" cfg.cacheHome;
+      default = { };
+      description = ''
+        Attribute set of files to link into the user's XDG
+        cache home.
+      '';
+    };
+
     cacheHome = mkOption {
       type = types.path;
       defaultText = "~/.cache";
@@ -136,6 +145,8 @@ in {
 
     {
       home.file = mkMerge [
+        (mapAttrs' (name: file: nameValuePair "${cfg.cacheHome}/${name}" file)
+          cfg.cacheFile)
         (mapAttrs' (name: file: nameValuePair "${cfg.configHome}/${name}" file)
           cfg.configFile)
         (mapAttrs' (name: file: nameValuePair "${cfg.dataHome}/${name}" file)


### PR DESCRIPTION
### Description

Add xdg.cacheFile to mimic configFile, dataFile, stateFile.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee 