### PR TITLE
lib/strings: add {toKebabCase,toSnakeCase,toCaseWithSeparator}; lib/deprecations: add mkSettingsRenamedOptionModules with transform

### DIFF
--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -6,6 +6,7 @@ rec {
   assertions = import ./assertions.nix { inherit lib; };
 
   booleans = import ./booleans.nix { inherit lib; };
+  deprecations = import ./deprecations.nix { inherit lib; };
   generators = import ./generators.nix { inherit lib; };
   gvariant = import ./gvariant.nix { inherit lib; };
   maintainers = import ./maintainers.nix;

--- a/modules/lib/deprecations.nix
+++ b/modules/lib/deprecations.nix
@@ -1,0 +1,50 @@
+{ lib }:
+{
+  /*
+    Returns a function that maps
+      [
+        "someOption"
+        ["fooBar" "someSubOption"]
+        { old = "someOtherOption"; new = ["foo_bar" "some_other_option"]}
+      ]
+
+    to
+      [
+        (lib.mkRenamedOptionModule
+          (oldPath ++ ["someOption"])
+          (newPath ++ ["some_option"])
+        )
+        (lib.mkRenamedOptionModule
+          (oldPath ++ ["fooBar" "someSubOption"])
+          (newPath ++ ["foo_bar" "some_sub_option"])
+        )
+        (lib.mkRenamedOptionModule
+          (oldPath ++ ["someOtherOption"])
+          (newPath ++ ["foo_bar" "some_other_option"])
+        )
+      ]
+
+    The transform parameter is a function that takes a string and returns a string.
+    It is applied to each element of the old option path to generate the new option path.
+    Defaults to lib.hm.strings.toSnakeCase.
+  */
+  mkSettingsRenamedOptionModules =
+    oldPrefix: newPrefix:
+    {
+      transform ? lib.hm.strings.toSnakeCase,
+    }:
+    map (
+      spec:
+      let
+        finalSpec =
+          if lib.isAttrs spec then
+            lib.mapAttrs (_: lib.toList) spec
+          else
+            {
+              old = lib.toList spec;
+              new = map transform finalSpec.old;
+            };
+      in
+      lib.mkRenamedOptionModule (oldPrefix ++ finalSpec.old) (newPrefix ++ finalSpec.new)
+    );
+}

--- a/modules/lib/strings.nix
+++ b/modules/lib/strings.nix
@@ -37,4 +37,19 @@ in
       safeName = replaceStrings unsafeInName (empties unsafeInName) path;
     in
     "hm_" + safeName;
+
+  /*
+       Convert a string from camelCase to snake_case
+    Type: string -> string
+  */
+  toSnakeCase =
+    let
+      splitByWords = builtins.split "([A-Z])";
+      processWord = s: if lib.isString s then s else "_" + lib.toLower (lib.elemAt s 0);
+    in
+    string:
+    let
+      words = splitByWords string;
+    in
+    lib.concatStrings (map processWord words);
 }

--- a/modules/lib/strings.nix
+++ b/modules/lib/strings.nix
@@ -52,4 +52,19 @@ in
       words = splitByWords string;
     in
     lib.concatStrings (map processWord words);
+
+  /*
+       Convert a string from camelCase to kebab-case
+    Type: string -> string
+  */
+  toKebabCase =
+    let
+      splitByWords = builtins.split "([A-Z])";
+      processWord = s: if lib.isString s then s else "-" + lib.toLower (lib.elemAt s 0);
+    in
+    string:
+    let
+      words = splitByWords string;
+    in
+    lib.concatStrings (map processWord words);
 }

--- a/modules/lib/strings.nix
+++ b/modules/lib/strings.nix
@@ -10,7 +10,7 @@ let
     upperChars
     ;
 in
