### PR TITLE
Fix documentation of nix-gc

### DIFF
--- a/modules/services/borgmatic.nix
+++ b/modules/services/borgmatic.nix
@@ -25,6 +25,8 @@ in
           the onCalendar option. See
           {manpage}`systemd.time(7)`
           for more information about the format.
+
+          ${lib.hm.darwin.intervalDocumentation}
         '';
       };
     };

--- a/modules/services/nix-gc.nix
+++ b/modules/services/nix-gc.nix
@@ -36,7 +36,7 @@ in
 
           On Linux this is a string as defined by {manpage}`systemd.time(7)`.
 
-          $lib.hm.darwin.{intervalDocumentation}
+          ${lib.hm.darwin.intervalDocumentation}
         '';
       };
 


### PR DESCRIPTION
### Description

In https://github.com/nix-community/home-manager/pull/7066, a bug was introduced to the documentation of `nix.gc.frequency`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->