### PR TITLE
mako: fix criterias typo

### DIFF
--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -17,7 +17,7 @@ let
 
   generateConfig = lib.generators.toINIWithGlobalSection { };
   settingsType = with types; attrsOf str;
-  criteriasType = types.attrsOf settingsType;
+  criteriaType = types.attrsOf settingsType;
 in
 {
   meta.maintainers = [ lib.maintainers.onny ];
@@ -27,14 +27,6 @@ in
       basePath = [
         "services"
         "mako"
-      ];
-
-      removedOptions = [
-        (lib.mkRemovedOptionModule [
-          "services"
-          "mako"
-          "extraConfig"
-        ] "Use services.mako.settings instead.")
       ];
 
       renamedOptions = [
@@ -70,7 +62,14 @@ in
         oldPrefix: newPrefix:
         map (option: lib.mkRenamedOptionModule (oldPrefix ++ [ option ]) (newPrefix ++ [ option ]));
     in
-    removedOptions
+    [
+      (lib.mkRemovedOptionModule [
+        "services"
+        "mako"
+        "extraConfig"
+      ] "Use services.mako.settings instead.")
+      (lib.mkRenamedOptionModule [ "services" "mako" "criterias" ] [ "services" "mako" "criteria" ])
+    ]
     ++ mkSettingsRenamedOptionModules basePath (basePath ++ [ "settings" ]) renamedOptions;
 
   options.services.mako = {
@@ -102,8 +101,8 @@ in
         here: <https://github.com/emersion/mako/blob/master/doc/mako.5.scd>.
       '';
     };
-    criterias = mkOption {
-      type = criteriasType;
+    criteria = mkOption {
+      type = criteriaType;
       default = { };
       example = {
         "actionable=true" = {
@@ -132,11 +131,11 @@ in
 
     home.packages = [ cfg.package ];
 
-    xdg.configFile."mako/config" = mkIf (cfg.settings != { } || cfg.criterias != { }) {
+    xdg.configFile."mako/config" = mkIf (cfg.settings != { } || cfg.criteria != { }) {
       onChange = "${cfg.package}/bin/makoctl reload || true";
       text = generateConfig {
         globalSection = cfg.settings;
-        sections = cfg.criterias;
+        sections = cfg.criteria;
       };
     };
   };

--- a/tests/modules/services/mako/example-config.nix
+++ b/tests/modules/services/mako/example-config.nix
@@ -18,7 +18,7 @@
       markup = "true";
     };
 
-    criterias = {
+    criteria = {
       "actionable=true" = {
         anchor = "top-left";
       };


### PR DESCRIPTION
### Description

causing issue in stylix because we have to disable typo checks https://github.com/danth/stylix/pull/1211/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
