### PR TITLE
wayprompt: init module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -304,6 +304,7 @@ let
       ./programs/watson.nix
       ./programs/waylogout.nix
       ./programs/waybar.nix
+      ./programs/wayprompt.nix
       ./programs/wezterm.nix
       ./programs/wlogout.nix
       ./programs/wofi.nix

--- a/modules/programs/wayprompt.nix
+++ b/modules/programs/wayprompt.nix
@@ -25,6 +25,8 @@ let
   };
 in
 {
+  meta.maintainers = [ lib.maintainers.panchoh ];
+
   options.programs.wayprompt = {
     enable = lib.mkEnableOption "Wayprompt, a password-prompter for Wayland";
 

--- a/modules/programs/wayprompt.nix
+++ b/modules/programs/wayprompt.nix
@@ -1,0 +1,67 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.wayprompt;
+
+  # Matches 6-hex-digit RGB or 8-hex-digit RGBA values
+  colourHexPattern = "^[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$";
+
+  isColourHex = str: builtins.match colourHexPattern str != null;
+
+  iniFormat = pkgs.formats.ini {
+    mkKeyValue = lib.generators.mkKeyValueDefault {
+      mkValueString =
+        v:
+        if lib.isString v then
+          (if isColourHex v then "0x${lib.strings.toUpper v};" else ''"${v}";'')
+        else
+          lib.generators.mkValueStringDefault { } v + ";";
+    } " = ";
+  };
+in
+{
+  options.programs.wayprompt = {
+    enable = lib.mkEnableOption "Wayprompt, a password-prompter for Wayland";
+
+    package = lib.mkPackageOption pkgs "wayprompt" { nullable = true; };
+
+    settings = lib.mkOption {
+      inherit (iniFormat) type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          general = {
+            font-regular = "sans:size=14";
+            pin-square-amount = 32;
+          };
+          colours = {
+            background = "0xffffffaa";
+          };
+        }
+      '';
+      description = ''
+        Configuration for wayprompt written to
+        {file}`$XDG_CONFIG_HOME/wayprompt/config.ini`.
+        See {manpage}`wayprompt(5)` for a list of available options.
+        Note that colours can be either 6-hex-digit RGB or 8-hex-digit RGBA values.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.wayprompt" pkgs lib.platforms.linux)
+    ];
+
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."wayprompt/config.ini" = lib.mkIf (cfg.settings != { }) {
+      source = iniFormat.generate "config.ini" cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -397,6 +397,7 @@ import nmtSrc {
       ./modules/programs/vesktop
       ./modules/programs/vinegar
       ./modules/programs/waybar
+      ./modules/programs/wayprompt
       ./modules/programs/wlogout
       ./modules/programs/wofi
       ./modules/programs/xmobar

--- a/tests/modules/programs/wayprompt/default.nix
+++ b/tests/modules/programs/wayprompt/default.nix
@@ -1,0 +1,4 @@
+{
+  wayprompt-empty-settings = ./empty-settings.nix;
+  wayprompt-example-settings = ./example-settings.nix;
+}

--- a/tests/modules/programs/wayprompt/empty-settings.nix
+++ b/tests/modules/programs/wayprompt/empty-settings.nix
@@ -1,0 +1,7 @@
+{
+  programs.wayprompt.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/wayprompt
+  '';
+}

--- a/tests/modules/programs/wayprompt/example-settings-expected.ini
+++ b/tests/modules/programs/wayprompt/example-settings-expected.ini
@@ -1,0 +1,8 @@
+[band]
+sunrise = 0xF7CD5D;
+sunset = 0xFAD6A5;
+white-with-alpha = 0xFFFFFF00;
+
+[group]
+some-integer = 42;
+some-string = "foo:bar=37";

--- a/tests/modules/programs/wayprompt/example-settings.nix
+++ b/tests/modules/programs/wayprompt/example-settings.nix
@@ -1,0 +1,29 @@
+{
+  config,
+  ...
+}:
+
+{
+  programs.wayprompt = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    settings = {
+      group = {
+        some-integer = 42;
+        some-string = "foo:bar=37";
+      };
+      band = {
+        sunrise = "F7CD5D";
+        sunset = "fad6a5";
+        white-with-alpha = "ffffff00";
+      };
+    };
+  };
+
+  nmt.script = ''
+    local configFile=home-files/.config/wayprompt/config.ini
+
+    assertFileExists $configFile
+    assertFileContent $configFile ${./example-settings-expected.ini}
+  '';
+}


### PR DESCRIPTION
### Description

Add module for [Wayprompt](https://git.sr.ht/~leon_plickat/wayprompt), a password-prompter, (including pinentry for GnuPG) for Wayland.

See also this [reddit post](https://www.reddit.com/r/swaywm/comments/xoawfu/wayprompt_layer_shell_pinentry_dropin_replacement/) for some usage examples.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@khaneliman