### PR TITLE
{hyprpolkitagent, lxqt-policykit-agent, polkit-gnome}: init modules

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -379,6 +379,7 @@ let
     ./services/playerctld.nix
     ./services/plex-mpv-shim.nix
     ./services/podman-linux
+    ./services/polkit-gnome.nix
     ./services/polybar.nix
     ./services/poweralertd.nix
     ./services/psd.nix

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -337,6 +337,7 @@ let
     ./services/hound.nix
     ./services/hypridle.nix
     ./services/hyprpaper.nix
+    ./services/hyprpolkitagent.nix
     ./services/imapnotify.nix
     ./services/kanshi.nix
     ./services/kbfs.nix

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -349,6 +349,7 @@ let
     ./services/linux-wallpaperengine.nix
     ./services/listenbrainz-mpd.nix
     ./services/lorri.nix
+    ./services/lxqt-policykit-agent.nix
     ./services/macos-remap-keys
     ./services/mako.nix
     ./services/mbsync.nix

--- a/modules/services/hyprpolkitagent.nix
+++ b/modules/services/hyprpolkitagent.nix
@@ -1,7 +1,6 @@
 { config, lib, pkgs, ... }:
 let
-  inherit (lib)
-    mkEnableOption mkPackageOption types literalExpression mkIf maintainers;
+  inherit (lib) mkEnableOption mkPackageOption mkIf maintainers;
   cfg = config.services.hyprpolkitagent;
 in {
   meta.maintainers = [ maintainers.bobvanderlinden ];
@@ -17,11 +16,11 @@ in {
     systemd.user.services.hyprpolkitagent = {
       Unit = {
         Description = "Hyprland PolicyKit Agent";
-        After = [ "graphical-session-pre.target" ];
-        PartOf = [ "graphical-session.target" ];
+        PartOf = [ config.wayland.systemd.target ];
+        After = [ config.wayland.systemd.target ];
       };
 
-      Install = { WantedBy = [ "graphical-session.target" ]; };
+      Install = { WantedBy = [ config.wayland.systemd.target ]; };
 
       Service = { ExecStart = "${cfg.package}/libexec/hyprpolkitagent"; };
     };

--- a/modules/services/hyprpolkitagent.nix
+++ b/modules/services/hyprpolkitagent.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib)
+    mkEnableOption mkPackageOption types literalExpression mkIf maintainers;
+  cfg = config.services.hyprpolkitagent;
+in {
+  meta.maintainers = [ maintainers.bobvanderlinden ];
+
+  options = {
+    services.hyprpolkitagent = {
+      enable = mkEnableOption "Hyprland Policykit Agent";
+      package = mkPackageOption pkgs "hyprpolkitagent" { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.hyprpolkitagent = {
+      Unit = {
+        Description = "Hyprland PolicyKit Agent";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+
+      Service = { ExecStart = "${cfg.package}/libexec/hyprpolkitagent"; };
+    };
+  };
+}

--- a/modules/services/hyprpolkitagent.nix
+++ b/modules/services/hyprpolkitagent.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) mkEnableOption mkPackageOption mkIf maintainers;
   cfg = config.services.hyprpolkitagent;
 in {
-  meta.maintainers = [ maintainers.bobvanderlinden ];
+  meta.maintainers = with maintainers; [ bobvanderlinden khaneliman ];
 
   options = {
     services.hyprpolkitagent = {

--- a/modules/services/lxqt-policykit-agent.nix
+++ b/modules/services/lxqt-policykit-agent.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib)
+    mkEnableOption mkPackageOption types literalExpression mkIf maintainers;
+  cfg = config.services.lxqt-policykit-agent;
+in {
+  meta.maintainers = [ maintainers.bobvanderlinden ];
+
+  options = {
+    services.lxqt-policykit-agent = {
+      enable = mkEnableOption "LXQT Policykit Agent";
+      package = mkPackageOption pkgs [ "lxqt" "lxqt-policykit" ] { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.lxqt-policykit-agent = {
+      Unit = {
+        Description = "LXQT PolicyKit Agent";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+
+      Service = { ExecStart = "${cfg.package}/bin/lxqt-policykit-agent"; };
+    };
+  };
+}

--- a/modules/services/polkit-gnome.nix
+++ b/modules/services/polkit-gnome.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib)
+    mkEnableOption mkPackageOption types literalExpression mkIf maintainers;
+  cfg = config.services.polkit-gnome;
+in {
+  meta.maintainers = [ maintainers.bobvanderlinden ];
+
+  options = {
+    services.polkit-gnome = {
+      enable = mkEnableOption "GNOME Policykit Agent";
+      package = mkPackageOption pkgs "polkit_gnome" { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.polkit-gnome = {
+      Unit = {
+        Description = "GNOME PolicyKit Agent";
+        After = [ "graphical-session-pre.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Install = { WantedBy = [ "graphical-session.target" ]; };
+
+      Service = {
+        ExecStart =
+          "${cfg.package}/libexec/polkit-gnome-authentication-agent-1";
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -506,6 +506,7 @@ in import nmtSrc {
     ./modules/services/home-manager-auto-upgrade
     ./modules/services/hypridle
     ./modules/services/hyprpaper
+    ./modules/services/hyprpolkitagent
     ./modules/services/imapnotify
     ./modules/services/kanshi
     ./modules/services/lieer

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -527,6 +527,7 @@ in import nmtSrc {
     ./modules/services/picom
     ./modules/services/playerctld
     ./modules/services/podman-linux
+    ./modules/services/polkit-gnome
     ./modules/services/polybar
     ./modules/services/recoll
     ./modules/services/redshift-gammastep

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -511,6 +511,7 @@ in import nmtSrc {
     ./modules/services/kanshi
     ./modules/services/lieer
     ./modules/services/linux-wallpaperengine
+    ./modules/services/lxqt-policykit-agent
     ./modules/services/mopidy
     ./modules/services/mpd
     ./modules/services/mpd-mpris

--- a/tests/modules/services/hyprpolkitagent/basic-configuration.nix
+++ b/tests/modules/services/hyprpolkitagent/basic-configuration.nix
@@ -1,0 +1,23 @@
+{
+  services.hyprpolkitagent.enable = true;
+
+  nmt.script = ''
+    clientServiceFile=home-files/.config/systemd/user/hyprpolkitagent.service
+
+    assertFileExists $clientServiceFile
+    assertFileContent $clientServiceFile ${
+      builtins.toFile "expected.service" ''
+        [Install]
+        WantedBy=graphical-session.target
+
+        [Service]
+        ExecStart=@hyprpolkitagent@/libexec/hyprpolkitagent
+
+        [Unit]
+        After=graphical-session-pre.target
+        Description=Hyprland PolicyKit Agent
+        PartOf=graphical-session.target
+      ''
+    }
+  '';
+}

--- a/tests/modules/services/hyprpolkitagent/basic-configuration.nix
+++ b/tests/modules/services/hyprpolkitagent/basic-configuration.nix
@@ -14,7 +14,7 @@
         ExecStart=@hyprpolkitagent@/libexec/hyprpolkitagent
 
         [Unit]
-        After=graphical-session-pre.target
+        After=graphical-session.target
         Description=Hyprland PolicyKit Agent
         PartOf=graphical-session.target
       ''

--- a/tests/modules/services/hyprpolkitagent/default.nix
+++ b/tests/modules/services/hyprpolkitagent/default.nix
@@ -1,0 +1,1 @@
+{ hyprpolkitagent-basic-configuration = ./basic-configuration.nix; }

--- a/tests/modules/services/lxqt-policykit-agent/basic-configuration.nix
+++ b/tests/modules/services/lxqt-policykit-agent/basic-configuration.nix
@@ -1,0 +1,23 @@
+{
+  services.lxqt-policykit-agent.enable = true;
+
+  nmt.script = ''
+    clientServiceFile=home-files/.config/systemd/user/lxqt-policykit-agent.service
+
+    assertFileExists $clientServiceFile
+    assertFileContent $clientServiceFile ${
+      builtins.toFile "expected.service" ''
+        [Install]
+        WantedBy=graphical-session.target
+
+        [Service]
+        ExecStart=@lxqt-policykit@/bin/lxqt-policykit-agent
+
+        [Unit]
+        After=graphical-session-pre.target
+        Description=LXQT PolicyKit Agent
+        PartOf=graphical-session.target
+      ''
+    }
+  '';
+}

--- a/tests/modules/services/lxqt-policykit-agent/default.nix
+++ b/tests/modules/services/lxqt-policykit-agent/default.nix
@@ -1,0 +1,1 @@
+{ lxqt-policykit-agent-basic-configuration = ./basic-configuration.nix; }

--- a/tests/modules/services/polkit-gnome/basic-configuration.nix
+++ b/tests/modules/services/polkit-gnome/basic-configuration.nix
@@ -1,0 +1,23 @@
+{
+  services.polkit-gnome.enable = true;
+
+  nmt.script = ''
+    clientServiceFile=home-files/.config/systemd/user/polkit-gnome.service
+
+    assertFileExists $clientServiceFile
+    assertFileContent $clientServiceFile ${
+      builtins.toFile "expected.service" ''
+        [Install]
+        WantedBy=graphical-session.target
+
+        [Service]
+        ExecStart=@polkit-gnome@/libexec/polkit-gnome-authentication-agent-1
+
+        [Unit]
+        After=graphical-session-pre.target
+        Description=GNOME PolicyKit Agent
+        PartOf=graphical-session.target
+      ''
+    }
+  '';
+}

--- a/tests/modules/services/polkit-gnome/default.nix
+++ b/tests/modules/services/polkit-gnome/default.nix
@@ -1,0 +1,1 @@
+{ polkit-gnome-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

Supersedes https://github.com/nix-community/home-manager/pull/5619
Resolves https://github.com/nix-community/home-manager/issues/3739


This adds polkit agent services for hyprland, gnome and lxqt. I have had the one from lxqt in my own configuration for a while and served me well, but recently wanted to check out other polkits and eventually switched to gnome's one.
I thought I'd add these to home-manager as well this time.

I was contemplating adding `security.polkit.agent = "gnome" or "hyprland" or "lxqt"`, but since there was no `security` directory I wasn't sure that was the right call for now and could be a future step.

All 3 of these tools do not have configuration(-files).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
