### PR TITLE
Add initial support for borgmatic on darwin

### DIFF
--- a/modules/lib/darwin.nix
+++ b/modules/lib/darwin.nix
@@ -1,0 +1,76 @@
+{ lib }:
+let
+  intervals = [
+    "hourly"
+    "daily"
+    "weekly"
+    "monthly"
+    "semiannually"
+    "annually"
+  ];
+
+  mkCalendarInterval =
+    frequency:
+    let
+      freq = {
+        "hourly" = [ { Minute = 0; } ];
+        "daily" = [
+          {
+            Hour = 0;
+            Minute = 0;
+          }
+        ];
+        "weekly" = [
+          {
+            Weekday = 1;
+            Hour = 0;
+            Minute = 0;
+          }
+        ];
+        "monthly" = [
+          {
+            Day = 1;
+            Hour = 0;
+            Minute = 0;
+          }
+        ];
+        "semiannually" = [
+          {
+            Month = 1;
+            Day = 1;
+            Hour = 0;
+            Minute = 0;
+          }
+          {
+            Month = 7;
+            Day = 1;
+            Hour = 0;
+            Minute = 0;
+          }
+        ];
+        "annually" = [
+          {
+            Month = 1;
+            Day = 1;
+            Hour = 0;
+            Minute = 0;
+          }
+        ];
+      };
+    in
+    freq.${frequency} or null;
+
+  intervalsString = lib.concatStringsSep ", " intervals;
+
+  assertInterval = option: interval: pkgs: {
+    assertion = (!pkgs.stdenv.isDarwin) || (lib.elem interval intervals);
+    message = "On Darwin ${option} must be one of: ${intervalsString}.";
+  };
+
+  intervalDocumentation = ''
+    On Darwin it must be one of: ${intervalsString}, which are implemented as defined in {manpage}`systemd.time(7)`.
+  '';
+in
+{
+  inherit mkCalendarInterval assertInterval intervalDocumentation;
+}

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -6,6 +6,7 @@ rec {
   assertions = import ./assertions.nix { inherit lib; };
 
   booleans = import ./booleans.nix { inherit lib; };
+  darwin = import ./darwin.nix { inherit lib; };
   deprecations = import ./deprecations.nix { inherit lib; };
   generators = import ./generators.nix { inherit lib; };
   gvariant = import ./gvariant.nix { inherit lib; };

--- a/modules/services/borgmatic.nix
+++ b/modules/services/borgmatic.nix
@@ -30,57 +30,57 @@ in
     };
   };
 
-  config = lib.mkIf serviceConfig.enable {
-    assertions = [
-      (lib.hm.assertions.assertPlatform "services.borgmatic" pkgs lib.platforms.linux)
-    ];
+  config = lib.mkIf serviceConfig.enable (
+    lib.mkMerge [
+      (lib.mkIf pkgs.stdenv.isLinux {
+        systemd.user = {
+          services.borgmatic = {
+            Unit = {
+              Description = "borgmatic backup";
+              # Prevent borgmatic from running unless the machine is
+              # plugged into power:
+              ConditionACPower = true;
+            };
+            Service = {
+              Type = "oneshot";
 
-    systemd.user = {
-      services.borgmatic = {
-        Unit = {
-          Description = "borgmatic backup";
-          # Prevent borgmatic from running unless the machine is
-          # plugged into power:
-          ConditionACPower = true;
+              # Lower CPU and I/O priority:
+              Nice = 19;
+              IOSchedulingClass = "best-effort";
+              IOSchedulingPriority = 7;
+              IOWeight = 100;
+
+              Restart = "no";
+              LogRateLimitIntervalSec = 0;
+
+              # Delay start to prevent backups running during boot:
+              ExecStartPre = "${pkgs.coreutils}/bin/sleep 3m";
+
+              ExecStart = ''
+                ${pkgs.systemd}/bin/systemd-inhibit \
+                  --who="borgmatic" \
+                  --what="sleep:shutdown" \
+                  --why="Prevent interrupting scheduled backup" \
+                  ${programConfig.package}/bin/borgmatic \
+                    --stats \
+                    --verbosity -1 \
+                    --list \
+                    --syslog-verbosity 1
+              '';
+            };
+          };
+
+          timers.borgmatic = {
+            Unit.Description = "Run borgmatic backup";
+            Timer = {
+              OnCalendar = serviceConfig.frequency;
+              Persistent = true;
+              RandomizedDelaySec = "10m";
+            };
+            Install.WantedBy = [ "timers.target" ];
+          };
         };
-        Service = {
-          Type = "oneshot";
-
-          # Lower CPU and I/O priority:
-          Nice = 19;
-          IOSchedulingClass = "best-effort";
-          IOSchedulingPriority = 7;
-          IOWeight = 100;
-
-          Restart = "no";
-          LogRateLimitIntervalSec = 0;
-
-          # Delay start to prevent backups running during boot:
-          ExecStartPre = "${pkgs.coreutils}/bin/sleep 3m";
-
-          ExecStart = ''
-            ${pkgs.systemd}/bin/systemd-inhibit \
-              --who="borgmatic" \
-              --what="sleep:shutdown" \
-              --why="Prevent interrupting scheduled backup" \
-              ${programConfig.package}/bin/borgmatic \
-                --stats \
-                --verbosity -1 \
-                --list \
-                --syslog-verbosity 1
-          '';
-        };
-      };
-
-      timers.borgmatic = {
-        Unit.Description = "Run borgmatic backup";
-        Timer = {
-          OnCalendar = serviceConfig.frequency;
-          Persistent = true;
-          RandomizedDelaySec = "10m";
-        };
-        Install.WantedBy = [ "timers.target" ];
-      };
-    };
-  };
+      })
+    ]
+  );
 }

