### PR TITLE
tests: enable all firefox tests on darwin (plus derivations)

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -199,6 +199,10 @@ import nmtSrc {
       ./modules/programs/eza
       ./modules/programs/fastfetch
       ./modules/programs/feh
+      ./modules/programs/firefox
+      ./modules/programs/firefox/firefox.nix
+      ./modules/programs/firefox/floorp.nix
+      ./modules/programs/firefox/librewolf.nix
       ./modules/programs/fish
       ./modules/programs/gallery-dl
       ./modules/programs/gh
@@ -363,10 +367,6 @@ import nmtSrc {
       ./modules/programs/distrobox
       ./modules/programs/element-desktop/linux.nix
       ./modules/programs/eww
-      ./modules/programs/firefox
-      ./modules/programs/firefox/firefox.nix
-      ./modules/programs/firefox/floorp.nix
-      ./modules/programs/firefox/librewolf.nix
       ./modules/programs/foot
       ./modules/programs/freetube
       ./modules/programs/fuzzel

--- a/tests/modules/programs/firefox/policies.nix
+++ b/tests/modules/programs/firefox/policies.nix
@@ -9,6 +9,8 @@ let
   cfg = lib.getAttrFromPath modulePath config;
 
   firefoxMockOverlay = import ./setup-firefox-mock-overlay.nix modulePath;
+
+  darwinPath = "Applications/${cfg.darwinAppName}.app/Contents/Resources";
 in
 {
   imports = [ firefoxMockOverlay ];
@@ -29,24 +31,32 @@ in
       };
     }
     // {
-      nmt.script = ''
-        jq=${lib.getExe pkgs.jq}
-        config_file="${cfg.finalPackage}/lib/${cfg.wrappedPackageName}/distribution/policies.json"
+      nmt.script =
+        let
+          libDir =
+            if pkgs.stdenv.hostPlatform.isDarwin then
+              "${cfg.finalPackage}/${darwinPath}"
+            else
+              "${cfg.finalPackage}/lib/${cfg.wrappedPackageName}";
+          config_file = "${libDir}/distribution/policies.json";
+        in
+        ''
+          jq=${lib.getExe pkgs.jq}
 
-        assertFileExists "$config_file"
+          assertFileExists "${config_file}"
 
-        blockAboutConfig_actual_value="$($jq ".policies.BlockAboutConfig" $config_file)"
+          blockAboutConfig_actual_value="$($jq ".policies.BlockAboutConfig" ${config_file})"
 
-        if [[ $blockAboutConfig_actual_value != "true" ]]; then
-          fail "Expected '$config_file' to set 'policies.BlockAboutConfig' to true"
-        fi
+          if [[ $blockAboutConfig_actual_value != "true" ]]; then
+            fail "Expected '${config_file}' to set 'policies.BlockAboutConfig' to true"
+          fi
 
-        downloadDirectory_actual_value="$($jq ".policies.DownloadDirectory" $config_file)"
+          downloadDirectory_actual_value="$($jq ".policies.DownloadDirectory" ${config_file})"
 
-        if [[ $downloadDirectory_actual_value != "\"/foo\"" ]]; then
-          fail "Expected '$config_file' to set 'policies.DownloadDirectory' to \"/foo\""
-        fi
-      '';
+          if [[ $downloadDirectory_actual_value != "\"/foo\"" ]]; then
+            fail "Expected '${config_file}' to set 'policies.DownloadDirectory' to \"/foo\""
+          fi
+        '';
     }
   );
 }

--- a/tests/modules/programs/firefox/profiles/bookmarks/attrset.nix
+++ b/tests/modules/programs/firefox/profiles/bookmarks/attrset.nix
@@ -74,7 +74,7 @@ in
     // {
       nmt.script = ''
         bookmarksUserJs=$(normalizeStorePaths \
-          home-files/${cfg.configPath}/bookmarks/user.js)
+          "home-files/${cfg.profilesPath}/bookmarks/user.js")
 
         assertFileContent \
           $bookmarksUserJs \
@@ -82,7 +82,7 @@ in
 
         bookmarksFile="$(sed -n \
           '/browser.bookmarks.file/ {s|^.*\(/nix/store[^"]*\).*|\1|;p}' \
-          $TESTED/home-files/${cfg.configPath}/bookmarks/user.js)"
+          "$TESTED/home-files/${cfg.profilesPath}/bookmarks/user.js")"
 
         assertFileContent \
           $bookmarksFile \

--- a/tests/modules/programs/firefox/profiles/bookmarks/default.nix
+++ b/tests/modules/programs/firefox/profiles/bookmarks/default.nix
@@ -2,7 +2,6 @@ modulePath:
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -82,7 +81,7 @@ in
     // {
       nmt.script = ''
         bookmarksUserJs=$(normalizeStorePaths \
-          home-files/${cfg.configPath}/bookmarks/user.js)
+          "home-files/${cfg.profilesPath}/bookmarks/user.js")
 
         assertFileContent \
           $bookmarksUserJs \
