### PR TITLE
zed-editor: respect user interactivity with settings and keymaps

### DIFF
--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -14,6 +14,16 @@ let
 
   cfg = config.programs.zed-editor;
   jsonFormat = pkgs.formats.json { };
+  impureConfigMerger = empty: jqOperation: path: staticSettings: ''
+    mkdir -p $(dirname ${lib.escapeShellArg path})
+    if [ ! -e ${lib.escapeShellArg path} ]; then
+      # No file? Create it
+      echo ${lib.escapeShellArg empty} > ${lib.escapeShellArg path}
+    fi
+    config="$(${pkgs.jq}/bin/jq -s ${lib.escapeShellArg jqOperation} ${lib.escapeShellArg path} ${lib.escapeShellArg staticSettings})"
+    printf '%s\n' "$config" > ${lib.escapeShellArg path}
+    unset config
+  '';
 
   mergedSettings =
     cfg.userSettings
@@ -155,34 +165,31 @@ in
       }
     );
 
-    xdg.configFile =
-      lib.attrsets.unionOfDisjoint
-        {
-          "zed/settings.json" = (
-            mkIf (mergedSettings != { }) {
-              source = jsonFormat.generate "zed-user-settings" mergedSettings;
-            }
-          );
+    home.activation = {
+      zedSettingsActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
+        impureConfigMerger "{}" ".[0] * .[1]" "${config.xdg.configHome}/zed/settings.json" (
+          jsonFormat.generate "zed-user-settings" mergedSettings
+        )
+      );
+      zedKeymapActivation = lib.hm.dag.entryAfter [ "linkGeneration" ] (
+        impureConfigMerger "[]"
+          ".[0] + .[1] | group_by(.context) | map(reduce .[] as $item ({}; . * $item))"
+          "${config.xdg.configHome}/zed/keymap.json"
+          (jsonFormat.generate "zed-user-keymaps" cfg.userKeymaps)
+      );
+    };
 
-          "zed/keymap.json" = (
-            mkIf (cfg.userKeymaps != { }) {
-              source = jsonFormat.generate "zed-user-keymaps" cfg.userKeymaps;
-            }
-          );
-        }
-        (
-          lib.mapAttrs' (
-            n: v:
-            lib.nameValuePair "zed/themes/${n}.json" {
-              source =
-                if lib.isString v then
-                  pkgs.writeText "zed-theme-${n}" v
-                else if builtins.isPath v || lib.isStorePath v then
-                  v
-                else
-                  jsonFormat.generate "zed-theme-${n}" v;
-            }
-          ) cfg.themes
-        );
+    xdg.configFile = lib.mapAttrs' (
+      n: v:
+      lib.nameValuePair "zed/themes/${n}.json" {
+        source =
+          if lib.isString v then
+            pkgs.writeText "zed-theme-${n}" v
+          else if builtins.isPath v || lib.isStorePath v then
+            v
+          else
+            jsonFormat.generate "zed-theme-${n}" v;
+      }
+    ) cfg.themes;
   };
 }


### PR DESCRIPTION


### Description
Merges frozen config from HM into dirty config.

Fixes https://github.com/nix-community/home-manager/issues/6835
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@libewa
