### PR TITLE
jq: add missing color option

### DIFF
--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -2211,6 +2211,17 @@ in {
           Nix's store) old Home-Manager generations.
         '';
       }
+
+      {
+        time = "2025-03-31T16:39:41+00:00";
+        condition = config.programs.jq.enable;
+        message = ''
+          Jq module now supports color for object keys
+
+          Your configuration will break if you have defined the "programs.jq.colors" option.
+          To resolve this, please add `objectKeys` to your assignment of `programs.jq.colors`.
+        '';
+      }
     ];
   };
 }

--- a/modules/programs/jq.nix
+++ b/modules/programs/jq.nix
@@ -20,6 +20,7 @@ let
       strings = colorType;
       arrays = colorType;
       objects = colorType;
+      objectKeys = colorType;
     };
   };
 
@@ -45,13 +46,14 @@ in {
 
         example = lib.literalExpression ''
           {
-            null    = "1;30";
-            false   = "0;31";
-            true    = "0;32";
-            numbers = "0;36";
-            strings = "0;33";
-            arrays  = "1;35";
-            objects = "1;37";
+            null       = "1;30";
+            false      = "0;31";
+            true       = "0;32";
+            numbers    = "0;36";
+            strings    = "0;33";
+            arrays     = "1;35";
+            objects    = "1;37";
+            objectKeys = "1;34";
           }
         '';
 
@@ -63,6 +65,7 @@ in {
           strings = "0;32";
           arrays = "1;37";
           objects = "1;37";
+          objectKeys = "1;34";
         };
 
         type = colorsType;
@@ -76,7 +79,7 @@ in {
     home.sessionVariables = let c = cfg.colors;
     in {
       JQ_COLORS =
-        "${c.null}:${c.false}:${c.true}:${c.numbers}:${c.strings}:${c.arrays}:${c.objects}";
+        "${c.null}:${c.false}:${c.true}:${c.numbers}:${c.strings}:${c.arrays}:${c.objects}:${c.objectKeys}";
     };
   };
 }


### PR DESCRIPTION
added "color for object keys" option
https://jqlang.org/manual/#colors

### Description
Change is not backwards compatible. 
Anyone who have programs.jq.colors option not empty will have to add objectKeys value
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@liff @bb010g