### PR TITLE
mako: refactor

### DIFF
--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -20,7 +20,87 @@ in
 {
   meta.maintainers = [ lib.maintainers.onny ];
 
-  imports = [ (lib.mkRenamedOptionModule [ "programs" "mako" ] [ "services" "mako" ]) ];
+  imports = [
+    (lib.mkRenamedOptionModule [ "programs" "mako" ] [ "services" "mako" ])
+
+    (lib.mkRemovedOptionModule [
+      "services"
+      "mako"
+      "extraConfig"
+    ] "Use services.mako.settings instead.")
+
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "maxVisible" ]
+      [ "services" "mako" "settings" "maxVisible" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "maxHistory" ]
+      [ "services" "mako" "settings" "maxHistory" ]
+    )
+    (lib.mkRenamedOptionModule [ "services" "mako" "sort" ] [ "services" "mako" "settings" "sort" ])
+    (lib.mkRenamedOptionModule [ "services" "mako" "output" ] [ "services" "mako" "settings" "output" ])
+    (lib.mkRenamedOptionModule [ "services" "mako" "layer" ] [ "services" "mako" "settings" "layer" ])
+    (lib.mkRenamedOptionModule [ "services" "mako" "anchor" ] [ "services" "mako" "settings" "anchor" ])
+    (lib.mkRenamedOptionModule [ "services" "mako" "font" ] [ "services" "mako" "settings" "font" ])
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "backgroundColor" ]
+      [ "services" "mako" "settings" "backgroundColor" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "textColor" ]
+      [ "services" "mako" "settings" "textColor" ]
+    )
+    (lib.mkRenamedOptionModule [ "services" "mako" "width" ] [ "services" "mako" "settings" "width" ])
+    (lib.mkRenamedOptionModule [ "services" "mako" "height" ] [ "services" "mako" "settings" "height" ])
+    (lib.mkRenamedOptionModule [ "services" "mako" "margin" ] [ "services" "mako" "settings" "margin" ])
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "padding" ]
+      [ "services" "mako" "settings" "padding" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "borderSize" ]
+      [ "services" "mako" "settings" "borderSize" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "borderColor" ]
+      [ "services" "mako" "settings" "borderColor" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "borderRadius" ]
+      [ "services" "mako" "settings" "borderRadius" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "progressColor" ]
+      [ "services" "mako" "settings" "progressColor" ]
+    )
+    (lib.mkRenamedOptionModule [ "services" "mako" "icons" ] [ "services" "mako" "settings" "icons" ])
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "maxIconSize" ]
+      [ "services" "mako" "settings" "maxIconSize" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "iconPath" ]
+      [ "services" "mako" "settings" "iconPath" ]
+    )
+    (lib.mkRenamedOptionModule [ "services" "mako" "markup" ] [ "services" "mako" "settings" "markup" ])
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "actions" ]
+      [ "services" "mako" "settings" "actions" ]
+    )
+    (lib.mkRenamedOptionModule [ "services" "mako" "format" ] [ "services" "mako" "settings" "format" ])
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "defaultTimeout" ]
+      [ "services" "mako" "settings" "defaultTimeout" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "ignoreTimeout" ]
+      [ "services" "mako" "settings" "ignoreTimeout" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "mako" "groupBy" ]
+      [ "services" "mako" "settings" "groupBy" ]
+    )
+  ];
 
   options.services.mako = {
     enable = mkEnableOption "mako";
@@ -51,21 +131,6 @@ in
         here: <https://github.com/emersion/mako/blob/master/doc/mako.5.scd>.
       '';
     };
-    extraConfig = mkOption {
-      type = types.lines;
-      default = "";
-      example = ''
-        [mode=do-not-disturb]
-        invisible=1
-
-        [app-name="Google Chrome"]
-        max-visible=1
-        history=0
-      '';
-      description = ''
-        Extra configuration lines to be appended at the end of the file.
-      '';
-    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -77,7 +142,7 @@ in
 
     xdg.configFile."mako/config" = mkIf (cfg.settings != { }) {
       onChange = "${cfg.package}/bin/makoctl reload || true";
-      text = (generateConfig cfg.settings) + "\n${cfg.extraConfig}";
+      text = generateConfig cfg.settings;
     };
   };
 }

