### PR TITLE
distrobox: make systemd unit optional

### DIFF
--- a/modules/programs/distrobox.nix
+++ b/modules/programs/distrobox.nix
@@ -21,9 +21,16 @@ in
 
   options.programs.distrobox = {
     enable = mkEnableOption "distrobox";
-
     package = mkPackageOption pkgs "distrobox" { };
-
+    enableSystemdUnit = mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whatever to enable a Systemd Unit that automatically rebuilds your
+        containers when changes are detected.
+      '';
+    };
     containers = mkOption {
       type = formatter.type;
       default = { };
@@ -77,7 +84,7 @@ in
       formatter.generate "containers.ini" cfg.containers
     );
 
-    systemd.user.services.distrobox-home-manager = {
+    systemd.user.services.distrobox-home-manager = mkIf cfg.enableSystemdUnit {
       Unit.Description = "Build the containers declared in ~/.config/distrobox/containers.ini";
       Install.WantedBy = [ "default.target" ];
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds an option `enableSystemdUnit` to the Distrobox module to make the Systemd Unit optional, and hard coded as is now.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
