### PR TITLE
{cliphist, wlsunset, swayr}: systemdTargets default to wayland.systemd target

### DIFF
--- a/modules/programs/swayr.nix
+++ b/modules/programs/swayr.nix
@@ -91,7 +91,7 @@ in {
     systemd.enable = lib.mkEnableOption "swayr systemd integration";
     systemd.target = mkOption {
       type = types.str;
-      default = "graphical-session.target";
+      default = config.wayland.systemd.target;
       description = ''
         Systemd target to bind to.
       '';

--- a/modules/services/cliphist.nix
+++ b/modules/services/cliphist.nix
@@ -35,7 +35,7 @@ in {
 
     systemdTargets = lib.mkOption {
       type = with lib.types; either (listOf str) str;
-      default = [ "graphical-session.target" ];
+      default = [ config.wayland.systemd.target ];
       example = "sway-session.target";
       description = ''
         The systemd targets that will automatically start the cliphist service.

--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -128,8 +128,8 @@ in {
     systemd.user.services.wlsunset = {
       Unit = {
         Description = "Day/night gamma adjustments for Wayland compositors.";
-        After = [ "graphical-session.target" ];
-        PartOf = [ "graphical-session.target" ];
+        After = [ cfg.systemdTarget ];
+        PartOf = [ cfg.systemdTarget ];
       };
 
       Service = {

--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -96,7 +96,7 @@ in {
 
     systemdTarget = mkOption {
       type = with types; str;
-      default = "graphical-session.target";
+      default = config.wayland.systemd.target;
       description = ''
         Systemd target to bind to.
       '';

--- a/tests/modules/services/wlsunset/wlsunset-service-expected.service
+++ b/tests/modules/services/wlsunset/wlsunset-service-expected.service
@@ -5,6 +5,6 @@ WantedBy=test.target
 ExecStart=@wlsunset@/bin/wlsunset -L 128.8 -T 6000 -g 0.6 -l 12.3 -t 3500
 
 [Unit]
-After=graphical-session.target
+After=test.target
 Description=Day/night gamma adjustments for Wayland compositors.
-PartOf=graphical-session.target
+PartOf=test.target


### PR DESCRIPTION
### Description
Closes https://github.com/nix-community/home-manager/issues/6706
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
