### PR TITLE
fish: Fix manpage completion generation with paths containing spaces

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -449,7 +449,7 @@ in {
           for src in $srcs; do
             if [ -d $src/share/man ]; then
               find -L $src/share/man -type f \
-                | xargs python ${cfg.package}/share/fish/tools/create_manpage_completions.py --directory $out \
+                -exec python ${cfg.package}/share/fish/tools/create_manpage_completions.py --directory $out {} + \
                 > /dev/null
             fi
           done

--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -4,4 +4,5 @@
   fish-functions = ./functions.nix;
   fish-no-functions = ./no-functions.nix;
   fish-plugins = ./plugins.nix;
+  fish-manpage = ./manpage.nix;
 }

--- a/tests/modules/programs/fish/manpage.nix
+++ b/tests/modules/programs/fish/manpage.nix
@@ -1,0 +1,12 @@
+{ lib, pkgs, ... }: {
+  config = {
+    programs.fish = { enable = true; };
+
+    home.packages = [
+      (pkgs.runCommand "manpage-with-space" { } ''
+        mkdir -p $out/share/man/man1
+        echo "It works!" >"$out/share/man/man1/hello -inject.1"
+      '')
+    ];
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Manual pages with spaces in their paths can lead to argument injection.

```console
$ man -w 'MPSCNNBatchNormalizationDataSource -p'
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/share/man/man3/MPSCNNBatchNormalizationDataSource -p.3
$ nix log /nix/store/...
usage: create_manpage_completions.py [-h] [-c CLEANUP_IN] [-d DIRECTORY] [-k]
                                     [-m] [-p] [-s] [-v {0,1,2}] [-z]
                                     [file_paths ...]
create_manpage_completions.py: error: unrecognized arguments: -.3
```

Alternatively, we can use `find -print0 | xargs -0` but let's use `find -exec` and save an invocation to `xargs`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
