### PR TITLE
davmail: init module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -66,6 +66,12 @@
     github = "bertof";
     githubId = 9915675;
   };
+  bmrips = {
+    name = "Benedikt Rips";
+    email = "benedikt.rips@gmail.com";
+    github = "bmrips";
+    githubId = 20407973;
+  };
   bricked = {
     name = "Bricked";
     email = "hello@bricked.dev";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -315,6 +315,7 @@ let
     ./services/conky.nix
     ./services/copyq.nix
     ./services/darkman.nix
+    ./services/davmail.nix
     ./services/devilspie2.nix
     ./services/dropbox.nix
     ./services/dunst.nix

--- a/modules/services/davmail.nix
+++ b/modules/services/davmail.nix
@@ -1,0 +1,128 @@
+{ config, lib, pkgs, ... }:
+let
+
+  inherit (lib)
+    mapAttrsRecursive mkDefault mkEnableOption mkIf mkOption optionalAttrs
+    types;
+
+  cfg = config.services.davmail;
+
+  javaProperties = pkgs.formats.javaProperties { };
+
+  settingsFile = javaProperties.generate "davmail.properties" cfg.settings;
+
+in {
+
+  meta.maintainers = [ lib.hm.maintainers.bmrips ];
+
+  options.services.davmail = {
+
+    enable = mkEnableOption "DavMail, an MS Exchange gateway.";
+
+    imitateOutlook = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether DavMail pretends to be Outlook.";
+      example = true;
+    };
+
+    settings = mkOption {
+      type = javaProperties.type;
+      default = { };
+      description = ''
+        Davmail configuration. Refer to
+        <http://davmail.sourceforge.net/serversetup.html>
+        and <http://davmail.sourceforge.net/advanced.html>
+        for details on supported values.
+      '';
+      example = {
+        "davmail.url" = "https://outlook.office365.com/EWS/Exchange.asmx";
+        "davmail.allowRemote" = true;
+        "davmail.imapPort" = 55555;
+        "davmail.bindAddress" = "10.0.1.2";
+        "davmail.smtpSaveInSent" = true;
+        "davmail.folderSizeLimit" = 10;
+        "davmail.caldavAutoSchedule" = false;
+        "log4j.logger.rootLogger" = "DEBUG";
+      };
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    assertions = [{
+      assertion = pkgs.stdenv.hostPlatform.isLinux;
+      message = "The DavMail service is only available on Linux.";
+    }];
+
+    services.davmail.settings = mapAttrsRecursive (_: mkDefault) {
+      "davmail.server" = true;
+      "davmail.disableUpdateCheck" = true;
+      "davmail.logFilePath" = "${config.xdg.stateHome}/davmail.log";
+      "davmail.logFileSize" = "1MB";
+      "davmail.mode" = "auto";
+      "davmail.url" = "https://outlook.office365.com/EWS/Exchange.asmx";
+      "davmail.caldavPort" = 1080;
+      "davmail.imapPort" = 1143;
+      "davmail.ldapPort" = 1389;
+      "davmail.popPort" = 1110;
+      "davmail.smtpPort" = 1025;
+
+      # The token file path is set because, otherwise, if oauth.persistToken
+      # is enabled, DavMail would attempt to write the token into generated
+      # configuration which lays in the Nix store.
+      "davmail.oauth.tokenFilePath" = "${config.xdg.stateHome}/davmail-tokens";
+
+      "log4j.logger.davmail" = "WARN";
+      "log4j.logger.httpclient.wire" = "WARN";
+      "log4j.logger.org.apache.commons.httpclient" = "WARN";
+      "log4j.rootLogger" = "WARN";
+    } // optionalAttrs cfg.imitateOutlook {
+      "davmail.oauth.clientId" = "d3590ed6-52b3-4102-aeff-aad2292ab01c";
+      "davmail.oauth.redirectUri" = "urn:ietf:wg:oauth:2.0:oob";
+    };
+
+    systemd.user.services.davmail = {
+      Unit = {
+        Description = "DavMail POP/IMAP/SMTP Exchange Gateway";
+        After = [ "graphical-session.target" "network.target" ];
+      };
+      Install.WantedBy = [ "graphical-session.target" ];
+      Service = {
+        Type = "simple";
+        ExecStart = "${pkgs.davmail}/bin/davmail ${settingsFile}";
+        Restart = "on-failure";
+
+        CapabilityBoundingSet = [ "" ];
+        DeviceAllow = [ "" ];
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectSystem = "strict";
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "@system-service";
+        SystemCallErrorNumber = "EPERM";
+        UMask = "0077";
+      };
+    };
+
+    home.packages = [ pkgs.davmail ];
+
+  };
+
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -491,6 +491,7 @@ in import nmtSrc {
     ./modules/services/copyq
     ./modules/services/conky
     ./modules/services/darkman
+    ./modules/services/davmail
     ./modules/services/devilspie2
     ./modules/services/dropbox
     ./modules/services/easyeffects

--- a/tests/modules/services/davmail/custom-settings.nix
+++ b/tests/modules/services/davmail/custom-settings.nix
@@ -1,0 +1,41 @@
+{ config, pkgs, ... }: {
+  services.davmail = {
+    enable = true;
+    settings = {
+      "davmail.imapPort" = 4444;
+      "davmail.oauth.redirectUri" = "urn:ietf:wg:oauth:2.0:oob";
+      "davmail.persistToken" = true;
+    };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/davmail.service
+    assertFileExists $serviceFile
+    configFile=$(grep -o '/nix/store/.*-davmail.properties' $TESTED/$serviceFile)
+    assertFileExists $configFile
+    assertFileContent $configFile ${
+      pkgs.writeText "custom-settings.properties" ''
+        # Generated with Nix
+
+        davmail.caldavPort = 1080
+        davmail.disableUpdateCheck = true
+        davmail.imapPort = 4444
+        davmail.ldapPort = 1389
+        davmail.logFilePath = ${config.xdg.stateHome}/davmail.log
+        davmail.logFileSize = 1MB
+        davmail.mode = auto
+        davmail.oauth.redirectUri = urn:ietf:wg:oauth:2.0:oob
+        davmail.oauth.tokenFilePath = ${config.xdg.stateHome}/davmail-tokens
+        davmail.persistToken = true
+        davmail.popPort = 1110
+        davmail.server = true
+        davmail.smtpPort = 1025
+        davmail.url = https://outlook.office365.com/EWS/Exchange.asmx
+        log4j.logger.davmail = WARN
+        log4j.logger.httpclient.wire = WARN
+        log4j.logger.org.apache.commons.httpclient = WARN
+        log4j.rootLogger = WARN
+      ''
+    }
+  '';
+}

--- a/tests/modules/services/davmail/default.nix
+++ b/tests/modules/services/davmail/default.nix
@@ -1,0 +1,4 @@
+{
+  davmail-custom-settings = ./custom-settings.nix;
+  davmail-imitateOutlook = ./imitateOutlook.nix;
+}

--- a/tests/modules/services/davmail/imitateOutlook.nix
+++ b/tests/modules/services/davmail/imitateOutlook.nix
@@ -1,0 +1,37 @@
+{ config, pkgs, ... }: {
+  services.davmail = {
+    enable = true;
+    imitateOutlook = true;
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/davmail.service
+    assertFileExists $serviceFile
+    configFile=$(grep -o '/nix/store/.*-davmail.properties' $TESTED/$serviceFile)
+    assertFileExists $configFile
+    assertFileContent $configFile ${
+      pkgs.writeText "imitateOutlook.properties" ''
+        # Generated with Nix
+
+        davmail.caldavPort = 1080
+        davmail.disableUpdateCheck = true
+        davmail.imapPort = 1143
+        davmail.ldapPort = 1389
+        davmail.logFilePath = ${config.xdg.stateHome}/davmail.log
+        davmail.logFileSize = 1MB
+        davmail.mode = auto
+        davmail.oauth.clientId = d3590ed6-52b3-4102-aeff-aad2292ab01c
+        davmail.oauth.redirectUri = urn:ietf:wg:oauth:2.0:oob
+        davmail.oauth.tokenFilePath = ${config.xdg.stateHome}/davmail-tokens
+        davmail.popPort = 1110
+        davmail.server = true
+        davmail.smtpPort = 1025
+        davmail.url = https://outlook.office365.com/EWS/Exchange.asmx
+        log4j.logger.davmail = WARN
+        log4j.logger.httpclient.wire = WARN
+        log4j.logger.org.apache.commons.httpclient = WARN
+        log4j.rootLogger = WARN
+      ''
+    }
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Initialize a module for the [DavMail](https://davmail.sourceforge.net/) service.

The code is mostly copied from the corresponding NixOS module; but slightly refactored. In addition, some restrictions on the systemd service were released to allow DavMail to launch a GUI when necessary.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
