### PR TITLE
fcitx5: set SDL_IM_MODULE

### DIFF
--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -1,5 +1,4 @@
 { config, pkgs, lib, ... }:
-
 let
   im = config.i18n.inputMethod;
   cfg = im.fcitx5;
@@ -41,6 +40,7 @@ in {
     home = {
       sessionVariables = {
         GLFW_IM_MODULE = "ibus"; # IME support in kitty
+        SDL_IM_MODULE = "fcitx";
         XMODIFIERS = "@im=fcitx";
       } // lib.optionalAttrs (!cfg.waylandFrontend) {
         GTK_IM_MODULE = "fcitx";
@@ -61,5 +61,4 @@ in {
       Install.WantedBy = [ "graphical-session.target" ];
     };
   };
-
 }


### PR DESCRIPTION
### Description

Sets `SDL_IM_MODULE` to `fcitx`to make fcitx5 work with sdl2 programs.
See https://fcitx-im.org/wiki/Setup_Fcitx_5#SDL_IM_MODULE and https://wiki.archlinux.org/title/Fcitx5#IM_modules
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@Kranzes
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
