### PR TITLE
jellyfin-mpv-shim: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -734,6 +734,12 @@
       }
     ];
   };
+  repparw = {
+    name = "repparw";
+    email = "ubritos@gmail.com";
+    github = "repparw";
+    githubId = 45952970;
+  };
   rosuavio = {
     name = "Rosario Pulella";
     email = "RosarioPulella@gmail.com";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -387,6 +387,7 @@ let
       ./services/hyprsunset.nix
       ./services/imapnotify.nix
       ./services/jankyborders.nix
+      ./services/jellyfin-mpv-shim.nix
       ./services/kanshi.nix
       ./services/kbfs.nix
       ./services/kdeconnect.nix

--- a/modules/services/jellyfin-mpv-shim.nix
+++ b/modules/services/jellyfin-mpv-shim.nix
@@ -1,0 +1,140 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (builtins) typeOf stringLength;
+  jsonFormat = pkgs.formats.json { };
+  cfg = config.services.jellyfin-mpv-shim;
+
+  renderOption =
+    option:
+    rec {
+      int = toString option;
+      float = int;
+      bool = lib.hm.booleans.yesNo option;
+      string = option;
+    }
+    .${typeOf option};
+
+  renderOptionValue =
+    value:
+    let
+      rendered = renderOption value;
+      length = toString (stringLength rendered);
+    in
+    "%${length}%${rendered}";
+
+  renderOptions = lib.generators.toKeyValue {
+    mkKeyValue = lib.generators.mkKeyValueDefault { mkValueString = renderOptionValue; } "=";
+    listsAsDuplicateKeys = true;
+  };
+
+  renderBindings =
+    bindings: lib.concatStringsSep "\n" (lib.mapAttrsToList (name: value: "${name} ${value}") bindings);
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.repparw ];
+
+  options = {
+    services.jellyfin-mpv-shim = {
+      enable = lib.mkEnableOption "Jellyfin mpv shim";
+
+      package = lib.mkPackageOption pkgs "jellyfin-mpv-shim" { };
+
+      settings = lib.mkOption {
+        type = jsonFormat.type;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            allow_transcode_to_h265 = false;
+            always_transcode = false;
+            audio_output = "hdmi";
+            auto_play = true;
+            fullscreen = true;
+            player_name = "mpv-shim";
+          }
+        '';
+        description = ''
+          Configuration written to
+          {file}`$XDG_CONFIG_HOME/jellyfin-mpv-shim/conf.json`. See
+          <https://github.com/jellyfin/jellyfin-mpv-shim#configuration>
+          for the configuration documentation.
+        '';
+      };
+
+      mpvConfig = lib.mkOption {
+        type = lib.types.nullOr (
+          lib.types.attrsOf (
+            lib.types.either lib.types.str (
+              lib.types.either lib.types.int (lib.types.either lib.types.bool lib.types.float)
+            )
+          )
+        );
+        default = null;
+        example = lib.literalExpression ''
+          {
+                    profile = "gpu-hq";
+                    force-window = true;
+                  }'';
+        description = ''
+          mpv configuration options to use for jellyfin-mpv-shim.
+          If null, jellyfin-mpv-shim will use its default mpv configuration.
+        '';
+      };
+
+      mpvBindings = lib.mkOption {
+        type = lib.types.nullOr (lib.types.attrsOf lib.types.str);
+        default = null;
+        example = lib.literalExpression ''
+          {
+                    WHEEL_UP = "seek 10";
+                    WHEEL_DOWN = "seek -10";
+                  }'';
+        description = ''
+          mpv input bindings to use for jellyfin-mpv-shim.
+          If null, jellyfin-mpv-shim will use its default input configuration.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.jellyfin-mpv-shim" pkgs lib.platforms.linux)
+    ];
+
+    xdg.configFile = {
+      "jellyfin-mpv-shim/conf.json" = lib.mkIf (cfg.settings != { }) {
+        source = jsonFormat.generate "jellyfin-mpv-shim-conf" cfg.settings;
+      };
+
+      "jellyfin-mpv-shim/mpv.conf" = lib.mkIf (cfg.mpvConfig != null) {
+        text = renderOptions cfg.mpvConfig;
+      };
+
+      "jellyfin-mpv-shim/input.conf" = lib.mkIf (cfg.mpvBindings != null) {
+        text = renderBindings cfg.mpvBindings;
+      };
+    };
+
+    systemd.user.services.jellyfin-mpv-shim = {
+      Unit = {
+        Description = "Jellyfin mpv shim";
+        Documentation = "https://github.com/jellyfin/jellyfin-mpv-shim";
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        ExecStart = "${lib.getExe cfg.package}";
+      };
+
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+    };
+  };
+}

