### PR TITLE
dwm-status: run with --quiet

### DIFF
--- a/modules/services/dwm-status.nix
+++ b/modules/services/dwm-status.nix
@@ -78,7 +78,7 @@ in
       };
 
       Service = {
-        ExecStart = "${cfg.package}/bin/dwm-status ${configFile}";
+        ExecStart = "${cfg.package}/bin/dwm-status ${configFile} --quiet";
       };
     };
   };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This turns of verbose logging such as printing that the time has updated every second.

~~Depends on https://github.com/NixOS/nixpkgs/pull/411463~~

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
