### PR TITLE
mpvpaper: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -183,6 +183,7 @@ let
       ./programs/mise.nix
       ./programs/mods.nix
       ./programs/mpv.nix
+      ./programs/mpvpaper.nix
       ./programs/mr.nix
       ./programs/msmtp.nix
       ./programs/mu.nix

--- a/modules/programs/mpvpaper.nix
+++ b/modules/programs/mpvpaper.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    types
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.mpvpaper;
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.mpvpaper = {
+    enable = mkEnableOption "mpvpaper";
+    package = mkPackageOption pkgs "mpvpaper" { nullable = true; };
+    pauseList = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        firefox
+        steam
+        obs
+      '';
+      description = ''
+        List of program names that will cause mpvpaper to pause.
+        Programs must be separed by spaces or newlines.
+      '';
+    };
+    stopList = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        firefox
+        steam
+        obs
+      '';
+      description = ''
+        List of program names that will cause mpvpaper to stop.
+        Programs must be separed by spaces or newlines.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.kickoff" pkgs lib.platforms.linux)
+    ];
+
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."mpvpaper/pauselist".text = mkIf (cfg.pauseList != "") cfg.pauseList;
+    xdg.configFile."mpvpaper/stoplist".text = mkIf (cfg.stopList != "") cfg.stopList;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -378,6 +378,7 @@ import nmtSrc {
       ./modules/programs/kodi
       ./modules/programs/looking-glass-client
       ./modules/programs/mangohud
+      ./modules/programs/mpvpaper
       ./modules/programs/ncmpcpp-linux
       ./modules/programs/nh
       ./modules/programs/onedrive

--- a/tests/modules/programs/mpvpaper/default.nix
+++ b/tests/modules/programs/mpvpaper/default.nix
@@ -1,0 +1,1 @@
+{ mpvpaper-example-config = ./example-config.nix; }

--- a/tests/modules/programs/mpvpaper/example-config.nix
+++ b/tests/modules/programs/mpvpaper/example-config.nix
@@ -1,0 +1,24 @@
+{
+  programs.mpvpaper = {
+    enable = true;
+    pauseList = ''
+      firefox
+      librewolf
+      steam
+    '';
+    stopList = ''
+      obs
+      virt-manager
+      gimp
+    '';
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/mpvpaper/pauselist
+    assertFileExists home-files/.config/mpvpaper/stoplist
+    assertFileContent home-files/.config/mpvpaper/pauselist \
+    ${./pauselist}
+    assertFileContent home-files/.config/mpvpaper/stoplist \
+    ${./stoplist}
+  '';
+}

--- a/tests/modules/programs/mpvpaper/pauselist
+++ b/tests/modules/programs/mpvpaper/pauselist
@@ -1,0 +1,3 @@
+firefox
+librewolf
+steam

--- a/tests/modules/programs/mpvpaper/stoplist
+++ b/tests/modules/programs/mpvpaper/stoplist
@@ -1,0 +1,3 @@
+obs
+virt-manager
+gimp


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR provides a module for configuring [mpvpaper](https://github.com/GhostNaN/mpvpaper) a video wallpaper program for wlroots based wayland compositors. It provides options for setting the 'pauselist' and 'stoplist'.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
