### PR TITLE
home-environment: add line-break after sessionSearchVariables

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -601,7 +601,7 @@ in
           (env: values: config.lib.shell.export
             env
             (config.lib.shell.prependToVar ":" env values))
-          cfg.sessionSearchVariables)
+          cfg.sessionSearchVariables) + "\n"
         + cfg.sessionVariablesExtra;
     };
 

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, pkgs, ... }:
 
 let
 
@@ -16,6 +16,7 @@ let
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
     export XDG_STATE_HOME="/home/hm-user/.local/state"
+
   '';
 
   darwinExpected = ''
@@ -29,6 +30,7 @@ let
     export XDG_CONFIG_HOME="/home/hm-user/.config"
     export XDG_DATA_HOME="/home/hm-user/.local/share"
     export XDG_STATE_HOME="/home/hm-user/.local/state"
+
   '';
 
   expected = pkgs.writeText "expected"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

PR #6593 broke activation when `sessionVariablesExtra` is used, e.g.: `services.ssh-agent` because it concatenate the strings without a line break, so the resulting `hm-session-vars.sh` file became:

```bash
export XCURSOR_PATH="/etc/profiles/per-user/thiagoko/share/icons${XCURSOR_PATH:+:}$XCURSOR_PATH"if [ -z "$SSH_AUTH_SOCK" ]; then
  export SSH_AUTH_SOCK=$XDG_RUNTIME_DIR/ssh-agent
fi
```

This commit fixes it by enforcing a line break between `sessionSearchVariables` and `sessionVariablesExtra`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
