### PR TITLE
Aerospace: Flatten on-window-detected.*.if values to fix incorrect TOML

### DIFF
--- a/modules/programs/aerospace.nix
+++ b/modules/programs/aerospace.nix
@@ -23,6 +23,22 @@ let
       else
         [ ]) (lib.attrNames set));
   filterNulls = filterListAndAttrsRecursive (v: v != null);
+
+  # Turns
+  #   {if = {foo = "xxx"; bar = "yyy"}}
+  # into
+  #   {"if.foo" = "xxx"; "if.bar" = "yyy"}
+  # so that the correct TOML is generated for the
+  # on-window-detected table.
+  flattenConditions = attrs:
+    let conditions = attrs."if" or { };
+    in builtins.removeAttrs attrs [ "if" ]
+    // lib.concatMapAttrs (n: v: { "if.${n}" = v; }) conditions;
+
+  flattenOnWindowDetected = cfg:
+    let owd = cfg.on-window-detected or [ ];
+    in cfg // { on-window-detected = map flattenConditions owd; };
+
 in {
   meta.maintainers = with lib.hm.maintainers; [ damidoug ];
 
@@ -234,7 +250,8 @@ in {
     home = {
       packages = lib.mkIf (cfg.package != null) [ cfg.package ];
       file.".config/aerospace/aerospace.toml".source =
-        tomlFormat.generate "aerospace" (filterNulls cfg.userSettings);
+        tomlFormat.generate "aerospace"
+        (filterNulls (flattenOnWindowDetected cfg.userSettings));
     };
   };
 }

--- a/tests/modules/programs/aerospace/aerospace.nix
+++ b/tests/modules/programs/aerospace/aerospace.nix
@@ -14,6 +14,20 @@
         alt-k = "focus up";
         alt-l = "focus right";
       };
+      on-window-detected = [
+        {
+          "if" = { app-id = "com.apple.MobileSMS"; };
+          run = [ "move-node-to-workspace 10" ];
+        }
+        {
+          "if" = { app-id = "ru.keepcoder.Telegram"; };
+          run = [ "move-node-to-workspace 10" ];
+        }
+        {
+          "if" = { app-id = "org.whispersystems.signal-desktop"; };
+          run = [ "move-node-to-workspace 10" ];
+        }
+      ];
     };
   };
 

--- a/tests/modules/programs/aerospace/settings-expected.toml
+++ b/tests/modules/programs/aerospace/settings-expected.toml
@@ -8,7 +8,6 @@ enable-normalization-opposite-orientation-for-nested-containers = true
 exec-on-workspace-change = []
 on-focus-changed = []
 on-focused-monitor-changed = ["move-mouse monitor-lazy-center"]
-on-window-detected = []
 start-at-login = false
 
 [gaps.outer]
@@ -25,3 +24,15 @@ alt-h = "focus left"
 alt-j = "focus down"
 alt-k = "focus up"
 alt-l = "focus right"
+
+[[on-window-detected]]
+"if.app-id" = "com.apple.MobileSMS"
+run = ["move-node-to-workspace 10"]
+
+[[on-window-detected]]
+"if.app-id" = "ru.keepcoder.Telegram"
+run = ["move-node-to-workspace 10"]
+
+[[on-window-detected]]
+"if.app-id" = "org.whispersystems.signal-desktop"
+run = ["move-node-to-workspace 10"]


### PR DESCRIPTION
### Description

The current aerospace.nix module produces incorrect TOML when for `userSettings.on-window-detected`. Using the following 

```nix
{
  on-window-detected = [
    {
      "if" = { app-id = "com.apple.MobileSMS"; };
      run = [ "move-node-to-workspace 10" ];
    }
    {
      "if" = { app-id = "ru.keepcoder.Telegram"; };
      run = [ "move-node-to-workspace 10" ];
    }
    {
      "if" = { app-id = "org.whispersystems.signal-desktop"; };
      run = [ "move-node-to-workspace 10" ];
    }
  ];
}
```

produces 

```toml
[[on-window-detected]]
run = ["move-node-to-workspace 10"]

[on-window-detected.if]
app-id = "com.apple.MobileSMS"

[[on-window-detected]]
run = ["move-node-to-workspace 10"]

[on-window-detected.if]
app-id = "ru.keepcoder.Telegram"

[[on-window-detected]]
run = ["move-node-to-workspace 10"]

[on-window-detected.if]
app-id = "org.whispersystems.signal-desktop"
```

when it should produce

```toml
[[on-window-detected]]
if.app-id = "com.apple.MobileSMS"
run = ["move-node-to-workspace 10"]

[[on-window-detected]]
if.app-id = "ru.keepcoder.Telegram"
run = ["move-node-to-workspace 10"]

[[on-window-detected]]
if.app-id = "org.whispersystems.signal-desktop"
run = ["move-node-to-workspace 10"]
```

These changes should fix this. Since the current implementation produces the wrong TOML, I believe this should be considered backwards compatible.

I'm not sure how to test this fully with Aerospace itself, the output differs slightly from the example above, it actually produces the following, with quoted keys:

```toml
[[on-window-detected]]
"if.app-id" = "com.apple.MobileSMS"
run = ["move-node-to-workspace 10"]
...
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@damidoug 
