### PR TITLE
New option `home.file.<name>.mode` copies instead of symlinks

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -138,68 +138,16 @@ in
     # source and target generation.
     home.activation.linkGeneration = lib.hm.dag.entryAfter [ "writeBoundary" ] (
       let
-        link = pkgs.writeShellScript "link" ''
-          ${config.lib.bash.initHomeManagerLib}
+        link = pkgs.replaceVars ./files/link.sh {
+          inherit (config.lib.bash) initHomeManagerLib;
+        };
 
-          newGenFiles="$1"
-          shift
-          for sourcePath in "$@" ; do
-            relativePath="''${sourcePath#$newGenFiles/}"
-            targetPath="$HOME/$relativePath"
-            if [[ -e "$targetPath" && ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
-              # The target exists, back it up
-              backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
-              run mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
-            fi
+        storeDir = lib.escapeShellArg builtins.storeDir;
 
-            if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath" ; then
-              # The target exists but is identical – don't do anything.
-              verboseEcho "Skipping '$targetPath' as it is identical to '$sourcePath'"
-            else
-              # Place that symlink, --force
-              # This can still fail if the target is a directory, in which case we bail out.
-              run mkdir -p $VERBOSE_ARG "$(dirname "$targetPath")"
-              run ln -Tsf $VERBOSE_ARG "$sourcePath" "$targetPath" || exit 1
-            fi
-          done
-        '';
-
-        cleanup = pkgs.writeShellScript "cleanup" ''
-          ${config.lib.bash.initHomeManagerLib}
-
-          # A symbolic link whose target path matches this pattern will be
-          # considered part of a Home Manager generation.
-          homeFilePattern="$(readlink -e ${lib.escapeShellArg builtins.storeDir})/*-home-manager-files/*"
-
-          newGenFiles="$1"
-          shift 1
-          for relativePath in "$@" ; do
-            targetPath="$HOME/$relativePath"
-            if [[ -e "$newGenFiles/$relativePath" ]] ; then
-              verboseEcho "Checking $targetPath: exists"
-            elif [[ ! "$(readlink "$targetPath")" == $homeFilePattern ]] ; then
-              warnEcho "Path '$targetPath' does not link into a Home Manager generation. Skipping delete."
-            else
-              verboseEcho "Checking $targetPath: gone (deleting)"
-              run rm $VERBOSE_ARG "$targetPath"
-
-              # Recursively delete empty parent directories.
-              targetDir="$(dirname "$relativePath")"
-              if [[ "$targetDir" != "." ]] ; then
-                pushd "$HOME" > /dev/null
-
-                # Call rmdir with a relative path excluding $HOME.
-                # Otherwise, it might try to delete $HOME and exit
-                # with a permission error.
-                run rmdir $VERBOSE_ARG \
-                    -p --ignore-fail-on-non-empty \
-                    "$targetDir"
-
-                popd > /dev/null
-              fi
-            fi
-          done
-        '';
+        cleanup = pkgs.replaceVars ./files/cleanup.sh {
+          inherit (config.lib.bash) initHomeManagerLib;
+          inherit storeDir;
+        };
       in
       ''
         function linkNewGen() {
@@ -280,93 +228,34 @@ in
 
     # Symlink directories and files that have the right execute bit.
     # Copy files that need their execute bit changed.
-    home-files =
-      pkgs.runCommandLocal "home-manager-files"
-        {
-          nativeBuildInputs = [ pkgs.xorg.lndir ];
-        }
-        (
-          ''
-            mkdir -p $out
-
-            # Needed in case /nix is a symbolic link.
-            realOut="$(realpath -m "$out")"
-
-            function insertFile() {
-              local source="$1"
-              local relTarget="$2"
-              local executable="$3"
-              local recursive="$4"
-              local ignorelinks="$5"
-
-              # If the target already exists then we have a collision. Note, this
-              # should not happen due to the assertion found in the 'files' module.
-              # We therefore simply log the conflict and otherwise ignore it, mainly
-              # to make the `files-target-config` test work as expected.
-              if [[ -e "$realOut/$relTarget" ]]; then
-                echo "File conflict for file '$relTarget'" >&2
-                return
-              fi
-
-              # Figure out the real absolute path to the target.
-              local target
-              target="$(realpath -m "$realOut/$relTarget")"
-
-              # Target path must be within $HOME.
-              if [[ ! $target == $realOut* ]] ; then
-                echo "Error installing file '$relTarget' outside \$HOME" >&2
-                exit 1
-              fi
-
-              mkdir -p "$(dirname "$target")"
-              if [[ -d $source ]]; then
-                if [[ $recursive ]]; then
-                  mkdir -p "$target"
-                  if [[ $ignorelinks ]]; then
-                    lndir -silent -ignorelinks "$source" "$target"
-                  else
-                    lndir -silent "$source" "$target"
-                  fi
-                else
-                  ln -s "$source" "$target"
-                fi
-              else
-                [[ -x $source ]] && isExecutable=1 || isExecutable=""
-
-                # Link the file into the home file directory if possible,
-                # i.e., if the executable bit of the source is the same we
-                # expect for the target. Otherwise, we copy the file and
-                # set the executable bit to the expected value.
-                if [[ $executable == inherit || $isExecutable == $executable ]]; then
-                  ln -s "$source" "$target"
-                else
-                  cp "$source" "$target"
-
-                  if [[ $executable == inherit ]]; then
-                    # Don't change file mode if it should match the source.
-                    :
-                  elif [[ $executable ]]; then
-                    chmod +x "$target"
-                  else
-                    chmod -x "$target"
-                  fi
-                fi
-              fi
-            }
-          ''
-          + lib.concatStrings (
-            lib.mapAttrsToList (n: v: ''
-              insertFile ${
-                lib.escapeShellArgs [
-                  (sourceStorePath v)
-                  v.target
-                  (if v.executable == null then "inherit" else toString v.executable)
-                  (toString v.recursive)
-                  (toString v.ignorelinks)
-                ]
-              }
-            '') cfg
-          )
-        );
+    home-files = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
+      name = "home-manager-files";
+      enableParallelBuilding = true;
+      preferLocalBuild = true;
+      allowSubstitutes = false;
+      nativeBuildInputs = [ pkgs.xorg.lndir ];
+      PATH = lib.makeBinPath finalAttrs.nativeBuildInputs;
+      passAsFile = [
+        "buildCommand"
+        "insertFiles"
+      ];
+      buildCommand = ./files/home-manager-files.sh;
+      insertFiles = lib.concatStrings (
+        lib.mapAttrsToList (n: v: ''
+          insertFile ${
+            lib.escapeShellArgs [
+              (sourceStorePath v)
+              v.target
+              (if v.executable == null then "inherit" else toString v.executable)
+              (toString v.recursive)
+              (toString v.ignorelinks)
+            ]
+          }
+        '') cfg
+      );
+      checkPhase = ''
+        ${pkgs.stdenvNoCC.shellDryRun} "$target"
+      '';
+    });
   };
 }

