### PR TITLE
nushell: expose config dir location as option

### DIFF
--- a/tests/modules/programs/nushell/config-dir.nix
+++ b/tests/modules/programs/nushell/config-dir.nix
@@ -1,0 +1,30 @@
+{ config, ... }:
+{
+  programs.nushell = {
+    enable = true;
+    configDir = "${config.xdg.configHome}/nushell-alt-path";
+    extraConfig = ''
+      # extra config
+    '';
+    extraEnv = ''
+      # extra env
+    '';
+    extraLogin = ''
+      # extra login
+    '';
+  };
+
+  nmt.script = ''
+    assertDirectoryExists home-files/.config/nushell-alt-path
+
+    assertFileExists home-files/.config/nushell-alt-path/config.nu
+    assertFileRegex home-files/.config/nushell-alt-path/config.nu '# extra config'
+
+    assertFileExists home-files/.config/nushell-alt-path/env.nu
+    assertFileRegex home-files/.config/nushell-alt-path/env.nu "# extra env"
+
+    assertFileExists home-files/.config/nushell-alt-path/login.nu
+    assertFileRegex home-files/.config/nushell-alt-path/login.nu '# extra login'
+
+  '';
+}

--- a/tests/modules/programs/nushell/default.nix
+++ b/tests/modules/programs/nushell/default.nix
@@ -1,1 +1,4 @@
-{ nushell-example-settings = ./example-settings.nix; }
+{
+  nushell-example-settings = ./example-settings.nix;
+  nushell-config-dir = ./config-dir.nix;
+}


### PR DESCRIPTION
### Description

This PR exposes the nushell configuration directory through the `programs.nushell.configDir` option.

#### Motivation

Nushell has different defaults for the configuration dir depending on the OS: `Library/Application Support/nushell` on MacOS and `.config/nushell` on Linux. However, setting `XDG_CONFIG_HOME` will override the default config unconditionally.

This means that there exists the possibility of the configuration not working in systems where users have `XDG_CONFIG_HOME` managed outside of home-manager (see https://github.com/nix-community/home-manager/issues/6484 for a related example).

This also allows just overriding the default location in general, for whatever the user might want to use it or for setting up integrations (adding files to `$nu.user-autoload-dirs` for example)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
