### PR TITLE
keepassxc: register as native messaging host

### DIFF
--- a/modules/programs/keepassxc.nix
+++ b/modules/programs/keepassxc.nix
@@ -45,12 +45,26 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
-    xdg.configFile = {
-      "keepassxc/keepassxc.ini" = lib.mkIf (cfg.settings != { }) {
-        source = iniFormat.generate "keepassxc-settings" cfg.settings;
-      };
-    };
-  };
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+
+      {
+        xdg.configFile = {
+          "keepassxc/keepassxc.ini" = lib.mkIf (cfg.settings != { }) {
+            source = iniFormat.generate "keepassxc-settings" cfg.settings;
+          };
+        };
+      }
+
+      (lib.mkIf (cfg.package != null) {
+        home.packages = [ cfg.package ];
+        programs.brave.nativeMessagingHosts = [ cfg.package ];
+        programs.chromium.nativeMessagingHosts = [ cfg.package ];
+        programs.firefox.nativeMessagingHosts = [ cfg.package ];
+        programs.floorp.nativeMessagingHosts = [ cfg.package ];
+        programs.vivaldi.nativeMessagingHosts = [ cfg.package ];
+      })
+
+    ]
+  );
 }


### PR DESCRIPTION
### Description

Register KeepassXC as a native messaging host in supported browsers to integrate with KeepassXC's browser extension.  See [this Discourse thread](https://discourse.nixos.org/t/keepassxc-browser-extension-integration/39553) for more information.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@d-brasher
