### PR TITLE
treewide: null package support

### DIFF
--- a/modules/programs/aerc.nix
+++ b/modules/programs/aerc.nix
@@ -38,7 +38,7 @@ in {
 
     enable = mkEnableOption "aerc";
 
-    package = mkPackageOption pkgs "aerc" { };
+    package = mkPackageOption pkgs "aerc" { nullable = true; };
 
     extraAccounts = mkOption {
       type = sectionsOrLines;
@@ -193,7 +193,7 @@ in {
       '';
     }];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file = {
       "${configDir}/accounts.conf" = mkIf genAccountsConf {

--- a/modules/programs/aerospace.nix
+++ b/modules/programs/aerospace.nix
@@ -29,7 +29,7 @@ in {
   options.programs.aerospace = {
     enable = lib.mkEnableOption "AeroSpace window manager";
 
-    package = lib.mkPackageOption pkgs "aerospace" { };
+    package = lib.mkPackageOption pkgs "aerospace" { nullable = true; };
 
     userSettings = mkOption {
       type = types.submodule {
@@ -232,7 +232,7 @@ in {
     ];
 
     home = {
-      packages = [ cfg.package ];
+      packages = lib.mkIf (cfg.package != null) [ cfg.package ];
       file.".config/aerospace/aerospace.toml".source =
         tomlFormat.generate "aerospace" (filterNulls cfg.userSettings);
     };

--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -132,7 +132,7 @@ in {
         '';
       };
 
-      package = mkPackageOption pkgs "alot" { };
+      package = mkPackageOption pkgs "alot" { nullable = true; };
 
       hooks = mkOption {
         type = types.lines;
@@ -231,7 +231,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."alot/config".text = configFile;
 

--- a/modules/programs/bacon.nix
+++ b/modules/programs/bacon.nix
@@ -19,7 +19,7 @@ in {
   options.programs.bacon = {
     enable = mkEnableOption "bacon, a background rust code checker";
 
-    package = mkPackageOption pkgs "bacon" { };
+    package = mkPackageOption pkgs "bacon" { nullable = true; };
 
     settings = mkOption {
       type = settingsFormat.type;
@@ -38,7 +38,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file."${configDir}/prefs.toml" = mkIf (cfg.settings != { }) {
       source = settingsFormat.generate "prefs.toml" cfg.settings;

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -29,7 +29,10 @@ in {
     programs.bash = {
       enable = mkEnableOption "GNU Bourne-Again SHell";
 
-      package = mkPackageOption pkgs "bash" { default = "bashInteractive"; };
+      package = mkPackageOption pkgs "bash" {
+        nullable = true;
+        default = "bashInteractive";
+      };
 
       enableCompletion = mkOption {
         type = types.bool;
@@ -195,7 +198,7 @@ in {
         }) ++ optional (cfg.historyFile != null)
         ''mkdir -p "$(dirname "$HISTFILE")"''));
   in mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file.".bash_profile".source = writeBashScript "bash_profile" ''
       # include .profile if it exists

--- a/modules/programs/bemenu.nix
+++ b/modules/programs/bemenu.nix
@@ -12,7 +12,7 @@ in {
   options.programs.bemenu = {
     enable = mkEnableOption "bemenu";
 
-    package = mkPackageOption pkgs "bemenu" { };
+    package = mkPackageOption pkgs "bemenu" { nullable = true; };
 
     settings = mkOption {
       type = with types; attrsOf (oneOf [ str number bool ]);
@@ -44,7 +44,7 @@ in {
     assertions =
       [ (hm.assertions.assertPlatform "programs.bemenu" pkgs platforms.linux) ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.sessionVariables = mkIf (cfg.settings != { }) {
       BEMENU_OPTS = cli.toGNUCommandLineShell { } cfg.settings;

--- a/modules/programs/borgmatic.nix
+++ b/modules/programs/borgmatic.nix
@@ -243,7 +243,7 @@ in {
     programs.borgmatic = {
       enable = mkEnableOption "Borgmatic";
 
-      package = mkPackageOption pkgs "borgmatic" { };
+      package = mkPackageOption pkgs "borgmatic" { nullable = true; };
 
       backups = mkOption {
         type = types.attrsOf configModule;
@@ -292,6 +292,6 @@ in {
           text = writeConfig config;
         }) cfg.backups;
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
   };
 }

--- a/modules/programs/boxxy.nix
+++ b/modules/programs/boxxy.nix
@@ -84,7 +84,7 @@ in {
   options.programs.boxxy = {
     enable = mkEnableOption "boxxy: Boxes in badly behaving applications";
 
-    package = mkPackageOption pkgs "boxxy" { };
+    package = mkPackageOption pkgs "boxxy" { nullable = true; };
 
     rules = mkOption {
       type = types.listOf boxxyRulesOpts;
@@ -102,7 +102,7 @@ in {
         settingsFormat.generate "boxxy-config.yaml" { rules = cfg.rules; };
     };
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
   };
 
   meta.maintainers = with lib.hm.maintainers; [ nikp123 ];

--- a/modules/programs/btop.nix
+++ b/modules/programs/btop.nix
@@ -25,7 +25,7 @@ in {
   options.programs.btop = {
     enable = lib.mkEnableOption "btop";
 
-    package = lib.mkPackageOption pkgs "btop" { };
+    package = lib.mkPackageOption pkgs "btop" { nullable = true; };
 
     settings = lib.mkOption {
       type = with lib.types; attrsOf (oneOf [ bool float int str ]);
@@ -51,7 +51,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."btop/btop.conf" =
       lib.mkIf (cfg.settings != { }) { text = finalConfig; };

--- a/modules/programs/bun.nix
+++ b/modules/programs/bun.nix
@@ -9,7 +9,7 @@ in {
   options.programs.bun = {
     enable = lib.mkEnableOption "Bun JavaScript runtime";
 
-    package = lib.mkPackageOption pkgs "bun" { };
+    package = lib.mkPackageOption pkgs "bun" { nullable = true; };
 
     settings = lib.mkOption {
       type = tomlFormat.type;
@@ -42,7 +42,13 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    warnings = lib.optional (cfg.package == null && cfg.enableGitIntegration) ''
+      You have enabled git integration for `bun` but have not set `package`.
+
+      Git integration will not be configured.
+    '';
+
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile.".bunfig.toml" = lib.mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "bun-config" cfg.settings;
@@ -50,10 +56,12 @@ in {
 
     # https://bun.sh/docs/install/lockfile#how-do-i-git-diff-bun-s-lockfile
     programs.git.attributes =
-      lib.mkIf cfg.enableGitIntegration [ "*.lockb binary diff=lockb" ];
-    programs.git.extraConfig.diff.lockb = lib.mkIf cfg.enableGitIntegration {
-      textconv = lib.getExe cfg.package;
-      binary = true;
-    };
+      lib.mkIf (cfg.enableGitIntegration && (cfg.package != null))
+      [ "*.lockb binary diff=lockb" ];
+    programs.git.extraConfig.diff.lockb =
+      lib.mkIf (cfg.enableGitIntegration && (cfg.package != null)) {
+        textconv = lib.getExe cfg.package;
+        binary = true;
+      };
   };
 }

--- a/modules/programs/cava.nix
+++ b/modules/programs/cava.nix
@@ -14,7 +14,7 @@ in {
   options.programs.cava = {
     enable = mkEnableOption "Cava audio visualizer";
 
-    package = mkPackageOption pkgs "cava" { };
+    package = mkPackageOption pkgs "cava" { nullable = true; };
 
     settings = mkOption {
       type = iniFmt.type;
@@ -39,7 +39,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."cava/config" = mkIf (cfg.settings != { }) {
       text = ''

--- a/modules/programs/cavalier.nix
+++ b/modules/programs/cavalier.nix
@@ -16,7 +16,7 @@ in {
   options.programs.cavalier = {
     enable = mkEnableOption "Cava audio visualizer GUI";
 
-    package = mkPackageOption pkgs "cavalier" { };
+    package = mkPackageOption pkgs "cavalier" { nullable = true; };
 
     settings = {
       general = mkOption {
@@ -81,7 +81,7 @@ in {
         lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile = {
       "Nickvision Cavalier/config.json" = mkIf (cfg.settings.general != { }) {

--- a/modules/programs/comodoro.nix
+++ b/modules/programs/comodoro.nix
@@ -10,7 +10,7 @@ in {
   options.programs.comodoro = {
     enable = lib.mkEnableOption "Comodoro, a CLI to manage your time";
 
-    package = lib.mkPackageOption pkgs "comodoro" { };
+    package = lib.mkPackageOption pkgs "comodoro" { nullable = true; };
 
     settings = lib.mkOption {
       type = lib.types.submodule { freeformType = tomlFormat.type; };
@@ -23,7 +23,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."comodoro/config.toml".source =
       tomlFormat.generate "comodoro-config.toml" cfg.settings;

--- a/modules/programs/darcs.nix
+++ b/modules/programs/darcs.nix
@@ -13,7 +13,7 @@ in {
     programs.darcs = {
       enable = mkEnableOption "darcs";
 
-      package = mkPackageOption pkgs "darcs" { };
+      package = mkPackageOption pkgs "darcs" { nullable = true; };
 
       author = mkOption {
         type = types.listOf types.str;
@@ -36,7 +36,7 @@ in {
   };
 
   config = mkIf cfg.enable (mkMerge [
-    { home.packages = [ cfg.package ]; }
+    { home.packages = lib.mkIf (cfg.package != null) [ cfg.package ]; }
 
     (mkIf (cfg.author != [ ]) {
       home.file.".darcs/author".text =

--- a/modules/programs/discocss.nix
+++ b/modules/programs/discocss.nix
@@ -11,9 +11,9 @@ in {
       enable = mkEnableOption
         "discocss, a tiny Discord CSS injector for Linux and MacOS";
 
-      package = mkPackageOption pkgs "discocss" { };
+      package = mkPackageOption pkgs "discocss" { nullable = true; };
 
-      discordPackage = mkPackageOption pkgs "discord" { };
+      discordPackage = mkPackageOption pkgs "discord" { nullable = true; };
 
       discordAlias = mkOption {
         type = types.bool;
@@ -37,10 +37,10 @@ in {
         "To use discocss with discordAlias you have to remove discord from home.packages, or set discordAlias to false.";
     }];
 
-    home.packages = [
+    home.packages = lib.mkIf (cfg.package != null) [
       (cfg.package.override {
         discordAlias = cfg.discordAlias;
-        discord = cfg.discordPackage;
+        discord = lib.mkIf (cfg.discordPackage != null) cfg.discordPackage;
       })
     ];
 

--- a/modules/programs/earthly.nix
+++ b/modules/programs/earthly.nix
@@ -12,7 +12,7 @@ in {
   options.programs.earthly = {
     enable = lib.mkEnableOption "earthly";
 
-    package = lib.mkPackageOption pkgs "earthly" { };
+    package = lib.mkPackageOption pkgs "earthly" { nullable = true; };
 
     settings = lib.mkOption {
       type = yamlFormat.type;
@@ -31,7 +31,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file.".earthly/config.yml" = lib.mkIf (cfg.settings != { }) {
       source = yamlFormat.generate "earthly-config" cfg.settings;

--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -72,7 +72,7 @@ with lib;
       '';
     };
 
-    package = mkPackageOption pkgs "eza" { };
+    package = mkPackageOption pkgs "eza" { nullable = true; };
   };
 
   config = let
@@ -105,7 +105,7 @@ with lib;
 
         programs.eza.icons = ${if cfg.icons then ''"auto"'' else "null"}'';
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     programs.bash.shellAliases = optionsAlias
       // optionalAttrs cfg.enableBashIntegration aliases;

--- a/modules/programs/fastfetch.nix
+++ b/modules/programs/fastfetch.nix
@@ -13,7 +13,7 @@ in {
   options.programs.fastfetch = {
     enable = mkEnableOption "Fastfetch";
 
-    package = mkPackageOption pkgs "fastfetch" { };
+    package = mkPackageOption pkgs "fastfetch" { nullable = true; };
 
     settings = mkOption {
       type = jsonFormat.type;
@@ -59,7 +59,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."fastfetch/config.jsonc" = mkIf (cfg.settings != { }) {
       source = jsonFormat.generate "config.jsonc" cfg.settings;

--- a/modules/programs/fd.nix
+++ b/modules/programs/fd.nix
@@ -30,7 +30,7 @@ with lib; {
       '';
     };
 
-    package = mkPackageOption pkgs "fd" { };
+    package = mkPackageOption pkgs "fd" { nullable = true; };
   };
 
   config = let
@@ -40,7 +40,7 @@ with lib; {
 
     optionsAlias = optionalAttrs (args != "") { fd = "fd ${args}"; };
   in mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     programs.bash.shellAliases = optionsAlias;
 

--- a/modules/programs/feh.nix
+++ b/modules/programs/feh.nix
@@ -33,7 +33,7 @@ in {
   options.programs.feh = {
     enable = mkEnableOption "feh - a fast and light image viewer";
 
-    package = mkPackageOption pkgs "feh" { };
+    package = mkPackageOption pkgs "feh" { nullable = true; };
 
     buttons = mkOption {
       default = { };
@@ -104,7 +104,7 @@ in {
         "To disable a keybinding, use `null` instead of an empty string.";
     }];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."feh/buttons" =
       mkIf (cfg.buttons != { }) { text = renderBindings cfg.buttons + "\n"; };

--- a/modules/programs/freetube.nix
+++ b/modules/programs/freetube.nix
@@ -21,7 +21,7 @@ in {
   options.programs.freetube = {
     enable = mkEnableOption "FreeTube, a YT client for Windows, Mac, and Linux";
 
-    package = mkPackageOption pkgs "freetube" { };
+    package = mkPackageOption pkgs "freetube" { nullable = true; };
 
     settings = mkOption {
       type = lib.types.attrs;
@@ -44,7 +44,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."FreeTube/hm_settings.db" = {
       source = pkgs.writeText "hm_settings.db" (settings cfg.settings);

--- a/modules/programs/fuzzel.nix
+++ b/modules/programs/fuzzel.nix
@@ -14,7 +14,7 @@ in {
   options.programs.fuzzel = {
     enable = mkEnableOption "fuzzel";
 
-    package = mkPackageOption pkgs "fuzzel" { };
+    package = mkPackageOption pkgs "fuzzel" { nullable = true; };
 
     settings = mkOption {
       type = iniFormat.type;
@@ -42,7 +42,7 @@ in {
         lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."fuzzel/fuzzel.ini" = mkIf (cfg.settings != { }) {
       source = iniFormat.generate "fuzzel.ini" cfg.settings;

--- a/modules/programs/gallery-dl.nix
+++ b/modules/programs/gallery-dl.nix
@@ -14,7 +14,7 @@ in {
   options.programs.gallery-dl = {
     enable = mkEnableOption "gallery-dl";
 
-    package = mkPackageOption pkgs "gallery-dl" { };
+    package = mkPackageOption pkgs "gallery-dl" { nullable = true; };
 
     settings = mkOption {
       type = jsonFormat.type;
@@ -34,7 +34,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."gallery-dl/config.json" = mkIf (cfg.settings != { }) {
       source = jsonFormat.generate "gallery-dl-settings" cfg.settings;

--- a/modules/programs/gh-dash.nix
+++ b/modules/programs/gh-dash.nix
@@ -12,7 +12,7 @@ in {
   options.programs.gh-dash = {
     enable = lib.mkEnableOption "GitHub CLI dashboard plugin";
 
-    package = lib.mkPackageOption pkgs "gh-dash" { };
+    package = lib.mkPackageOption pkgs "gh-dash" { nullable = true; };
 
     settings = lib.mkOption {
       type = yamlFormat.type;
@@ -32,9 +32,9 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-    programs.gh.extensions = [ cfg.package ];
+    programs.gh.extensions = (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."gh-dash/config.yml".source =
       yamlFormat.generate "gh-dash-config.yml" cfg.settings;

--- a/modules/programs/git-cliff.nix
+++ b/modules/programs/git-cliff.nix
@@ -13,7 +13,7 @@ in {
   options.programs.git-cliff = {
     enable = mkEnableOption "git-cliff changelog generator";
 
-    package = mkPackageOption pkgs "git-cliff" { };
+    package = mkPackageOption pkgs "git-cliff" { nullable = true; };
 
     settings = mkOption {
       type = tomlFormat.type;
@@ -34,7 +34,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile = {
       "git-cliff/cliff.toml" = mkIf (cfg.settings != { }) {

--- a/modules/programs/gradle.nix
+++ b/modules/programs/gradle.nix
@@ -50,7 +50,10 @@ in {
       '';
     };
 
-    package = mkPackageOption pkgs "gradle" { example = "pkgs.gradle_7"; };
+    package = mkPackageOption pkgs "gradle" {
+      nullable = true;
+      example = "pkgs.gradle_7";
+    };
 
     settings = mkOption {
       type = types.submodule { freeformType = settingsFormat.type; };
@@ -95,7 +98,7 @@ in {
 
   config = let gradleHome = "${config.home.homeDirectory}/${cfg.home}";
   in mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file = mkMerge ([{
       "${cfg.home}/gradle.properties" = mkIf (cfg.settings != { }) {

--- a/modules/programs/havoc.nix
+++ b/modules/programs/havoc.nix
@@ -13,7 +13,7 @@ in {
   options.programs.havoc = {
     enable = mkEnableOption "Havoc terminal";
 
-    package = mkPackageOption pkgs "havoc" { };
+    package = mkPackageOption pkgs "havoc" { nullable = true; };
 
     settings = mkOption {
       type = iniFormat.type;
@@ -54,7 +54,7 @@ in {
     assertions =
       [ (hm.assertions.assertPlatform "programs.havoc" pkgs platforms.linux) ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."havoc.cfg" = mkIf (cfg.settings != { }) {
       source = iniFormat.generate "havoc.cfg" cfg.settings;

--- a/modules/programs/himalaya.nix
+++ b/modules/programs/himalaya.nix
@@ -122,7 +122,7 @@ in {
   options = {
     programs.himalaya = {
       enable = mkEnableOption "the email client Himalaya CLI";
-      package = mkPackageOption pkgs "himalaya" { };
+      package = mkPackageOption pkgs "himalaya" { nullable = true; };
       settings = mkOption {
         type = types.submodule { freeformType = tomlFormat.type; };
         default = { };
@@ -153,7 +153,7 @@ in {
   };
 
   config = mkIf himalaya.enable {
-    home.packages = [ himalaya.package ];
+    home.packages = lib.mkIf (himalaya.package != null) [ himalaya.package ];
 
     xdg = {
       configFile."himalaya/config.toml".source = let
@@ -164,17 +164,18 @@ in {
         allConfig = globalConfig // { accounts = accountsConfig; };
       in tomlFormat.generate "himalaya.config.toml" allConfig;
 
-      desktopEntries.himalaya = mkIf pkgs.stdenv.hostPlatform.isLinux {
-        type = "Application";
-        name = "himalaya";
-        genericName = "Email Client";
-        comment = "CLI to manage emails";
-        terminal = true;
-        exec = "himalaya %u";
-        categories = [ "Network" ];
-        mimeType = [ "x-scheme-handler/mailto" "message/rfc822" ];
-        settings = { Keywords = "email"; };
-      };
+      desktopEntries.himalaya =
+        mkIf (pkgs.stdenv.hostPlatform.isLinux && (himalaya.package != null)) {
+          type = "Application";
+          name = "himalaya";
+          genericName = "Email Client";
+          comment = "CLI to manage emails";
+          terminal = true;
+          exec = "himalaya %u";
+          categories = [ "Network" ];
+          mimeType = [ "x-scheme-handler/mailto" "message/rfc822" ];
+          settings = { Keywords = "email"; };
+        };
     };
   };
 }

--- a/modules/programs/hyprlock.nix
+++ b/modules/programs/hyprlock.nix
@@ -25,7 +25,7 @@ in {
       '';
     };
 
-    package = lib.mkPackageOption pkgs "hyprlock" { };
+    package = lib.mkPackageOption pkgs "hyprlock" { nullable = true; };
 
     settings = lib.mkOption {
       type = with lib.types;
@@ -110,7 +110,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."hypr/hyprlock.conf" =
       let shouldGenerate = cfg.extraConfig != "" || cfg.settings != { };

--- a/modules/programs/i3status.nix
+++ b/modules/programs/i3status.nix
@@ -130,7 +130,7 @@ in {
       '';
     };
 
-    package = mkPackageOption pkgs "i3status" { };
+    package = mkPackageOption pkgs "i3status" { nullable = true; };
   };
 
   config = mkIf cfg.enable {
@@ -190,7 +190,7 @@ in {
       };
     };
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."i3status/config".text = concatStringsSep "\n" ([ ]
       ++ optional (cfg.general != { }) (formatModule "general" cfg.general)

--- a/modules/programs/imv.nix
+++ b/modules/programs/imv.nix
@@ -16,7 +16,7 @@ in {
     enable = mkEnableOption
       "imv: a command line image viewer intended for use with tiling window managers";
 
-    package = mkPackageOption pkgs "imv" { };
+    package = mkPackageOption pkgs "imv" { nullable = true; };
 
     settings = mkOption {
       default = { };
@@ -38,7 +38,7 @@ in {
     assertions =
       [ (hm.assertions.assertPlatform "programs.imv" pkgs platforms.linux) ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile =
       mkIf (cfg.settings != { }) { "imv/config".text = toConfig cfg.settings; };

--- a/modules/programs/jqp.nix
+++ b/modules/programs/jqp.nix
@@ -7,7 +7,7 @@ in {
   options.programs.jqp = {
     enable = lib.mkEnableOption "jqp, jq playground";
 
-    package = lib.mkPackageOption pkgs "jqp" { };
+    package = lib.mkPackageOption pkgs "jqp" { nullable = true; };
 
     settings = lib.mkOption {
       type = yamlFormat.type;
@@ -23,7 +23,7 @@ in {
   };
   config = lib.mkIf cfg.enable {
     home = {
-      packages = [ cfg.package ];
+      packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
       file.".jqp.yaml" = lib.mkIf (cfg.settings != { }) {
         source = yamlFormat.generate "jqp-config" cfg.settings;

--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -25,7 +25,7 @@ in {
     enable =
       mkEnableOption "a Git-compatible DVCS that is both simple and powerful";
 
-    package = mkPackageOption pkgs "jujutsu" { };
+    package = mkPackageOption pkgs "jujutsu" { nullable = true; };
 
     ediff = mkOption {
       type = types.bool;
@@ -54,7 +54,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file."${configDir}/jj/config.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "jujutsu-config" (cfg.settings

--- a/modules/programs/k9s.nix
+++ b/modules/programs/k9s.nix
@@ -24,7 +24,7 @@ in {
     enable =
       mkEnableOption "k9s - Kubernetes CLI To Manage Your Clusters In Style";
 
-    package = mkPackageOption pkgs "k9s" { };
+    package = mkPackageOption pkgs "k9s" { nullable = true; };
 
     settings = mkOption {
       type = yamlFormat.type;
@@ -182,7 +182,7 @@ in {
     enableXdgConfig = !isDarwin || config.xdg.enable;
 
   in mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile = mkIf enableXdgConfig ({
       "k9s/config.yaml" = mkIf (cfg.settings != { }) {

--- a/modules/programs/khal.nix
+++ b/modules/programs/khal.nix
@@ -168,7 +168,7 @@ in {
   options.programs.khal = {
     enable = mkEnableOption "khal, a CLI calendar application";
 
-    package = mkPackageOption pkgs "khal" { };
+    package = mkPackageOption pkgs "khal" { nullable = true; };
 
     locale = mkOption {
       type = lib.types.submodule { options = localeOptions; };
@@ -199,7 +199,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."khal/config".text = concatStringsSep "\n" ([ "[calendars]" ]
       ++ mapAttrsToList genCalendarStr khalAccounts ++ [

--- a/modules/programs/kubecolor.nix
+++ b/modules/programs/kubecolor.nix
@@ -55,7 +55,13 @@ in {
       "kube/color.yaml";
 
   in mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    warnings = optional (cfg.package == null && cfg.plugins != [ ]) ''
+      You have configured `enableAlias` for `kubecolor` but have not set `package`.
+
+      The alias will not be created.
+    '';
+
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.sessionVariables = if preferXdgDirectories then {
       KUBECOLOR_CONFIG = "${config.xdg.configHome}/${configPathSuffix}";
@@ -81,7 +87,8 @@ in {
       };
     };
 
-    home.shellAliases =
-      lib.mkIf cfg.enableAlias { kubectl = lib.getExe cfg.package; };
+    home.shellAliases = lib.mkIf (cfg.enableAlias && (cfg.package != null)) {
+      kubectl = lib.getExe cfg.package;
+    };
   };
 }

--- a/modules/programs/lapce.nix
+++ b/modules/programs/lapce.nix
@@ -7,7 +7,7 @@ let
 
   options = {
     enable = mkEnableOption "lapce";
-    package = mkPackageOption pkgs "lapce" { };
+    package = mkPackageOption pkgs "lapce" { nullable = true; };
     channel = mkOption {
       type = types.enum [ "stable" "nightly" ];
       default = "stable";
@@ -171,7 +171,7 @@ in {
   options.programs.lapce = options;
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg = let dir = "lapce-${cfg.channel}";
     in {

--- a/modules/programs/lazygit.nix
+++ b/modules/programs/lazygit.nix
@@ -16,7 +16,7 @@ in {
   options.programs.lazygit = {
     enable = mkEnableOption "lazygit, a simple terminal UI for git commands";
 
-    package = mkPackageOption pkgs "lazygit" { };
+    package = mkPackageOption pkgs "lazygit" { nullable = true; };
 
     settings = mkOption {
       type = yamlFormat.type;
@@ -45,7 +45,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file."Library/Application Support/lazygit/config.yml" =
       mkIf (cfg.settings != { } && (isDarwin && !config.xdg.enable)) {

--- a/modules/programs/ledger.nix
+++ b/modules/programs/ledger.nix
@@ -21,7 +21,7 @@ in {
   options.programs.ledger = {
     enable = mkEnableOption "ledger, a double-entry accounting system";
 
-    package = mkPackageOption pkgs "ledger" { };
+    package = mkPackageOption pkgs "ledger" { nullable = true; };
 
     settings = mkOption {
       type = with types; attrsOf (oneOf [ bool int str (listOf str) ]);
@@ -59,7 +59,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."ledger/ledgerrc" =
       mkIf (cfg.settings != { } || cfg.extraConfig != "") {

--- a/modules/programs/looking-glass-client.nix
+++ b/modules/programs/looking-glass-client.nix
@@ -11,7 +11,7 @@ in {
   options.programs.looking-glass-client = {
     enable = mkEnableOption "looking-glass-client";
 
-    package = mkPackageOption pkgs "looking-glass-client" { };
+    package = mkPackageOption pkgs "looking-glass-client" { nullable = true; };
 
     settings = mkOption {
       type = settingsFormat.type;
@@ -50,7 +50,7 @@ in {
         platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."looking-glass/client.ini" = mkIf (cfg.settings != { }) {
       source =

--- a/modules/programs/micro.nix
+++ b/modules/programs/micro.nix
@@ -15,7 +15,7 @@ in {
     programs.micro = {
       enable = mkEnableOption "micro, a terminal-based text editor";
 
-      package = mkPackageOption pkgs "micro" { };
+      package = mkPackageOption pkgs "micro" { nullable = true; };
 
       settings = mkOption {
         type = jsonFormat.type;
@@ -37,7 +37,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."micro/settings.json".source =
       jsonFormat.generate "micro-settings" cfg.settings;

--- a/modules/programs/mise.nix
+++ b/modules/programs/mise.nix
@@ -29,7 +29,7 @@ in {
     programs.mise = {
       enable = mkEnableOption "mise";
 
-      package = mkPackageOption pkgs "mise" { };
+      package = mkPackageOption pkgs "mise" { nullable = true; };
 
       enableBashIntegration =
         lib.hm.shell.mkBashIntegrationOption { inherit config; };
@@ -83,7 +83,15 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    warnings = optional (cfg.package == null && (cfg.enableBashIntegration
+      || cfg.enableZshIntegration || cfg.enableFishIntegration
+      || cfg.enableNushellIntegration)) ''
+        You have enabled shell integration for `mise` but have not set `package`.
+
+        The shell integration will not be added.
+      '';
+
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile = {
       "mise/config.toml" = mkIf (cfg.globalConfig != { }) {

--- a/modules/programs/mr.nix
+++ b/modules/programs/mr.nix
@@ -17,7 +17,7 @@ in {
     enable = mkEnableOption
       "mr, a tool to manage all your version control repositories";
 
-    package = mkPackageOption pkgs "mr" { };
+    package = mkPackageOption pkgs "mr" { nullable = true; };
 
     settings = mkOption {
       type = iniFormat.type;
@@ -42,7 +42,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
     home.file.".mrconfig".source = iniFormat.generate ".mrconfig" cfg.settings;
   };
 }

--- a/modules/programs/neovide.nix
+++ b/modules/programs/neovide.nix
@@ -11,7 +11,7 @@ in {
   options.programs.neovide = {
     enable = lib.mkEnableOption "Neovide, No Nonsense Neovim Client in Rust";
 
-    package = lib.mkPackageOption pkgs "neovide" { };
+    package = lib.mkPackageOption pkgs "neovide" { nullable = true; };
 
     settings = lib.mkOption {
       type = settingsFormat.type;
@@ -45,7 +45,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
     xdg.configFile."neovide/config.toml".source =
       settingsFormat.generate "config.toml" cfg.settings;
   };

--- a/modules/programs/nheko.nix
+++ b/modules/programs/nheko.nix
@@ -24,7 +24,7 @@ in {
   options.programs.nheko = {
     enable = mkEnableOption "Qt desktop client for Matrix";
 
-    package = mkPackageOption pkgs "nheko" { };
+    package = mkPackageOption pkgs "nheko" { nullable = true; };
 
     settings = mkOption {
       type = iniFmt.type;
@@ -64,7 +64,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file."${configDir}/nheko/nheko.conf" = mkIf (cfg.settings != { }) {
       text = ''

--- a/modules/programs/openstackclient.nix
+++ b/modules/programs/openstackclient.nix
@@ -9,7 +9,7 @@ in {
   options.programs.openstackclient = {
     enable = lib.mkEnableOption "OpenStack command-line client";
 
-    package = lib.mkPackageOption pkgs "openstackclient" { };
+    package = lib.mkPackageOption pkgs "openstackclient" { nullable = true; };
 
     clouds = lib.mkOption {
       type = lib.types.submodule { freeformType = yamlFormat.type; };
@@ -58,7 +58,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."openstack/clouds.yaml".source = yamlFormat.generate
       "openstackclient-clouds-yaml-${config.home.username}" {

--- a/modules/programs/papis.nix
+++ b/modules/programs/papis.nix
@@ -19,7 +19,7 @@ in {
   options.programs.papis = {
     enable = mkEnableOption "papis";
 
-    package = mkPackageOption pkgs "papis" { };
+    package = mkPackageOption pkgs "papis" { nullable = true; };
 
     settings = mkOption {
       type = with types; attrsOf (oneOf [ bool int str ]);
@@ -86,7 +86,7 @@ in {
         (", namely " + concatStringsSep "," defaultLibraries);
     }];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."papis/config" =
       mkIf (cfg.libraries != { }) { text = generators.toINI { } settingsIni; };

--- a/modules/programs/poetry.nix
+++ b/modules/programs/poetry.nix
@@ -20,6 +20,7 @@ in {
     enable = mkEnableOption "poetry";
 
     package = mkPackageOption pkgs "poetry" {
+      nullable = true;
       example = "pkgs.poetry.withPlugins (ps: with ps; [ poetry-plugin-up ])";
       extraDescription = "May be used to install custom poetry plugins.";
     };
@@ -45,7 +46,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file."${configDir}/pypoetry/config.toml" =
       lib.mkIf (cfg.settings != { }) {

--- a/modules/programs/rio.nix
+++ b/modules/programs/rio.nix
@@ -12,7 +12,7 @@ in {
       '';
     };
 
-    package = lib.mkPackageOption pkgs "rio" { };
+    package = lib.mkPackageOption pkgs "rio" { nullable = true; };
 
     settings = lib.mkOption {
       type = settingsFormat.type;
@@ -27,7 +27,7 @@ in {
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
     {
-      home.packages = [ cfg.package ];
+      home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
     }
 
     # Only manage configuration if not empty

--- a/modules/programs/ripgrep.nix
+++ b/modules/programs/ripgrep.nix
@@ -2,9 +2,7 @@
 
 with lib;
 
-let
-  cfg = config.programs.ripgrep;
-  configPath = "${config.xdg.configHome}/ripgrep/ripgreprc";
+let cfg = config.programs.ripgrep;
 in {
   meta.maintainers =
     [ lib.maintainers.khaneliman lib.hm.maintainers.pedorich-n ];
@@ -13,7 +11,7 @@ in {
     programs.ripgrep = {
       enable = mkEnableOption "Ripgrep";
 
-      package = mkPackageOption pkgs "ripgrep" { };
+      package = mkPackageOption pkgs "ripgrep" { nullable = true; };
 
       arguments = mkOption {
         type = with types; listOf str;
@@ -31,8 +29,9 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home = mkMerge [
-      { packages = [ cfg.package ]; }
+    home = let configPath = "${config.xdg.configHome}/ripgrep/ripgreprc";
+    in mkMerge [
+      { packages = lib.mkIf (cfg.package != null) [ cfg.package ]; }
       (mkIf (cfg.arguments != [ ]) {
         file."${configPath}".text = lib.concatLines cfg.arguments;
 

--- a/modules/programs/rofi-pass.nix
+++ b/modules/programs/rofi-pass.nix
@@ -12,8 +12,10 @@ in {
   options.programs.rofi.pass = {
     enable = mkEnableOption "rofi integration with password-store";
 
-    package =
-      mkPackageOption pkgs "rofi-pass" { example = "pkgs.rofi-pass-wayland"; };
+    package = mkPackageOption pkgs "rofi-pass" {
+      nullable = true;
+      example = "pkgs.rofi-pass-wayland";
+    };
 
     stores = mkOption {
       type = types.listOf types.str;
@@ -40,7 +42,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."rofi-pass/config".text = optionalString (cfg.stores != [ ])
       ("root=" + (concatStringsSep ":" cfg.stores) + "\n") + cfg.extraConfig

--- a/modules/programs/ruff.nix
+++ b/modules/programs/ruff.nix
@@ -15,7 +15,7 @@ in {
     enable = mkEnableOption
       "ruff, an extremely fast Python linter and code formatter, written in Rust";
 
-    package = mkPackageOption pkgs "ruff" { };
+    package = mkPackageOption pkgs "ruff" { nullable = true; };
 
     settings = mkOption {
       type = settingsFormat.type;
@@ -37,7 +37,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."ruff/ruff.toml".source =
       settingsFormat.generate "ruff.toml" cfg.settings;

--- a/modules/programs/sagemath.nix
+++ b/modules/programs/sagemath.nix
@@ -12,11 +12,11 @@ in {
   options.programs.sagemath = {
     enable = mkEnableOption "SageMath, a mathematics software system";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.sage;
-      defaultText = literalExpression "pkgs.sage";
-      description = "The SageMath package to use.";
+    package = lib.mkPackageOption pkgs "sage" {
+      nullable = true;
+      extraDescription = ''
+        The SageMath package to use.
+      '';
     };
 
     configDir = mkOption {
@@ -52,9 +52,10 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file."${cfg.configDir}/init.sage".text = cfg.initScript;
+
     home.sessionVariables = {
       DOT_SAGE = cfg.dataDir;
       SAGE_STARTUP_FILE = "${cfg.configDir}/init.sage";

--- a/modules/programs/sapling.nix
+++ b/modules/programs/sapling.nix
@@ -15,7 +15,7 @@ in {
     programs.sapling = {
       enable = mkEnableOption "Sapling";
 
-      package = mkPackageOption pkgs "sapling" { };
+      package = mkPackageOption pkgs "sapling" { nullable = true; };
 
       userName = mkOption {
         type = types.str;
@@ -48,7 +48,7 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
-      home.packages = [ cfg.package ];
+      home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
       programs.sapling.iniContent.ui = {
         username = cfg.userName + " <" + cfg.userEmail + ">";

--- a/modules/programs/sftpman.nix
+++ b/modules/programs/sftpman.nix
@@ -73,7 +73,7 @@ in {
     enable = mkEnableOption
       "sftpman, an application that handles sshfs/sftp file systems mounting";
 
-    package = mkPackageOption pkgs "sftpman" { };
+    package = mkPackageOption pkgs "sftpman" { nullable = true; };
 
     defaultSshKey = mkOption {
       type = types.nullOr types.str;
@@ -107,7 +107,7 @@ in {
       })
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile = mapAttrs' (name: value:
       nameValuePair "sftpman/mounts/${name}.json" {

--- a/modules/programs/sm64ex.nix
+++ b/modules/programs/sm64ex.nix
@@ -34,11 +34,7 @@ in {
   options.programs.sm64ex = {
     enable = mkEnableOption "sm64ex";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.sm64ex;
-      description = "The sm64ex package to use.";
-    };
+    package = lib.mkPackageOption pkgs "sm64ex" { nullable = true; };
 
     region = mkOption {
       type = types.nullOr (types.enum [ "us" "eu" "jp" ]);
@@ -120,7 +116,7 @@ in {
     configFile = optionals (cfg.settings != null)
       (concatStringsSep "\n" ((mapAttrsToList mkConfig cfg.settings)));
   in mkIf cfg.enable {
-    home.packages = [ package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.dataFile."sm64pc/sm64config.txt" =
       mkIf (cfg.settings != null) { text = configFile; };

--- a/modules/programs/spotify-player.nix
+++ b/modules/programs/spotify-player.nix
@@ -13,7 +13,7 @@ in {
   options.programs.spotify-player = {
     enable = mkEnableOption "spotify-player";
 
-    package = mkPackageOption pkgs "spotify-player" { };
+    package = mkPackageOption pkgs "spotify-player" { nullable = true; };
 
     settings = mkOption {
       type = tomlType;
@@ -162,7 +162,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile = {
       "spotify-player/app.toml" = mkIf (cfg.settings != { }) {

--- a/modules/programs/swaylock.nix
+++ b/modules/programs/swaylock.nix
@@ -33,7 +33,7 @@ in {
       '';
     };
 
-    package = mkPackageOption pkgs "swaylock" { };
+    package = mkPackageOption pkgs "swaylock" { nullable = true; };
 
     settings = mkOption {
       type = with types; attrsOf (oneOf [ bool float int str ]);
@@ -59,7 +59,7 @@ in {
         lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."swaylock/config" = mkIf (cfg.settings != { }) {
       text = concatStrings (mapAttrsToList (n: v:

--- a/modules/programs/taskwarrior.nix
+++ b/modules/programs/taskwarrior.nix
@@ -23,9 +23,6 @@ let
 
   formatPair = key: value:
     if isAttrs value then formatSet key value else formatLine key value;
-
-  homeConf = "${config.xdg.configHome}/task/home-manager-taskrc";
-  userConf = "${config.xdg.configHome}/task/taskrc";
 in {
   options = {
     programs.taskwarrior = {
@@ -85,13 +82,18 @@ in {
         '';
       };
 
-      package =
-        mkPackageOption pkgs "taskwarrior" { example = "pkgs.taskwarrior3"; };
+      package = mkPackageOption pkgs "taskwarrior" {
+        nullable = true;
+        example = "pkgs.taskwarrior3";
+      };
     };
   };
 
-  config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+  config = let
+    homeConf = "${config.xdg.configHome}/task/home-manager-taskrc";
+    userConf = "${config.xdg.configHome}/task/taskrc";
+  in mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file."${homeConf}".text = ''
       data.location=${cfg.dataLocation}

--- a/modules/programs/tofi.nix
+++ b/modules/programs/tofi.nix
@@ -12,7 +12,7 @@ in {
   options.programs.tofi = {
     enable = mkEnableOption "Tofi, a tiny dynamic menu for Wayland";
 
-    package = mkPackageOption pkgs "tofi" { };
+    package = mkPackageOption pkgs "tofi" { nullable = true; };
 
     settings = mkOption {
       type = with types;
@@ -46,7 +46,7 @@ in {
     assertions =
       [ (hm.assertions.assertPlatform "programs.tofi" pkgs platforms.linux) ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."tofi/config" = mkIf (cfg.settings != { }) {
       text = let

--- a/modules/programs/vifm.nix
+++ b/modules/programs/vifm.nix
@@ -12,7 +12,7 @@ in {
   options.programs.vifm = {
     enable = lib.mkEnableOption "vifm, a Vim-like file manager";
 
-    package = lib.mkPackageOption pkgs "vifm" { };
+    package = lib.mkPackageOption pkgs "vifm" { nullable = true; };
 
     extraConfig = mkOption {
       type = types.lines;
@@ -25,7 +25,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."vifm/vifmrc" =
       mkIf (cfg.extraConfig != "") { text = cfg.extraConfig; };

--- a/modules/programs/vim-vint.nix
+++ b/modules/programs/vim-vint.nix
@@ -14,7 +14,7 @@ in {
   options = {
     programs.vim-vint = {
       enable = mkEnableOption "the Vint linter for Vimscript";
-      package = mkPackageOption pkgs "vim-vint" { };
+      package = mkPackageOption pkgs "vim-vint" { nullable = true; };
 
       settings = mkOption {
         type = yamlFormat.type;
@@ -28,7 +28,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile.".vintrc.yaml".source =
       yamlFormat.generate "vim-vint-config" cfg.settings;

--- a/modules/programs/vinegar.nix
+++ b/modules/programs/vinegar.nix
@@ -6,7 +6,7 @@ in {
   options.programs.vinegar = {
     enable = lib.mkEnableOption "Vinegar";
 
-    package = lib.mkPackageOption pkgs "vinegar" { };
+    package = lib.mkPackageOption pkgs "vinegar" { nullable = true; };
 
     settings = lib.mkOption {
       type = lib.types.attrsOf toml.type;
@@ -41,7 +41,7 @@ in {
         lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."vinegar/config.toml" = lib.mkIf (cfg.settings != { }) {
       source = toml.generate "vinegar-config.toml" cfg.settings;

--- a/modules/programs/wlogout.nix
+++ b/modules/programs/wlogout.nix
@@ -72,7 +72,7 @@ in {
   options.programs.wlogout = with lib.types; {
     enable = mkEnableOption "wlogout";
 
-    package = mkPackageOption pkgs "wlogout" { };
+    package = mkPackageOption pkgs "wlogout" { nullable = true; };
 
     layout = mkOption {
       type = listOf wlogoutLayoutConfig;
@@ -132,7 +132,7 @@ in {
         lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."wlogout/layout" = mkIf (cfg.layout != [ ]) {
       source = pkgs.writeText "wlogout/layout" layoutContent;

--- a/modules/programs/wofi.nix
+++ b/modules/programs/wofi.nix
@@ -17,7 +17,7 @@ in {
     enable = mkEnableOption
       "wofi: a launcher/menu program for wlroots based wayland compositors such as sway";
 
-    package = mkPackageOption pkgs "wofi" { };
+    package = mkPackageOption pkgs "wofi" { nullable = true; };
 
     settings = mkOption {
       default = { };
@@ -58,7 +58,7 @@ in {
     assertions =
       [ (hm.assertions.assertPlatform "programs.wofi" pkgs platforms.linux) ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile = mkMerge [
       (mkIf (cfg.settings != { }) {

--- a/modules/programs/xplr.nix
+++ b/modules/programs/xplr.nix
@@ -9,7 +9,7 @@ let
     version = '${cfg.package.version}'
   '';
 
-  # If `value` is a Nix store path, create the symlink `/nix/store/newhash/${name}/*` 
+  # If `value` is a Nix store path, create the symlink `/nix/store/newhash/${name}/*`
   # to `/nix/store/oldhash/*` and returns `/nix/store/newhash`.
   wrapPlugin = name: value:
     if lib.isStorePath value then
@@ -49,7 +49,7 @@ in {
   options.programs.xplr = {
     enable = mkEnableOption "xplr, terminal UI based file explorer";
 
-    package = mkPackageOption pkgs "xplr" { };
+    package = mkPackageOption pkgs "xplr" { nullable = true; };
 
     plugins = mkOption {
       type = with types; nullOr (attrsOf (either package str));
@@ -58,7 +58,7 @@ in {
       description = ''
         An attribute set of plugin paths to be added to the [package.path]<https://www.lua.org/manual/5.4/manual.html#pdf-package.path> of the {file}`~/config/xplr/init.lua` configuration file.
 
-        Must be a package or string representing the plugin directory's path. 
+        Must be a package or string representing the plugin directory's path.
         If the path string is not absolute, it will be relative to {file}`$XDG_CONFIG_HOME/xplr/init.lua`.
       '';
       example = literalExpression ''
@@ -91,7 +91,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."xplr/init.lua".source =
       pkgs.writeText "init.lua" configFile;

--- a/modules/programs/yambar.nix
+++ b/modules/programs/yambar.nix
@@ -11,7 +11,7 @@ in {
   options.programs.yambar = {
     enable = lib.mkEnableOption "Yambar";
 
-    package = lib.mkPackageOption pkgs "yambar" { };
+    package = lib.mkPackageOption pkgs "yambar" { nullable = true; };
 
     settings = lib.mkOption {
       type = yamlFormat.type;
@@ -46,7 +46,7 @@ in {
         lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."yambar/config.yml" = lib.mkIf (cfg.settings != { }) {
       source = yamlFormat.generate "config.yml" cfg.settings;

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -12,7 +12,7 @@ in {
   options.programs.yazi = {
     enable = mkEnableOption "yazi";
 
-    package = lib.mkPackageOption pkgs "yazi" { };
+    package = lib.mkPackageOption pkgs "yazi" { nullable = true; };
 
     shellWrapperName = lib.mkOption {
       type = types.str;
@@ -159,7 +159,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     programs = let
       bashIntegration = ''

--- a/modules/programs/zk.nix
+++ b/modules/programs/zk.nix
@@ -11,7 +11,7 @@ in {
   options.programs.zk = {
     enable = lib.mkEnableOption "zk";
 
-    package = lib.mkPackageOption pkgs "zk" { };
+    package = lib.mkPackageOption pkgs "zk" { nullable = true; };
 
     settings = lib.mkOption {
       type = tomlFormat.type;
@@ -43,7 +43,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."zk/config.toml" = lib.mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "config.toml" cfg.settings;

--- a/modules/services/darkman.nix
+++ b/modules/services/darkman.nix
@@ -48,7 +48,7 @@ in {
       darkman, a tool that automatically switches dark-mode on and off based on
       the time of the day'';
 
-    package = mkPackageOption pkgs "darkman" { };
+    package = mkPackageOption pkgs "darkman" { nullable = true; };
 
     settings = mkOption {
       type = types.submodule { freeformType = yamlFormat.type; };
@@ -76,7 +76,7 @@ in {
       (hm.assertions.assertPlatform "services.darkman" pkgs platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile = {
       "darkman/config.yaml" = mkIf (cfg.settings != { }) {
@@ -91,7 +91,7 @@ in {
         (generateScripts "light-mode.d" cfg.lightModeScripts))
     ];
 
-    systemd.user.services.darkman = {
+    systemd.user.services.darkman = lib.mkIf (cfg.package != null) {
       Unit = {
         Description = "Darkman system service";
         Documentation = "man:darkman(1)";

--- a/modules/services/glance.nix
+++ b/modules/services/glance.nix
@@ -59,11 +59,11 @@ in {
         lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."glance/glance.yml".source = settingsFile;
 
-    systemd.user.services.glance = {
+    systemd.user.services.glance = lib.mkIf (cfg.package != null) {
       Unit = {
         Description = "Glance feed dashboard server";
         PartOf = [ "graphical-session.target" ];

--- a/modules/services/hypridle.nix
+++ b/modules/services/hypridle.nix
@@ -6,7 +6,7 @@ in {
   options.services.hypridle = {
     enable = lib.mkEnableOption "Hypridle, Hyprland's idle daemon";
 
-    package = lib.mkPackageOption pkgs "hypridle" { };
+    package = lib.mkPackageOption pkgs "hypridle" { nullable = true; };
 
     settings = lib.mkOption {
       type = with lib.types;
@@ -70,7 +70,7 @@ in {
       };
     };
 
-    systemd.user.services.hypridle = {
+    systemd.user.services.hypridle = lib.mkIf (cfg.package != null) {
       Install = { WantedBy = [ config.wayland.systemd.target ]; };
 
       Unit = {

--- a/modules/services/hyprpaper.nix
+++ b/modules/services/hyprpaper.nix
@@ -6,7 +6,7 @@ in {
   options.services.hyprpaper = {
     enable = lib.mkEnableOption "Hyprpaper, Hyprland's wallpaper daemon";
 
-    package = lib.mkPackageOption pkgs "hyprpaper" { };
+    package = lib.mkPackageOption pkgs "hyprpaper" { nullable = true; };
 
     settings = lib.mkOption {
       type = with lib.types;
@@ -64,7 +64,7 @@ in {
       };
     };
 
-    systemd.user.services.hyprpaper = {
+    systemd.user.services.hyprpaper = lib.mkIf (cfg.package != null) {
       Install = { WantedBy = [ config.wayland.systemd.target ]; };
 
       Unit = {

--- a/modules/services/listenbrainz-mpd.nix
+++ b/modules/services/listenbrainz-mpd.nix
@@ -15,7 +15,7 @@ in {
   options.services.listenbrainz-mpd = {
     enable = mkEnableOption "listenbrainz-mpd";
 
-    package = mkPackageOption pkgs "listenbrainz-mpd" { };
+    package = mkPackageOption pkgs "listenbrainz-mpd" { nullable = true; };
 
     settings = mkOption {
       type = tomlFormat.type;
@@ -29,7 +29,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    systemd.user.services."listenbrainz-mpd" = {
+    systemd.user.services."listenbrainz-mpd" = lib.mkIf (cfg.package != null) {
       Unit = {
         Description = "ListenBrainz submission client for MPD";
         Documentation = "https://codeberg.org/elomatreb/listenbrainz-mpd";

--- a/modules/services/pueue.nix
+++ b/modules/services/pueue.nix
@@ -15,7 +15,7 @@ in {
   options.services.pueue = {
     enable = mkEnableOption "Pueue, CLI process scheduler and manager";
 
-    package = mkPackageOption pkgs "pueue" { };
+    package = mkPackageOption pkgs "pueue" { nullable = true; };
 
     settings = mkOption {
       type = yamlFormat.type;
@@ -38,11 +38,11 @@ in {
     assertions =
       [ (hm.assertions.assertPlatform "services.pueue" pkgs platforms.linux) ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."pueue/pueue.yml".source = configFile;
 
-    systemd.user = {
+    systemd.user = lib.mkIf (cfg.package != null) {
       services.pueued = {
         Unit = {
           Description = "Pueue Daemon - CLI process scheduler and manager";

--- a/modules/services/swaync.nix
+++ b/modules/services/swaync.nix
@@ -79,7 +79,8 @@ in {
   config = lib.mkIf cfg.enable {
     # at-spi2-core is to minimize journalctl noise of:
     # "AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files"
-    home.packages = [ cfg.package pkgs.at-spi2-core ];
+    home.packages =
+      lib.mkIf (cfg.package != null) [ cfg.package pkgs.at-spi2-core ];
 
     xdg.configFile = {
       "swaync/config.json".source =
@@ -92,7 +93,7 @@ in {
       };
     };
 
-    systemd.user.services.swaync = {
+    systemd.user.services.swaync = lib.mkIf (cfg.package != null) {
       Unit = {
         Description = "Swaync notification daemon";
         Documentation = "https://github.com/ErikReider/SwayNotificationCenter";

--- a/modules/services/window-managers/fluxbox.nix
+++ b/modules/services/window-managers/fluxbox.nix
@@ -13,7 +13,7 @@ in {
     xsession.windowManager.fluxbox = {
       enable = mkEnableOption "Fluxbox window manager";
 
-      package = mkPackageOption pkgs "fluxbox" { };
+      package = mkPackageOption pkgs "fluxbox" { nullable = true; };
 
       init = mkOption {
         type = types.lines;
@@ -95,7 +95,7 @@ in {
         platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file = {
       ".fluxbox/init" = mkIf (cfg.init != "") { text = cfg.init; };

--- a/modules/services/window-managers/i3-sway/i3.nix
+++ b/modules/services/window-managers/i3-sway/i3.nix
@@ -208,7 +208,7 @@ in {
     xsession.windowManager.i3 = {
       enable = mkEnableOption "i3 window manager";
 
-      package = mkPackageOption pkgs "i3" { };
+      package = mkPackageOption pkgs "i3" { nullable = true; };
 
       config = mkOption {
         type = types.nullOr configModule;
@@ -232,7 +232,7 @@ in {
           platforms.linux)
       ];
 
-      home.packages = [ cfg.package ];
+      home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
       xsession.windowManager.command = "${cfg.package}/bin/i3";
 

--- a/modules/services/wob.nix
+++ b/modules/services/wob.nix
@@ -14,7 +14,7 @@ in {
 
   options.services.wob = {
     enable = mkEnableOption "wob";
-    package = mkPackageOption pkgs "wob" { };
+    package = mkPackageOption pkgs "wob" { nullable = true; };
 
     settings = mkOption {
       type = settingsFormat.type;
@@ -44,7 +44,7 @@ in {
       (lib.hm.assertions.assertPlatform "services.wob" pkgs lib.platforms.linux)
     ];
 
-    systemd.user = mkIf cfg.systemd {
+    systemd.user = mkIf (cfg.systemd && (cfg.package != null)) {
       services.wob = {
         Unit = {
           Description =

--- a/modules/services/wpaperd.nix
+++ b/modules/services/wpaperd.nix
@@ -22,7 +22,7 @@ in {
   options.services.wpaperd = {
     enable = lib.mkEnableOption "wpaperd";
 
-    package = lib.mkPackageOption pkgs "wpaperd" { };
+    package = lib.mkPackageOption pkgs "wpaperd" { nullable = true; };
 
     settings = lib.mkOption {
       type = tomlFormat.type;
@@ -54,7 +54,7 @@ in {
         lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile = {
       "wpaperd/wallpaper.toml" = mkIf (cfg.settings != { }) {
@@ -62,7 +62,7 @@ in {
       };
     };
 
-    systemd.user.services.wpaperd = {
+    systemd.user.services.wpaperd = lib.mkIf (cfg.package != null) {
       Install = { WantedBy = [ config.wayland.systemd.target ]; };
 
       Unit = {


### PR DESCRIPTION
Can generate the config without installing application through home-manager. Helpful when a package is broken (or not provided) on a specific platform through nixpkgs and needs to be installed through other means but you still can benefit from the declarative configuration. 

Skipping service only modules. 
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
