### PR TITLE
screen-locker: add lockCmdEnv option

### DIFF
--- a/modules/services/screen-locker.nix
+++ b/modules/services/screen-locker.nix
@@ -31,6 +31,14 @@ in {
       example = "\${pkgs.i3lock}/bin/i3lock -n -c 000000";
     };
 
+    lockCmdEnv = lib.mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "XSECURELOCK_PAM_SERVICE=xsecurelock" ];
+      description =
+        "Environment variables to source a with the locker command (lockCmd).";
+    };
+
     inactiveInterval = mkOption {
       type = types.int;
       default = 10;
@@ -127,6 +135,7 @@ in {
           ExecStart = concatStringsSep " "
             ([ "${cfg.xss-lock.package}/bin/xss-lock" "-s \${XDG_SESSION_ID}" ]
               ++ cfg.xss-lock.extraOptions ++ [ "-- ${cfg.lockCmd}" ]);
+          Environment = cfg.lockCmdEnv;
           Restart = "always";
         };
       };

--- a/tests/modules/services/screen-locker/basic-configuration.nix
+++ b/tests/modules/services/screen-locker/basic-configuration.nix
@@ -5,6 +5,7 @@
     enable = true;
     inactiveInterval = 5;
     lockCmd = "${pkgs.i3lock}/bin/i3lock -n -c AA0000";
+    lockCmdEnv = [ "DISPLAY=:0" "XAUTHORITY=/custom/path/.Xauthority" ];
     xss-lock = { extraOptions = [ "-test" ]; };
     xautolock = {
       enable = true;
@@ -19,6 +20,8 @@
 
     assertFileExists $xssService
     assertFileRegex $xssService 'ExecStart=.*/bin/xss-lock.*-test.*i3lock -n -c AA0000'
+    assertFileRegex $xssService 'Environment=DISPLAY=:0'
+    assertFileRegex $xssService 'Environment=XAUTHORITY=/custom/path/.Xauthority'
     assertFileRegex $xssService 'Restart=always'
     assertFileExists $xautolockService
     assertFileRegex $xautolockService 'ExecStart=.*/bin/xautolock.*-time 5.*-detectsleep.*-test.*'

--- a/tests/modules/services/screen-locker/moved-options.nix
+++ b/tests/modules/services/screen-locker/moved-options.nix
@@ -5,6 +5,7 @@
     enable = true;
     inactiveInterval = 5;
     lockCmd = "${pkgs.i3lock}/bin/i3lock -n -c AA0000";
+    lockCmdEnv = [ "DISPLAY=:0" "XAUTHORITY=/custom/path/.Xauthority" ];
     xssLockExtraOptions = [ "-test" ];
     xautolockExtraOptions = [ "-test" ];
     enableDetectSleep = true;


### PR DESCRIPTION
### Description

I use `xsecurelock` as a screen locker and it's mainly configurable through environment variables.

Instead of having to directly access the systemd service like this:
```nix
systemd.user.services.xss-lock.Service.Environment = "XSECURELOCK_PAM_SERVICE=xsecurelock";
```

I would like to add the environment through an option I called `lockCmdEnv`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@jrobsonchase @rszamszur 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
