### PR TITLE
mergiraf: use mergiraf cli to generate gitattributes

### DIFF
--- a/modules/programs/mergiraf.nix
+++ b/modules/programs/mergiraf.nix
@@ -13,6 +13,10 @@ let
     ;
   cfg = config.programs.mergiraf;
   mergiraf = "${cfg.package}/bin/mergiraf";
+
+  attributesFile = pkgs.runCommand "mergiraf-gitattributes" { buildInputs = [ cfg.package ]; } ''
+    mergiraf languages --gitattributes > $out
+  '';
 in
 {
   meta.maintainers = [ maintainers.bobvanderlinden ];
@@ -28,7 +32,7 @@ in
     home.packages = [ cfg.package ];
 
     programs.git = {
-      attributes = [ "* merge=mergiraf" ];
+      attributes = [ (builtins.readFile attributesFile) ];
       extraConfig = {
         merge.mergiraf = {
           name = "mergiraf";

--- a/tests/modules/programs/mergiraf/basic-configuration.nix
+++ b/tests/modules/programs/mergiraf/basic-configuration.nix
@@ -4,6 +4,6 @@
 
   nmt.script = ''
     assertFileContent "home-files/.config/git/config" ${./mergiraf-git.conf}
-    assertFileContent "home-files/.config/git/attributes" ${./mergiraf-git-attributes.conf}
+    assertFileExists "home-files/.config/git/attributes"
   '';
 }

--- a/tests/modules/programs/mergiraf/mergiraf-git-attributes.conf
+++ b/tests/modules/programs/mergiraf/mergiraf-git-attributes.conf
@@ -1,1 +1,0 @@
-* merge=mergiraf


### PR DESCRIPTION
Use `mergiraf` official supported languages list to generate git attributes instead of using a wildcard, as advised in the [official documentation](https://mergiraf.org/usage.html). 
We generate the git attributes, so we can't rely on testing, or they will break every so often

I'd like your opinion @bobvanderlinden 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
