### PR TITLE
fix(service/gpg-agent): ensure SSH_AUTH_SOCK is set on Darwin

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -371,7 +371,8 @@ in
         );
 
         home.sessionVariablesExtra = optionalString cfg.enableSshSupport ''
-          if [ -z "$SSH_AUTH_SOCK" ]; then
+          unset SSH_AGENT_PID
+          if [ "''${gnupg_SSH_AUTH_SOCK_by:-0}" -ne $$ ]; then
             export SSH_AUTH_SOCK="$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)"
           fi
         '';


### PR DESCRIPTION
This commit addresses https://github.com/nix-community/home-manager/issues/5997
At the root, the gpg-agent SSH integration is not working on Darwin
because shells are started with `SSH_AUTH_SOCK` already set to something
like `/private/tmp/com.apple.launchd.ozLmoURHDC/Listeners`, which
prevents the hook from setting the variable to the gpg-agent's socket.

This commit fixes the issue using a different mechanism to detect if the
current shell has already had the `SSH_AUTH_SOCK` variable set to the
gpg-agent's socket, namely by checking for `gnupg_SSH_AUTH_SOCK_by` as
documented in
https://www.gnupg.org/documentation/manuals/gnupg/Agent-Examples.html#Agent-Examples.

This is essentially a simplified version of
https://github.com/nix-community/home-manager/pull/5901 that does not
attempt to migrate gpg-agent over to launchd.

Signed-off-by: squat <lserven@gmail.com>
