### PR TITLE
Restic: fix `pruneOpts` erroring

### DIFF
--- a/modules/services/restic.nix
+++ b/modules/services/restic.nix
@@ -397,7 +397,7 @@ in
 
         Service =
           {
-            Type = "simple";
+            Type = "oneshot";
 
             X-RestartIfChanged = true;
             RuntimeDirectory = serviceName;

--- a/tests/integration/standalone/restic-home.nix
+++ b/tests/integration/standalone/restic-home.nix
@@ -106,6 +106,19 @@ in
           "--keep-hourly 3"
         ];
       };
+
+      prune-opts = {
+        inherit passwordFile paths exclude;
+        initialize = true;
+        repository = "/home/alice/repos/prune-opts";
+        pruneOpts = [
+          "--keep-yearly 4"
+          "--keep-monthly 3"
+          "--keep-weekly 2"
+          "--keep-daily 2"
+          "--keep-hourly 3"
+        ];
+      };
     };
   };
 }

--- a/tests/integration/standalone/restic.nix
+++ b/tests/integration/standalone/restic.nix
@@ -268,6 +268,9 @@ in
       assert int(actual) == 8, \
         f"Expected a snapshot count of 8 but got {actual}"
 
+    with subtest("Prune opts"):
+      systemctl_succeed_as_alice("start restic-backups-prune-opts.service")
+
     logout_alice()
   '';
 }


### PR DESCRIPTION
### Description

Resolves #6930

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
