### PR TITLE
rofi: modes optional

### DIFF
--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -339,7 +339,6 @@ in
       toRasi {
         configuration = (
           {
-            inherit modes;
             font = cfg.font;
             terminal = cfg.terminal;
             cycle = cfg.cycle;
@@ -347,6 +346,7 @@ in
             xoffset = cfg.xoffset;
             yoffset = cfg.yoffset;
           }
+          // lib.optionalAttrs (modes != [ ]) { inherit modes; }
           // cfg.extraConfig
         );
         # @theme must go after configuration but attrs are output in alphabetical order ('@' first)

--- a/tests/modules/programs/rofi/custom-theme-config.rasi
+++ b/tests/modules/programs/rofi/custom-theme-config.rasi
@@ -1,6 +1,5 @@
 configuration {
 location: 0;
-modes: [  ];
 xoffset: 0;
 yoffset: 0;
 }


### PR DESCRIPTION
Don't include the modes option if it hasn't been used.

### Description
Follow up to https://github.com/nix-community/home-manager/pull/6115
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
