### PR TITLE
helix: add extraConfig option

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
-
 with lib;
-
 let
   cfg = config.programs.helix;
   tomlFormat = pkgs.formats.toml { };
@@ -24,6 +22,20 @@ in {
       default = [ ];
       example = literalExpression "[ pkgs.marksman ]";
       description = "Extra packages available to hx.";
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra lines to be appended to the config file.
+        Use this if you would like to maintain order for helix settings (eg. for minor modes)
+      '';
+      example = literalExpression ''
+        [keys.normal.g] # Reverse Alphabetical Order
+        G = "goto_file_end"
+        g = "goto_file_start"
+      '';
     };
 
     defaultEditor = mkOption {
@@ -200,7 +212,9 @@ in {
     xdg.configFile = let
       settings = {
         "helix/config.toml" = mkIf (cfg.settings != { }) {
-          source = tomlFormat.generate "helix-config" cfg.settings;
+          text =
+            builtins.readFile (tomlFormat.generate "helix-config" cfg.settings)
+            + "\n" + cfg.extraConfig;
         };
         "helix/languages.toml" = mkIf (cfg.languages != { }) {
           source = tomlFormat.generate "helix-languages-config" cfg.languages;
@@ -210,10 +224,10 @@ in {
         };
       };
 
-      themes = (mapAttrs' (n: v:
+      themes = mapAttrs' (n: v:
         nameValuePair "helix/themes/${n}.toml" {
           source = tomlFormat.generate "helix-theme-${n}" v;
-        }) cfg.themes);
+        }) cfg.themes;
     in settings // themes;
   };
 }

--- a/tests/modules/programs/helix/example-settings.nix
+++ b/tests/modules/programs/helix/example-settings.nix
@@ -1,6 +1,4 @@
-{ config, ... }:
-
-{
+{ config, ... }: {
   programs.helix = {
     enable = true;
 
@@ -17,6 +15,12 @@
         esc = [ "collapse_selection" "keep_primary_selection" ];
       };
     };
+
+    extraConfig = ''
+      [keys.normal.G]
+      G = "goto_file_end"
+      g = "goto_file_start"
+    '';
 
     languages = {
       language-server.typescript-language-server = let

--- a/tests/modules/programs/helix/settings-expected.toml
+++ b/tests/modules/programs/helix/settings-expected.toml
@@ -12,3 +12,7 @@ esc = ["collapse_selection", "keep_primary_selection"]
 q = ":q"
 space = "file_picker"
 w = ":w"
+
+[keys.normal.G]
+G = "goto_file_end"
+g = "goto_file_start"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Add an extraConfig option for Helix. Fixes #6513

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.
**NOTE: I am assuming the tests pass, as I am facing an unrelated error on both of my machines. All the tests in the actions pass.**

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
