### PR TITLE
carapace: fix nushell PATH env var

### DIFF
--- a/modules/programs/carapace.nix
+++ b/modules/programs/carapace.nix
@@ -49,7 +49,7 @@ in
         extraConfig = ''
           source ${
             pkgs.runCommand "carapace-nushell-config.nu" { } ''
-              ${bin} _carapace nushell >> "$out"
+              ${bin} _carapace nushell | sed 's|"/homeless-shelter|$"($env.HOME)|g' >> "$out"
             ''
           }
         '';


### PR DESCRIPTION
### Description

`carapace _carapace nushell` adds `/homeless-shelter/.config/carapace/bin` to PATH, this changes it to ` $HOME/.config/carapace/bin`. Other shells don't have this problem as they run the relevant command and source on startup whereas Nix writes the command output to a file as part of the build.

### Checklist

- [ ] Change is backwards compatible. (Technically this would break someone's setup if they actually decided to use `/homeless-shelter/.config/carapace/bin` but that seems like a very silly thing to do.)

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef). (I couldn't figure out how to refer to the generated `carapace-nushell-config.nu` file from the test file.)

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@Weathercold
@bobvanderlinden