### PR TITLE
thunderbird: set additional gmail smtpserver settings

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -387,6 +387,8 @@ in {
         attrsOf (submodule ({ config, ... }: {
           config.thunderbird = {
             settings = lib.mkIf (config.flavor == "gmail.com") (id: {
+              "mail.smtpserver.smtp_${id}.authMethod" =
+                mkOptionDefault 10; # 10 = OAuth2
               "mail.server.server_${id}.authMethod" =
                 mkOptionDefault 10; # 10 = OAuth2
               "mail.server.server_${id}.socketType" =


### PR DESCRIPTION
### Description

When email account is gmail in thunderbird, set additional server settings.
Addition to already merged https://github.com/nix-community/home-manager/pull/6579.
As seen in https://github.com/nix-community/home-manager/issues/4988 the smtp authMethod wasn't include in the merge and is also needed, because without the authMethod is by default set to password only.

Please provide a brief description of your change.

Added a default option for the setting `mail.smtpserver.smtp_${id}.authMethod` exactly like in the above mentioned pr.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@d-dervishi

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
