### PR TITLE
feat(syncthing): impl encryptionPasswordFile

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -108,93 +108,80 @@ let
 
       ${curlShellFunction}
     ''
-    +
-
-      /*
-        Syncthing's rest API for the folders and devices is almost identical.
-        Hence we iterate them using lib.pipe and generate shell commands for both at
-        the same time.
-      */
-      (lib.pipe
-        {
-          # The attributes below are the only ones that are different for devices /
-          # folders.
-          devs = {
-            new_conf_IDs = map (v: v.id) devices;
-            GET_IdAttrName = "deviceID";
-            override = cfg.overrideDevices;
-            conf = devices;
-            baseAddress = curlAddressArgs "/rest/config/devices";
-          };
-          dirs = {
-            new_conf_IDs = map (v: v.id) folders;
-            GET_IdAttrName = "id";
-            override = cfg.overrideFolders;
-            conf = folders;
-            baseAddress = curlAddressArgs "/rest/config/folders";
-          };
-        }
-        [
-          # Now for each of these attributes, write the curl commands that are
-          # identical to both folders and devices.
-          (lib.mapAttrs (
-            conf_type: s:
-            # We iterate the `conf` list now, and run a curl -X POST command for each, that
-            # should update that device/folder only.
-            lib.pipe s.conf [
-              # Quoting https://docs.syncthing.net/rest/config.html:
-              #
-              # > PUT takes an array and POST a single object. In both cases if a
-              # given folder/device already exists, it’s replaced, otherwise a new
-              # one is added.
-              #
-              # What's not documented, is that using PUT will remove objects that
-              # don't exist in the array given. That's why we use here `POST`, and
-              # only if s.override == true then we DELETE the relevant folders
-              # afterwards.
-              (map (new_cfg: ''
-                curl -d ${lib.escapeShellArg (builtins.toJSON new_cfg)} -X POST ${s.baseAddress}
-              ''))
-              (lib.concatStringsSep "\n")
-            ]
-            /*
-              If we need to override devices/folders, we iterate all currently configured
-              IDs, via another `curl -X GET`, and we delete all IDs that are not part of
-              the Nix configured list of IDs
-            */
-            + lib.optionalString s.override ''
-              stale_${conf_type}_ids="$(curl -X GET ${s.baseAddress} | ${jq} \
-                --argjson new_ids ${lib.escapeShellArg (builtins.toJSON s.new_conf_IDs)} \
-                --raw-output \
-                '[.[].${s.GET_IdAttrName}] - $new_ids | .[]'
-              )"
-              for id in ''${stale_${conf_type}_ids}; do
-                curl -X DELETE ${s.baseAddress}/$id
-              done
-            ''
-          ))
-          builtins.attrValues
-          (lib.concatStringsSep "\n")
-        ]
-      )
-    +
-      /*
-        Now we update the other settings defined in cleanedConfig which are not
-        "folders" or "devices".
-      */
-      (lib.pipe cleanedConfig [
-        builtins.attrNames
-        (lib.subtractLists [
-          "folders"
-          "devices"
-        ])
-        (map (subOption: ''
-          curl -X PUT -d ${
-            lib.escapeShellArg (builtins.toJSON cleanedConfig.${subOption})
-          } ${curlAddressArgs "/rest/config/${subOption}"}
-        ''))
-        (lib.concatStringsSep "\n")
+    # We iterate the devices and run a curl -X POST command for each, to update that device only.
+    #
+    # Quoting https://docs.syncthing.net/rest/config.html:
+    #
+    # > PUT takes an array and POST a single object. In both cases if a
+    # given device already exists, it’s replaced, otherwise a new
+    # one is added.
+    #
+    # What's not documented, is that using PUT will remove objects that
+    # don't exist in the array given. That's why we use here `POST`, and
+    # only if cfg.overrideDevices == true then we DELETE the relevant devices
+    # afterwards.
+    + lib.pipe devices [
+      (map (new_device_cfg: ''
+        curl -d ${lib.escapeShellArg (builtins.toJSON new_device_cfg)} -X POST ${curlAddressArgs "/rest/config/devices"}
+      ''))
+      (lib.concatStringsSep "\n")
+    ]
+    # If we need to override devices, we iterate all currently configured
+    # IDs, via another `curl -X GET`, and we delete all IDs that are not part of
+    # the Nix configured list of IDs
+    + lib.optionalString cfg.overrideDevices ''
+      stale_devs_ids="$(curl -X GET ${curlAddressArgs "/rest/config/devices"} | ${jq} \
+        --argjson new_ids ${lib.escapeShellArg (builtins.toJSON (map (v: v.id) devices))} \
+        --raw-output \
+        '[.[].deviceID] - $new_ids | .[]'
+      )"
+      for id in ''${stale_devs_ids}; do
+        curl -X DELETE ${curlAddressArgs "/rest/config/devices/$id"}
+      done
+    ''
+    # Folders are updated in a similar way as devices, but we read encryption password from
+    # a file if it is given.
+    + lib.pipe folders [
+      (map (
+        new_folder_cfg:
+        let
+          jqExec = "${pkgs.jq}/bin/jq";
+        in
+        ''
+          devices=$(${jqExec} -c '.[] | .' <<< ${lib.escapeShellArg (builtins.toJSON new_folder_cfg.devices)} | while read line ; do if ${jqExec} -e 'has("encryptionPasswordFile")' >/dev/null <<< "$line"; then passwordFile=$(echo "$line" | ${jqExec} -c --raw-output '.encryptionPasswordFile'); ${jqExec} -c --rawfile password "$passwordFile" '.encryptionPassword=$password | del(.encryptionPasswordFile)' <<< "$line"; else echo "$line"; fi; done | ${jqExec} -c --slurp)
+          config=$(${jqExec} --argjson devices "$devices" '.devices = $devices' -c <<< ${lib.escapeShellArg (builtins.toJSON new_folder_cfg)})
+          curl --data @- -X POST ${curlAddressArgs "/rest/config/folders"} <<< "$config"
+        ''
+      ))
+      (lib.concatStringsSep "\n")
+    ]
+    + lib.optionalString cfg.overrideFolders ''
+      stale_dirs_ids="$(curl -X GET ${curlAddressArgs "/rest/config/folders"} | ${jq} \
+        --argjson new_ids ${lib.escapeShellArg (builtins.toJSON (map (v: v.id) folders))} \
+        --raw-output \
+        '[.[].id] - $new_ids | .[]'
+      )"
+      for id in ''${stale_dirs_ids}; do
+        curl -X DELETE ${curlAddressArgs "/rest/config/folders/$id"}
+      done
+    ''
+    #
+    # Now we update the other settings defined in cleanedConfig which are not
+    # "folders" or "devices".
+    #
+    + (lib.pipe cleanedConfig [
+      builtins.attrNames
+      (lib.subtractLists [
+        "folders"
+        "devices"
       ])
+      (map (subOption: ''
+        curl -X PUT -d ${
+          lib.escapeShellArg (builtins.toJSON cleanedConfig.${subOption})
+        } ${curlAddressArgs "/rest/config/${subOption}"}
+      ''))
+      (lib.concatStringsSep "\n")
+    ])
     + lib.optionalString (cfg.passwordFile != null) ''
       syncthing_password=$(${cat} ${cfg.passwordFile})
       curl -X PATCH -d '{"password": "'$syncthing_password'"}' ${curlAddressArgs "/rest/config/gui"}