-{
+rec {
   # Figures out a valid Nix store name for the given path.
   storeFileName =
     path:
@@ -39,32 +39,27 @@ in
     "hm_" + safeName;
 
   /*
-       Convert a string from camelCase to snake_case
-    Type: string -> string
+    Convert a string from camelCase to another case format using a separator
+    Type: string -> string -> string
   */
-  toSnakeCase =
+  toCaseWithSeparator =
+    separator: string:
     let
       splitByWords = builtins.split "([A-Z])";
-      processWord = s: if lib.isString s then s else "_" + lib.toLower (lib.elemAt s 0);
-    in
-    string:
-    let
+      processWord = s: if lib.isString s then s else separator + lib.toLower (lib.elemAt s 0);
       words = splitByWords string;
     in
     lib.concatStrings (map processWord words);
 
   /*
-       Convert a string from camelCase to kebab-case
+    Convert a string from camelCase to snake_case
     Type: string -> string
   */
-  toKebabCase =
-    let
-      splitByWords = builtins.split "([A-Z])";
-      processWord = s: if lib.isString s then s else "-" + lib.toLower (lib.elemAt s 0);
-    in
-    string:
-    let
-      words = splitByWords string;
-    in
-    lib.concatStrings (map processWord words);
+  toSnakeCase = toCaseWithSeparator "_";
+
+  /*
+    Convert a string from camelCase to kebab-case
+    Type: string -> string
+  */
+  toKebabCase = toCaseWithSeparator "-";
 }

--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -65,9 +65,9 @@ in
       ] "Use services.mako.settings instead.")
       (lib.mkRenamedOptionModule [ "services" "mako" "criterias" ] [ "services" "mako" "criteria" ])
     ]
-    ++ lib.deprecations.mkSettingsRenamedOptionModules basePath (
-      basePath ++ [ "settings" ]
-    ) renamedOptions;
+    ++ lib.hm.deprecations.mkSettingsRenamedOptionModules basePath (basePath ++ [ "settings" ]) {
+      transform = lib.hm.strings.toKebabCase;
+    } renamedOptions;
 
   options.services.mako = {
     enable = mkEnableOption "mako";

--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -56,10 +56,6 @@ in
         "ignoreTimeout"
         "groupBy"
       ];
-
-      mkSettingsRenamedOptionModules =
-        oldPrefix: newPrefix:
-        map (option: lib.mkRenamedOptionModule (oldPrefix ++ [ option ]) (newPrefix ++ [ option ]));
     in
     [
       (lib.mkRemovedOptionModule [
@@ -69,7 +65,9 @@ in
       ] "Use services.mako.settings instead.")
       (lib.mkRenamedOptionModule [ "services" "mako" "criterias" ] [ "services" "mako" "criteria" ])
     ]
-    ++ mkSettingsRenamedOptionModules basePath (basePath ++ [ "settings" ]) renamedOptions;
+    ++ lib.deprecations.mkSettingsRenamedOptionModules basePath (
+      basePath ++ [ "settings" ]
+    ) renamedOptions;
 
   options.services.mako = {
     enable = mkEnableOption "mako";

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -96,6 +96,7 @@ let
     "neomutt"
     "neovide"
     "neovim"
+    "newsboat"
     "nheko"
     "nix"
     "nix-direnv"

--- a/tests/modules/programs/man/apropos.nix
+++ b/tests/modules/programs/man/apropos.nix
@@ -7,12 +7,8 @@
 
     nmt.script = ''
       assertFileExists home-files/.manpath
-
       CACHE_DIR=$(cat $TESTED/home-files/.manpath | cut --delimiter=' ' --fields=3)
-
-      if [[ ! -f "$CACHE_DIR/index.bt" ]]; then
-          fail "Expected man cache files to exist (in $CACHE_DIR) but they were not found."
-      fi
+      assertFileExists "$CACHE_DIR/index.db"
     '';
   };
 }


### PR DESCRIPTION
### Description
Follow up to https://github.com/nix-community/home-manager/pull/6987#issuecomment-2856395024
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
