### PR TITLE
sesh: use '--icons'

### DIFF
--- a/modules/programs/sesh.nix
+++ b/modules/programs/sesh.nix
@@ -55,43 +55,57 @@ in
       default = "s";
       description = "Keybinding for invoking sesh in Tmux.";
     };
+
+    icons = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Display icons next to results ({option}`--icons` argument).
+      '';
+    };
   };
 
-  config = mkIf cfg.enable (mkMerge [
-    {
-      home.packages = [ cfg.package ];
-      home.file.".config/sesh/sesh.toml".source = tomlFormat.generate "sesh.toml" cfg.settings;
-    }
+  config =
+    let
+      args = lib.escapeShellArgs (lib.optional cfg.icons "--icons");
+      fzf-args = lib.escapeShellArgs (lib.optional cfg.icons "--ansi");
+    in
+    mkIf cfg.enable (mkMerge [
+      {
+        home.packages = [ cfg.package ];
+        home.file.".config/sesh/sesh.toml".source = tomlFormat.generate "sesh.toml" cfg.settings;
+      }
 
-    (mkIf cfg.enableAlias {
-      home.packages = lib.mkIf (cfg.fzfPackage != null) [ cfg.fzfPackage ];
-      home.shellAliases.s = "sesh connect $(sesh list | fzf)";
-    })
+      (mkIf cfg.enableAlias {
+        home.packages = lib.mkIf (cfg.fzfPackage != null) [ cfg.fzfPackage ];
+        home.shellAliases.s = "sesh connect $(sesh list ${args} | fzf ${fzf-args})";
+      })
 
-    (mkIf cfg.enableTmuxIntegration {
-      assertions = [
-        {
-          assertion = config.programs.fzf.tmux.enableShellIntegration;
-          message = "To use Tmux integration with sesh, enable `programs.fzf.tmux.enableShellIntegration`.";
-        }
-      ];
+      (mkIf cfg.enableTmuxIntegration {
+        assertions = [
+          {
+            assertion = config.programs.fzf.tmux.enableShellIntegration;
+            message = "To use Tmux integration with sesh, enable `programs.fzf.tmux.enableShellIntegration`.";
+          }
+        ];
 
-      home.packages = lib.mkIf (cfg.zoxidePackage != null) [ cfg.zoxidePackage ];
+        home.packages = lib.mkIf (cfg.zoxidePackage != null) [ cfg.zoxidePackage ];
 
-      programs.tmux.extraConfig = ''
-        bind-key "${cfg.tmuxKey}" run-shell "sesh connect \"$(
-          sesh list | fzf-tmux -p 55%,60% \
-            --no-sort --ansi --border-label ' sesh ' --prompt '⚡  ' \
-            --header '  ^a all ^t tmux ^g configs ^x zoxide ^d tmux kill ^f find' \
-            --bind 'tab:down,btab:up' \
-            --bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list)' \
-            --bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -t)' \
-            --bind 'ctrl-g:change-prompt(⚙️  )+reload(sesh list -c)' \
-            --bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -z)' \
-            --bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
-            --bind 'ctrl-d:execute(tmux kill-session -t {})+change-prompt(⚡  )+reload(sesh list)'
-        )\""
-      '';
-    })
-  ]);
+        programs.tmux.extraConfig = ''
+          bind-key "${cfg.tmuxKey}" run-shell "sesh connect \"$(
+            sesh list ${args} | fzf-tmux -p 55%,60% \
+              --no-sort --ansi --border-label ' sesh ' --prompt '⚡  ' \
+              --header '  ^a all ^t tmux ^g configs ^x zoxide ^d tmux kill ^f find' \
+              --bind 'tab:down,btab:up' \
+              --bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list ${args})' \
+              --bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list ${args} -t)' \
+              --bind 'ctrl-g:change-prompt(⚙️  )+reload(sesh list ${args} -c)' \
+              --bind 'ctrl-x:change-prompt(📁  )+reload(sesh list ${args} -z)' \
+              --bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
+              --bind 'ctrl-d:execute(tmux kill-session -t {})+change-prompt(⚡  )+reload(sesh list ${args})' \
+              -- ${fzf-args}
+          )\""
+        '';
+      })
+    ]);
 }


### PR DESCRIPTION
### Description

related to https://github.com/nix-community/home-manager/pull/5789#issuecomment-2779323292

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@michaelvanstraten
