### PR TITLE
wofi: allow path to style.css

### DIFF
--- a/modules/programs/wofi.nix
+++ b/modules/programs/wofi.nix
@@ -42,11 +42,7 @@ in
 
     style = mkOption {
       default = null;
-      type = types.nullOr types.lines;
-      description = ''
-        CSS style for wofi to use as a stylesheet. See
-        {manpage}`wofi(7)`.
-      '';
+      type = with types; nullOr (either lines path);
       example = ''
         * {
             font-family: monospace;
@@ -55,6 +51,10 @@ in
         window {
             background-color: #7c818c;
         }
+      '';
+      description = ''
+        CSS style for wofi to use as a stylesheet. See
+        {manpage}`wofi(7)`
       '';
     };
   };
@@ -70,7 +70,12 @@ in
       (mkIf (cfg.settings != { }) {
         "wofi/config".text = toConfig cfg.settings;
       })
-      (mkIf (cfg.style != null) { "wofi/style.css".text = cfg.style; })
+      (
+        let
+          styleFile = if lib.isString cfg.style then pkgs.writeText "wofi-style" cfg.style else cfg.style;
+        in
+        mkIf (cfg.style != null) { "wofi/style.css".source = styleFile; }
+      )
     ];
   };
 }

--- a/tests/modules/programs/wofi/default.nix
+++ b/tests/modules/programs/wofi/default.nix
@@ -1,4 +1,5 @@
 {
   wofi-basic-configuration = ./basic-configuration.nix;
   wofi-empty-configuration = ./empty-configuration.nix;
+  wofi-style-local-file = ./style-local-file.nix;
 }

--- a/tests/modules/programs/wofi/style-local-file.nix
+++ b/tests/modules/programs/wofi/style-local-file.nix
@@ -1,0 +1,12 @@
+{
+  programs.wofi = {
+    enable = true;
+    style = ./basic-style.css;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/wofi/style.css
+    assertFileContent home-files/.config/wofi/style.css \
+    ${./basic-style.css}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR allows the option `programs.wofi.style` to be set to either a string or a path. Closes #5448.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
