### PR TITLE
gpg-agent: pinentryPackage -> pinentry.package and add pinentry.program` 

### DIFF
--- a/tests/modules/services/gpg-agent/default-homedir.nix
+++ b/tests/modules/services/gpg-agent/default-homedir.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
@@ -9,6 +10,20 @@ lib.mkIf pkgs.stdenv.isLinux {
   services.gpg-agent.enable = true;
   services.gpg-agent.pinentryPackage = pkgs.pinentry-gnome3;
   programs.gpg.enable = true;
+
+  test.asserts.warnings.expected =
+    let
+      renamed = {
+        pinentryPackage = "pinentry.package";
+      };
+    in
+    lib.mapAttrsToList (
+      old: new:
+      builtins.replaceStrings [ "\n" ] [ " " ] ''
+        The option `services.gpg-agent.${old}' defined in
+        ${lib.showFiles options.services.gpg-agent.${old}.files}
+        has been renamed to `services.gpg-agent.${new}'.''
+    ) renamed;
 
   nmt.script = ''
     in="${config.systemd.user.sockets.gpg-agent.Socket.ListenStream}"

--- a/tests/modules/services/gpg-agent/default.nix
+++ b/tests/modules/services/gpg-agent/default.nix
@@ -1,4 +1,5 @@
 {
   gpg-agent-default-homedir = ./default-homedir.nix;
   gpg-agent-override-homedir = ./override-homedir.nix;
+  gpg-agent-pinentry-program = ./pinentry-program.nix;
 }

--- a/tests/modules/services/gpg-agent/override-homedir.nix
+++ b/tests/modules/services/gpg-agent/override-homedir.nix
@@ -5,7 +5,6 @@ let
 in
 {
   services.gpg-agent.enable = true;
-  services.gpg-agent.pinentryPackage = null; # Don't build pinentry package.
   programs.gpg = {
     enable = true;
     homedir = "/path/to/hash";

--- a/tests/modules/services/gpg-agent/pinentry-program.nix
+++ b/tests/modules/services/gpg-agent/pinentry-program.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+lib.mkIf pkgs.stdenv.isLinux {
+  services.gpg-agent.enable = true;
+  services.gpg-agent.pinentry = {
+    package = pkgs.pinentry-all;
+    program = "pinentry-qt";
+  };
+  programs.gpg.enable = true;
+
+  nmt.script = ''
+    in="${config.systemd.user.sockets.gpg-agent.Socket.ListenStream}"
+    if [[ $in != "%t/gnupg/S.gpg-agent" ]]
+    then
+      echo $in
+      fail "gpg-agent socket directory not set to default value"
+    fi
+
+    configFile=home-files/.gnupg/gpg-agent.conf
+    assertFileRegex $configFile "pinentry-program @pinentry-all@/bin/pinentry-qt"
+  '';
+}


### PR DESCRIPTION
### Description
Just declaring an alternative solution to https://github.com/nix-community/home-manager/pull/6874 for allowing a user to provide which binary they want to use for their `pinentry-program`.

Closes https://github.com/nix-community/home-manager/pull/6874 

Not sure if we want to make this more generic of a solution for package options treewide... 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
