### PR TITLE
xdg-autostart: Add readOnly option

### DIFF
--- a/modules/misc/xdg-autostart.nix
+++ b/modules/misc/xdg-autostart.nix
@@ -1,24 +1,30 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 let
   inherit (builtins) baseNameOf listToAttrs map unsafeDiscardStringContext;
   inherit (lib) literalExpression mkEnableOption mkIf mkOption types;
 
   cfg = config.xdg.autostart;
 
-  /* "/nix/store/x-foo/application.desktop" -> {
-       name = "autostart/application.desktop";
-       value = { source = "/nix/store/x-foo/application.desktop"; };
-     }
-  */
-  mapDesktopEntry = entry: {
-    name = "autostart/${unsafeDiscardStringContext (baseNameOf entry)}";
-    value.source = entry;
-  };
+  linkedDesktopEntries = pkgs.runCommandNoCCLocal "xdg-autostart-entries" { } ''
+    mkdir -p $out
+    ${lib.concatMapStringsSep "\n" (e: "ln -s ${e} $out") cfg.entries}
+  '';
+
 in {
   meta.maintainers = with lib.maintainers; [ Scrumplex ];
 
   options.xdg.autostart = {
     enable = mkEnableOption "creation of XDG autostart entries";
+
+    readOnly = mkOption {
+      type = lib.types.bool;
+      description = ''
+        Make `XDG_CONFIG_HOME/autostart` a symlink to a readonly directory so that
+        programs cannot install arbitrary autostart services.
+      '';
+      default = false;
+      example = true;
+    };
 
     entries = mkOption {
       type = with types; listOf path;
@@ -35,6 +41,9 @@ in {
   };
 
   config = mkIf (cfg.enable && cfg.entries != [ ]) {
-    xdg.configFile = listToAttrs (map mapDesktopEntry cfg.entries);
+    xdg.configFile.autostart = {
+      source = linkedDesktopEntries;
+      recursive = !cfg.readOnly;
+    };
   };
 }

--- a/tests/modules/misc/xdg/autostart-readonly.nix
+++ b/tests/modules/misc/xdg/autostart-readonly.nix
@@ -3,6 +3,7 @@
 {
   xdg.autostart = {
     enable = true;
+    readOnly = true;
     entries = [
       "${pkgs.test1}/share/applications/test1.desktop"
       "${pkgs.test2}/share/applications/test2.desktop"
@@ -27,7 +28,7 @@
   };
 
   nmt.script = ''
-    assertDirectoryExists home-files/.config/autostart
+    assertLinkExists home-files/.config/autostart
 
     assertFileExists home-files/.config/autostart/test1.desktop
     assertFileContent home-files/.config/autostart/test1.desktop \

--- a/tests/modules/misc/xdg/default.nix
+++ b/tests/modules/misc/xdg/default.nix
@@ -3,4 +3,5 @@
   xdg-default-locations = ./default-locations.nix;
   xdg-mime-disabled = ./mime-disabled.nix;
   xdg-autostart = ./autostart.nix;
+  xdg-autostart-readonly = ./autostart-readonly.nix;
 }


### PR DESCRIPTION
### Description

Some programs add a `.desktop` file to `XDG_CONFIG_HOME/autostart` when they are started (can't remember from the top of my head which program did for me, and I've already deleted the file), but I want to be able to explicitly grant programs permission to autostart in my home manager configuration. This PR adds a `xdg.autostart.readOnly` option to make that possible.

When `readOnly` is set to `true` the autostart entries are linked from a readonly directory in the nix store and `XDG_CONFIG_HOME/autostart` is a link to that directory, so that programs cannot install arbitrary autostart services.

I haven't added a test yet because I first wanted to check whether this has a chance of being merged and if we really need the `readOnly` option, or if we should just always make `XDG_CONFIG_HOME/autostart` readonly, because something similar was done without an option for backwards compatibility in https://github.com/nix-community/home-manager/pull/5553.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC @Scrumplex 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
