### PR TITLE
television: add shell integrations

### DIFF
--- a/modules/programs/television.nix
+++ b/modules/programs/television.nix
@@ -14,6 +14,7 @@ in
   options.programs.television = {
     enable = lib.mkEnableOption "television";
     package = lib.mkPackageOption pkgs "television" { nullable = true; };
+
     settings = lib.mkOption {
       type = tomlFormat.type;
       default = { };
@@ -36,6 +37,10 @@ in
         for the full list of options.
       '';
     };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
   };
 
   config = lib.mkIf cfg.enable {
@@ -44,5 +49,15 @@ in
     xdg.configFile."television/config.toml" = lib.mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "config.toml" cfg.settings;
     };
+
+    programs.bash.initExtra = lib.mkIf cfg.enableBashIntegration ''
+      eval "$(${lib.getExe cfg.package} init bash)"
+    '';
+    programs.zsh.initContent = lib.mkIf cfg.enableZshIntegration ''
+      eval "$(${lib.getExe cfg.package} init zsh)"
+    '';
+    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+      ${lib.getExe cfg.package} init fish | source
+    '';
   };
 }


### PR DESCRIPTION
### Description
fixes https://github.com/nix-community/home-manager/issues/6979
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
