### PR TITLE
treewide: remove unused code

### DIFF
--- a/docs/flake.nix
+++ b/docs/flake.nix
@@ -11,9 +11,9 @@
 
   outputs =
     {
-      self,
       nixpkgs,
       scss-reset,
+      ...
     }:
     let
       supportedSystems = [

--- a/home-manager/home-manager.nix
+++ b/home-manager/home-manager.nix
@@ -3,20 +3,9 @@
   confPath,
   confAttr ? null,
   check ? true,
-  newsReadIdsFile ? null,
 }:
 
 let
-  inherit (pkgs.lib)
-    concatMapStringsSep
-    fileContents
-    filter
-    length
-    optionalString
-    removeSuffix
-    replaceStrings
-    splitString
-    ;
 
   env = import ../modules {
     configuration =

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -10,11 +10,6 @@
       check ? true,
       # Deprecated:
       configuration ? null,
-      extraModules ? null,
-      stateVersion ? null,
-      username ? null,
-      homeDirectory ? null,
-      system ? null,
     }@args:
     let
       msgForRemovedArg = ''

--- a/modules/lib/dag.nix
+++ b/modules/lib/dag.nix
@@ -126,7 +126,6 @@ in
         i: before: after: entries:
         let
           name = "${tag}-${toString i}";
-          i' = i + 1;
         in
         if entries == [ ] then
           hm.dag.empty

--- a/modules/lib/types-dag.nix
+++ b/modules/lib/types-dag.nix
@@ -2,24 +2,13 @@
 
 let
   inherit (lib)
-    concatStringsSep
     defaultFunctor
-    fixedWidthNumber
     hm
-    imap1
-    isAttrs
-    isList
-    length
-    listToAttrs
-    mapAttrs
     mkIf
     mkOrder
     mkOption
     mkOptionType
-    nameValuePair
-    stringLength
     types
-    warn
     ;
 
   dagEntryOf =

--- a/modules/lib/types.nix
+++ b/modules/lib/types.nix
@@ -16,7 +16,6 @@ let
     mergeAttrs
     mergeDefaultOption
     mergeOneOption
-    mergeOptions
     mkOption
     mkOptionType
     showFiles

--- a/modules/programs/distrobox.nix
+++ b/modules/programs/distrobox.nix
@@ -6,8 +6,6 @@
 }:
 let
   inherit (lib)
-    generators
-    types
     mkIf
     mkEnableOption
     mkPackageOption

--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -16,31 +16,28 @@ let
 
   cfg = config.programs.fish;
 
