### PR TITLE
tmpfiles: also remove files that need to be removed during activation

### DIFF
--- a/modules/misc/tmpfiles.nix
+++ b/modules/misc/tmpfiles.nix
@@ -37,7 +37,7 @@ in
           # Please change the option ‘systemd.user.tmpfiles.rules’ instead.
           ${lib.concatStringsSep "\n" cfg.rules}
         '';
-        onChange = "${pkgs.systemd}/bin/systemd-tmpfiles --user --create";
+        onChange = "${pkgs.systemd}/bin/systemd-tmpfiles --user --remove --create";
       };
       "systemd/user/basic.target.wants/systemd-tmpfiles-setup.service".source =
         "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-setup.service";


### PR DESCRIPTION
### Description

Make sure that tmpfiles entries that ask for files/directories to be removed, are also executed

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

@dawidsowa 

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
