### PR TITLE
fzf: update zsh integration to be after plugins

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -198,7 +198,7 @@ in {
     # Still needs to be initialized after oh-my-zsh (order 800), otherwise
     # omz will take precedence.
     programs.zsh.initContent =
-      mkIf cfg.enableZshIntegration (mkOrder 810 zshIntegration);
+      mkIf cfg.enableZshIntegration (mkOrder 910 zshIntegration);
 
     programs.fish.interactiveShellInit =
       mkIf cfg.enableFishIntegration (mkOrder 200 fishIntegration);


### PR DESCRIPTION
### Description

ensure that fzf is initialized after plugins (fixes https://github.com/nix-community/home-manager/issues/6704#issuecomment-2758808689)

we could also add a config to disable plugin lazy loading 🤔 

### Checklist


- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@khaneliman
