### PR TITLE
neovide: fix error when no settings are declared

### DIFF
--- a/modules/programs/neovide.nix
+++ b/modules/programs/neovide.nix
@@ -21,6 +21,7 @@ in
 
     settings = lib.mkOption {
       type = settingsFormat.type;
+      default = { };
       example = lib.literalExpression ''
         {
           fork = false;
@@ -52,6 +53,8 @@ in
 
   config = lib.mkIf cfg.enable {
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
-    xdg.configFile."neovide/config.toml".source = settingsFormat.generate "config.toml" cfg.settings;
+    xdg.configFile."neovide/config.toml" = lib.mkIf (cfg.settings != { }) {
+      source = settingsFormat.generate "neovide-config.toml" cfg.settings;
+    };
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Closes #6982.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
