### PR TITLE
Add support for darwin to services.home-manager.autoExpire

### DIFF
--- a/modules/services/home-manager-auto-expire.nix
+++ b/modules/services/home-manager-auto-expire.nix
@@ -55,6 +55,8 @@ in
           as the `OnCalendar` option.
 
           The format is described in {manpage}`systemd.time(7)`.
+
+          ${lib.hm.darwin.intervalDocumentation}
         '';
       };
 
@@ -101,6 +103,23 @@ in
             Unit.Description = "Home Manager expire generations";
 
             Service.ExecStart = toString script;
+          };
+        };
+      })
+
+      (lib.mkIf pkgs.stdenv.isDarwin {
+        assertions = [
+          (lib.hm.darwin.assertInterval "services.home-manager.autoExpire.frequency" cfg.frequency pkgs)
+        ];
+
+        launchd.agents.home-manager-auto-expire = {
+          enable = true;
+          config = {
+            ProgramArguments = [ (toString script) ];
+            ProcessType = "Background";
+            StartCalendarInterval = lib.hm.darwin.mkCalendarInterval cfg.frequency;
+            StandardOutPath = "${config.home.homeDirectory}/Library/Logs/home-manager-auto-expire/launchd-stdout.log";
+            StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/home-manager-auto-expire/launchd-stderr.log";
           };
         };
       })

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -335,6 +335,7 @@ import nmtSrc {
       ./modules/services/emacs-darwin
       ./modules/services/espanso-darwin
       ./modules/services/git-sync-darwin
+      ./modules/services/home-manager-auto-expire-darwin
       ./modules/services/imapnotify-darwin
       ./modules/services/jankyborders
       ./modules/services/macos-remap-keys

--- a/tests/modules/services/home-manager-auto-expire-darwin/basic-configuration.nix
+++ b/tests/modules/services/home-manager-auto-expire-darwin/basic-configuration.nix
@@ -1,0 +1,14 @@
+{
+  services.home-manager.autoExpire = {
+    enable = true;
+    frequency = "weekly";
+  };
+
+  nmt.script = ''
+    serviceFile=LaunchAgents/org.nix-community.home.home-manager-auto-expire.plist
+    assertFileExists "$serviceFile"
+
+    serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+    assertFileContent "$serviceFileNormalized" ${./expected-agent.plist}
+  '';
+}

--- a/tests/modules/services/home-manager-auto-expire-darwin/default.nix
+++ b/tests/modules/services/home-manager-auto-expire-darwin/default.nix
@@ -1,0 +1,4 @@
+{
+  darwin-home-manager-autoExpire-service-basic-configuration = ./basic-configuration.nix;
+  darwin-home-manager-autoExpire-frequency-assertion = ./frequency-assertion.nix;
+}

--- a/tests/modules/services/home-manager-auto-expire-darwin/expected-agent.plist
+++ b/tests/modules/services/home-manager-auto-expire-darwin/expected-agent.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>org.nix-community.home.home-manager-auto-expire</string>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/nix/store/00000000000000000000000000000000-home-manager-auto-expire</string>
+	</array>
+	<key>StandardErrorPath</key>
+	<string>/home/hm-user/Library/Logs/home-manager-auto-expire/launchd-stderr.log</string>
+	<key>StandardOutPath</key>
+	<string>/home/hm-user/Library/Logs/home-manager-auto-expire/launchd-stdout.log</string>
+	<key>StartCalendarInterval</key>
+	<array>
+		<dict>
+			<key>Hour</key>
+			<integer>0</integer>
+			<key>Minute</key>
+			<integer>0</integer>
+			<key>Weekday</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/tests/modules/services/home-manager-auto-expire-darwin/frequency-assertion.nix
+++ b/tests/modules/services/home-manager-auto-expire-darwin/frequency-assertion.nix
@@ -1,0 +1,10 @@
+{
+  services.home-manager.autoExpire = {
+    enable = true;
+    frequency = "00:02:00";
+  };
+
+  test.asserts.assertions.expected = [
+    "On Darwin services.home-manager.autoExpire.frequency must be one of: hourly, daily, weekly, monthly, semiannually, annually."
+  ];
+}


### PR DESCRIPTION
### Description

When on darwin, services.home-manager.autoExpire will now generate a launchd agent.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@thiagokokada