### PR TITLE
misc: add librewolf native messaging hosts

### DIFF
--- a/modules/misc/mozilla-messaging-hosts.nix
+++ b/modules/misc/mozilla-messaging-hosts.nix
@@ -23,6 +23,12 @@ let
       "Library/Application Support/Mozilla/NativeMessagingHosts"
     else
       ".mozilla/native-messaging-hosts";
+
+  librewolfNativeMessagingHostsPath =
+    if isDarwin then
+      "Library/Application Support/LibreWolf/NativeMessagingHosts"
+    else
+      ".librewolf/native-messaging-hosts";
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -49,49 +55,77 @@ in
         List of Thunderbird native messaging hosts to configure.
       '';
     };
+
+    librewolfNativeMessagingHosts = lib.mkOption {
+      internal = true;
+      type = with lib.types; listOf package;
+      default = [ ];
+      description = ''
+        List of Librewolf native messaging hosts to configure.
+      '';
+    };
   };
 
   config =
-    lib.mkIf (cfg.firefoxNativeMessagingHosts != [ ] || cfg.thunderbirdNativeMessagingHosts != [ ])
+    lib.mkIf
+      (
+        cfg.firefoxNativeMessagingHosts != [ ]
+        || cfg.thunderbirdNativeMessagingHosts != [ ]
+        || cfg.librewolfNativeMessagingHosts != [ ]
+      )
       {
         home.file =
-          if isDarwin then
-            let
-              firefoxNativeMessagingHostsJoined = pkgs.symlinkJoin {
-                name = "ff-native-messaging-hosts";
-                paths = defaultPaths ++ cfg.firefoxNativeMessagingHosts;
-              };
-              thunderbirdNativeMessagingHostsJoined = pkgs.symlinkJoin {
-                name = "th-native-messaging-hosts";
-                paths = defaultPaths ++ cfg.thunderbirdNativeMessagingHosts;
-              };
-            in
-            {
-              "${thunderbirdNativeMessagingHostsPath}" = lib.mkIf (cfg.thunderbirdNativeMessagingHosts != [ ]) {
-                source = "${thunderbirdNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
+          let
+            mkNmhLink =
+              { name, nativeMessagingHosts }:
+              let
+                packageJoin = pkgs.symlinkJoin {
+                  inherit name;
+                  paths = lib.flatten (
+                    lib.concatLists [
+                      defaultPaths
+                      nativeMessagingHosts
+                    ]
+                  );
+                };
+              in
+              lib.mkIf (nativeMessagingHosts != [ ]) {
+                source = "${packageJoin}/lib/mozilla/native-messaging-hosts";
                 recursive = true;
                 ignorelinks = true;
+              };
+          in
+          if isDarwin then
+            {
+              "${thunderbirdNativeMessagingHostsPath}" = mkNmhLink {
+                name = "th-native-messaging-hosts";
+                nativeMessagingHosts = cfg.thunderbirdNativeMessagingHosts;
               };
 
-              "${firefoxNativeMessagingHostsPath}" = lib.mkIf (cfg.firefoxNativeMessagingHosts != [ ]) {
-                source = "${firefoxNativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
-                recursive = true;
-                ignorelinks = true;
+              "${firefoxNativeMessagingHostsPath}" = mkNmhLink {
+                name = "ff-native-messaging-hosts";
+                nativeMessagingHosts = cfg.firefoxNativeMessagingHosts;
+              };
+
+              "${librewolfNativeMessagingHostsPath}" = mkNmhLink {
+                name = "lw-native-messaging-hosts";
+                nativeMessagingHosts = cfg.librewolfNativeMessagingHosts;
               };
             }
           else
-            let
-              nativeMessagingHostsJoined = pkgs.symlinkJoin {
+            {
+              "${firefoxNativeMessagingHostsPath}" = mkNmhLink {
                 name = "mozilla-native-messaging-hosts";
                 # on Linux, the directory is shared between Firefox and Thunderbird; merge both into one
-                paths = defaultPaths ++ cfg.firefoxNativeMessagingHosts ++ cfg.thunderbirdNativeMessagingHosts;
+                nativeMessagingHosts = [
+                  cfg.firefoxNativeMessagingHosts
+                  cfg.thunderbirdNativeMessagingHosts
+                ];
               };
-            in
-            {
-              "${firefoxNativeMessagingHostsPath}" = {
-                source = "${nativeMessagingHostsJoined}/lib/mozilla/native-messaging-hosts";
-                recursive = true;
-                ignorelinks = true;
+
+              "${librewolfNativeMessagingHostsPath}" = mkNmhLink {
+                name = "librewolf-native-messaging-hosts";
+                nativeMessagingHosts = cfg.librewolfNativeMessagingHosts;
               };
             };
       };

--- a/modules/programs/firefox.nix
+++ b/modules/programs/firefox.nix
@@ -1,6 +1,8 @@
-{ lib, ... }:
+{ lib, config, ... }:
 let
   inherit (lib) mkRemovedOptionModule;
+
+  cfg = config.programs.firefox;
 
   modulePath = [
     "programs"
@@ -52,4 +54,11 @@ in
       modulePath ++ [ "enableIcedTea" ]
     ) "Support for this option has been removed.")
   ];
+
+  config = lib.mkIf cfg.enable {
+    mozilla.firefoxNativeMessagingHosts =
+      cfg.nativeMessagingHosts
+      # package configured native messaging hosts (entire browser actually)
+      ++ (lib.optional (cfg.finalPackage != null) cfg.finalPackage);
+  };
 }

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -862,11 +862,6 @@ in
 
       home.packages = lib.optional (cfg.finalPackage != null) cfg.finalPackage;
 
-      mozilla.firefoxNativeMessagingHosts =
-        cfg.nativeMessagingHosts
-        # package configured native messaging hosts (entire browser actually)
-        ++ (lib.optional (cfg.finalPackage != null) cfg.finalPackage);
-
       home.file = mkMerge (
         [
           {

--- a/modules/programs/floorp.nix
+++ b/modules/programs/floorp.nix
@@ -1,9 +1,11 @@
-{ lib, ... }:
+{ lib, config, ... }:
 let
   modulePath = [
     "programs"
     "floorp"
   ];
+
+  cfg = config.programs.floorp;
 
   mkFirefoxModule = import ./firefox/mkFirefoxModule.nix;
 in
@@ -26,4 +28,11 @@ in
       };
     })
   ];
+
+  config = lib.mkIf cfg.enable {
+    mozilla.firefoxNativeMessagingHosts =
+      cfg.nativeMessagingHosts
+      # package configured native messaging hosts (entire browser actually)
+      ++ (lib.optional (cfg.finalPackage != null) cfg.finalPackage);
+  };
 }

--- a/modules/programs/librewolf.nix
+++ b/modules/programs/librewolf.nix
@@ -34,6 +34,7 @@ in
       description = "LibreWolf is a privacy enhanced Firefox fork.";
       wrappedPackageName = "librewolf";
       unwrappedPackageName = "librewolf-unwrapped";
+      visible = true;
 
       platforms.linux = {
         configPath = ".librewolf";
@@ -68,5 +69,10 @@ in
     home.file.".librewolf/librewolf.overrides.cfg" = lib.mkIf (cfg.settings != { }) {
       text = mkOverridesFile cfg.settings;
     };
+
+    mozilla.librewolfNativeMessagingHosts =
+      cfg.nativeMessagingHosts
+      # package configured native messaging hosts (entire browser actually)
+      ++ (lib.optional (cfg.finalPackage != null) cfg.finalPackage);
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Current native messaging hosts implementation do not support LibreWolf.

mkFirefoxModule links to `.mozilla/native-messaging-hosts` by default, but LibreWolf use their own paths for native messaging hosts, requiring users to create the symlink manually.[1] 

I tested this on Firefox, LibreWolf, and Floorp on my nixos machine but couldn't test darwin. Additionally, I did a bit of refactoring to reduce code duplication.

[1]: https://librewolf.net/docs/faq/#how-do-i-get-native-messaging-to-work

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@booxter
@rycee
@bmrips
