### PR TITLE
mako: settings better freeform support; deprecate criteria

### DIFF
--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -131,6 +131,7 @@ in
       '';
     };
     criteria = mkOption {
+      visible = false;
       type = iniType;
       default = { };
       example = {
@@ -147,8 +148,21 @@ in
         };
       };
       description = ''
-        Criterias for mako's config. All the details can be found in the
+        Criteria for mako's config. All the details can be found in the
         CRITERIA section in the official documentation.
+
+        *Deprecated*: Use `settings` with nested attributes instead. For example:
+        ```nix
+        settings = {
+          # Global settings
+          anchor = "top-right";
+
+          # Criteria sections
+          "actionable=true" = {
+            anchor = "top-left";
+          };
+        };
+        ```
       '';
     };
   };
@@ -157,6 +171,28 @@ in
     assertions = [
       (lib.hm.assertions.assertPlatform "services.mako" pkgs lib.platforms.linux)
     ];
+
+    warnings = lib.optional (cfg.criteria != { }) ''
+      The option `services.mako.criteria` is deprecated and will be removed in a future release.
+      Please use `services.mako.settings` with nested attributes instead.
+
+      For example, instead of:
+        criteria = {
+          "actionable=true" = {
+            anchor = "top-left";
+          };
+        };
+
+      Use:
+        settings = {
+          # Global settings here...
+
+          # Criteria sections
+          "actionable=true" = {
+            anchor = "top-left";
+          };
+        };
+    '';
 
     home.packages = [ cfg.package ];
 

--- a/modules/services/mako.nix
+++ b/modules/services/mako.nix
@@ -14,9 +14,30 @@ let
 
   cfg = config.services.mako;
 
-  generateConfig = lib.generators.toINIWithGlobalSection { };
-  iniType = (pkgs.formats.ini { }).type;
-  iniAtomType = (pkgs.formats.ini { }).lib.types.atom;
+  generateConfig =
+    config:
+    let
+      formatValue = v: if builtins.isBool v then if v then "true" else "false" else toString v;
+
+      globalSettings = lib.filterAttrs (n: v: !(lib.isAttrs v)) config;
+      sectionSettings = lib.filterAttrs (n: v: lib.isAttrs v) config;
+
+      globalLines = lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (k: v: "${k}=${formatValue v}") globalSettings
+      );
+
+      formatSection =
+        name: attrs:
+        "\n[${name}]\n"
+        + lib.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "${k}=${formatValue v}") attrs);
+
+      sectionLines = lib.concatStringsSep "\n" (lib.mapAttrsToList formatSection sectionSettings);
+    in
+    if sectionSettings != { } then globalLines + "\n" + sectionLines + "\n" else globalLines + "\n";
+
+  iniFormat = pkgs.formats.ini { };
+  iniType = iniFormat.type;
+  iniAtomType = iniFormat.lib.types.atom;
 in
 {
   meta.maintainers = [ lib.maintainers.onny ];
@@ -73,29 +94,40 @@ in
     enable = mkEnableOption "mako";
     package = mkPackageOption pkgs "mako" { };
     settings = mkOption {
-      type = lib.types.attrsOf iniAtomType;
+      type = lib.types.attrsOf (
+        lib.types.oneOf [
+          iniAtomType
+          (lib.types.attrsOf iniAtomType)
+        ]
+      );
       default = { };
       example = ''
         {
-          actions = "true";
+          actions = true;
           anchor = "top-right";
           background-color = "#000000";
           border-color = "#FFFFFF";
-          border-radius = "0";
-          default-timeout = "0";
+          border-radius = 0;
+          default-timeout = 0;
           font = "monospace 10";
-          height = "100";
-          width = "300";
-          icons = "true";
-          ignore-timeout = "false";
+          height = 100;
+          width = 300;
+          icons = true;
+          ignore-timeout = false;
           layer = "top";
-          margin = "10";
-          markup = "true";
+          margin = 10;
+          markup = true;
+
+          # Section example
+          "actionable=true" = {
+            anchor = "top-left";
+          };
         }
       '';
       description = ''
-        Configuration settings for mako. All available options can be found
-        here: <https://github.com/emersion/mako/blob/master/doc/mako.5.scd>.
+        Configuration settings for mako. Can include both global settings and sections.
+        All available options can be found here:
+        <https://github.com/emersion/mako/blob/master/doc/mako.5.scd>.
       '';
     };
     criteria = mkOption {
@@ -130,10 +162,13 @@ in
 
     xdg.configFile."mako/config" = mkIf (cfg.settings != { } || cfg.criteria != { }) {
       onChange = "${cfg.package}/bin/makoctl reload || true";
-      text = generateConfig {
-        globalSection = cfg.settings;
-        sections = cfg.criteria;
-      };
+      text =
+        let
+          # Merge settings and criteria into a single attribute set
+          # where settings are at the top level and criteria are nested attributes
+          mergedConfig = cfg.settings // cfg.criteria;
+        in
+        generateConfig mergedConfig;
     };
   };
 }

--- a/tests/modules/services/mako/default.nix
+++ b/tests/modules/services/mako/default.nix
@@ -1,1 +1,4 @@
-{ mako-example-config = ./example-config.nix; }
+{
+  mako-example-config = ./example-config.nix;
+  mako-deprecated-criteria = ./deprecated-criteria.nix;
+}

