### PR TITLE
Build-time nushell config generation

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -122,17 +122,12 @@ in {
       '';
 
       programs.nushell = mkIf cfg.enableNushellIntegration {
-        extraEnv = ''
-          let atuin_cache = "${config.xdg.cacheHome}/atuin"
-          if not ($atuin_cache | path exists) {
-            mkdir $atuin_cache
-          }
-          ${
-            lib.getExe cfg.package
-          } init nu ${flagsStr} | save --force ${config.xdg.cacheHome}/atuin/init.nu
-        '';
         extraConfig = ''
-          source ${config.xdg.cacheHome}/atuin/init.nu
+          source ${
+            pkgs.runCommand "atuin-nushell-config" { } ''
+              ${lib.getExe cfg.package} init nu ${flagsStr} >> "$out"
+            ''
+          }
         '';
       };
     }

--- a/modules/programs/nix-your-shell.nix
+++ b/modules/programs/nix-your-shell.nix
@@ -25,22 +25,21 @@ in {
 
     programs = {
       fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
-        ${cfg.package}/bin/nix-your-shell fish | source
+        ${lib.getExe cfg.package} fish | source
       '';
 
       nushell = lib.mkIf cfg.enableNushellIntegration {
-        extraEnv = ''
-          mkdir ${config.xdg.cacheHome}/nix-your-shell
-          ${cfg.package}/bin/nix-your-shell nu | save --force ${config.xdg.cacheHome}/nix-your-shell/init.nu
-        '';
-
         extraConfig = ''
-          source ${config.xdg.cacheHome}/nix-your-shell/init.nu
+          source ${
+            pkgs.runCommand "nix-your-shell-nushell-config" { } ''
+              ${lib.getExe cfg.package} nu >> "$out"
+            ''
+          }
         '';
       };
 
       zsh.initContent = lib.mkIf cfg.enableZshIntegration ''
-        ${cfg.package}/bin/nix-your-shell zsh | source /dev/stdin
+        ${lib.getExe cfg.package} zsh | source /dev/stdin
       '';
     };
   };

--- a/modules/programs/oh-my-posh.nix
+++ b/modules/programs/oh-my-posh.nix
@@ -68,27 +68,26 @@ in {
     };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
-      eval "$(${cfg.package}/bin/oh-my-posh init bash ${configArgument})"
+      eval "$(${lib.getExe cfg.package} init bash ${configArgument})"
     '';
 
     programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
-      eval "$(${cfg.package}/bin/oh-my-posh init zsh ${configArgument})"
+      eval "$(${lib.getExe cfg.package} init zsh ${configArgument})"
     '';
 
     programs.fish.shellInit = mkIf cfg.enableFishIntegration ''
-      ${cfg.package}/bin/oh-my-posh init fish ${configArgument} | source
+      ${lib.getExe cfg.package} init fish ${configArgument} | source
     '';
 
     programs.nushell = mkIf cfg.enableNushellIntegration {
-      extraEnv = ''
-        let oh_my_posh_cache = "${config.xdg.cacheHome}/oh-my-posh"
-        if not ($oh_my_posh_cache | path exists) {
-          mkdir $oh_my_posh_cache
-        }
-        ${cfg.package}/bin/oh-my-posh init nu ${configArgument} --print | save --force ${config.xdg.cacheHome}/oh-my-posh/init.nu
-      '';
       extraConfig = ''
-        source ${config.xdg.cacheHome}/oh-my-posh/init.nu
+        source ${
+          pkgs.runCommand "oh-my-posh-nushell-config" { } ''
+            ${
+              lib.getExe cfg.package
+            } init nu ${configArgument} --print >> "$out"
+          ''
+        }
       '';
     };
   };

