### PR TITLE
thefuck: Add alias option

### DIFF
--- a/modules/programs/thefuck.nix
+++ b/modules/programs/thefuck.nix
@@ -24,6 +24,15 @@ in
     enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+
+    alias = lib.mkOption {
+      type = lib.types.str;
+      default = "fuck";
+      description = ''
+        `thefuck` needs an alias to be configured.
+        The default value is `fuck`, but you can use anything else as well.";
+      '';
+    };
   };
 
   config =
@@ -31,7 +40,7 @@ in
       cfg = config.programs.thefuck;
 
       cliArgs = lib.cli.toGNUCommandLineShell { } {
-        alias = true;
+        alias = cfg.alias;
         enable-experimental-instant-mode = cfg.enableInstantMode;
       };
 
@@ -49,7 +58,7 @@ in
           description = "Correct your previous console command";
           body = ''
             set -l fucked_up_command $history[1]
-            env TF_SHELL=fish TF_ALIAS=fuck PYTHONIOENCODING=utf-8 ${cfg.package}/bin/thefuck $fucked_up_command THEFUCK_ARGUMENT_PLACEHOLDER $argv | read -l unfucked_command
+            env TF_SHELL=fish TF_ALIAS=${cfg.alias} PYTHONIOENCODING=utf-8 ${cfg.package}/bin/thefuck $fucked_up_command THEFUCK_ARGUMENT_PLACEHOLDER $argv | read -l unfucked_command
             if [ "$unfucked_command" != "" ]
               eval $unfucked_command
               builtin history delete --exact --case-sensitive -- $fucked_up_command
@@ -63,7 +72,7 @@ in
 
       programs.nushell = mkIf cfg.enableNushellIntegration {
         extraConfig = ''
-          alias fuck = ${cfg.package}/bin/thefuck $"(history | last 1 | get command | get 0)"
+          alias ${cfg.alias} = ${cfg.package}/bin/thefuck $"(history | last 1 | get command | get 0)"
         '';
       };
     };

--- a/modules/programs/thefuck.nix
+++ b/modules/programs/thefuck.nix
@@ -28,10 +28,7 @@ in
     alias = lib.mkOption {
       type = lib.types.str;
       default = "fuck";
-      description = ''
-        `thefuck` needs an alias to be configured.
-        The default value is `fuck`, but you can use anything else as well.";
-      '';
+      description = "Alias used to invoke `thefuck`.";
     };
   };
 

--- a/tests/modules/programs/thefuck/integration-enabled-instant.nix
+++ b/tests/modules/programs/thefuck/integration-enabled-instant.nix
@@ -12,11 +12,11 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
-      'eval "$(@thefuck@/bin/thefuck --alias --enable-experimental-instant-mode)"'
+      'eval "$(@thefuck@/bin/thefuck --alias fuck --enable-experimental-instant-mode)"'
 
     assertFileExists home-files/.zshrc
     assertFileContains \
       home-files/.zshrc \
-      'eval "$(@thefuck@/bin/thefuck --alias --enable-experimental-instant-mode)"'
+      'eval "$(@thefuck@/bin/thefuck --alias fuck --enable-experimental-instant-mode)"'
   '';
 }

--- a/tests/modules/programs/thefuck/integration-enabled.nix
+++ b/tests/modules/programs/thefuck/integration-enabled.nix
@@ -11,7 +11,7 @@
     assertFileExists home-files/.bashrc
     assertFileContains \
       home-files/.bashrc \
-      'eval "$(@thefuck@/bin/thefuck --alias)"'
+      'eval "$(@thefuck@/bin/thefuck --alias fuck)"'
 
     assertFileExists home-files/.config/fish/functions/fuck.fish
     assertFileContains \
@@ -29,7 +29,7 @@
     assertFileExists home-files/.zshrc
     assertFileContains \
       home-files/.zshrc \
-      'eval "$(@thefuck@/bin/thefuck --alias)"'
+      'eval "$(@thefuck@/bin/thefuck --alias fuck)"'
 
     assertFileExists home-files/.config/nushell/config.nu
     assertFileContains \


### PR DESCRIPTION
Added an alias option supported by bash, zsh, fish, and nushell integration

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@ilaumjd 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
