### PR TITLE
[Backport release-24.11] yazi: add main.lua support to plugins (#6394)

### DIFF
--- a/modules/programs/yazi.nix
+++ b/modules/programs/yazi.nix
@@ -265,8 +265,12 @@ in {
                 toString missingFiles
               }";
             singularOpt = removeSuffix "s" opt;
+            isPluginValid = opt == "plugins"
+              && (any (file: pathExists "${value}/${file}") requiredFiles);
+            isValid =
+              if opt == "plugins" then isPluginValid else missingFiles == [ ];
           in {
-            assertion = isDir && missingFiles == [ ];
+            assertion = isDir && isValid;
             message = ''
               Value at `programs.yazi.${opt}.${name}` is not a valid yazi ${singularOpt}.
               ${msgNotDir}
@@ -281,6 +285,6 @@ in {
       "preview.png"
       "LICENSE"
       "LICENSE-tmtheme"
-    ]) ++ (mkAsserts "plugins" [ "init.lua" ]);
+    ]) ++ (mkAsserts "plugins" [ "init.lua" "main.lua" ]);
   };
 }


### PR DESCRIPTION
Yazi is deprecating init.lua for main.lua usages. This adds support for main.lua in plugins.

(cherry picked from commit 18fa9f323d8adbb0b7b8b98a8488db308210ed93)

### Description
Closes https://github.com/nix-community/home-manager/issues/7088
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or `./format`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
