### PR TITLE
i3bar-river: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -136,6 +136,7 @@ let
       ./programs/htop.nix
       ./programs/hyfetch.nix
       ./programs/hyprlock.nix
+      ./programs/i3bar-river.nix
       ./programs/i3blocks.nix
       ./programs/i3status-rust.nix
       ./programs/i3status.nix

--- a/modules/programs/i3bar-river.nix
+++ b/modules/programs/i3bar-river.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.i3bar-river;
+  formatter = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.i3bar-river = {
+    enable = mkEnableOption "i3bar-river";
+    package = mkPackageOption pkgs "i3bar-river" { nullable = true; };
+    settings = mkOption {
+      type = formatter.type;
+      default = { };
+      example = {
+        background = "#282828ff";
+        color = "#ffffffff";
+        separator = "#9a8a62ff";
+        font = "monospace 10";
+        height = 24;
+        margin_top = 0;
+        margin_bottom = 0;
+        margin_left = 0;
+        "wm.river" = {
+          max_tag = 0;
+        };
+      };
+      description = ''
+        Configuration settings for i3bar-river. All available options can be
+        found here: <https://github.com/MaxVerevkin/i3bar-river?tab=readme-ov-file#configuration>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."i3bar-river/config.toml" = mkIf (cfg.settings != { }) {
+      source = formatter.generate "i3bar-river-config.toml" cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -375,6 +375,7 @@ import nmtSrc {
       ./modules/programs/gnome-terminal
       ./modules/programs/hexchat
       ./modules/programs/hyprlock
+      ./modules/programs/i3bar-river
       ./modules/programs/i3blocks
       ./modules/programs/i3status-rust
       ./modules/programs/imv

--- a/tests/modules/programs/i3bar-river/config.toml
+++ b/tests/modules/programs/i3bar-river/config.toml
@@ -1,0 +1,11 @@
+background = "#282828ff"
+color = "#ffffffff"
+font = "monospace 10"
+height = 24
+margin_bottom = 0
+margin_left = 0
+margin_top = 0
+separator = "#9a8a62ff"
+
+["wm.river"]
+max_tag = 0

--- a/tests/modules/programs/i3bar-river/default.nix
+++ b/tests/modules/programs/i3bar-river/default.nix
@@ -1,0 +1,1 @@
+{ i3bar-river-example-config = ./example-config.nix; }

--- a/tests/modules/programs/i3bar-river/example-config.nix
+++ b/tests/modules/programs/i3bar-river/example-config.nix
@@ -1,0 +1,24 @@
+{
+  programs.i3bar-river = {
+    enable = true;
+    settings = {
+      background = "#282828ff";
+      color = "#ffffffff";
+      separator = "#9a8a62ff";
+      font = "monospace 10";
+      height = 24;
+      margin_top = 0;
+      margin_bottom = 0;
+      margin_left = 0;
+      "wm.river" = {
+        max_tag = 0;
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/i3bar-river/config.toml
+    assertFileContent home-files/.config/i3bar-river/config.toml \
+    ${./config.toml}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring [i3bar-river](https://github.com/MaxVerevkin/i3bar-river). Closes #5291.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
