### PR TITLE
launchd: refactor implementation

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -90,44 +90,6 @@ in {
         ln -s "${agentsDrv}" $out/LaunchAgents
       '';
 
-      home.activation.checkLaunchAgents =
-        hm.dag.entryBefore [ "writeBoundary" ] ''
-          checkLaunchAgents() {
-            local oldDir newDir dstDir err
-            oldDir=""
-            err=0
-            if [[ -n "''${oldGenPath:-}" ]]; then
-              oldDir="$(readlink -m "$oldGenPath/LaunchAgents")" || err=$?
-              if (( err )); then
-                oldDir=""
-              fi
-            fi
-            newDir=${escapeShellArg agentsDrv}
-            dstDir=${escapeShellArg dstDir}
-
-            local oldSrcPath newSrcPath dstPath agentFile agentName
-
-            find -L "$newDir" -maxdepth 1 -name '*.plist' -type f -print0 \
-                | while IFS= read -rd "" newSrcPath; do
-              agentFile="''${newSrcPath##*/}"
-              agentName="''${agentFile%.plist}"
-              dstPath="$dstDir/$agentFile"
-              oldSrcPath="$oldDir/$agentFile"
-
-              if [[ ! -e "$dstPath" ]]; then
-                continue
-              fi
-
-              if ! cmp --quiet "$oldSrcPath" "$dstPath"; then
-                errorEcho "Existing file '$dstPath' is in the way of '$newSrcPath'"
-                exit 1
-              fi
-            done
-          }
-
-          checkLaunchAgents
-        '';
-
       # NOTE: Launch Agent configurations can't be symlinked from the Nix store
       # because it needs to be owned by the user running it.
       home.activation.setupLaunchAgents =

--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -55,7 +55,7 @@ let
     done
   '';
 in {
-  meta.maintainers = with lib.maintainers; [ midchildan ];
+  meta.maintainers = with lib.maintainers; [ khaneliman midchildan ];
 
   options.launchd = {
     enable = lib.mkOption {


### PR DESCRIPTION
### Description
Closes https://github.com/nix-community/home-manager/issues/6536

Rework to drop the conflict check, these are home-manager generated and controlled plists and not user data. We will drop and redeploy whenever we need. 

Updated implementation for the deploy to unload and deploy without skipping an agent if there are any runtime issues from `launchd` so we don't skip deploying agents because of an agent that might have been deleted improperly. 

Tested scenarios:

- No changes:
  - We don't try to drop/recreate services
- Agent removed
  - We unload and remove plist
- Agent changed
  - We unload, remove, install, and load agent
- Plist deleted
  - We install and load agent
  - When bootstrap fails, we continue and don't block other agent activations


NOTE: 
This should fix issues with deploying the launchd agents, but doesn't resolve another issue discovered that profile generations aren't being properly updated on darwin. So we are usually comparing launchd agents against the wrong generation resulting in incorrect comparison results.

ie: It will say we had a launchd agent that changed since last generation, but it was actually a few generations ago and shouldn't need to be dropped/redeployed. This is the cause for the conflicting file check previously.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
