### PR TITLE
megasync: add option to enable wayland

### DIFF
--- a/modules/services/megasync.nix
+++ b/modules/services/megasync.nix
@@ -8,6 +8,13 @@ in {
       enable = lib.mkEnableOption "Megasync client";
 
       package = lib.mkPackageOption pkgs "megasync" { };
+
+      forceWayland = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        example = true;
+        description = "Force Megasync to run on wayland";
+      };
     };
   };
 
@@ -28,7 +35,11 @@ in {
 
       Install = { WantedBy = [ "graphical-session.target" ]; };
 
-      Service = { ExecStart = "${cfg.package}/bin/megasync"; };
+      Service = {
+        Environment =
+          lib.optionals cfg.forceWayland [ "DO_NOT_UNSET_XDG_SESSION_TYPE=1" ];
+        ExecStart = lib.getExe' cfg.package "megasync";
+      };
     };
   };
 }

--- a/modules/services/megasync.nix
+++ b/modules/services/megasync.nix
@@ -1,23 +1,17 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
-let
-
-  cfg = config.services.megasync;
-
+let cfg = config.services.megasync;
 in {
-  meta.maintainers = [ maintainers.GaetanLepage ];
+  meta.maintainers = [ lib.maintainers.GaetanLepage ];
 
   options = {
     services.megasync = {
-      enable = mkEnableOption "Megasync client";
+      enable = lib.mkEnableOption "Megasync client";
 
-      package = mkPackageOption pkgs "megasync" { };
+      package = lib.mkPackageOption pkgs "megasync" { };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       (lib.hm.assertions.assertPlatform "services.megasync" pkgs
         lib.platforms.linux)


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add a option for megasync to run on wayland.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@GaetanLepage 
