### PR TITLE
lutris: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -792,4 +792,10 @@
     github = "miku4k";
     githubId = 89653242;
   };
+  bikku = {
+    name = "Bikku";
+    email = "bikku+dev@slmail.me";
+    github = "b1kku";
+    githubId = 77858854;
+  };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -174,6 +174,7 @@ let
       ./programs/lieer.nix
       ./programs/looking-glass-client.nix
       ./programs/lsd.nix
+      ./programs/lutris.nix
       ./programs/man.nix
       ./programs/mangohud.nix
       ./programs/matplotlib.nix

--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -1,0 +1,190 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkIf
+    types
+    optional
+    optionalAttrs
+    toLower
+    listToAttrs
+    nameValuePair
+    mapAttrs'
+    getExe
+    ;
+  cfg = config.programs.lutris;
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+  options.programs.lutris = {
+
+    enable = mkEnableOption "lutris.";
+    package = mkOption {
+      default = pkgs.lutris;
+      description = ''
+        The lutris package to use.
+      '';
+      type = types.package;
+    };
+    steamPackage = mkOption {
+      default = null;
+      example = "pkgs.steam or osConfig.programs.steam.package";
+      description = ''
+        This must be the same you use for your system, or two instances will conflict,
+        for example, if you configure steam through the nixos module, a good value is "osConfig.programs.steam.package"
+      '';
+      type = types.nullOr types.package;
+    };
+    extraPackages = mkOption {
+      default = [ ];
+      example = "with pkgs; [mangohud winetricks gamescope gamemode umu-launcher]";
+      description = ''
+        List of packages to pass as extraPkgs to lutris.
+        Please note runners are not detected properly this way, use a proper option for those.
+      '';
+      type = types.listOf types.package;
+    };
+    protonPackages = mkOption {
+      default = [ ];
+      example = "[ pkgs.proton-ge-bin ]";
+      description = ''
+        List of proton packages to be added for lutris to use with umu-launcher.
+      '';
+      type = types.listOf types.package;
+    };
+    winePackages = mkOption {
+      default = [ ];
+      example = "[ pkgs.wineWow64Packages.full ]";
+      description = ''
+        List of wine packages to be added for lutris to use.
+      '';
+      type = types.listOf types.package;
+    };
+    runners = mkOption {
+      default = { };
+      example = ''
+        runners = {
+          cemu.package = pkgs.cemu;
+          pcsx2.config = {
+            system.disable_screen_saver = true;
+            runner.executable_path = "$\{pkgs.pcsx2}/bin/pcsx2-qt";
+          };
+        };
+      '';
+      description = ''
+        Attribute set of Lutris runners along with their configurations.
+        Each runner must be named exactly as lutris expects on `lutris --list-runners`.
+        Note that runners added here won't be configurable through Lutris using the GUI.
+      '';
+      type = types.attrsOf (
+        types.submodule {
+          options = {
+            package = mkOption {
+              default = null;
+              example = "pkgs.cemu";
+              description = ''
+                The package to use for this runner, nix will try to find the executable for this package.
+                A more specific path can be set by using settings.runner.executable_path instead.
+              '';
+              type = types.nullOr types.package;
+            };
+            settings = mkOption {
+              default = { };
+              description = ''
+                Settings passed directly to lutris for this runner's config at XDG_CONFIG/lutris/runners.
+              '';
+              type = types.submodule {
+                options = {
+                  runner = mkOption {
+                    default = { };
+                    description = ''
+                      Runner specific options.
+                      For references, you must look for the file of said runner on lutris' source code.
+                    '';
+                    type = types.submodule {
+                      freeformType = settingsFormat.type;
+                      options = {
+                        executable_path = mkOption {
+                          type = types.either types.str types.path;
+                          default = "";
+                          description = ''
+                            Specific option to point to a runner executable directly, don't set runner.package if you set this.
+                          '';
+                        };
+                      };
+                    };
+                  };
+                  system = mkOption {
+                    default = { };
+                    description = ''
+                      Lutris system options for this runner.
+                      Reference for system options:
+                      https://github.com/lutris/lutris/blob/master/lutris/sysoptions.py#L78
+                    '';
+                    type = types.submodule { freeformType = settingsFormat.type; };
+                  };
+                };
+              };
+            };
+          };
+        }
+      );
+    };
+  };
+  meta.maintainers = with lib.maintainers; [ bikku ];
+  config = mkIf cfg.enable {
+    home.packages =
+      let
+        lutris-overrides = {
+          # This only adds pkgs.steam to the extraPkgs, I see no reason to ever enable it.
+          steamSupport = false;
+          extraPkgs = (prev: cfg.extraPackages ++ optional (cfg.steamPackage != null) cfg.steamPackage);
+        };
+      in
+      [ (cfg.package.override lutris-overrides) ];
+
+    xdg.configFile =
+      let
+        buildRunnerConfig = (
+          runner_name: runner_config:
+          {
+            "${runner_name}" =
+              (optionalAttrs (runner_config.settings.runner != { }) runner_config.settings.runner)
+              // (optionalAttrs (runner_config.package != null) {
+                executable_path = getExe runner_config.package;
+              });
+          }
+          // optionalAttrs (runner_config.settings.system != { }) {
+            system = runner_config.settings.system;
+          }
+        );
+      in
+      mapAttrs' (
+        runner_name: runner_config:
+        nameValuePair "lutris/runners/${runner_name}.yml" {
+          source = settingsFormat.generate "${runner_name}.yml" (buildRunnerConfig runner_name runner_config);
+        }
+      ) cfg.runners;
+
+    xdg.dataFile =
+      let
+        buildWineLink =
+          type: packages:
+          map (
+            # lutris seems to not detect wine/proton if the name has some caps
+            package:
+            (nameValuePair "lutris/runners/${type}/${toLower package.name}" {
+              source = package;
+            })
+          ) packages;
+        steamcompattools = map (proton: proton.steamcompattool) cfg.protonPackages;
+      in
+      listToAttrs (buildWineLink "wine" cfg.winePackages ++ buildWineLink "proton" steamcompattools);
+  };
+}

