### PR TITLE
nushell: throw instead of abort

### DIFF
--- a/modules/lib/nushell.nix
+++ b/modules/lib/nushell.nix
@@ -81,5 +81,5 @@ rec {
           }${outroSpace}}"
       )
     else
-      abort "nushell.toNushell: type ${lib.typeOf v} is unsupported";
+      throw "nushell.toNushell: type ${lib.typeOf v} is unsupported";
 }


### PR DESCRIPTION
### Description

This PR prevents `lib.hm.nushell.toNushell` from unconditionally aborting the evaluation if an error is detected, allowing consumers to `tryEval` the result and provide a fallback value.

The `abort` was there originally because it's what the `toLua` function it's based on does, but I think it makes sense to `throw` in most cases. I'd even argue this should be a treewide change :)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Philipp-M @aidalgol 