### PR TITLE
librewolf: support darwin

### DIFF
--- a/modules/programs/librewolf.nix
+++ b/modules/programs/librewolf.nix
@@ -57,11 +57,6 @@ in {
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      (lib.hm.assertions.assertPlatform "programs.librewolf" pkgs
-        lib.platforms.linux)
-    ];
-
     home.file.".librewolf/librewolf.overrides.cfg" =
       lib.mkIf (cfg.settings != { }) { text = mkOverridesFile cfg.settings; };
   };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Removed an unnecessary Linux assertion. Although I don't understand why it was there in the first place, the module have never had anything Linux-specific.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@chayleaf @onny 
