### PR TITLE
fish: allow multiple commands for command option in abbreviations

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -185,7 +185,7 @@ let
       };
 
       command = mkOption {
-        type = with types; nullOr str;
+        type = with types; nullOr (either str (listOf str));
         default = null;
         description = ''
           Specifies the command(s) for which the abbreviation should expand. If

--- a/tests/modules/programs/fish/abbrs.nix
+++ b/tests/modules/programs/fish/abbrs.nix
@@ -39,6 +39,13 @@
           command = "git";
           expansion = "checkout";
         };
+        s = {
+          command = [
+            "git"
+            "hg"
+          ];
+          expansion = "status";
+        };
         dotdot = {
           regex = "^\\.\\.+$";
           function = "multicd";
@@ -70,6 +77,8 @@
         '"
         assertFileContains home-files/.config/fish/config.fish \
           "abbr --add --command git -- co checkout"
+        assertFileContains home-files/.config/fish/config.fish \
+          "abbr --add --command git --command hg -- s status"
         assertFileContains home-files/.config/fish/config.fish \
           "abbr --add --function multicd --regex '^\.\.+$' -- dotdot"
       '';


### PR DESCRIPTION
### Description

Allows the use of multiple commands for one abbreviation like so:
```nix
s = {
  command = ["git" "hg"];
  expansion = "status";
};
```

This then expands `s` to `status` if there is `git` or `hg` typed before.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
no maintainer – @zhaofengli hope you don’t mind checking since you were the last to edit :)
