### PR TITLE
home-environment: add home.sessionSearchVariables, 2nd try

### DIFF
--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -153,16 +153,17 @@ in {
 
       home.packages = [ cfg.package defaultIndexThemePackage ];
 
+      home.sessionVariables = {
+        XCURSOR_SIZE = mkDefault cfg.size;
+        XCURSOR_THEME = mkDefault cfg.name;
+      };
+
       # Set directory to look for cursors in, needed for some applications
       # that are unable to find cursors otherwise. See:
       # https://github.com/nix-community/home-manager/issues/2812
       # https://wiki.archlinux.org/title/Cursor_themes#Environment_variable
-      home.sessionVariables = {
-        XCURSOR_PATH = mkDefault ("$XCURSOR_PATH\${XCURSOR_PATH:+:}"
-          + "${config.home.profileDirectory}/share/icons");
-        XCURSOR_SIZE = mkDefault cfg.size;
-        XCURSOR_THEME = mkDefault cfg.name;
-      };
+      home.sessionSearchVariables.XCURSOR_PATH =
+        [ "${config.home.profileDirectory}/share/icons" ];
 
       # Add symlink of cursor icon directory to $HOME/.icons, needed for
       # backwards compatibility with some applications. See:

--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -38,14 +38,17 @@ in {
   config = lib.mkIf (im.enabled == "fcitx5") {
     i18n.inputMethod.package = fcitx5Package;
 
-    home.sessionVariables = {
-      GLFW_IM_MODULE = "ibus"; # IME support in kitty
-      XMODIFIERS = "@im=fcitx";
-      QT_PLUGIN_PATH =
-        "$QT_PLUGIN_PATH\${QT_PLUGIN_PATH:+:}${fcitx5Package}/${pkgs.qt6.qtbase.qtPluginPrefix}";
-    } // lib.optionalAttrs (!cfg.waylandFrontend) {
-      GTK_IM_MODULE = "fcitx";
-      QT_IM_MODULE = "fcitx";
+    home = {
+      sessionVariables = {
+        GLFW_IM_MODULE = "ibus"; # IME support in kitty
+        XMODIFIERS = "@im=fcitx";
+      } // lib.optionalAttrs (!cfg.waylandFrontend) {
+        GTK_IM_MODULE = "fcitx";
+        QT_IM_MODULE = "fcitx";
+      };
+
+      sessionSearchVariables.QT_PLUGIN_PATH =
+        [ "${fcitx5Package}/${pkgs.qt6.qtbase.qtPluginPrefix}" ];
     };
 
     systemd.user.services.fcitx5-daemon = {

--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -17,6 +17,14 @@ let
     };
 
 in rec {
+  # Produces a Bourne shell like statement that prepend new values to
+  # an possibly existing variable, using sep(arator).
+  # Example:
+  #   prependToVar ":" "PATH" [ "$HOME/bin" "$HOME/.local/bin" ]
+  #   => "$HOME/bin:$HOME/.local/bin:${PATH:+:}\$PATH"
+  prependToVar = sep: n: v:
+    "${lib.concatStringsSep sep v}\${${n}:+${sep}}\$${n}";
+
   # Produces a Bourne shell like variable export statement.
   export = n: v: ''export ${n}="${toString v}"'';
 

--- a/modules/misc/debug.nix
+++ b/modules/misc/debug.nix
@@ -16,7 +16,7 @@
   config = lib.mkIf config.home.enableDebugInfo {
     home.extraOutputsToInstall = [ "debug" ];
 
-    home.sessionVariables = {
+    home.sessionSearchVariables = {
       NIX_DEBUG_INFO_DIRS =
         "$NIX_DEBUG_INFO_DIRS\${NIX_DEBUG_INFO_DIRS:+:}${config.home.profileDirectory}/lib/debug";
     };

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -218,13 +218,10 @@ in {
       inherit (config.home) profileDirectory;
       qtVersions = with pkgs; [ qt5 qt6 ];
       makeQtPath = prefix:
-        lib.concatStringsSep ":"
         (map (qt: "${profileDirectory}/${qt.qtbase.${prefix}}") qtVersions);
     in {
-      QT_PLUGIN_PATH = "$QT_PLUGIN_PATH\${QT_PLUGIN_PATH:+:}"
-        + (makeQtPath "qtPluginPrefix");
-      QML2_IMPORT_PATH = "$QML2_IMPORT_PATH\${QML2_IMPORT_PATH:+:}"
-        + (makeQtPath "qtQmlPrefix");
+      QT_PLUGIN_PATH = makeQtPath "qtPluginPrefix";
+      QML2_IMPORT_PATH = makeQtPath "qtQmlPrefix";
     };
 
   in lib.mkIf cfg.enable {
@@ -248,19 +245,14 @@ in {
 
     home = {
       sessionVariables = envVars;
-      # home.sessionVariables does not support setting the same environment
-      # variable to different values.
-      # Since some other modules may set the QT_PLUGIN_PATH or QML2_IMPORT_PATH
-      # to their own value, e.g.: fcitx5, we avoid conflicts by setting
-      # the values in home.sessionVariablesExtra instead.
-      sessionVariablesExtra = ''
-        export QT_PLUGIN_PATH=${envVarsExtra.QT_PLUGIN_PATH}
-        export QML2_IMPORT_PATH=${envVarsExtra.QML2_IMPORT_PATH}
-      '';
+      sessionSearchVariables = envVarsExtra;
     };
 
     # Apply theming also to apps started by systemd.
-    systemd.user.sessionVariables = envVars // envVarsExtra;
+    systemd.user.sessionVariables = envVars // {
+      QT_PLUGIN_PATH = lib.concatStringsSep ":" envVarsExtra.QT_PLUGIN_PATH;
+      QML2_IMPORT_PATH = lib.concatStringsSep ":" envVarsExtra.QML2_IMPORT_PATH;
+    };
 
     home.packages = (lib.findFirst (x: x != [ ]) [ ] [
       (lib.optionals (platformTheme.package != null)

--- a/modules/targets/generic-linux.nix
+++ b/modules/targets/generic-linux.nix
@@ -47,13 +47,12 @@ in {
     # We need to append system-wide FHS directories due to the default prefix
     # resolving to the Nix store.
     # https://github.com/nix-community/home-manager/pull/2891#issuecomment-1101064521
-    home.sessionVariables = {
-      XCURSOR_PATH = "$XCURSOR_PATH\${XCURSOR_PATH:+:}"
-        + lib.concatStringsSep ":" [
-          "${config.home.profileDirectory}/share/icons"
-          "/usr/share/icons"
-          "/usr/share/pixmaps"
-        ];
+    home.sessionSearchVariables = {
+      XCURSOR_PATH = [
+        "${config.home.profileDirectory}/share/icons"
+        "/usr/share/icons"
+        "/usr/share/pixmaps"
+      ];
     };
 
     home.sessionVariablesExtra = ''

--- a/tests/modules/home-environment/default.nix
+++ b/tests/modules/home-environment/default.nix
@@ -1,4 +1,5 @@
 {
-  home-session-variables = ./session-variables.nix;
   home-session-path = ./session-path.nix;
+  home-session-search-variables = ./session-search-variables.nix;
+  home-session-variables = ./session-variables.nix;
 }

--- a/tests/modules/home-environment/session-path.nix
+++ b/tests/modules/home-environment/session-path.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ ... }:
 
 {
   imports = [
@@ -10,6 +10,6 @@
     hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
     assertFileExists $hmSessVars
     assertFileContains $hmSessVars \
-      'export PATH="$PATH''${PATH:+:}bar:baz:foo"'
+      'export PATH="bar:baz:foo''${PATH:+:}$PATH"'
   '';
 }

--- a/tests/modules/home-environment/session-search-variables.nix
+++ b/tests/modules/home-environment/session-search-variables.nix
@@ -1,0 +1,15 @@
+{ ... }:
+
+{
+  imports = [
+    ({ ... }: { config.home.sessionSearchVariables.TEST = [ "foo" ]; })
+    ({ ... }: { config.home.sessionSearchVariables.TEST = [ "bar" "baz" ]; })
+  ];
+
+  nmt.script = ''
+    hmSessVars=home-path/etc/profile.d/hm-session-vars.sh
+    assertFileExists $hmSessVars
+    assertFileContains $hmSessVars \
+      'export TEST="bar:baz:foo''${TEST:+:}$TEST"'
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR introduces `home.sessionSearchVariables` option, that is created to be a "generic" version of `home.sessionPath` for any environment variables that is similar to PATH (e.g.: MANPATH). This allows composition of those variables between multiple modules, avoiding issues like this one:

https://github.com/nix-community/home-manager/pull/4579/files#r1364374048

This PR also reimplements `home.sessionPath` as terms of `home.sessionSearchVariables`, to reduce code duplication and show that the code is correct, and migrates the `im/fcitx5` module to use it for `QT_PLUGIN_PATH`.

Replaces: https://github.com/nix-community/home-manager/pull/4582.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.
  + It is since this change the behavior from append to prepend in `PATH`, but the impact should be small.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
