### PR TITLE
flake.nix: expose create-news-entry as a package

### DIFF
--- a/docs/manual/contributing/guidelines.md
+++ b/docs/manual/contributing/guidelines.md
@@ -127,9 +127,7 @@ If your contribution includes a change that should be communicated to
 users of Home Manager then you can add a news entry. The entry must be
 formatted as described in [News](#sec-news).
 
-When new modules are added a news entry should be included but you do
-not need to create this entry manually. The merging maintainer will
-create the entry for you. This is to reduce the risk of merge conflicts.
+When new modules are added a news entry should be included.
 
 ## Use conditional modules and news {#sec-guidelines-conditional-modules}
 

--- a/docs/manual/contributing/news.md
+++ b/docs/manual/contributing/news.md
@@ -10,15 +10,19 @@ If you do have a change worthy of a news entry then please add one in
 [`news.nix`](https://github.com/nix-community/home-manager/blob/master/modules/misc/news.nix)
 but you should follow some basic guidelines:
 
--   Use the included
-    [`create-news-entry.sh`](https://github.com/nix-community/home-manager/blob/master/modules/misc/news/create-news-entry.sh)
-    script to generate a news entry file:
+-   Use the included news entry generator to create a news entry file:
+
+    ``` shell
+    $ nix run .#create-news-entry
+    ```
+
+    Alternatively, you can directly use the script:
 
     ``` shell
     $ modules/misc/news/create-news-entry.sh
     ```
 
-    this will create a new file inside `modules/misc/news` directory
+    This will create a new file inside the `modules/misc/news` directory
     with some placeholder information that you can edit.
 
 -   The entry condition should be as specific as possible. For example,

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,10 @@
             default = hmPkg;
             home-manager = hmPkg;
 
+            create-news-entry = pkgs.writeShellScriptBin "create-news-entry" ''
+              ./modules/misc/news/create-news-entry.sh
+            '';
+
             docs-html = docs.manual.html;
             docs-htmlOpenTool = docs.manual.htmlOpenTool;
             docs-json = docs.options.json;


### PR DESCRIPTION
Easier to `nix run .#create-news-entry` instead of finding the location to run.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
