### PR TITLE
mbsync: Wrap final maildir path with single quotes to prevent escapes

### DIFF
--- a/modules/programs/mbsync.nix
+++ b/modules/programs/mbsync.nix
@@ -288,7 +288,8 @@ in {
         createMaildir =
           hm.dag.entryBetween [ "linkGeneration" ] [ "writeBoundary" ] ''
             run mkdir -m700 -p $VERBOSE_ARG ${
-              concatMapStringsSep " " (a: a.maildir.absPath) mbsyncAccounts
+              concatMapStringsSep " " (a: escapeShellArg a.maildir.absPath)
+              mbsyncAccounts
             }
           '';
       };


### PR DESCRIPTION
### Description

If the user's requested mail directory has spaces or other special shell characters, our activation script breaks. Use `escapeShellArg` to prevent issues by wrapping with single quotes if there are special characters.

Closes #6569.

Cannot run tests on my desktop.

```
$ nix build --reference-lock-file flake.lock ./tests#test-all
error: opening directory '/nix/store/dvck5q5lsir2b217w6d2l1rpqq9a0hbp-hm_fishcompletionstraefik.fish': Too many open files
```

```
$ nix-shell --pure tests -A run.all
...
error: 'vinegar' was removed due to being blocked by Roblox, rendering the package useless
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
