### PR TITLE
home-manager: support passing `--log-format` to `nix-build`

### DIFF
--- a/docs/home-manager.1
+++ b/docs/home-manager.1
@@ -45,6 +45,7 @@
 .Op Fl -keep-failed
 .Op Fl -keep-going
 .Op Bro Fl L | Fl -print-build-logs Brc
+.Op Fl -log-format
 .Op Fl -show-trace
 .Op Fl -(no-)substitute
 .Op Fl -no-out-link
@@ -332,6 +333,13 @@ Passed on to
 Passed on to
 \fBnix build\fR()
 when building from a flake\&.
+.RE
+.Pp
+
+.It Cm Fl -log-format Ar format
+.RS 4
+Passed on to
+\fBnix-build\fR(1)\&.
 .RE
 .Pp
 

--- a/home-manager/completion.bash
+++ b/home-manager/completion.bash
@@ -300,7 +300,7 @@ _home-manager_completions ()
     Options=( "-f" "--file" "-b" "-A" "-I" "-h" "--help" "-n" "--dry-run" "-v" \
               "--verbose" "--cores" "--debug" "--impure" "--keep-failed" \
               "--keep-going" "-j" "--max-jobs" "--no-substitute" "--no-out-link" \
-              "-L" "--print-build-logs" \
+              "-L" "--print-build-logs" "--log-format" \
               "--show-trace" "--flake" "--substitute" "--builders" "--version" \
               "--update-input" "--override-input" "--experimental-features" \
               "--extra-experimental-features" "--refresh")

--- a/home-manager/completion.fish
+++ b/home-manager/completion.fish
@@ -61,6 +61,7 @@ complete -c home-manager -x -s j -l "max-jobs" -d "Max number of build jobs in p
 complete -c home-manager -x -l "option" -d "Set Nix configuration option"
 complete -c home-manager -x -l "builders" -d "Remote builders"
 complete -c home-manager -f -s L -l "print-build-logs" -d "Print full build logs on standard error"
+complete -c home-manager -x -l "log-format" -d "Set the format of log output"
 complete -c home-manager -f -l "show-trace" -d "Print stack trace of evaluation errors"
 complete -c home-manager -f -l "substitute"
 complete -c home-manager -f -l "no-substitute"

--- a/home-manager/completion.zsh
+++ b/home-manager/completion.zsh
@@ -21,6 +21,7 @@ _arguments \
   '--option[option]:NAME VALUE:()' \
   '--builders[builders]:SPEC:()' \
   '(-L --print-build-logs)'{--print-build-logs,-L}'[print build logs]' \
+  '--log-format[log format]:FORMAT:()' \
   '--show-trace[show trace]' \
   '--override-input[override flake input]:NAME VALUE:()' \
   '--update-input[update flake input]:NAME:()' \
@@ -63,6 +64,7 @@ case "$state" in
           '--no-out-link[no out link]' \
           '--no-substitute[no substitute]' \
           '--option[option]:NAME VALUE:()' \
+          '--log-format[log format]:FORMAT:()' \
           '--show-trace[show trace]' \
           '--substitute[substitute]' \
           '--builders[builders]:SPEC:()' \

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -907,6 +907,7 @@ function doHelp() {
     echo "  -j, --max-jobs NUM"
     echo "  --option NAME VALUE"
     echo "  -L, --print-build-logs"
+    echo "  --log-format FORMAT"
     echo "  --show-trace"
     echo "  --(no-)substitute"
     echo "  --no-out-link            Do not create a symlink to the output path"
@@ -1036,7 +1037,7 @@ while [[ $# -gt 0 ]]; do
             PASSTHROUGH_OPTS+=("$opt" "$1" "$2")
             shift 2
             ;;
-        -j|--max-jobs|--cores|--builders)
+        -j|--max-jobs|--cores|--builders|--log-format)
             [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             PASSTHROUGH_OPTS+=("$opt" "$1")
             shift


### PR DESCRIPTION
### Description

You can now pass `--log-format FORMAT` to `nix-build`, useful for piping into `nix-output-monitor`.

Closes #6093.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
