### PR TITLE
sway: add bindswitches option

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -408,8 +408,8 @@ let
                 bindsymArgs = lib.optionalString (cfg.config.bindkeysToCode) "--to-code";
               })
               (keycodebindingsStr keycodebindings)
-              (bindswitchesStr bindswitches)
             ]
+            ++ optional (builtins.attrNames bindswitches != [ ]) (bindswitchesStr bindswitches)
             ++ mapAttrsToList inputStr input
             ++ mapAttrsToList outputStr output # outputs
             ++ mapAttrsToList seatStr seat # seats

--- a/tests/modules/services/window-managers/sway/default.nix
+++ b/tests/modules/services/window-managers/sway/default.nix
@@ -1,6 +1,7 @@
 {
   sway-bar-focused-colors = ./sway-bar-focused-colors.nix;
   sway-bindkeys-to-code-and-extra-config = ./sway-bindkeys-to-code-and-extra-config.nix;
+  sway-bindswitches = ./sway-bindswitches.nix;
   sway-default = ./sway-default.nix;
   sway-followmouse = ./sway-followmouse.nix;
   sway-followmouse-legacy = ./sway-followmouse-legacy.nix;

--- a/tests/modules/services/window-managers/sway/sway-bindswitches.conf
+++ b/tests/modules/services/window-managers/sway/sway-bindswitches.conf
@@ -1,0 +1,110 @@
+font pango:monospace 8.000000
+floating_modifier Mod1
+default_border pixel 2
+default_floating_border pixel 2
+hide_edge_borders none
+focus_wrapping no
+focus_follows_mouse yes
+focus_on_window_activation smart
+mouse_warping output
+workspace_layout default
+workspace_auto_back_and_forth no
+client.focused #4c7899 #285577 #ffffff #2e9ef4 #285577
+client.focused_inactive #333333 #5f676a #ffffff #484e50 #5f676a
+client.unfocused #333333 #222222 #888888 #292d2e #222222
+client.urgent #2f343a #900000 #ffffff #900000 #900000
+client.placeholder #000000 #0c0c0c #ffffff #000000 #0c0c0c
+client.background #ffffff
+
+bindsym Mod1+0 workspace number 10
+bindsym Mod1+1 workspace number 1
+bindsym Mod1+2 workspace number 2
+bindsym Mod1+3 workspace number 3
+bindsym Mod1+4 workspace number 4
+bindsym Mod1+5 workspace number 5
+bindsym Mod1+6 workspace number 6
+bindsym Mod1+7 workspace number 7
+bindsym Mod1+8 workspace number 8
+bindsym Mod1+9 workspace number 9
+bindsym Mod1+Down focus down
+bindsym Mod1+Left focus left
+bindsym Mod1+Return exec @foot@/bin/foot
+bindsym Mod1+Right focus right
+bindsym Mod1+Shift+0 move container to workspace number 10
+bindsym Mod1+Shift+1 move container to workspace number 1
+bindsym Mod1+Shift+2 move container to workspace number 2
+bindsym Mod1+Shift+3 move container to workspace number 3
+bindsym Mod1+Shift+4 move container to workspace number 4
+bindsym Mod1+Shift+5 move container to workspace number 5
+bindsym Mod1+Shift+6 move container to workspace number 6
+bindsym Mod1+Shift+7 move container to workspace number 7
+bindsym Mod1+Shift+8 move container to workspace number 8
+bindsym Mod1+Shift+9 move container to workspace number 9
+bindsym Mod1+Shift+Down move down
+bindsym Mod1+Shift+Left move left
+bindsym Mod1+Shift+Right move right
+bindsym Mod1+Shift+Up move up
+bindsym Mod1+Shift+c reload
+bindsym Mod1+Shift+e exec swaynag -t warning -m 'You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.' -b 'Yes, exit sway' 'swaymsg exit'
+bindsym Mod1+Shift+h move left
+bindsym Mod1+Shift+j move down
+bindsym Mod1+Shift+k move up
+bindsym Mod1+Shift+l move right
+bindsym Mod1+Shift+minus move scratchpad
+bindsym Mod1+Shift+q kill
+bindsym Mod1+Shift+space floating toggle
+bindsym Mod1+Up focus up
+bindsym Mod1+a focus parent
+bindsym Mod1+b splith
+bindsym Mod1+d exec @dmenu@/bin/dmenu_run
+bindsym Mod1+e layout toggle split
+bindsym Mod1+f fullscreen toggle
+bindsym Mod1+h focus left
+bindsym Mod1+j focus down
+bindsym Mod1+k focus up
+bindsym Mod1+l focus right
+bindsym Mod1+minus scratchpad show
+bindsym Mod1+r mode resize
+bindsym Mod1+s layout stacking
+bindsym Mod1+space focus mode_toggle
+bindsym Mod1+v splitv
+bindsym Mod1+w layout tabbed
+
+bindswitch  lid:on exec echo "Lid moved"
+bindswitch --locked --reload  tablet:on exec echo "Lid moved"
+mode "resize" {
+  bindsym Down resize grow height 10 px
+  bindsym Escape mode default
+  bindsym Left resize shrink width 10 px
+  bindsym Return mode default
+  bindsym Right resize grow width 10 px
+  bindsym Up resize shrink height 10 px
+  bindsym h resize shrink width 10 px
+  bindsym j resize grow height 10 px
+  bindsym k resize shrink height 10 px
+  bindsym l resize grow width 10 px
+}
+
+bar {
+  font pango:monospace 8.000000
+  mode dock
+  hidden_state hide
+  position bottom
+  status_command @i3status@/bin/i3status
+  swaybar_command @sway@/bin/swaybar
+  workspace_buttons yes
+  strip_workspace_numbers no
+  tray_output *
+  colors {
+    background #000000
+    statusline #ffffff
+    separator #666666
+    focused_workspace #4c7899 #285577 #ffffff
+    active_workspace #333333 #5f676a #ffffff
+    inactive_workspace #333333 #222222 #888888
+    urgent_workspace #2f343a #900000 #ffffff
+    binding_mode #2f343a #900000 #ffffff
+  }
+}
+
+exec "@dbus@/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY SWAYSOCK XDG_CURRENT_DESKTOP XDG_SESSION_TYPE NIXOS_OZONE_WL XCURSOR_THEME XCURSOR_SIZE; systemctl --user reset-failed && systemctl --user start sway-session.target && swaymsg -mt subscribe '[]' || true && systemctl --user stop sway-session.target"

--- a/tests/modules/services/window-managers/sway/sway-bindswitches.nix
+++ b/tests/modules/services/window-managers/sway/sway-bindswitches.nix
@@ -1,0 +1,30 @@
+{ config, pkgs, ... }:
+
+{
+  home.enableNixpkgsReleaseCheck = false;
+  wayland.windowManager.sway = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@sway@"; };
+    checkConfig = false;
+    # overriding findutils causes issues
+    config.menu = "${pkgs.dmenu}/bin/dmenu_run";
+    config = {
+      bindswitches = {
+        "lid:on" = {
+          action = ''exec echo "Lid moved"'';
+        };
+        "tablet:on" = {
+          action = ''exec echo "Lid moved"'';
+          reload = true;
+          locked = true;
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/sway/config
+    assertFileContent home-files/.config/sway/config \
+      ${./sway-bindswitches.conf}
+  '';
+}


### PR DESCRIPTION
### Description

Adds the bindswitches option to the sway module.

Bindswitches allows you to run a sway command when a state changes (when a certain event occurs).
See https://github.com/swaywm/sway/wiki#clamshell-mode and sway(5) for more information

It was already possible to configure this through sway.extraConfig but I find this approach dirty as described by the [Nix RFC 42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md#part-1), and there is currently no settings as it describes.

- I copied the documentation from the man page, it should be fine in terms of license because sway is also using MIT
- This is my first contribution to Home Manager, so I'm not sure this is the right way to do it, but it works
- I tested this PR on my nixos configuration, and it works fine, see this [part](https://github.com/Eldolfin/nixos-config/blob/main/homes/oscar/pkgs/sway/default.nix#L126) for a real world usage: I execute swaylock when my laptop's lid is closed
- ~My added test passes, but I couldn't run all the tests as I'm getting the following error and I'm not sure what to do about it~
	```
     > -  Home Manager version 25.11 and
     > -  Nixpkgs version 25.05.
	 ```
    works with non flake version

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- ~If this PR adds a new module~

  - ~[ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).~

#### Maintainer CC

@Scrumplex @alexarice @sumnerevans @oxalica 