### PR TITLE
waveterm: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -303,6 +303,7 @@ let
       ./programs/rbenv.nix
       ./programs/wallust.nix
       ./programs/watson.nix
+      ./programs/waveterm.nix
       ./programs/waylogout.nix
       ./programs/waybar.nix
       ./programs/wayprompt.nix

--- a/modules/programs/waveterm.nix
+++ b/modules/programs/waveterm.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.waveterm;
+
+  formatter = pkgs.formats.json { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.waveterm = {
+    enable = mkEnableOption "waveterm";
+    package = mkPackageOption pkgs "waveterm" { nullable = true; };
+    settings = mkOption {
+      type = formatter.type;
+      default = { };
+      example = {
+        "app:dismissarchitecturewarning" = false;
+        "autoupdate:enabled" = false;
+        "term:fontsize" = 12.0;
+        "term:fontfamily" = "JuliaMono";
+        "term:theme" = "my-custom-theme";
+        "term:transparency" = 0.5;
+        "window:showhelp" = false;
+        "window:blur" = true;
+        "window:opacity" = 0.5;
+        "window:bgcolor" = "#000000";
+        "window:reducedmotion" = true;
+      };
+      description = ''
+        Configuration settings for WaveTerm. All available options can be
+        found here: <\https://docs.waveterm.dev/config#configuration-keys>.
+      '';
+    };
+
+    themes = mkOption {
+      type = formatter.type;
+      default = { };
+      example = {
+        default-dark = {
+          "display:name" = "Default Dark";
+          "display:order" = 1;
+          black = "#757575";
+          red = "#cc685c";
+          green = "#76c266";
+          yellow = "#cbca9b";
+          blue = "#85aacb";
+          magenta = "#cc72ca";
+          cyan = "#74a7cb";
+          white = "#c1c1c1";
+          brightBlack = "#727272";
+          brightRed = "#cc9d97";
+          brightGreen = "#a3dd97";
+          brightYellow = "#cbcaaa";
+          brightBlue = "#9ab6cb";
+          brightMagenta = "#cc8ecb";
+          brightCyan = "#b7b8cb";
+          brightWhite = "#f0f0f0";
+          gray = "#8b918a";
+          cmdtext = "#f0f0f0";
+          foreground = "#c1c1c1";
+          selectionBackground = "";
+          background = "#00000077";
+          cursorAccent = "";
+        };
+      };
+      description = ''
+        User defined terminal themes. All the details about available options and
+        format can be found here: <https://docs.waveterm.dev/config#terminal-theming>.
+      '';
+    };
+
+    bookmarks = mkOption {
+      type = formatter.type;
+      default = { };
+      example = {
+        "bookmark@google" = {
+          url = "https://www.google.com";
+          title = "Google";
+        };
+        "bookmark@claude" = {
+          url = "https://claude.ai";
+          title = "Claude";
+        };
+        "bookmark@github" = {
+          url = "https://github.com";
+          title = "GitHub";
+        };
+      };
+      description = ''
+        Bookmark definitions for WaveTerm. Details about the format and the options
+        can be found here: <https://docs.waveterm.dev/config#webbookmarks-configuration>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."waveterm/settings.json" = mkIf (cfg.settings != { }) {
+      source = formatter.generate "waveterm-settings" cfg.settings;
+    };
+    xdg.configFile."waveterm/termthemes.json" = mkIf (cfg.themes != { }) {
+      source = formatter.generate "waveterm-themes" cfg.themes;
+    };
+    xdg.configFile."waveterm/bookmarks.json" = mkIf (cfg.settings != { }) {
+      source = formatter.generate "waveterm-bookmarks" cfg.bookmarks;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -313,6 +313,7 @@ import nmtSrc {
       ./modules/programs/vscode
       ./modules/programs/wallust
       ./modules/programs/watson
+      ./modules/programs/waveterm
       ./modules/programs/wezterm
       ./modules/programs/yazi
       ./modules/programs/zed-editor

--- a/tests/modules/programs/waveterm/cfg/bookmarks.json
+++ b/tests/modules/programs/waveterm/cfg/bookmarks.json
@@ -1,0 +1,14 @@
+{
+  "bookmark@claude": {
+    "title": "Claude",
+    "url": "https://claude.ai"
+  },
+  "bookmark@github": {
+    "title": "GitHub",
+    "url": "https://github.com"
+  },
+  "bookmark@google": {
+    "title": "Google",
+    "url": "https://www.google.com"
+  }
+}

--- a/tests/modules/programs/waveterm/cfg/settings.json
+++ b/tests/modules/programs/waveterm/cfg/settings.json
@@ -1,0 +1,13 @@
+{
+  "app:dismissarchitecturewarning": false,
+  "autoupdate:enabled": false,
+  "term:fontfamily": "JuliaMono",
+  "term:fontsize": 12.0,
+  "term:theme": "my-custom-theme",
+  "term:transparency": 0.5,
+  "window:bgcolor": "#000000",
+  "window:blur": true,
+  "window:opacity": 0.5,
+  "window:reducedmotion": true,
+  "window:showhelp": false
+}

--- a/tests/modules/programs/waveterm/cfg/termthemes.json
+++ b/tests/modules/programs/waveterm/cfg/termthemes.json
@@ -1,0 +1,28 @@
+{
+  "default-dark": {
+    "background": "#00000077",
+    "black": "#757575",
+    "blue": "#85aacb",
+    "brightBlack": "#727272",
+    "brightBlue": "#9ab6cb",
+    "brightCyan": "#b7b8cb",
+    "brightGreen": "#a3dd97",
+    "brightMagenta": "#cc8ecb",
+    "brightRed": "#cc9d97",
+    "brightWhite": "#f0f0f0",
+    "brightYellow": "#cbcaaa",
+    "cmdtext": "#f0f0f0",
+    "cursorAccent": "",
+    "cyan": "#74a7cb",
+    "display:name": "Default Dark",
+    "display:order": 1,
+    "foreground": "#c1c1c1",
+    "gray": "#8b918a",
+    "green": "#76c266",
+    "magenta": "#cc72ca",
+    "red": "#cc685c",
+    "selectionBackground": "",
+    "white": "#c1c1c1",
+    "yellow": "#cbca9b"
+  }
+}

--- a/tests/modules/programs/waveterm/default.nix
+++ b/tests/modules/programs/waveterm/default.nix
@@ -1,0 +1,1 @@
+{ waveterm-example-config = ./example-config.nix; }

--- a/tests/modules/programs/waveterm/example-config.nix
+++ b/tests/modules/programs/waveterm/example-config.nix
@@ -1,0 +1,78 @@
+{
+  programs.waveterm = {
+    enable = true;
+    settings = {
+      "app:dismissarchitecturewarning" = false;
+      "autoupdate:enabled" = false;
+      "term:fontsize" = 12.0;
+      "term:fontfamily" = "JuliaMono";
+      "term:theme" = "my-custom-theme";
+      "term:transparency" = 0.5;
+      "window:showhelp" = false;
+      "window:blur" = true;
+      "window:opacity" = 0.5;
+      "window:bgcolor" = "#000000";
+      "window:reducedmotion" = true;
+    };
+
+    themes = {
+      default-dark = {
+        "display:name" = "Default Dark";
+        "display:order" = 1;
+        black = "#757575";
+        red = "#cc685c";
+        green = "#76c266";
+        yellow = "#cbca9b";
+        blue = "#85aacb";
+        magenta = "#cc72ca";
+        cyan = "#74a7cb";
+        white = "#c1c1c1";
+        brightBlack = "#727272";
+        brightRed = "#cc9d97";
+        brightGreen = "#a3dd97";
+        brightYellow = "#cbcaaa";
+        brightBlue = "#9ab6cb";
+        brightMagenta = "#cc8ecb";
+        brightCyan = "#b7b8cb";
+        brightWhite = "#f0f0f0";
+        gray = "#8b918a";
+        cmdtext = "#f0f0f0";
+        foreground = "#c1c1c1";
+        selectionBackground = "";
+        background = "#00000077";
+        cursorAccent = "";
+      };
+    };
+
+    bookmarks = {
+      "bookmark@google" = {
+        url = "https://www.google.com";
+        title = "Google";
+      };
+      "bookmark@claude" = {
+        url = "https://claude.ai";
+        title = "Claude";
+      };
+      "bookmark@github" = {
+        url = "https://github.com";
+        title = "GitHub";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/waveterm/settings.json
+    assertFileExists home-files/.config/waveterm/bookmarks.json
+    assertFileExists home-files/.config/waveterm/termthemes.json
+
+    assertFileContent home-files/.config/waveterm/settings.json \
+    ${./cfg/settings.json}
+
+    assertFileContent home-files/.config/waveterm/bookmarks.json \
+    ${./cfg/bookmarks.json}
+
+    assertFileContent home-files/.config/waveterm/termthemes.json \
+    ${./cfg/termthemes.json}
+
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring WaveTerm. It provides options for its settings, themes and bookmarks. Closes #6997.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
