### PR TITLE
firefox: fix migrate search v7 test for all firefox forks

### DIFF
--- a/tests/modules/programs/firefox/profiles/search/expected-migrate-search-v7.json
+++ b/tests/modules/programs/firefox/profiles/search/expected-migrate-search-v7.json
@@ -8,7 +8,7 @@
         "16": "file:///run/current-system/sw/share/icons/hicolor/scalable/apps/nix-snowflake.svg"
       },
       "_isAppProvided": false,
-      "_loadPath": "[home-manager]/programs.librewolf.profiles.migrateSearchV7.search.engines.\"Nix Packages\"",
+      "_loadPath": "[home-manager]/programs.@name@.profiles.migrateSearchV7.search.engines.\"Nix Packages\"",
       "_metaData": {
         "order": 1
       },
@@ -38,7 +38,7 @@
         "16": "https://wiki.nixos.org/favicon.ico"
       },
       "_isAppProvided": false,
-      "_loadPath": "[home-manager]/programs.librewolf.profiles.migrateSearchV7.search.engines.\"NixOS Wiki\"",
+      "_loadPath": "[home-manager]/programs.@name@.profiles.migrateSearchV7.search.engines.\"NixOS Wiki\"",
       "_metaData": {
         "order": 2
       },


### PR DESCRIPTION
### Description

I'm not sure why this wasn't caught by the CI run in #6505, but this fixes one of the new tests I added in that PR so that it works for all firefox forks.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@brckd @khaneliman

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
