### PR TITLE
astroid: Fix use of `fromJSON`

### DIFF
--- a/modules/programs/astroid.nix
+++ b/modules/programs/astroid.nix
@@ -36,7 +36,7 @@ let
 
   # See https://github.com/astroidmail/astroid/wiki/Configuration-Reference
   finalConfig = let
-    template = builtins.fromJSON (lib.readFile ./astroid-config-template.json);
+    template = lib.importJSON ./astroid-config-template.json;
     astroidConfig = lib.foldl' lib.recursiveUpdate template [
       {
         astroid.notmuch_config =

--- a/modules/programs/astroid.nix
+++ b/modules/programs/astroid.nix
@@ -36,7 +36,7 @@ let
 
   # See https://github.com/astroidmail/astroid/wiki/Configuration-Reference
   finalConfig = let
-    template = lib.fromJSON (lib.readFile ./astroid-config-template.json);
+    template = builtins.fromJSON (lib.readFile ./astroid-config-template.json);
     astroidConfig = lib.foldl' lib.recursiveUpdate template [
       {
         astroid.notmuch_config =

--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -73,9 +73,8 @@ in {
       let value = lib.getAttrFromPath [ "programs" "kitty" "theme" ] config;
       in if value != null then
         (let
-          matching = lib.filter (x: x.name == value) (builtins.fromJSON
-            (builtins.readFile
-              "${pkgs.kitty-themes}/share/kitty-themes/themes.json"));
+          matching = lib.filter (x: x.name == value) (lib.importJSON
+            "${pkgs.kitty-themes}/share/kitty-themes/themes.json");
         in lib.throwIf (lib.length matching == 0)
         "kitty-themes does not contain a theme named ${value}"
         lib.strings.removeSuffix ".conf"


### PR DESCRIPTION
### Description

Module was rewritten to use it from `lib`, when it is actually in `builtins`
### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.
  - [x] **Code tested with actual config**

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@khaneliman 