### PR TITLE
hyprland: load plugins using exec-once

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -287,12 +287,13 @@ in
           plugins:
           lib.hm.generators.toHyprconf {
             attrs = {
-              plugin =
+              "exec-once" =
                 let
                   mkEntry =
                     entry: if lib.types.package.check entry then "${entry}/lib/lib${entry.pname}.so" else entry;
+                  hyprctl = "${cfg.finalPackage}/bin/hyprctl";
                 in
-                map mkEntry cfg.plugins;
+                map (p: "${hyprctl} plugin load ${mkEntry p}") cfg.plugins;
             };
             inherit (cfg) importantPrefixes;
           };

--- a/tests/modules/services/window-managers/hyprland/multiple-devices-config.conf
+++ b/tests/modules/services/window-managers/hyprland/multiple-devices-config.conf
@@ -1,6 +1,6 @@
 exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
-plugin=/path/to/plugin1
-plugin=/nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
+exec-once=/nix/store/00000000000000000000000000000000-hyprland/bin/hyprctl plugin load /path/to/plugin1
+exec-once=/nix/store/00000000000000000000000000000000-hyprland/bin/hyprctl plugin load /nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 $mod=SUPER
 bezier=smoothOut, 0.36, 0, 0.66, -0.56
 bezier=smoothIn, 0.25, 1, 0.5, 1

--- a/tests/modules/services/window-managers/hyprland/simple-config.conf
+++ b/tests/modules/services/window-managers/hyprland/simple-config.conf
@@ -1,6 +1,6 @@
 exec-once = @dbus@/bin/dbus-update-activation-environment --systemd DISPLAY HYPRLAND_INSTANCE_SIGNATURE WAYLAND_DISPLAY XDG_CURRENT_DESKTOP && systemctl --user stop hyprland-session.target && systemctl --user start hyprland-session.target
-plugin=/path/to/plugin1
-plugin=/nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
+exec-once=/nix/store/00000000000000000000000000000000-hyprland/bin/hyprctl plugin load /path/to/plugin1
+exec-once=/nix/store/00000000000000000000000000000000-hyprland/bin/hyprctl plugin load /nix/store/00000000000000000000000000000000-foo/lib/libfoo.so
 $mod=SUPER
 bezier=smoothOut, 0.36, 0, 0.66, -0.56
 bezier=smoothIn, 0.25, 1, 0.5, 1


### PR DESCRIPTION
### Description

Change to match the behavior of hyprland flake - https://github.com/hyprwm/Hyprland/pull/9836

Should eliminate crashes / plugin version mismatches when updating hyprland.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@fufexan 
