### PR TITLE
docs: update filename of generated HTML manual

### DIFF
--- a/docs/manual/contributing/guidelines.md
+++ b/docs/manual/contributing/guidelines.md
@@ -81,7 +81,7 @@ Manager Git repository:
 
 ``` shell
 $ nix-build -A docs.html
-$ xdg-open ./result/share/doc/home-manager/index.html
+$ xdg-open ./result/share/doc/home-manager/index.xhtml
 ```
 
 When you have made changes to a module, it is a good idea to check that


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Since 613dbb35dbc142fd5cadca847f8677e64a502bfa, the manual produces an `index.xhtml` file, instead of a plain `index.html`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] (N/A) Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@awwpotato @khaneliman