### PR TITLE
i18n.inputMethod: align enable option with nixos

### DIFF
--- a/modules/i18n/input-method/default.nix
+++ b/modules/i18n/input-method/default.nix
@@ -133,5 +133,8 @@ in
     ];
   };
 
-  meta.maintainers = [ lib.hm.maintainers.kranzes ];
+  meta.maintainers = [
+    lib.hm.maintainers.kranzes
+    lib.maintainers.awwpotato
+  ];
 }

--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -82,7 +82,7 @@ in
     };
   };
 
-  config = lib.mkIf (im.enabled == "fcitx5") {
+  config = lib.mkIf (im.enable && im.type == "fcitx5") {
     i18n.inputMethod.package = fcitx5Package;
 
     home = {

--- a/modules/i18n/input-method/hime.nix
+++ b/modules/i18n/input-method/hime.nix
@@ -4,9 +4,11 @@
   lib,
   ...
 }:
-
+let
+  im = config.i18n.inputMethod;
+in
 {
-  config = lib.mkIf (config.i18n.inputMethod.enabled == "hime") {
+  config = lib.mkIf (im.enable && im.type == "hime") {
     i18n.inputMethod.package = pkgs.hime;
 
     home.sessionVariables = {

--- a/modules/i18n/input-method/kime.nix
+++ b/modules/i18n/input-method/kime.nix
@@ -14,6 +14,7 @@ let
     types
     ;
 
+  im = config.i18n.inputMethod;
   cfg = config.i18n.inputMethod.kime;
 in
 {
@@ -46,7 +47,7 @@ in
     };
   };
 
-  config = mkIf (config.i18n.inputMethod.enabled == "kime") {
+  config = mkIf (im.enable && im.type == "kime") {
     i18n.inputMethod.package = pkgs.kime;
 
     home.sessionVariables = {

--- a/modules/i18n/input-method/nabi.nix
+++ b/modules/i18n/input-method/nabi.nix
@@ -4,9 +4,11 @@
   lib,
   ...
 }:
-
+let
+  im = config.i18n.inputMethod;
+in
 {
-  config = lib.mkIf (config.i18n.inputMethod.enabled == "nabi") {
+  config = lib.mkIf (im.enable && im.type == "nabi") {
     i18n.inputMethod.package = pkgs.nabi;
 
     home.sessionVariables = {

--- a/modules/i18n/input-method/uim.nix
+++ b/modules/i18n/input-method/uim.nix
@@ -7,6 +7,7 @@
 
 let
   cfg = config.i18n.inputMethod.uim;
+  im = config.i18n.inputMethod;
 in
 {
   options = {
@@ -30,7 +31,7 @@ in
 
   };
 
-  config = lib.mkIf (config.i18n.inputMethod.enabled == "uim") {
+  config = lib.mkIf (im.enable && im.type == "uim") {
     i18n.inputMethod.package = pkgs.uim;
 
     home.sessionVariables = {

--- a/tests/modules/i18n/input-method/default.nix
+++ b/tests/modules/i18n/input-method/default.nix
@@ -1,4 +1,5 @@
 {
   input-method-fcitx5-configuration = ./fcitx5-configuration.nix;
+  input-method-fcitx5-old-enable = ./fcitx5-configuration.nix;
   input-method-kime-configuration = ./kime-configuration.nix;
 }

--- a/tests/modules/i18n/input-method/kime-configuration.nix
+++ b/tests/modules/i18n/input-method/kime-configuration.nix
@@ -13,7 +13,8 @@ let
 in
 {
   i18n.inputMethod = {
-    enabled = "kime";
+    enable = true;
+    type = "kime";
     kime.extraConfig = kimeConfig;
   };
 

--- a/tests/modules/i18n/input-method/old-fcitx5-enable.nix
+++ b/tests/modules/i18n/input-method/old-fcitx5-enable.nix
@@ -7,8 +7,7 @@
 
 lib.mkIf config.test.enableBig {
   i18n.inputMethod = {
-    enable = true;
-    type = "fcitx5";
+    enabled = "fcitx5";
     fcitx5 = {
       waylandFrontend = true;
       themes.example = {
@@ -26,6 +25,10 @@ lib.mkIf config.test.enableBig {
   };
 
   _module.args.pkgs = lib.mkForce realPkgs;
+
+  test.asserts.warnings.expected = [
+    "i18n.inputMethod.enabled will be removed in a future release. Please use .type, and .enable = true instead"
+  ];
 
   nmt.script = ''
     assertFileExists home-files/.config/systemd/user/fcitx5-daemon.service

--- a/tests/modules/misc/qt/qt-platform-theme-gtk.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-gtk.nix
@@ -6,7 +6,10 @@
     platformTheme.name = "gtk";
   };
 
-  i18n.inputMethod.enabled = "fcitx5";
+  i18n.inputMethod = {
+    enable = true;
+    type = "fcitx5";
+  };
 
   nixpkgs.overlays = [
     (final: prev: {


### PR DESCRIPTION
confusing for home-manager to use the deprecated style from nixos 
see: https://github.com/NixOS/nixpkgs/pull/310708

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@Kranzes