### PR TITLE
distrobox: replace hardcoded command path with config package's path

### DIFF
--- a/modules/programs/distrobox.nix
+++ b/modules/programs/distrobox.nix
@@ -87,7 +87,7 @@ in {
         if [[ $prev_hash != $new_hash ]]; then
           rm -rf /tmp/storage-run-1000/containers
           rm -rf /tmp/storage-run-1000/libpod/tmp
-          $HOME/.nix-profile/bin/distrobox-assemble create --file $containers_file
+          ${cfg.package}/bin/distrobox-assemble create --file $containers_file
           echo $new_hash > $prev_hash_file
         fi
       ''}";


### PR DESCRIPTION
### Description

The distrobox-home-manager systemd service was failing because it was trying to access the distrobox-assemble binary at a hardcoded path (`$HOME/.nix-profile/bin/distrobox-assemble`), which doesn't exist when the package is installed elsewhere.

This pr uses `${cfg.package}/bin/distrobox-assemble` instead, which properly references the installed package.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