--- a/modules/services/borgmatic.nix
+++ b/modules/services/borgmatic.nix
@@ -81,6 +81,27 @@ in
           };
         };
       })
+
+      (lib.mkIf pkgs.stdenv.isDarwin {
+        assertions = [
+          (lib.hm.darwin.assertInterval "services.borgmatic.frequency" serviceConfig.frequency pkgs)
+        ];
+
+        launchd.agents.borgmatic = {
+          enable = true;
+          config = {
+            ProgramArguments = [
+              (lib.getExe programConfig.package)
+              "--stats"
+              "--list"
+            ];
+            ProcessType = "Background";
+            StartCalendarInterval = lib.hm.darwin.mkCalendarInterval serviceConfig.frequency;
+            StandardOutPath = "${config.home.homeDirectory}/Library/Logs/borgmatic/launchd-stdout.log";
+            StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/borgmatic/launchd-stderr.log";
+          };
+        };
+      })
     ]
   );
 }

--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -66,7 +66,7 @@ let
         ];
       };
     in
-    freq.${frequency};
+    freq.${frequency} or null;
 
   nixPackage =
     if config.nix.enable && config.nix.package != null then config.nix.package else pkgs.nix;
@@ -95,7 +95,7 @@ in
 
           On Linux this is a string as defined by {manpage}`systemd.time(7)`.
 
-          On Darwin it must be one of: ${toString darwinIntervals}, which are
+          On Darwin it must be one of: ${lib.concatStringsSep ", " darwinIntervals}, which are
           implemented as defined in the manual page above.
         '';
       };
@@ -172,7 +172,7 @@ in
         assertions = [
           {
             assertion = lib.elem cfg.frequency darwinIntervals;
-            message = "On Darwin nix.gc.frequency must be one of: ${toString darwinIntervals}.";
+            message = "On Darwin nix.gc.frequency must be one of: ${lib.concatStringsSep ", " darwinIntervals}.";
           }
         ];
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -330,6 +330,7 @@ import nmtSrc {
       ./modules/launchd
       ./modules/programs/aerospace
       ./modules/programs/element-desktop/darwin.nix
+      ./modules/services/borgmatic-darwin
       ./modules/services/emacs-darwin
       ./modules/services/espanso-darwin
       ./modules/services/git-sync-darwin

--- a/tests/modules/services/borgmatic-darwin/basic-configuration.nix
+++ b/tests/modules/services/borgmatic-darwin/basic-configuration.nix
@@ -1,0 +1,14 @@
+{
+  services.borgmatic = {
+    enable = true;
+    frequency = "weekly";
+  };
+
+  nmt.script = ''
+    serviceFile=LaunchAgents/org.nix-community.home.borgmatic.plist
+
+    assertFileExists "$serviceFile"
+
+    assertFileContent "$serviceFile" ${./expected-agent.plist}
+  '';
+}

--- a/tests/modules/services/borgmatic-darwin/default.nix
+++ b/tests/modules/services/borgmatic-darwin/default.nix
@@ -1,0 +1,4 @@
+{
+  darwin-borgmatic-service-basic-configuration = ./basic-configuration.nix;
+  darwin-borgmatic-frequency-assertion = ./frequency-assertion.nix;
+}

--- a/tests/modules/services/borgmatic-darwin/expected-agent.plist
+++ b/tests/modules/services/borgmatic-darwin/expected-agent.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.nix-community.home.borgmatic</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>@borgmatic@/bin/borgmatic</string>
+		<string>--stats</string>
+		<string>--list</string>
+	</array>
+	<key>StandardErrorPath</key>
+	<string>/home/hm-user/Library/Logs/borgmatic/launchd-stderr.log</string>
+	<key>StandardOutPath</key>
+	<string>/home/hm-user/Library/Logs/borgmatic/launchd-stdout.log</string>
+	<key>StartCalendarInterval</key>
+	<array>
+		<dict>
+			<key>Hour</key>
+			<integer>0</integer>
+			<key>Minute</key>
+			<integer>0</integer>
+			<key>Weekday</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/tests/modules/services/borgmatic-darwin/frequency-assertion.nix
+++ b/tests/modules/services/borgmatic-darwin/frequency-assertion.nix
@@ -1,0 +1,10 @@
+{
+  services.borgmatic = {
+    enable = true;
+    frequency = "00:02:00";
+  };
+
+  test.asserts.assertions.expected = [
+    "On Darwin services.borgmatic.frequency must be one of: hourly, daily, weekly, monthly, semiannually, annually."
+  ];
+}

--- a/tests/modules/services/nix-gc-darwin/darwin-nix-gc-interval-assertion.nix
+++ b/tests/modules/services/nix-gc-darwin/darwin-nix-gc-interval-assertion.nix
@@ -1,0 +1,10 @@
+{
+  nix.gc = {
+    automatic = true;
+    frequency = "00:02:03";
+  };
+
+  test.asserts.assertions.expected = [
+    "On Darwin nix.gc.frequency must be one of: hourly, daily, weekly, monthly, semiannually, annually."
+  ];
+}

--- a/tests/modules/services/nix-gc-darwin/default.nix
+++ b/tests/modules/services/nix-gc-darwin/default.nix
@@ -1,1 +1,4 @@
-{ nix-gc = ./basic.nix; }
+{
+  nix-gc = ./basic.nix;
+  darwin-nix-gc-interval-assertion = ./darwin-nix-gc-interval-assertion.nix;
+}


### PR DESCRIPTION
### Description

On darwin, services.borgmatic should create a launchd agent.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->