--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -5,371 +5,79 @@
   ...
 }:
 let
-  inherit (lib) mkOption types;
+  inherit (lib)
+    types
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
 
   cfg = config.services.mako;
 
+  generateConfig = lib.generators.toKeyValue { };
 in
 {
   meta.maintainers = [ lib.maintainers.onny ];
 
   imports = [ (lib.mkRenamedOptionModule [ "programs" "mako" ] [ "services" "mako" ]) ];
 
-  options = {
-    services.mako = {
-      enable = lib.mkEnableOption ''
-        Mako, lightweight notification daemon for Wayland
+  options.services.mako = {
+    enable = mkEnableOption "mako";
+    package = mkPackageOption pkgs "mako" { };
+    settings = mkOption {
+      type = with types; attrsOf str;
+      default = { };
+      example = ''
+        {
+          actions = "true";
+          anchor = "top-right";
+          backgroundColor = "#000000";
+          borderColor = "#FFFFFF";
+          borderRadius = "0";
+          defaultTimeout = "0";
+          font = "monospace 10";
+          height = "100";
+          width = "300";
+          icons = "true";
+          ignoreTimeout = "false";
+          layer = "top";
+          margin = "10";
+          markup = "true";
+        }
       '';
+      description = ''
+        Configuration settings for mako. All available options can be found
+        here: <https://github.com/emersion/mako/blob/master/doc/mako.5.scd>.
+      '';
+    };
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        [mode=do-not-disturb]
+        invisible=1
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.mako;
-        defaultText = lib.literalExpression "pkgs.mako";
-        description = "The mako package to use.";
-      };
-
-      maxVisible = mkOption {
-        default = 5;
-        type = types.nullOr types.int;
-        description = ''
-          Set maximum number of visible notifications. Set -1 to show all.
-        '';
-      };
-
-      maxHistory = mkOption {
-        default = 5;
-        type = types.nullOr types.int;
-        description = ''
-          Set maximum number of expired notifications to keep in the history
-          buffer. Set 0 to disable history.
-        '';
-      };
-
-      sort = mkOption {
-        default = "-time";
-        type = types.nullOr (
-          types.enum [
-            "+time"
-            "-time"
-            "+priority"
-            "-priority"
-          ]
-        );
-        description = ''
-          Sorts incoming notifications by time and/or priority in ascending(+)
-          or descending(-) order.
-        '';
-      };
-
-      output = mkOption {
-        default = null;
-        type = types.nullOr types.str;
-        description = ''
-          Show notifications on the specified output. If empty, notifications
-          will appear on the focused output. Requires the compositor to support
-          the Wayland protocol xdg-output-unstable-v1 version 2.
-        '';
-      };
-
-      layer = mkOption {
-        default = "top";
-        type = types.nullOr (
-          types.enum [
-            "background"
-            "bottom"
-            "top"
-            "overlay"
-          ]
-        );
-        description = ''
-          Arrange mako at the specified layer, relative to normal windows.
-          Supported values are background, bottom, top, and overlay. Using
-          overlay will cause notifications to be displayed above fullscreen
-          windows, though this may also occur at top depending on your
-          compositor.
-        '';
-      };
-
-      anchor = mkOption {
-        default = "top-right";
-        type = types.nullOr (
-          types.enum [
-            "top-right"
-            "top-center"
-            "top-left"
-            "bottom-right"
-            "bottom-center"
-            "bottom-left"
-            "center-right"
-            "center-left"
-            "center"
-          ]
-        );
-        description = ''
-          Show notifications at the specified position on the output.
-          Supported values are top-right, top-center, top-left, bottom-right,
-          bottom-center, bottom-left, center-right, center-left and center.
-        '';
-      };
-
-      font = mkOption {
-        default = "monospace 10";
-        type = types.nullOr types.str;
-        description = ''
-          Font to use, in Pango format.
-        '';
-      };
-
-      backgroundColor = mkOption {
-        default = "#285577FF";
-        type = types.nullOr types.str;
-        description = ''
-          Set popup background color to a specific color, represented in hex
-          color code.
-        '';
-      };
-
-      textColor = mkOption {
-        default = "#FFFFFFFF";
-        type = types.nullOr types.str;
-        description = ''
-          Set popup text color to a specific color, represented in hex color
-          code.
-        '';
-      };
-
-      width = mkOption {
-        default = 300;
-        type = types.nullOr types.int;
-        description = ''
-          Set width of notification popups in specified number of pixels.
-        '';
-      };
-
-      height = mkOption {
-        default = 100;
-        type = types.nullOr types.int;
-        description = ''
-          Set maximum height of notification popups. Notifications whose text
-          takes up less space are shrunk to fit.
-        '';
-      };
-
-      margin = mkOption {
-        default = "10";
-        type = types.nullOr types.str;
-        description = ''
-          Set margin of each edge specified in pixels. Specify single value to
-          apply margin on all sides. Two comma-separated values will set
-          vertical and horizontal edges separately. Four comma-separated will
-          give each edge a separate value.
-          For example: 10,20,5 will set top margin to 10, left and right to 20
-          and bottom to five.
-        '';
-      };
-
-      padding = mkOption {
-        default = "5";
-        type = types.nullOr types.str;
-        description = ''
-          Set padding of each edge specified in pixels. Specify single value to
-          apply margin on all sides. Two comma-separated values will set
-          vertical and horizontal edges separately. Four comma-separated will
-          give each edge a separate value.
-          For example: 10,20,5 will set top margin to 10, left and right to 20
-          and bottom to five.
-        '';
-      };
-
-      borderSize = mkOption {
-        default = 1;
-        type = types.nullOr types.int;
-        description = ''
-          Set popup border size to the specified number of pixels.
-        '';
-      };
-
-      borderColor = mkOption {
-        default = "#4C7899FF";
-        type = types.nullOr types.str;
-        description = ''
-          Set popup border color to a specific color, represented in hex color
-          code.
-        '';
-      };
-
-      borderRadius = mkOption {
-        default = 0;
-        type = types.nullOr types.int;
-        description = ''
-          Set popup corner radius to the specified number of pixels.
-        '';
-      };
-
-      progressColor = mkOption {
-        default = "over #5588AAFF";
-        type = types.nullOr types.str;
-        description = ''
-          Set popup progress indicator color to a specific color,
-          represented in hex color code. To draw the progress
-          indicator on top of the background color, use the
-          `over` attribute. To replace the background
-          color, use the `source` attribute (this can
-          be useful when the notification is semi-transparent).
-        '';
-      };
-
-      icons = mkOption {
-        default = true;
-        type = types.nullOr types.bool;
-        description = ''
-          Whether or not to show icons in notifications.
-        '';
-      };
-
-      maxIconSize = mkOption {
-        default = 64;
-        type = types.nullOr types.int;
-        description = ''
-          Set maximum icon size to the specified number of pixels.
-        '';
-      };
-
-      iconPath = mkOption {
-        default = null;
-        type = types.nullOr types.str;
-        description = ''
-          Paths to search for icons when a notification specifies a name
-          instead of a full path. Colon-delimited. This approximates the search
-          algorithm used by the XDG Icon Theme Specification, but does not
-          support any of the theme metadata. Therefore, if you want to search
-          parent themes, you'll need to add them to the path manually.
-
-          The {file}`/usr/share/icons/hicolor` and
-          {file}`/usr/share/pixmaps` directories are
-          always searched.
-        '';
-      };
-
-      markup = mkOption {
-        default = true;
-        type = types.nullOr types.bool;
-        description = ''
-          If 1, enable Pango markup. If 0, disable Pango markup. If enabled,
-          Pango markup will be interpreted in your format specifier and in the
-          body of notifications.
-        '';
-      };
-
-      actions = mkOption {
-        default = true;
-        type = types.nullOr types.bool;
-        description = ''
-          Applications may request an action to be associated with activating a
-          notification. Disabling this will cause mako to ignore these requests.
-        '';
-      };
-
-      format = mkOption {
-        default = "<b>%s</b>\\n%b";
-        type = types.nullOr types.str;
-        description = ''
-          Set notification format string to format. See FORMAT SPECIFIERS for
-          more information. To change this for grouped notifications, set it
-          within a grouped criteria.
-        '';
-      };
-
-      defaultTimeout = mkOption {
-        default = 0;
-        type = types.nullOr types.int;
-        description = ''
-          Set the default timeout to timeout in milliseconds. To disable the
-          timeout, set it to zero.
-        '';
-      };
-
-      ignoreTimeout = mkOption {
-        default = false;
-        type = types.nullOr types.bool;
-        description = ''
-          If set, mako will ignore the expire timeout sent by notifications
-          and use the one provided by default-timeout instead.
-        '';
-      };
-
-      groupBy = mkOption {
-        default = null;
-        type = types.nullOr types.str;
-        description = ''
-          A comma-separated list of criteria fields that will be compared to
-          other visible notifications to determine if this one should form a
-          group with them. All listed criteria must be exactly equal for two
-          notifications to group.
-        '';
-      };
-
-      extraConfig = mkOption {
-        default = "";
-        type = types.lines;
-        example = lib.literalExpression ''
-          [urgency=low]
-          border-color=#b8bb26
-        '';
-        description = "Additional configuration.";
-      };
+        [app-name="Google Chrome"]
+        max-visible=1
+        history=0
+      '';
+      description = ''
+        Extra configuration lines to be appended at the end of the file.
+      '';
     };
   };
 
-  config =
-    let
-      boolToString = v: if v then "true" else "false";
-      optionalBoolean = name: val: lib.optionalString (val != null) "${name}=${boolToString val}";
-      optionalInteger = name: val: lib.optionalString (val != null) "${name}=${toString val}";
-      optionalString = name: val: lib.optionalString (val != null) "${name}=${val}";
-    in
-    lib.mkIf cfg.enable {
-      assertions = [
-        (lib.hm.assertions.assertPlatform "services.mako" pkgs lib.platforms.linux)
-      ];
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.mako" pkgs lib.platforms.linux)
+    ];
 
-      home.packages = [ cfg.package ];
+    home.packages = [ cfg.package ];
 
-      xdg.configFile."mako/config" = {
-        onChange = ''
-          ${cfg.package}/bin/makoctl reload || true
-        '';
-        text = ''
-          ${optionalInteger "max-visible" cfg.maxVisible}
-          ${optionalInteger "max-history" cfg.maxHistory}
-          ${optionalString "sort" cfg.sort}
-          ${optionalString "output" cfg.output}
-          ${optionalString "layer" cfg.layer}
-          ${optionalString "anchor" cfg.anchor}
-
-          ${optionalString "font" cfg.font}
-          ${optionalString "background-color" cfg.backgroundColor}
-          ${optionalString "text-color" cfg.textColor}
-          ${optionalInteger "width" cfg.width}
-          ${optionalInteger "height" cfg.height}
-          ${optionalString "margin" cfg.margin}
-          ${optionalString "padding" cfg.padding}
-          ${optionalInteger "border-size" cfg.borderSize}
-          ${optionalString "border-color" cfg.borderColor}
-          ${optionalInteger "border-radius" cfg.borderRadius}
-          ${optionalString "progress-color" cfg.progressColor}
-          ${optionalBoolean "icons" cfg.icons}
-          ${optionalInteger "max-icon-size" cfg.maxIconSize}
-          ${optionalString "icon-path" cfg.iconPath}
-          ${optionalBoolean "markup" cfg.markup}
-          ${optionalBoolean "actions" cfg.actions}
-          ${optionalString "format" cfg.format}
-          ${optionalInteger "default-timeout" cfg.defaultTimeout}
-          ${optionalBoolean "ignore-timeout" cfg.ignoreTimeout}
-          ${optionalString "group-by" cfg.groupBy}
-
-          ${cfg.extraConfig}
-        '';
-      };
+    xdg.configFile."mako/config" = mkIf (cfg.settings != { }) {
+      onChange = "${cfg.package}/bin/makoctl reload || true";
+      text = (generateConfig cfg.settings) + "\n${cfg.extraConfig}";
     };
+  };
 }

