### PR TITLE
superfile: add exiftool when metadata enabled

### DIFF
--- a/modules/programs/superfile.nix
+++ b/modules/programs/superfile.nix
@@ -18,6 +18,7 @@ let
     mkOption
     mkPackageOption
     nameValuePair
+    optional
     recursiveUpdate
     types
     hm
@@ -30,6 +31,8 @@ in
     enable = mkEnableOption "superfile - Pretty fancy and modern terminal file manager";
 
     package = mkPackageOption pkgs "superfile" { nullable = true; };
+
+    metadataPackage = mkPackageOption pkgs "exiftool" { nullable = true; };
 
     settings = mkOption {
       type = tomlFormat.type;
@@ -142,7 +145,12 @@ in
       ];
     in
     mkIf cfg.enable {
-      home.packages = mkIf (cfg.package != null) [ cfg.package ];
+      home.packages = mkIf (cfg.package != null) (
+        [ cfg.package ]
+        ++ optional (
+          cfg.metadataPackage != null && cfg.settings ? metadata && cfg.settings.metadata
+        ) cfg.metadataPackage
+      );
 
       xdg.configFile = mkIf enableXdgConfig configFiles;
       home.file = mkIf (!enableXdgConfig) configFiles;


### PR DESCRIPTION
### Description

<https://superfile.netlify.app/list/plugin-list>

Metadata option requires `exiftool` to work.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@LucasWagler 

#### CC

@mdaniels5757