-  pluginModule = types.submodule (
-    { config, ... }:
-    {
-      options = {
-        src = mkOption {
-          type = types.path;
-          description = ''
-            Path to the plugin folder.
+  pluginModule = types.submodule {
+    options = {
+      src = mkOption {
+        type = types.path;
+        description = ''
+          Path to the plugin folder.
 
-            Relevant pieces will be added to the fish function path and
-            the completion path. The {file}`init.fish` and
-            {file}`key_binding.fish` files are sourced if
-            they exist.
-          '';
-        };
-
-        name = mkOption {
-          type = types.str;
-          description = ''
-            The name of the plugin.
-          '';
-        };
+          Relevant pieces will be added to the fish function path and
+          the completion path. The {file}`init.fish` and
+          {file}`key_binding.fish` files are sourced if
+          they exist.
+        '';
       };
-    }
-  );
+
+      name = mkOption {
+        type = types.str;
+        description = ''
+          The name of the plugin.
+        '';
+      };
+    };
+  };
 
   functionModule = types.submodule {
     options = {
@@ -480,7 +477,6 @@ in
               destructiveSymlinkJoin =
                 args_@{
                   name,
-                  paths,
                   preferLocalBuild ? true,
                   allowSubstitutes ? false,
                   postBuild ? "",

--- a/modules/programs/gnome-terminal.nix
+++ b/modules/programs/gnome-terminal.nix
@@ -17,221 +17,212 @@ let
     "tty"
   ];
 
-  backForeSubModule = types.submodule (
-    { ... }:
-    {
-      options = {
-        foreground = mkOption {
-          type = types.str;
-          description = "The foreground color.";
-        };
-
-        background = mkOption {
-          type = types.str;
-          description = "The background color.";
-        };
+  backForeSubModule = types.submodule {
+    options = {
+      foreground = mkOption {
+        type = types.str;
+        description = "The foreground color.";
       };
-    }
-  );
 
-  profileColorsSubModule = types.submodule (
-    { ... }:
-    {
-      options = {
-        foregroundColor = mkOption {
-          type = types.str;
-          description = "The foreground color.";
-        };
-
-        backgroundColor = mkOption {
-          type = types.str;
-          description = "The background color.";
-        };
-
-        boldColor = mkOption {
-          default = null;
-          type = types.nullOr types.str;
-          description = "The bold color, null to use same as foreground.";
-        };
-
-        palette = mkOption {
-          type = types.listOf types.str;
-          description = "The terminal palette.";
-        };
-
-        cursor = mkOption {
-          default = null;
-          type = types.nullOr backForeSubModule;
-          description = "The color for the terminal cursor.";
-        };
-
-        highlight = mkOption {
-          default = null;
-          type = types.nullOr backForeSubModule;
-          description = "The colors for the terminal’s highlighted area.";
-        };
+      background = mkOption {
+        type = types.str;
+        description = "The background color.";
       };
-    }
-  );
+    };
+  };
 
-  profileSubModule = types.submodule (
-    { name, config, ... }:
-    {
-      options = {
-        default = mkOption {
-          default = false;
-          type = types.bool;
-          description = "Whether this should be the default profile.";
-        };
-
-        visibleName = mkOption {
-          type = types.str;
-          description = "The profile name.";
-        };
-
-        colors = mkOption {
-          default = null;
-          type = types.nullOr profileColorsSubModule;
-          description = "The terminal colors, null to use system default.";
-        };
-
-        cursorBlinkMode = mkOption {
-          default = "system";
-          type = types.enum [
-            "system"
-            "on"
-            "off"
-          ];
-          description = "The cursor blink mode.";
-        };
-
-        cursorShape = mkOption {
-          default = "block";
-          type = types.enum [
-            "block"
-            "ibeam"
-            "underline"
-          ];
-          description = "The cursor shape.";
-        };
-
-        font = mkOption {
-          default = null;
-          type = types.nullOr types.str;
-          description = "The font name, null to use system default.";
-        };
-
-        allowBold = mkOption {
-          default = null;
-          type = types.nullOr types.bool;
-          description = ''
-            If `true`, allow applications in the
-            terminal to make text boldface.
-          '';
-        };
-
-        scrollOnOutput = mkOption {
-          default = true;
-          type = types.bool;
-          description = "Whether to scroll when output is written.";
-        };
-
-        showScrollbar = mkOption {
-          default = true;
-          type = types.bool;
-          description = "Whether the scroll bar should be visible.";
-        };
-
-        scrollbackLines = mkOption {
-          default = 10000;
-          type = types.nullOr types.int;
-          description = ''
-            The number of scrollback lines to keep, null for infinite.
-          '';
-        };
-
-        customCommand = mkOption {
-          default = null;
-          type = types.nullOr types.str;
-          description = ''
-            The command to use to start the shell, or null for default shell.
-          '';
-        };
-
-        loginShell = mkOption {
-          default = false;
-          type = types.bool;
-          description = "Run command as a login shell.";
-        };
-
-        backspaceBinding = mkOption {
-          default = "ascii-delete";
-          type = eraseBinding;
-          description = ''
-            Which string the terminal should send to an application when the user
-            presses the *Backspace* key.
-
-            `auto`
-            : Attempt to determine the right value from the terminal's IO settings.
-
-            `ascii-backspace`
-            : Send an ASCII backspace character (`0x08`).
-
-            `ascii-delete`
-            : Send an ASCII delete character (`0x7F`).
-
-            `delete-sequence`
-            : Send the `@7` control sequence.
-
-            `tty`
-            : Send terminal's "erase" setting.
-          '';
-        };
-
-        boldIsBright = mkOption {
-          default = null;
-          type = types.nullOr types.bool;
-          description = "Whether bold text is shown in bright colors.";
-        };
-
-        deleteBinding = mkOption {
-          default = "delete-sequence";
-          type = eraseBinding;
-          description = ''
-            Which string the terminal should send to an application when the user
-            presses the *Delete* key.
-
-            `auto`
-            : Send the `@7` control sequence.
-
-            `ascii-backspace`
-            : Send an ASCII backspace character (`0x08`).
-
-            `ascii-delete`
-            : Send an ASCII delete character (`0x7F`).
-
-            `delete-sequence`
-            : Send the `@7` control sequence.
-
-            `tty`
-            : Send terminal's "erase" setting.
-          '';
-        };
-
-        audibleBell = mkOption {
-          default = true;
-          type = types.bool;
-          description = "Turn on/off the terminal's bell.";
-        };
-
-        transparencyPercent = mkOption {
-          default = null;
-          type = types.nullOr (types.ints.between 0 100);
-          description = "Background transparency in percent.";
-        };
+  profileColorsSubModule = types.submodule {
+    options = {
+      foregroundColor = mkOption {
+        type = types.str;
+        description = "The foreground color.";
       };
-    }
-  );
+
+      backgroundColor = mkOption {
+        type = types.str;
+        description = "The background color.";
+      };
+
+      boldColor = mkOption {
+        default = null;
+        type = types.nullOr types.str;
+        description = "The bold color, null to use same as foreground.";
+      };
+
+      palette = mkOption {
+        type = types.listOf types.str;
+        description = "The terminal palette.";
+      };
+
+      cursor = mkOption {
+        default = null;
+        type = types.nullOr backForeSubModule;
+        description = "The color for the terminal cursor.";
+      };
+
+      highlight = mkOption {
+        default = null;
+        type = types.nullOr backForeSubModule;
+        description = "The colors for the terminal’s highlighted area.";
+      };
+    };
+  };
+
+  profileSubModule = types.submodule {
+    options = {
+      default = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Whether this should be the default profile.";
+      };
+
+      visibleName = mkOption {
+        type = types.str;
+        description = "The profile name.";
+      };
+
+      colors = mkOption {
+        default = null;
+        type = types.nullOr profileColorsSubModule;
+        description = "The terminal colors, null to use system default.";
+      };
+
+      cursorBlinkMode = mkOption {
+        default = "system";
+        type = types.enum [
+          "system"
+          "on"
+          "off"
+        ];
+        description = "The cursor blink mode.";
+      };
+
+      cursorShape = mkOption {
+        default = "block";
+        type = types.enum [
+          "block"
+          "ibeam"
+          "underline"
+        ];
+        description = "The cursor shape.";
+      };
+
+      font = mkOption {
+        default = null;
+        type = types.nullOr types.str;
+        description = "The font name, null to use system default.";
+      };
+
+      allowBold = mkOption {
+        default = null;
+        type = types.nullOr types.bool;
+        description = ''
+          If `true`, allow applications in the
+          terminal to make text boldface.
+        '';
+      };
+
+      scrollOnOutput = mkOption {
+        default = true;
+        type = types.bool;
+        description = "Whether to scroll when output is written.";
+      };
+
+      showScrollbar = mkOption {
+        default = true;
+        type = types.bool;
+        description = "Whether the scroll bar should be visible.";
+      };
+
+      scrollbackLines = mkOption {
+        default = 10000;
+        type = types.nullOr types.int;
+        description = ''
+          The number of scrollback lines to keep, null for infinite.
+        '';
+      };
+
+      customCommand = mkOption {
+        default = null;
+        type = types.nullOr types.str;
+        description = ''
+          The command to use to start the shell, or null for default shell.
+        '';
+      };
+
+      loginShell = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Run command as a login shell.";
+      };
+
+      backspaceBinding = mkOption {
+        default = "ascii-delete";
+        type = eraseBinding;
+        description = ''
+          Which string the terminal should send to an application when the user
+          presses the *Backspace* key.
+
+          `auto`
+          : Attempt to determine the right value from the terminal's IO settings.
+
+          `ascii-backspace`
+          : Send an ASCII backspace character (`0x08`).
+
+          `ascii-delete`
+          : Send an ASCII delete character (`0x7F`).
+
+          `delete-sequence`
+          : Send the `@7` control sequence.
+
+          `tty`
+          : Send terminal's "erase" setting.
+        '';
+      };
+
+      boldIsBright = mkOption {
+        default = null;
+        type = types.nullOr types.bool;
+        description = "Whether bold text is shown in bright colors.";
+      };
+
+      deleteBinding = mkOption {
+        default = "delete-sequence";
+        type = eraseBinding;
+        description = ''
+          Which string the terminal should send to an application when the user
+          presses the *Delete* key.
+
+          `auto`
+          : Send the `@7` control sequence.
+
+          `ascii-backspace`
+          : Send an ASCII backspace character (`0x08`).
+
+          `ascii-delete`
+          : Send an ASCII delete character (`0x7F`).
+
+          `delete-sequence`
+          : Send the `@7` control sequence.
+
+          `tty`
+          : Send terminal's "erase" setting.
+        '';
+      };
+
+      audibleBell = mkOption {
+        default = true;
+        type = types.bool;
+        description = "Turn on/off the terminal's bell.";
+      };
+
+      transparencyPercent = mkOption {
+        default = null;
+        type = types.nullOr (types.ints.between 0 100);
+        description = "Background transparency in percent.";
+      };
+    };
+  };
 
   buildProfileSet =
     pcfg:

--- a/modules/programs/joshuto.nix
+++ b/modules/programs/joshuto.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (lib) mkIf mkOption types;
+  inherit (lib) mkIf mkOption;
 
   cfg = config.programs.joshuto;
   tomlFormat = pkgs.formats.toml { };

--- a/modules/programs/lapce.nix
+++ b/modules/programs/lapce.nix
@@ -173,7 +173,6 @@ let
       author,
       name,
       version,
-      hash,
     }@args:
     pkgs.stdenvNoCC.mkDerivation {
       pname = "lapce-plugin-${author}-${name}";

--- a/modules/programs/mbsync-accounts.nix
+++ b/modules/programs/mbsync-accounts.nix
@@ -12,7 +12,7 @@ let
     ]);
 
   perAccountGroups =
-    { name, config, ... }:
+    { name, ... }:
     {
       options = {
         name = mkOption {
@@ -43,7 +43,7 @@ let
 
   # Options for configuring channel(s) that will be composed together into a group.
   channel =
-    { name, config, ... }:
+    { name, ... }:
     {
       options = {
         name = mkOption {

--- a/modules/programs/mergiraf.nix
+++ b/modules/programs/mergiraf.nix
@@ -8,8 +8,6 @@ let
   inherit (lib)
     mkEnableOption
     mkPackageOption
-    types
-    literalExpression
     mkIf
     maintainers
     ;

--- a/modules/programs/ncmpcpp.nix
+++ b/modules/programs/ncmpcpp.nix
@@ -43,25 +43,21 @@ let
       str
     ];
 
-  bindingType = types.submodule (
-    { name, config, ... }:
-    {
-      options = {
-        key = mkOption {
-          type = types.str;
-          description = "Key to bind.";
-          example = "j";
-        };
-
-        command = mkOption {
-          type = with types; either str (listOf str);
-          description = "Command or sequence of commands to be executed.";
-          example = "scroll_down";
-        };
+  bindingType = types.submodule {
+    options = {
+      key = mkOption {
+        type = types.str;
+        description = "Key to bind.";
+        example = "j";
       };
-    }
-  );
 
+      command = mkOption {
+        type = with types; either str (listOf str);
+        description = "Command or sequence of commands to be executed.";
+        example = "scroll_down";
+      };
+    };
+  };
 in
 {
   meta.maintainers = [ lib.hm.maintainers.olmokramer ];

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -447,7 +447,6 @@ in
       programs.neovim.generatedConfigs =
         let
           grouped = lib.lists.groupBy (x: x.type) pluginsNormalized;
-          concatConfigs = lib.concatMapStrings (p: p.config);
           configsOnly = lib.foldl (acc: p: if p.config != null then acc ++ [ p.config ] else acc) [ ];
         in
         lib.mapAttrs (name: vals: lib.concatStringsSep "\n" (configsOnly vals)) grouped;

--- a/modules/programs/onedrive.nix
+++ b/modules/programs/onedrive.nix
@@ -11,8 +11,6 @@ let
     mkPackageOption
     mkOption
     types
-    concatStringsSep
-    mapAttrsToList
     ;
 
   cfg = config.programs.onedrive;

--- a/modules/programs/papis.nix
+++ b/modules/programs/papis.nix
@@ -55,7 +55,7 @@ in
     libraries = mkOption {
       type = types.attrsOf (
         types.submodule (
-          { config, name, ... }:
+          { name, ... }:
           {
             options = {
               name = mkOption {

--- a/modules/programs/pyenv.nix
+++ b/modules/programs/pyenv.nix
@@ -9,8 +9,6 @@ let
 
   cfg = config.programs.pyenv;
 
-  tomlFormat = pkgs.formats.toml { };
-
 in
 {
   meta.maintainers = with lib.maintainers; [ tmarkus ];

--- a/modules/programs/qcal.nix
+++ b/modules/programs/qcal.nix
@@ -13,14 +13,6 @@ let
     lib.filterAttrs (_: a: a.qcal.enable) config.accounts.calendar.accounts
   );
 
-  rename =
-    oldname:
-    builtins.getAttr oldname {
-      url = "Url";
-      userName = "Username";
-      passwordCommand = "PasswordCmd";
-    };
-
   filteredAccounts =
     let
       mkAccount =

--- a/modules/programs/sftpman.nix
+++ b/modules/programs/sftpman.nix
@@ -11,66 +11,64 @@ let
 
   jsonFormat = pkgs.formats.json { };
 
-  mountOpts =
-    { config, name, ... }:
-    {
-      options = {
-        host = mkOption {
-          type = types.str;
-          description = "The host to connect to.";
-        };
+  mountOpts = {
+    options = {
+      host = mkOption {
+        type = types.str;
+        description = "The host to connect to.";
+      };
 
-        port = mkOption {
-          type = types.port;
-          default = 22;
-          description = "The port to connect to.";
-        };
+      port = mkOption {
+        type = types.port;
+        default = 22;
+        description = "The port to connect to.";
+      };
 
-        user = mkOption {
-          type = types.str;
-          description = "The username to authenticate with.";
-        };
+      user = mkOption {
+        type = types.str;
+        description = "The username to authenticate with.";
+      };
 
-        mountOptions = mkOption {
-          type = types.listOf types.str;
-          default = [ ];
-          description = "Options to pass to sshfs.";
-        };
+      mountOptions = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Options to pass to sshfs.";
+      };
 
-        mountPoint = mkOption {
-          type = types.str;
-          description = "The remote path to mount.";
-        };
+      mountPoint = mkOption {
+        type = types.str;
+        description = "The remote path to mount.";
+      };
 
-        authType = mkOption {
-          type = types.enum [
-            "password"
-            "publickey"
-            "hostbased"
-            "keyboard-interactive"
-            "gssapi-with-mic"
-          ];
-          default = "publickey";
-          description = "The authentication method to use.";
-        };
+      authType = mkOption {
+        type = types.enum [
+          "password"
+          "publickey"
+          "hostbased"
+          "keyboard-interactive"
+          "gssapi-with-mic"
+        ];
+        default = "publickey";
+        description = "The authentication method to use.";
+      };
 
-        sshKey = mkOption {
-          type = types.nullOr types.str;
-          default = cfg.defaultSshKey;
-          defaultText = lib.literalExpression "config.programs.sftpman.defaultSshKey";
-          description = ''
-            Path to the SSH key to use for authentication.
-            Only applies if authMethod is `publickey`.
-          '';
-        };
+      sshKey = mkOption {
+        type = types.nullOr types.str;
+        default = cfg.defaultSshKey;
+        defaultText = lib.literalExpression "config.programs.sftpman.defaultSshKey";
+        description = ''
+          Path to the SSH key to use for authentication.
+          Only applies if authMethod is `publickey`.
+        '';
+      };
 
-        beforeMount = mkOption {
-          type = types.str;
-          default = "true";
-          description = "Command to run before mounting.";
-        };
+      beforeMount = mkOption {
+        type = types.str;
+        default = "true";
+        description = "Command to run before mounting.";
       };
     };
+  };
 in
 {
   meta.maintainers = with lib.maintainers; [ fugi ];

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -70,288 +70,285 @@ let
     };
   };
 
-  matchBlockModule = types.submodule (
-    { dagName, ... }:
-    {
-      options = {
-        host = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          example = "*.example.org";
-          description = ''
-            `Host` pattern used by this conditional block.
-            See
-            {manpage}`ssh_config(5)`
-            for `Host` block details.
-            This option is ignored if
-            {option}`ssh.matchBlocks.*.match`
-            if defined.
-          '';
-        };
-
-        match = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          example = ''
-            host <hostname> canonical
-            host <hostname> exec "ping -c1 -q 192.168.17.1"'';
-          description = ''
-            `Match` block conditions used by this block. See
-            {manpage}`ssh_config(5)`
-            for `Match` block details.
-            This option takes precedence over
-            {option}`ssh.matchBlocks.*.host`
-            if defined.
-          '';
-        };
-
-        port = mkOption {
-          type = types.nullOr types.port;
-          default = null;
-          description = "Specifies port number to connect on remote host.";
-        };
-
-        forwardAgent = mkOption {
-          default = null;
-          type = types.nullOr types.bool;
-          description = ''
-            Whether the connection to the authentication agent (if any)
-            will be forwarded to the remote machine.
-          '';
-        };
-
-        forwardX11 = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Specifies whether X11 connections will be automatically redirected
-            over the secure channel and {env}`DISPLAY` set.
-          '';
-        };
-
-        forwardX11Trusted = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Specifies whether remote X11 clients will have full access to the
-            original X11 display.
-          '';
-        };
-
-        identitiesOnly = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Specifies that ssh should only use the authentication
-            identity explicitly configured in the
-            {file}`~/.ssh/config` files or passed on the
-            ssh command-line, even if {command}`ssh-agent`
-            offers more identities.
-          '';
-        };
-
-        identityFile = mkOption {
-          type = with types; either (listOf str) (nullOr str);
-          default = [ ];
-          apply =
-            p:
-            if p == null then
-              [ ]
-            else if lib.isString p then
-              [ p ]
-            else
-              p;
-          description = ''
-            Specifies files from which the user identity is read.
-            Identities will be tried in the given order.
-          '';
-        };
-
-        identityAgent = mkOption {
-          type = with types; either (listOf str) (nullOr str);
-          default = [ ];
-          apply =
-            p:
-            if p == null then
-              [ ]
-            else if lib.isString p then
-              [ p ]
-            else
-              p;
-          description = ''
-            Specifies the location of the ssh identity agent.
-          '';
-        };
-
-        user = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Specifies the user to log in as.";
-        };
-
-        hostname = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "Specifies the real host name to log into.";
-        };
-
-        serverAliveInterval = mkOption {
-          type = types.int;
-          default = 0;
-          description = "Set timeout in seconds after which response will be requested.";
-        };
-
-        serverAliveCountMax = mkOption {
-          type = types.ints.positive;
-          default = 3;
-          description = ''
-            Sets the number of server alive messages which may be sent
-            without SSH receiving any messages back from the server.
-          '';
-        };
-
-        sendEnv = mkOption {
-          type = types.listOf types.str;
-          default = [ ];
-          description = ''
-            Environment variables to send from the local host to the
-            server.
-          '';
-        };
-
-        setEnv = mkOption {
-          type =
-            with types;
-            attrsOf (oneOf [
-              str
-              path
-              int
-              float
-            ]);
-          default = { };
-          description = ''
-            Environment variables and their value to send to the server.
-          '';
-        };
-
-        compression = mkOption {
-          type = types.nullOr types.bool;
-          default = null;
-          description = ''
-            Specifies whether to use compression. Omitted from the host
-            block when `null`.
-          '';
-        };
-
-        checkHostIP = mkOption {
-          type = types.bool;
-          default = true;
-          description = ''
-            Check the host IP address in the
-            {file}`known_hosts` file.
-          '';
-        };
-
-        proxyCommand = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "The command to use to connect to the server.";
-        };
-
-        proxyJump = mkOption {
-          type = types.nullOr types.str;
-          default = null;
-          description = "The proxy host to use to connect to the server.";
-        };
-
-        certificateFile = mkOption {
-          type = with types; either (listOf str) (nullOr str);
-          default = [ ];
-          apply =
-            p:
-            if p == null then
-              [ ]
-            else if lib.isString p then
-              [ p ]
-            else
-              p;
-          description = ''
-            Specifies files from which the user certificate is read.
-          '';
-        };
-
-        addressFamily = mkOption {
-          default = null;
-          type = types.nullOr (
-            types.enum [
-              "any"
-              "inet"
-              "inet6"
-            ]
-          );
-          description = ''
-            Specifies which address family to use when connecting.
-          '';
-        };
-
-        localForwards = mkOption {
-          type = types.listOf forwardModule;
-          default = [ ];
-          example = literalExpression ''
-            [
-              {
-                bind.port = 8080;
-                host.address = "10.0.0.13";
-                host.port = 80;
-              }
-            ];
-          '';
-          description = ''
-            Specify local port forwardings. See
-            {manpage}`ssh_config(5)` for `LocalForward`.
-          '';
-        };
-
-        remoteForwards = mkOption {
-          type = types.listOf forwardModule;
-          default = [ ];
-          example = literalExpression ''
-            [
-              {
-                bind.port = 8080;
-                host.address = "10.0.0.13";
-                host.port = 80;
-              }
-            ];
-          '';
-          description = ''
-            Specify remote port forwardings. See
-            {manpage}`ssh_config(5)` for `RemoteForward`.
-          '';
-        };
-
-        dynamicForwards = mkOption {
-          type = types.listOf dynamicForwardModule;
-          default = [ ];
-          example = literalExpression ''
-            [ { port = 8080; } ];
-          '';
-          description = ''
-            Specify dynamic port forwardings. See
-            {manpage}`ssh_config(5)` for `DynamicForward`.
-          '';
-        };
-
-        extraOptions = mkOption {
-          type = types.attrsOf types.str;
-          default = { };
-          description = "Extra configuration options for the host.";
-        };
+  matchBlockModule = types.submodule {
+    options = {
+      host = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "*.example.org";
+        description = ''
+          `Host` pattern used by this conditional block.
+          See
+          {manpage}`ssh_config(5)`
+          for `Host` block details.
+          This option is ignored if
+          {option}`ssh.matchBlocks.*.match`
+          if defined.
+        '';
       };
 
-      #    config.host = mkDefault dagName;
-    }
-  );
+      match = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = ''
+          host <hostname> canonical
+          host <hostname> exec "ping -c1 -q 192.168.17.1"'';
+        description = ''
+          `Match` block conditions used by this block. See
+          {manpage}`ssh_config(5)`
+          for `Match` block details.
+          This option takes precedence over
+          {option}`ssh.matchBlocks.*.host`
+          if defined.
+        '';
+      };
+
+      port = mkOption {
+        type = types.nullOr types.port;
+        default = null;
+        description = "Specifies port number to connect on remote host.";
+      };
+
+      forwardAgent = mkOption {
+        default = null;
+        type = types.nullOr types.bool;
+        description = ''
+          Whether the connection to the authentication agent (if any)
+          will be forwarded to the remote machine.
+        '';
+      };
+
+      forwardX11 = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Specifies whether X11 connections will be automatically redirected
+          over the secure channel and {env}`DISPLAY` set.
+        '';
+      };
+
+      forwardX11Trusted = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Specifies whether remote X11 clients will have full access to the
+          original X11 display.
+        '';
+      };
+
+      identitiesOnly = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Specifies that ssh should only use the authentication
+          identity explicitly configured in the
+          {file}`~/.ssh/config` files or passed on the
+          ssh command-line, even if {command}`ssh-agent`
+          offers more identities.
+        '';
+      };
+
+      identityFile = mkOption {
+        type = with types; either (listOf str) (nullOr str);
+        default = [ ];
+        apply =
+          p:
+          if p == null then
+            [ ]
+          else if lib.isString p then
+            [ p ]
+          else
+            p;
+        description = ''
+          Specifies files from which the user identity is read.
+          Identities will be tried in the given order.
+        '';
+      };
+
+      identityAgent = mkOption {
+        type = with types; either (listOf str) (nullOr str);
+        default = [ ];
+        apply =
+          p:
+          if p == null then
+            [ ]
+          else if lib.isString p then
+            [ p ]
+          else
+            p;
+        description = ''
+          Specifies the location of the ssh identity agent.
+        '';
+      };
+
+      user = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Specifies the user to log in as.";
+      };
+
+      hostname = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Specifies the real host name to log into.";
+      };
+
+      serverAliveInterval = mkOption {
+        type = types.int;
+        default = 0;
+        description = "Set timeout in seconds after which response will be requested.";
+      };
+
+      serverAliveCountMax = mkOption {
+        type = types.ints.positive;
+        default = 3;
+        description = ''
+          Sets the number of server alive messages which may be sent
+          without SSH receiving any messages back from the server.
+        '';
+      };
+
+      sendEnv = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Environment variables to send from the local host to the
+          server.
+        '';
+      };
+
+      setEnv = mkOption {
+        type =
+          with types;
+          attrsOf (oneOf [
+            str
+            path
+            int
+            float
+          ]);
+        default = { };
+        description = ''
+          Environment variables and their value to send to the server.
+        '';
+      };
+
+      compression = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = ''
+          Specifies whether to use compression. Omitted from the host
+          block when `null`.
+        '';
+      };
+
+      checkHostIP = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Check the host IP address in the
+          {file}`known_hosts` file.
+        '';
+      };
+
+      proxyCommand = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "The command to use to connect to the server.";
+      };
+
+      proxyJump = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "The proxy host to use to connect to the server.";
+      };
+
+      certificateFile = mkOption {
+        type = with types; either (listOf str) (nullOr str);
+        default = [ ];
+        apply =
+          p:
+          if p == null then
+            [ ]
+          else if lib.isString p then
+            [ p ]
+          else
+            p;
+        description = ''
+          Specifies files from which the user certificate is read.
+        '';
+      };
+
+      addressFamily = mkOption {
+        default = null;
+        type = types.nullOr (
+          types.enum [
+            "any"
+            "inet"
+            "inet6"
+          ]
+        );
+        description = ''
+          Specifies which address family to use when connecting.
+        '';
+      };
+
+      localForwards = mkOption {
+        type = types.listOf forwardModule;
+        default = [ ];
+        example = literalExpression ''
+          [
+            {
+              bind.port = 8080;
+              host.address = "10.0.0.13";
+              host.port = 80;
+            }
+          ];
+        '';
+        description = ''
+          Specify local port forwardings. See
+          {manpage}`ssh_config(5)` for `LocalForward`.
+        '';
+      };
+
+      remoteForwards = mkOption {
+        type = types.listOf forwardModule;
+        default = [ ];
+        example = literalExpression ''
+          [
+            {
+              bind.port = 8080;
+              host.address = "10.0.0.13";
+              host.port = 80;
+            }
+          ];
+        '';
+        description = ''
+          Specify remote port forwardings. See
+          {manpage}`ssh_config(5)` for `RemoteForward`.
+        '';
+      };
+
+      dynamicForwards = mkOption {
+        type = types.listOf dynamicForwardModule;
+        default = [ ];
+        example = literalExpression ''
+          [ { port = 8080; } ];
+        '';
+        description = ''
+          Specify dynamic port forwardings. See
+          {manpage}`ssh_config(5)` for `DynamicForward`.
+        '';
+      };
+
+      extraOptions = mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        description = "Extra configuration options for the host.";
+      };
+    };
+
+    #    config.host = mkDefault dagName;
+  };
 
   matchBlockStr =
     key: cf:

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -275,7 +275,7 @@ in
                 feedAccounts = mkOption {
                   type = types.attrsOf (
                     types.submodule (
-                      { config, name, ... }:
+                      { name, ... }:
                       {
                         options = {
                           name = mkOption {

--- a/modules/programs/wlogout.nix
+++ b/modules/programs/wlogout.nix
@@ -7,7 +7,6 @@
 
 let
   inherit (lib)
-    all
     filterAttrs
     isStorePath
     literalExpression

--- a/modules/programs/zplug.nix
+++ b/modules/programs/zplug.nix
@@ -9,25 +9,20 @@ let
 
   cfg = config.programs.zsh.zplug;
 
-  pluginModule = types.submodule (
-    { config, ... }:
-    {
-      options = {
-        name = mkOption {
-          type = types.str;
-          description = "The name of the plugin.";
-        };
-
-        tags = mkOption {
-          type = types.listOf types.str;
-          default = [ ];
-          description = "The plugin tags.";
-        };
+  pluginModule = types.submodule {
+    options = {
+      name = mkOption {
+        type = types.str;
+        description = "The name of the plugin.";
       };
 
-    }
-  );
-
+      tags = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "The plugin tags.";
+      };
+    };
+  };
 in
 {
   options.programs.zsh.zplug = {

--- a/modules/services/lxqt-policykit-agent.nix
+++ b/modules/services/lxqt-policykit-agent.nix
@@ -8,8 +8,6 @@ let
   inherit (lib)
     mkEnableOption
     mkPackageOption
-    types
-    literalExpression
     mkIf
     maintainers
     ;

--- a/modules/services/polkit-gnome.nix
+++ b/modules/services/polkit-gnome.nix
@@ -8,8 +8,6 @@ let
   inherit (lib)
     mkEnableOption
     mkPackageOption
-    types
-    literalExpression
     mkIf
     maintainers
     ;

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -12,7 +12,6 @@ let
   inherit (lib)
     any
     attrValues
-    getAttr
     hm
     isBool
     literalExpression

--- a/modules/targets/darwin/user-defaults/opts-currenthost.nix
+++ b/modules/targets/darwin/user-defaults/opts-currenthost.nix
@@ -10,15 +10,6 @@ let
         default = null;
       }
     );
-
-  mkNullableEnableOption =
-    name:
-    lib.mkOption {
-      type = with lib.types; nullOr bool;
-      default = null;
-      example = true;
-      description = "Whether to enable ${name}.";
-    };
 in
 {
   freeformType = with lib.types; attrsOf (attrsOf anything);

--- a/templates/nix-darwin/flake.nix
+++ b/templates/nix-darwin/flake.nix
@@ -10,8 +10,7 @@
   };
 
   outputs =
-    inputs@{
-      nixpkgs,
+    {
       home-manager,
       darwin,
       ...

--- a/templates/nixos/flake.nix
+++ b/templates/nixos/flake.nix
@@ -8,7 +8,7 @@
   };
 
   outputs =
-    inputs@{ nixpkgs, home-manager, ... }:
+    { nixpkgs, home-manager, ... }:
     {
       nixosConfigurations = {
         hostname = nixpkgs.lib.nixosSystem {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -41,11 +41,7 @@ let
       if lib.isDerivation value then scrubbedValue // newDrvAttrs else scrubbedValue
     else
       value;
-  scrubDerivations =
-    attrs:
-    let
-    in
-    lib.mapAttrs scrubDerivation attrs;
+  scrubDerivations = attrs: lib.mapAttrs scrubDerivation attrs;
 
   # Globally unscrub a few selected packages that are used by a wide selection of tests.
   whitelist =

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -18,7 +18,7 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs =
-    { self, nixpkgs, ... }:
+    { nixpkgs, ... }:
     let
       forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
     in

--- a/tests/integration/standalone/alice-home-init.nix
+++ b/tests/integration/standalone/alice-home-init.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, ... }:
-
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.

--- a/tests/integration/standalone/alice-home-next.nix
+++ b/tests/integration/standalone/alice-home-next.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ pkgs, ... }:
 
 {
   home.username = "alice";

--- a/tests/integration/standalone/home-with-symbols-init.nix
+++ b/tests/integration/standalone/home-with-symbols-init.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, ... }:
-
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.

--- a/tests/integration/standalone/home-with-symbols.nix
+++ b/tests/integration/standalone/home-with-symbols.nix
@@ -2,8 +2,6 @@
 
 let
 
-  inherit (pkgs.lib) escapeShellArg;
-
   nixHome = "/home/alice@home\\extra";
   pyHome = "/home/alice@home\\\\extra";
 

--- a/tests/integration/standalone/nh.nix
+++ b/tests/integration/standalone/nh.nix
@@ -2,8 +2,6 @@
 
 let
 
-  inherit (pkgs.lib) escapeShellArg;
-
   home = "/home/alice";
 
 in

--- a/tests/lib/generators/tokdl.nix
+++ b/tests/lib/generators/tokdl.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
 {
   home.file."tokdl-result.txt".text = lib.hm.generators.toKDL { } {

--- a/tests/lib/generators/toscfg-empty.nix
+++ b/tests/lib/generators/toscfg-empty.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
 {
   home.file."toscfg-empty-result.txt".text = lib.hm.generators.toSCFG { } { };

--- a/tests/lib/generators/toscfg-err-dir-empty-name.nix
+++ b/tests/lib/generators/toscfg-err-dir-empty-name.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
 {
   home.file."toscfg-err-dir-empty-name-result.txt".text = lib.hm.generators.toSCFG { } { "" = [ ]; };

--- a/tests/lib/generators/toscfg-example.nix
+++ b/tests/lib/generators/toscfg-example.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ lib, ... }:
 
 {
   home.file."toscfg-example-result.txt".text = lib.hm.generators.toSCFG { } {

--- a/tests/lib/types/dag-merge.nix
+++ b/tests/lib/types/dag-merge.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 

--- a/tests/modules/misc/xdg/default-locations.nix
+++ b/tests/modules/misc/xdg/default-locations.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, ... }:
 {
   config = {
     # Test fallback behavior for stateVersion >= 20.09, which is pure.

--- a/tests/modules/misc/xdg/system-dirs.nix
+++ b/tests/modules/misc/xdg/system-dirs.nix
@@ -1,6 +1,5 @@
 {
   config,
-  lib,
   pkgs,
   ...
 }:

--- a/tests/modules/misc/xdg/user-dirs-null.nix
+++ b/tests/modules/misc/xdg/user-dirs-null.nix
@@ -1,6 +1,5 @@
 {
   config,
-  lib,
   pkgs,
   ...
 }:

--- a/tests/modules/programs/cava/cava-basic-configuration.nix
+++ b/tests/modules/programs/cava/cava-basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   programs.cava = {

--- a/tests/modules/programs/cavalier/cavalier-cava-settings.nix
+++ b/tests/modules/programs/cavalier/cavalier-cava-settings.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   programs.cavalier = {

--- a/tests/modules/programs/cavalier/cavalier-general-settings.nix
+++ b/tests/modules/programs/cavalier/cavalier-general-settings.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   programs.cavalier = {

--- a/tests/modules/programs/darcs/author.nix
+++ b/tests/modules/programs/darcs/author.nix
@@ -1,5 +1,3 @@
-{ pkgs, ... }:
-
 {
   config = {
     programs.darcs = {

--- a/tests/modules/programs/darcs/boring.nix
+++ b/tests/modules/programs/darcs/boring.nix
@@ -1,5 +1,3 @@
-{ pkgs, ... }:
-
 {
   config = {
     programs.darcs = {

--- a/tests/modules/programs/fish/manpage.nix
+++ b/tests/modules/programs/fish/manpage.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ pkgs, ... }:
 {
   config = {
     programs.fish = {

--- a/tests/modules/programs/i3status-rust/with-custom.nix
+++ b/tests/modules/programs/i3status-rust/with-custom.nix
@@ -1,6 +1,5 @@
 {
   config,
-  lib,
   pkgs,
   ...
 }:

--- a/tests/modules/programs/i3status-rust/with-default.nix
+++ b/tests/modules/programs/i3status-rust/with-default.nix
@@ -1,6 +1,5 @@
 {
   config,
-  lib,
   pkgs,
   ...
 }:

--- a/tests/modules/programs/i3status-rust/with-extra-settings.nix
+++ b/tests/modules/programs/i3status-rust/with-extra-settings.nix
@@ -1,6 +1,5 @@
 {
   config,
-  lib,
   pkgs,
   ...
 }:

--- a/tests/modules/programs/i3status-rust/with-multiple-bars.nix
+++ b/tests/modules/programs/i3status-rust/with-multiple-bars.nix
@@ -1,6 +1,5 @@
 {
   config,
-  lib,
   pkgs,
   ...
 }:

--- a/tests/modules/programs/i3status-rust/with-version-02xx.nix
+++ b/tests/modules/programs/i3status-rust/with-version-02xx.nix
@@ -1,6 +1,5 @@
 {
   config,
-  lib,
   pkgs,
   ...
 }:

--- a/tests/modules/programs/kakoune/whitespace-highlighter.nix
+++ b/tests/modules/programs/kakoune/whitespace-highlighter.nix
@@ -1,5 +1,3 @@
-{ lib, ... }:
-
 {
   imports = [ ./stubs.nix ];
 

--- a/tests/modules/programs/mangohud/basic-configuration.nix
+++ b/tests/modules/programs/mangohud/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/mergiraf/basic-configuration.nix
+++ b/tests/modules/programs/mergiraf/basic-configuration.nix
@@ -1,5 +1,3 @@
-{ config, lib, ... }:
-
 {
   programs.git.enable = true;
   programs.mergiraf.enable = true;

--- a/tests/modules/programs/mpv/mpv-example-settings.nix
+++ b/tests/modules/programs/mpv/mpv-example-settings.nix
@@ -1,7 +1,5 @@
 {
   config,
-  lib,
-  pkgs,
   ...
 }:
 

--- a/tests/modules/programs/mpv/mpv-invalid-settings.nix
+++ b/tests/modules/programs/mpv/mpv-invalid-settings.nix
@@ -1,6 +1,4 @@
 {
-  config,
-  lib,
   pkgs,
   ...
 }:

--- a/tests/modules/programs/ssh/includes.nix
+++ b/tests/modules/programs/ssh/includes.nix
@@ -1,7 +1,5 @@
 {
   config,
-  lib,
-  pkgs,
   ...
 }:
 

--- a/tests/modules/programs/swayr/basic-configuration.nix
+++ b/tests/modules/programs/swayr/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/swayr/empty-configuration.nix
+++ b/tests/modules/programs/swayr/empty-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/vesktop/basic-configuration.nix
+++ b/tests/modules/programs/vesktop/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/programs/zsh/aliases.nix
+++ b/tests/modules/programs/zsh/aliases.nix
@@ -1,5 +1,3 @@
-{ config, ... }:
-
 {
   programs.zsh = {
     enable = true;

--- a/tests/modules/services/dropbox/basic-configuration.nix
+++ b/tests/modules/services/dropbox/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/services/espanso/basic-configuration.nix
+++ b/tests/modules/services/espanso/basic-configuration.nix
@@ -1,7 +1,4 @@
-espansoExtraArgs:
-{ config, ... }:
-
-{
+espansoExtraArgs: {
   services.espanso = {
     enable = true;
     configs = {

--- a/tests/modules/services/fnott/example-settings.nix
+++ b/tests/modules/services/fnott/example-settings.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 

--- a/tests/modules/services/fnott/systemd-user-service.nix
+++ b/tests/modules/services/fnott/systemd-user-service.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 

--- a/tests/modules/services/gromit-mpx/basic-configuration.nix
+++ b/tests/modules/services/gromit-mpx/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   services.gromit-mpx = {

--- a/tests/modules/services/gromit-mpx/default-configuration.nix
+++ b/tests/modules/services/gromit-mpx/default-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   services.gromit-mpx = {

--- a/tests/modules/services/kanshi/alias-assertion.nix
+++ b/tests/modules/services/kanshi/alias-assertion.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 {
   config = {
     services.kanshi = {

--- a/tests/modules/services/kanshi/basic-configuration.nix
+++ b/tests/modules/services/kanshi/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 {
   config = {
     services.kanshi = {

--- a/tests/modules/services/kanshi/new-configuration.nix
+++ b/tests/modules/services/kanshi/new-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 {
   config = {
     services.kanshi = {

--- a/tests/modules/services/mpdscribble/basic-configuration.nix
+++ b/tests/modules/services/mpdscribble/basic-configuration.nix
@@ -1,7 +1,4 @@
 {
-  config,
-  lib,
-  pkgs,
   ...
 }:
 

--- a/tests/modules/services/pantalaimon/basic-configuration.nix
+++ b/tests/modules/services/pantalaimon/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/services/parcellite/parcellite.nix
+++ b/tests/modules/services/parcellite/parcellite.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   services.parcellite = {

--- a/tests/modules/services/pass-secret-service/basic-configuration.nix
+++ b/tests/modules/services/pass-secret-service/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   services.pass-secret-service = {

--- a/tests/modules/services/pass-secret-service/default-configuration.nix
+++ b/tests/modules/services/pass-secret-service/default-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   services.pass-secret-service = {

--- a/tests/modules/services/polybar/basic-configuration.nix
+++ b/tests/modules/services/polybar/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/services/polybar/empty-configuration.nix
+++ b/tests/modules/services/polybar/empty-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/services/sxhkd/service.nix
+++ b/tests/modules/services/sxhkd/service.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   xsession = {

--- a/tests/modules/services/trayer/basic-configuration.nix
+++ b/tests/modules/services/trayer/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/services/wlsunset/wlsunset-service.nix
+++ b/tests/modules/services/wlsunset/wlsunset-service.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/services/xsettingsd/basic-configuration.nix
+++ b/tests/modules/services/xsettingsd/basic-configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, ... }:
 
 {
   config = {

--- a/tests/modules/systemd/empty-user-config.nix
+++ b/tests/modules/systemd/empty-user-config.nix
@@ -1,5 +1,3 @@
-{ pkgs, ... }:
-
 {
   nmt.script = ''
     userConf=home-files/.config/systemd/user.conf


### PR DESCRIPTION
### Description
generated using `deadnix --edit --no-lambda-arg` with some manual editing to remove `{ ... }:`
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
