### PR TITLE
treewide: zsh initExtra -> initContent

### DIFF
--- a/modules/misc/vte.nix
+++ b/modules/misc/vte.nix
@@ -45,7 +45,7 @@
     })
 
     (lib.mkIf config.programs.zsh.enableVteIntegration {
-      programs.zsh.initExtra = ''
+      programs.zsh.initContent = ''
         . ${pkgs.vte}/etc/profile.d/vte.sh
       '';
     })

--- a/modules/programs/antidote.nix
+++ b/modules/programs/antidote.nix
@@ -31,12 +31,12 @@ in {
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
-    programs.zsh.initExtraBeforeCompInit = let
+    programs.zsh.initContent = let
       configFiles = pkgs.runCommand "hm_antidote-files" { } ''
         echo "${zPluginStr cfg.plugins}" > $out
       '';
       hashId = parseHashId "${configFiles}";
-    in ''
+    in (mkOrder 550 ''
       ## home-manager/antidote begin :
       source ${cfg.package}/share/antidote/antidote.zsh
       ${optionalString cfg.useFriendlyNames
@@ -50,6 +50,6 @@ in {
       antidote load $bundlefile $staticfile
 
       ## home-manager/antidote end
-    '';
+    '');
   };
 }

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -114,7 +114,7 @@ in {
         fi
       '';
 
-      programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
         if [[ $options[zle] = on ]]; then
           eval "$(${lib.getExe cfg.package} init zsh ${flagsStr})"
         fi

--- a/modules/programs/autojump.nix
+++ b/modules/programs/autojump.nix
@@ -30,7 +30,7 @@ in {
       . ${package}/share/autojump/autojump.bash
     '');
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       . ${package}/share/autojump/autojump.zsh
     '';
 

--- a/modules/programs/broot.nix
+++ b/modules/programs/broot.nix
@@ -214,7 +214,7 @@ in {
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration (shellInit "bash");
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration (shellInit "zsh");
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration (shellInit "zsh");
 
     programs.fish.shellInit = mkIf cfg.enableFishIntegration (shellInit "fish");
 

--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -37,7 +37,7 @@ in {
         source <(${bin} _carapace bash)
       '';
 
-      zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      zsh.initContent = mkIf cfg.enableZshIntegration ''
         source <(${bin} _carapace zsh)
       '';
 

--- a/modules/programs/command-not-found/command-not-found.nix
+++ b/modules/programs/command-not-found/command-not-found.nix
@@ -47,7 +47,7 @@ in {
 
   config = mkIf cfg.enable {
     programs.bash.initExtra = shInit "command_not_found_handle";
-    programs.zsh.initExtra = shInit "command_not_found_handler";
+    programs.zsh.initContent = shInit "command_not_found_handler";
 
     home.packages = [ commandNotFound ];
   };

--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -207,9 +207,9 @@ in {
       '';
 
       # Set `LS_COLORS` before Oh My Zsh and `initExtra`.
-      programs.zsh.initExtraBeforeCompInit = mkIf cfg.enableZshIntegration ''
+      programs.zsh.initContent = mkIf cfg.enableZshIntegration (mkOrder 550 ''
         eval $(${pkgs.coreutils}/bin/dircolors -b ${dircolorsPath})
-      '';
+      '');
     }
     (mkIf (!config.home.preferXdgDirectories) {
       home.file.".dir_colors".text = dircolorsConfig;

--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -121,7 +121,7 @@ in {
         eval "$(${getExe cfg.package} hook bash)"
       '');
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       eval "$(${getExe cfg.package} hook zsh)"
     '';
 

--- a/modules/programs/eww.nix
+++ b/modules/programs/eww.nix
@@ -54,7 +54,7 @@ in {
       fi
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       if [[ $TERM != "dumb" ]]; then
         eval "$(${ewwCmd} shell-completions --shell zsh)"
       fi

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -195,7 +195,7 @@ in {
     # Note, since fzf unconditionally binds C-r we use `mkOrder` to make the
     # initialization show up a bit earlier. This is to make initialization of
     # other history managers, like mcfly or atuin, take precedence.
-    programs.zsh.initExtra =
+    programs.zsh.initContent =
       mkIf cfg.enableZshIntegration (mkOrder 200 zshIntegration);
 
     programs.fish.interactiveShellInit =

--- a/modules/programs/ghostty.nix
+++ b/modules/programs/ghostty.nix
@@ -194,7 +194,7 @@ in {
     })
 
     (lib.mkIf cfg.enableZshIntegration {
-      programs.zsh.initExtra = ''
+      programs.zsh.initContent = ''
         if [[ -n $GHOSTTY_RESOURCES_DIR ]]; then
           source "$GHOSTTY_RESOURCES_DIR"/shell-integration/zsh/ghostty-integration
         fi

--- a/modules/programs/git-worktree-switcher.nix
+++ b/modules/programs/git-worktree-switcher.nix
@@ -33,7 +33,7 @@ in {
       optionalString cfg.enableBashIntegration (initScript "bash");
     programs.fish.interactiveShellInit =
       optionalString cfg.enableFishIntegration (initScript "fish");
-    programs.zsh.initExtra =
+    programs.zsh.initContent =
       optionalString cfg.enableZshIntegration (initScript "zsh");
   };
 }

--- a/modules/programs/granted.nix
+++ b/modules/programs/granted.nix
@@ -23,7 +23,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ package ];
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       function assume() {
         export GRANTED_ALIAS_CONFIGURED="true"
         source ${package}/bin/assume "$@"

--- a/modules/programs/hstr.nix
+++ b/modules/programs/hstr.nix
@@ -30,7 +30,7 @@ in {
       eval "$(${cfg.package}/bin/hstr --show-configuration)"
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       eval "$(${cfg.package}/bin/hstr --show-zsh-configuration)"
     '';
   };

--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -93,7 +93,7 @@ in {
     programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
       SHELL=fish eval (${shellCommand})
     '';
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       eval "$(SHELL=zsh ${shellCommand})"
     '';
     programs.nushell.extraConfig = mkIf cfg.enableNushellIntegration ''

--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -282,7 +282,7 @@ in {
     programs.fish.interactiveShellInit =
       mkIf cfg.shellIntegration.enableFishIntegration shellIntegrationInit.fish;
 
-    programs.zsh.initExtra =
+    programs.zsh.initContent =
       mkIf cfg.shellIntegration.enableZshIntegration shellIntegrationInit.zsh;
   };
 }

--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -141,7 +141,7 @@ in {
 
       programs.bash.initExtra = mkIf cfg.enableBashIntegration bashIntegration;
 
-      programs.zsh.initExtra = mkIf cfg.enableZshIntegration zshIntegration;
+      programs.zsh.initContent = mkIf cfg.enableZshIntegration zshIntegration;
 
       programs.fish.shellInit = mkIf cfg.enableFishIntegration fishIntegration;
 

--- a/modules/programs/mise.nix
+++ b/modules/programs/mise.nix
@@ -108,7 +108,7 @@ in {
         eval "$(${getExe cfg.package} activate bash)"
       '';
 
-      zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      zsh.initContent = mkIf cfg.enableZshIntegration ''
         eval "$(${getExe cfg.package} activate zsh)"
       '';
 

--- a/modules/programs/mods.nix
+++ b/modules/programs/mods.nix
@@ -65,7 +65,7 @@ in {
       source <(${cfg.package}/bin/mods completion bash)
     '');
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration (mkOrder 200 ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration (mkOrder 200 ''
       source <(${cfg.package}/bin/mods completion zsh)
     '');
 

--- a/modules/programs/navi.nix
+++ b/modules/programs/navi.nix
@@ -66,7 +66,7 @@ in {
       fi
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       if [[ $options[zle] = on ]]; then
         eval "$(${cfg.package}/bin/navi widget zsh)"
       fi

--- a/modules/programs/nix-index.nix
+++ b/modules/programs/nix-index.nix
@@ -41,7 +41,7 @@ in {
       source ${cfg.package}/etc/profile.d/command-not-found.sh
     '';
 
-    programs.zsh.initExtra = lib.mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = lib.mkIf cfg.enableZshIntegration ''
       source ${cfg.package}/etc/profile.d/command-not-found.sh
     '';
 

--- a/modules/programs/nix-your-shell.nix
+++ b/modules/programs/nix-your-shell.nix
@@ -45,7 +45,7 @@ in {
         '';
       };
 
-      zsh.initExtra = mkIf cfg.enableZshIntegration ''
+      zsh.initContent = mkIf cfg.enableZshIntegration ''
         ${cfg.package}/bin/nix-your-shell zsh | source /dev/stdin
       '';
     };

--- a/modules/programs/oh-my-posh.nix
+++ b/modules/programs/oh-my-posh.nix
@@ -71,7 +71,7 @@ in {
       eval "$(${cfg.package}/bin/oh-my-posh init bash ${configArgument})"
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       eval "$(${cfg.package}/bin/oh-my-posh init zsh ${configArgument})"
     '';
 

--- a/modules/programs/opam.nix
+++ b/modules/programs/opam.nix
@@ -36,7 +36,7 @@ in {
       eval "$(${cfg.package}/bin/opam env --shell=bash)"
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       eval "$(${cfg.package}/bin/opam env --shell=zsh)"
     '';
 

--- a/modules/programs/pay-respects.nix
+++ b/modules/programs/pay-respects.nix
@@ -35,7 +35,7 @@ in {
         ''}
       '';
 
-      zsh.initExtra = ''
+      zsh.initContent = ''
         ${optionalString cfg.enableZshIntegration ''
           eval "$(${payRespectsCmd} zsh --alias)"
         ''}

--- a/modules/programs/pazi.nix
+++ b/modules/programs/pazi.nix
@@ -29,7 +29,7 @@ in {
       eval "$(${pkgs.pazi}/bin/pazi init bash)"
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       eval "$(${pkgs.pazi}/bin/pazi init zsh)"
     '';
 

--- a/modules/programs/powerline-go.nix
+++ b/modules/programs/powerline-go.nix
@@ -142,27 +142,28 @@ in {
         fi
       '';
 
-    programs.zsh.initExtra = mkIf (cfg.enable && config.programs.zsh.enable) ''
-      function powerline_precmd() {
-        ${
-          if evalMode then "eval " else "PS1="
-        }"$(${pkgs.powerline-go}/bin/powerline-go -error $? -shell zsh${commandLineArguments})"
-        ${cfg.extraUpdatePS1}
-      }
+    programs.zsh.initContent =
+      mkIf (cfg.enable && config.programs.zsh.enable) ''
+        function powerline_precmd() {
+          ${
+            if evalMode then "eval " else "PS1="
+          }"$(${pkgs.powerline-go}/bin/powerline-go -error $? -shell zsh${commandLineArguments})"
+          ${cfg.extraUpdatePS1}
+        }
 
-      function install_powerline_precmd() {
-        for s in "$\{precmd_functions[@]}"; do
-          if [ "$s" = "powerline_precmd" ]; then
-            return
-          fi
-        done
-        precmd_functions+=(powerline_precmd)
-      }
+        function install_powerline_precmd() {
+          for s in "$\{precmd_functions[@]}"; do
+            if [ "$s" = "powerline_precmd" ]; then
+              return
+            fi
+          done
+          precmd_functions+=(powerline_precmd)
+        }
 
-      if [ "$TERM" != "linux" ]; then
-        install_powerline_precmd
-      fi
-    '';
+        if [ "$TERM" != "linux" ]; then
+          install_powerline_precmd
+        fi
+      '';
 
     # https://github.com/justjanne/powerline-go#fish
     programs.fish.interactiveShellInit =

--- a/modules/programs/pyenv.nix
+++ b/modules/programs/pyenv.nix
@@ -54,7 +54,7 @@ in {
       eval "$(${lib.getExe cfg.package} init - bash)"
     '';
 
-    programs.zsh.initExtra = lib.mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = lib.mkIf cfg.enableZshIntegration ''
       export PYENV_ROOT="${cfg.rootDirectory}"
       eval "$(${lib.getExe cfg.package} init - zsh)"
     '';

--- a/modules/programs/pywal.nix
+++ b/modules/programs/pywal.nix
@@ -11,7 +11,7 @@ in {
 
     home.packages = [ pkgs.pywal ];
 
-    programs.zsh.initExtra = ''
+    programs.zsh.initContent = ''
       # Import colorscheme from 'wal' asynchronously
       # &   # Run the process in the background.
       # ( ) # Hide shell job control messages.

--- a/modules/programs/rbenv.nix
+++ b/modules/programs/rbenv.nix
@@ -79,7 +79,7 @@ in {
       eval "$(${cfg.package}/bin/rbenv init - bash)"
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       eval "$(${cfg.package}/bin/rbenv init - zsh)"
     '';
 

--- a/modules/programs/scmpuff.nix
+++ b/modules/programs/scmpuff.nix
@@ -45,7 +45,7 @@ in {
       eval "$(${cfg.package}/bin/scmpuff init ${mkArgs "bash"})"
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       eval "$(${cfg.package}/bin/scmpuff init ${mkArgs "zsh"})"
     '';
 

--- a/modules/programs/skim.nix
+++ b/modules/programs/skim.nix
@@ -114,7 +114,7 @@ in {
       fi
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       if [[ $options[zle] = on ]]; then
         . ${cfg.package}/share/skim/completion.zsh
         . ${cfg.package}/share/skim/key-bindings.zsh

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -106,7 +106,7 @@ in {
       fi
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       if [[ $TERM != "dumb" ]]; then
         eval "$(${starshipCmd} init zsh)"
       fi

--- a/modules/programs/thefuck.nix
+++ b/modules/programs/thefuck.nix
@@ -57,7 +57,7 @@ with lib;
       };
     };
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration shEvalCmd;
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration shEvalCmd;
 
     programs.nushell = mkIf cfg.enableNushellIntegration {
       extraConfig = ''

--- a/modules/programs/watson.nix
+++ b/modules/programs/watson.nix
@@ -80,7 +80,7 @@ in {
       source ${cfg.package}/share/bash-completion/completions/watson
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       source ${cfg.package}/share/zsh/site-functions/_watson
     '';
 

--- a/modules/programs/wezterm.nix
+++ b/modules/programs/wezterm.nix
@@ -108,6 +108,7 @@ in {
 
     programs.bash.initExtra =
       mkIf cfg.enableBashIntegration shellIntegrationStr;
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration shellIntegrationStr;
+    programs.zsh.initContent =
+      mkIf cfg.enableZshIntegration shellIntegrationStr;
   };
 }

--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -196,7 +196,7 @@ in {
     in {
       bash.initExtra = mkIf cfg.enableBashIntegration bashIntegration;
 
-      zsh.initExtra = mkIf cfg.enableZshIntegration bashIntegration;
+      zsh.initContent = mkIf cfg.enableZshIntegration bashIntegration;
 
       fish.functions.${cfg.shellWrapperName} =
         mkIf cfg.enableFishIntegration fishIntegration;

--- a/modules/programs/z-lua.nix
+++ b/modules/programs/z-lua.nix
@@ -56,7 +56,7 @@ in {
       })"
     '';
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       eval "$(${pkgs.z-lua}/bin/z --init zsh ${
         concatStringsSep " " cfg.options
       })"

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -73,7 +73,7 @@ in {
       eval "$(${zellijCmd} setup --generate-auto-start bash)"
     '');
 
-    programs.zsh.initExtra = mkIf cfg.enableZshIntegration (mkOrder 200 ''
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration (mkOrder 200 ''
       eval "$(${zellijCmd} setup --generate-auto-start zsh)"
     '');
 

--- a/modules/programs/zplug.nix
+++ b/modules/programs/zplug.nix
@@ -44,7 +44,7 @@ in {
   config = mkIf cfg.enable {
     home.packages = [ pkgs.zplug ];
 
-    programs.zsh.initExtraBeforeCompInit = ''
+    programs.zsh.initContent = mkOrder 550 ''
       export ZPLUG_HOME=${cfg.zplugHome}
 
       source ${pkgs.zplug}/share/zplug/init.zsh

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -300,7 +300,7 @@ in {
       '';
 
       programs.bash.initExtra = mkIf cfg.enableBashIntegration gpgInitStr;
-      programs.zsh.initExtra = mkIf cfg.enableZshIntegration gpgZshInitStr;
+      programs.zsh.initContent = mkIf cfg.enableZshIntegration gpgZshInitStr;
       programs.fish.interactiveShellInit =
         mkIf cfg.enableFishIntegration gpgFishInitStr;
 


### PR DESCRIPTION
Migrating in tree usages of zsh initExtra to initContent before deprecating. Will maintain similar priorities as previous options, for backwards compatibility. Maintainers can change priority, as they see fit. 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
