### PR TITLE
foot: enable duplicate keys

### DIFF
--- a/modules/programs/foot.nix
+++ b/modules/programs/foot.nix
@@ -6,7 +6,7 @@
 }:
 let
   cfg = config.programs.foot;
-  iniFormat = pkgs.formats.ini { };
+  iniFormat = pkgs.formats.ini { listsAsDuplicateKeys = true; };
 in
 {
   meta.maintainers = with lib.maintainers; [ plabadens ];

--- a/tests/modules/programs/foot/default.nix
+++ b/tests/modules/programs/foot/default.nix
@@ -2,4 +2,5 @@
   foot-example-settings = ./example-settings.nix;
   foot-empty-settings = ./empty-settings.nix;
   foot-systemd-user-service = ./systemd-user-service.nix;
+  foot-regex-modes = ./regex-modes.nix;
 }

--- a/tests/modules/programs/foot/regex-modes-expected.ini
+++ b/tests/modules/programs/foot/regex-modes-expected.ini
@@ -1,0 +1,11 @@
+[key-bindings]
+regex-launch=[one] Shift+Control+1
+regex-launch=[two] Shift+Control+2
+
+[regex:one]
+launch=echo Regex one works
+regex=(some regex)
+
+[regex:two]
+launch=echo Second also works!
+regex=(some other regex)

--- a/tests/modules/programs/foot/regex-modes.nix
+++ b/tests/modules/programs/foot/regex-modes.nix
@@ -1,0 +1,29 @@
+{ config, ... }:
+{
+  programs.foot = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    settings = {
+      "regex:one" = {
+        regex = "(some regex)";
+        launch = "echo Regex one works";
+      };
+      "regex:two" = {
+        regex = "(some other regex)";
+        launch = "echo Second also works!";
+      };
+
+      key-bindings.regex-launch = [
+        "[one] Shift+Control+1"
+        "[two] Shift+Control+2"
+      ];
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/foot/foot.ini \
+      ${./regex-modes-expected.ini}
+  '';
+}


### PR DESCRIPTION
closes #5873



### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@plabadens 