### PR TITLE
nixgl: use original package name

### DIFF
--- a/modules/misc/nixgl.nix
+++ b/modules/misc/nixgl.nix
@@ -217,7 +217,10 @@ in
           # Wrap the package's binaries with nixGL, while preserving the rest of
           # the outputs and derivation attributes.
           (pkg.overrideAttrs (old: {
-            name = "nixGL-${pkg.name}";
+            # Leave the name unchanged and rely on the hash to differentiate
+            # from the original package. Some modules rely on the package name
+            # to e.g. compute config directory paths.
+            name = pkg.name;
 
             # Make sure this is false for the wrapper derivation, so nix doesn't expect
             # a new debug output to be produced. We won't be producing any debug info


### PR DESCRIPTION
### Description

Some home manager modules depend on the name, so changing it in the wrapper can break them.

Fixes #6608 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
