### PR TITLE
gh-dash: fix

### DIFF
--- a/modules/programs/gh-dash.nix
+++ b/modules/programs/gh-dash.nix
@@ -34,7 +34,7 @@ in {
   config = lib.mkIf cfg.enable {
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-    programs.gh.extensions = (cfg.package != null) [ cfg.package ];
+    programs.gh.extensions = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."gh-dash/config.yml".source =
       yamlFormat.generate "gh-dash-config.yml" cfg.settings;

--- a/tests/modules/programs/gh-dash/config.nix
+++ b/tests/modules/programs/gh-dash/config.nix
@@ -1,11 +1,14 @@
 {
-  programs.gh-dash = {
-    enable = true;
-    settings = {
-      prSections = [{
-        title = "My Pull Requests";
-        filters = "is:open author:@me";
-      }];
+  programs = {
+    gh.enable = true;
+    gh-dash = {
+      enable = true;
+      settings = {
+        prSections = [{
+          title = "My Pull Requests";
+          filters = "is:open author:@me";
+        }];
+      };
     };
   };
 


### PR DESCRIPTION
Missing mkIf, update test to catch integration with `gh` properly. 

Resolves https://github.com/nix-community/home-manager/issues/6584
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
