### PR TITLE
emacs: respect `defaultEditor` on Darwin

### DIFF
--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -120,6 +120,14 @@ in
 
   config = mkIf cfg.enable (
     lib.mkMerge [
+      {
+        home.sessionVariables = mkIf cfg.defaultEditor {
+          EDITOR = lib.getBin (
+            pkgs.writeShellScript "editor" ''exec ${lib.getBin cfg.package}/bin/emacsclient "''${@:---create-frame}"''
+          );
+        };
+      }
+
       (mkIf pkgs.stdenv.isLinux {
         systemd.user.services.emacs =
           {
@@ -179,15 +187,7 @@ in
             };
           };
 
-        home = {
-          packages = optional cfg.client.enable (lib.hiPrio clientDesktopItem);
-
-          sessionVariables = mkIf cfg.defaultEditor {
-            EDITOR = lib.getBin (
-              pkgs.writeShellScript "editor" ''exec ${lib.getBin cfg.package}/bin/emacsclient "''${@:---create-frame}"''
-            );
-          };
-        };
+        home.packages = optional cfg.client.enable (lib.hiPrio clientDesktopItem);
       })
 
       (mkIf (cfg.socketActivation.enable && pkgs.stdenv.isLinux) {


### PR DESCRIPTION
### Description

Currently on Darwin, `services.emacs.defaultEditor = true` isn't respected, as the variable is only configured on Linux.

This PR simply moves the variable out to a common block, so it's applied on all platforms.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@tadfisher
