### PR TITLE
wayprompt: add news entry for linux

### DIFF
--- a/modules/misc/news/2025-05-08_17-45-24.nix
+++ b/modules/misc/news/2025-05-08_17-45-24.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+
+{
+  time = "2025-05-08T17:45:24+02:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'programs.wayprompt'.
+
+    Wayprompt is a password prompter for Wayland, including a drop-in
+    replacement for GnuPG’s pinentry ('pinentry-wayprompt').
+
+    Note that the Wayland compositor must support the Layer Shell protocol.
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add missing news entry for the recently added Wayprompt module.
See #7002.

Folks, in the official docs, it is stated that if you contribute a module, you don’t have to add the news entry, and that the merger will take care of that (to reduce merge conflicts). OTOH, with the recent introduction of `create-news-entry.sh`, this shouldn’t be a problem anymore, and in fact some of the last module contributions include a news entry in their PR.
Should we update the docs to reflect this?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@awwpotato @khaneliman @rycee