### PR TITLE
halloy: add themes option

### DIFF
--- a/modules/programs/halloy.nix
+++ b/modules/programs/halloy.nix
@@ -10,11 +10,12 @@ let
     mkEnableOption
     mkPackageOption
     mkOption
+    types
     ;
 
   cfg = config.programs.halloy;
 
-  formatter = pkgs.formats.toml { };
+  tomlFormat = pkgs.formats.toml { };
 in
 {
   meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
@@ -23,7 +24,7 @@ in
     enable = mkEnableOption "halloy";
     package = mkPackageOption pkgs "halloy" { nullable = true; };
     settings = mkOption {
-      type = formatter.type;
+      inherit (tomlFormat) type;
       default = { };
       example = {
         "buffer.channel.topic".enabled = true;
@@ -38,12 +39,57 @@ in
         found here: <https://halloy.chat/configuration/index.html>.
       '';
     };
+    themes = mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          tomlFormat.type
+          types.lines
+          types.path
+        ]
+      );
+      default = { };
+      example = {
+        general = {
+          background = "<string>";
+          border = "<string>";
+          horizontal_rule = "<string>";
+          unread_indicator = "<string>";
+        };
+        text = {
+          primary = "<string>";
+          secondary = "<string>";
+          tertiary = "<string>";
+          success = "<string>";
+          error = "<string>";
+        };
+      };
+      description = ''
+        Each theme is written to {file}`$XDG_CONFIG_HOME/halloy/themes/NAME.toml`.
+        See <https://halloy.chat/configuration/themes/index.html> for more information.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
     home.packages = mkIf (cfg.package != null) [ cfg.package ];
-    xdg.configFile."halloy/config.toml" = mkIf (cfg.settings != { }) {
-      source = formatter.generate "halloy-config" cfg.settings;
-    };
+    xdg.configFile = lib.mkMerge [
+      {
+        "halloy/config.toml" = mkIf (cfg.settings != { }) {
+          source = tomlFormat.generate "halloy-config" cfg.settings;
+        };
+      }
+      (lib.mapAttrs' (
+        name: value:
+        lib.nameValuePair "halloy/themes/${name}.toml" {
+          source =
+            if lib.isString value then
+              pkgs.writeText "halloy-theme-${name}" value
+            else if builtins.isPath value || lib.isStorePath value then
+              value
+            else
+              tomlFormat.generate "halloy-theme-${name}" value;
+        }
+      ) cfg.themes)
+    ];
   };
 }

--- a/tests/modules/programs/halloy/example-config.nix
+++ b/tests/modules/programs/halloy/example-config.nix
@@ -9,11 +9,29 @@
         channels = [ "#halloy" ];
       };
     };
+    themes.my-theme = {
+      general = {
+        background = "<string>";
+        border = "<string>";
+        horizontal_rule = "<string>";
+        unread_indicator = "<string>";
+      };
+      text = {
+        primary = "<string>";
+        secondary = "<string>";
+        tertiary = "<string>";
+        success = "<string>";
+        error = "<string>";
+      };
+    };
   };
 
   nmt.script = ''
     assertFileExists home-files/.config/halloy/config.toml
     assertFileContent home-files/.config/halloy/config.toml \
-    ${./example-config.toml}
+      ${./example-config.toml}
+    assertFileExists home-files/.config/halloy/themes/my-theme.toml
+    assertFileContent home-files/.config/halloy/themes/my-theme.toml \
+      ${./my-theme.toml}
   '';
 }

--- a/tests/modules/programs/halloy/my-theme.toml
+++ b/tests/modules/programs/halloy/my-theme.toml
@@ -1,0 +1,12 @@
+[general]
+background = "<string>"
+border = "<string>"
+horizontal_rule = "<string>"
+unread_indicator = "<string>"
+
+[text]
+error = "<string>"
+primary = "<string>"
+secondary = "<string>"
+success = "<string>"
+tertiary = "<string>"


### PR DESCRIPTION
### Description
follow up to https://github.com/nix-community/home-manager/pull/7034
cc @surfaceflinger 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC
@aguirre-matteo 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
