### PR TITLE
clipcat: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -332,6 +332,7 @@ let
       ./services/cachix-agent.nix
       ./services/caffeine.nix
       ./services/cbatticon.nix
+      ./services/clipcat.nix
       ./services/cliphist.nix
       ./services/clipman.nix
       ./services/clipmenu.nix

--- a/modules/services/clipcat.nix
+++ b/modules/services/clipcat.nix
@@ -1,0 +1,164 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    types
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.services.clipcat;
+
+  formatter = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.services.clipcat = {
+    enable = mkEnableOption "clipcat";
+    package = mkPackageOption pkgs "clipcat" { };
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+    enableSystemdUnit = mkOption {
+      type = types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Enable clipcat's Systemd Unit.
+      '';
+    };
+    daemonSettings = mkOption {
+      type = formatter.type;
+      default = {
+        daemonize = true;
+      };
+      example = ''
+        {
+          daemonize = true;
+          max_history = 50;
+          history_file_path = "/home/<username>/.cache/clipcat/clipcatd-history";
+          pid_file = "/run/user/<user-id>/clipcatd.pid";
+          primary_threshold_ms = 5000;
+          log = {
+            file_path = "/path/to/log/file";
+            emit_journald = true;
+            emit_stdout = false;
+            emit_stderr = false;
+            level = "INFO";
+          };
+        }
+      '';
+      description = ''
+        Configuration settings for clipcatd. All available options can be found
+        here: <https://github.com/xrelkd/clipcat?tab=readme-ov-file#configuration>.
+      '';
+    };
+    ctlSettings = mkOption {
+      type = formatter.type;
+      default = { };
+      example = ''
+        {
+          server_endpoint = "/run/user/<user-id>/clipcat/grpc.sock";
+          log = {
+            file_path = "/path/to/log/file";
+            emit_journald = true;
+            emit_stdout = false;
+            emit_stderr = false;
+            level = "INFO";
+          };
+        }
+      '';
+      description = ''
+        Configuration settings for clipcatctl. All available options can be found
+        here: <https://github.com/xrelkd/clipcat?tab=readme-ov-file#configuration>.
+      '';
+    };
+    menuSettings = mkOption {
+      type = formatter.type;
+      default = { };
+      example = ''
+        {
+          server_endpoint = "/run/user/<user-id>/clipcat/grpc.sock";
+          finder = "rofi";
+          rofi = {
+            line_length = 100;
+            menu_length = 30;
+            menu_prompt = "Clipcat";
+            extra_arguments = [
+              "-mesg"
+              "Please select a clip"
+            ];
+          };
+          dmenu = {
+            line_length = 100;
+            menu_length = 30;
+            menu_prompt = "Clipcat";
+          };
+        }
+      '';
+      description = ''
+        Configuration settings for clipcat-menu. All available options can be found
+        here: <https://github.com/xrelkd/clipcat?tab=readme-ov-file#configuration>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.clipcat" pkgs lib.platforms.linux)
+    ];
+
+    home.packages = [ cfg.package ];
+
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
+      if type clipcat-menu >/dev/null 2>&1; then
+          alias clipedit=' clipcat-menu --finder=builtin edit'
+          alias clipdel=' clipcat-menu --finder=builtin remove'
+
+          bindkey -s '^\' "^Q clipcat-menu --finder=builtin insert ^J"
+          bindkey -s '^]' "^Q clipcat-menu --finder=builtin remove ^J"
+      fi
+    '';
+
+    systemd.user.services.clipcat = mkIf cfg.enableSystemdUnit {
+      Unit = {
+        Description = "Clipcat Daemon";
+        PartOf = "graphical-session.target";
+      };
+
+      Install.WantedBy = [ "graphical-session.target" ];
+
+      Service = {
+        ExecStartPre = "${pkgs.writeShellScript "clipcatd-exec-start-pre" ''
+          PATH=/run/current-system/sw/bin:
+          rm -f %t/clipcat/grpc.sock
+        ''}";
+
+        ExecStart = "${pkgs.writeShellScript "clipcatd-exec-start" ''
+          PATH=/run/current-system/sw/bin:
+          ${cfg.package}/bin/clipcatd --no-daemon --replace
+        ''}";
+
+        Restart = "on-failure";
+        Type = "simple";
+      };
+    };
+
+    xdg.configFile = {
+      "clipcat/clipcatd.toml" = mkIf (cfg.daemonSettings != { }) {
+        source = formatter.generate "clipcatd.toml" cfg.daemonSettings;
+      };
+      "clipcat/clipcatctl.toml" = mkIf (cfg.ctlSettings != { }) {
+        source = formatter.generate "clipcatctl.toml" cfg.ctlSettings;
+      };
+      "clipcat/clipcat-menu.toml" = mkIf (cfg.menuSettings != { }) {
+        source = formatter.generate "clipcat-menu.toml" cfg.menuSettings;
+      };
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -406,6 +406,7 @@ import nmtSrc {
       ./modules/services/blanket
       ./modules/services/borgmatic
       ./modules/services/cachix-agent
+      ./modules/services/clipcat
       ./modules/services/cliphist
       ./modules/services/clipman
       ./modules/services/clipse

--- a/tests/modules/services/clipcat/cfg/ctl.toml
+++ b/tests/modules/services/clipcat/cfg/ctl.toml
@@ -1,0 +1,7 @@
+server_endpoint = "/run/user/<user-id>/clipcat/grpc.sock"
+[log]
+emit_journald = true
+emit_stderr = false
+emit_stdout = false
+file_path = "/path/to/log/file"
+level = "INFO"

--- a/tests/modules/services/clipcat/cfg/daemon.toml
+++ b/tests/modules/services/clipcat/cfg/daemon.toml
@@ -1,0 +1,12 @@
+daemonize = true
+history_file_path = "/home/<username>/.cache/clipcat/clipcatd-history"
+max_history = 50
+pid_file = "/run/user/<user-id>/clipcatd.pid"
+primary_threshold_ms = 5000
+
+[log]
+emit_journald = true
+emit_stderr = false
+emit_stdout = false
+file_path = "/path/to/log/file"
+level = "INFO"

--- a/tests/modules/services/clipcat/cfg/menu.toml
+++ b/tests/modules/services/clipcat/cfg/menu.toml
@@ -1,0 +1,12 @@
+finder = "rofi"
+server_endpoint = "/run/user/<user-id>/clipcat/grpc.sock"
+[dmenu]
+line_length = 100
+menu_length = 30
+menu_prompt = "Clipcat"
+
+[rofi]
+extra_arguments = ["-mesg", "Please select a clip"]
+line_length = 100
+menu_length = 30
+menu_prompt = "Clipcat"

--- a/tests/modules/services/clipcat/default.nix
+++ b/tests/modules/services/clipcat/default.nix
@@ -1,0 +1,1 @@
+{ clipcat-example-config = ./example-config.nix; }

--- a/tests/modules/services/clipcat/example-config.nix
+++ b/tests/modules/services/clipcat/example-config.nix
@@ -1,0 +1,65 @@
+{
+  services.clipcat = {
+    enable = true;
+    daemonSettings = {
+      daemonize = true;
+      max_history = 50;
+      history_file_path = "/home/<username>/.cache/clipcat/clipcatd-history";
+      pid_file = "/run/user/<user-id>/clipcatd.pid";
+      primary_threshold_ms = 5000;
+      log = {
+        file_path = "/path/to/log/file";
+        emit_journald = true;
+        emit_stdout = false;
+        emit_stderr = false;
+        level = "INFO";
+      };
+    };
+
+    ctlSettings = {
+      server_endpoint = "/run/user/<user-id>/clipcat/grpc.sock";
+      log = {
+        file_path = "/path/to/log/file";
+        emit_journald = true;
+        emit_stdout = false;
+        emit_stderr = false;
+        level = "INFO";
+      };
+    };
+
+    menuSettings = {
+      server_endpoint = "/run/user/<user-id>/clipcat/grpc.sock";
+      finder = "rofi";
+      rofi = {
+        line_length = 100;
+        menu_length = 30;
+        menu_prompt = "Clipcat";
+        extra_arguments = [
+          "-mesg"
+          "Please select a clip"
+        ];
+      };
+      dmenu = {
+        line_length = 100;
+        menu_length = 30;
+        menu_prompt = "Clipcat";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/clipcat/clipcatd.toml
+    assertFileExists home-files/.config/clipcat/clipcatctl.toml
+    assertFileExists home-files/.config/clipcat/clipcat-menu.toml
+
+    assertFileContent home-files/.config/clipcat/clipcatd.toml \
+    ${./cfg/daemon.toml}
+
+    assertFileContent home-files/.config/clipcat/clipcatctl.toml \
+    ${./cfg/ctl.toml}
+
+    assertFileContent home-files/.config/clipcat/clipcat-menu.toml \
+    ${./cfg/menu.toml}
+
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring Clipcat (clipcatctl, clipcatd, clipcat-menu) and its respective Systemd Unit. Closes #6297.

NOTE: I didn't added `{ nullable = true; }` to the package option since the package is needed in the Systemd Unit (`"${cfg.package}/bin/clipcatd"`). Feel free to show me an alternative.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
