### PR TITLE
playerctld: add to `$PATH`

### DIFF
--- a/modules/services/playerctld.nix
+++ b/modules/services/playerctld.nix
@@ -26,6 +26,8 @@ in {
         lib.platforms.linux)
     ];
 
+    home.packages = [ cfg.package ];
+
     systemd.user.services.playerctld = {
       Unit.Description = "MPRIS media player daemon";
 


### PR DESCRIPTION
### Description

Add `playerctl` to `$PATH`.

This will make third-party program calls more convenient (e.g. `niri`).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Fendse 
