### PR TITLE
firefox: fix wrong syntax grammar for search setting isAppProvided

### DIFF
--- a/modules/programs/firefox/profiles/search.nix
+++ b/modules/programs/firefox/profiles/search.nix
@@ -48,8 +48,8 @@ let
     let
       requiredInput = {
         inherit name;
-        isAppProvided = input.isAppProvided or removeAttrs input [ "metaData" ]
-          == { };
+        isAppProvided =
+          input.isAppProvided or (removeAttrs input [ "metaData" ] == { });
         metaData = input.metaData or { };
       };
     in if requiredInput.isAppProvided then


### PR DESCRIPTION
The or operator is left associative, and since there is another argument after the first term, the interpreter tries to apply whatever the or-expression evaluates to.  If the first operand is unset, it evaluates to removeAttrs, and everything is fine, but if it is set to a boolean (which is what it should be set to), then it tries to apply a boolean to arguments, and we get a type error.  Bracketing explicitly with parentheses fixes this.

It presumably went unnoticed because not many people have tried setting the option
`programs.firefox.profiles.<profile>.search.engines.<engine>.isAppProvided`.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee @brckd @HPsaucii 