### PR TITLE
(backport to 24.11) broot: get rid of IFDs (#6723)

### DIFF
--- a/tests/modules/programs/broot/broot.nix
+++ b/tests/modules/programs/broot/broot.nix
@@ -7,7 +7,7 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.config/broot/conf.toml
-    assertFileContains home-files/.config/broot/conf.toml 'modal = true'
+    assertFileExists home-files/.config/broot/conf.hjson
+    assertFileContains home-files/.config/broot/conf.hjson '"modal": true'
   '';
 }


### PR DESCRIPTION
### Description

As requested in https://github.com/nix-community/home-manager/issues/6616#issuecomment-2775115182.

### Checklist

- [ ] Change is backwards compatible.
  - More or less, see description of original PR.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.
    - `test-neovim-plugin-config` fails, but already does so prior to this PR.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@aheaume 