### PR TITLE
Support user accounts managed by external identity management systems

### DIFF
--- a/docs/release-notes/rl-2505.md
+++ b/docs/release-notes/rl-2505.md
@@ -21,6 +21,16 @@ This release has the following notable changes:
   tests are available through a Nix Flake file inside the `tests`
   directory. See [](#sec-tests) for example commands.
 
+- The Home Manager NixOS module now supports
+  [home-manager.users](#nixos-opt-home-manager.users) entries that do not have
+  corresponding `users.users.<name>` entries, making it easier to provide Home
+  Manager configurations for users managed through external identity management
+  systems.  To take advantage of this, such users must have their
+  [](#opt-home.username) and [](#opt-home.homeDirectory) attributes set to
+  high-precedence values with `lib.mkForce` or similar, overriding the defaults
+  that pull from, respectively, `users.users.<name>.name` and
+  `users.users.<name>.home`.
+
 ## State Version Changes {#sec-release-25.05-state-version-changes}
 
 The state version in this release includes the changes below. These

--- a/docs/release-notes/rl-2505.md
+++ b/docs/release-notes/rl-2505.md
@@ -31,6 +31,13 @@ This release has the following notable changes:
   that pull from, respectively, `users.users.<name>.name` and
   `users.users.<name>.home`.
 
+- The Home Manager NixOS module option
+  [home-manager.useUserPackages](#nixos-opt-home-manager.useUserPackages) now
+  sets the default value of the newly-introduced per-user
+  [](#opt-home.useUserPackages) option, making it possible to define a policy
+  on the use of `users.users.<name>.packages` for package installation, and to
+  override that policy on a user-specific basis.
+
 ## State Version Changes {#sec-release-25.05-state-version-changes}
 
 The state version in this release includes the changes below. These

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -26,18 +26,23 @@ in
         extraSpecialArgs.nixosConfig = config;
 
         sharedModules = [
-          {
-            key = "home-manager#nixos-shared-module";
+          (
+            { ... }@usercfg:
+            {
+              key = "home-manager#nixos-shared-module";
 
-            config = {
-              # The per-user directory inside /etc/profiles is not known by
-              # fontconfig by default.
-              fonts.fontconfig.enable = lib.mkDefault (cfg.useUserPackages && config.fonts.fontconfig.enable);
+              config = {
+                # The per-user directory inside /etc/profiles is not known by
+                # fontconfig by default.
+                fonts.fontconfig.enable = lib.mkDefault (
+                  usercfg.config.home.useUserPackages != { } && config.fonts.fontconfig.enable
+                );
 
-              # Inherit glibcLocales setting from NixOS.
-              i18n.glibcLocales = lib.mkDefault config.i18n.glibcLocales;
-            };
-          }
+                # Inherit glibcLocales setting from NixOS.
+                i18n.glibcLocales = lib.mkDefault config.i18n.glibcLocales;
+              };
+            }
+          )
         ];
       };
     }

--- a/tests/integration/nixos/basics.nix
+++ b/tests/integration/nixos/basics.nix
@@ -1,98 +1,190 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 
 {
   name = "nixos-basics";
   meta.maintainers = [ pkgs.lib.maintainers.rycee ];
 
   nodes.machine =
-    { ... }:
+    { config, ... }:
+    let
+      inherit (config.home-manager.users) bob;
+    in
     {
       imports = [ ../../../nixos ]; # Import the HM NixOS module.
 
+      security.pam.services = {
+        chpasswd = { };
+        passwd = { };
+      };
+
+      system.activationScripts.addBobUser =
+        lib.fullDepEntry
+          ''
+            ${pkgs.shadow}/bin/useradd \
+              --comment 'Manually-created user' \
+              --create-home --no-user-group \
+              --gid ${lib.escapeShellArg config.users.groups.users.name} \
+              --home-dir ${lib.escapeShellArg bob.home.homeDirectory} \
+              --no-user-group \
+              --shell ${lib.escapeShellArg (lib.getExe config.users.defaultUserShell)} \
+              ${lib.escapeShellArg bob.home.username}
+          ''
+          [
+            "groups"
+            "users"
+          ];
+
       virtualisation.memorySize = 2048;
+
+      # To be able to add the `bob` account with `useradd`.
+      users.mutableUsers = true;
 
       users.users.alice = {
         isNormalUser = true;
         description = "Alice Foobar";
-        password = "foobar";
         uid = 1000;
       };
 
-      home-manager.users.alice =
-        { ... }:
+      home-manager.users =
+        let
+          common = {
+            home.stateVersion = "24.11";
+            home.file.test.text = "testfile";
+            # Enable a light-weight systemd service.
+            services.pueue.enable = true;
+          };
+        in
         {
-          home.stateVersion = "24.11";
-          home.file.test.text = "testfile";
-          # Enable a light-weight systemd service.
-          services.pueue.enable = true;
+          alice = common;
+
+          # User without corresponding entry in `users.users`.
+          bob =
+            { name, ... }:
+            {
+              imports = [ common ];
+              home.stateVersion = "24.11";
+              home.username = lib.mkForce name;
+              home.homeDirectory = lib.mkForce "/var/tmp/hm/home/bob";
+            };
         };
     };
 
-  testScript = ''
-    def login_as_alice():
-      machine.wait_until_tty_matches("1", "login: ")
-      machine.send_chars("alice\n")
-      machine.wait_until_tty_matches("1", "Password: ")
-      machine.send_chars("foobar\n")
-      machine.wait_until_tty_matches("1", "alice\\@machine")
+  testScript =
+    { nodes, ... }:
+    let
+      inherit (nodes.machine.home-manager.users) alice bob;
+      password = "foobar";
+    in
+    ''
+      import pprint
+      from contextlib import contextmanager
+      from typing import Callable, Dict, Optional
 
-    def logout_alice():
-      machine.send_chars("exit\n")
+      def wait_for_unit_properties(
+        machine: Machine, unit: str, check: Callable[[Dict[str, str]], Dict[str, Optional[str]]], user: Optional[str] = None, timeout: int = 900,
+      ) -> None:
+        def unit_has_properties(_):
+          info = machine.get_unit_info(unit, user)
+          mismatches = check(info)
+          if mismatches == {}:
+            return True
+          else:
+            machine.log(f"unit {unit} has unexpected properties {pprint.pformat(mismatches)}")
+            return False
 
-    def alice_cmd(cmd):
-      return f"su -l alice --shell /bin/sh -c $'export XDG_RUNTIME_DIR=/run/user/$UID ; {cmd}'"
+        with machine.nested(f"waiting for unit {unit} to satisfy expected properties"):
+          retry(unit_has_properties, timeout)
 
-    def succeed_as_alice(cmd):
-      return machine.succeed(alice_cmd(cmd))
+      def wait_for_oneshot_successful_completion(
+        machine: Machine, unit: str, user: Optional[str] = None, timeout: int = 900
+      ) -> None:
+        def unit_is_successfully_completed_oneshot(info: Dict[str, str]) -> Dict[str, Optional[str]]:
+          assert "Type" in info, f"unit {unit}'s properties include 'Type'"
+          assert info["Type"] == "oneshot", f"expected unit {unit}'s 'Type' to be 'oneshot'; got {info['Type']}"
 
-    def fail_as_alice(cmd):
-      return machine.fail(alice_cmd(cmd))
+          props = ["ActiveState", "Result", "SubState"]
 
-    start_all()
+          if all([prop in info for prop in props]):
+            if "RemainAfterExit" in info and info["RemainAfterExit"] == "yes":
+              if info["ActiveState"] == "active" and info["Result"] == "success" and info["SubState"] == "exited":
+                return {}
+            elif info["ActiveState"] == "inactive" and info["Result"] == "success" and info["SubState"] == "dead":
+              return {}
 
-    machine.wait_for_console_text("Finished Home Manager environment for alice.")
+          return {prop: info.get(prop) for prop in props}
 
-    with subtest("Home Manager file"):
-      # The file should be linked with the expected content.
-      path = "/home/alice/test"
-      machine.succeed(f"test -L {path}")
-      actual = machine.succeed(f"cat {path}")
-      expected = "testfile"
-      assert actual == expected, f"expected {path} to contain {expected}, but got {actual}"
+        return wait_for_unit_properties(
+          machine, unit, unit_is_successfully_completed_oneshot, user=user, timeout=timeout
+        )
 
-    with subtest("Pueue service"):
-      login_as_alice()
+      @contextmanager
+      def user_login(machine: Machine, user: str, password: str):
+        machine.wait_until_tty_matches("1", "login: ")
+        machine.send_chars(f"{user}\n")
+        machine.wait_until_tty_matches("1", "Password: ")
+        machine.send_chars(f"{password}\n")
+        machine.wait_until_tty_matches("1", f"{user}\\@{machine.name}")
 
-      actual = succeed_as_alice("pueue status")
-      expected = "running"
-      assert expected in actual, f"expected pueue status to contain {expected}, but got {actual}"
+        try:
+          yield
+        finally:
+          machine.send_chars("exit\n")
 
-      # Shut down pueue, then run the activation again. Afterwards, the service
-      # should be running.
-      machine.succeed("systemctl --user -M alice@.host stop pueued.service")
+      def cmd_for_user(user: str, cmd: str) -> str:
+        return f"su -l {user} --shell /bin/sh -c $'export XDG_RUNTIME_DIR=/run/user/$UID ; {cmd}'"
 
-      fail_as_alice("pueue status")
+      def succeed_as_user(user: str, cmd: str) -> str:
+        return machine.succeed(cmd_for_user(user, cmd))
 
-      machine.systemctl("restart home-manager-alice.service")
-      machine.wait_for_console_text("Finished Home Manager environment for alice.")
+      def fail_as_user(user: str, cmd: str) -> str:
+        return machine.fail(cmd_for_user(user, cmd))
 
-      actual = succeed_as_alice("pueue status")
-      expected = "running"
-      assert expected in actual, f"expected pueue status to contain {expected}, but got {actual}"
+      start_all()
 
-      logout_alice()
+      for user in ["${alice.home.username}", "${bob.home.username}"]:
+        user_hm_unit = f"home-manager-{user}.service"
+        wait_for_oneshot_successful_completion(machine, user_hm_unit)
 
-    with subtest("GC root and profile"):
-      # There should be a GC root and Home Manager profile and they should point
-      # to the same path in the Nix store.
-      gcroot = "/home/alice/.local/state/home-manager/gcroots/current-home"
-      gcrootTarget = machine.succeed(f"readlink {gcroot}")
+        machine.succeed(f"echo '{user}:${password}' | ${pkgs.shadow}/bin/chpasswd")
 
-      profile = "/home/alice/.local/state/nix/profiles"
-      profileTarget = machine.succeed(f"readlink {profile}/home-manager")
-      profile1Target = machine.succeed(f"readlink {profile}/{profileTarget}")
+        with subtest(f"Home Manager file (user {user})"):
+          # The file should be linked with the expected content.
+          path = f"~{user}/test"
+          machine.succeed(f"test -L {path}")
+          actual = machine.succeed(f"cat {path}")
+          expected = "testfile"
+          assert actual == expected, f"expected {path} to contain {expected}, but got {actual}"
 
-      assert gcrootTarget == profile1Target, \
-        f"expected GC root and profile to point to same, but pointed to {gcrootTarget} and {profile1Target}"
-  '';
+        with subtest(f"Pueue service (user {user})"):
+          with user_login(machine, user, "${password}"):
+            actual = succeed_as_user(user, "pueue status")
+            expected = "running"
+            assert expected in actual, f"expected pueue status to contain {expected}, but got {actual}"
+
+            # Shut down pueue, then run the activation again. Afterwards, the
+            # service should be running.
+            machine.succeed(f"systemctl --user -M {user}@.host stop pueued.service")
+
+            fail_as_user(user, "pueue status")
+
+            machine.systemctl(f"restart {user_hm_unit}")
+            wait_for_oneshot_successful_completion(machine, user_hm_unit)
+
+            actual = succeed_as_user(user, "pueue status")
+            expected = "running"
+            assert expected in actual, f"expected pueue status to contain {expected}, but got {actual}"
+
+        with subtest(f"GC root and profile (user {user})"):
+          # There should be a GC root and Home Manager profile and they should
+          # point to the same path in the Nix store.
+          gcroot = f"~{user}/.local/state/home-manager/gcroots/current-home"
+          gcrootTarget = machine.succeed(f"readlink {gcroot}")
+
+          profile = f"~{user}/.local/state/nix/profiles"
+          profileTarget = machine.succeed(f"readlink {profile}/home-manager")
+          profile1Target = machine.succeed(f"readlink {profile}/{profileTarget}")
+
+          assert gcrootTarget == profile1Target, \
+            f"expected GC root and profile to point to same, but pointed to {gcrootTarget} and {profile1Target}"
+    '';
 }

--- a/tests/modules/home-environment/default.nix
+++ b/tests/modules/home-environment/default.nix
@@ -2,4 +2,5 @@
   home-session-path = ./session-path.nix;
   home-session-search-variables = ./session-search-variables.nix;
   home-session-variables = ./session-variables.nix;
+  home-use-user-packages = ./use-user-packages.nix;
 }

--- a/tests/modules/home-environment/use-user-packages.nix
+++ b/tests/modules/home-environment/use-user-packages.nix
@@ -1,0 +1,7 @@
+{
+  home.useUserPackages = true;
+
+  test.asserts.warnings.expected = [
+    "You have enabled `home.useUserPackages`, but this option has no effect outside of NixOS configurations."
+  ];
+}


### PR DESCRIPTION
### Description

This changeset introduces support in the NixOS module for entries in `home-manager.users` that do not have corresponding entries in `users.users`.  The goal is to support Home Manager configurations for users provided by external identity management systems, as described in #5244, without resorting to hacks like re-specifying those users' details (UIDs, etc.) in `users.users`.

### Checklist

- [x] Change is backwards compatible.  **NOTE**: this changeset alters the semantics of `home-manager.useUserPackages`: that option now provides the default value of the per-user option `home-manager.users.<name>.home.useUserPackages`, rather than globally instituting (or not) the use of `users.users.<name>.packages`.  I believe this change is backward-compatible, given that no Home Manager NixOS module configuration will have used `home-manager.users.<name>.home.useUserPackages` before now, and so existing configurations will continue to globally use (or not) `users.users.<name>.packages`.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~If this PR adds a new module~

  - ~[ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
