### PR TITLE
gh: add `hosts` option

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -146,14 +146,24 @@ in
       '';
       example = literalExpression "[ pkgs.gh-eco ]";
     };
+
+    hosts = mkOption {
+      inherit (yamlFormat) type;
+      default = { };
+      description = "Host-specific configuration written to {file}`$XDG_CONFIG_HOME/gh/hosts.yml`.";
+      example."github.com".user = "<your_username>";
+    };
   };
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."gh/config.yml".source = yamlFormat.generate "gh-config.yml" (
-      { version = "1"; } // cfg.settings
-    );
+    xdg.configFile = {
+      "gh/config.yml".source = yamlFormat.generate "gh-config.yml" ({ version = "1"; } // cfg.settings);
+      "gh/hosts.yml" = mkIf (cfg.hosts != { }) {
+        source = yamlFormat.generate "gh-hosts.yml" cfg.hosts;
+      };
+    };
 
     # Version 2.40.0+ of `gh` needs to migrate account formats, this needs to
     # happen before the version = 1 is placed in the configuration file. Running

--- a/tests/modules/programs/gh/default.nix
+++ b/tests/modules/programs/gh/default.nix
@@ -2,5 +2,6 @@
   gh-config-file = ./config-file.nix;
   gh-credential-helper = ./credential-helper.nix;
   gh-extensions = ./extensions.nix;
+  gh-hosts-file = ./hosts-file.nix;
   gh-warnings = ./warnings.nix;
 }

--- a/tests/modules/programs/gh/hosts-file.nix
+++ b/tests/modules/programs/gh/hosts-file.nix
@@ -1,0 +1,18 @@
+{
+  programs.gh = {
+    enable = true;
+    hosts."github.com" = {
+      git_protocol = "ssh";
+      user = "my_username";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/gh/hosts.yml
+    assertFileContent home-files/.config/gh/hosts.yml ${builtins.toFile "hosts.yml" ''
+      github.com:
+        git_protocol: ssh
+        user: my_username
+    ''}
+  '';
+}


### PR DESCRIPTION
### Description

Add a `programs.gh.hosts` option that -- similar to `programs.gh.settings` -- gives structured access to `$XDG_CONFIG_HOME/gh/hosts.yml`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@gerschtli
@berbiche

