### PR TITLE
debug: make NIX_DEBUG_INFO_DIRS a list of strings

### DIFF
--- a/modules/misc/debug.nix
+++ b/modules/misc/debug.nix
@@ -17,8 +17,7 @@
     home.extraOutputsToInstall = [ "debug" ];
 
     home.sessionSearchVariables = {
-      NIX_DEBUG_INFO_DIRS =
-        "$NIX_DEBUG_INFO_DIRS\${NIX_DEBUG_INFO_DIRS:+:}${config.home.profileDirectory}/lib/debug";
+      NIX_DEBUG_INFO_DIRS = [ "${config.home.profileDirectory}/lib/debug" ];
     };
   };
 }


### PR DESCRIPTION
Fixup of daab32302b0bdd9bfff9e75d32375353d95b9c4f.

-------

### Description

NIX_DEBUG_INFO_DIRS is the wrong shape.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->