### PR TITLE
vesktop: add support for multiple themes

### DIFF
--- a/tests/modules/programs/vesktop/basic-configuration.nix
+++ b/tests/modules/programs/vesktop/basic-configuration.nix
@@ -13,7 +13,7 @@
         discordBranch = "stable";
       };
       vencord = {
-        theme = ''
+        themes.my_theme = ''
           .privateChannels_f0963d::after {
             content: "";
             position: absolute;
@@ -51,8 +51,8 @@
       assertFileExists $configDir/settings/settings.json
       assertFileContent $configDir/settings/settings.json \
         ${./basic-vencord-settings.json}
-      assertFileExists $configDir/themes/theme.css
-      assertFileContent $configDir/themes/theme.css \
+      assertFileExists $configDir/themes/my_theme.css
+      assertFileContent $configDir/themes/my_theme.css \
         ${./basic-theme.css}
     '';
   };

--- a/tests/modules/programs/vesktop/basic-vencord-settings.json
+++ b/tests/modules/programs/vesktop/basic-vencord-settings.json
@@ -2,9 +2,6 @@
   "autoUpdate": false,
   "autoUpdateNotification": false,
   "disableMinSize": true,
-  "enabledThemes": [
-    "theme.css"
-  ],
   "notifyAboutUpdates": false,
   "plugins": {
     "FakeNitro": {


### PR DESCRIPTION
### Description
adds to #5587
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@Flameopathic @LilleAila 