--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -20,87 +20,47 @@ in
 {
   meta.maintainers = [ lib.maintainers.onny ];
 
-  imports = [
-    (lib.mkRenamedOptionModule [ "programs" "mako" ] [ "services" "mako" ])
+  imports =
+    let
+      basePath = [
+        "services"
+        "mako"
+      ];
 
-    (lib.mkRemovedOptionModule [
-      "services"
-      "mako"
-      "extraConfig"
-    ] "Use services.mako.settings instead.")
+      renamedOptions = [
+        "maxVisible"
+        "maxHistory"
+        "sort"
+        "output"
+        "layer"
+        "anchor"
+        "font"
+        "backgroundColor"
+        "textColor"
+        "width"
+        "height"
+        "margin"
+        "padding"
+        "borderSize"
+        "borderColor"
+        "borderRadius"
+        "progressColor"
+        "icons"
+        "maxIconSize"
+        "iconPath"
+        "markup"
+        "actions"
+        "format"
+        "defaultTimeout"
+        "ignoreTimeout"
+        "groupBy"
+      ];
 
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "maxVisible" ]
-      [ "services" "mako" "settings" "maxVisible" ]
-    )
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "maxHistory" ]
-      [ "services" "mako" "settings" "maxHistory" ]
-    )
-    (lib.mkRenamedOptionModule [ "services" "mako" "sort" ] [ "services" "mako" "settings" "sort" ])
-    (lib.mkRenamedOptionModule [ "services" "mako" "output" ] [ "services" "mako" "settings" "output" ])
-    (lib.mkRenamedOptionModule [ "services" "mako" "layer" ] [ "services" "mako" "settings" "layer" ])
-    (lib.mkRenamedOptionModule [ "services" "mako" "anchor" ] [ "services" "mako" "settings" "anchor" ])
-    (lib.mkRenamedOptionModule [ "services" "mako" "font" ] [ "services" "mako" "settings" "font" ])
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "backgroundColor" ]
-      [ "services" "mako" "settings" "backgroundColor" ]
-    )
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "textColor" ]
-      [ "services" "mako" "settings" "textColor" ]
-    )
-    (lib.mkRenamedOptionModule [ "services" "mako" "width" ] [ "services" "mako" "settings" "width" ])
-    (lib.mkRenamedOptionModule [ "services" "mako" "height" ] [ "services" "mako" "settings" "height" ])
-    (lib.mkRenamedOptionModule [ "services" "mako" "margin" ] [ "services" "mako" "settings" "margin" ])
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "padding" ]
-      [ "services" "mako" "settings" "padding" ]
-    )
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "borderSize" ]
-      [ "services" "mako" "settings" "borderSize" ]
-    )
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "borderColor" ]
-      [ "services" "mako" "settings" "borderColor" ]
-    )
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "borderRadius" ]
-      [ "services" "mako" "settings" "borderRadius" ]
-    )
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "progressColor" ]
-      [ "services" "mako" "settings" "progressColor" ]
-    )
-    (lib.mkRenamedOptionModule [ "services" "mako" "icons" ] [ "services" "mako" "settings" "icons" ])
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "maxIconSize" ]
-      [ "services" "mako" "settings" "maxIconSize" ]
-    )
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "iconPath" ]
-      [ "services" "mako" "settings" "iconPath" ]
-    )
-    (lib.mkRenamedOptionModule [ "services" "mako" "markup" ] [ "services" "mako" "settings" "markup" ])
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "actions" ]
-      [ "services" "mako" "settings" "actions" ]
-    )
-    (lib.mkRenamedOptionModule [ "services" "mako" "format" ] [ "services" "mako" "settings" "format" ])
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "defaultTimeout" ]
-      [ "services" "mako" "settings" "defaultTimeout" ]
-    )
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "ignoreTimeout" ]
-      [ "services" "mako" "settings" "ignoreTimeout" ]
-    )
-    (lib.mkRenamedOptionModule
-      [ "services" "mako" "groupBy" ]
-      [ "services" "mako" "settings" "groupBy" ]
-    )
-  ];
+      mkSettingsRenamedOptionModules =
+        oldPrefix: newPrefix:
+        map (option: lib.mkRenamedOptionModule (oldPrefix ++ [ option ]) (newPrefix ++ [ option ]));
+    in
+    mkSettingsRenamedOptionModules basePath (basePath ++ [ "settings" ]) renamedOptions;
 
   options.services.mako = {
     enable = mkEnableOption "mako";

--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -27,6 +27,14 @@ in
         "mako"
       ];
 
