### PR TITLE
xdg-autostart: fix runCommandNoCCLocal deprecation

### DIFF
--- a/modules/misc/xdg-autostart.nix
+++ b/modules/misc/xdg-autostart.nix
@@ -5,12 +5,6 @@
   ...
 }:
 let
-  inherit (builtins)
-    baseNameOf
-    listToAttrs
-    map
-    unsafeDiscardStringContext
-    ;
   inherit (lib)
     literalExpression
     mkEnableOption
@@ -21,7 +15,7 @@ let
 
   cfg = config.xdg.autostart;
 
-  linkedDesktopEntries = pkgs.runCommandNoCCLocal "xdg-autostart-entries" { } ''
+  linkedDesktopEntries = pkgs.runCommandLocal "xdg-autostart-entries" { } ''
     mkdir -p $out
     ${lib.concatMapStringsSep "\n" (e: "ln -s ${e} $out") cfg.entries}
   '';


### PR DESCRIPTION
### Description

Replace `runcommandNoCCLocal` by `runCommandLocal` because the former is an alias of the latter. This change fixes builds where `allowAliases = false`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Scrumplex
