### PR TITLE
Gammastep tray

### DIFF
--- a/modules/services/redshift-gammastep/lib/options.nix
+++ b/modules/services/redshift-gammastep/lib/options.nix
@@ -189,8 +189,10 @@ in {
       in {
         Description = "${programName} colour temperature adjuster";
         Documentation = serviceDocumentation;
-        After = [ "graphical-session.target" ] ++ geoclueAgentService;
+        After = [ "graphical-session.target" ]
+          ++ (lib.optional cfg.tray "tray.target") ++ geoclueAgentService;
         Wants = geoclueAgentService;
+        Requires = lib.mkIf cfg.tray "tray.target";
         PartOf = [ "graphical-session.target" ];
       };
 

--- a/tests/modules/services/redshift-gammastep/default.nix
+++ b/tests/modules/services/redshift-gammastep/default.nix
@@ -1,4 +1,6 @@
 {
   gammastep-basic-configuration = ./gammastep-basic-configuration.nix;
+  gammastep-tray-configuration = ./gammastep-tray-configuration.nix;
   redshift-basic-configuration = ./redshift-basic-configuration.nix;
+  redshift-tray-configuration = ./redshift-tray-configuration.nix;
 }

--- a/tests/modules/services/redshift-gammastep/gammastep-tray-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/gammastep-tray-configuration-expected.service
@@ -1,0 +1,15 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@gammastep@/bin/gammastep-indicator -c /home/hm-user/.config/gammastep/config.ini
+Restart=on-failure
+RestartSec=3
+
+[Unit]
+After=graphical-session.target
+After=tray.target
+Description=Gammastep colour temperature adjuster
+Documentation=https://gitlab.com/chinstrap/gammastep/
+PartOf=graphical-session.target
+Requires=tray.target

--- a/tests/modules/services/redshift-gammastep/gammastep-tray-configuration.nix
+++ b/tests/modules/services/redshift-gammastep/gammastep-tray-configuration.nix
@@ -1,0 +1,25 @@
+{
+  services.gammastep = {
+    enable = true;
+    provider = "manual";
+    dawnTime = "6:00-7:45";
+    duskTime = "18:35-20:15";
+    settings = {
+      general = {
+        adjustment-method = "randr";
+        gamma = 0.8;
+      };
+      randr = { screen = 0; };
+    };
+    tray = true;
+  };
+
+  nmt.script = ''
+    assertFileContent \
+        home-files/.config/gammastep/config.ini \
+        ${./gammastep-basic-configuration-file-expected.conf}
+    assertFileContent \
+        home-files/.config/systemd/user/gammastep.service \
+        ${./gammastep-tray-configuration-expected.service}
+  '';
+}

--- a/tests/modules/services/redshift-gammastep/redshift-tray-configuration-expected.service
+++ b/tests/modules/services/redshift-gammastep/redshift-tray-configuration-expected.service
@@ -1,0 +1,15 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@redshift@/bin/redshift-gtk -c /home/hm-user/.config/redshift/redshift.conf
+Restart=on-failure
+RestartSec=3
+
+[Unit]
+After=graphical-session.target
+After=tray.target
+Description=Redshift colour temperature adjuster
+Documentation=http://jonls.dk/redshift/
+PartOf=graphical-session.target
+Requires=tray.target

--- a/tests/modules/services/redshift-gammastep/redshift-tray-configuration.nix
+++ b/tests/modules/services/redshift-gammastep/redshift-tray-configuration.nix
@@ -1,0 +1,25 @@
+{
+  services.redshift = {
+    enable = true;
+    provider = "manual";
+    latitude = 0.0;
+    longitude = "0.0";
+    settings = {
+      redshift = {
+        adjustment-method = "randr";
+        gamma = 0.8;
+      };
+      randr = { screen = 0; };
+    };
+    tray = true;
+  };
+
+  nmt.script = ''
+    assertFileContent \
+        home-files/.config/redshift/redshift.conf \
+        ${./redshift-basic-configuration-file-expected.conf}
+    assertFileContent \
+        home-files/.config/systemd/user/redshift.service \
+        ${./redshift-tray-configuration-expected.service}
+  '';
+}


### PR DESCRIPTION
### Description

Fix a missing dependency for `tray.target` in `redshift/gammastep` module when the tray feature is enabled.

This caused a race condition that could result in the redshift/gammastep systemd user unit failing because the tray provider (e.g. waybar) isn't ready yet.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee 
@thiagokokada 