### PR TITLE
wofi: merge multiple style definitions

### DIFF
--- a/modules/programs/wofi.nix
+++ b/modules/programs/wofi.nix
@@ -37,7 +37,7 @@ in {
 
     style = mkOption {
       default = null;
-      type = types.nullOr types.str;
+      type = types.nullOr types.lines;
       description = ''
         CSS style for wofi to use as a stylesheet. See
         {manpage}`wofi(7)`.


### PR DESCRIPTION
### Description
Brings functional of merging multiple style definitions that other modules have (waybar) to wofi. Not having this is causing issues in https://github.com/danth/stylix/issues/891, where users might want to add on to what is set by stylix.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