--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -38,29 +38,25 @@ in {
 
     programs.bash.initExtra = lib.mkIf cfg.enableBashIntegration
       (lib.mkOrder 2000 ''
-        eval "$(${cfg.package}/bin/zoxide init bash ${cfgOptions})"
+        eval "$(${lib.getExe cfg.package} init bash ${cfgOptions})"
       '');
 
     programs.zsh.initContent = lib.mkIf cfg.enableZshIntegration
       (lib.mkOrder 2000 ''
-        eval "$(${cfg.package}/bin/zoxide init zsh ${cfgOptions})"
+        eval "$(${lib.getExe cfg.package} init zsh ${cfgOptions})"
       '');
 
     programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
-      ${cfg.package}/bin/zoxide init fish ${cfgOptions} | source
+      ${lib.getExe cfg.package} init fish ${cfgOptions} | source
     '';
 
     programs.nushell = lib.mkIf cfg.enableNushellIntegration {
-      extraEnv = ''
-        let zoxide_cache = "${config.xdg.cacheHome}/zoxide"
-        if not ($zoxide_cache | path exists) {
-          mkdir $zoxide_cache
-        }
-        ${cfg.package}/bin/zoxide init nushell ${cfgOptions} |
-          save --force ${config.xdg.cacheHome}/zoxide/init.nu
-      '';
       extraConfig = ''
-        source ${config.xdg.cacheHome}/zoxide/init.nu
+        source ${
+          pkgs.runCommand "zoxide-nushell-config" { } ''
+            ${lib.getExe cfg.package} init nushell ${cfgOptions} >> "$out"
+          ''
+        }
       '';
     };
   };

--- a/tests/modules/programs/carapace/nushell.nix
+++ b/tests/modules/programs/carapace/nushell.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, ... }:
+{ lib, pkgs, realPkgs, config, ... }:
 
 {
   programs = {
@@ -6,17 +6,16 @@
     nushell.enable = true;
   };
 
+  _module.args.pkgs = lib.mkForce realPkgs;
+
   nmt.script = let
     configDir = if pkgs.stdenv.isDarwin && !config.xdg.enable then
       "home-files/Library/Application Support/nushell"
     else
       "home-files/.config/nushell";
   in ''
-    assertFileExists "${configDir}/env.nu"
-    assertFileRegex "${configDir}/env.nu" \
-      '/nix/store/.*carapace.*/bin/carapace _carapace nushell \| save -f \$"(\$carapace_cache)/init\.nu"'
     assertFileExists "${configDir}/config.nu"
     assertFileRegex "${configDir}/config.nu" \
-      'source /.*/\.cache/carapace/init\.nu'
+      'source /nix/store/[^/]*-carapace-nushell-config'
   '';
 }

--- a/tests/modules/programs/nix-your-shell/enable-shells.nix
+++ b/tests/modules/programs/nix-your-shell/enable-shells.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, ... }:
+{ lib, pkgs, realPkgs, config, ... }:
 
 {
   programs = {
@@ -13,6 +13,8 @@
     zsh.enable = true;
   };
 
+  _module.args.pkgs = lib.mkForce realPkgs;
+
   nmt.script = let
     nushellConfigDir = if pkgs.stdenv.isDarwin && !config.xdg.enable then
       "home-files/Library/Application Support/nushell"
@@ -20,23 +22,18 @@
       "home-files/.config/nushell";
   in ''
     assertFileExists home-files/.config/fish/config.fish
-    assertFileContains \
+    assertFileRegex \
       home-files/.config/fish/config.fish \
-      '@nix-your-shell@/bin/nix-your-shell fish | source'
+      '/nix/store/[^/]*-nix-your-shell-[^/]*/bin/nix-your-shell fish | source'
 
     assertFileExists ${nushellConfigDir}/config.nu
-    assertFileContains \
+    assertFileRegex \
       ${nushellConfigDir}/config.nu \
-      'source ${config.xdg.cacheHome}/nix-your-shell/init.nu'
-
-    assertFileExists ${nushellConfigDir}/env.nu
-    assertFileContains \
-      ${nushellConfigDir}/env.nu \
-      '@nix-your-shell@/bin/nix-your-shell nu | save --force ${config.xdg.cacheHome}/nix-your-shell/init.nu'
+      'source /nix/store/[^/]*-nix-your-shell-nushell-config'
 
     assertFileExists home-files/.zshrc
-    assertFileContains \
+    assertFileRegex \
       home-files/.zshrc \
-      '@nix-your-shell@/bin/nix-your-shell zsh | source /dev/stdin'
+      '/nix/store/[^/]*-nix-your-shell-[^/]*/bin/nix-your-shell zsh | source /dev/stdin'
   '';
 }