@@ -90,7 +89,7 @@ in
 
         bookmarksFile="$(sed -n \
           '/browser.bookmarks.file/ {s|^.*\(/nix/store[^"]*\).*|\1|;p}' \
-          $TESTED/home-files/${cfg.configPath}/bookmarks/user.js)"
+          "$TESTED/home-files/${cfg.profilesPath}/bookmarks/user.js")"
 
         assertFileContent \
           $bookmarksFile \

--- a/tests/modules/programs/firefox/profiles/containers/default.nix
+++ b/tests/modules/programs/firefox/profiles/containers/default.nix
@@ -25,7 +25,7 @@ in
     // {
       nmt.script = ''
         assertFileContent \
-          home-files/${cfg.configPath}/containers/containers.json \
+          "home-files/${cfg.profilesPath}/containers/containers.json" \
           ${./expected-containers.json}
       '';
     }

--- a/tests/modules/programs/firefox/profiles/extensions/default.nix
+++ b/tests/modules/programs/firefox/profiles/extensions/default.nix
@@ -32,7 +32,7 @@ in
     // {
       nmt.script = ''
         assertFileContent \
-          home-files/${cfg.configPath}/extensions/browser-extension-data/uBlock0@raymondhill.net/storage.js \
+          "home-files/${cfg.profilesPath}/extensions/browser-extension-data/uBlock0@raymondhill.net/storage.js" \
           ${./expected-storage.js}
       '';
     }

--- a/tests/modules/programs/firefox/profiles/overwrite/default.nix
+++ b/tests/modules/programs/firefox/profiles/overwrite/default.nix
@@ -1,5 +1,10 @@
 modulePath:
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
 
@@ -31,17 +36,25 @@ in
       };
     }
     // {
-      nmt.script = ''
-        assertFileRegex \
-          home-path/bin/${cfg.wrappedPackageName} \
-          MOZ_APP_LAUNCHER
+      nmt.script =
+        let
+          binPath =
+            if pkgs.hostPlatform.isDarwin then
+              "Applications/${cfg.darwinAppName}.app/Contents/MacOS"
+            else
+              "bin";
+        in
+        ''
+          assertFileRegex \
+            "home-path/${binPath}/${cfg.wrappedPackageName}" \
+            MOZ_APP_LAUNCHER
 
-        assertDirectoryExists home-files/${cfg.configPath}/basic
+          assertDirectoryExists "home-files/${cfg.profilesPath}/basic"
 
-        assertFileContent \
-          home-files/${cfg.configPath}/test/user.js \
-          ${./expected-user.js}
-      '';
+          assertFileContent \
+            "home-files/${cfg.profilesPath}/test/user.js" \
+            ${./expected-user.js}
+        '';
     }
   );
 }

--- a/tests/modules/programs/firefox/profiles/search/default.nix
+++ b/tests/modules/programs/firefox/profiles/search/default.nix
@@ -260,23 +260,23 @@ in
           }
 
           assertFirefoxSearchContent \
-            home-files/${cfg.configPath}/search/search.json.mozlz4 \
+            "home-files/${cfg.profilesPath}/search/search.json.mozlz4" \
             ${withName ./expected-search.json}
 
           assertFirefoxSearchContent \
-            home-files/${cfg.configPath}/searchWithoutDefault/search.json.mozlz4 \
+            "home-files/${cfg.profilesPath}/searchWithoutDefault/search.json.mozlz4" \
             ${withName ./expected-search-without-default.json}
 
           assertFirefoxSearchContent \
-            home-files/${cfg.configPath}/migrateSearchV7/search.json.mozlz4 \
+            "home-files/${cfg.profilesPath}/migrateSearchV7/search.json.mozlz4" \
             ${withName ./expected-migrate-search-v7.json}
 
           assertFirefoxSearchContent \
-            home-files/${cfg.configPath}/migrateIconsV11/search.json.mozlz4 \
+            "home-files/${cfg.profilesPath}/migrateIconsV11/search.json.mozlz4" \
             ${withName ./expected-migrate-icons-v11.json}
 
           assertFirefoxSearchContent \
-            home-files/${cfg.configPath}/migrateIconsV12/search.json.mozlz4 \
+            "home-files/${cfg.profilesPath}/migrateIconsV12/search.json.mozlz4" \
             ${withName ./expected-migrate-icons-v12.json}
         '';
     }

--- a/tests/modules/programs/firefox/profiles/settings/default.nix
+++ b/tests/modules/programs/firefox/profiles/settings/default.nix
@@ -1,5 +1,10 @@
 modulePath:
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
 
@@ -31,17 +36,25 @@ in
       };
     }
     // {
-      nmt.script = ''
-        assertFileRegex \
-          home-path/bin/${cfg.wrappedPackageName} \
-          MOZ_APP_LAUNCHER
+      nmt.script =
+        let
+          binPath =
+            if pkgs.hostPlatform.isDarwin then
+              "Applications/${cfg.darwinAppName}.app/Contents/MacOS"
+            else
+              "bin";
+        in
+        ''
+          assertFileRegex \
+            "home-path/${binPath}/${cfg.wrappedPackageName}" \
+            MOZ_APP_LAUNCHER
 
