### PR TITLE
foliate: init

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -160,6 +160,7 @@
     - modules/programs/cmus.nix
     - modules/programs/ncspot.nix
     - modules/programs/spotify-player.nix
+    - modules/programs/foliate.nix
     - modules/programs/freetube.nix
     - modules/programs/yt-dlp.nix
     - modules/programs/kodi.nix

--- a/modules/misc/news/2025/05/2025-05-12_15-21-57.nix
+++ b/modules/misc/news/2025/05/2025-05-12_15-21-57.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+{
+  time = "2025-05-12T22:21:57+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: `programs.foliate`
+
+    Foliate is a modern e-book reader tailored for GNOME.
+  '';
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -362,6 +362,7 @@ let
       ./services/flameshot.nix
       ./services/fluidsynth.nix
       ./services/fnott.nix
+      ./programs/foliate.nix
       ./services/fusuma.nix
       ./services/getmail.nix
       ./services/git-sync.nix

--- a/modules/programs/foliate.nix
+++ b/modules/programs/foliate.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    mkIf
+    types
+    mapAttrs'
+    nameValuePair
+    ;
+
+  cfg = config.programs.foliate;
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  meta.maintainers = [ lib.maintainers.awwpotato ];
+
+  options.programs.foliate = {
+    enable = mkEnableOption "Foliate";
+    package = mkPackageOption pkgs "foliate" { nullable = true; };
+    settings = mkOption {
+      type = with types; attrsOf (either lib.hm.types.gvariant (attrsOf lib.hm.types.gvariant));
+      default = { };
+      description = ''
+        Added to `config.dconf.settings` under `com/github/johnfactotum/Foliate`,
+        the scheme is defined at
+        <https://github.com/johnfactotum/foliate/blob/gtk4/data/com.github.johnfactotum.Foliate.gschema.xml>
+      '';
+      example = lib.literalExpression ''
+        {
+          myTheme = {
+            color-scheme = 0;
+            library = {
+              view-mode = "grid";
+              show-covers = true;
+            };
+            "viewer/view" = {
+              theme = "My Theme";
+            };
+            "viewer/font" = {
+              monospace = "Maple Mono";
+              default-size = 12;
+            };
+          };
+        }
+      '';
+    };
+    themes = mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          jsonFormat.type
+          types.str
+          types.path
+        ]
+      );
+      description = ''
+        Each theme is written to
+        {file}`$XDG_CONFIG_HOME/com.github.johnfactotum.Foliate/themes/NAME.json`.
+        See <https://github.com/johnfactotum/foliate/blob/gtk4/src/themes.js>
+        for implementation of themes in Foliate.
+      '';
+      default = { };
+      example = lib.literalExpression ''
+        {
+          label = "My Theme";
+          light = {
+            fg = "#89b4fa";
+            bg = "#1e1e2e";
+            link = "#89b4fa";
+          };
+          dark = { };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.foliate" pkgs lib.platforms.linux)
+    ];
+
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    dconf.settings = mapAttrs' (
+      name: value:
+      if builtins.isAttrs value then
+        nameValuePair "com/github/johnfactotum/Foliate/${name}" value
+      else
+        nameValuePair "com/github/johnfactotum/Foliate" { ${name} = value; }
+    ) cfg.settings;
+
+    xdg.configFile = mapAttrs' (
+      name: value:
+      nameValuePair "com.github.johnfactotum.Foliate/themes/${name}.json" {
+        source =
+          if lib.isString value then
+            pkgs.writeText "foliate-theme-${name}" value
+          else if builtins.isPath value || lib.isStorePath value then
+            value
+          else
+            jsonFormat.generate "foliate-theme-${name}" value;
+      }
+    ) cfg.themes;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -365,6 +365,7 @@ import nmtSrc {
       ./modules/programs/distrobox
       ./modules/programs/element-desktop/linux.nix
       ./modules/programs/eww
+      ./modules/programs/foliate
       ./modules/programs/foot
       ./modules/programs/freetube
       ./modules/programs/fuzzel

--- a/tests/modules/programs/foliate/basic-theme.nix
+++ b/tests/modules/programs/foliate/basic-theme.nix
@@ -1,0 +1,45 @@
+{ pkgs, ... }:
+{
+  programs.foliate = {
+    enable = true;
+    settings = {
+      color-scheme = 0;
+      library = {
+        view-mode = "grid";
+        show-covers = true;
+      };
+      "viewer/view" = {
+        theme = "My Theme";
+      };
+      "viewer/font" = {
+        monospace = "Maple Mono";
+        default-size = 12;
+      };
+    };
+    themes.myTheme = {
+      label = "My Theme";
+      light = {
+        fg = "#89b4fa";
+        bg = "#1e1e2e";
+        link = "#89b4fa";
+      };
+      dark = { };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/com.github.johnfactotum.Foliate/themes/myTheme.json
+    assertFileContent home-files/.config/com.github.johnfactotum.Foliate/themes/myTheme.json \
+      ${pkgs.writeText "expected-foliate-theme" ''
+        {
+          "dark": {},
+          "label": "My Theme",
+          "light": {
+            "bg": "#1e1e2e",
+            "fg": "#89b4fa",
+            "link": "#89b4fa"
+          }
+        }
+      ''}
+  '';
+}

--- a/tests/modules/programs/foliate/default.nix
+++ b/tests/modules/programs/foliate/default.nix
@@ -1,0 +1,3 @@
+{
+  foliate-basic-theme = ./basic-theme.nix;
+}


### PR DESCRIPTION
### Description
~I'm intentionally not including a settings option because it uses dconf and I don't want to deal with that right now.~ I did add a settings option but it's kinda hacky.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
