### PR TITLE
zsh: fix concatenation of aliases and global aliases

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -732,10 +732,11 @@ in
 
         (lib.mkIf (aliasesStr != "" || cfg.shellGlobalAliases != {}) (mkOrder 1100
           ((optionalString (aliasesStr != "") aliasesStr) +
-           (optionalString (cfg.shellGlobalAliases != {})
+                (optionalString (cfg.shellGlobalAliases != {})
+                 (optionalString (cfg.shellAliases != {}) "\n" +
              (concatStringsSep "\n" (lib.mapAttrsToList
                (k: v: "alias -g -- ${lib.escapeShellArg k}=${lib.escapeShellArg v}")
-               cfg.shellGlobalAliases))))))
+               cfg.shellGlobalAliases)))))))
 
         (lib.mkIf (dirHashesStr != "") (mkOrder 1150 ''
           # Named Directory Hashes

--- a/tests/modules/programs/zsh/aliases.nix
+++ b/tests/modules/programs/zsh/aliases.nix
@@ -1,0 +1,52 @@
+{ config, ... }:
+
+{
+  programs.zsh = {
+    enable = true;
+
+    shellAliases = {
+      test1 = "alias";
+      test2 = "alias2";
+    };
+    shellGlobalAliases = { global = "test"; };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+
+    assertFileContent home-files/.zshrc ${
+      builtins.toFile "expected-.zshrc" ''
+        typeset -U path cdpath fpath manpath
+        for profile in ''${(z)NIX_PROFILES}; do
+          fpath+=($profile/share/zsh/site-functions $profile/share/zsh/$ZSH_VERSION/functions $profile/share/zsh/vendor-completions)
+        done
+
+        HELPDIR="@zsh@/share/zsh/$ZSH_VERSION/help"
+
+        autoload -U compinit && compinit
+        # History options should be set in .zshrc and after oh-my-zsh sourcing.
+        # See https://github.com/nix-community/home-manager/issues/177.
+        HISTSIZE="10000"
+        SAVEHIST="10000"
+
+        HISTFILE="$HOME/.zsh_history"
+        mkdir -p "$(dirname "$HISTFILE")"
+
+        setopt HIST_FCNTL_LOCK
+        unsetopt APPEND_HISTORY
+        setopt HIST_IGNORE_DUPS
+        unsetopt HIST_IGNORE_ALL_DUPS
+        unsetopt HIST_SAVE_NO_DUPS
+        unsetopt HIST_FIND_NO_DUPS
+        setopt HIST_IGNORE_SPACE
+        unsetopt HIST_EXPIRE_DUPS_FIRST
+        setopt SHARE_HISTORY
+        unsetopt EXTENDED_HISTORY
+
+
+        alias -- test1=alias
+        alias -- test2=alias2
+        alias -g -- global=test''
+    }
+  '';
+}

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -1,13 +1,14 @@
 {
-  zsh-session-variables = ./session-variables.nix;
-  zsh-history-path-new-default = ./history-path-new-default.nix;
-  zsh-history-path-new-custom = ./history-path-new-custom.nix;
-  zsh-history-path-old-default = ./history-path-old-default.nix;
-  zsh-history-path-old-custom = ./history-path-old-custom.nix;
+  zsh-abbr = ./zsh-abbr.nix;
+  zsh-aliases = ./aliases.nix;
   zsh-history-ignore-pattern = ./history-ignore-pattern.nix;
+  zsh-history-path-new-custom = ./history-path-new-custom.nix;
+  zsh-history-path-new-default = ./history-path-new-default.nix;
+  zsh-history-path-old-custom = ./history-path-old-custom.nix;
+  zsh-history-path-old-default = ./history-path-old-default.nix;
   zsh-history-substring-search = ./history-substring-search.nix;
   zsh-prezto = ./prezto.nix;
+  zsh-session-variables = ./session-variables.nix;
   zsh-syntax-highlighting = ./syntax-highlighting.nix;
-  zsh-abbr = ./zsh-abbr.nix;
   zshrc-contents-priorities = ./zshrc-content-priorities.nix;
 }


### PR DESCRIPTION
Accidentally bump the lines against each other. Adding a newline to move global aliases to another line when you have both.

### Description
Closes https://github.com/nix-community/home-manager/issues/6697
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
