### PR TITLE
rclone: correctly escape whitespace in secrets + type check remote configs

### DIFF
--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -124,7 +124,7 @@ in {
           lib.mapAttrsToList (secret: secretFile: ''
             ${lib.getExe cfg.package} config update \
               ${remote.name} config_refresh_token=false \
-              ${secret} $(cat ${secretFile}) \
+              ${secret} "$(cat ${secretFile})" \
               --quiet > /dev/null
           '') remote.value.secrets or { };
 

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -17,7 +17,16 @@ in {
           options = {
             config = lib.mkOption {
               type = with lib.types;
-                attrsOf (nullOr (oneOf [ bool int float str ]));
+                let
+                  baseType = attrsOf (nullOr (oneOf [ bool int float str ]));
+
+                  # Should we verify whether type constitutes a valid remote?
+                  remoteConfigType = addCheck baseType (lib.hasAttr "type") // {
+                    name = "rcloneRemoteConfig";
+                    description =
+                      "An attribute set containing a remote type and options.";
+                  };
+                in remoteConfigType;
               default = { };
               description = ''
                 Regular configuration options as described in rclone's documentation

--- a/tests/integration/standalone/rclone/default.nix
+++ b/tests/integration/standalone/rclone/default.nix
@@ -98,6 +98,21 @@
         ./secrets-with-whitespace.conf
       } /home/alice/.config/rclone/rclone.conf")
 
+    with subtest("Un-typed remote"):
+      succeed_as_alice("install -m644 ${
+        ./no-type.nix
+      } /home/alice/.config/home-manager/test-remote.nix")
+
+      actual = fail_as_alice("home-manager switch")
+      expected = "Activating createRcloneConfig"
+      assert expected not in actual, \
+        f"expected home-manager switch to contain {expected}, but got {actual}"
+
+      expected = "An attribute set containing a remote type and options."
+      assert expected not in actual, \
+        f"expected home-manager switch to contain {expected}, but got {actual}"
+
+
     # TODO: verify correct activation order with the agenix and sops hm modules
 
     logout_alice()

--- a/tests/integration/standalone/rclone/default.nix
+++ b/tests/integration/standalone/rclone/default.nix
@@ -84,6 +84,20 @@
         ./with-secrets-in-store.conf
       } /home/alice/.config/rclone/rclone.conf")
 
+    with subtest("Secrets with spaces"):
+      succeed_as_alice("install -m644 ${
+        ./secrets-with-whitespace.nix
+      } /home/alice/.config/home-manager/test-remote.nix")
+
+      actual = succeed_as_alice("home-manager switch")
+      expected = "Activating createRcloneConfig"
+      assert expected in actual, \
+        f"expected home-manager switch to contain {expected}, but got {actual}"
+
+      succeed_as_alice("diff -u ${
+        ./secrets-with-whitespace.conf
+      } /home/alice/.config/rclone/rclone.conf")
+
     # TODO: verify correct activation order with the agenix and sops hm modules
 
     logout_alice()

--- a/tests/integration/standalone/rclone/no-type.nix
+++ b/tests/integration/standalone/rclone/no-type.nix
@@ -1,0 +1,9 @@
+{
+  programs.rclone.remotes = {
+    alices-cool-remote-v4.config = {
+      description = "this value does not have a type";
+      some-key = "value pairs";
+      another-key-value = "pair";
+    };
+  };
+}

--- a/tests/integration/standalone/rclone/secrets-with-whitespace.conf
+++ b/tests/integration/standalone/rclone/secrets-with-whitespace.conf
@@ -1,0 +1,5 @@
+[alices-cool-remote-v3]
+description = alices speeedy remote
+type = memory
+spaces-secret = This is a secret with spaces, it has single spaces,                  and lots of spaces :3
+

--- a/tests/integration/standalone/rclone/secrets-with-whitespace.nix
+++ b/tests/integration/standalone/rclone/secrets-with-whitespace.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }: {
+  programs.rclone.remotes = {
+    alices-cool-remote-v3 = {
+      config = {
+        type = "memory";
+        description = "alices speeedy remote";
+      };
+      secrets.spaces-secret = "${pkgs.writeText "secret" ''
+        This is a secret with spaces, it has single spaces,                  and lots of spaces :3
+      ''}";
+    };
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible. - Adding the type check backwards compatible? Should make it a warning?

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