-        assertDirectoryExists home-files/${cfg.configPath}/basic
+          assertDirectoryExists "home-files/${cfg.profilesPath}/basic"
 
-        assertFileContent \
-          home-files/${cfg.configPath}/test/user.js \
-          ${./expected-user.js}
-      '';
+          assertFileContent \
+            "home-files/${cfg.profilesPath}/test/user.js" \
+            ${./expected-user.js}
+        '';
     }
   );
 }

--- a/tests/modules/programs/firefox/profiles/userchrome/default.nix
+++ b/tests/modules/programs/firefox/profiles/userchrome/default.nix
@@ -34,27 +34,35 @@ in
       };
     }
     // {
-      nmt.script = ''
-        assertFileRegex \
-          home-path/bin/${cfg.wrappedPackageName} \
-          MOZ_APP_LAUNCHER
+      nmt.script =
+        let
+          binPath =
+            if pkgs.hostPlatform.isDarwin then
+              "Applications/${cfg.darwinAppName}.app/Contents/MacOS"
+            else
+              "bin";
+        in
+        ''
+          assertFileRegex \
+            "home-path/${binPath}/${cfg.wrappedPackageName}" \
+            MOZ_APP_LAUNCHER
 
-        assertDirectoryExists home-files/${cfg.configPath}/basic
+          assertDirectoryExists "home-files/${cfg.profilesPath}/basic"
 
-        assertFileContent \
-          home-files/${cfg.configPath}/lines/chrome/userChrome.css \
-          ${./chrome/userChrome.css}
+          assertFileContent \
+            "home-files/${cfg.profilesPath}/lines/chrome/userChrome.css" \
+            ${./chrome/userChrome.css}
 
-        assertFileContent \
-          home-files/${cfg.configPath}/file/chrome/userChrome.css \
-          ${./chrome/userChrome.css}
+          assertFileContent \
+            "home-files/${cfg.profilesPath}/file/chrome/userChrome.css" \
+            ${./chrome/userChrome.css}
 
-        assertPathNotExists \
-          home-files/${cfg.configPath}/derivation-file/chrome/extraFile.css
-        assertFileContent \
-          home-files/${cfg.configPath}/derivation-file/chrome/userChrome.css \
-          ${./chrome/userChrome.css}
-      '';
+          assertPathNotExists \
+            "home-files/${cfg.profilesPath}/derivation-file/chrome/extraFile.css"
+          assertFileContent \
+            "home-files/${cfg.profilesPath}/derivation-file/chrome/userChrome.css" \
+            ${./chrome/userChrome.css}
+        '';
     }
   );
 }

--- a/tests/modules/programs/firefox/setup-firefox-mock-overlay.nix
+++ b/tests/modules/programs/firefox/setup-firefox-mock-overlay.nix
@@ -9,6 +9,7 @@ modulePath:
 let
 
   cfg = lib.getAttrFromPath modulePath config;
+  darwinPath = "Applications/${cfg.darwinAppName}.app/Contents/MacOS";
 
 in
 {
@@ -26,12 +27,21 @@ in
           meta.description = "I pretend to be ${cfg.name}";
         };
         outPath = null;
-        buildScript = ''
-          echo BUILD
-          mkdir -p "$out"/{bin,lib}
-          touch "$out/bin/${cfg.wrappedPackageName}"
-          chmod 755 "$out/bin/${cfg.wrappedPackageName}"
-        '';
+        buildScript =
+          if realPkgs.stdenv.hostPlatform.isDarwin then
+            ''
+              echo BUILD
+              mkdir -p "$out"/${darwinPath}
+              touch "$out/${darwinPath}/${cfg.wrappedPackageName}"
+              chmod 755 "$out/${darwinPath}/${cfg.wrappedPackageName}"
+            ''
+          else
+            ''
+              echo BUILD
+              mkdir -p "$out"/{bin,lib}
+              touch "$out/bin/${cfg.wrappedPackageName}"
+              chmod 755 "$out/bin/${cfg.wrappedPackageName}"
+            '';
       };
 
       chrome-gnome-shell = {

--- a/tests/modules/programs/firefox/state-version-19_09.nix
+++ b/tests/modules/programs/firefox/state-version-19_09.nix
@@ -1,5 +1,10 @@
 modulePath:
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = lib.getAttrFromPath modulePath config;
 
@@ -8,7 +13,7 @@ in
 {
   imports = [ firefoxMockOverlay ];
 
-  config = lib.mkIf config.test.enableBig (
+  config = lib.mkIf (config.test.enableBig && !pkgs.hostPlatform.isDarwin) (
     {
       home.stateVersion = "19.09";
     }


### PR DESCRIPTION
Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>

### Description

Enable all firefox tests on darwin.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
