### PR TITLE
kickoff: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -158,6 +158,7 @@ let
       ./programs/keychain.nix
       ./programs/khal.nix
       ./programs/khard.nix
+      ./programs/kickoff.nix
       ./programs/kitty.nix
       ./programs/kodi.nix
       ./programs/kubecolor.nix

--- a/modules/programs/kickoff.nix
+++ b/modules/programs/kickoff.nix
@@ -19,10 +19,6 @@ in
 {
   meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
-  assertions = [
-    (lib.hm.assertions.assertPlatform "programs.kickoff" pkgs lib.platforms.linux)
-  ];
-
   options.programs.kickoff = {
     enable = mkEnableOption "kickoff";
     package = mkPackageOption pkgs "kickoff" { nullable = true; };
@@ -49,6 +45,10 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.kickoff" pkgs lib.platforms.linux)
+    ];
+
     home.packages = mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile = mkIf (cfg.settings != { }) {

--- a/modules/programs/kickoff.nix
+++ b/modules/programs/kickoff.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.kickoff;
+
+  formatter = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.kickoff = {
+    enable = mkEnableOption "kickoff";
+    package = mkPackageOption pkgs "kickoff" { nullable = true; };
+    settings = mkOption {
+      type = formatter.type;
+      default = { };
+      example = ''
+        padding = 100;
+        font_size = 32;
+        search.show_hidden_files = false;
+        history.decrease_interval = 48;
+
+        keybinding = {
+          paste = [ "ctrl+v" ];
+          execute = [ "KP_Enter" "Return" ];
+          complete = [ "Tab" ];
+        };
+      '';
+      description = ''
+        Configuration settings for kickoff. All the available options can be found
+        here: <https://github.com/j0ru/kickoff/blob/main/assets/default_config.toml>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile = mkIf (cfg.settings != { }) {
+      "kickoff/config.toml".source = formatter.generate "kickoff-config-toml" cfg.settings;
+    };
+  };
+}

--- a/modules/programs/kickoff.nix
+++ b/modules/programs/kickoff.nix
@@ -19,6 +19,10 @@ in
 {
   meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
 
+  assertions = [
+    (lib.hm.assertions.assertPlatform "programs.kickoff" pkgs lib.platforms.linux)
+  ];
+
   options.programs.kickoff = {
     enable = mkEnableOption "kickoff";
     package = mkPackageOption pkgs "kickoff" { nullable = true; };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -227,7 +227,6 @@ import nmtSrc {
       ./modules/programs/keepassxc
       ./modules/programs/khal
       ./modules/programs/khard
-      ./modules/programs/kickoff
       ./modules/programs/kitty
       ./modules/programs/kubecolor
       ./modules/programs/lapce
@@ -377,6 +376,7 @@ import nmtSrc {
       ./modules/programs/i3status-rust
       ./modules/programs/imv
       ./modules/programs/kodi
+      ./modules/programs/kickoff
       ./modules/programs/looking-glass-client
       ./modules/programs/mangohud
       ./modules/programs/ncmpcpp-linux

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -227,6 +227,7 @@ import nmtSrc {
       ./modules/programs/keepassxc
       ./modules/programs/khal
       ./modules/programs/khard
+      ./modules/programs/kickoff
       ./modules/programs/kitty
       ./modules/programs/kubecolor
       ./modules/programs/lapce

--- a/tests/modules/programs/kickoff/default.nix
+++ b/tests/modules/programs/kickoff/default.nix
@@ -1,0 +1,1 @@
+{ kickoff-example-config = ./example-config.nix; }

--- a/tests/modules/programs/kickoff/example-config.nix
+++ b/tests/modules/programs/kickoff/example-config.nix
@@ -1,0 +1,26 @@
+{
+  programs.kickoff = {
+    enable = true;
+    settings = {
+      padding = 100;
+      font_size = 32;
+      search.show_hidden_files = false;
+      history.decrease_interval = 48;
+
+      keybinding = {
+        paste = [ "ctrl+v" ];
+        execute = [
+          "KP_Enter"
+          "Return"
+        ];
+        complete = [ "Tab" ];
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/kickoff/config.toml
+    assertFileContent home-files/.config/kickoff/config.toml \
+    ${./example-config.toml}
+  '';
+}

--- a/tests/modules/programs/kickoff/example-config.toml
+++ b/tests/modules/programs/kickoff/example-config.toml
@@ -1,0 +1,13 @@
+font_size = 32
+padding = 100
+
+[history]
+decrease_interval = 48
+
+[keybinding]
+complete = ["Tab"]
+execute = ["KP_Enter", "Return"]
+paste = ["ctrl+v"]
+
+[search]
+show_hidden_files = false


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring [kickoff](https://github.com/j0ru/kickoff) a minimal program launcher.
Closes #6076.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
