### PR TITLE
yazi: remove assertions

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -276,49 +276,5 @@ in
         ) cfg.plugins)
       ]
     );
-
-    assertions =
-      let
-        mkAsserts =
-          opt: requiredFiles:
-          mapAttrsToList (
-            name: value:
-            let
-              isDir = lib.pathIsDirectory "${value}";
-              msgNotDir = optionalString (!isDir) "The path or package should be a directory, not a single file.";
-              isFileMissing =
-                file: !(lib.pathExists "${value}/${file}") || lib.pathIsDirectory "${value}/${file}";
-              missingFiles = lib.filter isFileMissing requiredFiles;
-              msgFilesMissing = optionalString (
-                missingFiles != [ ]
-              ) "The ${singularOpt} is missing these files: ${toString missingFiles}";
-              singularOpt = lib.removeSuffix "s" opt;
-              isPluginValid =
-                opt == "plugins" && (lib.any (file: lib.pathExists "${value}/${file}") requiredFiles);
-              isValid = if opt == "plugins" then isPluginValid else missingFiles == [ ];
-            in
-            {
-              assertion = isDir && isValid;
-              message = ''
-                Value at `programs.yazi.${opt}.${name}` is not a valid yazi ${singularOpt}.
-                ${msgNotDir}
-                ${msgFilesMissing}
-                Evaluated value: `${value}`
-              '';
-            }
-          ) cfg.${opt};
-      in
-      (mkAsserts "flavors" [
-        "flavor.toml"
-        "tmtheme.xml"
-        "README.md"
-        "preview.png"
-        "LICENSE"
-        "LICENSE-tmtheme"
-      ])
-      ++ (mkAsserts "plugins" [
-        "init.lua"
-        "main.lua"
-      ]);
   };
 }


### PR DESCRIPTION
Contains IFD and unnecessarily restricts user's configuration.

Came up in previous issues and on matrix again recently. 
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
