### PR TITLE
mkFirefoxModule: fix userChrome with leading comment

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -874,7 +874,11 @@ in
                 "chrome"
               else
                 "chrome/userChrome.css";
-            sourcePath = if lib.types.path.check profile.userChrome then profile.userChrome else null;
+            sourcePath =
+              if ((i: lib.isPath i && lib.types.path.check i) profile.userChrome) then
+                profile.userChrome
+              else
+                null;
           in
           # Merge the regular profile settings with extension settings
           mkMerge (

--- a/tests/modules/programs/firefox/profiles/userchrome/chrome/userChrome.css
+++ b/tests/modules/programs/firefox/profiles/userchrome/chrome/userChrome.css
@@ -1,3 +1,7 @@
+/*
+  This is a simple comment that should be written inside the `chrome/userChrome.css`
+*/
+
 #urlbar {
   min-width: none !important;
   border: none !important;

--- a/tests/modules/programs/firefox/profiles/userchrome/default.nix
+++ b/tests/modules/programs/firefox/profiles/userchrome/default.nix
@@ -18,14 +18,17 @@ in
         basic.isDefault = true;
         lines = {
           id = 1;
-          userChrome = # CSS
-            ''
-              #urlbar {
-                min-width: none !important;
-                border: none !important;
-                outline: none !important;
-              }
-            '';
+          userChrome = ''
+            /*
+              This is a simple comment that should be written inside the `chrome/userChrome.css`
+            */
+
+            #urlbar {
+              min-width: none !important;
+              border: none !important;
+              outline: none !important;
+            }
+          '';
         };
         path = {
           id = 2;

--- a/tests/modules/programs/firefox/profiles/userchrome/expected-userchrome.css
+++ b/tests/modules/programs/firefox/profiles/userchrome/expected-userchrome.css
@@ -1,3 +1,7 @@
+/*
+  This is a simple comment that should be written inside the `chrome/userChrome.css`
+*/
+
 #urlbar {
   min-width: none !important;
   border: none !important;


### PR DESCRIPTION
### Description
Closes https://github.com/nix-community/home-manager/issues/6834
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
