### PR TITLE
zellij: Add additional options for integrating with shells; default integration disabled again

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2157,6 +2157,18 @@ in {
           See https://github.com/WGUNDERWOOD/tex-fmt for more information.
         '';
       }
+
+      {
+        time = "2025-03-24T22:31:45+00:00";
+        message = ''
+          The following default values change from 'true' to
+          'false':
+
+          - programs.zellij.enableBashIntegration
+          - programs.zellij.enableFishIntegration
+          - programs.zellij.enableZshIntegration
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -6,7 +6,7 @@ let
   cfg = config.programs.zellij;
   yamlFormat = pkgs.formats.yaml { };
 in {
-  meta.maintainers = [ lib.hm.maintainers.mainrs ];
+  meta.maintainers = [ lib.maintainers.khaneliman lib.hm.maintainers.mainrs ];
 
   options.programs.zellij = {
     enable = lib.mkEnableOption "Zellij";

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -8,18 +8,39 @@ let
   yamlFormat = pkgs.formats.yaml { };
   zellijCmd = getExe cfg.package;
 
+  autostartOnShellStartModule = types.submodule {
+    options = {
+      enable = mkEnableOption "" // {
+        description = ''
+          Whether to autostart Zellij session on shell creation.
+        '';
+      };
+
+      attachExistingSession = mkEnableOption "" // {
+        description = ''
+          Whether to attach to the default session after being autostarted if a Zellij session already exists.
+        '';
+      };
+
+      exitShellOnExit = mkEnableOption "" // {
+        description = ''
+          Whether to exit the shell when Zellij exits after being autostarted.
+        '';
+      };
+    };
+  };
 in {
   meta.maintainers = [ hm.maintainers.mainrs ];
 
   options.programs.zellij = {
-    enable = mkEnableOption "zellij";
+    enable = mkEnableOption "Zellij";
 
     package = mkOption {
       type = types.package;
       default = pkgs.zellij;
       defaultText = literalExpression "pkgs.zellij";
       description = ''
-        The zellij package to install.
+        The Zellij package to install.
       '';
     };
 
@@ -41,6 +62,15 @@ in {
 
         See <https://zellij.dev/documentation> for the full
         list of options.
+      '';
+    };
+
+    autostartOnShellStart = mkOption {
+      type = types.nullOr autostartOnShellStartModule;
+      default = null;
+      description = ''
+        Options related to autostarting Zellij on shell creation.
+        Requires enable<Shell>Integration to apply to the respective <Shell>.
       '';
     };
 
@@ -69,17 +99,32 @@ in {
         text = lib.hm.generators.toKDL { } cfg.settings;
       };
 
-    programs.bash.initExtra = mkIf cfg.enableBashIntegration (mkOrder 200 ''
-      eval "$(${zellijCmd} setup --generate-auto-start bash)"
-    '');
+    programs.zsh.initExtra = mkIf (cfg.enableZshIntegration)
+      (if cfg.autostartOnShellStart.enable then (mkOrder 200 ''
+        eval "$(${zellijCmd} setup --generate-auto-start zsh)"
+      '') else
+        "");
 
-    programs.zsh.initContent = mkIf cfg.enableZshIntegration (mkOrder 200 ''
-      eval "$(${zellijCmd} setup --generate-auto-start zsh)"
-    '');
-
-    programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration
-      (mkOrder 200 ''
+    programs.fish.interactiveShellInit = mkIf (cfg.enableFishIntegration)
+      (if cfg.autostartOnShellStart.enable then ''
         eval (${zellijCmd} setup --generate-auto-start fish | string collect)
-      '');
+      '' else
+        "");
+
+    programs.bash.initExtra = mkIf (cfg.enableBashIntegration)
+      (if cfg.autostartOnShellStart.enable then ''
+        eval "$(${zellijCmd} setup --generate-auto-start bash)"
+      '' else
+        "");
+
+    home.sessionVariables = mkIf cfg.autostartOnShellStart.enable {
+      ZELLIJ_AUTO_ATTACH =
+        if cfg.autostartOnShellStart.attachExistingSession then
+          "true"
+        else
+          "false";
+      ZELLIJ_AUTO_EXIT =
+        if cfg.autostartOnShellStart.exitShellOnExit then "true" else "false";
+    };
   };
 }

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -5,6 +5,12 @@ let
 
   cfg = config.programs.zellij;
   yamlFormat = pkgs.formats.yaml { };