--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -139,6 +139,10 @@ in
   };
   meta.maintainers = [ lib.hm.maintainers.bikku ];
   config = mkIf cfg.enable {
+      assertions = [
+      (lib.hm.assertions.assertPlatform "programs.lutris" pkgs lib.platforms.linux)
+    ];
+
     home.packages =
       let
         lutris-overrides = {

--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -159,10 +159,10 @@ in
           runner_name: runner_config:
           {
             "${runner_name}" =
-              (optionalAttrs (runner_config.settings.runner != { }) runner_config.settings.runner)
-              // (optionalAttrs (runner_config.package != null) {
+              (optionalAttrs (runner_config.package != null) {
                 executable_path = getExe runner_config.package;
-              });
+              })
+              // (optionalAttrs (runner_config.settings.runner != { }) runner_config.settings.runner);
           }
           // optionalAttrs (runner_config.settings.system != { }) {
             system = runner_config.settings.system;

--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -177,10 +177,13 @@ in
           runner_name: runner_config:
           {
             "${runner_name}" =
-              (optionalAttrs (runner_config.package != null) {
-                executable_path = getExe runner_config.package;
-              })
-              // (optionalAttrs (runner_config.settings.runner != { }) runner_config.settings.runner);
+              (optionalAttrs (runner_config.settings.runner != { }) runner_config.settings.runner)
+              // (optionalAttrs
+                (runner_config.package != null && runner_config.settings.runner.executable_path == "")
+                {
+                  executable_path = getExe runner_config.package;
+                }
+              );
           }
           // optionalAttrs (runner_config.settings.system != { }) {
             system = runner_config.settings.system;

--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -137,7 +137,7 @@ in
       );
     };
   };
