### PR TITLE
lutris: fix runners not working due to wrong setting name

### DIFF
--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -75,7 +75,7 @@ in
           cemu.package = pkgs.cemu;
           pcsx2.config = {
             system.disable_screen_saver = true;
-            runner.executable_path = "$\{pkgs.pcsx2}/bin/pcsx2-qt";
+            runner.runner_executable = "$\{pkgs.pcsx2}/bin/pcsx2-qt";
           };
         };
       '';
@@ -92,7 +92,7 @@ in
               example = "pkgs.cemu";
               description = ''
                 The package to use for this runner, nix will try to find the executable for this package.
-                A more specific path can be set by using settings.runner.executable_path instead.
+                A more specific path can be set by using settings.runner.runner_executable instead.
               '';
               type = types.nullOr types.package;
             };
@@ -112,7 +112,7 @@ in
                     type = types.submodule {
                       freeformType = settingsFormat.type;
                       options = {
-                        executable_path = mkOption {
+                        runner_executable = mkOption {
                           type = types.either types.str types.path;
                           default = "";
                           description = ''
@@ -149,16 +149,16 @@ in
         redundantRunners = attrNames (
           filterAttrs (
             _: runner_config:
-            runner_config.package != null && runner_config.settings.runner.executable_path != ""
+            runner_config.package != null && runner_config.settings.runner.runner_executable != ""
           ) cfg.runners
         );
       in
       mkIf (redundantRunners != [ ]) [
         ''
           Under programs.lutris.runners, the following lutris runners had both a
-          <runner>.package and <runner>.settings.runner.executable_path options set:
+          <runner>.package and <runner>.settings.runner.runner_executable options set:
             - ${concatStringsSep ", " redundantRunners}
-          Note that executable_path overrides package, setting both is pointless.
+          Note that runner_executable overrides package, setting both is pointless.
         ''
       ];
     home.packages =
@@ -179,9 +179,9 @@ in
             "${runner_name}" =
               (optionalAttrs (runner_config.settings.runner != { }) runner_config.settings.runner)
               // (optionalAttrs
-                (runner_config.package != null && runner_config.settings.runner.executable_path == "")
+                (runner_config.package != null && runner_config.settings.runner.runner_executable == "")
                 {
-                  executable_path = getExe runner_config.package;
+                  runner_executable = getExe runner_config.package;
                 }
               );
           }

--- a/tests/modules/programs/lutris/runners-configuration.nix
+++ b/tests/modules/programs/lutris/runners-configuration.nix
@@ -6,7 +6,7 @@
       cemu.package = pkgs.cemu;
       pcsx2.settings = {
         system.disable_screen_saver = true;
-        runner.executable_path = "${pkgs.pcsx2}/bin/pcsx2-qt";
+        runner.runner_executable = "${pkgs.pcsx2}/bin/pcsx2-qt";
       };
       rpcs3 = {
         package = pkgs.rpcs3;
@@ -23,18 +23,18 @@
       runnersDir = "home-files/.config/lutris/runners";
       expectedCemu = builtins.toFile "cemu.yml" ''
         cemu:
-          executable_path: '${lib.getExe pkgs.cemu}'
+          runner_executable: '${lib.getExe pkgs.cemu}'
       '';
       expectedPcsx2 = builtins.toFile "pcsx2.yml" ''
         pcsx2:
-          executable_path: '${pkgs.pcsx2}/bin/pcsx2-qt'
+          runner_executable: '${pkgs.pcsx2}/bin/pcsx2-qt'
         system:
           disable_screen_saver: true
       '';
       expectedRpcs3 = builtins.toFile "rpcs3.yml" ''
         rpcs3:
-          executable_path: '${lib.getExe pkgs.rpcs3}'
           nogui: true
+          runner_executable: '${lib.getExe pkgs.rpcs3}'
         system:
           disable_screen_saver: true
       '';


### PR DESCRIPTION
### Description
Apologies! It seems somewhere between testing and writing the module #6964 I confused the setting `runner_executable` for `executable_path` and didn't realize until now the runners part of lutris wasn't working.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
