### PR TITLE
firefox: don't show migration warning when bookmarks isn't set

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -383,27 +383,31 @@ in {
           bookmarks = mkOption {
             type = (with types;
               coercedTo bookmarkTypes.settingsType (bookmarks:
-                warn ''
-                  ${cfg.name} bookmarks have been refactored into a submodule that now explicitly require a 'force' option to be enabled.
+                if bookmarks != { } then
+                  warn ''
+                    ${cfg.name} bookmarks have been refactored into a submodule that now explicitly require a 'force' option to be enabled.
 
-                  Replace:
+                    Replace:
 
-                  ${moduleName}.profiles.${name}.bookmarks = [ ... ];
+                    ${moduleName}.profiles.${name}.bookmarks = [ ... ];
 
-                  With:
+                    With:
 
-                  ${moduleName}.profiles.${name}.bookmarks = {
+                    ${moduleName}.profiles.${name}.bookmarks = {
+                      force = true;
+                      settings = [ ... ];
+                    };
+                  '' {
                     force = true;
-                    settings = [ ... ];
-                  };
-                '' {
-                  force = true;
-                  settings = bookmarks;
-                }) (submodule ({ config, ... }:
-                  import ./profiles/bookmarks.nix {
-                    inherit config lib pkgs;
-                    modulePath = modulePath ++ [ "profiles" name "bookmarks" ];
-                  })));
+                    settings = bookmarks;
+                  }
+                else
+                  { }) (submodule ({ config, ... }:
+                    import ./profiles/bookmarks.nix {
+                      inherit config lib pkgs;
+                      modulePath = modulePath
+                        ++ [ "profiles" name "bookmarks" ];
+                    })));
             default = { };
             internal = !enableBookmarks;
             description = "Declarative bookmarks.";


### PR DESCRIPTION
### Description

Continuing from #6670, this stops the migration warning from being shown if you didn't have any bookmarks set.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@khaneliman @brckd 
