### PR TITLE
mergiraf: init module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -170,6 +170,7 @@ let
     ./programs/mbsync.nix
     ./programs/mcfly.nix
     ./programs/mercurial.nix
+    ./programs/mergiraf.nix
     ./programs/micro.nix
     ./programs/mise.nix
     ./programs/mods.nix

--- a/modules/programs/mergiraf.nix
+++ b/modules/programs/mergiraf.nix
@@ -1,0 +1,31 @@
+{ pkgs, config, lib, ... }:
+let
+  inherit (lib)
+    mkEnableOption mkPackageOption types literalExpression mkIf maintainers;
+  cfg = config.programs.mergiraf;
+  mergiraf = "${cfg.package}/bin/mergiraf";
+in {
+  meta.maintainers = [ maintainers.bobvanderlinden ];
+
+  options = {
+    programs.mergiraf = {
+      enable = mkEnableOption "mergiraf";
+      package = mkPackageOption pkgs "mergiraf" { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    programs.git = {
+      attributes = [ "* merge=mergiraf" ];
+      extraConfig = {
+        merge.mergiraf = {
+          name = "mergiraf";
+          driver =
+            "${mergiraf} merge --git %O %A %B -s %S -x %X -y %Y -p %P -l %L";
+        };
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -131,6 +131,7 @@ let
       "lsd"
       "lieer"
       "mbsync"
+      "mergiraf"
       "micro"
       "mise"
       "mpv"
@@ -340,6 +341,7 @@ in import nmtSrc {
     ./modules/programs/lieer
     ./modules/programs/man
     ./modules/programs/mbsync
+    ./modules/programs/mergiraf
     ./modules/programs/micro
     ./modules/programs/mise
     ./modules/programs/mods

--- a/tests/modules/programs/mergiraf/basic-configuration.nix
+++ b/tests/modules/programs/mergiraf/basic-configuration.nix
@@ -1,0 +1,13 @@
+{ config, lib, ... }:
+
+{
+  programs.git.enable = true;
+  programs.mergiraf.enable = true;
+
+  nmt.script = ''
+    assertFileContent "home-files/.config/git/config" ${./mergiraf-git.conf}
+    assertFileContent "home-files/.config/git/attributes" ${
+      ./mergiraf-git-attributes.conf
+    }
+  '';
+}

--- a/tests/modules/programs/mergiraf/default.nix
+++ b/tests/modules/programs/mergiraf/default.nix
@@ -1,0 +1,1 @@
+{ mergiraf-basic-configuration = ./basic-configuration.nix; }

--- a/tests/modules/programs/mergiraf/mergiraf-git-attributes.conf
+++ b/tests/modules/programs/mergiraf/mergiraf-git-attributes.conf
@@ -1,0 +1,1 @@
+* merge=mergiraf

--- a/tests/modules/programs/mergiraf/mergiraf-git.conf
+++ b/tests/modules/programs/mergiraf/mergiraf-git.conf
@@ -1,0 +1,9 @@
+[gpg]
+	format = "openpgp"
+
+[gpg "openpgp"]
+	program = "@gnupg@/bin/gpg"
+
+[merge "mergiraf"]
+	driver = "@mergiraf@/bin/mergiraf merge --git %O %A %B -s %S -x %X -y %Y -p %P -l %L"
+	name = "mergiraf"


### PR DESCRIPTION
### Description

This adds git integration for [mergiraf](https://mergiraf.org/). It sets up git to use mergiraf to automatically resolve merge conflicts. See https://mergiraf.org/usage.html#registration-as-a-git-merge-driver

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
