### PR TITLE
Add sessionVariablesOnce to home-env, bash and zsh

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -110,12 +110,21 @@ in {
         '';
       };
 
+      sessionVariablesOnce = mkOption {
+        default = { };
+        type = types.attrs;
+        example = { MAILCHECK = 30; };
+        description = ''
+          Environment variables that will be set once at the start of the Bash session.
+        '';
+      };
+
       sessionVariables = mkOption {
         default = { };
         type = types.attrs;
         example = { MAILCHECK = 30; };
         description = ''
-          Environment variables that will be set for the Bash session.
+          Environment variables that will be set for each Bash session.
         '';
       };
 
@@ -182,6 +191,7 @@ in {
     (map (v: "shopt ${switch v} ${removePrefix "-" v}") cfg.shellOptions);
 
     sessionVarsStr = config.lib.shell.exportAll cfg.sessionVariables;
+    sessionVarsOnceStr = config.lib.shell.exportAll cfg.sessionVariablesOnce;
 
     historyControlStr = (concatStringsSep "\n"
       (mapAttrsToList (n: v: "${n}=${v}")
@@ -221,6 +231,12 @@ in {
       . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
       ${sessionVarsStr}
+
+      # Only source these once
+      if [[ -z "$__HM_BASH_SESS_VARS_SOURCED" ]]; then
+        export __HM_BASH_SESS_VARS_SOURCED=1
+        ${sessionVarsOnceStr}
+      fi
 
       ${cfg.profileExtra}
     '';

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -12,6 +12,7 @@ let
     relToDotDir "plugins" else ".zsh/plugins";
 
   envVarsStr = config.lib.zsh.exportAll cfg.sessionVariables;
+  envVarsOnceStr = config.lib.zsh.exportAll cfg.sessionVariablesOnce;
   localVarsStr = config.lib.zsh.defineAll cfg.localVariables;
 
   aliasesStr = concatStringsSep "\n" (
@@ -464,11 +465,18 @@ in
         description = "The default base keymap to use.";
       };
 
+      sessionVariablesOnce = mkOption {
+        default = {};
+        type = types.attrs;
+        example = { MAILCHECK = 30; };
+        description = "Environment variables that will be set once at the start of a zsh session.";
+      };
+
       sessionVariables = mkOption {
         default = {};
         type = types.attrs;
         example = { MAILCHECK = 30; };
-        description = "Environment variables that will be set for zsh session.";
+        description = "Environment variables that will be set for each zsh session.";
       };
 
       initExtraBeforeCompInit = mkOption {
@@ -603,10 +611,12 @@ in
         # Environment variables
         . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
 
+        ${envVarsStr}
+
         # Only source this once
         if [[ -z "$__HM_ZSH_SESS_VARS_SOURCED" ]]; then
           export __HM_ZSH_SESS_VARS_SOURCED=1
-          ${envVarsStr}
+          ${envVarsOnceStr}
         fi
       '';
     }


### PR DESCRIPTION
### Description

There are some [issues](https://github.com/nix-community/home-manager/issues/3999) about users that expect their environment variables to change when they change their `sessionVariables` in their config files. I am one of them.

I learned twice the hard way that they are only sourced once per session and for me this is quite unintuitive. I thought sessions always start fresh and all variables are set at the beginning always.

F.e. when opening a new terminal with zsh, the sessionVariables are not set after they are changed, but only after logging out and in entirely.

In fact, bash did not have the same behavior, making me think that maybe zsh shouldn't even have this in the first place. Happy to amend this change to drop the "only once" behavior from zsh program entirely.

As for home session vars, I think it might make sense, and I added a field explicitly for this purpose, `sessionVariablesOnce`. This solution was suggested [here](https://github.com/nix-community/home-manager/issues/3999#issuecomment-1564478072) by user @Bujiraso. 

### Checklist

- [ ] Change is backwards compatible.

Unfortunately, people expecting the `Once` behavior for their regular variables might end up with very long variables in the end, but since this is mostly used for PATH-like variables, this will not break any functionality. So IMO this is backwards compatible *enough*.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

They both seem broken. They error on stuff totally unrelated to my changes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@rycee (no maintainers for `programs.zsh`)