### PR TITLE
gimp: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -117,6 +117,7 @@ let
       ./programs/gh-dash.nix
       ./programs/ghostty.nix
       ./programs/git-cliff.nix
+      ./programs/gimp.nix
       ./programs/git-credential-oauth.nix
       ./programs/git-worktree-switcher.nix
       ./programs/git.nix

--- a/modules/programs/gimp.nix
+++ b/modules/programs/gimp.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    types
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.gimp;
+in
+{
+  options.programs.gimp = {
+    enable = mkEnableOption "gimp";
+    package = mkPackageOption pkgs "gimp-with-plugins" { nullable = true; };
+    plugins = mkOption {
+      type = with types; listOf package;
+      default = [ ];
+      example = ''
+        with pkgs.gimpPlugins; [ gmic bimp fourier ];
+      '';
+      description = ''
+        List of Gimp plugins to install. Requires Gimp with plugins.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    warnings = lib.optional (cfg.package == null && cfg.plugins != [ ]) ''
+      You have configured `plugins` for Gimp, but havee not set `package`.
+
+      The listed plugins will not be installed.
+    '';
+
+    home.packages = mkIf (cfg.package != null) [ cfg.package ] ++ cfg.plugins;
+  };
+}

--- a/modules/programs/gimp.nix
+++ b/modules/programs/gimp.nix
@@ -16,6 +16,8 @@ let
   cfg = config.programs.gimp;
 in
 {
+  meta.maintainers = with lib.hm.maintainers [ aguirre-matteo ];
+
   options.programs.gimp = {
     enable = mkEnableOption "gimp";
     package = mkPackageOption pkgs "gimp-with-plugins" { nullable = true; };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for enabling Gimp and its plugins. It seems Gimp uses a large amount of config files at ~/.config/GIMP/, some of them are updated every time Gimp starts/closes, some of them not, but they are a lot and a have the package version as a prefix (see `man gimp`, FILES section), so it will require constant maintenance and could easily break. Closes #6178.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
