### PR TITLE
[Backport release-24.11] flake-module: add flake-parts module

### DIFF
--- a/docs/manual/nix-flakes.md
+++ b/docs/manual/nix-flakes.md
@@ -30,6 +30,7 @@ nix-flakes/prerequisites.md
 nix-flakes/standalone.md
 nix-flakes/nixos.md
 nix-flakes/nix-darwin.md
+nix-flakes/flake-parts.md
 ```
 
 

--- a/docs/manual/nix-flakes/flake-parts.md
+++ b/docs/manual/nix-flakes/flake-parts.md
@@ -1,0 +1,40 @@
+# flake-parts module {#sec-flakes-flake-parts-module}
+
+When using [flake-parts](https://flake.parts)
+you may wish to import home-manager's flake module,
+`flakeModules.home-manager`.
+
+``` nix
+{
+  description = "flake-parts configuration";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        # Import home-manager's flake module
+        inputs.home-manager.flakeModules.home-manager
+      ];
+      flake = {
+        # Define `homeModules`, `homeConfigurations`,
+        # `nixosConfigurations`, etc here
+      };
+      # See flake.parts for more features, such as `perSystem`
+    };
+}
+```
+
+The flake module defines the `flake.homeModules` and `flake.homeConfigurations`
+options, allowing them to be properly merged if they are defined in multiple
+modules.
+
+If you are only defining `homeModules` and/or `homeConfigurations` once in a
+single module, flake-parts should work fine without importing
+`flakeModules.home-manager`.
+

--- a/docs/manual/nix-flakes/flake-parts.md
+++ b/docs/manual/nix-flakes/flake-parts.md
@@ -1,7 +1,7 @@
 # flake-parts module {#sec-flakes-flake-parts-module}
 
 When using [flake-parts](https://flake.parts)
-you may wish to import home-manager's flake module,
+you may wish to import Home Manager's flake module,
 `flakeModules.home-manager`.
 
 ``` nix
@@ -37,4 +37,3 @@ modules.
 If you are only defining `homeModules` and/or `homeConfigurations` once in a
 single module, flake-parts should work fine without importing
 `flakeModules.home-manager`.
-

--- a/docs/manual/nix-flakes/flake-parts.md
+++ b/docs/manual/nix-flakes/flake-parts.md
@@ -22,7 +22,7 @@ you may wish to import Home Manager's flake module,
         inputs.home-manager.flakeModules.home-manager
       ];
       flake = {
-        # Define `homeModules`, `homeConfigurations`,
+        # Define `homeManagerModules`, `homeConfigurations`,
         # `nixosConfigurations`, etc here
       };
       # See flake.parts for more features, such as `perSystem`
@@ -30,10 +30,10 @@ you may wish to import Home Manager's flake module,
 }
 ```
 
-The flake module defines the `flake.homeModules` and `flake.homeConfigurations`
+The flake module defines the `flake.homeManagerModules` and `flake.homeConfigurations`
 options, allowing them to be properly merged if they are defined in multiple
 modules.
 
-If you are only defining `homeModules` and/or `homeConfigurations` once in a
+If you are only defining `homeManagerModules` and/or `homeConfigurations` once in a
 single module, flake-parts should work fine without importing
 `flakeModules.home-manager`.

--- a/docs/manual/nix-flakes/flake-parts.md
+++ b/docs/manual/nix-flakes/flake-parts.md
@@ -22,7 +22,7 @@ you may wish to import Home Manager's flake module,
         inputs.home-manager.flakeModules.home-manager
       ];
       flake = {
-        # Define `homeManagerModules`, `homeConfigurations`,
+        # Define `homeModules`, `homeConfigurations`,
         # `nixosConfigurations`, etc here
       };
       # See flake.parts for more features, such as `perSystem`
@@ -30,10 +30,10 @@ you may wish to import Home Manager's flake module,
 }
 ```
 
-The flake module defines the `flake.homeManagerModules` and `flake.homeConfigurations`
+The flake module defines the `flake.homeModules` and `flake.homeConfigurations`
 options, allowing them to be properly merged if they are defined in multiple
 modules.
 
