### PR TITLE
fcitx5: add `themes` and `classicUiConfig` options

### DIFF
--- a/tests/modules/i18n/input-method/fcitx5-configuration.nix
+++ b/tests/modules/i18n/input-method/fcitx5-configuration.nix
@@ -8,13 +8,28 @@
 lib.mkIf config.test.enableBig {
   i18n.inputMethod = {
     enabled = "fcitx5";
-    fcitx5.waylandFrontend = true;
+    fcitx5 = {
+      waylandFrontend = true;
+      themes.example = {
+        theme = ''
+          [Metadata]
+          Name=example
+          Version=0.1
+          Author=home-manager
+          Description=Theme for testing
+          ScaleWithDPI=True
+        '';
+      };
+      classicUiConfig = "Theme=example";
+    };
   };
 
   _module.args.pkgs = lib.mkForce realPkgs;
 
   nmt.script = ''
     assertFileExists home-files/.config/systemd/user/fcitx5-daemon.service
+    assertFileExists home-files/.local/share/fcitx5/themes/example/theme.conf
+    assertFileExists home-files/.local/share/fcitx5/conf/classicui.conf
     assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'GTK_IM_MODULE'
     assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'QT_IM_MODULE'
   '';


### PR DESCRIPTION
### Description
- Adds `themes` option with several suboptions
- Adds `classicUiConfig` option for `classicui.conf` configuration
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
