### PR TITLE
mkFirefoxModule: revert userChrome changes

### DIFF
--- a/tests/modules/programs/firefox/profiles/userchrome/default.nix
+++ b/tests/modules/programs/firefox/profiles/userchrome/default.nix
@@ -1,12 +1,15 @@
 modulePath:
-{ config, lib, ... }:
-
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
 
   cfg = lib.getAttrFromPath modulePath config;
 
   firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
-
 in
 {
   imports = [ firefoxMockOverlay ];
@@ -18,36 +21,15 @@ in
         basic.isDefault = true;
         lines = {
           id = 1;
-          userChrome = ''
-            /*
-              This is a simple comment that should be written inside the `chrome/userChrome.css`
-            */
-
-            #urlbar {
-              min-width: none !important;
-              border: none !important;
-              outline: none !important;
-            }
-          '';
+          userChrome = builtins.readFile ./chrome/userChrome.css;
         };
-        path = {
+        file = {
           id = 2;
           userChrome = ./chrome/userChrome.css;
         };
-        folder = {
-          id = 3;
-          userChrome = ./chrome;
-        };
-        derivation = {
+        derivation-file = {
           id = 4;
-          userChrome = config.lib.test.mkStubPackage {
-            name = "wavefox";
-            buildScript = ''
-              mkdir -p $out
-              ln -s ${./chrome/userChrome.css} $out/userChrome.css
-              echo test > $out/README.md
-            '';
-          };
+          userChrome = pkgs.writeText "userChrome.css" (builtins.readFile ./chrome/userChrome.css);
         };
       };
     }
@@ -59,28 +41,18 @@ in
 
         assertDirectoryExists home-files/${cfg.configPath}/basic
 
-        assertPathNotExists \
-          home-files/${cfg.configPath}/lines/chrome/extraFile.css
         assertFileContent \
           home-files/${cfg.configPath}/lines/chrome/userChrome.css \
           ${./chrome/userChrome.css}
 
+        assertFileContent \
+          home-files/${cfg.configPath}/file/chrome/userChrome.css \
+          ${./chrome/userChrome.css}
+
         assertPathNotExists \
-          home-files/${cfg.configPath}/path/chrome/extraFile.css
+          home-files/${cfg.configPath}/derivation-file/chrome/extraFile.css
         assertFileContent \
-          home-files/${cfg.configPath}/path/chrome/userChrome.css \
-          ${./chrome/userChrome.css}
-
-        assertFileExists \
-          home-files/${cfg.configPath}/folder/chrome/extraFile.css
-        assertFileContent \
-          home-files/${cfg.configPath}/folder/chrome/userChrome.css \
-          ${./chrome/userChrome.css}
-
-        assertFileExists \
-          home-files/${cfg.configPath}/derivation/chrome/README.md
-        assertFileContent \
-          home-files/${cfg.configPath}/derivation/chrome/userChrome.css \
+          home-files/${cfg.configPath}/derivation-file/chrome/userChrome.css \
           ${./chrome/userChrome.css}
       '';
     }


### PR DESCRIPTION
Reverting all the recent userChrome changes because of too many issues and bikeshedding.

### Description
Closes https://github.com/nix-community/home-manager/issues/6882
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
