### PR TITLE
news: create an individual file for each news entry

### DIFF
--- a/docs/manual/contributing/news.md
+++ b/docs/manual/contributing/news.md
@@ -10,13 +10,16 @@ If you do have a change worthy of a news entry then please add one in
 [`news.nix`](https://github.com/nix-community/home-manager/blob/master/modules/misc/news.nix)
 but you should follow some basic guidelines:
 
--   The entry timestamp should be in ISO-8601 format having \"+00:00\"
-    as time zone. For example, \"2017-09-13T17:10:14+00:00\". A suitable
-    timestamp can be produced by the command
+-   Use the included
+    [`create-news-entry.sh`](https://github.com/nix-community/home-manager/blob/master/modules/misc/news/create-news-entry.sh)
+    script to generate a news entry file:
 
     ``` shell
-    $ date --iso-8601=second --universal
+    $ modules/misc/news/create-news-entry.sh
     ```
+
+    this will create a new file inside `modules/misc/news` directory
+    with some placeholder information that you can edit.
 
 -   The entry condition should be as specific as possible. For example,
     if you are changing or deprecating a specific option then you could

--- a/home-manager/build-news.nix
+++ b/home-manager/build-news.nix
@@ -6,8 +6,8 @@
 
 let
   inherit (builtins)
-    concatStringsSep filter hasAttr isString length optionalString readFile
-    replaceStrings sort split;
+    concatStringsSep filter hasAttr isString length readFile replaceStrings sort
+    split;
 
   newsJson = builtins.fromJSON (builtins.readFile newsJsonFile);
 

--- a/modules/misc/news.nix
+++ b/modules/misc/news.nix
@@ -45,6 +45,13 @@ let
       id = lib.mkDefault (builtins.hashString "sha256" config.message);
     };
   });
+
+  isNixFile = n: v: v == "regular" && lib.hasSuffix ".nix" n;
+  # builtins.attrNames return the values in alphabetical order
+  newsFiles =
+    builtins.attrNames (lib.filterAttrs isNixFile (builtins.readDir ./news));
+  newsEntries =
+    builtins.map (newsFile: import (./news + "/${newsFile}")) newsFiles;
 in {
   meta.maintainers = [ lib.maintainers.rycee ];
 
@@ -96,15 +103,8 @@ in {
     news.json.output = pkgs.writeText "hm-news.json"
       (builtins.toJSON { inherit (cfg) display entries; });
 
-    # Add news entries in chronological order (i.e., latest time
-    # should be at the bottom of the list). The time should be
-    # formatted as given in the output of
-    #
-    #     date --iso-8601=second --universal
-    #
-    # On darwin (or BSD like systems) use
-    #
-    #     date -u +'%Y-%m-%dT%H:%M:%S+00:00'
+    # DO NOT define new entries here, instead use the `./create-news-entry.sh`
+    # script and create an individual news file inside `news` sub-directory.
     news.entries = [
       {
         time = "2021-06-02T04:24:10+00:00";
@@ -2231,6 +2231,6 @@ in {
           See https://github.com/ivaaaan/smug for more information.
         '';
       }
-    ];
+    ] ++ newsEntries;
   };
 }

--- a/modules/misc/news/2025-04-02_13-01-34.nix
+++ b/modules/misc/news/2025-04-02_13-01-34.nix
@@ -1,0 +1,10 @@
+{
+  time = "2025-04-02T13:01:34+00:00";
+  condition = true;
+  message = ''
+    A new way to define news is available.
+
+    Instead of editing the previous news.nix file, you can now define entries
+    using individual files. This should reduce the number of merge conflicts.
+  '';
+}

--- a/modules/misc/news/create-news-entry.sh
+++ b/modules/misc/news/create-news-entry.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -I https://github.com/NixOS/nixpkgs/archive/05f0934825c2a0750d4888c4735f9420c906b388.tar.gz -i bash -p coreutils
+
+DATE="$(date --iso-8601=second --universal)"
+FILENAME="$(date --date="$DATE" +"%Y-%m-%d_%H-%M-%S").nix"
+DIRNAME="$(dirname -- "${BASH_SOURCE[0]}")"
+
+cd "$DIRNAME" || {
+  >&2 echo "Failed to change to the script directory: $DIRNAME"
+  exit 1
+}
+
+cat - << EOF > "$FILENAME"
+{
+  time = "$DATE";
+  condition = true;
+  message = ''
+    PLACEHOLDER
+  '';
+}
+EOF
+
+echo "Successfully created a news file: $DIRNAME/$FILENAME"
+echo "You can open the file above in your text editor and edit now."


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
The current way to define a news entry in Home-Manager is error prone (since you need to type the date manually) and also it is common cause of conflicts after merges because all entries are defined in the same file.

This commit fixes this: we can now create individual news entries for each new entry. A script `create-news-entry.sh` also helps to create it in the correct format (with the correct filenames and structure).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
