### PR TITLE
`zoxide`: update `mkOrder` to place bash configuration at end of bashrc

### DIFF
--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -48,7 +48,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkOrder 150 ''
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkOrder 2000 ''
       eval "$(${cfg.package}/bin/zoxide init bash ${cfgOptions})"
     '');
 


### PR DESCRIPTION
I updated my flake a few weeks back and `zoxide` has been giving me an error recently:

```
zoxide: detected a possible configuration issue.
Please ensure that zoxide is initialized right at the end of your shell configuration file (usually ~/.bashrc).

If the issue persists, consider filing an issue at:
https://github.com/ajeetdsouza/zoxide/issues

Disable this message by setting _ZO_DOCTOR=0.
```

To be fair, I haven't noticed any issues with `zoxide` apart from this error message.

The `zoxide` eval statement in my `.bashrc` is not "right at the end" of the file as mentioned in the message which isn't surprising given that it is given a `mkOrder 150`. In my own config, I increased this to `2000` (to ensure it comes after any `mkAfter`s which are `mkOrder 1500`) to ensure it happens at the end of the script. After doing so, it appears at the end of my `bashrc` and I no longer get the error message.

I'm open to suggestions on the exact value to use as `2000` may be overkill and I'm unaware of other programs which may need to be evaluated last with more urgency than `zoxide`.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@marsam 
