### PR TITLE
way-displays: fix failing use of `lib.mkDefault`

### DIFF
--- a/modules/services/way-displays.nix
+++ b/modules/services/way-displays.nix
@@ -83,7 +83,7 @@ in
       yaml.generate "way-displays-config.yaml"
         (mergeSets [
           {
-            CALLBACK_CMD = lib.mkDefault "${pkgs.libnotify}/bin/notify-send \"way-displays \${CALLBACK_LEVEL}\" \"\${CALLBACK_MSG}\"";
+            CALLBACK_CMD = "${pkgs.libnotify}/bin/notify-send \"way-displays \${CALLBACK_LEVEL}\" \"\${CALLBACK_MSG}\"";
           }
           cfg.settings
         ]);


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

The use of `lib.mkDefault` causes problems in the generated yaml. I am seeing:


```yaml
CALLBACK_CMD:
  _type: override
  content: /nix/store/sg9dlv7zva7285340idna4czhsmp418x-libnotify-0.8.4/bin/notify-send
    "way-displays ${CALLBACK_LEVEL}" "${CALLBACK_MSG}"
  priority: 1000
```

for the defaults. It should just be:

```yaml
CALLBACK_CMD: /nix/store/sg9dlv7zva7285340idna4czhsmp418x-libnotify-0.8.4/bin/notify-send "way-displays ${CALLBACK_LEVEL}" "${CALLBACK_MSG}"
```

But the use of `lib.mkDefault` is not necessary here, since we are using `mergeSets` anyway, so the option can be overridden by a user without `lib.mkForce`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->