### PR TITLE
fcitx5: fix iniFormat usage

### DIFF
--- a/modules/i18n/input-method/fcitx5.nix
+++ b/modules/i18n/input-method/fcitx5.nix
@@ -222,7 +222,7 @@ in
           optionalFile =
             p: f: v:
             lib.optionalAttrs (v != { }) {
-              "fcitx5/${p}".source = f v;
+              "fcitx5/${p}".source = f "fcitx5-${builtins.replaceStrings [ "/" ] [ "-" ] p}" v;
             };
         in
         lib.attrsets.mergeAttrsList [
@@ -249,7 +249,7 @@ in
             else if builtins.isString attrs.theme then
               pkgs.writeText "fcitx5-theme.conf" attrs.theme
             else
-              iniFormat.generate attrs.theme
+              iniFormat.generate "fcitx5-${name}-theme" attrs.theme
           ))
         ]
       ) cfg.themes;

--- a/tests/modules/i18n/input-method/fcitx5/old-enable.nix
+++ b/tests/modules/i18n/input-method/fcitx5/old-enable.nix
@@ -20,7 +20,7 @@ lib.mkIf config.test.enableBig {
           ScaleWithDPI=True
         '';
       };
-      classicUiConfig = "Theme=example";
+      settings.addons.classicui.globalSection.Theme = "example";
     };
   };
 
@@ -32,8 +32,8 @@ lib.mkIf config.test.enableBig {
 
   nmt.script = ''
     assertFileExists home-files/.config/systemd/user/fcitx5-daemon.service
+    assertFileExists home-files/.config/fcitx5/conf/classicui.conf
     assertFileExists home-files/.local/share/fcitx5/themes/example/theme.conf
-    assertFileExists home-files/.local/share/fcitx5/conf/classicui.conf
     assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'GTK_IM_MODULE'
     assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'QT_IM_MODULE'
   '';


### PR DESCRIPTION
### Description
not sure why the tests didn't catch this.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
