### PR TITLE
thunderbird: add message filters option

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -155,6 +155,32 @@ let
     '') prefs)}
     ${extraPrefs}
   '';
+
+  mkFilterToIniString = f:
+    if f.text == null then
+      ''
+        name="${f.name}"
+        enabled="${if f.enabled then "yes" else "no"}"
+        type="${f.type}"
+        action="${f.action}"
+      '' + optionalString (f.actionValue != null) ''
+        actionValue="${f.actionValue}"
+      '' + ''
+        condition="${f.condition}"
+      '' + optionalString (f.extraConfig != null) f.extraConfig
+    else
+      f.text;
+
+  mkFilterListToIni = filters:
+    ''
+      version="9"
+      logging="no"
+    '' + concatStrings (map (f: mkFilterToIniString f) filters);
+
+  getEmailAccountsForProfile = profileName: accounts:
+    (filter (a:
+      a.thunderbird.profiles == [ ]
+      || any (p: p == profileName) a.thunderbird.profiles) accounts);
 in {
   meta.maintainers = with hm.maintainers; [ d-dervishi jkarlson ];
 
@@ -408,6 +434,71 @@ in {
                 argument is an automatically generated identifier.
               '';
             };
+
+            messageFilters = mkOption {
+              type = with types;
+                listOf (submodule {
+                  options = {
+                    name = mkOption {
+                      type = str;
+                      description = "Name for the filter.";
+                    };
+                    enabled = mkOption {
+                      type = bool;
+                      default = true;
+                      description = "Whether this filter is currently active.";
+                    };
+                    type = mkOption {
+                      type = str;
+                      description = "Type for this filter.";
+                    };
+                    action = mkOption {
+                      type = str;
+                      description = "Action to perform on matched messages.";
+                    };
+                    actionValue = mkOption {
+                      type = nullOr str;
+                      default = null;
+                      description =
+                        "Argument passed to the filter action, e.g. a folder path.";
+                    };
+                    condition = mkOption {
+                      type = str;
+                      description = "Condition to match messages against.";
+                    };
+                    extraConfig = mkOption {
+                      type = nullOr str;
+                      default = null;
+                      description = "Extra settings to apply to the filter";
+                    };
+                    text = mkOption {
+                      type = nullOr str;
+                      default = null;
+                      description = ''
+                        The raw text of the filter.
+                        Note that this will override all other options.
+                      '';
+                    };
+                  };
+                });
+              default = [ ];
+              defaultText = literalExpression "[ ]";
+              example = literalExpression ''
+                [
+                  {
+                    name = "Mark as Read on Archive";
+                    enabled = true;
+                    type = "128";
+                    action = "Mark read";
+                    condition = "ALL";
+                  }
+                ]
+              '';
+              description = ''
+                List of message filters to add to this Thunderbird account
+                configuration.
+              '';
+            };
           };
         });
     };
@@ -463,9 +554,7 @@ in {
         mkIf (profile.userContent != "") { text = profile.userContent; };
 
       "${thunderbirdProfilesPath}/${name}/user.js" = let
-        emailAccounts = filter (a:
-          a.thunderbird.profiles == [ ]
-          || any (p: p == name) a.thunderbird.profiles) enabledAccountsWithId;
+        emailAccounts = getEmailAccountsForProfile name enabledAccountsWithId;
 
         smtp = filter (a: a.smtp != null) emailAccounts;
 
@@ -514,6 +603,15 @@ in {
           recursive = true;
           force = true;
         };
-    }));
+    }) ++ (mapAttrsToList (name: profile:
+      let
+        emailAccountsWithFilters =
+          (filter (a: a.thunderbird.messageFilters != [ ])
+            (getEmailAccountsForProfile name enabledAccountsWithId));
+      in (builtins.listToAttrs (map (a: {
+        name =
+          "${thunderbirdConfigPath}/${name}/ImapMail/${a.id}/msgFilterRules.dat";
+        value = { text = mkFilterListToIni a.thunderbird.messageFilters; };
+      }) emailAccountsWithFilters))) cfg.profiles));
   };
 }

--- a/tests/modules/programs/thunderbird/thunderbird-expected-msgFilterRules.dat
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-msgFilterRules.dat
@@ -1,0 +1,7 @@
+version="9"
+logging="no"
+name="Mark as Read on Archive"
+enabled="yes"
+type="128"
+action="Mark read"
+condition="ALL"

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -6,6 +6,13 @@
       thunderbird = {
         enable = true;
         profiles = [ "first" ];
+        messageFilters = [{
+          name = "Mark as Read on Archive";
+          enabled = true;
+          type = "128";
+          action = "Mark read";
+          condition = "ALL";
+        }];
       };
 
       aliases = [ "home-manager@example.com" ];
@@ -99,5 +106,13 @@
     assertFileExists home-files/${profilesDir}/first/chrome/userContent.css
     assertFileContent home-files/${profilesDir}/first/chrome/userContent.css \
       <(echo "* { color: red !important; }")
+
+    assertFileExists home-files/.thunderbird/first/ImapMail/${
+      builtins.hashString "sha256" "hm@example.com"
+    }/msgFilterRules.dat
+    assertFileContent home-files/.thunderbird/first/ImapMail/${
+      builtins.hashString "sha256" "hm@example.com"
+    }/msgFilterRules.dat \
+      ${./thunderbird-expected-msgFilterRules.dat}
   '';
 }


### PR DESCRIPTION
Add option to declare account-specific message filters.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.
    ~~Neither of these are working for me currently, even against master, happy to re-run if there's something I'm missing~~

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@d-dervishi @hakan-demirli @ethorsoe @javaes