### PR TITLE
programs.numbat: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -18,6 +18,12 @@
     github = "abayomi185";
     githubId = 21103047;
   };
+  Aehmlo = {
+    name = "Alex";
+    email = "1622250+Aehmlo@users.noreply.github.com";
+    github = "Aehmlo";
+    githubId = 1622250;
+  };
   afresquet = {
     name = "Alvaro Fresquet";
     email = "alvarofresquet@gmail.com";

--- a/modules/misc/news/2025-05-10_21-08-48.nix
+++ b/modules/misc/news/2025-05-10_21-08-48.nix
@@ -1,0 +1,7 @@
+{
+  time = "2025-05-11T01:08:48+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.numbat'.
+  '';
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -208,6 +208,7 @@ let
       ./programs/nnn.nix
       ./programs/noti.nix
       ./programs/notmuch.nix
+      ./programs/numbat.nix
       ./programs/nushell.nix
       ./programs/obs-studio.nix
       ./programs/octant.nix

--- a/modules/programs/numbat.nix
+++ b/modules/programs/numbat.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) mkIf;
+  cfg = config.programs.numbat;
+  tomlFormat = pkgs.formats.toml { };
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/numbat"
+    else
+      "${config.xdg.configHome}/numbat";
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [
+    Aehmlo
+  ];
+
+  options.programs.numbat = {
+    enable = lib.mkEnableOption "Numbat";
+
+    package = lib.mkPackageOption pkgs "numbat" { nullable = true; };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = {
+        intro-banner = "short";
+        prompt = "> ";
+        exchange-rates.fetching-policy = "on-first-use";
+      };
+      description = ''
+        Options to add to {file}`config.toml`. See
+        <https://numbat.dev/doc/cli-customization.html#configuration> for options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    home.file."${configDir}/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "numbat-config" cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -257,6 +257,7 @@ import nmtSrc {
       ./modules/programs/nix-init
       ./modules/programs/nix-your-shell
       ./modules/programs/nnn
+      ./modules/programs/numbat
       ./modules/programs/nushell
       ./modules/programs/oh-my-posh
       ./modules/programs/onlyoffice

--- a/tests/modules/programs/numbat/default.nix
+++ b/tests/modules/programs/numbat/default.nix
@@ -1,0 +1,4 @@
+{
+  numbat-example-config = ./example-config.nix;
+  numbat-empty-config = ./empty-config.nix;
+}

--- a/tests/modules/programs/numbat/empty-config.nix
+++ b/tests/modules/programs/numbat/empty-config.nix
@@ -1,0 +1,18 @@
+{
+  pkgs,
+  ...
+}:
+let
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/numbat"
+    else
+      ".config/numbat";
+in
+{
+  programs.numbat.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists 'home-files/${configDir}/config.toml'
+  '';
+}

--- a/tests/modules/programs/numbat/example-config.nix
+++ b/tests/modules/programs/numbat/example-config.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/numbat"
+    else
+      ".config/numbat";
+in
+{
+  programs.numbat = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    settings = {
+      intro-banner = "short";
+      prompt = "> ";
+      exchange-rates.fetching-policy = "on-first-use";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists 'home-files/${configDir}/config.toml'
+    assertFileContent $(normalizeStorePaths 'home-files/${configDir}/config.toml') \
+      ${builtins.toFile "expected.toml" ''
+        intro-banner = "short"
+        prompt = "> "
+        [exchange-rates]
+        fetching-policy = "on-first-use"
+      ''}
+  '';
+}


### PR DESCRIPTION
### Description

This PR adds a module for configuring [Numbat](https://numbat.dev/), a high-precision scientific calculator with full support for physical units. It uses [RFC 42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)-style `settings` and provides `enable` and `package` options.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
