### PR TITLE
direnv: Fix `default` syntax for nushell integration

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -195,7 +195,7 @@ in
                         | merge ($env.ENV_CONVERSIONS? | default {})
                         | get -i $key
                         | get -i from_string
-                        | default {|x| $x}
+                        | if ($in | is-empty) { {|x| $x} } else { $in }
                     ) $value
                     return [ $key $value ]
                 }


### PR DESCRIPTION
### Description

I'm running nightly nushell, where, after https://github.com/nushell/nushell/pull/15654, the direnv integration fails due to `default` behaving differently when passing a closure. 

![image](https://github.com/user-attachments/assets/f0da85da-f44a-4fd4-ad32-12ff83250245)

The fix is more verbose and less idiomatic than the original code, but keeping it that way would require a version check, something like this:

```nix
''
# ...
| default ${
    if (lib.versionAtLeast config.programs.nushell.package.version "0.104.1") then
    "{ {|x| $x} }"
    else
    "{|x| $x}"
    }
# ...
''
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@khaneliman @rycee @shikanime 
