### PR TITLE
bacon: add prefs location to settings decription

### DIFF
--- a/modules/programs/bacon.nix
+++ b/modules/programs/bacon.nix
@@ -41,7 +41,8 @@ in
         };
       };
       description = ''
-        Bacon configuration.
+        Bacon configuration written to either {file}`Library/Application Support/org.dystroy.bacon/prefs.toml`
+        (darwin) or {file}`$XDG_CONFIG_HOME/bacon/prefs.toml`.
         For available settings see <https://dystroy.org/bacon/#global-preferences>.
       '';
     };
@@ -51,7 +52,7 @@ in
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file."${configDir}/prefs.toml" = lib.mkIf (cfg.settings != { }) {
-      source = settingsFormat.generate "prefs.toml" cfg.settings;
+      source = settingsFormat.generate "bacon-prefs" cfg.settings;
     };
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
