### PR TITLE
zsh: update doc to show how to add `initContent` at multiple location.

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -515,6 +515,16 @@ in
             - 550: Before completion initialization (replaces initExtraBeforeCompInit)
             - 1000 (default): General configuration (replaces initExtra)
             - 1500 (mkAfter): Last to run configuration
+
+            To specify both content in Early initialization and General configuration, use `lib.mkMerge`.
+
+            e.g.
+
+            initContent = let
+                zshConfigEarlyInit = lib.mkOrder 500 "do something";
+                zshConfig = lib.mkOrder 1000 "do something";
+            in
+                lib.mkMerge [ zshConfigEarlyInit zshConfig ];
           '';
         };
 


### PR DESCRIPTION

### Description

As an elementary Nix user unfamiliar with the Nix language, it took me a lot time to discover the `lib.mkMerge` function and understand its usage for achieving the same effect as specifying both `initExtraFirst` and `initExtra` in previous versions.

I hope that including example configurations directly in the documentation would help users like myself (basic Nix users) by saving a lot time when updating configurations to align with upstream changes.  

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ x] Change is backwards compatible.

- [x ] Code formatted with `nix fmt` or `./format`.

- [ x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

