### PR TITLE
format: fix failing with newer treefmt; use /var/empty for temp home

### DIFF
--- a/format
+++ b/format
@@ -2,8 +2,8 @@
 #! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/42a1c966be226125b48c384171c44c651c236c22.tar.gz -i bash -p git gnugrep gnused findutils nixfmt-tree
 # Avoid being affected by system and user git config.
 export GIT_CONFIG_NOSYSTEM=1
-export HOME=
-export XDG_CONFIG_HOME=
+export HOME=/var/empty
+export XDG_CONFIG_HOME=/var/empty
 
 nixfmt_args=()
 files=()

--- a/format
+++ b/format
@@ -32,4 +32,4 @@ git_root=$(git rev-parse --show-toplevel)
 git ls-files -z --cached --others --full-name -- "${files[@]}" |
     grep -z '\.nix$' |
     sed -z "s|^|$git_root/|" |
-    xargs -0 treefmt "${nixfmt_args[@]}"
+    xargs -0 treefmt --no-cache "${nixfmt_args[@]}"


### PR DESCRIPTION
### Description
See commit message for details. Fixes https://github.com/nix-community/home-manager/issues/6858

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
