### PR TITLE
mcfly: fix mcfly-fzf in non-interactive shells

### DIFF
--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -7,22 +7,33 @@ let
 
   tomlFormat = pkgs.formats.toml { };
 
+  # These shell integrations all wrap `mcfly-fzf init` in an interactive shell
+  # check, due to a buggy interactivity check in its initialization.
+  # See: https://github.com/nix-community/home-manager/issues/6663
+  # and https://github.com/bnprks/mcfly-fzf/issues/10
+
   bashIntegration = ''
     eval "$(${getExe pkgs.mcfly} init bash)"
   '' + optionalString cfg.fzf.enable ''
-    eval "$(${getExe pkgs.mcfly-fzf} init bash)"
+    if [[ $- =~ i ]]; then
+      eval "$(${getExe pkgs.mcfly-fzf} init bash)"
+    fi
   '';
 
   fishIntegration = ''
     ${getExe pkgs.mcfly} init fish | source
   '' + optionalString cfg.fzf.enable ''
-    ${getExe pkgs.mcfly-fzf} init fish | source
+    if [[ -o interactive ]]; then
+      ${getExe pkgs.mcfly-fzf} init fish | source
+    fi
   '';
 
   zshIntegration = ''
     eval "$(${getExe pkgs.mcfly} init zsh)"
   '' + optionalString cfg.fzf.enable ''
-    eval "$(${getExe pkgs.mcfly-fzf} init zsh)"
+    if status is-interactive
+      eval "$(${getExe pkgs.mcfly-fzf} init zsh)"
+    end
   '';
 
 in {

--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -23,17 +23,17 @@ let
   fishIntegration = ''
     ${getExe pkgs.mcfly} init fish | source
   '' + optionalString cfg.fzf.enable ''
-    if [[ -o interactive ]]; then
-      ${getExe pkgs.mcfly-fzf} init fish | source
-    fi
+    if status is-interactive
+      eval "$(${getExe pkgs.mcfly-fzf} init zsh)"
+    end
   '';
 
   zshIntegration = ''
     eval "$(${getExe pkgs.mcfly} init zsh)"
   '' + optionalString cfg.fzf.enable ''
-    if status is-interactive
-      eval "$(${getExe pkgs.mcfly-fzf} init zsh)"
-    end
+    if [[ -o interactive ]]; then
+      ${getExe pkgs.mcfly-fzf} init fish | source
+    fi
   '';
 
 in {


### PR DESCRIPTION
### Description

mcfly-fzf's initialization steps don't properly check for interactive shells. It does check, but only after checking if mcfly has been initialized. Because mcfly does not initiate itself on non-interactive shells, that causes mcfly-fzf to return an exit code, breaking non-interactive shells.

Closes https://github.com/nix-community/home-manager/issues/6663
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@trueNAHO @rycee @iofq
