### PR TITLE
smug: init module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -738,4 +738,10 @@
     github = "michaelvanstraten";
     githubId = 50352631;
   };
+  mipmip = {
+    name = "Pim Snel";
+    email = "post@pimsnel.com";
+    github = "mipmip";
+    githubId = 658612;
+  };
 }

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2222,6 +2222,15 @@ in {
           To resolve this, please add `objectKeys` to your assignment of `programs.jq.colors`.
         '';
       }
+      {
+        time = "2025-03-24T15:29:33+00:00";
+        message = ''
+          A new module is available: 'programs.smug'.
+
+          Session manager and task runner for tmux written in Go.
+          See https://github.com/ivaaaan/smug for more information.
+        '';
+      }
     ];
   };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -242,6 +242,7 @@ let
     ./programs/sioyek.nix
     ./programs/skim.nix
     ./programs/sm64ex.nix
+    ./programs/smug.nix
     ./programs/spotify-player.nix
     ./programs/sqls.nix
     ./programs/ssh.nix

--- a/modules/programs/smug.nix
+++ b/modules/programs/smug.nix
@@ -1,0 +1,145 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.smug;
+  iniFormat = pkgs.formats.yaml { };
+
+  mkOptionCommands = description:
+    lib.mkOption {
+      type = lib.types.nullOr (lib.types.listOf lib.types.str);
+      default = null;
+      description = description;
+    };
+
+  mkOptionRoot = description:
+    lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = description;
+    };
+
+in {
+  meta.maintainers = with lib.hm.maintainers; [ mipmip ];
+
+  options.programs.smug = {
+
+    enable = lib.mkEnableOption "Smug session manager";
+
+    package = lib.mkPackageOption pkgs "smug" { nullable = true; };
+
+    projects = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule [{
+        options = {
+          root = mkOptionRoot ''
+            Root path in filesystem of the smug project. This is where tmux
+            changes its directory to.
+
+            Application defaults to `$HOME`.
+          '';
+
+          windows = lib.mkOption {
+            type = lib.types.listOf (lib.types.submodule [{
+              options = {
+                name = lib.mkOption {
+                  type = lib.types.str;
+                  description = ''
+                    Name of the tmux window;
+                  '';
+                };
+
+                root = mkOptionRoot
+                  "Root path of window. This is relative to the path of the smug project.";
+
+                commands =
+                  mkOptionCommands "Commands to execute when window starts.";
+
+                layout = lib.mkOption {
+                  type = lib.types.enum [
+                    "main-horizontal"
+                    "main-vertical"
+                    "even-vertical"
+                    "even-horizontal"
+                    "tiled"
+                  ];
+                  description = ''
+                    Layout of window when opening panes.
+                  '';
+                };
+
+                manual = lib.mkOption {
+                  type = lib.types.nullOr lib.types.bool;
+                  default = null;
+                  description = ''
+                    Start window only manually, using the -w arg
+                  '';
+                };
+
+                panes = lib.mkOption {
+                  default = null;
+                  description = ''
+                    Panes to open in a window.
+                  '';
+                  type = lib.types.nullOr (lib.types.listOf
+                    (lib.types.submodule [{
+                      options = {
+                        root = mkOptionRoot
+                          "Root path of pane. This is relative to the path of the smug project.";
+                        commands = mkOptionCommands
+                          "Commands to execute when pane starts.";
+                        type = lib.mkOption {
+                          type = lib.types.enum [ "horizontal" "vertical" ];
+                          description = ''
+                            Type of pane.
+                          '';
+                        };
+                      };
+                    }]));
+                };
+              };
+            }]);
+            description = ''
+              Windows to create in the project session
+            '';
+          };
+
+          env = lib.mkOption {
+            type = lib.types.nullOr (lib.types.attrsOf lib.types.str);
+            default = null;
+            description = "Environment Variables to set in session.";
+          };
+
+          beforeStart = mkOptionCommands
+            "Commands to execute before the tmux-session starts.";
+
+          stop = mkOptionCommands
+            "Commands to execute after the tmux-session is destroyed.";
+        };
+      }]);
+      default = { };
+      description = "Attribute set with project configurations.";
+    };
+  };
+
+  config = let
+    cleanedProjects =
+      lib.filterAttrsRecursive (name: value: value != null) cfg.projects;
+
+    mkProjects = lib.attrsets.mapAttrs' (k: v: {
+      name = "${config.home.homeDirectory}/.config/smug/${k}.yml";
+      value.source = let
+        prjConf = lib.attrsets.mapAttrs' (name: value:
+          (lib.attrsets.nameValuePair
+            (if name == "beforeStart" then "before_start" else name) (value))) v
+          // {
+            session = k;
+            windows = lib.lists.forEach v.windows (winprop:
+              (lib.filterAttrsRecursive (name: value: value != null) winprop));
+          };
+      in iniFormat.generate "smug-project-${k}" prjConf;
+    });
+
+  in lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+    home.file = mkProjects cleanedProjects;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -172,6 +172,7 @@ let
       "sioyek"
       "skhd"
       "sm64ex"
