### PR TITLE
kconfig: escape arguments properly

### DIFF
--- a/modules/misc/qt/kconfig.nix
+++ b/modules/misc/qt/kconfig.nix
@@ -74,8 +74,8 @@ in
               lib.mapAttrsToList (group: value: toLine file (path ++ [ group ]) value) value
             else
               "run ${pkgs.kdePackages.kconfig}/bin/kwriteconfig6 --file '${configHome}/${file}' ${
-                lib.concatMapStringsSep " " (x: "--group ${x}") (lib.lists.init path)
-              } --key '${lib.lists.last path}' ${toValue value}";
+                lib.concatMapStringsSep " " (x: "--group ${lib.escapeShellArg x}") (lib.lists.init path)
+              } --key ${lib.escapeShellArg (lib.lists.last path)} ${toValue value}";
           lines = lib.flatten (lib.mapAttrsToList (file: attrs: toLine file [ ] attrs) cfg);
         in
         builtins.concatStringsSep "\n" lines


### PR DESCRIPTION
Previously shell arguments were not escaped properly, leading to breakage on group names containing characters with special meaning to the shell (in particular spaces); theoretically keys containing single quotes would be affected too. Escape all arguments passed to the shell properly instead.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
