### PR TITLE
pgcli: init

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -333,6 +333,12 @@
     github = "msyds";
     githubId = 65362461;
   };
+  nickthegroot = {
+    name = "Nick DeGroot";
+    email = "nick@nickthegroot.com";
+    github = "nickthegroot";
+    githubId = 1966472;
+  };
   nikp123 = {
     name = "nikp123";
     email = "nikp123@users.noreply.github.com";

--- a/modules/misc/news/2025/05/2025-05-15_14-37-58.nix
+++ b/modules/misc/news/2025/05/2025-05-15_14-37-58.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-05-15T21:37:58+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.pgcli`
+
+    pgcli is a Python CLI that lets you connect to Postgres databases and run queries with syntax highlighting and auto-completion.
+  '';
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -226,6 +226,7 @@ let
       ./programs/pay-respects.nix
       ./programs/pazi.nix
       ./programs/pet.nix
+      ./programs/pgcli.nix
       ./programs/pidgin.nix
       ./programs/pistol.nix
       ./programs/piston-cli.nix

--- a/modules/programs/pgcli.nix
+++ b/modules/programs/pgcli.nix
@@ -1,0 +1,58 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+
+let
+
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    literalExpression
+    ;
+
+  iniFormat = pkgs.formats.ini { };
+  cfg = config.programs.pgcli;
+
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.nickthegroot ];
+
+  options.programs.pgcli = {
+    enable = mkEnableOption "pgcli";
+
+    package = mkPackageOption pkgs "pgcli" { nullable = true; };
+
+    settings = mkOption {
+      type = iniFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          main = {
+            smart_completion = true;
+            vi = true;
+          };
+
+          "named queries".simple = "select * from abc where a is not Null";
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/pgcli/config`.
+        See <https://www.pgcli.com/config>
+        for more information.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."pgcli/config" = lib.mkIf (cfg.settings != { }) {
+      source = iniFormat.generate "pgcli-config" cfg.settings;
+    };
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -266,6 +266,7 @@ import nmtSrc {
       ./modules/programs/papis
       ./modules/programs/pay-respects
       ./modules/programs/pet
+      ./modules/programs/pgcli
       ./modules/programs/pistol
       ./modules/programs/pls
       ./modules/programs/poetry

--- a/tests/modules/programs/pgcli/default.nix
+++ b/tests/modules/programs/pgcli/default.nix
@@ -1,0 +1,4 @@
+{
+  pgcli-example-settings = ./example-settings.nix;
+  pgcli-empty-settings = ./empty-settings.nix;
+}

--- a/tests/modules/programs/pgcli/empty-settings.nix
+++ b/tests/modules/programs/pgcli/empty-settings.nix
@@ -1,0 +1,7 @@
+{
+  programs.pgcli.enable = true;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/pgcli/config
+  '';
+}

--- a/tests/modules/programs/pgcli/example-settings.nix
+++ b/tests/modules/programs/pgcli/example-settings.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+
+let
+  expected = builtins.toFile "config" ''
+    [main]
+    vi=true
+  '';
+in
+{
+  programs.pgcli = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    settings = {
+      main.vi = true;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/pgcli/config
+    assertFileContent home-files/.config/pgcli/config '${expected}'
+  '';
+}


### PR DESCRIPTION
### Description

Init [`pgcli`](https://www.pgcli.com/) ([nixpkg](https://github.com/NixOS/nixpkgs/blob/75d6654eebd55b9264fbeac146e09f6726874c47/pkgs/development/python-modules/pgcli/default.nix)), allowing for simple configuration of the config through nix.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or `./format`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).