--- a/modules/files/cleanup.sh
+++ b/modules/files/cleanup.sh
@@ -1,0 +1,36 @@
+# -*- mode: sh; sh-shell: bash -*-
+
+@initHomeManagerLib@
+
+# A symbolic link whose target path matches this pattern will be
+# considered part of a Home Manager generation.
+homeFilePattern="$(readlink -e @storeDir@)/*-home-manager-files/*"
+
+newGenFiles="$1"
+shift 1
+for relativePath in "$@" ; do
+  targetPath="$HOME/$relativePath"
+  if [[ -e "$newGenFiles/$relativePath" ]] ; then
+    verboseEcho "Checking $targetPath: exists"
+  elif [[ ! "$(readlink "$targetPath")" == $homeFilePattern ]] ; then
+    warnEcho "Path '$targetPath' does not link into a Home Manager generation. Skipping delete."
+  else
+    verboseEcho "Checking $targetPath: gone (deleting)"
+    run rm $VERBOSE_ARG "$targetPath"
+
+    # Recursively delete empty parent directories.
+    targetDir="$(dirname "$relativePath")"
+    if [[ "$targetDir" != "." ]] ; then
+      pushd "$HOME" > /dev/null
+
+      # Call rmdir with a relative path excluding $HOME.
+      # Otherwise, it might try to delete $HOME and exit
+      # with a permission error.
+      run rmdir $VERBOSE_ARG \
+          -p --ignore-fail-on-non-empty \
+          "$targetDir"
+
+      popd > /dev/null
+    fi
+  fi
+done

