### PR TITLE
nix-darwin: use `launchctl asuser` to get correct Mach bootstrap context

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -19,7 +19,7 @@ in
       system.activationScripts.postActivation.text = lib.concatStringsSep "\n" (
         lib.mapAttrsToList (username: usercfg: ''
           echo Activating home-manager configuration for ${usercfg.home.username}
-          sudo -u ${usercfg.home.username} --set-home ${pkgs.writeShellScript "activation-${usercfg.home.username}" ''
+          launchctl asuser "$(id -u ${usercfg.home.username})" sudo -u ${usercfg.home.username} --set-home ${pkgs.writeShellScript "activation-${usercfg.home.username}" ''
             ${lib.optionalString (
               cfg.backupFileExtension != null
             ) "export HOME_MANAGER_BACKUP_EXT=${lib.escapeShellArg cfg.backupFileExtension}"}


### PR DESCRIPTION
### Description

This is important on multi-user systems for example:

```
{
  home-manager.users.user1.home.activation.setDefaultBrowser = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
    ${lib.getExe pkgs.defaultbrowser} firefox
  '';

  home-manager.users.user2.home.activation.setDefaultBrowser = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
    ${lib.getExe pkgs.defaultbrowser} chrome
  '';
}
```

If I run activation as `user1` then `user2`'s `defaultbrowser chrome` command will fail to work without the `launchctl asuser`.

See: https://github.com/nix-darwin/nix-darwin/pull/1341#discussion_r1989887502

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@khaneliman 