### PR TITLE
ci: remove GitLab rycee/nur-expression update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,15 +18,3 @@ pages:
   rules:
     - if: $CI_COMMIT_BRANCH == "master"
       when: always
-
-Deploy NUR:
-  stage: deploy
-  variables:
-    HM_BRANCH: $CI_COMMIT_REF_NAME
-    HM_COMMIT_SHA: $CI_COMMIT_SHA
-  trigger:
-    project: rycee/nur-expressions
-    branch: master
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH =~ /^release-/
-      when: always


### PR DESCRIPTION
### Description

This removes the automatic update of the Home Manager packaging in <https://gitlab.com/rycee/nur-expressions/>. That setup is very old and brittle, it should therefore not be used.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
