### PR TITLE
[24.11 backport] xdg-mime: Fix cross compilation

### DIFF
--- a/modules/misc/xdg-mime.nix
+++ b/modules/misc/xdg-mime.nix
@@ -63,15 +63,19 @@ in {
       if [[ -w $out/share/mime && -w $out/share/mime/packages && -d $out/share/mime/packages ]]; then
         XDG_DATA_DIRS=$out/share \
         PKGSYSTEM_ENABLE_FSYNC=0 \
-        ${getExe cfg.sharedMimeInfoPackage} \
-          -V $out/share/mime > /dev/null
+        ${
+          getExe
+          (cfg.sharedMimeInfoPackage.__spliced.buildHost or cfg.sharedMimeInfoPackage)
+        } -V $out/share/mime > /dev/null
       fi
 
       if [[ -w $out/share/applications ]]; then
-        ${getExe' cfg.desktopFileUtilsPackage "update-desktop-database"} \
-          $out/share/applications
+        ${
+          getExe'
+          (cfg.desktopFileUtilsPackage.__spliced.buildHost or cfg.desktopFileUtilsPackage)
+          "update-desktop-database"
+        } $out/share/applications
       fi
     '';
   };
-
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

Backport of #6500

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
