### PR TITLE
sway-easyfocus: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -265,6 +265,7 @@ let
       ./programs/starship.nix
       ./programs/streamlink.nix
       ./programs/superfile.nix
+      ./programs/sway-easyfocus.nix
       ./programs/swayimg.nix
       ./programs/swaylock.nix
       ./programs/swayr.nix

--- a/modules/programs/sway-easyfocus.nix
+++ b/modules/programs/sway-easyfocus.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.sway-easyfocus;
+  formatter = pkgs.formats.yaml { };
+in
+{
+  options.programs.sway-easyfocus = {
+    enable = mkEnableOption "sway-easyfocus";
+    package = mkPackageOption pkgs "sway-easyfocus" { nullable = true; };
+    settings = mkOption {
+      type = formatter.type;
+      default = { };
+      example = {
+        chars = "fjghdkslaemuvitywoqpcbnxz";
+        window_background_color = "d1f21";
+        window_background_opacity = 0.2;
+        focused_background_color = "285577";
+        focused_background_opacity = 1.0;
+        focused_text_color = "ffffff";
+        font_family = "monospace";
+        font_weight = "bold";
+        font_size = "medium";
+      };
+      description = ''
+        Configuration settings for sway-easyfocus. All available options can be found here:
+        <https://github.com/edzdez/sway-easyfocus?tab=readme-ov-file#config-file>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."sway-easyfocus/config.yaml" = mkIf (cfg.settings != { }) {
+      source = formatter.generate "sway-easyfocus-config.yaml" cfg.settings;
+    };
+  };
+}

--- a/modules/programs/sway-easyfocus.nix
+++ b/modules/programs/sway-easyfocus.nix
@@ -16,6 +16,8 @@ let
   formatter = pkgs.formats.yaml { };
 in
 {
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
   options.programs.sway-easyfocus = {
     enable = mkEnableOption "sway-easyfocus";
     package = mkPackageOption pkgs "sway-easyfocus" { nullable = true; };

--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -63,11 +63,6 @@ in
         map (option: lib.mkRenamedOptionModule (oldPrefix ++ [ option ]) (newPrefix ++ [ option ]));
     in
     [
-      (lib.mkRemovedOptionModule [
-        "services"
-        "mako"
-        "extraConfig"
-      ] "Use services.mako.settings instead.")
       (lib.mkRenamedOptionModule [ "services" "mako" "criterias" ] [ "services" "mako" "criteria" ])
     ]
     ++ mkSettingsRenamedOptionModules basePath (basePath ++ [ "settings" ]) renamedOptions;
@@ -122,6 +117,15 @@ in
         CRITERIA section in the official documentation.
       '';
     };
+    extraConfig = mkOption {
+      default = "";
+      type = types.lines;
+      example = lib.literalExpression ''
+        [urgency=low]
+        border-color=#b8bb26
+      '';
+      description = "Additional configuration.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -133,10 +137,12 @@ in
 
     xdg.configFile."mako/config" = mkIf (cfg.settings != { } || cfg.criteria != { }) {
       onChange = "${cfg.package}/bin/makoctl reload || true";
-      text = generateConfig {
-        globalSection = cfg.settings;
-        sections = cfg.criteria;
-      };
+      text =
+        generateConfig {
+          globalSection = cfg.settings;
+          sections = cfg.criteria;
+        }
+        + cfg.extraConfig;
     };
   };
 }

--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -63,6 +63,11 @@ in
         map (option: lib.mkRenamedOptionModule (oldPrefix ++ [ option ]) (newPrefix ++ [ option ]));
     in
     [
+      (lib.mkRemovedOptionModule [
+        "services"
+        "mako"
+        "extraConfig"
+      ] "Use services.mako.settings instead.")
       (lib.mkRenamedOptionModule [ "services" "mako" "criterias" ] [ "services" "mako" "criteria" ])
     ]
     ++ mkSettingsRenamedOptionModules basePath (basePath ++ [ "settings" ]) renamedOptions;
@@ -117,15 +122,6 @@ in
         CRITERIA section in the official documentation.
       '';
     };
-    extraConfig = mkOption {
-      default = "";
-      type = types.lines;
-      example = lib.literalExpression ''
-        [urgency=low]
-        border-color=#b8bb26
-      '';
-      description = "Additional configuration.";
-    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -137,12 +133,10 @@ in
 
     xdg.configFile."mako/config" = mkIf (cfg.settings != { } || cfg.criteria != { }) {
       onChange = "${cfg.package}/bin/makoctl reload || true";
-      text =
-        generateConfig {
-          globalSection = cfg.settings;
-          sections = cfg.criteria;
-        }
-        + cfg.extraConfig;
+      text = generateConfig {
+        globalSection = cfg.settings;
+        sections = cfg.criteria;
+      };
     };
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -392,6 +392,7 @@ import nmtSrc {
       ./modules/programs/rbw
       ./modules/programs/rofi
       ./modules/programs/rofi-pass
+      ./modules/programs/sway-easyfocus
       ./modules/programs/swayimg
       ./modules/programs/swaylock
       ./modules/programs/swayr

--- a/tests/modules/programs/sway-easyfocus/config.yaml
+++ b/tests/modules/programs/sway-easyfocus/config.yaml
@@ -1,0 +1,9 @@
+chars: fjghdkslaemuvitywoqpcbnxz
+focused_background_color: '285577'
+focused_background_opacity: 1.0
+focused_text_color: ffffff
+font_family: monospace
+font_size: medium
+font_weight: bold
+window_background_color: d1f21
+window_background_opacity: 0.2

--- a/tests/modules/programs/sway-easyfocus/default.nix
+++ b/tests/modules/programs/sway-easyfocus/default.nix
@@ -1,0 +1,1 @@
+{ sway-easyfocus-example-config = ./example-config.nix; }

--- a/tests/modules/programs/sway-easyfocus/example-config.nix
+++ b/tests/modules/programs/sway-easyfocus/example-config.nix
@@ -1,0 +1,22 @@
+{
+  programs.sway-easyfocus = {
+    enable = true;
+    settings = {
+      chars = "fjghdkslaemuvitywoqpcbnxz";
+      window_background_color = "d1f21";
+      window_background_opacity = 0.2;
+      focused_background_color = "285577";
+      focused_background_opacity = 1.0;
+      focused_text_color = "ffffff";
+      font_family = "monospace";
+      font_weight = "bold";
+      font_size = "medium";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/sway-easyfocus/config.yaml
+    assertFileContent home-files/.config/sway-easyfocus/config.yaml \
+    ${./config.yaml}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring Sway-Easyfocus. Closes #5050.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