--- a/tests/modules/programs/oh-my-posh/nushell.nix
+++ b/tests/modules/programs/oh-my-posh/nushell.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, ... }:
+{ lib, pkgs, realPkgs, config, ... }:
 
 {
   programs = {
@@ -10,25 +10,17 @@
     };
   };
 
+  _module.args.pkgs = lib.mkForce realPkgs;
+
   nmt.script = let
     configFile = if pkgs.stdenv.isDarwin && !config.xdg.enable then
       "home-files/Library/Application Support/nushell/config.nu"
     else
       "home-files/.config/nushell/config.nu";
-
-    envFile = if pkgs.stdenv.isDarwin && !config.xdg.enable then
-      "home-files/Library/Application Support/nushell/env.nu"
-    else
-      "home-files/.config/nushell/env.nu";
   in ''
-    assertFileExists "${envFile}"
-    assertFileRegex \
-      "${envFile}" \
-      '/bin/oh-my-posh init nu --config .*--print \| save --force /.*/home-files/\.cache/oh-my-posh/init\.nu'
-
     assertFileExists "${configFile}"
     assertFileRegex \
       "${configFile}" \
-      'source /.*/\.cache/oh-my-posh/init\.nu'
+      'source /nix/store/[^/]*-oh-my-posh-nushell-config'
   '';
 }

--- a/tests/modules/programs/pay-respects/integration-disabled.nix
+++ b/tests/modules/programs/pay-respects/integration-disabled.nix
@@ -1,3 +1,5 @@
+{ lib, realPkgs, ... }:
+
 {
   programs = {
     pay-respects.enable = true;
@@ -11,10 +13,12 @@
     nushell.enable = true;
   };
 
+  _module.args.pkgs = lib.mkForce realPkgs;
+
   nmt.script = ''
-    assertFileNotRegex home-files/.bashrc '@pay-respects@/bin/pay-respects'
-    assertFileNotRegex home-files/.zshrc '@pay-respects@/bin/pay-respects'
-    assertFileNotRegex home-files/.config/fish/config.fish '@pay-respects@/bin/pay-respects'
-    assertFileNotRegex home-files/.config/nushell/config.nu '@pay-respects@/bin/pay-respects'
+    assertFileNotRegex home-files/.bashrc '/nix/store/[^/]*-pay-respects-[^/]*/bin/pay-respects'
+    assertFileNotRegex home-files/.zshrc '/nix/store/[^/]*-pay-respects-[^/]*/bin/pay-respects'
+    assertFileNotRegex home-files/.config/fish/config.fish '/nix/store/[^/]*-pay-respects-[^/]*/bin/pay-respects'
+    assertFileNotRegex home-files/.config/nushell/config.nu 'source /nix/store/[^/]*-pay-respects-nushell-config'
   '';
 }

