### PR TITLE
direnv: update nushell env conversion logic

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -175,6 +175,7 @@ in
       # Using mkAfter to make it more likely to appear after other
       # manipulations of the prompt.
       programs.nushell.extraConfig = mkIf cfg.enableNushellIntegration (mkAfter ''
+        use std/config env-conversions
         $env.config = ($env.config? | default {})
         $env.config.hooks = ($env.config.hooks? | default {})
         $env.config.hooks.pre_prompt = (
@@ -186,8 +187,8 @@ in
                 | default {}
                 | items {|key, value|
                     let value = do (
-                        $env.ENV_CONVERSIONS?
-                        | default {}
+                        { PATH: (env-conversions).path }
+                        | merge ($env.ENV_CONVERSIONS? | default {})
                         | get -i $key
                         | get -i from_string
                         | default {|x| $x}
@@ -198,6 +199,7 @@ in
                 | load-env
             }
         )
+        hide env-conversions
       '');
 
       home.sessionVariables = lib.mkIf (cfg.silent && !isVersion236orHigher) { DIRENV_LOG_FORMAT = ""; };


### PR DESCRIPTION
### Description
Direnv exports PATH as a string, nu expects it to be a list and breaks some functionality like external command completion. This requires nushell 0.104.0, which is merged into nixpkgs-unstable.

Change loosely based on [this](https://github.com/nushell/nushell.github.io/pull/1878) while trying to not change the logic too much
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC
@khaneliman
@rycee
@shikanime
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
