### PR TITLE
rclone: declarative mounts

### DIFF
--- a/tests/integration/standalone/rclone/default.nix
+++ b/tests/integration/standalone/rclone/default.nix
@@ -1,20 +1,36 @@
 { pkgs, ... }:
 
+let
+  sshKeys = import "${pkgs.path}/nixos/tests/ssh-keys.nix" pkgs;
+
+  baseMachine = extend: {
+    imports = [
+      "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix"
+      extend
+    ];
+    virtualisation.memorySize = 2048;
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
+    };
+  };
+in
 {
   name = "rclone";
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-      virtualisation.memorySize = 2048;
-      users.users.alice = {
-        isNormalUser = true;
-        description = "Alice Foobar";
-        password = "foobar";
-        uid = 1000;
-      };
+  nodes = {
+    machine = baseMachine { };
+
+    remote = baseMachine {
+      services.openssh.enable = true;
+
+      users.users.alice.openssh.authorizedKeys.keys = [
+        sshKeys.snakeOilEd25519PublicKey
+      ];
     };
+  };
 
   testScript = ''
     start_all()
@@ -36,8 +52,13 @@
     def alice_cmd(cmd):
       return f"su -l alice --shell /bin/sh -c $'export XDG_RUNTIME_DIR=/run/user/$UID ; {cmd}'"
 
-    def succeed_as_alice(*cmds):
-      return machine.succeed(*map(alice_cmd,cmds))
+    def succeed_as_alice(*cmds, box=machine):
+      return box.succeed(*map(alice_cmd,cmds))
+
+    def systemctl_succeed_as_alice(cmd):
+      status, out = machine.systemctl(cmd, "alice")
+      assert status == 0, f"failed to run systemctl {cmd}"
+      return out
 
     def fail_as_alice(*cmds):
       return machine.fail(*map(alice_cmd,cmds))
@@ -100,6 +121,65 @@
 
 
     # TODO: verify correct activation order with the agenix and sops hm modules
+
+    remote.wait_for_unit("network.target")
+    remote.wait_for_unit("multi-user.target")
+
+    with subtest("Mount a remote (sftp)"):
+      # https://rclone.org/commands/rclone_mount/#vfs-directory-cache
+      # Sending a SIGHUP evicts every dcache entry
+      def clear_vfs_dcache():
+        svc_name = "rclone-mount:.home.alice.files@alices-sftp-remote.service"
+        succeed_as_alice(f"kill -s HUP $(systemctl --user show -p MainPID --value {svc_name})")
+        succeed_as_alice(
+          "sync",
+          "sleep 5",
+          box=remote
+        )
+
+      succeed_as_alice(
+        "mkdir -p /home/alice/.ssh",
+        "install -m644 ${./mount.nix} /home/alice/.config/home-manager/test-remote.nix"
+      )
+
+      actual = succeed_as_alice("home-manager switch")
+      expected = "Activating createRcloneConfig"
+      assert expected in actual, \
+        f"expected home-manager switch to contain {expected}, but got {actual}"
+
+      # remote -> machine
+      succeed_as_alice(
+        "mkdir /home/alice/files",
+        "touch /home/alice/files/test",
+        "echo started > /home/alice/files/log",
+        box=remote
+      )
+
+      succeed_as_alice("ls /home/alice/remote-files/test")
+
+      test_log = succeed_as_alice("cat /home/alice/remote-files/log")
+      expected = "started";
+      assert expected in test_log, \
+        f"Mounted file does not have expected contents. Expected {test_log} to contain \"{expected}\""
+
+      # machine -> remote
+      succeed_as_alice(
+        "touch /home/alice/remote-files/new-file",
+        "echo testing this works both ways! >> /home/alice/remote-files/log",
+      )
+
+      clear_vfs_dcache()
+
+      succeed_as_alice("ls /home/alice/files/new-file", box=remote)
+
+      test_log = succeed_as_alice("cat /home/alice/files/log", box=remote)
+      expected = "testing this works both ways!"
+      assert expected in test_log, \
+        f"Mounted file does not have expected contents. Expected {test_log} to contain \"{expected}\""
+
+      expected = "started"
+      assert expected in test_log, \
+        f"Mounted file does not have expected contents. Expected {test_log} to contain \"{expected}\""
 
     logout_alice()
   '';

--- a/tests/integration/standalone/rclone/mount.nix
+++ b/tests/integration/standalone/rclone/mount.nix
@@ -1,0 +1,27 @@
+{ pkgs, lib, ... }:
+let
+  sshKeys = import "${pkgs.path}/nixos/tests/ssh-keys.nix" pkgs;
+in
+{
+  programs.rclone.remotes = {
+    alices-sftp-remote = {
+      config = {
+        type = "sftp";
+        host = "remote";
+        user = "alice";
+        # https://rclone.org/sftp/#ssh-authentication
+        key_pem = lib.pipe sshKeys.snakeOilEd25519PrivateKey.text [
+          lib.trim
+          (lib.replaceStrings [ "\n" ] [ "\\n" ])
+        ];
+        known_hosts = sshKeys.snakeOilEd25519PublicKey;
+      };
+      mounts = {
+        "/home/alice/files" = {
+          enable = true;
+          mountPoint = "/home/alice/remote-files";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
