### PR TITLE
helix: add support for path and string themes

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -131,7 +131,13 @@ in
     };
 
     themes = mkOption {
-      type = types.attrsOf tomlFormat.type;
+      type = types.attrsOf (
+        types.oneOf [
+          tomlFormat.type
+          types.path
+          types.lines
+        ]
+      );
       default = { };
       example = literalExpression ''
         {
@@ -245,7 +251,13 @@ in
         themes = lib.mapAttrs' (
           n: v:
           lib.nameValuePair "helix/themes/${n}.toml" {
-            source = tomlFormat.generate "helix-theme-${n}" v;
+            source =
+              if lib.isAttrs v then
+                tomlFormat.generate "helix-theme-${n}" v
+              else if builtins.isPath cfg.style || lib.isStorePath cfg.style then
+                cfg.style
+              else
+                pkgs.writeText "helix-theme-${n}" v;
           }
         ) cfg.themes;
       in


### PR DESCRIPTION
### Description
The waybar module has similar functionality. Adding this because stylix team would like to be able to use a string/path for the theme as disused in https://github.com/danth/stylix/pull/1125#issuecomment-2791094566 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@Philipp-M 