+      removedOptions = [
+        (lib.mkRemovedOptionModule [
+          "services"
+          "mako"
+          "extraConfig"
+        ] "Use services.mako.settings instead.")
+      ];
+
       renamedOptions = [
         "maxVisible"
         "maxHistory"
@@ -60,7 +68,8 @@ in
         oldPrefix: newPrefix:
         map (option: lib.mkRenamedOptionModule (oldPrefix ++ [ option ]) (newPrefix ++ [ option ]));
     in
-    mkSettingsRenamedOptionModules basePath (basePath ++ [ "settings" ]) renamedOptions;
+    removedOptions
+    ++ mkSettingsRenamedOptionModules basePath (basePath ++ [ "settings" ]) renamedOptions;
 
   options.services.mako = {
     enable = mkEnableOption "mako";

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -437,6 +437,7 @@ import nmtSrc {
       ./modules/services/lieer
       ./modules/services/linux-wallpaperengine
       ./modules/services/lxqt-policykit-agent
+      ./modules/services/mako
       ./modules/services/mopidy
       ./modules/services/mpd
       ./modules/services/mpd-mpris

--- a/tests/modules/services/mako/config
+++ b/tests/modules/services/mako/config
@@ -12,10 +12,3 @@ layer=top
 margin=10
 markup=true
 width=300
-
-[mode=do-not-disturb]
-invisible=1
-
-[app-name="Google Chrome"]
-max-visible=1
-history=0

--- a/tests/modules/services/mako/config
+++ b/tests/modules/services/mako/config
@@ -12,3 +12,12 @@ layer=top
 margin=10
 markup=true
 width=300
+
+[actionable=true]
+anchor=top-left
+
+[app-name=Google\ Chrome]
+max-visible=5
+
+[field1=value field2=value]
+text-alignment=left

--- a/tests/modules/services/mako/config
+++ b/tests/modules/services/mako/config
@@ -1,0 +1,21 @@
+actions=true
+anchor=top-right
+backgroundColor=#000000
+borderColor=#FFFFFF
+borderRadius=0
+defaultTimeout=0
+font=monospace 10
+height=100
+icons=true
+ignoreTimeout=false
+layer=top
+margin=10
+markup=true
+width=300
+
+[mode=do-not-disturb]
+invisible=1
+
+[app-name="Google Chrome"]
+max-visible=1
+history=0

--- a/tests/modules/services/mako/default.nix
+++ b/tests/modules/services/mako/default.nix
@@ -1,0 +1,1 @@
+{ mako-example-config = ./example-config.nix; }

--- a/tests/modules/services/mako/example-config.nix
+++ b/tests/modules/services/mako/example-config.nix
@@ -1,0 +1,35 @@
+{
+  services.mako = {
+    enable = true;
+    settings = {
+      actions = "true";
+      anchor = "top-right";
+      backgroundColor = "#000000";
+      borderColor = "#FFFFFF";
+      borderRadius = "0";
+      defaultTimeout = "0";
+      font = "monospace 10";
+      height = "100";
+      width = "300";
+      icons = "true";
+      ignoreTimeout = "false";
+      layer = "top";
+      margin = "10";
+      markup = "true";
+    };
+    extraConfig = ''
+      [mode=do-not-disturb]
+      invisible=1
+
+      [app-name="Google Chrome"]
+      max-visible=1
+      history=0
+    '';
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/mako/config
+    assertFileContent home-files/.config/mako/config \
+    ${./config}
+  '';
+}

--- a/tests/modules/services/mako/example-config.nix
+++ b/tests/modules/services/mako/example-config.nix
@@ -17,14 +17,6 @@
       margin = "10";
       markup = "true";
     };
-    extraConfig = ''
-      [mode=do-not-disturb]
-      invisible=1
-
-      [app-name="Google Chrome"]
-      max-visible=1
-      history=0
-    '';
   };
 
   nmt.script = ''

--- a/tests/modules/services/mako/example-config.nix
+++ b/tests/modules/services/mako/example-config.nix
@@ -17,6 +17,20 @@
       margin = "10";
       markup = "true";
     };
+
+    criterias = {
+      "actionable=true" = {
+        anchor = "top-left";
+      };
+
+      "app-name=Google\\ Chrome" = {
+        max-visible = "5";
+      };
+
+      "field1=value field2=value" = {
+        text-alignment = "left";
+      };
+    };
   };
 
   nmt.script = ''


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR refactors the `services.mako` module to replace all its configuration options with `settings` and `criterias`. I also added a test for the configuration. . Indirectly closes #6251.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
