### PR TITLE
granted: fix fish shell integration

### DIFF
--- a/modules/programs/granted.nix
+++ b/modules/programs/granted.nix
@@ -33,7 +33,7 @@ in {
 
     programs.fish.functions.assume = mkIf cfg.enableFishIntegration ''
       set -x GRANTED_ALIAS_CONFIGURED "true"
-      source ${package}/share/assume.fish
+      source ${package}/share/assume.fish $argv
       set -e GRANTED_ALIAS_CONFIGURED
     '';
   };


### PR DESCRIPTION
### Description

Without `$argv` the function will not pass any flags or arguments to the `assume.fish` script.  These are necessary to use assume to access the AWS console or use IAM role chaining.

Fixes issue raised in PR comments

https://github.com/nix-community/home-manager/pull/6549#issuecomment-2713885598

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@wcarlsen 
