### PR TITLE
fish: add command option for abbreviations

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -167,6 +167,16 @@ let
         '';
       };
 
+      command = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          Specifies the command(s) for which the abbreviation should expand. If
+          set, the abbreviation will only expand when used as an argument to
+          the given command(s).
+        '';
+      };
+
       setCursor = mkOption {
         type = with types; (either bool str);
         default = false;
@@ -201,7 +211,7 @@ let
               (lib.generators.mkValueStringDefault { } v)
             ];
         } {
-          inherit position regex function;
+          inherit position regex command function;
           set-cursor = setCursor;
         };
       modifiers = if isAttrs def then mods else "";

--- a/tests/modules/programs/fish/abbrs.nix
+++ b/tests/modules/programs/fish/abbrs.nix
@@ -34,6 +34,10 @@
             end
           '';
         };
+        co = {
+          command = "git";
+          expansion = "checkout";
+        };
         dotdot = {
           regex = "^\\.\\.+$";
           function = "multicd";
@@ -64,6 +68,8 @@
           cd ..
         end
         '"
+        assertFileContains home-files/.config/fish/config.fish \
+          "abbr --add --command git -- co checkout"
         assertFileContains home-files/.config/fish/config.fish \
           "abbr --add --function multicd --regex '^\.\.+$' -- dotdot"
       '';


### PR DESCRIPTION
### Description

The fish shell has added a flag to the abbr command which allows one to expand it only if it is typed after a real command e.g.:
git s<Space> -> git status
s<Space> -> s

Also see the last example here: https://fishshell.com/docs/current/cmds/abbr.html#examples

Also every test ran fine, but one firefox related one, which doesn't seem to relate to my change.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@isabelroses
