### PR TITLE
kime: fix systemd service

### DIFF
--- a/modules/i18n/input-method/kime.nix
+++ b/modules/i18n/input-method/kime.nix
@@ -63,7 +63,11 @@ in
         Description = "Kime input method editor";
         PartOf = [ "graphical-session.target" ];
       };
-      Service.ExecStart = "${pkgs.kime}/bin/kime";
+      Service = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${pkgs.kime}/bin/kime";
+      };
       Install.WantedBy = [ "graphical-session.target" ];
     };
   };


### PR DESCRIPTION
### Description

Since the `kime` command basically runs other subcommands, such as `kime-wayland`, and then exits, it should be defined as a oneshot service.

```bash
● kime-daemon.service - Kime input method editor
     Loaded: loaded (/home/user/.config/systemd/user/kime-daemon.service; enabled; preset: ignored)
     Active: active (exited) since Sun 2025-04-27 05:59:02 UTC; 3 days ago
 Invocation: c45e54817331430d91d448935bd6edad
   Main PID: 3532 (code=exited, status=0/SUCCESS)
      Tasks: 6 (limit: 18609)
     Memory: 165M (peak: 199M)
        CPU: 4min 26.547s
     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/kime-daemon.service
             ├─3534 /nix/store/7xwccammjd3b78328bha9vwm56h23bvf-kime-3.1.1/bin/kime
             ├─3536 kime-xim
             ├─3538 kime-wayland
             └─3539 kime-indicator

Apr 27 05:59:02 host systemd[3335]: Starting Kime input method editor...
Apr 27 05:59:02 host systemd[3335]: Finished Kime input method editor.
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@awwpotato 
