### PR TITLE
ghostty: fix config syntax file location on darwin

### DIFF
--- a/modules/programs/ghostty.nix
+++ b/modules/programs/ghostty.nix
@@ -186,7 +186,7 @@ in
           syntaxes.ghostty = {
             src = cfg.package;
             file =
-              if pkgs.stdenv.isDarwin then
+              if pkgs.stdenv.hostPlatform.isDarwin then
                 "Applications/Ghostty.app/Contents/Resources/bat/syntaxes/ghostty.sublime-syntax"
               else
                 "share/bat/syntaxes/ghostty.sublime-syntax";

--- a/modules/programs/ghostty.nix
+++ b/modules/programs/ghostty.nix
@@ -185,7 +185,11 @@ in
         programs.bat = lib.mkIf (cfg.package != null) {
           syntaxes.ghostty = {
             src = cfg.package;
-            file = "share/bat/syntaxes/ghostty.sublime-syntax";
+            file =
+              if pkgs.stdenv.isDarwin then
+                "Applications/Ghostty.app/Contents/Resources/bat/syntaxes/ghostty.sublime-syntax"
+              else
+                "share/bat/syntaxes/ghostty.sublime-syntax";
           };
           config.map-syntax = [ "${config.xdg.configHome}/ghostty/config:Ghostty Config" ];
         };


### PR DESCRIPTION
### Description

Home Manager creates broken link to the Ghostty config syntax highlighting definition file, because it has different location on Darwin. This PR updates path to the config for Darwin users.

Fixes #6961

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@HeitorAugustoLN
@khaneliman
