### PR TITLE
mcfly: Fix mcfly-fzf initialization crash for fish and zsh

### DIFF
--- a/modules/programs/mcfly.nix
+++ b/modules/programs/mcfly.nix
@@ -37,7 +37,7 @@ let
       ${getExe cfg.package} init fish | source
     ''
     + optionalString cfg.fzf.enable ''
-      eval "$(${getExe cfg.mcflyFzfPackage} init fish)"
+      ${getExe cfg.mcflyFzfPackage} init fish | source
     '';
 
   zshIntegration =
@@ -46,7 +46,7 @@ let
     ''
     + optionalString cfg.fzf.enable ''
       if [[ -o interactive ]]; then
-        ${getExe cfg.mcflyFzfPackage} init zsh | source
+      eval "$(${getExe cfg.mcflyFzfPackage} init zsh)"
       fi
     '';
 


### PR DESCRIPTION
### Description
Fixes #6826

An erroneous change was made when mcfly-fzf was modified to disable on non-interactive shells for fish and zsh. The fish version of the plugin initialization was used for zsh and vice versa. Oddly the erroneous change doesn't seem to make mcfly-fzf crash on fish but it does however crash on zsh; I went ahead and corrected the error for both shells just to be on the safe side. Tested on my flake and can confirm it works

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
