### PR TITLE
progs: firefox: *.userChrome may be path or drv 

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -397,12 +397,19 @@ in
               };
 
               userChrome = mkOption {
-                type = types.oneOf [
-                  types.lines
-                  types.path
-                ];
-                default = "";
-                description = "Custom ${appName} user chrome CSS.";
+                type = types.nullOr (
+                  types.oneOf [
+                    types.lines
+                    types.path
+                  ]
+                );
+                default = null;
+                description = ''
+                  Custom ${appName} user chrome CSS.
+
+                  This can be a path to a file or directory in the Nix store,
+                  or a derivation, or a verbatim multi-line string.
+                '';
                 example = ''
                   /* Hide tab bar in FF Quantum */
                   @-moz-document url(chrome://browser/content/browser.xul), url(chrome://browser/content/browser.xhtml) {
@@ -861,20 +868,26 @@ in
         ]
         ++ lib.flip mapAttrsToList cfg.profiles (
           _: profile:
+          let
+            chromePath = if lib.pathIsDirectory profile.userChrome then "chrome" else "chrome/userChrome.css";
+            sourcePath = if lib.types.path.check profile.userChrome then profile.userChrome else null;
+          in
           # Merge the regular profile settings with extension settings
           mkMerge (
             [
+              (mkIf (profile.userChrome != null) {
+                "${profilesPath}/${profile.path}/${chromePath}" =
+                  if sourcePath == null then
+                    {
+                      text = profile.userChrome;
+                    }
+                  else
+                    {
+                      source = sourcePath;
+                    };
+              })
               {
                 "${profilesPath}/${profile.path}/.keep".text = "";
-
-                "${profilesPath}/${profile.path}/chrome/userChrome.css" = mkIf (profile.userChrome != "") (
-                  let
-                    key = if builtins.isString profile.userChrome then "text" else "source";
-                  in
-                  {
-                    "${key}" = profile.userChrome;
-                  }
-                );
 
                 "${profilesPath}/${profile.path}/chrome/userContent.css" = mkIf (profile.userContent != "") (
                   let


### PR DESCRIPTION
### Description

This allows `programs.firefox.profiles.*.userChrome` to be set to a:
derivation, path/path-like string to directory or file, or multiline
text to be used as content verbatim.

This allows setting, for example(s):
```nix
programs.firefox.profiles."jacob.default".userChrome = pkgs.wavefox;
programs.firefox.profiles."jacob.default".userChrome =
    "${pkgs.wavefox}/userChrome.css";
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] (Painstakingly) Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
