### PR TITLE
carapace: conditionally disable unnecessary fish completion workaround

### DIFF
--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -61,18 +61,23 @@ in {
       };
     };
 
-    xdg.configFile =
-      mkIf (config.programs.fish.enable && cfg.enableFishIntegration) (
+    xdg.configFile = mkIf (config.programs.fish.enable
+      && cfg.enableFishIntegration
+      && lib.versionOlder config.programs.fish.package.version "4.0.0") (
         # Convert the entries from `carapace --list` to empty
         # xdg.configFile."fish/completions/NAME.fish" entries.
         #
         # This is to disable fish builtin completion for each of the
-        # carapace-supported completions It is in line with the instructions from
+        # carapace-supported completions.
+        #
+        # This is necessary for carapace to properly work with fish version < 4.0b1.
+        #
+        # It is in line with the instructions from
         # carapace-bin:
         #
         #   carapace --list | awk '{print $1}' | xargs -I{} touch ~/.config/fish/completions/{}.fish
         #
-        # See https://github.com/rsteube/carapace-bin#getting-started
+        # See https://carapace-sh.github.io/carapace-bin/setup.html#fish
         let
           carapaceListFile = pkgs.runCommandLocal "carapace-list" {
             buildInputs = [ cfg.package ];

--- a/tests/modules/programs/carapace/fish.nix
+++ b/tests/modules/programs/carapace/fish.nix
@@ -8,13 +8,17 @@ lib.mkIf config.test.enableBig {
 
   nixpkgs.overlays = [ (self: super: { inherit (realPkgs) carapace; }) ];
 
-  nmt.script = ''
+  nmt.script = let
+    needsCompletionOverrides = lib.versionOlder realPkgs.fish.version "4.0.0";
+  in ''
     assertFileExists home-files/.config/fish/config.fish
     assertFileRegex home-files/.config/fish/config.fish \
       '/nix/store/.*carapace.*/bin/carapace _carapace fish \| source'
-
-    # Check whether completions are overridden.
+  '' + (lib.optionalString needsCompletionOverrides ''
+    # Check whether completions are overridden, necessary for fish < 4.0
     assertFileExists home-files/.config/fish/completions/git.fish
     assertFileContent home-files/.config/fish/completions/git.fish /dev/null
-  '';
+  '') + (lib.optionalString (!needsCompletionOverrides) ''
+    assertPathNotExists home-files/.config/fish/completions
+  '');
 }


### PR DESCRIPTION

### Description

This disables a workaround used for getting carapace to work correctly with the fish shell.
This workaround stopped being necessary with fish 4.0 (which has been in nixpkgs unstable for a few weeks now), as noted in https://carapace-sh.github.io/carapace-bin/setup.html#fish.

I was debating removing this workaround entirely instead of just adding a version check, but I wasn't sure if it's okay to assume that home-manager `master` users also use nixpkgs unstable.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Weathercold 
@bobvanderlinden 
