### PR TITLE
xmonad: fix binary name lookup on armv7l when cross-compiled

### DIFF
--- a/modules/services/window-managers/xmonad.nix
+++ b/modules/services/window-managers/xmonad.nix
@@ -111,6 +111,12 @@ in
 
   config =
     let
+      # GHC sets OS_ARCH to arm in case of armv7l, need to coerce
+      executableSystemSuffix =
+        if pkgs.stdenv.hostPlatform.isArmv7 then
+          "arm-${lib.toLower pkgs.stdenv.hostPlatform.uname.system}"
+        else
+          pkgs.stdenv.hostPlatform.system;
 
       xmonadBin = "${
         pkgs.runCommandLocal "xmonad-compile"
@@ -141,15 +147,15 @@ in
 
             # The resulting binary name depends on the arch and os
             # https://github.com/xmonad/xmonad/blob/56b0f850bc35200ec23f05c079eca8b0a1f90305/src/XMonad/Core.hs#L565-L572
-            if [ -f "$XMONAD_DATA_DIR/xmonad-${pkgs.stdenv.hostPlatform.system}" ]; then
+            if [ -f "$XMONAD_DATA_DIR/xmonad-${executableSystemSuffix}" ]; then
               # xmonad 0.15.0
-              mv "$XMONAD_DATA_DIR/xmonad-${pkgs.stdenv.hostPlatform.system}" $out/bin/
+              mv "$XMONAD_DATA_DIR/xmonad-${executableSystemSuffix}" $out/bin/
             else
               # xmonad 0.17.0 (https://github.com/xmonad/xmonad/commit/9813e218b034009b0b6d09a70650178980e05d54)
-              mv "$XMONAD_CACHE_DIR/xmonad-${pkgs.stdenv.hostPlatform.system}" $out/bin/
+              mv "$XMONAD_CACHE_DIR/xmonad-${executableSystemSuffix}" $out/bin/
             fi
           ''
-      }/bin/xmonad-${pkgs.stdenv.hostPlatform.system}";
+      }/bin/xmonad-${executableSystemSuffix}";
 
     in
     mkIf cfg.enable (mkMerge [


### PR DESCRIPTION
### Description

This patch along with https://github.com/NixOS/nixpkgs/pull/397767 allows pre-built xmonad running on `armv7l` target.

GHC converts `armv7l` and similar to just `arm` https://git.science.uu.nl/f100183/ghc/-/blob/8fa4bf9ab3f4ea4b208f4a43cc90857987e6d497/aclocal.m4#L1874 making `hostPlatform.system` point to `xmonad-arm7l-linux` instead of correct `xmonad-arm-linux`.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
