### PR TITLE
shell: separate posix-shells from bash

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -633,6 +633,7 @@ in
     programs.zsh.shellAliases = cfg.shellAliases;
     programs.fish.shellAliases = cfg.shellAliases;
     programs.nushell.shellAliases = cfg.shellAliases;
+    programs.sh.shellAliases = cfg.shellAliases;
 
     home.sessionVariables =
       let

--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -107,4 +107,5 @@ in
   mkIonIntegrationOption = mkShellIntegrationOption "Ion";
   mkNushellIntegrationOption = mkShellIntegrationOption "Nushell";
   mkZshIntegrationOption = mkShellIntegrationOption "Zsh";
+  mkShIntegrationOption = mkShellIntegrationOption "Sh";
 }

--- a/modules/misc/news/2026/05/2026-05-16_12-54-11.nix
+++ b/modules/misc/news/2026/05/2026-05-16_12-54-11.nix
@@ -1,0 +1,13 @@
+{
+  time = "2026-05-16T19:54:11+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.sh'. 'programs.sh' will control all POSIX compatible shells (e.g. dash, bash, zsh, etc.).
+
+    For now, 'programs.sh' is enabled by default if 'programs.bash' is enabled for backwards compatibilty.
+
+    This also means a breaking change: bash's configuration is now stored in '~/.bash-profile' and '~/.bashrc' *only*. Since 'programs.sh' is enabled by default if bash is enabled, this should not be a problem, but is something to be aware of.
+
+    If you were using 'programs.bash' to configure the POSIX shells, this you should move that configuration into 'programs.sh'.
+  '';
+}

--- a/modules/misc/shell.nix
+++ b/modules/misc/shell.nix
@@ -25,6 +25,7 @@ in
       '';
     };
 
+    enableShIntegration = lib.hm.shell.mkShIntegrationOption shellIntegrationParameters;
     enableBashIntegration = lib.hm.shell.mkBashIntegrationOption shellIntegrationParameters;
     enableFishIntegration = lib.hm.shell.mkFishIntegrationOption shellIntegrationParameters;
     enableIonIntegration = lib.hm.shell.mkIonIntegrationOption shellIntegrationParameters;

--- a/modules/misc/ssh-auth-sock.nix
+++ b/modules/misc/ssh-auth-sock.nix
@@ -11,16 +11,16 @@ let
     };
 
   initSubmodule = {
-    options.bash = mkShellInitOption "bash";
+    options.sh = mkShellInitOption "sh";
     options.fish = mkShellInitOption "fish";
     options.nushell = mkShellInitOption "nushell";
   };
 
   # Preserve $SSH_AUTH_SOCK only if it stems from a forwarded agent which
   # is the case if both $SSH_AUTH_SOCK and $SSH_CONNECTION are set.
-  bashIntegration = ''
+  shIntegration = ''
     if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then
-      ${cfg.initialization.bash}
+      ${cfg.initialization.sh}
     fi
   '';
   fishIntegration = ''
@@ -54,7 +54,7 @@ in
       proper {option}`programs.(bash|fish|nushell|zsh).*` options.
     '';
     example = {
-      bash = "export SSH_AUTH_SOCK=$HOME/.ssh/agent.sock";
+      sh = "export SSH_AUTH_SOCK=$HOME/.ssh/agent.sock";
       fish = "set -x SSH_AUTH_SOCK $HOME/.ssh/agent.sock";
       nushell = "$env.SSH_AUTH_SOCK = $HOME/.ssh/agent.sock";
     };
@@ -65,9 +65,10 @@ in
 
   config = lib.mkIf (cfg.initialization != null) {
     # $SSH_AUTH_SOCK has to be set early since other tools rely on it
-    programs.bash.profileExtra = lib.mkOrder 900 bashIntegration;
+    programs.sh.profileExtra = lib.mkOrder 900 shIntegration;
+    programs.bash.profileExtra = lib.mkOrder 900 shIntegration;
     programs.fish.shellInit = lib.mkOrder 900 fishIntegration;
     programs.nushell.extraConfig = lib.mkOrder 900 nushellIntegration;
-    programs.zsh.envExtra = lib.mkOrder 900 bashIntegration;
+    programs.zsh.envExtra = lib.mkOrder 900 shIntegration;
   };
 }

