### PR TITLE
helix: avoid IFD

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -212,9 +212,13 @@ in {
     xdg.configFile = let
       settings = {
         "helix/config.toml" = mkIf (cfg.settings != { }) {
-          text =
-            builtins.readFile (tomlFormat.generate "helix-config" cfg.settings)
-            + "\n" + cfg.extraConfig;
+          source = let
+            configFile = tomlFormat.generate "config.toml" cfg.settings;
+            extraConfigFile =
+              pkgs.writeText "extra-config.toml" ("\n" + cfg.extraConfig);
+          in pkgs.runCommand "helix-config.toml" { } ''
+            cat ${configFile} ${extraConfigFile} >> $out
+          '';
         };
         "helix/languages.toml" = mkIf (cfg.languages != { }) {
           source = tomlFormat.generate "helix-languages-config" cfg.languages;


### PR DESCRIPTION
### Description

Avoids IFD in the helix module which was introduced in #6575.
The helix module fails to build when `--no-allow-import-from-derivation` is enabled.

Command to reproduce the results:

```
nix build --reference-lock-file flake.lock --no-allow-import-from-derivation ./tests#test-helix-example-settings
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@Philipp-M 
