### PR TITLE
fontconfig: Provide default fontconfig config files

### DIFF
--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -96,6 +96,19 @@ in
       # trying to write to a read-only location.
       (pkgs.runCommandLocal "dummy-fc-dir1" { } "mkdir -p $out/lib/fontconfig")
       (pkgs.runCommandLocal "dummy-fc-dir2" { } "mkdir -p $out/lib/fontconfig")
+      # Provide fontconfig default files from /etc/fonts/
+      (pkgs.runCommand "fontconfig-conf" { } ''
+        dst=$out/etc/fonts/conf.d
+        mkdir -p $dst
+
+        # fonts.conf
+        ln -s ${pkgs.fontconfig.out}/etc/fonts/fonts.conf \
+              $dst/../fonts.conf
+
+        # fontconfig default config files
+        ln -s ${pkgs.fontconfig.out}/etc/fonts/conf.d/*.conf \
+              $dst/
+      '')
     ];
 
     home.extraProfileCommands = ''

--- a/tests/modules/misc/fontconfig/no-font-package.nix
+++ b/tests/modules/misc/fontconfig/no-font-package.nix
@@ -7,5 +7,7 @@
 
   nmt.script = ''
     assertPathNotExists home-path/lib/fontconfig/cache
+    assertLinkExists home-path/etc/fonts/fonts.conf
+    assertDirectoryExists home-path/etc/fonts/conf.d
   '';
 }


### PR DESCRIPTION
### Description

Make home-manager provide fontconfig's default config files in `home-path/etc/font`, this fixes and issue where fonts would render incorrectly if the system was not already providing the fontconfig default config files.

#### Context

Using standalone hm, with fontconfig disabled in my NixOS config and enabled in hm, I have been experiencing font rendering issues in several programs, particularly in mako emojis would be oversized. This was due to fontconfig not being able to find its default config files that come with the package. This fixes that issue.

This change can be a starting point to then add all of the fontconfig options that NixOS provides in home-manager as well (as the implementation is similar so far).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@rycee 
