### PR TITLE
eza: default disable nushell integration again

### DIFF
--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -47,7 +47,10 @@ in
 
     enableIonIntegration = lib.hm.shell.mkIonIntegrationOption { inherit config; };
 
-    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
+    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; } // {
+      default = false;
+      example = true;
+    };
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
 

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -35,6 +35,7 @@ let
     "earthly"
     "emacs"
     "espanso"
+    "eza"
     "fastfetch"
     "feh"
     "fzf"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -196,6 +196,7 @@ import nmtSrc {
       ./modules/programs/direnv
       ./modules/programs/earthly
       ./modules/programs/emacs
+      ./modules/programs/eza
       ./modules/programs/fastfetch
       ./modules/programs/feh
       ./modules/programs/fish

--- a/tests/modules/programs/eza/bash.nix
+++ b/tests/modules/programs/eza/bash.nix
@@ -1,0 +1,38 @@
+{
+  programs = {
+    bash.enable = true;
+
+    eza = {
+      enable = true;
+      enableBashIntegration = true;
+      extraOptions = [
+        "--group-directories-first"
+        "--header"
+      ];
+      icons = "auto";
+      git = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileContains \
+      home-files/.bashrc \
+      "alias eza='eza --icons auto --git --group-directories-first --header'"
+    assertFileContains \
+      home-files/.bashrc \
+      "alias ls=eza"
+    assertFileContains \
+      home-files/.bashrc \
+      "alias ll='eza -l'"
+    assertFileContains \
+      home-files/.bashrc \
+      "alias la='eza -a'"
+    assertFileContains \
+      home-files/.bashrc \
+      "alias lt='eza --tree'"
+    assertFileContains \
+      home-files/.bashrc \
+      "alias lla='eza -la'"
+  '';
+}

--- a/tests/modules/programs/eza/default.nix
+++ b/tests/modules/programs/eza/default.nix
@@ -1,0 +1,8 @@
+{
+  eza-bash = ./bash.nix;
+  eza-fish = ./fish.nix;
+  eza-ion = ./ion.nix;
+  eza-nushell = ./nushell.nix;
+  eza-theme = ./theme.nix;
+  eza-zsh = ./zsh.nix;
+}

--- a/tests/modules/programs/eza/fish.nix
+++ b/tests/modules/programs/eza/fish.nix
@@ -1,0 +1,38 @@
+{
+  programs = {
+    fish.enable = true;
+
+    eza = {
+      enable = true;
+      enableFishIntegration = true;
+      extraOptions = [
+        "--group-directories-first"
+        "--header"
+      ];
+      icons = "auto";
+      git = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/fish/config.fish
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      "alias eza 'eza --icons auto --git --group-directories-first --header'"
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      "alias ls eza"
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      "alias ll 'eza -l'"
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      "alias la 'eza -a'"
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      "alias lt 'eza --tree'"
+    assertFileContains \
+      home-files/.config/fish/config.fish \
+      "alias lla 'eza -la'"
+  '';
+}

--- a/tests/modules/programs/eza/ion.nix
+++ b/tests/modules/programs/eza/ion.nix
@@ -1,0 +1,38 @@
+{
+  programs = {
+    ion.enable = true;
+
+    eza = {
+      enable = true;
+      enableIonIntegration = true;
+      extraOptions = [
+        "--group-directories-first"
+        "--header"
+      ];
+      icons = "auto";
+      git = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/ion/initrc
+    assertFileContains \
+      home-files/.config/ion/initrc \
+      "alias eza = 'eza --icons auto --git --group-directories-first --header'"
+    assertFileContains \
+      home-files/.config/ion/initrc \
+      "alias ls = eza"
+    assertFileContains \
+      home-files/.config/ion/initrc \
+      "alias ll = 'eza -l'"
+    assertFileContains \
+      home-files/.config/ion/initrc \
+      "alias la = 'eza -a'"
+    assertFileContains \
+      home-files/.config/ion/initrc \
+      "alias lt = 'eza --tree'"
+    assertFileContains \
+      home-files/.config/ion/initrc \
+      "alias lla = 'eza -la'"
+  '';
+}

--- a/tests/modules/programs/eza/nushell.nix
+++ b/tests/modules/programs/eza/nushell.nix
@@ -1,0 +1,38 @@
+{
+  programs = {
+    nushell.enable = true;
+
+    eza = {
+      enable = true;
+      enableNushellIntegration = true;
+      extraOptions = [
+        "--group-directories-first"
+        "--header"
+      ];
+      icons = "auto";
+      git = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/nushell/config.nu
+    assertFileContains \
+      home-files/.config/nushell/config.nu \
+      'alias "eza" = eza --icons auto --git --group-directories-first --header'
+    assertFileContains \
+      home-files/.config/nushell/config.nu \
+      'alias "ls" = eza'
+    assertFileContains \
+      home-files/.config/nushell/config.nu \
+      'alias "ll" = eza -l'
+    assertFileContains \
+      home-files/.config/nushell/config.nu \
+      'alias "la" = eza -a'
+    assertFileContains \
+      home-files/.config/nushell/config.nu \
+      'alias "lt" = eza --tree'
+    assertFileContains \
+      home-files/.config/nushell/config.nu \
+      'alias "lla" = eza -la'
+  '';
+}

--- a/tests/modules/programs/eza/theme.nix
+++ b/tests/modules/programs/eza/theme.nix
@@ -1,0 +1,20 @@
+{
+  programs.eza = {
+    enable = true;
+    theme = {
+      colors = {
+        background = "254";
+        foreground = "237";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/eza/theme.yml
+    assertFileContent home-files/.config/eza/theme.yml ${builtins.toFile "eza-theme-expected.yml" ''
+      colors:
+        background: '254'
+        foreground: '237'
+    ''}
+  '';
+}

--- a/tests/modules/programs/eza/zsh.nix
+++ b/tests/modules/programs/eza/zsh.nix
@@ -1,0 +1,38 @@
+{
+  programs = {
+    zsh.enable = true;
+
+    eza = {
+      enable = true;
+      enableZshIntegration = true;
+      extraOptions = [
+        "--group-directories-first"
+        "--header"
+      ];
+      icons = "auto";
+      git = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+    assertFileContains \
+      home-files/.zshrc \
+      "alias -- eza='eza --icons auto --git --group-directories-first --header'"
+    assertFileContains \
+      home-files/.zshrc \
+      "alias -- ls=eza"
+    assertFileContains \
+      home-files/.zshrc \
+      "alias -- ll='eza -l'"
+    assertFileContains \
+      home-files/.zshrc \
+      "alias -- la='eza -a'"
+    assertFileContains \
+      home-files/.zshrc \
+      "alias -- lt='eza --tree'"
+    assertFileContains \
+      home-files/.zshrc \
+      "alias -- lla='eza -la'"
+  '';
+}


### PR DESCRIPTION
Reverting default behavior for this module again since the nushell integration causes a breaking behavior with the `ls` alias.

### Description
Closes https://github.com/nix-community/home-manager/issues/6687
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
