### PR TITLE
zsh: update zsh initContent example to use lib.literalExpression

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -455,8 +455,10 @@ in
       initContent = mkOption {
         default = "";
         type = types.lines;
-        example = lib.mkOrder 1000 ''
-          echo "Hello, initContent!"
+        example = lib.literalExpression ''
+          lib.mkOrder 1000 ''''
+            echo "Hello zsh initContent!"
+          '''';
         '';
         description = "Content to be added to {file}`.zshrc`. To specify the order, use `lib.mkOrder`.";
       };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Fix zsh `initContent` option example display error, see previous discussion: https://github.com/nix-community/home-manager/pull/6479#discussion_r1997554441

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@teto 