### PR TITLE
wayvnc: init

### DIFF
--- a/modules/misc/news/2025/05/2025-05-24_18-18-40.nix
+++ b/modules/misc/news/2025/05/2025-05-24_18-18-40.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+{
+  time = "2025-05-24T18:18:40+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: `services.wayvnc`
+
+    wayvnc is a VNC server for wlroots based Wayland compositors.
+  '';
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -470,6 +470,7 @@ let
       ./services/vdirsyncer.nix
       ./services/volnoti.nix
       ./services/way-displays.nix
+      ./services/wayvnc.nix
       ./services/window-managers/awesome.nix
       ./services/window-managers/bspwm/default.nix
       ./services/window-managers/fluxbox.nix

--- a/modules/services/wayvnc.nix
+++ b/modules/services/wayvnc.nix
@@ -1,0 +1,95 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+
+  cfg = config.services.wayvnc;
+
+  format = pkgs.formats.keyValue { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ Scrumplex ];
+
+  options.services.wayvnc = {
+    enable = mkEnableOption "wayvnc VNC server";
+
+    package = mkPackageOption pkgs "wayvnc" { };
+
+    autoStart = mkEnableOption "autostarting of wayvnc";
+
+    systemdTarget = mkOption {
+      type = types.str;
+      default = config.wayland.systemd.target;
+      defaultText = literalExpression "config.wayland.systemd.target";
+      description = ''
+        Systemd target to bind to.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = format.type;
+
+        options = {
+          address = mkOption {
+            description = ''
+              The address to which the server shall bind, e.g. 0.0.0.0 or
+              localhost.
+            '';
+            type = types.str;
+            example = "0.0.0.0";
+          };
+          port = mkOption {
+            description = ''
+              The port to which the server shall bind.
+            '';
+            type = types.port;
+            example = 5901;
+          };
+        };
+      };
+      description = ''
+        See CONFIGURATION section in {manpage}`wayvnc(1)`.
+      '';
+      default = { };
+      example = {
+        address = "0.0.0.0";
+        port = 5901;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.wayvnc" pkgs lib.platforms.linux)
+    ];
+
+    systemd.user.services."wayvnc" = {
+      Unit = {
+        Description = "wayvnc VNC server";
+        Documentation = [ "man:wayvnc(1)" ];
+        After = [ cfg.systemdTarget ];
+        PartOf = [ cfg.systemdTarget ];
+      };
+      Service.ExecStart = [ (getExe cfg.package) ];
+      Install.WantedBy = lib.mkIf cfg.autoStart [ cfg.systemdTarget ];
+    };
+
+    # For manpage and wayvncctl
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."wayvnc/config".source = format.generate "wayvnc.conf" cfg.settings;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -496,6 +496,7 @@ import nmtSrc {
       ./modules/services/udiskie
       ./modules/services/volnoti
       ./modules/services/way-displays
+      ./modules/services/wayvnc
       ./modules/services/window-managers/bspwm
       ./modules/services/window-managers/herbstluftwm
       ./modules/services/window-managers/hyprland

--- a/tests/modules/services/wayvnc/default.nix
+++ b/tests/modules/services/wayvnc/default.nix
@@ -1,0 +1,3 @@
+{
+  wayvnc-simple = ./simple.nix;
+}

--- a/tests/modules/services/wayvnc/simple-config
+++ b/tests/modules/services/wayvnc/simple-config
@@ -1,0 +1,3 @@
+address=0.0.0.0
+port=5901
+username=foobar

--- a/tests/modules/services/wayvnc/simple.nix
+++ b/tests/modules/services/wayvnc/simple.nix
@@ -1,0 +1,26 @@
+{ config, ... }:
+{
+  services.wayvnc = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    autoStart = true;
+
+    settings = {
+      address = "0.0.0.0";
+      port = 5901;
+      username = "foobar";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/systemd/user/wayvnc.service
+    assertFileContent \
+      $(normalizeStorePaths home-files/.config/systemd/user/wayvnc.service) \
+      ${./simple.service}
+
+    assertFileExists home-files/.config/wayvnc/config
+    assertFileContent home-files/.config/wayvnc/config ${./simple-config}
+  '';
+
+}

--- a/tests/modules/services/wayvnc/simple.service
+++ b/tests/modules/services/wayvnc/simple.service
@@ -1,0 +1,11 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=/nix/store/00000000000000000000000000000000-dummy/bin/dummy
+
+[Unit]
+After=graphical-session.target
+Description=wayvnc VNC server
+Documentation=man:wayvnc(1)
+PartOf=graphical-session.target


### PR DESCRIPTION
### Description

Module for [wayvnc](https://github.com/any1/wayvnc).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
