### PR TITLE
home-manager: add support for custom backup command (#6424)

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -977,6 +977,11 @@ while [[ $# -gt 0 ]]; do
             EXTRA_NIX_PATH+=("$1")
             shift
             ;;
+        -B)
+            [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
+            export HOME_MANAGER_BACKUP_COMMAND="$1"
+            shift
+            ;;
         -b)
             [[ -v 1 && $1 != -* ]] || errMissingOptArg "$opt"
             export HOME_MANAGER_BACKUP_EXT="$1"

--- a/modules/files.nix
+++ b/modules/files.nix
@@ -146,10 +146,15 @@ in
           for sourcePath in "$@" ; do
             relativePath="''${sourcePath#$newGenFiles/}"
             targetPath="$HOME/$relativePath"
-            if [[ -e "$targetPath" && ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
-              # The target exists, back it up
-              backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
-              run mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
+            if [[ -e "$targetPath" && ! -L "$targetPath" ]] ; then
+              if [[ -n "$HOME_MANAGER_BACKUP_COMMAND" ]] ; then
+                # TODO: Bail out early?
+                run $HOME_MANAGER_BACKUP_COMMAND "$targetPath" || errorEcho "Running `$HOME_MANAGER_BACKUP_COMMAND` on '$targetPath' failed."
+              elif [[ -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
+                # The target exists, back it up
+                backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
+                run mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
+              fi
             fi
 
             if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath" ; then

--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -30,6 +30,9 @@ for sourcePath in "$@" ; do
     if cmp -s "$sourcePath" "$targetPath"; then
       # First compare the files' content. If they're equal, we're fine.
       warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be skipped since they are the same"
+    elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_COMMAND" ]] ; then
+      # Next, try to run the custom backup command. Assume this always succeeds.
+      :
     elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
       # Next, try to move the file to a backup location if configured and possible
       backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
@@ -50,9 +53,11 @@ if [[ ${#collisionErrors[@]} -gt 0 ]] ; then
 - Move or remove the files below and try again.
 - In standalone mode, use 'home-manager switch -b backup' to back up
   files automatically.
-- When used as a NixOS or nix-darwin module, set
-    'home-manager.backupFileExtension'
-  to, for example, 'backup' and rebuild."
+- When used as a NixOS or nix-darwin module, set either
+    'home-manager.backupFileExtension', or
+    'home-manager.backupCommand'
+  to move the file to a new location in the same directory, or run a
+  custom command."
   for error in "${collisionErrors[@]}" ; do
     errorEcho "$error"
   done

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -23,6 +23,9 @@ in
             ${lib.optionalString (
               cfg.backupFileExtension != null
             ) "export HOME_MANAGER_BACKUP_EXT=${lib.escapeShellArg cfg.backupFileExtension}"}
+            ${lib.optionalString (
+              cfg.backupCommand != null
+            ) "export HOME_MANAGER_BACKUP_COMMAND=${lib.escapeShellArg cfg.backupCommand}"}
             ${lib.optionalString cfg.verbose "export VERBOSE=1"}
             exec ${usercfg.home.activationPackage}/activate
           ''}

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -77,6 +77,16 @@ in
       argument in Home Manager. This disables the Home Manager
       options {option}`nixpkgs.*`'';
 
+    backupCommand = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = lib.literalExpression "''${pkgs.trash-cli}/bin/trash";
+      description = ''
+        On activation run this command on each existing file
+        rather than exiting with an error.
+      '';
+    };
+
     backupFileExtension = mkOption {
       type = types.nullOr types.str;
       default = null;

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -14,6 +14,9 @@ let
     lib.optionalAttrs (cfg.backupFileExtension != null) {
       HOME_MANAGER_BACKUP_EXT = cfg.backupFileExtension;
     }
+    // lib.optionalAttrs (cfg.backupCommand != null) {
+      HOME_MANAGER_BACKUP_COMMAND = cfg.backupCommand;
+    }
     // lib.optionalAttrs cfg.verbose { VERBOSE = "1"; };
 
 in


### PR DESCRIPTION
### Description

This PR adds support for a custom backup command in Home Manager.  
A new `backupCommand` option is introduced, allowing users to specify a shell command to run on existing files that would otherwise block activation (e.g., moving files to trash, archiving, or custom backup logic). If set, this command is used in preference to the existing `backupFileExtension` mechanism.

- Adds `backupCommand` option to NixOS and nix-darwin modules.
- Exports `HOME_MANAGER_BACKUP_COMMAND` environment variable when set.
- Updates activation logic to invoke the custom backup command if provided.
- Updates collision checking and user-facing instructions to document the new option.

This enables more flexible and user-defined backup workflows during Home Manager activations.

This resolves [Optional user defined script for error handling in case of home-manager backup file already existing #6424](https://github.com/nix-community/home-manager/issues/6424).

---

### Checklist

- [x] Change is backwards compatible.
  - Behaviour is only changed if the new option `backupCommand`, or the new environment variable `HOME_MANAGER_BACKUP_COMMAND` is used.
- [x] Code formatted.
- [x] Code tested.
- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  - Requires additional integration test for backing up files generally.
- [x] Commit messages formatted.

- If this PR adds a new module...
  . N/A

#### Maintainer CC

N/A
