### PR TITLE
newsboat: add a package option to the module

### DIFF
--- a/modules/programs/newsboat.nix
+++ b/modules/programs/newsboat.nix
@@ -39,6 +39,8 @@ in {
     programs.newsboat = {
       enable = mkEnableOption "the Newsboat feed reader";
 
+      package = mkPackageOption pkgs "newsboat" { nullable = true; };
+
       urls = mkOption {
         type = types.listOf (types.submodule {
           options = {
@@ -132,7 +134,7 @@ in {
       '';
     }];
 
-    home.packages = [ pkgs.newsboat ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     # Use ~/.newsboat on stateVersion < 21.05 and use ~/.config/newsboat for
     # stateVersion >= 21.05.


### PR DESCRIPTION
### Description

The newboat module did not have a package option. 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@sumnerevans 
