### PR TITLE
vesktop: init module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -648,6 +648,18 @@
     github = "pedorich-n";
     githubId = 15573098;
   };
+  LilleAila = {
+    name = "LilleAila";
+    email = "olai@olai.dev";
+    github = "LilleAila";
+    githubId = 67327023;
+    keys = [
+      {
+        longkeyid = "ed25519/0xD1ACCDCF2B9B9799";
+        fingerprint = "8185 29F9 BB4C 33F0 69BB  9782 D1AC CDCF 2B9B 9799";
+      }
+    ];
+  };
   PopeRigby = {
     name = "PopeRigby";
     github = "poperigby";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -278,6 +278,7 @@ let
       ./programs/translate-shell.nix
       ./programs/urxvt.nix
       ./programs/vdirsyncer.nix
+      ./programs/vesktop.nix
       ./programs/vifm.nix
       ./programs/vim-vint.nix
       ./programs/vim.nix

--- a/modules/programs/vesktop.nix
+++ b/modules/programs/vesktop.nix
@@ -1,0 +1,112 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+
+  cfg = config.programs.vesktop;
+  jsonFormat = pkgs.formats.json { };
+
+in
+{
+  meta.maintainers = [
+    lib.hm.maintainers.LilleAila
+    lib.maintainers.Flameopathic
+  ];
+
+  options.programs.vesktop = {
+    enable = lib.mkEnableOption "Vesktop, an alternate client for Discord with Vencord built-in";
+    package = lib.mkPackageOption pkgs "vesktop" { };
+    settings = lib.mkOption {
+      type = jsonFormat.type;
+      default = { };
+      description = ''
+        Vesktop settings written to
+        {file}`$XDG_CONFIG_HOME/vesktop/settings.json`. See
+        <https://github.com/Vencord/Vesktop/blob/main/src/shared/settings.d.ts>
+        for available options.
+      '';
+      example = lib.literalExpression ''
+        {
+          appBadge = false;
+          arRPC = true;
+          checkUpdates = false;
+          customTitleBar = false;
+          disableMinSize = true;
+          minimizeToTray = false;
+          tray = false;
+          splashBackground = "#000000";
+          splashColor = "#ffffff";
+          splashTheming = true;
+          staticTitle = true;
+          hardwareAcceleration = true;
+          discordBranch = "stable";
+        }
+      '';
+    };
+
+    vencord = {
+      useSystem = lib.mkEnableOption "Vencord package from Nixpkgs";
+      theme = lib.mkOption {
+        description = "The theme to use for Vencord";
+        default = null;
+        type =
+          with lib.types;
+          nullOr (oneOf [
+            lines
+            path
+          ]);
+      };
+      settings = lib.mkOption {
+        type = jsonFormat.type;
+        default = { };
+        description = ''
+          Vencord settings written to
+          {file}`$XDG_CONFIG_HOME/vesktop/settings/settings.json`. See
+          <https://github.com/Vendicated/Vencord/blob/main/src/api/Settings.ts>
+          for available options.
+        '';
+        example = lib.literalExpression ''
+          {
+            autoUpdate = false;
+            autoUpdateNotification = false;
+            notifyAboutUpdates = false;
+            useQuickCss = true;
+            disableMinSize = true;
+            plugins = {
+              MessageLogger = {
+                enabled = true;
+                ignoreSelf = true;
+              };
+              FakeNitro.enabled = true;
+            };
+          }
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        home.packages = [
+          (cfg.package.override { withSystemVencord = cfg.vencord.useSystem; })
+        ];
+        xdg.configFile."vesktop/settings.json".source = jsonFormat.generate "vesktop-settings" cfg.settings;
+        xdg.configFile."vesktop/settings/settings.json".source =
+          jsonFormat.generate "vencord-settings" cfg.vencord.settings;
+      }
+      (lib.mkIf (cfg.vencord.theme != null) {
+        programs.vesktop.vencord.settings.enabledThemes = [ "theme.css" ];
+        xdg.configFile."vesktop/themes/theme.css".source =
+          if builtins.isPath cfg.vencord.theme || lib.isStorePath cfg.vencord.theme then
+            cfg.vencord.theme
+          else
+            pkgs.writeText "vesktop/themes/theme.css" cfg.vencord.theme;
+      })
+    ]
+  );
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -547,6 +547,7 @@ import nmtSrc {
       ./modules/programs/swayr
       ./modules/programs/terminator
       ./modules/programs/tofi
+      ./modules/programs/vesktop
       ./modules/programs/vinegar
       ./modules/programs/waybar
       ./modules/programs/wlogout

--- a/tests/modules/programs/vesktop/basic-configuration.nix
+++ b/tests/modules/programs/vesktop/basic-configuration.nix
@@ -1,0 +1,59 @@
+{ config, pkgs, ... }:
+
+{
+  config = {
+    programs.vesktop = {
+      enable = true;
+      settings = {
+        tray = false;
+        minimizeToTray = false;
+        hardwareAcceleration = true;
+        customTitleBar = false;
+        staticTitle = true;
+        discordBranch = "stable";
+      };
+      vencord = {
+        theme = ''
+          .privateChannels_f0963d::after {
+            content: "";
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            top: 0;
+            left: 0;
+            z-index: 1000;
+            background: linear-gradient(to bottom, transparent 85%, var(--base00));
+            pointer-events: none;
+          }
+        '';
+        settings = {
+          autoUpdate = false;
+          autoUpdateNotification = false;
+          notifyAboutUpdates = false;
+          useQuickCss = true;
+          disableMinSize = true;
+          plugins = {
+            MessageLogger = {
+              enabled = true;
+              ignoreSelf = true;
+            };
+            FakeNitro.enabled = true;
+          };
+        };
+      };
+    };
+
+    nmt.script = ''
+      configDir=home-files/.config/vesktop
+      assertFileExists $configDir/settings.json
+      assertFileContent $configDir/settings.json \
+        ${./basic-settings.json}
+      assertFileExists $configDir/settings/settings.json
+      assertFileContent $configDir/settings/settings.json \
+        ${./basic-vencord-settings.json}
+      assertFileExists $configDir/themes/theme.css
+      assertFileContent $configDir/themes/theme.css \
+        ${./basic-theme.css}
+    '';
+  };
+}

--- a/tests/modules/programs/vesktop/basic-settings.json
+++ b/tests/modules/programs/vesktop/basic-settings.json
@@ -1,0 +1,8 @@
+{
+  "customTitleBar": false,
+  "discordBranch": "stable",
+  "hardwareAcceleration": true,
+  "minimizeToTray": false,
+  "staticTitle": true,
+  "tray": false
+}

--- a/tests/modules/programs/vesktop/basic-theme.css
+++ b/tests/modules/programs/vesktop/basic-theme.css
@@ -1,0 +1,11 @@
+.privateChannels_f0963d::after {
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  background: linear-gradient(to bottom, transparent 85%, var(--base00));
+  pointer-events: none;
+}

--- a/tests/modules/programs/vesktop/basic-vencord-settings.json
+++ b/tests/modules/programs/vesktop/basic-vencord-settings.json
@@ -1,0 +1,19 @@
+{
+  "autoUpdate": false,
+  "autoUpdateNotification": false,
+  "disableMinSize": true,
+  "enabledThemes": [
+    "theme.css"
+  ],
+  "notifyAboutUpdates": false,
+  "plugins": {
+    "FakeNitro": {
+      "enabled": true
+    },
+    "MessageLogger": {
+      "enabled": true,
+      "ignoreSelf": true
+    }
+  },
+  "useQuickCss": true
+}

--- a/tests/modules/programs/vesktop/default.nix
+++ b/tests/modules/programs/vesktop/default.nix
@@ -1,0 +1,1 @@
+{ vesktop-basic-configuration = ./basic-configuration.nix; }


### PR DESCRIPTION
### Description

- Adds module for Vesktop
- Rebases #5587 onto master and combines three commits
- Supercedes and closes #5587 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@LilleAila 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
