### PR TITLE
gpg-agent: support pinentryBinary

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -296,6 +296,7 @@ in
           configuration file.
         '';
       };
+
       pinentryPackage = mkOption {
         type = types.nullOr types.package;
         example = lib.literalExpression "pkgs.pinentry-gnome3";
@@ -308,6 +309,15 @@ in
           ```nix
           home.packages = [ pkgs.gcr ];
           ```
+        '';
+      };
+
+      pinentryBinary = mkOption {
+        type = types.nullOr (types.path);
+        example = "\${pkgs.wayprompt}/bin/wayprompt-pinentry";
+        default = null;
+        description = ''
+          Which binary to use for `pinentry-program`.
         '';
       };
 
@@ -324,6 +334,14 @@ in
   config = mkIf cfg.enable (
     lib.mkMerge [
       {
+        assertions = [
+          {
+            assertion = cfg.pinentryBinary == null || cfg.pinentryPackage == null;
+            message = "pinentryBinary and pinentryPackage cannot both be set.";
+          }
+        ];
+      }
+      {
         home.file."${homedir}/gpg-agent.conf".text = lib.concatStringsSep "\n" (
           optional (cfg.enableSshSupport) "enable-ssh-support"
           ++ optional cfg.grabKeyboardAndMouse "grab"
@@ -336,6 +354,7 @@ in
           ++ optional (cfg.maxCacheTtl != null) "max-cache-ttl ${toString cfg.maxCacheTtl}"
           ++ optional (cfg.maxCacheTtlSsh != null) "max-cache-ttl-ssh ${toString cfg.maxCacheTtlSsh}"
           ++ optional (cfg.pinentryPackage != null) "pinentry-program ${lib.getExe cfg.pinentryPackage}"
+          ++ optional (cfg.pinentryBinary != null) "pinentry-program ${cfg.pinentryBinary}"
           ++ [ cfg.extraConfig ]
         );
 


### PR DESCRIPTION
### Description

This adds a new option, `pinentryBinary` to the `gpg-agent` service definition. And and assertion that it is not set at the same time as `pinentryPackage`.

This is to support prompts like `wayprompt` that have than one exe output, or don't follow the naming assumption that `pinentryPackage` relies on.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

~~- If this PR adds a new module~~

  - [ ] ~~Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).~~

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
