### PR TITLE
feat(bat): interactive init for `batpipe` and `batman`

### DIFF
--- a/modules/programs/bat.nix
+++ b/modules/programs/bat.nix
@@ -1,6 +1,8 @@
 { config, lib, pkgs, ... }:
 let
-  inherit (lib) literalExpression mkEnableOption mkOption mkIf types;
+  inherit (builtins) elem;
+  inherit (lib)
+    getExe literalExpression mkEnableOption mkOption mkIf optionalString types;
 
   cfg = config.programs.bat;
 
@@ -18,6 +20,26 @@ let
         --${k}
       '') (attrNames enabledBoolFlags);
     in keyValuePairs + switches;
+
+  initScript = { program, shell, flags ? [ ], }:
+    if (shell != "fish") then ''
+      eval "$(${getExe program} ${toString flags})"
+    '' else ''
+      ${getExe program} ${toString flags} | source
+    '';
+
+  shellInit = shell:
+    optionalString (elem pkgs.bat-extras.batpipe cfg.extraPackages)
+    (initScript {
+      program = pkgs.bat-extras.batpipe;
+      inherit shell;
+    }) + optionalString (elem pkgs.bat-extras.batman cfg.extraPackages)
+    (initScript {
+      program = pkgs.bat-extras.batman;
+      inherit shell;
+      flags = [ "--export-env" ];
+    });
+
 in {
   meta.maintainers = with lib.maintainers; [ khaneliman ];
 
@@ -167,6 +189,19 @@ in {
           run ${lib.getExe cfg.package} cache --build
         )
       '';
+
+      programs = {
+        bash =
+          mkIf (!config.programs.fish.enable) { initExtra = shellInit "bash"; };
+        fish = mkIf config.programs.fish.enable {
+          interactiveShellInit = shellInit "fish";
+        };
+        zsh =
+          mkIf (!config.programs.fish.enable && config.programs.zsh.enable) {
+            initExtra = shellInit "zsh";
+          };
+      };
+
     }
   ]);
 }


### PR DESCRIPTION
### Description

let `batpipe` and `batman` set up useful env vars for interactive shell
sessions if declared in `programs.bat.extraPackages`, as demonstrated in
upstream nixpkgs

this commit is adapted from the nixpkgs equivalent as it was seen here:
https://github.com/NixOS/nixpkgs/blob/698214a32beb4f4c8e3942372c694f40848b360d/nixos/modules/programs/bat.nix

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@khaneliman 
