### PR TITLE
tests: dont use realPkgs

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -131,6 +131,7 @@ let
         "granted"
         "helix"
         "himalaya"
+        "hjson-go"
         "htop"
         "hyfetch"
         "i3status"

--- a/tests/modules/config/home-cursor/default.nix
+++ b/tests/modules/config/home-cursor/default.nix
@@ -1,12 +1,20 @@
+let
+  package = {
+    buildScript = ''
+      mkdir -p $out/share/icons/catppuccin-macchiato-blue-cursors
+      echo test > $out/share/icons/catppuccin-macchiato-blue-cursors/index.theme
+    '';
+  };
+in
 {
   # Ensure backwards compatibility with existing configs
   home-cursor-legacy =
-    { realPkgs, ... }:
+    { config, ... }:
     {
       config = {
         home.pointerCursor = {
-          package = realPkgs.catppuccin-cursors.macchiatoBlue;
           name = "catppuccin-macchiato-blue-standard";
+          package = config.lib.test.mkStubPackage package;
           size = 64;
           gtk.enable = true;
           hyprcursor.enable = true;
@@ -16,9 +24,7 @@
         home.stateVersion = "24.11";
 
         nmt.script = ''
-          assertFileContent \
-            home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme \
-            ${./expected-index.theme}
+          assertFileExists home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme
 
           hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
           assertFileExists $hmEnvFile
@@ -61,12 +67,12 @@
     };
 
   home-cursor-legacy-disabled-with-enable =
-    { realPkgs, ... }:
+    { config, ... }:
     {
       config = {
         home.pointerCursor = {
           enable = false;
-          package = realPkgs.catppuccin-cursors.macchiatoBlue;
+          package = config.lib.test.mkStubPackage package;
           name = "catppuccin-macchiato-blue-standard";
           size = 64;
           gtk.enable = true;
@@ -90,12 +96,12 @@
     };
 
   home-cursor-legacy-enabled-with-enable =
-    { realPkgs, ... }:
+    { config, ... }:
     {
       config = {
         home.pointerCursor = {
           enable = true;
-          package = realPkgs.catppuccin-cursors.macchiatoBlue;
+          package = config.lib.test.mkStubPackage package;
           name = "catppuccin-macchiato-blue-standard";
           size = 64;
           gtk.enable = true;
@@ -106,9 +112,7 @@
         home.stateVersion = "24.11";
 
         nmt.script = ''
-          assertFileContent \
-            home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme \
-            ${./expected-index.theme}
+          assertFileExists home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme
 
           hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
           assertFileExists $hmEnvFile
@@ -122,12 +126,12 @@
     };
 
   home-cursor =
-    { realPkgs, ... }:
+    { config, ... }:
     {
       config = {
         home.pointerCursor = {
           enable = true;
-          package = realPkgs.catppuccin-cursors.macchiatoBlue;
+          package = config.lib.test.mkStubPackage package;
           name = "catppuccin-macchiato-blue-standard";
           size = 64;
           gtk.enable = true;
@@ -138,9 +142,7 @@
         home.stateVersion = "25.05";
 
         nmt.script = ''
-          assertFileContent \
-            home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme \
-            ${./expected-index.theme}
+          assertFileExists home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme
 
           hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
           assertFileExists $hmEnvFile
@@ -153,12 +155,12 @@
     };
 
   home-cursor-disabled =
-    { realPkgs, ... }:
+    { config, ... }:
     {
       config = {
         home.pointerCursor = {
           enable = false;
-          package = realPkgs.catppuccin-cursors.macchiatoBlue;
+          package = config.lib.test.mkStubPackage package;
           name = "catppuccin-macchiato-blue-standard";
           size = 64;
           gtk.enable = true;

--- a/tests/modules/config/home-cursor/expected-index.theme
+++ b/tests/modules/config/home-cursor/expected-index.theme
@@ -1,3 +1,0 @@
-[Icon Theme]
-Name=Catppuccin Macchiato Blue
-Comment=based on Volantes Cursors

--- a/tests/modules/programs/broot/broot.nix
+++ b/tests/modules/programs/broot/broot.nix
@@ -1,12 +1,25 @@
-{ realPkgs, ... }:
+{ config, ... }:
 
 {
   programs.broot = {
     enable = true;
+    package = (
+      config.lib.test.mkStubPackage {
+        name = "broot";
+        extraAttrs = {
+          src = config.lib.test.mkStubPackage {
+            name = "broot-src";
+            buildScript = ''
+              mkdir -p $out/resources/default-conf/
+              echo test > $out/resources/default-conf/conf.hjson
+            '';
+          };
+        };
+      }
+    );
+
     settings.modal = true;
   };
-
-  nixpkgs.overlays = [ (self: super: { inherit (realPkgs) broot hjson-go; }) ];
 
   nmt.script = ''
     assertFileExists home-files/.config/broot/conf.hjson

--- a/tests/modules/programs/thunderbird/thunderbird-native-messaging-host.nix
+++ b/tests/modules/programs/thunderbird/thunderbird-native-messaging-host.nix
@@ -1,24 +1,29 @@
 # Confirm that both Firefox and Thunderbird can be configured at the same time.
-{ lib, realPkgs, ... }:
-lib.recursiveUpdate (import ./thunderbird.nix { inherit lib realPkgs; }) {
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+  nativeHostsDir =
+    if isDarwin then "Library/Mozilla/NativeMessagingHosts" else ".mozilla/native-messaging-hosts";
+in
+lib.recursiveUpdate (import ./thunderbird.nix { inherit config lib pkgs; }) {
   programs.thunderbird = {
-    nativeMessagingHosts = with realPkgs; [
-      # NOTE: this is not a real Thunderbird native host module but Firefox; no
-      # native hosts are currently packaged for nixpkgs or elsewhere, so we
-      # have to improvise. Packaging wise, Firefox and Thunderbird native hosts
-      # are identical though. The test doesn't care if the host was meant for
-      # either as long as the right paths are present in the package.
-      browserpass
+    nativeMessagingHosts = [
+      (config.lib.test.mkStubPackage {
+        name = "browserpass";
+        buildScript = ''
+          mkdir -p $out/lib/mozilla/native-messaging-hosts
+          echo test > $out/lib/mozilla/native-messaging-hosts/com.github.browserpass.native.json
+        '';
+      })
     ];
   };
 
-  nmt.script =
-    let
-      isDarwin = realPkgs.stdenv.hostPlatform.isDarwin;
-      nativeHostsDir =
-        if isDarwin then "Library/Mozilla/NativeMessagingHosts" else ".mozilla/native-messaging-hosts";
-    in
-    ''
-      assertFileExists home-files/${nativeHostsDir}/com.github.browserpass.native.json
-    '';
+  nmt.script = ''
+    assertFileExists home-files/${nativeHostsDir}/com.github.browserpass.native.json
+  '';
 }

--- a/tests/modules/programs/thunderbird/thunderbird-with-firefox.nix
+++ b/tests/modules/programs/thunderbird/thunderbird-with-firefox.nix
@@ -1,9 +1,13 @@
 # Confirm that both Firefox and Thunderbird can be configured at the same time.
-{ lib, realPkgs, ... }:
-lib.recursiveUpdate (import ./thunderbird.nix { inherit lib realPkgs; }) {
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+lib.recursiveUpdate (import ./thunderbird.nix { inherit config lib pkgs; }) {
   programs.firefox = {
     enable = true;
-    # Darwin doesn't support wrapped Firefox, using unwrapped instead
-    package = realPkgs.firefox-unwrapped;
+    package = null;
   };
 }

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -1,6 +1,12 @@
-{ lib, realPkgs, ... }:
 {
-  imports = [ ../../accounts/email-test-accounts.nix ];
+  config,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ../../accounts/email-test-accounts.nix
+  ];
 
   accounts.email.accounts = {
     "hm@example.com" = {
@@ -54,13 +60,12 @@
 
   programs.thunderbird = {
     enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "thunderbird";
+    };
 
     # Disable warning so that platforms' behavior is the same
     darwinSetupWarning = false;
-
-    # Darwin doesn't support wrapped Thunderbird, using unwrapped instead;
-    # using -latest- because ESR is currently broken on Darwin
-    package = realPkgs.thunderbird-latest-unwrapped;
 
     profiles = {
       first = {
@@ -105,7 +110,7 @@
 
   nmt.script =
     let
-      isDarwin = realPkgs.stdenv.hostPlatform.isDarwin;
+      isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
       configDir = if isDarwin then "Library/Thunderbird" else ".thunderbird";
       profilesDir = if isDarwin then "${configDir}/Profiles" else "${configDir}";
       platform = if isDarwin then "darwin" else "linux";


### PR DESCRIPTION
Not relevant for testing and CI broken because of upstream issues. 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
