### PR TITLE
xdg: legacy fix and test tweaks

### DIFF
--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -133,6 +133,8 @@ in {
       xdg.configHome =
         mkDefault (getEnvFallback "XDG_CONFIG_HOME" defaultConfigHome);
       xdg.dataHome = mkDefault (getEnvFallback "XDG_DATA_HOME" defaultDataHome);
+      xdg.stateHome =
+        mkDefault (getEnvFallback "XDG_STATE_HOME" defaultStateHome);
     })
 
     # "Modern" deterministic setup.

--- a/modules/misc/xdg.nix
+++ b/modules/misc/xdg.nix
@@ -116,10 +116,10 @@ in {
         XDG_STATE_HOME = cfg.stateHome;
       };
     in mkIf cfg.enable {
-      xdg.cacheHome = mkDefault defaultCacheHome;
-      xdg.configHome = mkDefault defaultConfigHome;
-      xdg.dataHome = mkDefault defaultDataHome;
-      xdg.stateHome = mkDefault defaultStateHome;
+      xdg.cacheHome = mkOptionDefault defaultCacheHome;
+      xdg.configHome = mkOptionDefault defaultConfigHome;
+      xdg.dataHome = mkOptionDefault defaultDataHome;
+      xdg.stateHome = mkOptionDefault defaultStateHome;
 
       home.sessionVariables = variables;
       systemd.user.sessionVariables =
@@ -129,20 +129,21 @@ in {
     # Legacy non-deterministic setup.
     (mkIf (!cfg.enable && versionOlder config.home.stateVersion "20.09") {
       xdg.cacheHome =
-        mkDefault (getEnvFallback "XDG_CACHE_HOME" defaultCacheHome);
+        mkOptionDefault (getEnvFallback "XDG_CACHE_HOME" defaultCacheHome);
       xdg.configHome =
-        mkDefault (getEnvFallback "XDG_CONFIG_HOME" defaultConfigHome);
-      xdg.dataHome = mkDefault (getEnvFallback "XDG_DATA_HOME" defaultDataHome);
+        mkOptionDefault (getEnvFallback "XDG_CONFIG_HOME" defaultConfigHome);
+      xdg.dataHome =
+        mkOptionDefault (getEnvFallback "XDG_DATA_HOME" defaultDataHome);
       xdg.stateHome =
-        mkDefault (getEnvFallback "XDG_STATE_HOME" defaultStateHome);
+        mkOptionDefault (getEnvFallback "XDG_STATE_HOME" defaultStateHome);
     })
 
     # "Modern" deterministic setup.
     (mkIf (!cfg.enable && versionAtLeast config.home.stateVersion "20.09") {
-      xdg.cacheHome = mkDefault defaultCacheHome;
-      xdg.configHome = mkDefault defaultConfigHome;
-      xdg.dataHome = mkDefault defaultDataHome;
-      xdg.stateHome = mkDefault defaultStateHome;
+      xdg.cacheHome = mkOptionDefault defaultCacheHome;
+      xdg.configHome = mkOptionDefault defaultConfigHome;
+      xdg.dataHome = mkOptionDefault defaultDataHome;
+      xdg.stateHome = mkOptionDefault defaultStateHome;
     })
 
     {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -92,7 +92,7 @@ let
 
       # Fix impurities. Without these some of the user's environment
       # will leak into the tests through `builtins.getEnv`.
-      xdg.enable = true;
+      xdg.enable = lib.mkDefault true;
       home = {
         username = "hm-user";
         homeDirectory = "/home/hm-user";

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -124,6 +124,7 @@ in import nmtSrc {
     ./modules/misc/manual
     ./modules/misc/nix
     ./modules/misc/specialisation
+    ./modules/misc/xdg
     ./modules/programs/aerc
     ./modules/programs/alacritty
     ./modules/programs/alot
@@ -269,6 +270,7 @@ in import nmtSrc {
     ./modules/services/yubikey-agent-darwin
     ./modules/targets-darwin
   ] ++ lib.optionals isLinux [
+    ./modules/misc/xdg/linux.nix
     ./modules/config/home-cursor
     ./modules/config/i18n
     ./modules/i18n/input-method
@@ -278,7 +280,6 @@ in import nmtSrc {
     ./modules/misc/numlock
     ./modules/misc/pam
     ./modules/misc/qt
-    ./modules/misc/xdg
     ./modules/misc/xsession
     ./modules/programs/abook
     ./modules/programs/autorandr

--- a/tests/modules/misc/xdg/default-locations.nix
+++ b/tests/modules/misc/xdg/default-locations.nix
@@ -1,7 +1,7 @@
 { config, lib, ... }: {
   config = {
     # Test fallback behavior for stateVersion >= 20.09, which is pure.
-    xdg.enable = lib.mkForce false;
+    xdg.enable = false;
     home.stateVersion = "20.09";
 
     xdg.configFile.test.text = "config";

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -1,13 +1,6 @@
 {
-  xdg-mime-apps-basics = ./mime-apps-basics.nix;
-  xdg-system-dirs = ./system-dirs.nix;
-  xdg-desktop-entries = ./desktop-entries.nix;
   xdg-file-gen = ./file-gen.nix;
   xdg-default-locations = ./default-locations.nix;
-  xdg-user-dirs-null = ./user-dirs-null.nix;
-  xdg-portal = ./portal.nix;
-  xdg-mime = ./mime.nix;
   xdg-mime-disabled = ./mime-disabled.nix;
-  xdg-mime-package = ./mime-packages.nix;
   xdg-autostart = ./autostart.nix;
 }

--- a/tests/modules/misc/xdg/linux.nix
+++ b/tests/modules/misc/xdg/linux.nix
@@ -1,0 +1,9 @@
+{
+  xdg-mime-apps-basics = ./mime-apps-basics.nix;
+  xdg-system-dirs = ./system-dirs.nix;
+  xdg-desktop-entries = ./desktop-entries.nix;
+  xdg-user-dirs-null = ./user-dirs-null.nix;
+  xdg-portal = ./portal.nix;
+  xdg-mime = ./mime.nix;
+  xdg-mime-package = ./mime-packages.nix;
+}

--- a/tests/modules/programs/k9s/empty-settings.nix
+++ b/tests/modules/programs/k9s/empty-settings.nix
@@ -3,7 +3,7 @@
 {
   programs.k9s.enable = true;
 
-  xdg.enable = lib.mkIf pkgs.stdenv.isDarwin (lib.mkForce false);
+  xdg.enable = lib.mkIf pkgs.stdenv.isDarwin false;
 
   nmt.script = let
     configDir = if !pkgs.stdenv.isDarwin then

--- a/tests/modules/programs/k9s/example-settings.nix
+++ b/tests/modules/programs/k9s/example-settings.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, ... }:
 
 {
-  xdg.enable = lib.mkIf pkgs.stdenv.isDarwin (lib.mkForce false);
+  xdg.enable = lib.mkIf pkgs.stdenv.isDarwin false;
 
   programs.k9s = {
     enable = true;


### PR DESCRIPTION
### Description

XDG tweaks for fixing a legacy behavior found while testing on darwin. Pulling out of https://github.com/nix-community/home-manager/pull/6550 to get it into master quicker since that might be a longer process.. 
 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
