### PR TITLE
github: remove Sumner as automatic assignee on issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Ask for a new feature to be added (module, program, etc.)
 title: ''
 labels: feature request
-assignees: rycee, berbiche, sumnerevans
+assignees: rycee, berbiche
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -5,7 +5,7 @@ labels: [bug, triage]
 
 # We cannot use nix-community/home-manager
 # See https://github.com/dear-github/dear-github/issues/170
-assignees: [rycee, berbiche, sumnerevans]
+assignees: [rycee, berbiche]
 
 body:
 - type: checkboxes


### PR DESCRIPTION
### Description

I'd like to tenure my resignation from maintainership of the home-manager project. I haven't been able to contribute nearly as much as I would have liked to over the last years.

Thank you for the opportunity to help maintain this great project. I will happily to continue to occasionally contribute as a normal contributor rather than a maintainer going forward.

Signed-off-by: Sumner Evans <me@sumnerevans.com>

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@rycee @khaneliman

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
