### PR TITLE
auto-upgrade: unbreak on unattended, loginctl enable-linger systems

### DIFF
--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -8,6 +8,16 @@ let
     path = config.programs.home-manager.path;
   };
 
+  autoUpgradeApp = pkgs.writeShellApplication {
+    name = "home-manager-auto-upgrade";
+    text = ''
+      echo "Update Nix's channels"
+      nix-channel --update
+      echo "Upgrade Home Manager"
+      home-manager switch
+    '';
+    runtimeInputs = with pkgs; [ homeManagerPackage nix ];
+  };
 in {
   meta.maintainers = [ lib.hm.maintainers.pinage404 ];
 
@@ -52,14 +62,7 @@ in {
 
       services.home-manager-auto-upgrade = {
         Unit.Description = "Home Manager upgrade";
-
-        Service.ExecStart = toString
-          (pkgs.writeShellScript "home-manager-auto-upgrade" ''
-            echo "Update Nix's channels"
-            ${pkgs.nix}/bin/nix-channel --update
-            echo "Upgrade Home Manager"
-            ${homeManagerPackage}/bin/home-manager switch
-          '');
+        Service.ExecStart = "${autoUpgradeApp}/bin/home-manager-auto-upgrade";
       };
     };
   };


### PR DESCRIPTION
Fixes https://github.com/nix-community/home-manager/issues/3127

Tested on my servers with the following configuration:
```
  services.home-manager.autoUpgrade = {
    enable = true;
    frequency = "03:40";
  };
  # TODO: upstream to home-manager
  systemd.user.services.home-manager-auto-upgrade.Service.ExecStart = lib.mkForce ("${pkgs.writeShellApplication {
    name = "home-manager-auto-upgrade";
    text = ''
      echo "Update Nix's channels"
      nix-channel --update
      echo "Upgrade Home Manager"
      home-manager switch
    '';
    runtimeInputs = with pkgs; [
      nix
      (callPackage <home-manager/home-manager> { path = config.programs.home-manager.path; })
    ];
  }}/bin/home-manager-auto-upgrade");
```
By running:
```
home-manager switch
systemctl --user start home-manager-auto-upgrade.service
journalctl --user -u home-manager-auto-upgrade.service -f
```
And then confirming that everything seemed to be working fine.
Disclaimer: I haven't waited 24 hours yet so the auto-run didn't happen yet, but I don't see why it would fail. I'll make sure to come report here if it does fail, as I have alerting setup for failing systemd services.

Code tested 

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

cc @pinage404 