### PR TITLE
git: configure patdiff through [patdiff] git section

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -496,6 +496,17 @@ in
           '';
         };
       };
+
+      patdiff = {
+        enable = mkEnableOption "" // {
+          description = ''
+            Whether to enable the {command}`patdiff` differ.
+            See <https://opensource.janestreet.com/patdiff/>
+          '';
+        };
+
+        package = mkPackageOption pkgs "patdiff" { };
+      };
     };
   };
 
@@ -526,10 +537,11 @@ in
                   cfg.difftastic.enable
                   cfg.diff-highlight.enable
                   cfg.riff.enable
+                  cfg.patdiff.enable
                 ];
               in
               lib.count lib.id enabled <= 1;
-            message = "Only one of 'programs.git.delta.enable' or 'programs.git.difftastic.enable' or 'programs.git.diff-so-fancy.enable' or 'programs.git.diff-highlight' can be set to true at the same time.";
+            message = "Only one of 'programs.git.delta.enable' or 'programs.git.difftastic.enable' or 'programs.git.diff-so-fancy.enable' or 'programs.git.diff-highlight' or 'programs.git.patdiff' can be set to true at the same time.";
           }
         ];
 
@@ -898,6 +910,20 @@ in
             };
 
             interactive.diffFilter = "${riffExe} --color=on";
+          };
+        }
+      )
+
+      (
+        let
+          patdiffPackage = cfg.patdiff.package;
+          patdiffCommand = "${lib.getExe' patdiffPackage "patdiff-git-wrapper"}";
+        in
+        mkIf cfg.patdiff.enable {
+          home.packages = [ patdiffPackage ];
+
+          programs.git.iniContent = {
+            diff.external = patdiffCommand;
           };
         }
       )

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -45,6 +45,7 @@ let
     "gh-dash"
     "ghostty"
     "git"
+    "patdiff"
     "gitMinimal"
     "git-cliff"
     "git-credential-oauth"

--- a/tests/modules/programs/git/default.nix
+++ b/tests/modules/programs/git/default.nix
@@ -9,4 +9,5 @@
   git-without-signing = ./git-without-signing.nix;
   git-with-hooks = ./git-with-hooks.nix;
   git-with-maintenance = ./git-with-maintenance.nix;
+  git-patdiff = ./git-patdiff.nix;
 }

--- a/tests/modules/programs/git/git-patdiff-expected.conf
+++ b/tests/modules/programs/git/git-patdiff-expected.conf
@@ -1,0 +1,19 @@
+[commit]
+	gpgSign = true
+
+[diff]
+	external = "@patdiff@/bin/patdiff-git-wrapper"
+
+[gpg]
+	format = "openpgp"
+
+[gpg "openpgp"]
+	program = "path-to-gpg"
+
+[tag]
+	gpgSign = true
+
+[user]
+	email = "user@example.org"
+	name = "John Doe"
+	signingKey = "00112233445566778899AABBCCDDEEFF"

--- a/tests/modules/programs/git/git-patdiff.nix
+++ b/tests/modules/programs/git/git-patdiff.nix
@@ -1,0 +1,20 @@
+{
+  programs.git = {
+    enable = true;
+    signing = {
+      signer = "path-to-gpg";
+      format = "openpgp";
+      key = "00112233445566778899AABBCCDDEEFF";
+      signByDefault = true;
+    };
+    userEmail = "user@example.org";
+    userName = "John Doe";
+
+    patdiff.enable = true;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileContent home-files/.config/git/config ${./git-patdiff-expected.conf}
+  '';
+}


### PR DESCRIPTION
### Description

This adds the ability to enable the `patdiff` program as git differ.
Website of the project: https://opensource.janestreet.com/patdiff/

I have tested it via a test and not building it myself, since I'm still on 24.11 and it doesn't evaluate.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@rycee
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