--- a/modules/files/home-manager-files.sh
+++ b/modules/files/home-manager-files.sh
@@ -1,0 +1,70 @@
+# -*- mode: sh; sh-shell: bash -*-
+
+mkdir -p $out
+
+# Needed in case /nix is a symbolic link.
+realOut="$(realpath -m "$out")"
+
+function insertFile() {
+  local source="$1"
+  local relTarget="$2"
+  local executable="$3"
+  local recursive="$4"
+  local ignorelinks="$5"
+
+  # If the target already exists then we have a collision. Note, this
+  # should not happen due to the assertion found in the 'files' module.
+  # We therefore simply log the conflict and otherwise ignore it, mainly
+  # to make the `files-target-config` test work as expected.
+  if [[ -e "$realOut/$relTarget" ]]; then
+    echo "File conflict for file '$relTarget'" >&2
+    return
+  fi
+
+  # Figure out the real absolute path to the target.
+  local target
+  target="$(realpath -m "$realOut/$relTarget")"
+
+  # Target path must be within $HOME.
+  if [[ ! $target == $realOut* ]] ; then
+    echo "Error installing file '$relTarget' outside \$HOME" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$target")"
+  if [[ -d $source ]]; then
+    if [[ $recursive ]]; then
+      mkdir -p "$target"
+      if [[ $ignorelinks ]]; then
+        lndir -silent -ignorelinks "$source" "$target"
+      else
+        lndir -silent "$source" "$target"
+      fi
+    else
+      ln -s "$source" "$target"
+    fi
+  else
+    [[ -x $source ]] && isExecutable=1 || isExecutable=""
+
+    # Link the file into the home file directory if possible,
+    # i.e., if the executable bit of the source is the same we
+    # expect for the target. Otherwise, we copy the file and
+    # set the executable bit to the expected value.
+    if [[ $executable == inherit || $isExecutable == $executable ]]; then
+      ln -s "$source" "$target"
+    else
+      cp "$source" "$target"
+
+      if [[ $executable == inherit ]]; then
+        # Don't change file mode if it should match the source.
+        :
+      elif [[ $executable ]]; then
+        chmod +x "$target"
+      else
+        chmod -x "$target"
+      fi
+    fi
+  fi
+}
+
+source "$insertFilesPath"

