### PR TITLE
dircolors: add nushell integration

### DIFF
--- a/modules/programs/dircolors.nix
+++ b/modules/programs/dircolors.nix
@@ -68,8 +68,7 @@ in
         if config.home.preferXdgDirectories then "${config.xdg.configHome}/dir_colors" else "~/.dir_colors";
 
       dircolorsConfig = lib.concatStringsSep "\n" (
-        [ ]
-        ++ lib.mapAttrsToList formatLine cfg.settings
+        lib.mapAttrsToList formatLine cfg.settings
         ++ [ "" ]
         ++ lib.optional (cfg.extraConfig != "") cfg.extraConfig
       );

--- a/tests/modules/programs/dircolors/settings.nix
+++ b/tests/modules/programs/dircolors/settings.nix
@@ -1,7 +1,8 @@
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 {
   config = {
     programs.zsh.enable = true;
+    programs.nushell.enable = true;
 
     programs.dircolors = {
       enable = true;
@@ -17,15 +18,27 @@
       '';
     };
 
-    nmt.script = ''
-      assertFileContent \
-        home-files/.dir_colors \
-        ${./settings-expected.conf}
+    nmt.script =
+      let
+        nushellConfigDir =
+          if pkgs.stdenv.isDarwin && !config.xdg.enable then
+            "home-files/Library/Application Support/nushell"
+          else
+            "home-files/.config/nushell";
+      in
+      ''
+        assertFileContent \
+          home-files/.dir_colors \
+          ${./settings-expected.conf}
 
 
-      assertFileRegex  \
-        home-files/.zshrc \
-        "eval \$(${pkgs.coreutils}/bin/dircolors -b ~/.dir_colors)"
-    '';
+        assertFileRegex \
+          home-files/.zshrc \
+          "eval \$(${pkgs.coreutils}/bin/dircolors -b ~/.dir_colors)"
+
+        assertFileExists "${nushellConfigDir}/env.nu"
+        assertFileRegex  "${nushellConfigDir}/env.nu" \
+          "source /nix/store/[^/]*-dircolors.nu"
+      '';
   };
 }

--- a/tests/modules/programs/dircolors/xdg-config-settings.nix
+++ b/tests/modules/programs/dircolors/xdg-config-settings.nix
@@ -4,6 +4,7 @@
     home.preferXdgDirectories = true;
 
     programs.zsh.enable = true;
+    programs.nushell.enable = true;
 
     programs.dircolors = {
       enable = true;
@@ -19,14 +20,26 @@
       '';
     };
 
-    nmt.script = ''
-      assertFileContent \
-        home-files/.config/dir_colors \
-        ${./settings-expected.conf}
+    nmt.script =
+      let
+        nushellConfigDir =
+          if pkgs.stdenv.isDarwin && !config.xdg.enable then
+            "home-files/Library/Application Support/nushell"
+          else
+            "home-files/.config/nushell";
+      in
+      ''
+        assertFileContent \
+          home-files/.config/dir_colors \
+          ${./settings-expected.conf}
 
-      assertFileRegex  \
-        home-files/.zshrc \
-        "eval \$(${pkgs.coreutils}/bin/dircolors -b ${config.xdg.configHome}/dir_colors)"
-    '';
+        assertFileRegex \
+          home-files/.zshrc \
+          "eval \$(${pkgs.coreutils}/bin/dircolors -b ${config.xdg.configHome}/dir_colors)"
+
+        assertFileExists "${nushellConfigDir}/env.nu"
+        assertFileRegex  "${nushellConfigDir}/env.nu" \
+          "source /nix/store/[^/]*-dircolors.nu"
+      '';
   };
 }


### PR DESCRIPTION
### Description
Adds nushell support to dircolors module
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@justinlovinger 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