--- a/tests/modules/services/jellyfin-mpv-shim/default.nix
+++ b/tests/modules/services/jellyfin-mpv-shim/default.nix
@@ -1,0 +1,3 @@
+{
+  jellyfin-mpv-shim-example-settings = ./jellyfin-mpv-shim-example-settings.nix;
+}

--- a/tests/modules/services/jellyfin-mpv-shim/jellyfin-mpv-shim-example-settings-expected-bindings
+++ b/tests/modules/services/jellyfin-mpv-shim/jellyfin-mpv-shim-example-settings-expected-bindings
@@ -1,0 +1,3 @@
+Alt+0 set window-scale 0.5
+WHEEL_DOWN seek -10
+WHEEL_UP seek 10

--- a/tests/modules/services/jellyfin-mpv-shim/jellyfin-mpv-shim-example-settings-expected-config
+++ b/tests/modules/services/jellyfin-mpv-shim/jellyfin-mpv-shim-example-settings-expected-config
@@ -1,0 +1,3 @@
+cache-default=%7%4000000
+force-window=%3%yes
+ytdl-format=%19%bestvideo+bestaudio

--- a/tests/modules/services/jellyfin-mpv-shim/jellyfin-mpv-shim-example-settings-expected-settings
+++ b/tests/modules/services/jellyfin-mpv-shim/jellyfin-mpv-shim-example-settings-expected-settings
@@ -1,0 +1,8 @@
+{
+     "allow_transcode_to_h265": false,
+     "always_transcode": false,
+     "audio_output": "hdmi",
+     "auto_play": true,
+     "fullscreen": true,
+     "player_name": "mpv-shim"
+}

--- a/tests/modules/services/jellyfin-mpv-shim/jellyfin-mpv-shim-example-settings.nix
+++ b/tests/modules/services/jellyfin-mpv-shim/jellyfin-mpv-shim-example-settings.nix
@@ -1,0 +1,39 @@
+{ ... }:
+{
+  services.jellyfin-mpv-shim = {
+    enable = true;
+
+    settings = {
+      allow_transcode_to_h265 = false;
+      always_transcode = false;
+      audio_output = "hdmi";
+      auto_play = true;
+      fullscreen = true;
+      player_name = "mpv-shim";
+    };
+
+    mpvBindings = {
+      WHEEL_UP = "seek 10";
+      WHEEL_DOWN = "seek -10";
+      "Alt+0" = "set window-scale 0.5";
+    };
+
+    mpvConfig = {
+      force-window = true;
+      ytdl-format = "bestvideo+bestaudio";
+      cache-default = 4000000;
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+       home-files/.config/jellyfin-mpv-shim/conf.json \
+       ${./jellyfin-mpv-shim-example-settings-expected-settings}
+    assertFileContent \
+       home-files/.config/jellyfin-mpv-shim/mpv.conf \
+       ${./jellyfin-mpv-shim-example-settings-expected-config}
+    assertFileContent \
+       home-files/.config/jellyfin-mpv-shim/input.conf \
+       ${./jellyfin-mpv-shim-example-settings-expected-bindings}
+  '';
+}


### PR DESCRIPTION
### Description

Init of service jellyfin-mpv-shim, emulating plex-mpv-shim already provided.

### Checklist

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).