--- a/tests/modules/services/mako/default.nix
+++ b/tests/modules/services/mako/default.nix
@@ -1,4 +1,5 @@
 {
   mako-example-config = ./example-config.nix;
   mako-deprecated-criteria = ./deprecated-criteria.nix;
+  mako-renamed-options = ./renamed-options.nix;
 }

--- a/tests/modules/services/mako/deprecated-criteria.nix
+++ b/tests/modules/services/mako/deprecated-criteria.nix
@@ -1,0 +1,65 @@
+{
+  services.mako = {
+    enable = true;
+    # Global settings
+    settings = {
+      actions = true;
+      anchor = "top-right";
+      background-color = "#000000";
+      border-color = "#FFFFFF";
+      border-radius = 0;
+      default-timeout = 0;
+      font = "monospace 10";
+      height = 100;
+      width = 300;
+      icons = true;
+      ignore-timeout = false;
+      layer = "top";
+      margin = 10;
+      markup = true;
+    };
+
+    # Using deprecated criteria option
+    criteria = {
+      "actionable=true" = {
+        anchor = "top-left";
+      };
+      "app-name=Google\\ Chrome" = {
+        max-visible = 5;
+      };
+      "field1=value field2=value" = {
+        text-alignment = "left";
+      };
+    };
+  };
+
+  test.asserts.warnings.expected = [
+    ''
+      The option `services.mako.criteria` is deprecated and will be removed in a future release.
+      Please use `services.mako.settings` with nested attributes instead.
+
+      For example, instead of:
+        criteria = {
+          "actionable=true" = {
+            anchor = "top-left";
+          };
+        };
+
+      Use:
+        settings = {
+          # Global settings here...
+
+          # Criteria sections
+          "actionable=true" = {
+            anchor = "top-left";
+          };
+        };
+    ''
+  ];
+
+  nmt.script = ''
+    assertFileExists home-files/.config/mako/config
+    assertFileContent home-files/.config/mako/config \
+    ${./config}
+  '';
+}

--- a/tests/modules/services/mako/example-config.nix
+++ b/tests/modules/services/mako/example-config.nix
@@ -16,17 +16,13 @@
       layer = "top";
       margin = 10;
       markup = true;
-    };
 
-    criteria = {
       "actionable=true" = {
         anchor = "top-left";
       };
-
       "app-name=Google\\ Chrome" = {
         max-visible = 5;
       };
-
       "field1=value field2=value" = {
         text-alignment = "left";
       };

--- a/tests/modules/services/mako/renamed-options-config
+++ b/tests/modules/services/mako/renamed-options-config
@@ -1,0 +1,27 @@
+actions=true
+anchor=top-right
+background-color=#000000
+border-color=#FFFFFF
+border-radius=0
+border-size=2
+default-timeout=5000
+font=monospace 10
+format=<b>%s</b>
+%b
+group-by=app-name
+height=100
+icon-path=/usr/share/icons/hicolor
+icons=true
+ignore-timeout=false
+layer=top
+margin=10
+markup=true
+max-history=5
+max-icon-size=32
+max-visible=3
+output=HDMI-A-1
+padding=5,10
+progress-color=#4C7899
+sort=-time
+text-color=#FFFFFF
+width=300

--- a/tests/modules/services/mako/renamed-options.nix
+++ b/tests/modules/services/mako/renamed-options.nix
@@ -1,0 +1,77 @@
+{ lib, options, ... }:
+{
+  services.mako = {
+    enable = true;
+    # Using old option names that should be renamed to settings.kebab-case
+    actions = true;
+    anchor = "top-right";
+    backgroundColor = "#000000";
+    borderColor = "#FFFFFF";
+    borderRadius = 0;
+    borderSize = 2;
+    defaultTimeout = 5000;
+    font = "monospace 10";
+    format = "<b>%s</b>\n%b";
+    groupBy = "app-name";
+    height = 100;
+    iconPath = "/usr/share/icons/hicolor";
+    icons = true;
+    ignoreTimeout = false;
+    layer = "top";
+    margin = 10;
+    markup = true;
+    maxHistory = 5;
+    maxIconSize = 32;
+    maxVisible = 3;
+    output = "HDMI-A-1";
+    padding = "5,10";
+    progressColor = "#4C7899";
+    sort = "-time";
+    textColor = "#FFFFFF";
+    width = 300;
+  };
+
+  test.asserts.warnings.expected =
+    let
+      renamedOptions = [
+        "groupBy"
+        "ignoreTimeout"
+        "defaultTimeout"
+        "format"
+        "actions"
+        "markup"
+        "iconPath"
+        "maxIconSize"
+        "icons"
+        "progressColor"
+        "borderRadius"
+        "borderColor"
+        "borderSize"
+        "padding"
+        "margin"
+        "height"
+        "width"
+        "textColor"
+        "backgroundColor"
+        "font"
+        "anchor"
+        "layer"
+        "output"
+        "sort"
+        "maxHistory"
+        "maxVisible"
+      ];
+    in
+    map (
+      option:
+      ''The option `services.mako.${option}' defined in ${
+        lib.showFiles options.services.mako.${option}.files
+      } has been renamed to `services.mako.settings.${lib.hm.strings.toKebabCase option}'.''
+    ) renamedOptions;
+
+  nmt.script = ''
+    assertFileExists home-files/.config/mako/config
+    assertFileContent home-files/.config/mako/config \
+    ${./renamed-options-config}
+  '';
+}


### PR DESCRIPTION
### Description
Follow up to https://github.com/nix-community/home-manager/pull/6977#issuecomment-2868993720

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
