### PR TITLE
swaylock: accept path type for settings values

### DIFF
--- a/modules/programs/swaylock.nix
+++ b/modules/programs/swaylock.nix
@@ -36,7 +36,7 @@ in {
     package = mkPackageOption pkgs "swaylock" { nullable = true; };
 
     settings = mkOption {
-      type = with types; attrsOf (oneOf [ bool float int str ]);
+      type = with types; attrsOf (oneOf [ bool float int path str ]);
       default = { };
       description = ''
         Default arguments to {command}`swaylock`. An empty set


### PR DESCRIPTION
### Description

Currently, `path` values are not accepted as `programs.swaylock.settings` values:
```
error: A definition for option `home-manager.users.gaetan.programs.swaylock.settings.image' is not of type `boolean or floating point number or signed integer or string'.
```

This would allow for:
```nix
programs.swaylock = {
  enable = true;

  settings.image = ./wallpaper.png;
};
```


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

cc @rcerc
