### PR TITLE
direnv: fix silent option after update to direnv v2.36.0

### DIFF
--- a/tests/modules/programs/direnv/default.nix
+++ b/tests/modules/programs/direnv/default.nix
@@ -5,4 +5,5 @@
   direnv-nushell = ./nushell.nix;
   direnv-stdlib = ./stdlib.nix;
   direnv-stdlib-and-nix-direnv = ./stdlib-and-nix-direnv.nix;
+  direnv-silent = ./silent.nix;
 }

--- a/tests/modules/programs/direnv/silent.nix
+++ b/tests/modules/programs/direnv/silent.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+{
+  programs.bash.enable = true;
+  programs.direnv = {
+    enable = true;
+    silent = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/direnv/direnv.toml
+    assertFileContent \
+      home-files/.config/direnv/direnv.toml \
+      ${pkgs.writeText "direnv.toml" ''
+        [global]
+        log_filter = "^$"
+        log_format = "-"
+      ''}
+  '';
+}


### PR DESCRIPTION
see https://github.com/direnv/direnv/issues/68 (bottom of thread)

### Description
Closes https://github.com/nix-community/home-manager/issues/6822
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@rycee @khaneliman @shikanime 