### PR TITLE
formatter: use a different treefmt root

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,11 +50,11 @@
       {
         formatter = forAllSystems (
           system:
-          nixpkgs.legacyPackages.${system}.nixfmt-tree.override ({
+          nixpkgs.legacyPackages.${system}.nixfmt-tree.override {
             settings = {
               tree-root-file = "release.json";
             };
-          })
+          }
         );
 
         packages = forAllSystems (

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,14 @@
         forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
       in
       {
-        formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
+        formatter = forAllSystems (
+          system:
+          nixpkgs.legacyPackages.${system}.nixfmt-tree.override ({
+            settings = {
+              tree-root-file = "release.json";
+            };
+          })
+        );
 
         packages = forAllSystems (
           system:


### PR DESCRIPTION
Problem: i use jujutsu as a VCS these days https://jj-vcs.github.io/jj/ and when using jujutsu workspaces, they dont contain the `.git` file/folder that git worktrees have. `nix fmt` thus fails `with Error: failed to load config: failed to find tree-root based on tree-root-file: could not find [.git/index] in /home/teto/hm2`

solution: use a different (unique) root file. I first tried with flake.nix for instnace but we have several in the tree while there is only one "release.json"

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
