### PR TITLE
aerospace: revert flattening on-window-detected rules

### DIFF
--- a/modules/programs/aerospace.nix
+++ b/modules/programs/aerospace.nix
@@ -35,27 +35,6 @@ let
       ) (lib.attrNames set)
     );
   filterNulls = filterListAndAttrsRecursive (v: v != null);
-
-  # Turns
-  #   {if = {foo = "xxx"; bar = "yyy"}}
-  # into
-  #   {"if.foo" = "xxx"; "if.bar" = "yyy"}
-  # so that the correct TOML is generated for the
-  # on-window-detected table.
-  flattenConditions =
-    attrs:
-    let
-      conditions = attrs."if" or { };
-    in
-    builtins.removeAttrs attrs [ "if" ] // lib.concatMapAttrs (n: v: { "if.${n}" = v; }) conditions;
-
-  flattenOnWindowDetected =
-    cfg:
-    let
-      owd = cfg.on-window-detected or [ ];
-    in
-    cfg // { on-window-detected = map flattenConditions owd; };
-
 in
 {
   meta.maintainers = with lib.hm.maintainers; [ damidoug ];
@@ -291,7 +270,7 @@ in
     home = {
       packages = lib.mkIf (cfg.package != null) [ cfg.package ];
       file.".config/aerospace/aerospace.toml".source = tomlFormat.generate "aerospace" (
-        filterNulls (flattenOnWindowDetected cfg.userSettings)
+        filterNulls cfg.userSettings
       );
     };
   };

--- a/tests/modules/programs/aerospace/aerospace.nix
+++ b/tests/modules/programs/aerospace/aerospace.nix
@@ -14,26 +14,6 @@
         alt-k = "focus up";
         alt-l = "focus right";
       };
-      on-window-detected = [
-        {
-          "if" = {
-            app-id = "com.apple.MobileSMS";
-          };
-          run = [ "move-node-to-workspace 10" ];
-        }
-        {
-          "if" = {
-            app-id = "ru.keepcoder.Telegram";
-          };
-          run = [ "move-node-to-workspace 10" ];
-        }
-        {
-          "if" = {
-            app-id = "org.whispersystems.signal-desktop";
-          };
-          run = [ "move-node-to-workspace 10" ];
-        }
-      ];
     };
   };
 

--- a/tests/modules/programs/aerospace/settings-expected.toml
+++ b/tests/modules/programs/aerospace/settings-expected.toml
@@ -8,6 +8,7 @@ enable-normalization-opposite-orientation-for-nested-containers = true
 exec-on-workspace-change = []
 on-focus-changed = []
 on-focused-monitor-changed = ["move-mouse monitor-lazy-center"]
+on-window-detected = []
 start-at-login = false
 
 [gaps.outer]
@@ -24,15 +25,3 @@ alt-h = "focus left"
 alt-j = "focus down"
 alt-k = "focus up"
 alt-l = "focus right"
-
-[[on-window-detected]]
-"if.app-id" = "com.apple.MobileSMS"
-run = ["move-node-to-workspace 10"]
-
-[[on-window-detected]]
-"if.app-id" = "ru.keepcoder.Telegram"
-run = ["move-node-to-workspace 10"]
-
-[[on-window-detected]]
-"if.app-id" = "org.whispersystems.signal-desktop"
-run = ["move-node-to-workspace 10"]


### PR DESCRIPTION

### Description

This reverts commits 95861b5d9fc73f080b385776167c3dd2874e355b and d2c014e1c73195d1958abec0c5ca6112b07b79da (PR #6778), as they broke Aerospace configuration loading. Whilst the generated TOML configuration wasn't the best, it was completely valid, whereas after the aforementioned PR it was no longer valid.

The reason it's no longer valid is because the "if.app-id" in quotes is interpreted as a full key, instead of being nested in the "if" table. As a visual demonstration of the issue in JSON form, it's meant to be like this:

```json
{
  "if": {
    "app-id": "asdf"
  }
}
```

Whereas after the PR it was this, because of the quotes:

```json
{
  "if.app-id": "asdf"
}
```

Which isn't valid Aerospace configuration. For reference here is the error that occurred after the PR was merged:

<details>
<summary>Screenshot</summary>
<img src="https://github.com/user-attachments/assets/bd0a723b-4f2c-410c-9b37-a45643a31b23">
</details>

Closes #6790

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@damidoug
@axman6 (author of original PR)
@khaneliman (merger of original PR)
