### PR TITLE
chawan: init module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -84,6 +84,7 @@ let
       ./programs/carapace.nix
       ./programs/cava.nix
       ./programs/cavalier.nix
+      ./programs/chawan.nix
       ./programs/chromium.nix
       ./programs/cmus.nix
       ./programs/command-not-found/command-not-found.nix

--- a/modules/programs/chawan.nix
+++ b/modules/programs/chawan.nix
@@ -1,0 +1,47 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.chawan;
+  tomlFormat = (pkgs.formats.toml { });
+  tomlType = tomlFormat.type;
+  toConf = tomlFormat.generate "config.toml";
+in
+{
+  meta.maintainers = [ lib.maintainers.noodlez1232 ];
+
+  options.programs.chawan = {
+    enable = lib.mkEnableOption "chawan, A TUI web browser";
+    package = lib.mkPackageOption pkgs "chawan" { nullable = true; };
+    settings = lib.mkOption {
+      default = { };
+      type = tomlType;
+      description = ''
+        Configuration options for chawan.
+
+        See {manpage}`cha-config(5)`
+      '';
+      example = lib.literalExpression ''
+        {
+          buffer = {
+            images = true;
+            autofocus = true;
+          };
+          pager."C-k" = "() => pager.load('https://duckduckgo.com/?=')";
+        }
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile = lib.mkIf (cfg.settings != { }) {
+      "chawan/config.toml" = {
+        source = toConf cfg.settings;
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Description

This is a super cool TUI browser capable of CSS and other cool stuff. Reminiscent of ELinks but modern and better.

More info here: https://sr.ht/~bptato/chawan/


### Checklist


- [X] Change is backwards compatible.

- [X] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
