### PR TITLE
rmpc: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -237,6 +237,7 @@ let
       ./programs/rio.nix
       ./programs/ripgrep.nix
       ./programs/ripgrep-all.nix
+      ./programs/rmpc.nix
       ./programs/rofi-pass.nix
       ./programs/rofi.nix
       ./programs/rtorrent.nix

--- a/modules/programs/rmpc.nix
+++ b/modules/programs/rmpc.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    types
+    ;
+
+  cfg = config.programs.rmpc;
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.rmpc = {
+    enable = mkEnableOption "rmpc";
+    package = mkPackageOption pkgs "rmpc" { nullable = true; };
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        (
+            address: "127.0.0.1:6600",
+            password: None,
+            theme: None,
+            cache_dir: None,
+            on_song_change: None,
+            volume_step: 5,
+            max_fps: 30,
+            scrolloff: 0,
+            wrap_navigation: false,
+            enable_mouse: true,
+            enable_config_hot_reload: true,
+            status_update_interval_ms: 1000,
+            select_current_song_on_change: false,
+            browser_song_sort: [Disc, Track, Artist, Title],
+        )
+      '';
+      description = ''
+        Configuration settings for rmpc in the Rusty Object Notation
+        format. All available options can be found in the official
+        documentation at <https://mierak.github.io/rmpc/next/configuration/>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile = mkIf (cfg.extraConfig != "") {
+      "rmpc/config.ron".text = cfg.extraConfig;
+    };
+  };
+}

--- a/modules/programs/rmpc.nix
+++ b/modules/programs/rmpc.nix
@@ -21,7 +21,7 @@ in
   options.programs.rmpc = {
     enable = mkEnableOption "rmpc";
     package = mkPackageOption pkgs "rmpc" { nullable = true; };
-    extraConfig = mkOption {
+    config = mkOption {
       type = types.lines;
       default = "";
       example = ''
@@ -52,8 +52,8 @@ in
 
   config = mkIf cfg.enable {
     home.packages = mkIf (cfg.package != null) [ cfg.package ];
-    xdg.configFile = mkIf (cfg.extraConfig != "") {
-      "rmpc/config.ron".text = cfg.extraConfig;
+    xdg.configFile = mkIf (cfg.config != "") {
+      "rmpc/config.ron".text = cfg.config;
     };
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -277,6 +277,7 @@ import nmtSrc {
       ./modules/programs/rio
       ./modules/programs/ripgrep
       ./modules/programs/ripgrep-all
+      ./modules/programs/rmpc
       ./modules/programs/ruff
       ./modules/programs/sagemath
       ./modules/programs/sapling

--- a/tests/modules/programs/rmpc/default.nix
+++ b/tests/modules/programs/rmpc/default.nix
@@ -1,0 +1,1 @@
+{ rmpc-example-config = ./example-config.nix; }

--- a/tests/modules/programs/rmpc/example-config.nix
+++ b/tests/modules/programs/rmpc/example-config.nix
@@ -1,0 +1,29 @@
+{
+  programs.rmpc = {
+    enable = true;
+    extraConfig = ''
+      (
+          address: "127.0.0.1:6600",
+          password: None,
+          theme: None,
+          cache_dir: None,
+          on_song_change: None,
+          volume_step: 5,
+          max_fps: 30,
+          scrolloff: 0,
+          wrap_navigation: false,
+          enable_mouse: true,
+          enable_config_hot_reload: true,
+          status_update_interval_ms: 1000,
+          select_current_song_on_change: false,
+          browser_song_sort: [Disc, Track, Artist, Title],
+      )
+    '';
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/rmpc/config.ron
+    assertFileContent home-files/.config/rmpc/config.ron \
+    ${./example-config.ron}
+  '';
+}

--- a/tests/modules/programs/rmpc/example-config.nix
+++ b/tests/modules/programs/rmpc/example-config.nix
@@ -1,7 +1,7 @@
 {
   programs.rmpc = {
     enable = true;
-    extraConfig = ''
+    config = ''
       (
           address: "127.0.0.1:6600",
           password: None,

--- a/tests/modules/programs/rmpc/example-config.ron
+++ b/tests/modules/programs/rmpc/example-config.ron
@@ -1,0 +1,16 @@
+(
+    address: "127.0.0.1:6600",
+    password: None,
+    theme: None,
+    cache_dir: None,
+    on_song_change: None,
+    volume_step: 5,
+    max_fps: 30,
+    scrolloff: 0,
+    wrap_navigation: false,
+    enable_mouse: true,
+    enable_config_hot_reload: true,
+    status_update_interval_ms: 1000,
+    select_current_song_on_change: false,
+    browser_song_sort: [Disc, Track, Artist, Title],
+)


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring [RMPC](https://github.com/mierak/rmpc), a terminal based Media Player.
Since the config format of RMPC is the Rusty Object Notation (RON), and Nixpkgs doesn't have a generator for that,
I added the `extraConfig` options instead of `settings`. Closes #6611.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
