### PR TITLE
home-manager: add force option for gtk-2 config

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -169,6 +169,8 @@ in
             The location to put the GTK configuration file.
           '';
         };
+
+        force = lib.mkEnableOption "GTK 2 config force overwrite (workaround for bug #6188)";
       };
 
       gtk3 = {
@@ -294,10 +296,14 @@ in
         cfg.cursorTheme
       ];
 
-      home.file.${cfg2.configLocation}.text =
-        lib.concatMapStrings (l: l + "\n") (lib.mapAttrsToList formatGtk2Option gtkIni)
-        + cfg2.extraConfig
-        + "\n";
+      home.file.${cfg2.configLocation} = {
+        text =
+          lib.concatMapStrings (l: l + "\n") (lib.mapAttrsToList formatGtk2Option gtkIni)
+          + cfg2.extraConfig
+          + "\n";
+
+        force = cfg2.force;
+      };
 
       home.sessionVariables.GTK2_RC_FILES = cfg2.configLocation;
 

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -170,7 +170,7 @@ in
           '';
         };
 
-        force = lib.mkEnableOption "GTK 2 config force overwrite (workaround for bug #6188)";
+        force = lib.mkEnableOption "GTK 2 config force overwrite without creating a backup";
       };
 
       gtk3 = {

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -302,7 +302,7 @@ in
           + cfg2.extraConfig
           + "\n";
 
-        force = cfg2.force;
+        inherit (cfg2) force
       };
 
       home.sessionVariables.GTK2_RC_FILES = cfg2.configLocation;

--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -302,7 +302,7 @@ in
           + cfg2.extraConfig
           + "\n";
 
-        inherit (cfg2) force
+        inherit (cfg2) force;
       };
 
       home.sessionVariables.GTK2_RC_FILES = cfg2.configLocation;


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
This adds `gtk.gtk2.force` enable option which maps directly onto `home.files.${cfg2.configLocation}.force` to allow overwrite of the `gtkrc-2.0` file (workaround for bug #6188).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@rycee 