### PR TITLE
treewide: use mkPackageOption

### DIFF
--- a/modules/programs/alacritty.nix
+++ b/modules/programs/alacritty.nix
@@ -10,12 +10,7 @@ in {
     programs.alacritty = {
       enable = mkEnableOption "Alacritty";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.alacritty;
-        defaultText = literalExpression "pkgs.alacritty";
-        description = "The Alacritty package to install.";
-      };
+      package = lib.mkPackageOption pkgs "alacritty" { };
 
       settings = mkOption {
         type = tomlFormat.type;

--- a/modules/programs/eclipse.nix
+++ b/modules/programs/eclipse.nix
@@ -13,14 +13,9 @@ in {
     programs.eclipse = {
       enable = mkEnableOption "Eclipse";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.eclipses.eclipse-platform;
-        defaultText = literalExpression "pkgs.eclipses.eclipse-platform";
-        example = literalExpression "pkgs.eclipses.eclipse-java";
-        description = ''
-          The Eclipse package to install.
-        '';
+      package = lib.mkPackageOption pkgs "eclipse" {
+        default = [ "eclipses" "eclipse-platform" ];
+        example = "pkgs.eclipses.eclipse-java";
       };
 
       enableLombok = mkOption {

--- a/modules/programs/eww.nix
+++ b/modules/programs/eww.nix
@@ -13,15 +13,7 @@ in {
   options.programs.eww = {
     enable = mkEnableOption "eww";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.eww;
-      defaultText = literalExpression "pkgs.eww";
-      example = literalExpression "pkgs.eww";
-      description = ''
-        The eww package to install.
-      '';
-    };
+    package = lib.mkPackageOption pkgs "eww" { };
 
     configDir = mkOption {
       type = types.nullOr types.path;

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -254,14 +254,7 @@ in {
     programs.fish = {
       enable = mkEnableOption "fish, the friendly interactive shell";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.fish;
-        defaultText = literalExpression "pkgs.fish";
-        description = ''
-          The fish package to install. May be used to change the version.
-        '';
-      };
+      package = lib.mkPackageOption pkgs "fish" { };
 
       generateCompletions = mkEnableOption
         "the automatic generation of completions based upon installed man pages"

--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -13,12 +13,7 @@ in {
   options.programs.foot = {
     enable = mkEnableOption "Foot terminal";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.foot;
-      defaultText = literalExpression "pkgs.foot";
-      description = "The foot package to install";
-    };
+    package = lib.mkPackageOption pkgs "foot" { };
 
     server.enable = mkEnableOption "Foot terminal server";
 

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -76,12 +76,10 @@ in {
     programs.git = {
       enable = mkEnableOption "Git";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.git;
-        defaultText = literalExpression "pkgs.git";
-        description = ''
-          Git package to install. Use {var}`pkgs.gitAndTools.gitFull`
+      package = lib.mkPackageOption pkgs "git" {
+        example = "pkgs.gitFull";
+        extraDescription = ''
+          Use {var}`pkgs.gitFull`
           to gain access to {command}`git send-email` for instance.
         '';
       };

--- a/modules/programs/ion.nix
+++ b/modules/programs/ion.nix
@@ -14,14 +14,7 @@ in {
   options.programs.ion = {
     enable = mkEnableOption "the Ion Shell. Compatible with Redox and Linux";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.ion;
-      defaultText = literalExpression "pkgs.ion";
-      description = ''
-        The ion package to install. May be used to change the version.
-      '';
-    };
+    package = lib.mkPackageOption pkgs "ion" { };
 
     initExtra = mkOption {
       type = types.lines;

--- a/modules/programs/java.nix
+++ b/modules/programs/java.nix
@@ -21,14 +21,9 @@ in {
         '';
       };
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.jdk;
-        defaultText = "pkgs.jdk";
-        description = ''
-          Java package to install. Typical values are
-          `pkgs.jdk` or `pkgs.jre`.
-        '';
+      package = lib.mkPackageOption pkgs "java" {
+        default = "jdk";
+        example = "pkgs.jre";
       };
     };
   };

--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -21,14 +21,7 @@ in {
   options.programs.keychain = {
     enable = mkEnableOption "keychain";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.keychain;
-      defaultText = literalExpression "pkgs.keychain";
-      description = ''
-        Keychain package to install.
-      '';
-    };
+    package = lib.mkPackageOption pkgs "keychain" { };
 
     keys = mkOption {
       type = types.listOf types.str;

--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -89,14 +89,7 @@ in {
   options.programs.kitty = {
     enable = mkEnableOption "Kitty terminal emulator";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.kitty;
-      defaultText = literalExpression "pkgs.kitty";
-      description = ''
-        Kitty package to install.
-      '';
-    };
+    package = lib.mkPackageOption pkgs "kitty" { };
 
     darwinLaunchOptions = mkOption {
       type = types.nullOr (types.listOf types.str);

--- a/modules/programs/mangohud.nix
+++ b/modules/programs/mangohud.nix
@@ -28,12 +28,7 @@ in {
     programs.mangohud = {
       enable = mkEnableOption "Mangohud";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.mangohud;
-        defaultText = literalExpression "pkgs.mangohud";
-        description = "The Mangohud package to install.";
-      };
+      package = lib.mkPackageOption pkgs "mangohud" { };
 
       enableSessionWide = mkOption {
         type = types.bool;

--- a/modules/programs/mercurial.nix
+++ b/modules/programs/mercurial.nix
@@ -14,12 +14,7 @@ in {
     programs.mercurial = {
       enable = mkEnableOption "Mercurial";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.mercurial;
-        defaultText = literalExpression "pkgs.mercurial";
-        description = "Mercurial package to install.";
-      };
+      package = lib.mkPackageOption pkgs "mercurial" { };
 
       userName = mkOption {
         type = types.str;

--- a/modules/programs/mods.nix
+++ b/modules/programs/mods.nix
@@ -10,12 +10,7 @@ in {
   options.programs.mods = {
     enable = mkEnableOption "mods";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.mods;
-      defaultText = literalExpression "pkgs.mods";
-      description = "The mods package to install";
-    };
+    package = lib.mkPackageOption pkgs "mods" { };
 
     settings = mkOption {
       type = yamlFormat.type;

--- a/modules/programs/obs-studio.nix
+++ b/modules/programs/obs-studio.nix
@@ -13,14 +13,7 @@ in {
     programs.obs-studio = {
       enable = mkEnableOption "obs-studio";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.obs-studio;
-        defaultText = literalExpression "pkgs.obs-studio";
-        description = ''
-          OBS Studio package to install.
-        '';
-      };
+      package = lib.mkPackageOption pkgs "obs-studio" { };
 
       finalPackage = mkOption {
         type = types.package;

--- a/modules/programs/opam.nix
+++ b/modules/programs/opam.nix
@@ -12,12 +12,7 @@ in {
   options.programs.opam = {
     enable = mkEnableOption "Opam";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.opam;
-      defaultText = literalExpression "pkgs.opam";
-      description = "Opam package to install.";
-    };
+    package = lib.mkPackageOption pkgs "opam" { };
 
     enableBashIntegration =
       lib.hm.shell.mkBashIntegrationOption { inherit config; };

--- a/modules/programs/pqiv.nix
+++ b/modules/programs/pqiv.nix
@@ -11,12 +11,7 @@ in {
   options.programs.pqiv = {
     enable = mkEnableOption "pqiv image viewer";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.pqiv;
-      defaultText = literalExpression "pkgs.pqiv";
-      description = "The pqiv package to install.";
-    };
+    package = lib.mkPackageOption pkgs "pqiv" { };
 
     settings = mkOption {
       type = iniFormat.type;

--- a/modules/programs/qutebrowser.nix
+++ b/modules/programs/qutebrowser.nix
@@ -41,12 +41,7 @@ in {
   options.programs.qutebrowser = {
     enable = mkEnableOption "qutebrowser";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.qutebrowser;
-      defaultText = literalExpression "pkgs.qutebrowser";
-      description = "Qutebrowser package to install.";
-    };
+    package = lib.mkPackageOption pkgs "qutebrowser" { };
 
     aliases = mkOption {
       type = types.attrsOf types.str;

--- a/modules/programs/swayimg.nix
+++ b/modules/programs/swayimg.nix
@@ -8,12 +8,9 @@ in {
 
   options.programs.swayimg = {
     enable = lib.mkEnableOption "swayimg";
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.swayimg;
-      defaultText = lib.literalExpression "pkgs.swayimg";
-      description = "The swayimg package to install";
-    };
+
+    package = lib.mkPackageOption pkgs "swayimg" { };
+
     settings = lib.mkOption {
       type = iniFormat.type;
       default = { };

--- a/modules/programs/terminator.nix
+++ b/modules/programs/terminator.nix
@@ -33,12 +33,7 @@ in {
   options.programs.terminator = {
     enable = mkEnableOption "terminator, a tiling terminal emulator";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.terminator;
-      example = literalExpression "pkgs.terminator";
-      description = "terminator package to install.";
-    };
+    package = lib.mkPackageOption pkgs "terminator" { };
 
     config = mkOption {
       default = { };

--- a/modules/programs/tint2.nix
+++ b/modules/programs/tint2.nix
@@ -13,12 +13,7 @@ in {
     enable =
       mkEnableOption "tint2, a simple, unobtrusive and light panel for Xorg";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.tint2;
-      defaultText = literalExpression "pkgs.tint2";
-      description = "Tint2 package to install.";
-    };
+    package = lib.mkPackageOption pkgs "tint2" { };
 
     extraConfig = mkOption {
       type = types.lines;

--- a/modules/programs/tiny.nix
+++ b/modules/programs/tiny.nix
@@ -15,12 +15,7 @@ in {
     programs.tiny = {
       enable = mkEnableOption "tiny, a TUI IRC client written in Rust";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.tiny;
-        defaultText = literalExpression "pkgs.tiny";
-        description = "The {command}`tiny` package to install.";
-      };
+      package = lib.mkPackageOption pkgs "tiny" { };
 
       settings = mkOption {
         type = format.type;

--- a/modules/programs/tmate.nix
+++ b/modules/programs/tmate.nix
@@ -13,13 +13,7 @@ in {
     programs.tmate = {
       enable = mkEnableOption "tmate";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.tmate;
-        defaultText = literalExpression "pkgs.tmate";
-        example = literalExpression "pkgs.tmate";
-        description = "The tmate package to install.";
-      };
+      package = lib.mkPackageOption pkgs "tmate" { };
 
       host = mkOption {
         type = with types; nullOr str;

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -226,13 +226,7 @@ in {
         '';
       };
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.tmux;
-        defaultText = literalExpression "pkgs.tmux";
-        example = literalExpression "pkgs.tmux";
-        description = "The tmux package to install";
-      };
+      package = lib.mkPackageOption pkgs "tmux" { };
 
       reverseSplit = mkOption {
         default = false;

--- a/modules/programs/urxvt.nix
+++ b/modules/programs/urxvt.nix
@@ -10,12 +10,7 @@ in {
   options.programs.urxvt = {
     enable = mkEnableOption "rxvt-unicode terminal emulator";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.rxvt-unicode;
-      defaultText = literalExpression "pkgs.rxvt-unicode";
-      description = "rxvt-unicode package to install.";
-    };
+    package = lib.mkPackageOption pkgs "rxvt-unicode" { };
 
     fonts = mkOption {
       type = types.listOf types.str;

--- a/modules/programs/wezterm.nix
+++ b/modules/programs/wezterm.nix
@@ -16,12 +16,7 @@ in {
   options.programs.wezterm = {
     enable = mkEnableOption "wezterm";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.wezterm;
-      defaultText = literalExpression "pkgs.wezterm";
-      description = "The Wezterm package to install.";
-    };
+    package = lib.mkPackageOption pkgs "wezterm" { };
 
     extraConfig = mkOption {
       type = types.lines;

--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -9,14 +9,7 @@ in {
   options.programs.zoxide = {
     enable = lib.mkEnableOption "zoxide";
 
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.zoxide;
-      defaultText = lib.literalExpression "pkgs.zoxide";
-      description = ''
-        Zoxide package to install.
-      '';
-    };
+    package = lib.mkPackageOption pkgs "zoxide" { };
 
     options = lib.mkOption {
       type = lib.types.listOf lib.types.str;

--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -14,12 +14,7 @@ in {
 
     enableNotifications = mkEnableOption "lorri build notifications";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.lorri;
-      defaultText = literalExpression "pkgs.lorri";
-      description = "Which lorri package to install.";
-    };
+    package = lib.mkPackageOption pkgs "lorri" { };
 
     nixPackage = mkOption {
       type = types.package;

--- a/modules/services/polybar.nix
+++ b/modules/services/polybar.nix
@@ -72,12 +72,8 @@ in {
     services.polybar = {
       enable = mkEnableOption "Polybar status bar";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.polybar;
-        defaultText = literalExpression "pkgs.polybar";
-        description = "Polybar package to install.";
-        example = literalExpression ''
+      package = lib.mkPackageOption pkgs "polybar" {
+        example = ''
           pkgs.polybar.override {
             i3GapsSupport = true;
             alsaSupport = true;

--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -49,12 +49,7 @@ in {
   in {
     enable = mkEnableOption "idle manager for Wayland";
 
-    package = mkOption {
-      type = types.package;
-      default = pkgs.swayidle;
-      defaultText = literalExpression "pkgs.swayidle";
-      description = "Swayidle package to install.";
-    };
+    package = lib.mkPackageOption pkgs "swayidle" { };
 
     timeouts = mkOption {
       type = with types; listOf (submodule timeoutModule);


### PR DESCRIPTION
### Description
Converting all the `mkOption` definitions to use the upstreamed `mkPackageOption` helper. 
https://github.com/nixos/nixpkgs/blob/master/lib/options.nix#L309-L309

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
