### PR TITLE
Stop garbage-collection empty fish completion packages

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -383,6 +383,15 @@ in
       '';
     };
 
+    home.extraDependencies = mkOption {
+      type = types.listOf types.pathInStore;
+      default = [ ];
+      description = ''
+        A list of paths that should be included in the home
+        closure but generally not visible.
+      '';
+    };
+
     home.path = mkOption {
       internal = true;
       description = "The derivation installing the user packages.";
@@ -780,6 +789,8 @@ in
       pkgs.runCommand "home-manager-generation"
         {
           preferLocalBuild = true;
+          passAsFile = [ "extraDependencies" ];
+          inherit (config.home) extraDependencies;
         }
         ''
           mkdir -p $out
@@ -796,6 +807,8 @@ in
 
           ln -s ${config.home-files} $out/home-files
           ln -s ${cfg.path} $out/home-path
+
+          cp "$extraDependenciesPath" "$out/extra-dependencies"
 
           ${cfg.extraBuilderCommands}
         '';


### PR DESCRIPTION
### Description

- Adds `home.extraDependencies`, which (like `system.extraDependencies` in NixOS) adds a package to the runtime closure without exposing it elsewhere.
- Uses this to keep empty Fish completions around. These are otherwise needlessly garbage-collected: garbage-collecting them saves almost no space (just an empty directory) and they're usually rebuilt soon after. See #6157.

The diff for the Fish change looks large, but all it does is add the inputs to `destructiveSymlinkJoin` to `home.extraDependencies` too: I have to move some code around to make that possible.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

(nmt-test-firefox-profiles-search and nmt-test-floorp-profiles-search fail, but they do so on master too... I'll try to find some time to track down what's going wrong there. Might be somehow related to #6668, since they're failing with output differing on `librewolf` versus `firefox` / `floorp` respectively...)

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

I don't know how to meaningfully unit-test this, but I can probably figure out how to add an integration test if you need one: along the lines of "in a VM test, run `nix-store --query -R ~/.local/state/home-manager/gcroots/current-home` and confirm some package added to `home.extraDependencies` is in there".

I'd appreciate suggestions on how to test this: I'm pretty new to Nix tests, and this is a bit fiddly to test because the whole point is that there should be no observable side effect of what I'm changing other than something not getting GC'd (which I don't know how to test other than running `nix` in an integration test).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@rycee for home-environment

I don't see a maintainer listed for Fish...