### PR TITLE
swaync: use lib.getExe

### DIFF
--- a/modules/services/swaync.nix
+++ b/modules/services/swaync.nix
@@ -79,20 +79,20 @@ in {
   config = lib.mkIf cfg.enable {
     # at-spi2-core is to minimize journalctl noise of:
     # "AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files"
-    home.packages =
-      lib.mkIf (cfg.package != null) [ cfg.package pkgs.at-spi2-core ];
+    home.packages = [ cfg.package pkgs.at-spi2-core ];
 
     xdg.configFile = {
       "swaync/config.json" = {
         source = jsonFormat.generate "config.json" cfg.settings;
-        onChange = "${cfg.package}/bin/swaync-client --reload-config";
+        onChange = "${lib.getExe' cfg.package "swaync-client"} --reload-config";
       };
       "swaync/style.css" = lib.mkIf (cfg.style != null) {
+
         source = if builtins.isPath cfg.style || lib.isStorePath cfg.style then
           cfg.style
         else
           pkgs.writeText "swaync/style.css" cfg.style;
-        onChange = "${cfg.package}/bin/swaync-client --reload-css";
+        onChange = "${lib.getExe' cfg.package "swaync-client"} --reload-css";
       };
     };
 
@@ -108,7 +108,7 @@ in {
       Service = {
         Type = "dbus";
         BusName = "org.freedesktop.Notifications";
-        ExecStart = "${cfg.package}/bin/swaync";
+        ExecStart = "${lib.getExe cfg.package}";
         Restart = "on-failure";
       };
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
