### PR TITLE
services/autorandr: improve service configurability

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -291,6 +291,12 @@
     github = "loicreynier";
     githubId = 88983487;
   };
+  lowlevl = {
+    name = "maya_t";
+    email = "lowlevl@users.noreply.github.com";
+    github = "lowlevl";
+    githubId = 15341887;
+  };
   LucasWagler = {
     name = "Lucas Wagler";
     email = "lucas@wagler.dev";

--- a/modules/services/autorandr.nix
+++ b/modules/services/autorandr.nix
@@ -30,6 +30,21 @@ in
         type = lib.types.bool;
         description = "Treat outputs as connected even if their lids are closed.";
       };
+
+      matchEdid = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+        description = "Match displays based on edid instead of name.";
+      };
+
+      extraOptions = lib.mkOption {
+        default = [ ];
+        type = lib.types.listOf lib.types.str;
+        example = [
+          "--force"
+        ];
+        description = "Extra options to pass to Autorandr.";
+      };
     };
   };
 
@@ -47,7 +62,15 @@ in
 
       Service = {
         Type = "oneshot";
-        ExecStart = "${cfg.package}/bin/autorandr --change ${lib.optionalString cfg.ignoreLid "--ignore-lid"}";
+        ExecStart =
+          let
+            args = lib.escapeShellArgs (
+              lib.optional cfg.ignoreLid "--ignore-lid"
+              ++ lib.optional cfg.matchEdid "--match-edid"
+              ++ cfg.extraOptions
+            );
+          in
+          "${lib.getExe cfg.package} --change ${args}";
       };
 
       Install.WantedBy = [ "graphical-session.target" ];

--- a/modules/services/autorandr.nix
+++ b/modules/services/autorandr.nix
@@ -23,6 +23,8 @@ in
         '';
       };
 
+      package = lib.mkPackageOption pkgs "autorandr" { };
+
       ignoreLid = lib.mkOption {
         default = false;
         type = lib.types.bool;
@@ -45,7 +47,7 @@ in
 
       Service = {
         Type = "oneshot";
-        ExecStart = "${pkgs.autorandr}/bin/autorandr --change ${lib.optionalString cfg.ignoreLid "--ignore-lid"}";
+        ExecStart = "${cfg.package}/bin/autorandr --change ${lib.optionalString cfg.ignoreLid "--ignore-lid"}";
       };
 
       Install.WantedBy = [ "graphical-session.target" ];

--- a/modules/services/autorandr.nix
+++ b/modules/services/autorandr.nix
@@ -8,7 +8,10 @@ let
   cfg = config.services.autorandr;
 in
 {
-  meta.maintainers = [ lib.maintainers.GaetanLepage ];
+  meta.maintainers = [
+    lib.maintainers.GaetanLepage
+    lib.hm.maintainers.lowlevl
+  ];
 
   options = {
     services.autorandr = {

--- a/modules/services/autorandr.nix
+++ b/modules/services/autorandr.nix
@@ -55,7 +55,7 @@ in
 
     systemd.user.services.autorandr = {
       Unit = {
-        Description = "autorandr";
+        Description = "Auto-detect the connected display hardware and load the appropriate X11 setup using xrandr";
         After = [ "graphical-session.target" ];
         PartOf = [ "graphical-session.target" ];
       };


### PR DESCRIPTION
### Description

- Add myself as a maintainer in home-manager for `services/autorandr`.
- Add a `package` option to be able to easily override the packages and add `matchEdid` and `extraOptions` for configuration of the `autorandr` service.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

~~- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~~; There are no test cases for this service, it simply creates a systemd configuration.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@GaetanLepage

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
