### PR TITLE
Add sensible defaults to the localModule similar to the calendar localModule

### DIFF
--- a/modules/accounts/contacts.nix
+++ b/modules/accounts/contacts.nix
@@ -21,12 +21,13 @@ let
             "filesystem"
             "singlefile"
           ];
+          default = "filesystem";
           description = "The type of the storage.";
         };
 
         fileExt = mkOption {
           type = types.nullOr types.str;
-          default = null;
+          default = ".vcf";
           description = "The file extension to use.";
         };
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

As I described
[here](https://github.com/nix-community/home-manager/issues/4531#issuecomment-2795286473),
the local module for contact does not have proper defaults so the module always
has to be explicitly defined. This change sets hopefully sensible defaults so
it doesn't have to be explicitly configured. The defaults match the calendar module

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@teto

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
