### PR TITLE
granted: Add override for package

### DIFF
--- a/modules/programs/granted.nix
+++ b/modules/programs/granted.nix
@@ -5,13 +5,19 @@ with lib;
 let
 
   cfg = config.programs.granted;
-  package = pkgs.granted;
 
 in {
   meta.maintainers = [ hm.maintainers.wcarlsen ];
 
   options.programs.granted = {
     enable = mkEnableOption "granted";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.granted;
+      defaultText = literalExpression "pkgs.granted";
+      description = "The granted package to install.";
+    };
 
     enableZshIntegration =
       lib.hm.shell.mkZshIntegrationOption { inherit config; };
@@ -21,19 +27,19 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ package ];
+    home.packages = [ cfg.package ];
 
     programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
       function assume() {
         export GRANTED_ALIAS_CONFIGURED="true"
-        source ${package}/bin/assume "$@"
+        source ${cfg.package}/bin/assume "$@"
         unset GRANTED_ALIAS_CONFIGURED
       }
     '';
 
     programs.fish.functions.assume = mkIf cfg.enableFishIntegration ''
       set -x GRANTED_ALIAS_CONFIGURED "true"
-      source ${package}/share/assume.fish $argv
+      source ${cfg.package}/share/assume.fish $argv
       set -e GRANTED_ALIAS_CONFIGURED
     '';
   };

--- a/modules/programs/granted.nix
+++ b/modules/programs/granted.nix
@@ -12,12 +12,7 @@ in {
   options.programs.granted = {
     enable = mkEnableOption "granted";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.granted;
-      defaultText = literalExpression "pkgs.granted";
-      description = "The granted package to install.";
-    };
+    package = lib.mkPackageOption pkgs "granted" { };
 
     enableZshIntegration =
       lib.hm.shell.mkZshIntegrationOption { inherit config; };


### PR DESCRIPTION
I would like to use the unstable version in my home-manager so let's make it possible to override.

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
 
 @wcarlsen