### PR TITLE
visidata: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -294,6 +294,7 @@ let
       ./programs/vinegar.nix
       ./programs/vscode.nix
       ./programs/vscode/haskell.nix
+      ./programs/visidata.nix
       ./programs/pywal.nix
       ./programs/rbenv.nix
       ./programs/wallust.nix

--- a/modules/programs/visidata.nix
+++ b/modules/programs/visidata.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    types
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.visidata;
+in
+{
+  options.programs.visidata = {
+    enable = mkEnableOption "Visidata";
+    package = mkPackageOption pkgs "visidata" { nullable = true; };
+    visidatarc = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        options.min_memory_mb=100  # stop processing without 100MB free
+
+        bindkey('0', 'go-leftmost')   # alias '0' to go to first column, like vim
+
+        def median(values):
+            L = sorted(values)
+            return L[len(L)//2]
+
+        vd.aggregator('median', median)
+      '';
+      description = ''
+        Configuration settings and Python function declarations
+        to be written to ~/.visidatarc. All available options
+        can be found here: <https://www.visidata.org/docs/>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    home.file.".visidatarc" = mkIf (cfg.visidatarc != "") { text = cfg.visidatarc; };
+  };
+}

--- a/modules/programs/visidata.nix
+++ b/modules/programs/visidata.nix
@@ -16,6 +16,8 @@ let
   cfg = config.programs.visidata;
 in
 {
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
   options.programs.visidata = {
     enable = mkEnableOption "Visidata";
     package = mkPackageOption pkgs "visidata" { nullable = true; };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -309,6 +309,7 @@ import nmtSrc {
       ./modules/programs/uv
       ./modules/programs/vifm
       ./modules/programs/vim-vint
+      ./modules/programs/visidata
       ./modules/programs/vscode
       ./modules/programs/wallust
       ./modules/programs/watson

--- a/tests/modules/programs/visidata/config
+++ b/tests/modules/programs/visidata/config
@@ -1,0 +1,9 @@
+options.min_memory_mb=100
+
+bindkey('0', 'go-leftmost')
+
+def median(values):
+    L = sorted(values)
+    return L[len(L)//2]
+
+vd.aggregator('median', median)

--- a/tests/modules/programs/visidata/default.nix
+++ b/tests/modules/programs/visidata/default.nix
@@ -1,0 +1,1 @@
+{ visidata-example-config = ./example-config.nix; }

--- a/tests/modules/programs/visidata/example-config.nix
+++ b/tests/modules/programs/visidata/example-config.nix
@@ -1,0 +1,22 @@
+{
+  programs.visidata = {
+    enable = true;
+    visidatarc = ''
+      options.min_memory_mb=100
+
+      bindkey('0', 'go-leftmost')
+
+      def median(values):
+          L = sorted(values)
+          return L[len(L)//2]
+
+      vd.aggregator('median', median)
+    '';
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.visidatarc
+    assertFileContent home-files/.visidatarc \
+    ${./config}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring [Visidata](https://www.visidata.org/), an interactive multi-tool for tabular data. Closes #6202.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
