### PR TITLE
podman: set switch method to "restart"

### DIFF
--- a/modules/services/podman-linux/containers.nix
+++ b/modules/services/podman-linux/containers.nix
@@ -136,6 +136,7 @@ let
               else
                 "Service for container ${name}"
             );
+            X-SwitchMethod = "restart";
           };
         } containerDef.extraConfig
       );


### PR DESCRIPTION
### Description

Restart quadlet containers on switch instead of stop-start.

Reason:

I have containers A, B and container B has

```nix
Unit = rec {
  Requires = [
    "podman-A.service"
  ];
  After = Requires;
}
```

in it's config.

When I update A configuration, switch stops A, systemd automatically stops B, switch starts A but not B. B is stopped now.

Setting `X-SwitchMethod = "restart"` fixes it.

Also it may worth it to set SwitchMethod in other units like networks.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
