### PR TITLE
podman: fix podman-user-wait-network-online

### DIFF
--- a/modules/services/podman-linux/services.nix
+++ b/modules/services/podman-linux/services.nix
@@ -65,7 +65,9 @@ in {
       xdg.configFile."systemd/user/podman-user-wait-network-online.service.d/50-exec-search-path.conf".text =
         ''
           [Service]
-          ExecSearchPath=${pkgs.bashInteractive}/bin:${pkgs.systemd}/bin:/bin
+          ExecSearchPath=${
+            makeBinPath (with pkgs; [ bashInteractive systemd coreutils ])
+          }:/bin
         '';
     })
   ]);


### PR DESCRIPTION
### Description

Fixes #6146.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted

#### Maintainer CC

@n-hass @rycee