### PR TITLE
Fix firefox native messaging hosts with relative symlinks

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -297,6 +297,7 @@ in
               local relTarget="$2"
               local executable="$3"
               local recursive="$4"
+              local ignorelinks="$5"
 
               # If the target already exists then we have a collision. Note, this
               # should not happen due to the assertion found in the 'files' module.
@@ -321,7 +322,11 @@ in
               if [[ -d $source ]]; then
                 if [[ $recursive ]]; then
                   mkdir -p "$target"
-                  lndir -silent "$source" "$target"
+                  if [[ $ignorelinks ]]; then
+                    lndir -silent -ignorelinks "$source" "$target"
+                  else
+                    lndir -silent "$source" "$target"
+                  fi
                 else
                   ln -s "$source" "$target"
                 fi
@@ -357,6 +362,7 @@ in
                   v.target
                   (if v.executable == null then "inherit" else toString v.executable)
                   (toString v.recursive)
+                  (toString v.ignorelinks)
                 ]
               }
             '') cfg

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -102,6 +102,18 @@ in
               '';
             };
 
+            ignorelinks = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                When `recursive` is enabled, adds `-ignorelinks` flag to lndir
+
+                It causes lndir to not treat symbolic links in the source directory specially.
+                The link created in the target directory will point back to the corresponding
+                (symbolic link) file in the source directory. If the link is to a directory
+              '';
+            };
+
             onChange = mkOption {
               type = types.lines;
               default = "";

--- a/modules/misc/mozilla-messaging-hosts.nix
+++ b/modules/misc/mozilla-messaging-hosts.nix
@@ -70,11 +70,13 @@ in
               "${thunderbirdNativeMessagingHostsPath}" = lib.mkIf (cfg.thunderbirdNativeMessagingHosts != [ ]) {
                 source = "${thunderbirdNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
                 recursive = true;
+                ignorelinks = true;
               };
 
               "${firefoxNativeMessagingHostsPath}" = lib.mkIf (cfg.firefoxNativeMessagingHosts != [ ]) {
                 source = "${firefoxNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
                 recursive = true;
+                ignorelinks = true;
               };
             }
           else
@@ -89,6 +91,7 @@ in
               "${firefoxNativeMessagingHostsPath}" = {
                 source = "${nativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
                 recursive = true;
+                ignorelinks = true;
               };
             };
       };


### PR DESCRIPTION
### Description
#5381 But scoped to firefox and thunderbird

I don't know how to name this `home.file` option better and what description to write for it, suggestions are welcome.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC
@rycee @kira-bruneau @Lillecarl @mlyxshi @khaneliman
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
