### PR TITLE
thunderbird: set additional gmail server settings

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -358,7 +358,17 @@ in {
 
     accounts.email.accounts = mkOption {
       type = with types;
-        attrsOf (submodule {
+        attrsOf (submodule ({ config, ... }: {
+          config.thunderbird = {
+            settings = lib.mkIf (config.flavor == "gmail.com") (id: {
+              "mail.server.server_${id}.authMethod" =
+                mkOptionDefault 10; # 10 = OAuth2
+              "mail.server.server_${id}.socketType" =
+                mkOptionDefault 3; # SSL/TLS
+              "mail.server.server_${id}.is_gmail" =
+                mkOptionDefault true; # handle labels, trash, etc
+            });
+          };
           options.thunderbird = {
             enable =
               mkEnableOption "the Thunderbird mail client for this account";
@@ -409,7 +419,7 @@ in {
               '';
             };
           };
-        });
+        }));
     };
   };
 


### PR DESCRIPTION
### Description

When email account is gmail in thunderbird, set additional server settings.
As of March 2025, gmail only allows ssl/oauth0 authentication, so here I set the authMethod accordingly.

Also setting 'is_gmail' to true in thunderbird settings such that labels and trash work out of the box when the email account flavor is "gmail". This brings in the gmail configs for how it handles folders, labels, and archiving messages.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