--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -249,8 +249,11 @@ in
       home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
       home.file.".bash_profile".source = writeBashScript "bash_profile" ''
-        # include .profile if it exists
-        [[ -f ~/.profile ]] && . ~/.profile
+        . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
+
+        ${sessionVarsStr}
+
+        ${cfg.profileExtra}
 
         # include .bashrc if it exists
         [[ -f ~/.bashrc ]] && . ~/.bashrc
@@ -266,15 +269,6 @@ in
           fi
         ''
       );
-
-      home.file.".profile".source = writeBashScript "profile" ''
-        . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
-
-        ${sessionVarsStr}
-
-        ${cfg.profileExtra}
-      '';
-
       home.file.".bashrc".source = writeBashScript "bashrc" ''
         ${cfg.bashrcExtra}
 

--- a/modules/programs/sh.nix
+++ b/modules/programs/sh.nix
@@ -1,0 +1,140 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    optionalAttrs
+    types
+    ;
+
+  cfg = config.programs.sh;
+
+  writePosixScript =
+    name: text:
+    pkgs.writeTextFile {
+      inherit name text;
+      checkPhase = ''
+        ${pkgs.stdenv.shellDryRun} "$target"
+      '';
+    };
+
+in
+{
+  meta.maintainers = [ lib.maintainers.noodlez1232 ];
+
+  options = {
+    programs.sh = {
+      enable = lib.mkEnableOption "configuration of POSIX compliant shells (e.g. runtime shells)" // {
+        default = config.programs.bash.enable;
+        defaultText = lib.literalMD "[](#opt-programs.bash.enable)";
+        example = true;
+      };
+
+      historySize = mkOption {
+        type = types.nullOr types.int;
+        default = 10000;
+        description = "Number of history lines to keep in memory.";
+      };
+
+      shellAliases = mkOption {
+        default = { };
+        type = types.attrsOf types.str;
+        example = lib.literalExpression ''
+          {
+            ll = "ls -l";
+            ".." = "cd ..";
+          }
+        '';
+        description = ''
+          An attribute set that maps aliases (the top level attribute names in
+          this option) to command strings or directly to build outputs.
+        '';
+      };
+
+      sessionVariables = mkOption {
+        default = { };
+        type =
+          with types;
+          lazyAttrsOf (
+            nullOr (oneOf [
+              str
+              path
+              int
+              float
+              bool
+            ])
+          );
+        example = {
+          MAILCHECK = 30;
+        };
+        description = ''
+          Environment variables that will be set for the POSIX shell session.
+
+          Setting a value to `null` will skip setting the variable at all, which
+          may be useful when overriding.
+        '';
+      };
+
+      profileExtra = mkOption {
+        default = "";
+        type = types.lines;
+        description = ''
+          Extra commands that should be run when initializing a login
+          shell.
+        '';
+      };
+
+      initExtra = mkOption {
+        default = "";
+        type = types.lines;
+        description = ''
+          Extra commands that should be run when initializing an
+          interactive shell.
+        '';
+      };
+    };
+  };
+
+  config =
+    let
+      aliasesStr = lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (k: v: "alias ${k}=${lib.escapeShellArg v}") cfg.shellAliases
+      );
+
+      sessionVarsStr = config.lib.shell.exportAll cfg.sessionVariables;
+
+      historyControlStr = (
+        lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (n: v: "${n}=${v}") (
+            optionalAttrs (cfg.historySize != null) {
+              HISTSIZE = toString cfg.historySize;
+            }
+          )
+        )
+      );
+    in
+    mkIf cfg.enable {
+      home.file.".profile".source = writePosixScript "profile" ''
+        . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
+
+        ENV="$HOME/.shinit"; export ENV
+
+        ${sessionVarsStr}
+
+        ${cfg.profileExtra}
+      '';
+
+      home.file.".shinit".source = writePosixScript "shinit" ''
+        ${historyControlStr}
+
+        ${aliasesStr}
+
+        ${cfg.initExtra}
+      '';
+    };
+}

