### PR TITLE
alot: allow commas in maildir path

### DIFF
--- a/modules/programs/alot.nix
+++ b/modules/programs/alot.nix
@@ -96,10 +96,10 @@ let
           sendmail_command = optionalString (alot.sendMailCommand != null) alot.sendMailCommand;
         }
         // optionalAttrs (folders.sent != null) {
-          sent_box = "maildir" + "://" + maildir.absPath + "/" + folders.sent;
+          sent_box = "'maildir" + "://" + maildir.absPath + "/" + folders.sent + "'";
         }
         // optionalAttrs (folders.drafts != null) {
-          draft_box = "maildir" + "://" + maildir.absPath + "/" + folders.drafts;
+          draft_box = "'maildir" + "://" + maildir.absPath + "/" + folders.drafts + "'";
         }
         // optionalAttrs (aliases != [ ]) {
           aliases = concatStringsSep "," aliases;

--- a/tests/modules/programs/alot/alot-expected.conf
+++ b/tests/modules/programs/alot/alot-expected.conf
@@ -26,10 +26,10 @@ prefer_plaintext = True
 
 [[hm@example.com]]
 address=hm@example.com
-draft_box=maildir:///home/hm-user/Mail/hm@example.com/Drafts
+draft_box='maildir:///home/hm-user/Mail/hm@example.com/Drafts'
 realname=H. M. Test
 sendmail_command=
-sent_box=maildir:///home/hm-user/Mail/hm@example.com/Sent
+sent_box='maildir:///home/hm-user/Mail/hm@example.com/Sent'
 auto_remove_unread = True
 ask_subject = False
 handle_mouse = True


### PR DESCRIPTION
### Description

Previously, maildir path was not escaped in any way, so using a path with commas lead to a TypeError:

```
TypeError: expected string or bytes-like object, got 'list'
```

This change wraps the maildir path in quotes to allow commas and other special characters to be tolerated.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
