### PR TITLE
Kubecolor oc alias and zsh completions

### DIFF
--- a/modules/programs/kubecolor.nix
+++ b/modules/programs/kubecolor.nix
@@ -92,6 +92,7 @@ in {
 
     home.shellAliases = lib.mkIf (cfg.enableAlias && (cfg.package != null)) {
       kubectl = lib.getExe cfg.package;
+      oc = lib.mkIf (builtins.elem pkgs.openshift config.home.packages) "env KUBECTL_COMMAND=${lib.getExe pkgs.openshift} ${lib.getExe cfg.package}";
     };
 
     programs.zsh.initContent =

--- a/modules/programs/kubecolor.nix
+++ b/modules/programs/kubecolor.nix
@@ -92,7 +92,10 @@ in {
 
     home.shellAliases = lib.mkIf (cfg.enableAlias && (cfg.package != null)) {
       kubectl = lib.getExe cfg.package;
-      oc = lib.mkIf (builtins.elem pkgs.openshift config.home.packages) "env KUBECTL_COMMAND=${lib.getExe pkgs.openshift} ${lib.getExe cfg.package}";
+      oc = lib.mkIf (builtins.elem pkgs.openshift config.home.packages)
+        "env KUBECTL_COMMAND=${lib.getExe pkgs.openshift} ${
+          lib.getExe cfg.package
+        }";
     };
 
     programs.zsh.initContent =

--- a/modules/programs/kubecolor.nix
+++ b/modules/programs/kubecolor.nix
@@ -25,6 +25,9 @@ in {
       '';
     };
 
+    enableZshIntegration =
+      lib.hm.shell.mkZshIntegrationOption { inherit config; };
+
     settings = mkOption {
       type = yamlFormat.type;
       default = { };
@@ -90,5 +93,8 @@ in {
     home.shellAliases = lib.mkIf (cfg.enableAlias && (cfg.package != null)) {
       kubectl = lib.getExe cfg.package;
     };
+
+    programs.zsh.initContent =
+      lib.mkIf cfg.enableZshIntegration "compdef kubecolor=kubectl";
   };
 }

--- a/tests/modules/programs/kubecolor/default.nix
+++ b/tests/modules/programs/kubecolor/default.nix
@@ -2,4 +2,6 @@
   kubecolor-empty-config = ./empty-config.nix;
   kubecolor-example-config-default-paths = ./example-config-default-paths.nix;
   kubecolor-example-config-xdg-paths = ./example-config-xdg-paths.nix;
+  kubecolor-does-have-openshift = ./does-have-openshift.nix;
+  kubecolor-does-not-have-openshift = ./does-not-have-openshift.nix;
 }

--- a/tests/modules/programs/kubecolor/does-have-openshift.nix
+++ b/tests/modules/programs/kubecolor/does-have-openshift.nix
@@ -1,0 +1,33 @@
+{ config, pkgs, ... }:
+
+{
+  programs.kubecolor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "kubecolor";
+      version = "0.4.0";
+    };
+    enableAlias = true;
+  };
+  programs.zsh = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "zsh";
+      version = "5.9";
+    };
+  };
+  nixpkgs.overlays = [
+    (self: super: rec {
+      openshift = config.lib.test.mkStubPackage {
+        name = "openshift";
+        version = "4.16.0";
+      };
+    })
+  ];
+  home.packages = [ pkgs.openshift ];
+
+  nmt.script = ''
+    assertFileRegex 'home-files/.zshrc' '^alias.* oc=.*'
+  '';
+}
+

--- a/tests/modules/programs/kubecolor/does-not-have-openshift.nix
+++ b/tests/modules/programs/kubecolor/does-not-have-openshift.nix
@@ -1,0 +1,24 @@
+{ config, ... }:
+
+{
+  programs.kubecolor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "kubecolor";
+      version = "0.4.0";
+    };
+    enableAlias = true;
+  };
+  programs.zsh = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "zsh";
+      version = "5.9";
+    };
+  };
+
+  nmt.script = ''
+    assertFileNotRegex 'home-files/.zshrc' '^alias.* oc=.*'
+  '';
+}
+


### PR DESCRIPTION
### Description

- Add a kubecolor alias for `oc`. See https://github.com/kubecolor/kubecolor/blob/main/README.md#whats-this
- Add an option `enableZshIntegration` which fixes ZSH completions for `kubectl` (and `oc`). See https://kubecolor.github.io/setup/shells/zsh/#completions 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@ajgon 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
