### PR TITLE
fzf: fix zsh integration (keybinds rewritten by omz)

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -195,8 +195,10 @@ in {
     # Note, since fzf unconditionally binds C-r we use `mkOrder` to make the
     # initialization show up a bit earlier. This is to make initialization of
     # other history managers, like mcfly or atuin, take precedence.
+    # Still needs to be initialized after oh-my-zsh (order 800), otherwise
+    # omz will take precedence.
     programs.zsh.initContent =
-      mkIf cfg.enableZshIntegration (mkOrder 200 zshIntegration);
+      mkIf cfg.enableZshIntegration (mkOrder 810 zshIntegration);
 
     programs.fish.interactiveShellInit =
       mkIf cfg.enableFishIntegration (mkOrder 200 fishIntegration);


### PR DESCRIPTION
### Description

fzf history keybind (^R) was being rewritten by omz.
This PR moves the initialization of the fzf zsh integration just after omz integration (but sill before other history managers, eg: atuin)

Fixes https://github.com/nix-community/home-manager/issues/6704

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
