### PR TITLE
wallust: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -433,6 +433,12 @@
     githubId = 56614642;
     name = "Ilan Joselevich";
   };
+  kiara = {
+    name = "kiara";
+    email = "cinereal@riseup.net";
+    github = "KiaraGrouwstra";
+    githubId = 3059397;
+  };
   mager = {
     email = "andreas@mager.eu";
     github = "AndreasMager";

--- a/modules/misc/news/2025-04-20_00-39-01.nix
+++ b/modules/misc/news/2025-04-20_00-39-01.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-04-20T05:39:01+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.wallust'.
+
+    Wallust generates colors from an images, similar to pywal.
+  '';
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -286,6 +286,7 @@ let
       ./programs/vscode/haskell.nix
       ./programs/pywal.nix
       ./programs/rbenv.nix
+      ./programs/wallust.nix
       ./programs/watson.nix
       ./programs/waylogout.nix
       ./programs/waybar.nix

--- a/modules/programs/wallust.nix
+++ b/modules/programs/wallust.nix
@@ -21,7 +21,9 @@ in
 
   options.programs.wallust = {
     enable = mkEnableOption "Wallust color scheme generator";
-    package = mkPackageOption pkgs "wallust" { };
+
+    package = mkPackageOption pkgs "wallust" { nullable = true; };
+
     settings = mkOption {
       type = tomlFormat.type;
       default = { };
@@ -38,7 +40,8 @@ in
     };
   };
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
     xdg.configFile."wallust/wallust.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "wallust.toml" cfg.settings;
     };

--- a/modules/programs/wallust.nix
+++ b/modules/programs/wallust.nix
@@ -1,0 +1,46 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    mkIf
+    literalExpression
+    ;
+  cfg = config.programs.wallust;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ kiara ];
+
+  options.programs.wallust = {
+    enable = mkEnableOption "Wallust color scheme generator";
+    package = mkPackageOption pkgs "wallust" { };
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          palette = "softdark";
+        }
+      '';
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/wallust/wallust.toml`.
+        See <https://explosion-mental.codeberg.page/wallust/config/> for
+        documentation.
+      '';
+    };
+  };
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    xdg.configFile."wallust/wallust.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "wallust.toml" cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -469,6 +469,7 @@ import nmtSrc {
       ./modules/programs/vifm
       ./modules/programs/vim-vint
       ./modules/programs/vscode
+      ./modules/programs/wallust
       ./modules/programs/watson
       ./modules/programs/wezterm
       ./modules/programs/yazi

--- a/tests/modules/programs/wallust/default.nix
+++ b/tests/modules/programs/wallust/default.nix
@@ -1,0 +1,3 @@
+{
+  wallust = ./wallust.nix;
+}

--- a/tests/modules/programs/wallust/expected.toml
+++ b/tests/modules/programs/wallust/expected.toml
@@ -1,0 +1,2 @@
+backend = "fastresize"
+color_space = "lchmixed"

--- a/tests/modules/programs/wallust/wallust.nix
+++ b/tests/modules/programs/wallust/wallust.nix
@@ -1,0 +1,16 @@
+{
+  home.enableNixpkgsReleaseCheck = false;
+  programs.wallust = {
+    enable = true;
+    backend = "full";
+    settings = {
+      backend = "fastresize";
+      color_space = "lchmixed";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/wallust/wallust.toml
+    assertFileContent home-files/.config/wallust/wallust.toml ${./expected.toml}
+  '';
+}


### PR DESCRIPTION
### Description

closes #6566.
note this wallust module is still relatively modest compared to the existing pywal one, which is a bit more opinionated, coming with templates for a few applications.
if anything tho, it already enables configuring the program using nix.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@aguirre-matteo
