### PR TITLE
mcfly: Fix swapped shell names

### DIFF
--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -24,7 +24,7 @@ let
     ${getExe pkgs.mcfly} init fish | source
   '' + optionalString cfg.fzf.enable ''
     if status is-interactive
-      eval "$(${getExe pkgs.mcfly-fzf} init zsh)"
+      eval "$(${getExe pkgs.mcfly-fzf} init fish)"
     end
   '';
 
@@ -32,7 +32,7 @@ let
     eval "$(${getExe pkgs.mcfly} init zsh)"
   '' + optionalString cfg.fzf.enable ''
     if [[ -o interactive ]]; then
-      ${getExe pkgs.mcfly-fzf} init fish | source
+      ${getExe pkgs.mcfly-fzf} init zsh | source
     fi
   '';
 


### PR DESCRIPTION
### Description

In #6669 I accidentally swapped the condition syntax for zsh and fish. When I fixed that, I just swapped the entire blocks. That caused the shells to be backwards though, so it is currently broken on master. Sorry! This PR fixes it.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@khaneliman 