### PR TITLE
podman: include systemd in quadlet service path

### DIFF
--- a/modules/services/podman-linux/containers.nix
+++ b/modules/services/podman-linux/containers.nix
@@ -95,6 +95,7 @@ let
               "/run/wrappers/bin"
               "/run/current-system/sw/bin"
               "${config.home.homeDirectory}/.nix-profile/bin"
+              "${pkgs.systemd}/bin"
             ]);
           };
           Restart = "always";

--- a/tests/modules/services/podman-linux/container-expected.service
+++ b/tests/modules/services/podman-linux/container-expected.service
@@ -27,7 +27,7 @@ WantedBy=default.target
 WantedBy=multi-user.target
 
 [Service]
-Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:/home/hm-user/.nix-profile/bin
+Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:/home/hm-user/.nix-profile/bin:@systemd@/bin
 Restart=on-failure
 TimeoutStopSec=30
 Environment=PODMAN_SYSTEMD_UNIT=%n

--- a/tests/modules/services/podman-linux/integration-container-bld-expected.service
+++ b/tests/modules/services/podman-linux/integration-container-bld-expected.service
@@ -15,7 +15,7 @@ WantedBy=default.target
 WantedBy=multi-user.target
 
 [Service]
-Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:/home/hm-user/.nix-profile/bin
+Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:/home/hm-user/.nix-profile/bin:@systemd@/bin
 Restart=always
 TimeoutStopSec=30
 Environment=PODMAN_SYSTEMD_UNIT=%n

--- a/tests/modules/services/podman-linux/integration-container-expected.service
+++ b/tests/modules/services/podman-linux/integration-container-expected.service
@@ -18,7 +18,7 @@ WantedBy=default.target
 WantedBy=multi-user.target
 
 [Service]
-Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:/home/hm-user/.nix-profile/bin
+Environment=PATH=/run/wrappers/bin:/run/current-system/sw/bin:/home/hm-user/.nix-profile/bin:@systemd@/bin
 Restart=always
 TimeoutStopSec=30
 Environment=PODMAN_SYSTEMD_UNIT=%n


### PR DESCRIPTION
Podman uses `systemd-run` to setup transient systemd timers, e.g. for healthchecks.
On systems where `systemd` is not present in `/run/current-system/sw/bin` or `~/.nix-profile/bin` (like one of my Ubuntu hosts), setting up the transient timers will fail. For containers with healthchecks configured, this results in the container being stuck in `starting` state.

Relevant issue here: https://github.com/containers/podman/issues/25034

This PR adds `systemd` to the quadlets service PATH in order for healthchecks to be setup correctly.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
