### PR TITLE
swaylock: fix path values in config file

### DIFF
--- a/modules/programs/swaylock.nix
+++ b/modules/programs/swaylock.nix
@@ -74,7 +74,12 @@ in
     xdg.configFile."swaylock/config" = lib.mkIf (cfg.settings != { }) {
       text = lib.concatStrings (
         lib.mapAttrsToList (
-          n: v: if v == false then "" else (if v == true then n else n + "=" + builtins.toString v) + "\n"
+          n: v:
+          if v == false then
+            ""
+          else
+            (if v == true then n else n + "=" + (if builtins.isPath v then "${v}" else builtins.toString v))
+            + "\n"
         ) cfg.settings
       );
     };


### PR DESCRIPTION
### Description

Currently, `path` settings values are converted to strings using `builtins.toString`.
This **does not** create a proper dependency to the path destination for the swaylock config.
Hence, the referenced file is subject to being garbage-collected, making the config file invalid.

This patch instead properly interpolates the path which fixes this issue.

Before (no dependency on the referenced file)
![image](https://github.com/user-attachments/assets/d93373dc-415e-46bc-b562-7c2a39feea3e)

After:
![image](https://github.com/user-attachments/assets/b04ad145-2287-417c-87da-758062ff609b)


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

cc @rcerc 
