### PR TITLE
workflows: only run conflicts and update flake on main repo

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'nix-community'
     steps:
       - uses: mschilde/auto-label-merge-conflicts@master
         with:

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository_owner == 'nix-community'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description
github keeps sending me emails b/c they are failing on my fork (e.g. https://github.com/awwpotato/home-manager/actions/runs/14610278483/job/40986902179, https://github.com/awwpotato/home-manager/actions/runs/14609635006/job/40985133944)
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
