### PR TITLE
thunderbird: fix accounts being removed

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -704,7 +704,9 @@ in
                     "account1"
                   ];
                 in
-                accountsOrderIds ++ (lib.lists.subtractLists accountsOrderIds enabledAccountsIds);
+                lib.optionals (accounts != [ ]) (
+                  accountsOrderIds ++ (lib.lists.subtractLists accountsOrderIds enabledAccountsIds)
+                );
             in
             {
               text = mkUserJs (builtins.foldl' (a: b: a // b) { } (


### PR DESCRIPTION
### Description

Even if no accounts were configured, it was defaulting to just account1, which meant all other accounts were deleted every time thunderbird was restarted. This fixes that by defaulting to the empty list (so it remains unset in the user.js).

Introduced #6310 (probably)

Fixes #6800

Btw, I'm not even sure whether `account1` always corresponds to the local folders account; on my machine, it instead corresponds to the first email account I added. I feel like trying to handle thunderbird account management through home-manager is inherently fragile.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@d-dervishi @jKarlson @nfelber

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