--- a/modules/files/link.sh
+++ b/modules/files/link.sh
@@ -1,0 +1,25 @@
+# -*- mode: sh; sh-shell: bash -*-
+
+@initHomeManagerLib@
+
+newGenFiles="$1"
+shift
+for sourcePath in "$@" ; do
+  relativePath="${sourcePath#$newGenFiles/}"
+  targetPath="$HOME/$relativePath"
+  if [[ -e "$targetPath" && ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
+    # The target exists, back it up
+    backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
+    run mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
+  fi
+
+  if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath" ; then
+    # The target exists but is identical – don't do anything.
+    verboseEcho "Skipping '$targetPath' as it is identical to '$sourcePath'"
+  else
+    # Place that symlink, --force
+    # This can still fail if the target is a directory, in which case we bail out.
+    run mkdir -p $VERBOSE_ARG "$(dirname "$targetPath")"
+    run ln -Tsf $VERBOSE_ARG "$sourcePath" "$targetPath" || exit 1
+  fi
+done

--- a/modules/files/link.sh
+++ b/modules/files/link.sh
@@ -2,24 +2,84 @@
 
 @initHomeManagerLib@
 
+@modes@
+
+function getMode() {
+  local path="$1"
+  local mode="${modes["$path"]}"
+
+  if [[ -n $mode && $mode != symlink ]]; then
+    echo "$mode"
+  fi
+}
+
+function isCopiedSubPath() {
+  local path="$1"
+
+  for modePath in "${!modes[@]}"; do
+    if [[ $path == "$modePath" ]]; then
+      return 1
+    fi
+  done
+
+  for modePath in "${!modes[@]}"; do
+    if [[ $path == "$modePath"* ]]; then
+      local mode
+      mode="$(getMode "$modePath")"
+
+      if [[ -z $mode ]]; then
+        return 1
+      else
+        return 0
+      fi
+    fi
+  done
+
+  errorEcho "'$path' does not mach a modePath nor is it a subpath of any modePath"
+  exit 1
+}
+
 newGenFiles="$1"
-shift
+oldGenFiles="$2"
+shift 2
 for sourcePath in "$@" ; do
   relativePath="${sourcePath#$newGenFiles/}"
   targetPath="$HOME/$relativePath"
-  if [[ -e "$targetPath" && ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
-    # The target exists, back it up
-    backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
-    run mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
+  oldSourcePath="$oldGenFiles/$relativePath"
+  mode="$(getMode "$relativePath")"
+
+  if isCopiedSubPath "$relativePath"; then
+    continue
   fi
 
-  if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath" ; then
+  # The target exists, and
+  if [[ -e "$targetPath" && ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" &&
+        # should not be copied, or
+        (-z $mode ||
+           # is not identical to source, and
+           (! $(cmp -s "$sourcePath" "$targetPath") &&
+             # there's no old version, or
+             (! -e "$oldSourcePath" ||
+              # it's not equal to the old version either
+              ! $(cmp -s "$oldSourcePath" "$targetPath")))) ]] ; then
+    # back it up
+    backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
+    run mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Backup: Moving '$targetPath' failed!"
+  fi
+
+  if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath"; then
     # The target exists but is identical – don't do anything.
     verboseEcho "Skipping '$targetPath' as it is identical to '$sourcePath'"
-  else
+  elif [[ -z $mode ]]; then
     # Place that symlink, --force
     # This can still fail if the target is a directory, in which case we bail out.
     run mkdir -p $VERBOSE_ARG "$(dirname "$targetPath")"
     run ln -Tsf $VERBOSE_ARG "$sourcePath" "$targetPath" || exit 1
+  else
+    # Copy that file, --force
+    # This can still fail if the target is a directory, in which case we bail out.
+    run mkdir -p $VERBOSE_ARG "$(dirname "$targetPath")"
+    run cp -TLf $VERBOSE_ARG "$sourcePath" "$targetPath" || exit 1
+    run chmod $VERBOSE_ARG $mode "$targetPath"
   fi
 done

--- a/modules/lib/file-type.nix
+++ b/modules/lib/file-type.nix
@@ -138,6 +138,17 @@ in
                 link.
               '';
             };
+
+            mode = mkOption {
+              type = types.str;
+              default = "symlink";
+              example = "0600";
+              description = ''
+                If set to something else than `symlink`,
+                the file is copied instead of symlinked, with the given
+                file mode.
+              '';
+            };
           };
 
           config = {

--- a/modules/programs/browserpass.nix
+++ b/modules/programs/browserpass.nix
@@ -38,49 +38,41 @@ in
           let
             dir =
               if isDarwin then
-                "Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+                "Library/Application Support/BraveSoftware/Brave-Browser"
               else
-                ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts";
+                ".config/BraveSoftware/Brave-Browser";
           in
           [
             {
               # Policies are read from `/etc/brave/policies` only
               # https://github.com/brave/brave-browser/issues/19052
-              "${dir}/com.github.browserpass.native.json".source =
+              "${dir}/NativeMessagingHosts/com.github.browserpass.native.json".source =
                 "${pkgs.browserpass}/lib/browserpass/hosts/chromium/com.github.browserpass.native.json";
             }
           ]
         else if x == "chrome" then
           let
-            dir =
-              if isDarwin then
-                "Library/Application Support/Google/Chrome/NativeMessagingHosts"
-              else
-                ".config/google-chrome/NativeMessagingHosts";
+            dir = if isDarwin then "Library/Application Support/Google/Chrome" else ".config/google-chrome";
           in
           [
             {
-              "${dir}/com.github.browserpass.native.json".source =
+              "${dir}/NativeMessagingHosts/com.github.browserpass.native.json".source =
                 "${pkgs.browserpass}/lib/browserpass/hosts/chromium/com.github.browserpass.native.json";
-              "${dir}/../policies/managed/com.github.browserpass.native.json".source =
+              "${dir}/policies/managed/com.github.browserpass.native.json".source =
                 "${pkgs.browserpass}/lib/browserpass/policies/chromium/com.github.browserpass.native.json";
             }
           ]
         else if x == "chromium" then
           let
-            dir =
-              if isDarwin then
-                "Library/Application Support/Chromium/NativeMessagingHosts"
-              else
-                ".config/chromium/NativeMessagingHosts";
+            dir = if isDarwin then "Library/Application Support/Chromium" else ".config/chromium";
           in
           [
             {
-              "${dir}/com.github.browserpass.native.json".source =
+              "${dir}/NativeMessagingHosts/com.github.browserpass.native.json".source =
                 "${pkgs.browserpass}/lib/browserpass/hosts/chromium/com.github.browserpass.native.json";
             }
             {
-              "${dir}/../policies/managed/com.github.browserpass.native.json".source =
+              "${dir}/policies/managed/com.github.browserpass.native.json".source =
                 "${pkgs.browserpass}/lib/browserpass/policies/chromium/com.github.browserpass.native.json";
             }
           ]
@@ -115,17 +107,13 @@ in
 
         else if x == "vivaldi" then
           let
-            dir =
-              if isDarwin then
-                "Library/Application Support/Vivaldi/NativeMessagingHosts"
-              else
-                ".config/vivaldi/NativeMessagingHosts";
+            dir = if isDarwin then "Library/Application Support/Vivaldi" else ".config/vivaldi";
           in
           [
             {
-              "${dir}/com.github.browserpass.native.json".source =
+              "${dir}/NativeMessagingHosts/com.github.browserpass.native.json".source =
                 "${pkgs.browserpass}/lib/browserpass/hosts/chromium/com.github.browserpass.native.json";
-              "${dir}/../policies/managed/com.github.browserpass.native.json".source =
+              "${dir}/policies/managed/com.github.browserpass.native.json".source =
                 "${pkgs.browserpass}/lib/browserpass/policies/chromium/com.github.browserpass.native.json";
             }
           ]


### PR DESCRIPTION
### Description

Add an option `home.file.<name>.mode` that allows copy instead of linking and permission setting.

Fixes #3090.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

#### Maintainer CC

@rycee @khaneliman 
