### PR TITLE
nixos,darwin: add _osClass as a specialArg

### DIFF
--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -6,6 +6,7 @@
   config,
   lib,
   pkgs,
+  _class,
   ...
 }:
 
@@ -28,6 +29,7 @@ let
     specialArgs = {
       lib = extendedLib;
       osConfig = config;
+      osClass = _class;
       modulesPath = builtins.toString ../modules;
     } // cfg.extraSpecialArgs;
     modules = [


### PR DESCRIPTION
### Description

I think it would be cool to propagate the `_class`, similar to `config` via `osConfig`. I went with `_osClass` after nixpkgs uses `_class`.

also see: https://github.com/NixOS/nixpkgs/pull/395141

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
