### PR TITLE
Dconf: Fix config section not appling correctly

### DIFF
--- a/modules/misc/dconf.nix
+++ b/modules/misc/dconf.nix
@@ -76,13 +76,13 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable (
-    {
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
       home.packages = [ pkgs.dconf ];
       dbus.packages = [ pkgs.dconf ];
       home.sessionVariables.GIO_EXTRA_MODULES = "${pkgs.dconf.lib}/lib/gio/modules";
-    }
-    // lib.mkIf (cfg.settings != { }) {
+    })
+    (lib.mkIf (cfg.enable && cfg.settings != { }) {
       # Make sure the dconf directory exists.
       xdg.configFile."dconf/.keep".source = builtins.toFile "keep" "";
 
@@ -147,6 +147,6 @@ in
           unset DCONF_DBUS_RUN_SESSION
         ''
       );
-    }
-  );
+    })
+  ];
 }

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -9,6 +9,7 @@ let
     if [ -n "$__HM_SESS_VARS_SOURCED" ]; then return; fi
     export __HM_SESS_VARS_SOURCED=1
 
+    export GIO_EXTRA_MODULES="${pkgs.dconf}/lib/gio/modules"
     export LOCALE_ARCHIVE_2_27="${config.i18n.glibcLocales}/lib/locale/locale-archive"
     export V1="v1"
     export V2="v2-v1"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
