### PR TITLE
firefox: add release option

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -24,6 +24,7 @@ let
     mkIf
     mkMerge
     mkOption
+    mkOptionDefault
     optionalString
     optional
     setAttrByPath
@@ -235,6 +236,12 @@ in
       '';
     };
 
+    release = mkOption {
+      internal = true;
+      type = types.str;
+      description = "Upstream release version used to fetch from `releases.mozilla.org`.";
+    };
+
     languagePacks = mkOption {
       type = types.listOf types.str;
       default = [ ];
@@ -242,7 +249,9 @@ in
         The language packs to install. Available language codes can be found
         on the releases page:
         `https://releases.mozilla.org/pub/firefox/releases/''${version}/linux-x86_64/xpi/`,
-        replacing `''${version}` with the version of ${appName} you have.
+        replacing `''${version}` with the version of ${appName} you have. If
+        the version string of your Firefox derivative diverts from the upstream
+        version, try setting the `release` option.
       '';
       example = [
         "en-GB"
@@ -952,6 +961,7 @@ in
     }
     // setAttrByPath modulePath {
       finalPackage = wrapPackage cfg.package;
+      release = mkOptionDefault (builtins.head (lib.splitString "-" cfg.package.version));
 
       policies = {
         ExtensionSettings = lib.mkIf (cfg.languagePacks != [ ]) (
@@ -960,7 +970,7 @@ in
               lang:
               lib.nameValuePair "langpack-${lang}@firefox.mozilla.org" {
                 installation_mode = "normal_installed";
-                install_url = "https://releases.mozilla.org/pub/firefox/releases/${cfg.package.version}/linux-x86_64/xpi/${lang}.xpi";
+                install_url = "https://releases.mozilla.org/pub/firefox/releases/${cfg.release}/linux-x86_64/xpi/${lang}.xpi";
               }
             ) cfg.languagePacks
           )


### PR DESCRIPTION
Adds the `release` option to declare what upstream release version is used to fetch rom `releases.mozilla.org`. Used to fetch language packs. See https://github.com/nix-community/home-manager/issues/6758#issuecomment-2781465236. 

Closes #6758

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@getchoo @brckd @HPsaucii