### PR TITLE
modules/programs/ssh: support identityAgent

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -167,6 +167,22 @@ let
           '';
         };
 
+        identityAgent = mkOption {
+          type = with types; either (listOf str) (nullOr str);
+          default = [ ];
+          apply =
+            p:
+            if p == null then
+              [ ]
+            else if lib.isString p then
+              [ p ]
+            else
+              p;
+          description = ''
+            Specifies the location of the ssh identity agent.
+          '';
+        };
+
         user = mkOption {
           type = types.nullOr types.str;
           default = null;
@@ -362,6 +378,7 @@ let
       ++ optional (cf.proxyCommand != null) "  ProxyCommand ${cf.proxyCommand}"
       ++ optional (cf.proxyJump != null) "  ProxyJump ${cf.proxyJump}"
       ++ map (file: "  IdentityFile ${file}") cf.identityFile
+      ++ map (file: "  IdentityAgent ${file}") cf.identityAgent
       ++ map (file: "  CertificateFile ${file}") cf.certificateFile
       ++ map (f: "  LocalForward" + addressPort f.bind + addressPort f.host) cf.localForwards
       ++ map (f: "  RemoteForward" + addressPort f.bind + addressPort f.host) cf.remoteForwards


### PR DESCRIPTION
### Description

Allow configuring `identityAgent` in the ssh config.

I manually set up the identity agent/paths to better handle/understand how forwarding/agents work in my various usages (local, remote with gpg forwarded, etc).

This is a pretty straight-forward module-option -> config key change.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] **(hopefully not needed)** Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