-  meta.maintainers = with lib.maintainers; [ bikku ];
+  meta.maintainers = [ lib.hm.maintainers.bikku ];
   config = mkIf cfg.enable {
     home.packages =
       let

--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -139,7 +139,7 @@ in
   };
   meta.maintainers = [ lib.hm.maintainers.bikku ];
   config = mkIf cfg.enable {
-      assertions = [
+    assertions = [
       (lib.hm.assertions.assertPlatform "programs.lutris" pkgs lib.platforms.linux)
     ];
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -237,6 +237,7 @@ import nmtSrc {
       ./modules/programs/lf
       ./modules/programs/lsd
       ./modules/programs/lieer
+      ./modules/programs/lutris
       ./modules/programs/man
       ./modules/programs/mbsync
       ./modules/programs/mergiraf

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -237,7 +237,6 @@ import nmtSrc {
       ./modules/programs/lf
       ./modules/programs/lsd
       ./modules/programs/lieer
-      ./modules/programs/lutris
       ./modules/programs/man
       ./modules/programs/mbsync
       ./modules/programs/mergiraf
@@ -382,6 +381,7 @@ import nmtSrc {
       ./modules/programs/kodi
       ./modules/programs/kickoff
       ./modules/programs/looking-glass-client
+      ./modules/programs/lutris
       ./modules/programs/mangohud
       ./modules/programs/mpvpaper
       ./modules/programs/ncmpcpp-linux

--- a/tests/modules/programs/lutris/default.nix
+++ b/tests/modules/programs/lutris/default.nix
@@ -1,0 +1,5 @@
+{
+  lutris-runners = ./runners-configuration.nix;
+  # lutris-wine = ./wine-configuration.nix;
+  lutris-empty = ./empty.nix;
+}

--- a/tests/modules/programs/lutris/empty.nix
+++ b/tests/modules/programs/lutris/empty.nix
@@ -1,0 +1,14 @@
+{ pkgs, lib, ... }:
+{
+  programs.lutris.enable = true;
+  nmt.script =
+    let
+      wineRunnersDir = "home-files/.local/share/lutris/runners";
+      runnersDir = "home-files/.config/lutris/runners";
+    in
+    ''
+      assertPathNotExists ${wineRunnersDir}/proton
+      assertPathNotExists ${wineRunnersDir}/wine
+      assertPathNotExists ${runnersDir}
+    '';
+}

--- a/tests/modules/programs/lutris/runners-configuration.nix
+++ b/tests/modules/programs/lutris/runners-configuration.nix
@@ -1,0 +1,50 @@
+{ pkgs, lib, ... }:
+{
+  programs.lutris = {
+    enable = true;
+    runners = {
+      cemu.package = pkgs.cemu;
+      pcsx2.settings = {
+        system.disable_screen_saver = true;
+        runner.executable_path = "${pkgs.pcsx2}/bin/pcsx2-qt";
+      };
+      rpcs3 = {
+        package = pkgs.rpcs3;
+        settings = {
+          system.disable_screen_saver = true;
+          runner.nogui = true;
+        };
+      };
+    };
+  };
+
+  nmt.script =
+    let
+      runnersDir = "home-files/.config/lutris/runners";
+      expectedCemu = builtins.toFile "cemu.yml" ''
+        cemu:
+          executable_path: '${lib.getExe pkgs.cemu}'
+      '';
+      expectedPcsx2 = builtins.toFile "pcsx2.yml" ''
+        pcsx2:
+          executable_path: '${pkgs.pcsx2}/bin/pcsx2-qt'
+        system:
+          disable_screen_saver: true
+      '';
+      expectedRpcs3 = builtins.toFile "rpcs3.yml" ''
+        rpcs3:
+          executable_path: '${lib.getExe pkgs.rpcs3}'
+          nogui: true
+        system:
+          disable_screen_saver: true
+      '';
+    in
+    ''
+      assertFileExists ${runnersDir}/cemu.yml
+      assertFileContent ${runnersDir}/cemu.yml ${expectedCemu}
+      assertFileExists ${runnersDir}/pcsx2.yml
+      assertFileContent ${runnersDir}/pcsx2.yml ${expectedPcsx2}
+      assertFileExists ${runnersDir}/rpcs3.yml
+      assertFileContent ${runnersDir}/rpcs3.yml ${expectedRpcs3}
+    '';
+}

--- a/tests/modules/programs/lutris/wine-configuration.nix
+++ b/tests/modules/programs/lutris/wine-configuration.nix
@@ -1,0 +1,17 @@
+{ pkgs, lib, ... }:
+{
+  programs.lutris = {
+    enable = true;
+    protonPackages = with pkgs; [ proton-ge-bin ];
+    winePackages = with pkgs; [ wineWow64Packages.full ];
+  };
+
+  nmt.script =
+    let
+      runnersDir = "home-files/.local/share/lutris/runners";
+    in
+    ''
+      assertFileExists ${runnersDir}/proton/${lib.toLower pkgs.proton-ge-bin.steamcompattool.name}/proton
+      assertFileExists ${runnersDir}/wine/${lib.toLower pkgs.wineWow64Packages.name}/bin/wine
+    '';
+}


### PR DESCRIPTION
### Description
Add a lutris module.
I've been using a similar version on my personal config for a while, only ever added features I found absolutely necessary to use lutris properly:
- Add any number of wine packages
- Add any number of proton packages
- Link runners directly from nix instead of using lutris.
- Specify the steam package lutris should use.
- Extra packages passed to lutris (mainly since it's often missing essential things, such as umu-launcher)

I'm aware #6213 has an implementation already, but I do not agree that runners should be added to the user's home path, instead for normal runners I set the runner's config variable 'runner_executable' to the package executable directly.

As a side effect of "hijacking" the runner's config for this I also added the ability to configure these entirely.
Wine/proton packages are linked directly to `.local/share/lutris/runners` where lutris normally expects them

I haven't added the ability to configure lutris' global `system` defaults as it felt redundant since u can just provide them to each runner, but idm adding it if that's something that should be added.

I've also had issues while building tests for wine/proton packages I link directly to `.local/share/lutris/runners`, and I'm unsure how to fix it since it only seems to happen while testing, so I've disabled those tests for now, any advice is greatly appreciated.
```
error: A definition for option `xdg.dataFile."lutris/runners/proton/proton-ge-bin-ge-proton9-27".source' is not of type `absolute path'. Definition values:
- In `/nix/store/dr1dnzfgzrk5dwj5vr7chs1a6a2lhw3r-source/modules/programs/lutris.nix': "@proton-ge-bin@"
```
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
