### PR TITLE
zsh: deprecate initLocation options in favor of initContent

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -500,29 +500,69 @@ in
           default = "";
           type = types.lines;
           example = lib.literalExpression ''
-            lib.mkOrder 1000 ''''
+            lib.mkOrder 1200 ''''
               echo "Hello zsh initContent!"
             '''';
           '';
-          description = "Content to be added to {file}`.zshrc`. To specify the order, use `lib.mkOrder`.";
+          description = ''
+            Content to be added to {file}`.zshrc`.
+
+            To specify the order, use `lib.mkOrder`.
+
+            Common order values:
+            - 500 (mkBefore): Early initialization (replaces initExtraFirst)
+            - 550: Before completion initialization (replaces initExtraBeforeCompInit)
+            - 1000 (default): General configuration (replaces initExtra)
+            - 1500 (mkAfter): Last to run configuration
+          '';
         };
 
         initExtraBeforeCompInit = mkOption {
           default = "";
           type = types.lines;
-          description = "Extra commands that should be added to {file}`.zshrc` before compinit.";
+          apply =
+            x:
+            lib.warnIfNot (x == "") ''
+              `programs.zsh.initExtraBeforeCompInit` is deprecated, use `programs.zsh.initContent` with `lib.mkOrder 550` instead.
+
+              Example: programs.zsh.initContent = lib.mkOrder 550 "your content here";
+            '' x;
+          visible = false;
+          description = ''
+            Extra commands that should be added to {file}`.zshrc` before compinit.
+          '';
         };
 
         initExtra = mkOption {
           default = "";
           type = types.lines;
-          description = "Extra commands that should be added to {file}`.zshrc`.";
+          visible = false;
+          apply =
+            x:
+            lib.warnIfNot (x == "") ''
+              `programs.zsh.initExtra` is deprecated, use `programs.zsh.initContent` instead.
+
+              Example: programs.zsh.initContent = "your content here";
+            '' x;
+          description = ''
+            Extra commands that should be added to {file}`.zshrc`.
+          '';
         };
 
         initExtraFirst = mkOption {
           default = "";
           type = types.lines;
-          description = "Commands that should be added to top of {file}`.zshrc`.";
+          visible = false;
+          apply =
+            x:
+            lib.warnIfNot (x == "") ''
+              `programs.zsh.initExtraFirst` is deprecated, use `programs.zsh.initContent` with `lib.mkBefore` instead.
+
+              Example: programs.zsh.initContent = lib.mkBefore "your content here";
+            '' x;
+          description = ''
+            Commands that should be added to top of {file}`.zshrc`.
+          '';
         };
 
         envExtra = mkOption {


### PR DESCRIPTION
https://github.com/nix-community/home-manager/pull/6479 introduced a more comprehensive option that allows fine tuning location of zsh config. Encourage using that over the predetermined locations.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