--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -333,6 +333,8 @@ in
         };
       };
 
+      enableShIntegration = lib.hm.shell.mkShIntegrationOption { inherit config; };
+
       enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
       enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
@@ -367,7 +369,7 @@ in
     );
 
     sshAuthSock.initialization = lib.mkIf cfg.enableSshSupport {
-      bash = ''
+      sh = ''
         unset SSH_AGENT_PID
         if [ "''${gnupg_SSH_AUTH_SOCK_by:-0}" -ne $$ ]; then
           export SSH_AUTH_SOCK="$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)"
@@ -393,6 +395,7 @@ in
     };
 
     programs = {
+      sh.initExtra = mkIf cfg.enableShIntegration gpgBashInitStr;
       bash.initExtra = mkIf cfg.enableBashIntegration gpgBashInitStr;
       zsh.initContent = mkIf cfg.enableZshIntegration gpgZshInitStr;
       fish.interactiveShellInit = mkIf cfg.enableFishIntegration gpgFishInitStr;

--- a/modules/services/proton-pass-agent.nix
+++ b/modules/services/proton-pass-agent.nix
@@ -75,7 +75,7 @@ in
       home.packages = [ cfg.package ];
 
       sshAuthSock.initialization = {
-        bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
+        sh = ''export SSH_AUTH_SOCK="${socketPath}"'';
         fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
         nushell = "$env.SSH_AUTH_SOCK = ${
           if pkgs.stdenv.isDarwin then

--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -69,7 +69,7 @@ in
             "$XDG_RUNTIME_DIR/${cfg.socket}";
       in
       {
-        bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
+        sh = ''export SSH_AUTH_SOCK="${socketPath}"'';
         fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
         nushell = "$env.SSH_AUTH_SOCK = ${
           if pkgs.stdenv.isDarwin then

--- a/modules/services/ssh-tpm-agent.nix
+++ b/modules/services/ssh-tpm-agent.nix
@@ -74,7 +74,7 @@ in
     # Override ssh-agent's $SSH_AUTH_SOCK definition since ssh-tpm-agent is a
     # proxy to it.
     sshAuthSock.initialization = lib.mkOverride 90 {
-      bash = ''export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'';
+      sh = ''export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'';
       fish = ''set -x SSH_AUTH_SOCK "$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'';
       nushell = ''$env.SSH_AUTH_SOCK = $"($env.XDG_RUNTIME_DIR)/ssh-tpm-agent.sock"'';
     };

--- a/modules/services/yubikey-agent.nix
+++ b/modules/services/yubikey-agent.nix
@@ -31,7 +31,7 @@ in
             "\${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-agent/yubikey-agent.sock";
       in
       {
-        bash = ''export SSH_AUTH_SOCK="${socketPath}"'';
+        sh = ''export SSH_AUTH_SOCK="${socketPath}"'';
         fish = ''set -x SSH_AUTH_SOCK "${socketPath}"'';
         nushell = "$env.SSH_AUTH_SOCK = ${
           if pkgs.stdenv.isDarwin then

--- a/tests/modules/misc/ssh-auth-sock/initialization.nix
+++ b/tests/modules/misc/ssh-auth-sock/initialization.nix
@@ -1,16 +1,20 @@
 {
+  programs.sh.enable = true;
   programs.bash.enable = true;
   programs.fish.enable = true;
   programs.nushell.enable = true;
   programs.zsh.enable = true;
 
   sshAuthSock.initialization = {
-    bash = "echo bash/zsh";
+    sh = "echo bash/zsh/sh";
     fish = "echo fish";
     nushell = "echo nushell";
   };
 
   nmt.script = ''
+    assertFileContains \
+      home-files/.bash_profile \
+      'if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then'
     assertFileContains \
       home-files/.profile \
       'if [ -z "$SSH_AUTH_SOCK" -o -z "$SSH_CONNECTION" ]; then'

--- a/tests/modules/programs/sh/default.nix
+++ b/tests/modules/programs/sh/default.nix
@@ -1,0 +1,3 @@
+{
+  sh-session-variables = ./session-variables.nix;
+}

--- a/tests/modules/programs/sh/session-variables.nix
+++ b/tests/modules/programs/sh/session-variables.nix
@@ -1,13 +1,12 @@
 { config, ... }:
 
 {
-  programs.bash = {
+  programs.sh = {
     enable = true;
-    enableCompletion = false;
 
     sessionVariables = {
       V1 = "v1";
-      V2 = "v2-${config.programs.bash.sessionVariables.V1}";
+      V2 = "v2-${config.programs.sh.sessionVariables.V1}";
       IS_EMPTY = "";
       IS_NULL = null;
       IS_TRUE = true;
@@ -16,11 +15,13 @@
   };
 
   nmt.script = ''
-    assertFileExists home-files/.bash_profile
+    assertFileExists home-files/.profile
     assertFileContent \
-      "$(normalizeStorePaths home-files/.bash_profile)" \
+      "$(normalizeStorePaths home-files/.profile)" \
       ${builtins.toFile "session-variables-expected" ''
         . "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
+
+        ENV="$HOME/.shinit"; export ENV
 
         export IS_EMPTY=""
         export IS_FALSE="false"
@@ -29,9 +30,6 @@
         export V2="v2-v1"
 
 
-
-        # include .bashrc if it exists
-        [[ -f ~/.bashrc ]] && . ~/.bashrc
       ''}
   '';
 }

--- a/tests/modules/services/gpg-agent/ssh-support.nix
+++ b/tests/modules/services/gpg-agent/ssh-support.nix
@@ -1,4 +1,5 @@
 {
+  programs.sh.enable = true;
   programs.bash.enable = true;
   programs.fish.enable = true;
   programs.nushell.enable = true;
@@ -10,6 +11,10 @@
   };
 
   nmt.script = ''
+    assertFileContains \
+      home-files/.bash_profile \
+      'export SSH_AUTH_SOCK="$(@gnupg@/bin/gpgconf --list-dirs agent-ssh-socket)"'
+
     assertFileContains \
       home-files/.profile \
       'export SSH_AUTH_SOCK="$(@gnupg@/bin/gpgconf --list-dirs agent-ssh-socket)"'
@@ -23,6 +28,9 @@
       home-files/.zshenv \
       'export SSH_AUTH_SOCK="$(@gnupg@/bin/gpgconf --list-dirs agent-ssh-socket)"'
 
+    assertFileContains \
+      home-files/.shinit \
+      '@gnupg@/bin/gpg-connect-agent --quiet updatestartuptty /bye'
     assertFileContains \
       home-files/.bashrc \
       '@gnupg@/bin/gpg-connect-agent --quiet updatestartuptty /bye'

--- a/tests/modules/services/proton-pass-agent/ssh-auth-sock.nix
+++ b/tests/modules/services/proton-pass-agent/ssh-auth-sock.nix
@@ -1,6 +1,7 @@
 { pkgs, ... }:
 
 {
+  programs.sh.enable = true;
   programs.bash.enable = true;
   programs.fish.enable = true;
   programs.nushell.enable = true;
@@ -26,6 +27,9 @@
           "($env.XDG_RUNTIME_DIR)";
     in
     ''
+      assertFileContains \
+        home-files/.bash_profile \
+        'export SSH_AUTH_SOCK="${bashDir}/proton-pass-agent"'
       assertFileContains \
         home-files/.profile \
         'export SSH_AUTH_SOCK="${bashDir}/proton-pass-agent"'

--- a/tests/modules/services/ssh-agent/darwin/ssh-auth-sock.nix
+++ b/tests/modules/services/ssh-agent/darwin/ssh-auth-sock.nix
@@ -1,4 +1,5 @@
 {
+  programs.sh.enable = true;
   programs.bash.enable = true;
   programs.fish.enable = true;
   programs.nushell.enable = true;
@@ -6,6 +7,9 @@
   services.ssh-agent.enable = true;
 
   nmt.script = ''
+    assertFileContains \
+      home-files/.bash_profile \
+      'export SSH_AUTH_SOCK="$(@system_cmds@/bin/getconf DARWIN_USER_TEMP_DIR)/ssh-agent"'
     assertFileContains \
       home-files/.profile \
       'export SSH_AUTH_SOCK="$(@system_cmds@/bin/getconf DARWIN_USER_TEMP_DIR)/ssh-agent"'

--- a/tests/modules/services/ssh-agent/linux/ssh-auth-sock.nix
+++ b/tests/modules/services/ssh-agent/linux/ssh-auth-sock.nix
@@ -1,4 +1,5 @@
 {
+  programs.sh.enable = true;
   programs.bash.enable = true;
   programs.fish.enable = true;
   programs.nushell.enable = true;
@@ -6,6 +7,9 @@
   services.ssh-agent.enable = true;
 
   nmt.script = ''
+    assertFileContains \
+      home-files/.bash_profile \
+      'export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent"'
     assertFileContains \
       home-files/.profile \
       'export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent"'

--- a/tests/modules/services/ssh-tpm-agent/ssh-auth-sock.nix
+++ b/tests/modules/services/ssh-tpm-agent/ssh-auth-sock.nix
@@ -1,4 +1,5 @@
 {
+  programs.sh.enable = true;
   programs.bash.enable = true;
   programs.fish.enable = true;
   programs.nushell.enable = true;
@@ -6,6 +7,9 @@
   services.ssh-tpm-agent.enable = true;
 
   nmt.script = ''
+    assertFileContains \
+      home-files/.bash_profile \
+      'export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'
     assertFileContains \
       home-files/.profile \
       'export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-tpm-agent.sock"'

--- a/tests/modules/services/yubikey-agent/darwin/ssh-auth-sock.nix
+++ b/tests/modules/services/yubikey-agent/darwin/ssh-auth-sock.nix
@@ -1,4 +1,5 @@
 {
+  programs.sh.enable = true;
   programs.bash.enable = true;
   programs.fish.enable = true;
   programs.nushell.enable = true;
@@ -6,6 +7,9 @@
   services.yubikey-agent.enable = true;
 
   nmt.script = ''
+    assertFileContains \
+      home-files/.bash_profile \
+      'export SSH_AUTH_SOCK="/tmp/yubikey-agent.sock"'
     assertFileContains \
       home-files/.profile \
       'export SSH_AUTH_SOCK="/tmp/yubikey-agent.sock"'

--- a/tests/modules/services/yubikey-agent/linux/ssh-auth-sock.nix
+++ b/tests/modules/services/yubikey-agent/linux/ssh-auth-sock.nix
@@ -1,4 +1,5 @@
 {
+  programs.sh.enable = true;
   programs.bash.enable = true;
   programs.fish.enable = true;
   programs.nushell.enable = true;
@@ -6,6 +7,9 @@
   services.yubikey-agent.enable = true;
 
   nmt.script = ''
+    assertFileContains \
+      home-files/.bash_profile \
+      'export SSH_AUTH_SOCK="''${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-agent/yubikey-agent.sock"'
     assertFileContains \
       home-files/.profile \
       'export SSH_AUTH_SOCK="''${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-agent/yubikey-agent.sock"'


### PR DESCRIPTION
### Description

Creates a posix-compliant `.profile` and `.shinit` usable from any posix-compliant shell. This is great for runtime scripts to have their variables set without having to import `programs.enable.bash`

For backwards compatibility, it is enabled by default only if `programs.enable.bash` is enabled.

This commit also changes bash's `.profile` to be `.bash_profile`, once again, to keep them separate, since bash is not posix compliant, its profile should not be included in the normal `.profile`.

fixes: https://github.com/nix-community/home-manager/issues/5474
fixes: https://github.com/nix-community/home-manager/issues/6412


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@rycee 