### PR TITLE
home-manager: Feature test for flake support

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -43,13 +43,9 @@ function setWorkDir() {
     fi
 }
 
-# Checks whether the 'flakes' and 'nix-command' Nix options are enabled.
+# Check to see if flakes are functionally available.
 function hasFlakeSupport() {
-    type -p nix > /dev/null \
-        && nix show-config 2> /dev/null \
-            | grep experimental-features \
-            | grep flakes \
-            | grep -q nix-command
+    nix eval --expr 'builtins.getFlake' > /dev/null 2>&1
 }
 
 # Attempts to set the HOME_MANAGER_CONFIG global variable.


### PR DESCRIPTION
Feature testing flakes / nix-command is more robust over configuration sniffing. Ultimately, the deciding factor should be if flakes work -- not if the config looks like they will / won't work.

This alternative test both asserts that the `nix` command is enabled, and that flakes are enabled, without depending on whether or not flakes are emitted as an experimental feature.

This is both repairing support for Determinate Nix 3, and prepares for a potential future where Nix itself considers Flakes stable.

Closes #6702

Backport of #6824 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

cc @khaneliman 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
