### PR TITLE
neomutt: use correct neomutt in config file

### DIFF
--- a/modules/programs/neomutt.nix
+++ b/modules/programs/neomutt.nix
@@ -507,7 +507,7 @@ in
             "set crypt_use_gpgme = yes"
             "alternative_order text/enriched text/plain text"
             "set delete = yes"
-            (optionalString cfg.vimKeys "source ${pkgs.neomutt}/share/doc/neomutt/vim-keys/vim-keys.rc")
+            (optionalString cfg.vimKeys "source ${cfg.package}/share/doc/neomutt/vim-keys/vim-keys.rc")
           ]
           ++ (lib.optionals (cfg.binds != [ ]) [
             ''


### PR DESCRIPTION
### Description

neomutt currently depends transitively via notmuch on emacs.
As currently phrased, building the neomutt config unconditionally takes nixpkgs's neomutt, not the one home-manager has been configured to use, so it pulls in emacs even if you use `package = pkgs.neomutt.override {withNotmuch = false;};`.

### Checklist

I've manually tested that the resulting home-manager doesn't depend on `emacs` when building with neomutt's `package = pkgs.neomutt.override {withNotmuch = false;};`. The build without that `package = ` config gets as far as trying to build emacs on my machine with this home-manager, which I take to mean that existing users are unbroken by this change.

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
