### PR TITLE
firefox: fix assertion when missing force for extensions

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -650,11 +650,11 @@ in {
               message = ''
                 Using '${
                   lib.showAttrPath (modulePath
-                    ++ [ "profiles" profileName "extensions" "settings" ])
+                    ++ [ "profiles" config.name "extensions" "settings" ])
                 }' will override all previous extensions settings.
                 Enable '${
                   lib.showAttrPath (modulePath
-                    ++ [ "profiles" profileName "extensions" "force" ])
+                    ++ [ "profiles" config.name "extensions" "force" ])
                 }' to acknowledge this.
               '';
             }


### PR DESCRIPTION
### Description

Fixes https://github.com/danth/stylix/issues/1049. I missed replacing `profileName` -> `config.name` when refactoring profile-specific assertions in #6402 :melting_face:.

Thanks for tracking the issue to my commit @danth!

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@brckd @khaneliman