### PR TITLE
sketchybar: add module

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -259,6 +259,7 @@ let
       ./programs/sesh.nix
       ./programs/sftpman.nix
       ./programs/sioyek.nix
+      ./programs/sketchybar.nix
       ./programs/skim.nix
       ./programs/sm64ex.nix
       ./programs/smug.nix

--- a/modules/programs/sketchybar.nix
+++ b/modules/programs/sketchybar.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    types
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.sketchybar;
+
+  getSource = { name, arg }: if lib.isString arg then pkgs.writeText name arg else arg;
+
+  getSketchybarrc =
+    setting:
+    if setting != "" then
+      {
+        "sketchybar/sketchybarrc".source = getSource {
+          name = "sketchybarrc";
+          arg = setting;
+        };
+      }
+    else
+      { };
+
+  getPlugins =
+    set:
+    lib.mapAttrs' (
+      name: value:
+      lib.nameValuePair "sketchybar/plugins/${name}.sh" {
+        source = getSource {
+          name = "sketchybar-plugin-${name}";
+          arg = value;
+        };
+      }
+    ) set;
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.sketchybar = {
+    enable = mkEnableOption "sketchybar";
+    package = mkPackageOption pkgs "sketchybar" { nullable = true; };
+    sketchybarrc = mkOption {
+      type = with types; either lines path;
+      default = "";
+      example = ''
+        PLUGIN_DIR="$CONFIG_DIR/plugins"
+
+        sketchybar --bar position=top height=40 blur_radius=30 color=0x40000000
+      '';
+      description = ''
+        Script to be written to the sketchybarrc. All the details about its contents
+        can be found here: <https://felixkratz.github.io/SketchyBar/config/bar>.
+      '';
+    };
+    plugins = mkOption {
+      type = with types; attrsOf (either lines path);
+      default = { };
+      example = {
+        window_title = ./plugins/window_title.sh;
+        btc = ./plugins/btc.sh;
+        eth = ./plugins/eth.sh;
+      };
+      description = ''
+        Pluggins for SketchyBar. You can find some plugins at:
+        <https://github.com/FelixKratz/SketchyBar/discussions/12>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.sketchybar" pkgs lib.platforms.darwin)
+    ];
+
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile = (getSketchybarrc cfg.sketchybarrc) // (getPlugins cfg.plugins);
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -330,6 +330,7 @@ import nmtSrc {
       ./modules/launchd
       ./modules/programs/aerospace
       ./modules/programs/element-desktop/darwin.nix
+      ./modules/programs/sketchybar
       ./modules/services/emacs-darwin
       ./modules/services/espanso-darwin
       ./modules/services/git-sync-darwin

--- a/tests/modules/programs/sketchybar/default.nix
+++ b/tests/modules/programs/sketchybar/default.nix
@@ -1,0 +1,5 @@
+{
+  sketchybar-script-path = ./script-path.nix;
+  sketchybar-script-string = ./script-string.nix;
+  sketchybar-plugins = ./plugins.nix;
+}

--- a/tests/modules/programs/sketchybar/plugins.nix
+++ b/tests/modules/programs/sketchybar/plugins.nix
@@ -1,0 +1,25 @@
+{
+  programs.sketchybar = {
+    enable = true;
+    plugins = {
+      disk = ./plugins/disk.sh;
+      network = ./plugins/network.sh;
+      ram = ''
+        sketchybar -m --set "$NAME" label="$(memory_pressure | grep "System-wide memory free percentage:" | awk '{ printf("%02.0f\n", 100-$5"%") }')%"
+      '';
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/sketchybar/plugins/disk.sh
+    assertFileExists home-files/.config/sketchybar/plugins/network.sh
+    assertFileExists home-files/.config/sketchybar/plugins/ram.sh
+
+    assertFileContent home-files/.config/sketchybar/plugins/disk.sh \
+    ${./plugins/disk.sh}
+    assertFileExists home-files/.config/sketchybar/plugins/network.sh \
+    ${./plugins/network.sh}
+    assertFileExists home-files/.config/sketchybar/plugins/ram.sh \
+    ${./plugins/ram.sh}
+  '';
+}

--- a/tests/modules/programs/sketchybar/plugins/disk.sh
+++ b/tests/modules/programs/sketchybar/plugins/disk.sh
@@ -1,0 +1,1 @@
+sketchybar -m --set "$NAME" label="$(df -H | grep -E '^(/dev/disk3s5).' | awk '{ printf ("%s\n", $5) }')"

--- a/tests/modules/programs/sketchybar/plugins/network.sh
+++ b/tests/modules/programs/sketchybar/plugins/network.sh
@@ -1,0 +1,20 @@
+UPDOWN=$(ifstat -i "en0" -b 0.1 1 | tail -n1)
+DOWN=$(echo "$UPDOWN" | awk "{ print \$1 }" | cut -f1 -d ".")
+UP=$(echo "$UPDOWN" | awk "{ print \$2 }" | cut -f1 -d ".")
+
+DOWN_FORMAT=""
+if [ "$DOWN" -gt "999" ]; then
+	DOWN_FORMAT=$(echo "$DOWN" | awk '{ printf "%03.0f Mbps", $1 / 1000}')
+else
+	DOWN_FORMAT=$(echo "$DOWN" | awk '{ printf "%03.0f kbps", $1}')
+fi
+
+UP_FORMAT=""
+if [ "$UP" -gt "999" ]; then
+	UP_FORMAT=$(echo "$UP" | awk '{ printf "%03.0f Mbps", $1 / 1000}')
+else
+	UP_FORMAT=$(echo "$UP" | awk '{ printf "%03.0f kbps", $1}')
+fi
+
+sketchybar -m --set network.down label="$DOWN_FORMAT" icon.highlight=$(if [ "$DOWN" -gt "0" ]; then echo "on"; else echo "off"; fi) \
+	--set network.up label="$UP_FORMAT" icon.highlight=$(if [ "$UP" -gt "0" ]; then echo "on"; else echo "off"; fi)

--- a/tests/modules/programs/sketchybar/plugins/ram.sh
+++ b/tests/modules/programs/sketchybar/plugins/ram.sh
@@ -1,0 +1,1 @@
+sketchybar -m --set "$NAME" label="$(memory_pressure | grep "System-wide memory free percentage:" | awk '{ printf("%02.0f\n", 100-$5"%") }')%"

--- a/tests/modules/programs/sketchybar/script-path.nix
+++ b/tests/modules/programs/sketchybar/script-path.nix
@@ -1,0 +1,12 @@
+{
+  programs.sketchybar = {
+    enable = true;
+    sketchybarrc = ./sketchybarrc;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/sketchybar/sketchybarrc
+    assertFileContent home-files/.config/sketchybar/sketchybarrc \
+    ${./sketchybarrc}
+  '';
+}

--- a/tests/modules/programs/sketchybar/script-string.nix
+++ b/tests/modules/programs/sketchybar/script-string.nix
@@ -1,0 +1,16 @@
+{
+  programs.sketchybar = {
+    enable = true;
+    sketchybarrc = ''
+      PLUGIN_DIR="$CONFIG_DIR/plugins"
+
+      sketchybar --bar position=top height=40 blur_radius=30 color=0x40000000
+    '';
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/sketchybar/sketchybarrc
+    assertFileContent home-files/.config/sketchybar/sketchybarrc \
+    ${./sketchybarrc}
+  '';
+}

--- a/tests/modules/programs/sketchybar/sketchybarrc
+++ b/tests/modules/programs/sketchybar/sketchybarrc
@@ -1,0 +1,3 @@
+PLUGIN_DIR="$CONFIG_DIR/plugins"
+
+sketchybar --bar position=top height=40 blur_radius=30 color=0x40000000


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring Sketchybar. Closes #7017.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
