### PR TITLE
kdeconnect: trigger indicator service after generic tray.target

### DIFF
--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -68,12 +68,7 @@ in {
       systemd.user.services.kdeconnect-indicator = {
         Unit = {
           Description = "kdeconnect-indicator";
-          After = [
-            "graphical-session.target"
-            "polybar.service"
-            "taffybar.service"
-            "stalonetray.service"
-          ];
+          After = [ "graphical-session.target" "tray.target" ];
           PartOf = [ "graphical-session.target" ];
           Requires = [ "tray.target" ];
         };


### PR DESCRIPTION
Each of `polybar.service`, `stalonetray.service` and `taffybar.service` contains `WantedBy=tray.target`.

So we can use a single `tray.target` in `kdeconnect-indicator.service`'s `After=`.

This also makes the applet service tray implementation agnostic, so long as it integrates with `tray.target`.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@adisbladis 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