-If you are only defining `homeManagerModules` and/or `homeConfigurations` once in a
+If you are only defining `homeModules` and/or `homeConfigurations` once in a
 single module, flake-parts should work fine without importing
 `flakeModules.home-manager`.

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -1,0 +1,32 @@
+{ lib, flake-parts-lib, moduleLocation, ... }:
+let inherit (lib) toString mapAttrs mkOption types;
+in {
+  options = {
+    flake = flake-parts-lib.mkSubmoduleOptions {
+      homeConfigurations = mkOption {
+        type = types.lazyAttrsOf types.raw;
+        default = { };
+        description = ''
+          Instantiated Home-Manager configurations.
+
+          `homeConfigurations` is for specific installations. If you want to expose
+          reusable configurations, add them to `homeModules` in the form of modules, so
+          that you can reference them in this or another flake's `homeConfigurations`.
+        '';
+      };
+      homeModules = mkOption {
+        type = types.lazyAttrsOf types.unspecified;
+        default = { };
+        apply = mapAttrs (k: v: {
+          _file = "${toString moduleLocation}#homeModules.${k}";
+          imports = [ v ];
+        });
+        description = ''
+          Home-Manager modules.
+
+          You may use this for reusable pieces of configuration, service modules, etc.
+        '';
+      };
+    };
+  };
+}

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -4,7 +4,7 @@ in {
   options = {
     flake = flake-parts-lib.mkSubmoduleOptions {
       homeConfigurations = mkOption {
-        type = types.lazyAttrsOf types.deferredModule;
+        type = types.lazyAttrsOf types.raw;
         default = { };
         description = ''
           Instantiated Home Manager configurations.
@@ -15,7 +15,7 @@ in {
         '';
       };
       homeManagerModules = mkOption {
-        type = types.lazyAttrsOf types.unspecified;
+        type = types.lazyAttrsOf types.deferredModule;
         default = { };
         apply = mapAttrs (k: v: {
           _class = "homeManager";

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -14,11 +14,11 @@ in {
           that you can reference them in this or another flake's `homeConfigurations`.
         '';
       };
-      homeModules = mkOption {
+      homeManagerModules = mkOption {
         type = types.lazyAttrsOf types.unspecified;
         default = { };
         apply = mapAttrs (k: v: {
-          _file = "${toString moduleLocation}#homeModules.${k}";
+          _file = "${toString moduleLocation}#homeManagerModules.${k}";
           imports = [ v ];
         });
         description = ''

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -7,7 +7,7 @@ in {
         type = types.lazyAttrsOf types.raw;
         default = { };
         description = ''
-          Instantiated Home-Manager configurations.
+          Instantiated Home Manager configurations.
 
           `homeConfigurations` is for specific installations. If you want to expose
           reusable configurations, add them to `homeModules` in the form of modules, so
@@ -22,7 +22,7 @@ in {
           imports = [ v ];
         });
         description = ''
-          Home-Manager modules.
+          Home Manager modules.
 
           You may use this for reusable pieces of configuration, service modules, etc.
         '';

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -14,12 +14,12 @@ in {
           that you can reference them in this or another flake's `homeConfigurations`.
         '';
       };
-      homeManagerModules = mkOption {
+      homeModules = mkOption {
         type = types.lazyAttrsOf types.deferredModule;
         default = { };
         apply = mapAttrs (k: v: {
           _class = "homeManager";
-          _file = "${toString moduleLocation}#homeManagerModules.${k}";
+          _file = "${toString moduleLocation}#homeModules.${k}";
           imports = [ v ];
         });
         description = ''

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -4,7 +4,7 @@ in {
   options = {
     flake = flake-parts-lib.mkSubmoduleOptions {
       homeConfigurations = mkOption {
-        type = types.lazyAttrsOf types.raw;
+        type = types.lazyAttrsOf types.deferredModule;
         default = { };
         description = ''
           Instantiated Home Manager configurations.

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -18,6 +18,7 @@ in {
         type = types.lazyAttrsOf types.unspecified;
         default = { };
         apply = mapAttrs (k: v: {
+          _class = "homeManager";
           _file = "${toString moduleLocation}#homeManagerModules.${k}";
           imports = [ v ];
         });

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,11 @@
       # unofficial; deprecated in Nix 2.8
       darwinModule = self.darwinModules.default;
 
+      flakeModules = rec {
+        home-manager = import ./flake-module.nix;
+        default = home-manager;
+      };
+
       templates = {
         standalone = {
           path = ./templates/standalone;


### PR DESCRIPTION
### Description
closes https://github.com/nix-community/home-manager/issues/7016
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
