### PR TITLE
msmtp: fix missing inherits

### DIFF
--- a/modules/programs/msmtp.nix
+++ b/modules/programs/msmtp.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib) mkOption optionalAttrs types;
 
   cfg = config.programs.msmtp;
 
@@ -11,8 +11,8 @@ let
 
   accountStr = account:
     with account;
-    concatStringsSep "\n" ([ "account ${name}" ]
-      ++ mapAttrsToList (n: v: n + " " + v) ({
+    lib.concatStringsSep "\n" ([ "account ${name}" ]
+      ++ lib.mapAttrsToList (n: v: n + " " + v) ({
         host = smtp.host;
         from = address;
         auth = "on";
@@ -26,8 +26,8 @@ let
           tls_trust_file = smtp.tls.certificatesFile;
         } // optionalAttrs (passwordCommand != null) {
           passwordeval = toString passwordCommand;
-        } // msmtp.extraConfig) ++ optional primary "account default : ${name}"
-      ++ map (alias: ''
+        } // msmtp.extraConfig)
+      ++ lib.optional primary "account default : ${name}" ++ map (alias: ''
 
         account ${alias} : ${name}
         from ${alias}


### PR DESCRIPTION
### Description
Closes https://github.com/nix-community/home-manager/issues/6740
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
