### PR TITLE
xdg-portal: improve description of `extraPortals`

### DIFF
--- a/modules/misc/xdg-portal.nix
+++ b/modules/misc/xdg-portal.nix
@@ -35,9 +35,12 @@ in {
       type = types.listOf types.package;
       default = [ ];
       description = ''
-        List of additional portals that should be passed to the
-        `xdg-desktop-portal.service`, via the `XDG_DESKTOP_PORTAL_DIR`
-        variable.
+        List of additional portals that should be added to the environment.
+
+        The directory where the portal definitions have been merged together
+        (likely `~/.nix-profile/share/xdg-desktop-portal/portals`) will get
+        passed to `xdg-desktop-portal.service` via the
+        `NIX_XDG_DESKTOP_PORTAL_DIR` environment variable.
 
         Portals allow interaction with system, like choosing files or taking
         screenshots. At minimum, a desktop portal implementation should be


### PR DESCRIPTION
### Description

- Specified more clearly how the extra portals affect the environment

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@Misterio77 
