### PR TITLE
home-manager: use --argstr for news file paths to handle special chars

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -791,8 +791,8 @@ function buildNews() {
     nix-instantiate \
         --no-build-output --strict \
         --eval '<home-manager/home-manager/build-news.nix>' \
-        --arg newsJsonFile "\"$(escapeForNix "$newsJsonFile")\"" \
-        --arg newsReadIdsFile "\"$(escapeForNix "$readIdsFile")\"" \
+        --argstr newsJsonFile "\"$(escapeForNix "$newsJsonFile")\"" \
+        --argstr newsReadIdsFile "\"$(escapeForNix "$readIdsFile")\"" \
         "${extraArgs[@]}" \
         > "$newsNixFile"
 }


### PR DESCRIPTION
Fix #5279 where paths with special characters such as @ break news handling.

### Description

This simply uses --argstr instead of --arg when invoking build-news.nix so that special characters such as '@' are properly evaluated.

See also discussion in https://discourse.nixos.org/t/62168/11

### Checklist

- [Y ] Change is backwards compatible.

- [ Y] Code formatted with `./format`.

- [ Y] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ N] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [Y ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [N ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