+
+  mkShellIntegrationOption = option:
+    option // {
+      default = false;
+      example = true;
+    };
 in {
   meta.maintainers = [ lib.maintainers.khaneliman lib.hm.maintainers.mainrs ];
 
@@ -61,14 +67,14 @@ in {
       '';
     };
 
-    enableBashIntegration =
-      lib.hm.shell.mkBashIntegrationOption { inherit config; };
+    enableBashIntegration = mkShellIntegrationOption
+      (lib.hm.shell.mkBashIntegrationOption { inherit config; });
 
-    enableFishIntegration =
-      lib.hm.shell.mkFishIntegrationOption { inherit config; };
+    enableFishIntegration = mkShellIntegrationOption
+      (lib.hm.shell.mkFishIntegrationOption { inherit config; });
 
-    enableZshIntegration =
-      lib.hm.shell.mkZshIntegrationOption { inherit config; };
+    enableZshIntegration = mkShellIntegrationOption
+      (lib.hm.shell.mkZshIntegrationOption { inherit config; });
   };
 
   config = let

--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -17,14 +17,7 @@ in {
   options.programs.zellij = {
     enable = lib.mkEnableOption "Zellij";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.zellij;
-      defaultText = lib.literalExpression "pkgs.zellij";
-      description = ''
-        The Zellij package to install.
-      '';
-    };
+    package = lib.mkPackageOption pkgs "zellij" { };
 
     settings = lib.mkOption {
       type = yamlFormat.type;

--- a/tests/modules/programs/zellij/enable-shells.nix
+++ b/tests/modules/programs/zellij/enable-shells.nix
@@ -4,9 +4,16 @@
   programs = {
     zellij = {
       enable = true;
-      enableBashIntegration = true;
+
+      autostartOnShellStart = {
+        enable = true;
+        attachExistingSession = true;
+        exitShellOnExit = true;
+      };
+
       enableZshIntegration = true;
       enableFishIntegration = true;
+      enableBashIntegration = true;
     };
     bash.enable = true;
     zsh.enable = true;
@@ -32,5 +39,13 @@
     assertFileContains \
       home-files/.config/fish/config.fish \
       'eval (@zellij@/bin/zellij setup --generate-auto-start fish | string collect)'
+
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileContains \
+      home-path/etc/profile.d/hm-session-vars.sh \
+      'export ZELLIJ_AUTO_ATTACH="true"'
+    assertFileContains \
+      home-path/etc/profile.d/hm-session-vars.sh \
+      'export ZELLIJ_AUTO_EXIT="true"'
   '';
 }

--- a/tests/modules/programs/zellij/enable-shells.nix
+++ b/tests/modules/programs/zellij/enable-shells.nix
@@ -5,11 +5,8 @@
     zellij = {
       enable = true;
 
-      autostartOnShellStart = {
-        enable = true;
-        attachExistingSession = true;
-        exitShellOnExit = true;
-      };
+      attachExistingSession = true;
+      exitShellOnExit = true;
 
       enableZshIntegration = true;
       enableFishIntegration = true;


### PR DESCRIPTION
### Description
Closes https://github.com/nix-community/home-manager/pull/6037
Follow up to discussion in https://github.com/nix-community/home-manager/pull/6358

Seems like interest was lost in that PR. Decisions made for restructuring from their approach:

- The environment variables mentioned, are only checked inside the `auto-start` scripts. It is also clearly described in their documentation. https://zellij.dev/documentation/integration.html
  - https://github.com/search?q=repo%3Azellij-org%2Fzellij%20ZELLIJ_AUTO_ATTACH&type=code
  - https://github.com/search?q=repo%3Azellij-org%2Fzellij+ZELLIJ_AUTO_EXIT&type=code

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
