### PR TITLE
jujutsu: store configuration in $XDG_CONFIG_HOME for all platforms

### DIFF
--- a/modules/programs/jujutsu.nix
+++ b/modules/programs/jujutsu.nix
@@ -9,9 +9,14 @@ let
 
   cfg = config.programs.jujutsu;
   tomlFormat = pkgs.formats.toml { };
+  packageVersion = lib.getVersion cfg.package;
 
-  configDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else config.xdg.configHome;
-
+  # jj v0.29+ deprecated support for "~/Library/Application Support" on Darwin.
+  configDir =
+    if pkgs.stdenv.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
+      "Library/Application Support"
+    else
+      config.xdg.configHome;
 in
 {
   meta.maintainers = [ lib.maintainers.shikanime ];

--- a/tests/modules/programs/jujutsu/empty-config.nix
+++ b/tests/modules/programs/jujutsu/empty-config.nix
@@ -1,7 +1,19 @@
-{ pkgs, ... }:
-
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
-  configDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+  cfg = config.programs.jujutsu;
+  packageVersion = lib.getVersion cfg.package;
+
+  # jj v0.29+ deprecated support for "~/Library/Application Support" on Darwin.
+  configDir =
+    if pkgs.stdenv.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
+      "Library/Application Support"
+    else
+      ".config";
 in
 {
   programs.jujutsu.enable = true;

--- a/tests/modules/programs/jujutsu/example-config.nix
+++ b/tests/modules/programs/jujutsu/example-config.nix
@@ -1,7 +1,19 @@
-{ pkgs, config, ... }:
-
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
-  configDir = if pkgs.stdenv.isDarwin then "Library/Application Support" else ".config";
+  cfg = config.programs.jujutsu;
+  packageVersion = lib.getVersion cfg.package;
+
+  # jj v0.29+ deprecated support for "~/Library/Application Support" on Darwin.
+  configDir =
+    if pkgs.stdenv.isDarwin && !(lib.versionAtLeast packageVersion "0.29.0") then
+      "Library/Application Support"
+    else
+      ".config";
 in
 {
   programs.jujutsu = {


### PR DESCRIPTION
Following https://github.com/jj-vcs/jj/pull/6300, Jujutsu has deprecated support for configuration files in `~/Library/Application Support` for darwin. The XDG-standard configuration location can be used instead, for all platforms.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
