### PR TITLE
wlsunset: Start after graphical-session

### DIFF
--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -129,6 +129,7 @@ in {
       Unit = {
         Description = "Day/night gamma adjustments for Wayland compositors.";
         PartOf = [ "graphical-session.target" ];
+        After = [ "graphical-session.target" ];
       };
 
       Service = {

--- a/tests/modules/services/wlsunset/wlsunset-service-expected.service
+++ b/tests/modules/services/wlsunset/wlsunset-service-expected.service
@@ -5,5 +5,6 @@ WantedBy=test.target
 ExecStart=@wlsunset@/bin/wlsunset -L 128.8 -T 6000 -g 0.6 -l 12.3 -t 3500
 
 [Unit]
+After=graphical-session.target
 Description=Day/night gamma adjustments for Wayland compositors.
 PartOf=graphical-session.target


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Fixes the wlsunset service to correctly start after `graphical-session.target` is initialized. Previously, wlsunset was unable to start on some Wayland compositors like Niri because the display was not yet initialized at the time of service activation.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@matrss 
