### PR TITLE
mcfly: Fix fzf overriding mcfly's Ctrl+R bind

### DIFF
--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -23,9 +23,7 @@ let
   fishIntegration = ''
     ${getExe pkgs.mcfly} init fish | source
   '' + optionalString cfg.fzf.enable ''
-    if status is-interactive
-      eval "$(${getExe pkgs.mcfly-fzf} init fish)"
-    end
+    eval "$(${getExe pkgs.mcfly-fzf} init fish)"
   '';
 
   zshIntegration = ''
@@ -143,7 +141,8 @@ in {
 
       programs.zsh.initContent = mkIf cfg.enableZshIntegration zshIntegration;
 
-      programs.fish.shellInit = mkIf cfg.enableFishIntegration fishIntegration;
+      programs.fish.interactiveShellInit =
+        mkIf cfg.enableFishIntegration fishIntegration;
 
       home.sessionVariables.MCFLY_KEY_SCHEME = cfg.keyScheme;
 


### PR DESCRIPTION
### Description
In the fzf module, there is a comment about overriding the order to prevent this from happening:
```nix
    # Note, since fzf unconditionally binds C-r we use `mkOrder` to make the
    # initialization show up a bit earlier. This is to make initialization of
    # other history managers, like mcfly or atuin, take precedence.

    programs.fish.interactiveShellInit =
      mkIf cfg.enableFishIntegration (mkOrder 200 fishIntegration);
```

However it does not work, and mcfly appears in a separate block in config.fish, *before* fzf, since mcfly is not using interactiveShellInit, meaning the ctrl+r bind is the fzf bind when the intended behavior is to prioritise mcfly. Example:
```fish
# config.fish
/nix/store/anzmx9jfbl2gf2m2ivy5fnavl99kf13c-mcfly-0.9.3/bin/mcfly init fish | source
if status is-interactive
    eval "$(/nix/store/80l3p88i1kkbskf6zq14yz4kg520rbv5-mcfly-fzf-0.1.3/bin/mcfly-fzf init fish)"
end
# ...
status is-interactive; and begin

    # Abbreviations

    # Aliases

    # Interactive shell initialisation
    /nix/store/8p7nggqkcdz1spffg99hlgdl9pyawcxr-fzf-0.60.3/bin/fzf --fish | source
end
```
This commit turns that into:
```fish
status is-interactive; and begin
    # ...
    
    # Interactive shell initialisation
    /nix/store/8p7nggqkcdz1spffg99hlgdl9pyawcxr-fzf-0.60.3/bin/fzf --fish | source
   
    # ...

    /nix/store/anzmx9jfbl2gf2m2ivy5fnavl99kf13c-mcfly-0.9.3/bin/mcfly init fish | source
    eval "$(/nix/store/80l3p88i1kkbskf6zq14yz4kg520rbv5-mcfly-fzf-0.1.3/bin/mcfly-fzf init fish)"
end
```

And that displays the intended behavior in shell usage.

This commit moves both mcfly and mcfly-fzf into the main is-interactive block, which is technically unneccesary as the checks are done internally (but mcfly-fzf is broken in this regard https://github.com/bnprks/mcfly-fzf/issues/10), but the only other, slightly less elegant way to do this is adding another is-interactive block at the end of the config using `shellInitLast`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
