### PR TITLE
tests/firefox: fix test commands

### DIFF
--- a/tests/modules/programs/firefox/profiles/userchrome/default.nix
+++ b/tests/modules/programs/firefox/profiles/userchrome/default.nix
@@ -48,13 +48,13 @@ in
 
         assertDirectoryExists home-files/${cfg.configPath}/basic
 
-        assertFileNotExists \
+        assertPathNotExists \
           home-files/${cfg.configPath}/lines/chrome/extraFile.css
         assertFileContent \
           home-files/${cfg.configPath}/lines/chrome/userChrome.css \
           ${./chrome/userChrome.css}
 
-        assertFileNotExists \
+        assertPathNotExists \
           home-files/${cfg.configPath}/path/chrome/extraFile.css
         assertFileContent \
           home-files/${cfg.configPath}/path/chrome/userChrome.css \


### PR DESCRIPTION
Tests passed, but looks like `nmt` was swallowing the command not found errors.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