+      "smug"
       "spotify-player"
       "starship"
       "taskwarrior"
@@ -390,6 +391,7 @@ in import nmtSrc {
     ./modules/programs/sftpman
     ./modules/programs/sioyek
     ./modules/programs/sm64ex
+    ./modules/programs/smug
     ./modules/programs/spotify-player
     ./modules/programs/ssh
     ./modules/programs/starship

--- a/tests/modules/programs/smug/blogdemo.yml
+++ b/tests/modules/programs/smug/blogdemo.yml
@@ -1,0 +1,33 @@
+before_start:
+- docker-compose -f my-microservices/docker-compose.yml up -d
+env:
+  FOO: bar
+root: ~/Developer/blog
+session: blogdemo
+stop:
+- docker stop $(docker ps -q)
+windows:
+- commands:
+  - docker-compose start
+  layout: main-vertical
+  manual: true
+  name: code
+  panes:
+  - commands:
+    - docker-compose exec php /bin/sh
+    - clear
+    root: .
+    type: horizontal
+  root: blog
+- commands:
+  - docker-compose start
+  layout: tiled
+  name: infrastructure
+  panes:
+  - commands:
+    - docker-compose up -d
+    - docker-compose exec php /bin/sh
+    - clear
+    root: .
+    type: horizontal
+  root: ~/Developer/blog/my-microservices

--- a/tests/modules/programs/smug/default.nix
+++ b/tests/modules/programs/smug/default.nix
@@ -1,0 +1,4 @@
+{
+  smug-settings = ./settings.nix;
+  smug-empty-settings = ./empty-settings.nix;
+}

--- a/tests/modules/programs/smug/empty-settings.nix
+++ b/tests/modules/programs/smug/empty-settings.nix
@@ -1,0 +1,6 @@
+{
+  programs.smug.enable = true;
+  nmt.script = ''
+    assertPathNotExists home-files/.config/smug
+  '';
+}

--- a/tests/modules/programs/smug/settings.nix
+++ b/tests/modules/programs/smug/settings.nix
@@ -1,0 +1,54 @@
+{
+  programs = {
+    smug = {
+      enable = true;
+
+      projects = {
+
+        blogdemo = {
+          root = "~/Developer/blog";
+          beforeStart = [
+            "docker-compose -f my-microservices/docker-compose.yml up -d" # my-microservices/docker-compose.yml is a relative to `root`-al
+          ];
+          env = { FOO = "bar"; };
+          stop = [ "docker stop $(docker ps -q)" ];
+          windows = [
+            {
+              name = "code";
+              root = "blog";
+              manual = true;
+              layout = "main-vertical";
+              commands = [ "docker-compose start" ];
+              panes = [{
+                type = "horizontal";
+                root = ".";
+                commands = [ "docker-compose exec php /bin/sh" "clear" ];
+              }];
+            }
+
+            {
+              name = "infrastructure";
+              root = "~/Developer/blog/my-microservices";
+              layout = "tiled";
+              commands = [ "docker-compose start" ];
+              panes = [{
+                type = "horizontal";
+                root = ".";
+                commands = [
+                  "docker-compose up -d"
+                  "docker-compose exec php /bin/sh"
+                  "clear"
+                ];
+              }];
+            }
+          ];
+        };
+
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/smug/blogdemo.yml ${./blogdemo.yml}
+  '';
+}


### PR DESCRIPTION
### Description

This adds smug, a session manager and task runner for tmux, as module. It includes support to write smug session configurations.  I also added multiple tests.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->