### PR TITLE
cliphist: use configured systemdTargets throughout service

### DIFF
--- a/modules/services/cliphist.nix
+++ b/modules/services/cliphist.nix
@@ -61,7 +61,8 @@ in {
     systemd.user.services.cliphist = {
       Unit = {
         Description = "Clipboard management daemon";
-        PartOf = [ "graphical-session.target" ];
+        PartOf = lib.toList cfg.systemdTargets;
+        After = lib.toList cfg.systemdTargets;
       };
 
       Service = {
@@ -77,7 +78,8 @@ in {
     systemd.user.services.cliphist-images = lib.mkIf cfg.allowImages {
       Unit = {
         Description = "Clipboard management daemon - images";
-        PartOf = [ "graphical-session.target" ];
+        PartOf = lib.toList cfg.systemdTargets;
+        After = lib.toList cfg.systemdTargets;
       };
 
       Service = {


### PR DESCRIPTION
Was running into issues with it not starting properly. This fixed my issue.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
