### PR TITLE
nh: remove incorrect warning on gc conflicts

### DIFF
--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -1,15 +1,11 @@
 {
   config,
-  osConfig,
   lib,
   pkgs,
   ...
 }:
-
 let
-
   cfg = config.programs.nh;
-
 in
 {
   meta.maintainers = with lib.maintainers; [ johnrtitor ];
@@ -60,12 +56,8 @@ in
 
   config = {
     warnings =
-      (lib.optional (cfg.clean.enable && osConfig != null && osConfig.nix.gc.automatic)
-        "programs.nh.clean.enable and nix.gc.automatic (system-wide in configuration.nix) are both enabled. Please use one or the other to avoid conflict."
-      )
-      ++ (lib.optional (cfg.clean.enable && config.nix.gc.automatic)
-        "programs.nh.clean.enable and nix.gc.automatic (Home-Manager) are both enabled. Please use one or the other to avoid conflict."
-      );
+      lib.optional (cfg.clean.enable && config.nix.gc.automatic)
+        "programs.nh.clean.enable and nix.gc.automatic (Home-Manager) are both enabled. Please use one or the other to avoid conflict.";
 
     home = lib.mkIf cfg.enable {
       packages = [ cfg.package ];


### PR DESCRIPTION
### Description

From what I understand, the warning relating to the system GC conflicting with the nh user GC (added in #6470)  was incorrect. There shouldn't be any conflict between osConfig.nix.gc and programs.nh.clean as our home-manager service only cleans user profiles (which nix-collect-garbage does not do).

In this scenario they should both work at the same time as they are cleaning two different things.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

~~- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~~

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  ~~- [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~~

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@JohnRTitor 
