### PR TITLE
fish: add binds option

### DIFF
--- a/tests/modules/programs/fish/binds.nix
+++ b/tests/modules/programs/fish/binds.nix
@@ -1,0 +1,46 @@
+{ lib, ... }:
+{
+  config = {
+    programs.fish = {
+      enable = true;
+
+      binds = {
+        "ctrl-d".command = "exit";
+
+        "ctrl-c" = {
+          mode = "insert";
+          command = [
+            "kill-whole-line"
+            "repaint"
+          ];
+        };
+
+        "ctrl-g" = {
+          command = [
+            "git diff"
+            "repaint"
+          ];
+        };
+      };
+    };
+
+    # Needed to avoid error with dummy fish package.
+    xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+      builtins.toFile "empty" ""
+    );
+
+    nmt = {
+      description = "if fish.binds is set, check function exists and contains valid binds";
+      script = ''
+        assertFileExists home-files/.config/fish/functions/fish_user_key_bindings.fish
+
+        assertFileContains home-files/.config/fish/functions/fish_user_key_bindings.fish \
+          "bind ctrl-d exit"
+        assertFileContains home-files/.config/fish/functions/fish_user_key_bindings.fish \
+          "bind --mode insert ctrl-c kill-whole-line repaint"
+        assertFileContains home-files/.config/fish/functions/fish_user_key_bindings.fish \
+          "bind ctrl-g 'git diff' repaint"
+      '';
+    };
+  };
+}

--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -5,4 +5,5 @@
   fish-no-functions = ./no-functions.nix;
   fish-plugins = ./plugins.nix;
   fish-manpage = ./manpage.nix;
+  fish-binds = ./binds.nix;
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
binds options that will be save in fish_user_key_bindings function

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