--- a/tests/modules/programs/pay-respects/integration-enabled.nix
+++ b/tests/modules/programs/pay-respects/integration-enabled.nix
@@ -1,3 +1,5 @@
+{ lib, realPkgs, ... }:
+
 {
   programs = {
     pay-respects.enable = true;
@@ -7,25 +9,27 @@
     nushell.enable = true;
   };
 
+  _module.args.pkgs = lib.mkForce realPkgs;
+
   nmt.script = ''
     assertFileExists home-files/.bashrc
-    assertFileContains \
+    assertFileRegex \
       home-files/.bashrc \
-      'eval "$(@pay-respects@/bin/pay-respects bash --alias)"'
+      'eval "$(/nix/store/[^/]*-pay-respects-[^/]*/bin/pay-respects bash --alias)"'
 
     assertFileExists home-files/.zshrc
-    assertFileContains \
+    assertFileRegex \
       home-files/.zshrc \
-      'eval "$(@pay-respects@/bin/pay-respects zsh --alias)"'
+      'eval "$(/nix/store/[^/]*-pay-respects-[^/]*/bin/pay-respects zsh --alias)"'
 
     assertFileExists home-files/.config/fish/config.fish
-    assertFileContains \
+    assertFileRegex \
       home-files/.config/fish/config.fish \
-      '@pay-respects@/bin/pay-respects fish --alias | source'
+      '/nix/store/[^/]*-pay-respects-[^/]*/bin/pay-respects fish --alias | source'
 
     assertFileExists home-files/.config/nushell/config.nu
-    assertFileContains \
+    assertFileRegex \
       home-files/.config/nushell/config.nu \
-      '@pay-respects@/bin/pay-respects nushell --alias [<alias>]'
+      'source /nix/store/[^/]*-pay-respects-nushell-config'
   '';
 }

--- a/tests/modules/programs/starship/fish_with_interactive.nix
+++ b/tests/modules/programs/starship/fish_with_interactive.nix
@@ -10,7 +10,7 @@
     export GOT="$(tail -n 5 `_abs home-files/.config/fish/config.fish`)"
     export NOT_EXPECTED="
     if test \"\$TERM\" != dumb
-        /home/hm-user/.nix-profile/bin/starship init fish | source
+        @starship@/bin/starship init fish | source
 
     end"
 

--- a/tests/modules/programs/starship/fish_without_interactive.nix
+++ b/tests/modules/programs/starship/fish_without_interactive.nix
@@ -14,7 +14,7 @@
     export GOT="$(tail -n 5 `_abs home-files/.config/fish/config.fish`)"
     export EXPECTED="
     if test \"\$TERM\" != dumb
-        /home/hm-user/.nix-profile/bin/starship init fish | source
+        @starship@/bin/starship init fish | source
 
     end"
 


### PR DESCRIPTION
### Description
Instead of running programs that print their shell config to stdout every time nushell initializes and saving their output to disk in .cache directory then sourcing it in the main config.nu file, just generate the config during nix build and source it directly from the nix store.

If you want you can implement something similar for all other shells too. It's just that for nushell this seems to be the only rational way.

also pay-respects nushell integration didn't ever work, now it generates the configuration correctly.
but even though the configuration that pay-respects generates is added to nushell config.nu correctly now it still doesn't work for me. On invocation it gives suggestions for the command that invoked it so not the last one before it that it is supposed to fix.

By the way, I have no idea why but tests fail even though I edited them according to my changes and error messages are either not helpful or I can't read them, I may know how to make nix modules but I never had to deal with home-manager test framework and am not ready to spend weeks trying to figure it out myself so help me with that.

like this for example:
```console
error: builder for '/nix/store/96d9f0h8sp47b5m4yjxssl8rbcx11nwn-carapace-nushell-config.drv' failed with exit code 127;
       last 1 log lines:
       > /build/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 1: @carapace@/bin/carapace: No such file or directory
       For full logs, run 'nix log /nix/store/96d9f0h8sp47b5m4yjxssl8rbcx11nwn-carapace-nushell-config.drv'.
```
full log does not say anything new because the log is 1 line long.
I don't know why tests expect `@carapace@/bin/carapace` while generating nushell config if they are only supposed to for other shells. There are more test failures of the same kind.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC
@ALameLlama @Weathercold @bobvanderlinden @water-sucks @terlar 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