@@ -475,11 +462,38 @@ in
                       };
 
                       devices = mkOption {
-                        type = with types; listOf str;
+                        type = types.listOf (
+                          types.oneOf [
+                            types.str
+                            (types.submodule {
+                              options = {
+                                deviceID = mkOption {
+                                  type = types.str;
+                                  description = ''
+                                    The ID of the device.
+                                    Corresponds to `services.syncthing.settings.devices.<name>.id`.
+                                  '';
+                                };
+                                encryptionPasswordFile = mkOption {
+                                  type = types.nullOr types.path;
+                                  default = null;
+                                  description = ''
+                                    Path to a file containing a password used to encrypt the files before sending them
+                                    to this device. May include environment variables, which are evaluated in the
+                                    syncthing services environment.
+                                  '';
+                                };
+                              };
+                            })
+                          ]
+                        );
                         default = [ ];
                         description = ''
-                          The devices this folder should be shared with. Each device must
-                          be defined in the [devices](#opt-services.syncthing.settings.devices) option.
+                          The devices this folder should be shared with.
+                          Must be either the attribute name of the corresponding attribute in the
+                          [devices](#opt-services.syncthing.settings.devices) option
+                          or an attribute set as accepted by the
+                          [Syncthing API](https://docs.syncthing.net/rest/config.html#rest-config-folders-id-rest-config-devices-id).
                         '';
                       };
 


### PR DESCRIPTION
### Description

Syncthing allows setting a password for specific devices a specific folder is shared with. Files are encrypted before being send to this device. The password can be set using the API by setting the `encryptionPassword` property of the given device in a folder config.

Previously it was not possible to use this functionality of Syncthing with this Home Manager module, because the the devices attribute of a configured folder only accepted strings. The module than created a device item as expected by the Syncthing API, but only set the `deviceID` attribute of this item, but neglected the optional `encryptionPassword` attribute.

The changes of this PR enable the usage of encrypted folder sharing, by adjusting the handling of configured folders. The items of the `devices` list of a folder config may now be attribute sets instead of strings. While strings are handled in the same way as previously, the attribute sets must contain the `deviceID` attribute may additionally contain an `encryptionPasswordFile` attribute, whose value must be a path to a file, whose content will be used as the value for the `encryptionPassword` attribute send to Syncthing.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@rycee 