### PR TITLE
flake.nix: remove treefmt-nix input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           exit 1
         fi
     - run: nix-build --show-trace -A docs.jsonModuleMaintainers
-    - run: nix flake check
+    - run: ./format --ci
     - run: nix-shell --show-trace . -A install
     - run: yes | home-manager -I home-manager=. uninstall
     - run: nix-shell -j auto --show-trace --arg enableBig false --pure tests -A run.all

--- a/flake.lock
+++ b/flake.lock
@@ -18,28 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1743748085,
-        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,20 +1,12 @@
 {
   description = "Home Manager for Nix";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-
-    treefmt-nix = {
-      url = "github:numtide/treefmt-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs =
     {
       self,
       nixpkgs,
-      treefmt-nix,
       ...
     }:
     {
@@ -54,23 +46,9 @@
     // (
       let
         forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
-
-        treefmtEval = forAllSystems (
-          system:
-          treefmt-nix.lib.evalModule nixpkgs.legacyPackages.${system} {
-            # Formatting configuration
-            programs = {
-              nixfmt.enable = true;
-            };
-          }
-        );
       in
       {
-        checks = forAllSystems (system: {
-          formatting = treefmtEval.${system}.config.build.check self;
-        });
-
-        formatter = forAllSystems (system: treefmtEval.${system}.config.build.wrapper);
+        formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
 
         packages = forAllSystems (
           system:

--- a/format
+++ b/format
@@ -14,7 +14,7 @@ for arg do
             echo "$0 [-c]"
             exit
             ;;
-        -c)
+        --ci)
             nixfmt_args+=("$arg")
             ;;
         -*)


### PR DESCRIPTION
Removing input until I have time to migrate usage to a dev flake for all the dev dependencies.

Follow up to discussion in matrix and https://github.com/nix-community/home-manager/pull/6772#issuecomment-2787276350
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
