### PR TITLE
waybar: integrate with tray.target

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -321,7 +321,7 @@ in {
           Description =
             "Highly customizable Wayland bar for Sway and Wlroots based compositors.";
           Documentation = "https://github.com/Alexays/Waybar/wiki";
-          PartOf = [ cfg.systemd.target ];
+          PartOf = [ cfg.systemd.target "tray.target" ];
           After = [ cfg.systemd.target ];
           ConditionEnvironment = "WAYLAND_DISPLAY";
           X-Restart-Triggers = optional (settings != [ ])
@@ -339,8 +339,8 @@ in {
           Environment = [ "GTK_DEBUG=interactive" ];
         };
 
-        Install.WantedBy =
-          lib.optional (cfg.systemd.target != null) cfg.systemd.target;
+        Install.WantedBy = [ "tray.target" ]
+          ++ lib.optional (cfg.systemd.target != null) cfg.systemd.target;
       };
     })
   ]);

--- a/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
+++ b/tests/modules/programs/waybar/systemd-with-graphical-session-target.service
@@ -1,4 +1,5 @@
 [Install]
+WantedBy=tray.target
 WantedBy=sway-session.target
 
 [Service]
@@ -13,3 +14,4 @@ ConditionEnvironment=WAYLAND_DISPLAY
 Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
 Documentation=https://github.com/Alexays/Waybar/wiki
 PartOf=sway-session.target
+PartOf=tray.target


### PR DESCRIPTION
Inspired by [#3432][0], but with a smaller footprint.

This change makes it so that services with `Requires=tray.target` and `After=tray.target`, such as [`blueman-applet`][1] or [`network-manager-applet`][2] get started *after* waybar is ready.

[0]: https://github.com/nix-community/home-manager/pull/3432
[1]: https://github.com/nix-community/home-manager/blob/6c2b79403e9ae852fbf1d55b29f2ea4d2aa43255/modules/services/blueman-applet.nix
[2]: https://github.com/nix-community/home-manager/blob/6c2b79403e9ae852fbf1d55b29f2ea4d2aa43255/modules/services/network-manager-applet.nix

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
