### PR TITLE
claude-code: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -81,6 +81,7 @@ let
     ./programs/cava.nix
     ./programs/cavalier.nix
     ./programs/chromium.nix
+    ./programs/claude-code.nix
     ./programs/cmus.nix
     ./programs/command-not-found/command-not-found.nix
     ./programs/comodoro.nix

--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -1,0 +1,75 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkIf mkOption types;
+  cfg = config.programs.claude-code;
+in {
+  meta.maintainers = with lib.maintainers; [ malo ];
+
+  options.programs.claude-code = {
+    enable = lib.mkEnableOption "Claude Code CLI";
+
+    package = lib.mkPackageOption pkgs "claude-code" { };
+
+    disableAutoUpdate = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to disable the automatic update check on startup.
+        This is recommended when using home-manager to manage {command}`claude`.
+      '';
+    };
+
+    enableOptionalDependencies = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to install the optional dependencies for {command}`claude`.
+        This includes:
+        - {command}`git` (for git operations)
+        - {command}`rg` (for code search)
+        - {command}`gh` (GitHub CLI, for GitHub operations)
+        - {command}`glab` (GitLab CLI, for GitLab operations)
+      '';
+    };
+
+    withGitHubCLI = mkOption {
+      type = types.bool;
+      default = cfg.enableOptionalDependencies;
+      description = ''
+        Whether to enable GitHub CLI ({command}`gh`) as a dependency.
+        This is useful if you work with GitHub repositories.
+
+        Defaults to the value of {option}`programs.claude-code.enableOptionalDependencies`.
+      '';
+    };
+
+    withGitLabCLI = mkOption {
+      type = types.bool;
+      default = cfg.enableOptionalDependencies;
+      description = ''
+        Whether to install GitLab CLI ({command}`glab`) as a dependency.
+        This is useful if you work with GitLab repositories.
+
+        Defaults to the value of {option}`programs.claude-code.enableOptionalDependencies`.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ cfg.package ] ++ lib.optional cfg.withGitLabCLI pkgs.glab;
+
+    # Enable integrated modules for dependencies when needed
+    programs.git.enable = mkIf cfg.enableOptionalDependencies true;
+    programs.gh.enable = mkIf cfg.withGitHubCLI true;
+    programs.ripgrep.enable = mkIf cfg.enableOptionalDependencies true;
+
+    # Add activation script to disable auto-updates if the user wants that
+    home.activation.disableClaudeAutoUpdates = lib.mkIf cfg.disableAutoUpdate
+      (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        $DRY_RUN_CMD ${
+          lib.getExe cfg.package
+        } config set -g autoUpdaterStatus disabled || true
+      '');
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -83,6 +83,7 @@ let
       "btop"
       "carapace"
       "cava"
+      "claude-code"
       "cmus"
       "comodoro"
       "darcs"
@@ -294,6 +295,7 @@ in import nmtSrc {
     ./modules/programs/btop
     ./modules/programs/carapace
     ./modules/programs/cava
+    ./modules/programs/claude-code
     ./modules/programs/cmus
     ./modules/programs/comodoro
     ./modules/programs/darcs

--- a/tests/modules/programs/claude-code/default.nix
+++ b/tests/modules/programs/claude-code/default.nix
@@ -1,0 +1,1 @@
+{ claude-code = ./test.nix; }

--- a/tests/modules/programs/claude-code/test.nix
+++ b/tests/modules/programs/claude-code/test.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+{
+  nixpkgs.overlays = [
+    (self: super: {
+      claude-code = pkgs.writeShellScriptBin "claude" ''
+        echo "Claude Code CLI mock"
+      '';
+    })
+  ];
+
+  programs.claude-code = { enable = true; };
+
+  nmt.script = ''
+    assertFileRegex activate "claude config set -g autoUpdaterStatus disabled"
+  '';
+}


### PR DESCRIPTION
### Description

This PR adds support for Anthropic's Claude Code CLI to Home Manager.

Features:
  - Provides options to disable auto-updates (defaults to `true`)
    - `claude-code` tries to update at each start, which isn't compatible with Nix.
    - There is a setting, [`autoUpdaterStatus`](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview#global-configuration), which can be used to disable this behavior.
    - The natural way to handle this would be to have `home-manager` manage the settings file it uses (`~/.claude.json`). However, this file is updated frequently by the application with project specific settings, so managing it with `home-manager` isn't really an option.
    - As such, this module adds `claude config set -g autoUpdaterStatus disabled` to the activation script when `programs.claude-code.disableAutoUpdate` is set to `true` (which is the default).
  - Provides options to install optional runtime dependencies.

(This is my first PR to `home-manager`, apologies in advance if something about this PR doesn't match conventions etc.)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).
