### PR TITLE
onlyoffice: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -24,6 +24,12 @@
     github = "afresquet";
     githubId = 29437693;
   };
+  aguirre-matteo = {
+    name = "aguirre-matteo";
+    email = "aguirre.matteo.nix@gmail.com";
+    github = "aguirre-matteo";
+    githubId = 158215792;
+  };
   amesgen = {
     name = "amesgen";
     email = "amesgen@amesgen.de";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -195,6 +195,7 @@ let
     ./programs/octant.nix
     ./programs/offlineimap.nix
     ./programs/oh-my-posh.nix
+    ./programs/onlyoffice.nix
     ./programs/opam.nix
     ./programs/openstackclient.nix
     ./programs/pandoc.nix

--- a/modules/programs/onlyoffice.nix
+++ b/modules/programs/onlyoffice.nix
@@ -1,0 +1,49 @@
+{ lib, pkgs, config, ... }:
+
+let
+  inherit (lib)
+    types isBool boolToString concatStringsSep mapAttrsToList mkIf
+    mkEnableOption mkPackageOption mkOption;
+
+  cfg = config.programs.onlyoffice;
+
+  attrToString = name: value:
+    let newvalue = if (isBool value) then (boolToString value) else value;
+    in "${name}=${newvalue}";
+
+  getFinalConfig = set:
+    (concatStringsSep "\n" (mapAttrsToList attrToString set)) + "\n";
+in {
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.onlyoffice = {
+    enable = mkEnableOption "distrobox";
+
+    package = mkPackageOption pkgs "onlyoffice-desktopeditors" { };
+
+    settings = mkOption {
+      type = with types; attrsOf (either bool str);
+      default = { };
+      example = ''
+        UITheme = "theme-contrast-dark";
+        editorWindowMode = false;
+        forcedRtl = false;
+        maximized = true;
+        titlebar = "custom";
+      '';
+      description = ''
+        Configuration settings for Onlyoffice.
+
+        All configurable options can be deduced by enabling them through the
+        GUI and observing the changes in ~/.config/onlyoffice/DesktopEditors.conf.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."onlyoffice/DesktopEditors.conf".source =
+      pkgs.writeText "DesktopEditors.conf" (getFinalConfig cfg.settings);
+  };
+}

--- a/modules/programs/onlyoffice.nix
+++ b/modules/programs/onlyoffice.nix
@@ -41,7 +41,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."onlyoffice/DesktopEditors.conf".source =
       pkgs.writeText "DesktopEditors.conf" (getFinalConfig cfg.settings);

--- a/modules/programs/onlyoffice.nix
+++ b/modules/programs/onlyoffice.nix
@@ -17,7 +17,7 @@ in {
   meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
   options.programs.onlyoffice = {
-    enable = mkEnableOption "distrobox";
+    enable = mkEnableOption "onlyoffice";
 
     package =
       mkPackageOption pkgs "onlyoffice-desktopeditors" { nullable = true; };

--- a/modules/programs/onlyoffice.nix
+++ b/modules/programs/onlyoffice.nix
@@ -19,7 +19,7 @@ in {
   options.programs.onlyoffice = {
     enable = mkEnableOption "distrobox";
 
-    package = mkPackageOption pkgs "onlyoffice-desktopeditors" { };
+    package = mkPackageOption pkgs "onlyoffice-desktopeditors" { nullable = true; };
 
     settings = mkOption {
       type = with types; attrsOf (either bool str);

--- a/modules/programs/onlyoffice.nix
+++ b/modules/programs/onlyoffice.nix
@@ -19,7 +19,8 @@ in {
   options.programs.onlyoffice = {
     enable = mkEnableOption "distrobox";
 
-    package = mkPackageOption pkgs "onlyoffice-desktopeditors" { nullable = true; };
+    package =
+      mkPackageOption pkgs "onlyoffice-desktopeditors" { nullable = true; };
 
     settings = mkOption {
       type = with types; attrsOf (either bool str);

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -353,6 +353,7 @@ in import nmtSrc {
     ./modules/programs/nnn
     ./modules/programs/nushell
     ./modules/programs/oh-my-posh
+    ./modules/programs/onlyoffice
     ./modules/programs/openstackclient
     ./modules/programs/pandoc
     ./modules/programs/papis

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -142,6 +142,7 @@ let
       "nix-index"
       "nix-your-shell"
       "ollama"
+      "onlyoffice"
       "openstackclient"
       "papis"
       "pay-respects"
@@ -353,6 +354,7 @@ in import nmtSrc {
     ./modules/programs/nnn
     ./modules/programs/nushell
     ./modules/programs/oh-my-posh
+    ./modules/programs/onlyoffice
     ./modules/programs/openstackclient
     ./modules/programs/pandoc
     ./modules/programs/papis
@@ -457,7 +459,6 @@ in import nmtSrc {
     ./modules/programs/looking-glass-client
     ./modules/programs/mangohud
     ./modules/programs/ncmpcpp-linux
-    ./modules/programs/onlyoffice
     ./modules/programs/pqiv
     ./modules/programs/rbw
     ./modules/programs/rofi

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -142,7 +142,7 @@ let
       "nix-index"
       "nix-your-shell"
       "ollama"
-      "onlyoffice"
+      "onlyoffice-desktopeditors"
       "openstackclient"
       "papis"
       "pay-respects"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -353,7 +353,6 @@ in import nmtSrc {
     ./modules/programs/nnn
     ./modules/programs/nushell
     ./modules/programs/oh-my-posh
-    ./modules/programs/onlyoffice
     ./modules/programs/openstackclient
     ./modules/programs/pandoc
     ./modules/programs/papis
@@ -458,6 +457,7 @@ in import nmtSrc {
     ./modules/programs/looking-glass-client
     ./modules/programs/mangohud
     ./modules/programs/ncmpcpp-linux
+    ./modules/programs/onlyoffice
     ./modules/programs/pqiv
     ./modules/programs/rbw
     ./modules/programs/rofi

--- a/tests/modules/programs/onlyoffice/default.nix
+++ b/tests/modules/programs/onlyoffice/default.nix
@@ -1,0 +1,1 @@
+{ onlyoffice-example-config = ./example-config.nix; }

--- a/tests/modules/programs/onlyoffice/example-config.conf
+++ b/tests/modules/programs/onlyoffice/example-config.conf
@@ -1,0 +1,7 @@
+UITheme=theme-contrast-dark
+editorWindowMode=false
+forcedRtl=false
+locale=es-ES
+maximized=true
+position=@Rect(100 56 1266 668)
+titlebar=custom

--- a/tests/modules/programs/onlyoffice/example-config.nix
+++ b/tests/modules/programs/onlyoffice/example-config.nix
@@ -1,0 +1,20 @@
+{
+  programs.onlyoffice = {
+    enable = true;
+    settings = {
+      UITheme = "theme-contrast-dark";
+      editorWindowMode = false;
+      forcedRtl = false;
+      locale = "es-ES";
+      maximized = true;
+      position = "@Rect(100 56 1266 668)";
+      titlebar = "custom";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/onlyoffice/DesktopEditors.conf
+    assertFileContent home-files/.config/onlyoffice/DesktopEditors.conf \
+    ${./example-config.conf}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Added programs/onlyoffice.nix module, that provides `enable`, `package` and `settings` options at `programs.onlyoffice`.
All the available settings at `settings` can be deduced by modifing the config in the GUI and observing the changes in ~/.config/onlyoffice/DesktopEditors.conf.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
