### PR TITLE
swaync: use x-restart-triggers for reload

### DIFF
--- a/tests/modules/services/swaync/swaync.nix
+++ b/tests/modules/services/swaync/swaync.nix
@@ -10,8 +10,11 @@
   };
 
   nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/swaync.service
+    serviceFile=$(normalizeStorePaths $serviceFile)
+
     assertFileContent \
-      home-files/.config/systemd/user/swaync.service \
+      $serviceFile \
       ${
         builtins.toFile "swaync.service" ''
           [Install]
@@ -29,6 +32,7 @@
           Description=Swaync notification daemon
           Documentation=https://github.com/ErikReider/SwayNotificationCenter
           PartOf=graphical-session.target
+          X-Restart-Triggers=/nix/store/00000000000000000000000000000000-config.json
         ''
       }
   '';


### PR DESCRIPTION
Try to use x-restart-triggers to hot reload on file change, since users with impermanence setups were running into issues with onChange.

Tested myself and works to reload swaync when doing home-manager activation with changing styling. Just not as seamless of a reload as using the cli, but will help prevent issues with impermanence users. 
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
