### PR TITLE
hwatch: add module

### DIFF
--- a/modules/misc/news/2025/05/2025-05-29_14-33-51.nix
+++ b/modules/misc/news/2025/05/2025-05-29_14-33-51.nix
@@ -1,0 +1,7 @@
+{
+  time = "2025-05-29T18:33:51+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.hwatch'.
+  '';
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -139,6 +139,7 @@ let
       ./programs/home-manager.nix
       ./programs/hstr.nix
       ./programs/htop.nix
+      ./programs/hwatch.nix
       ./programs/hyfetch.nix
       ./programs/hyprlock.nix
       ./programs/i3bar-river.nix

--- a/modules/programs/hwatch.nix
+++ b/modules/programs/hwatch.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    types
+    ;
+  cfg = config.programs.hwatch;
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [
+    Aehmlo
+  ];
+
+  options.programs.hwatch = {
+    enable = lib.mkEnableOption ''
+      hwatch, a modern alternative to the {command}`watch` command
+    '';
+
+    package = lib.mkPackageOption pkgs "hwatch" { nullable = true; };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [
+        "--exec"
+        "--precise"
+      ];
+      description = ''
+        Extra command-line arguments to pass to {command}`hwatch`.
+        These will be used to populate the {env}`HWATCH` environment variable.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    home.sessionVariables = mkIf (cfg.extraArgs != [ ]) {
+      HWATCH = lib.concatMapStringsSep " " lib.escapeShellArg cfg.extraArgs;
+    };
+  };
+
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -216,6 +216,7 @@ import nmtSrc {
       ./modules/programs/helix
       ./modules/programs/himalaya
       ./modules/programs/htop
+      ./modules/programs/hwatch
       ./modules/programs/hyfetch
       ./modules/programs/i3status
       ./modules/programs/inori

--- a/tests/modules/programs/hwatch/default.nix
+++ b/tests/modules/programs/hwatch/default.nix
@@ -1,0 +1,4 @@
+{
+  hwatch-empty-config = ./empty-config.nix;
+  hwatch-example-config = ./example-config.nix;
+}

--- a/tests/modules/programs/hwatch/empty-config.nix
+++ b/tests/modules/programs/hwatch/empty-config.nix
@@ -1,0 +1,15 @@
+{
+  config,
+  ...
+}:
+
+{
+  programs.hwatch = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+  };
+
+  nmt.script = ''
+    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh "HWATCH"
+  '';
+}

--- a/tests/modules/programs/hwatch/example-config.nix
+++ b/tests/modules/programs/hwatch/example-config.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  ...
+}:
+
+{
+  programs.hwatch = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    extraArgs = [
+      "--exec"
+      "--precise"
+    ];
+  };
+
+  nmt.script = ''
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh 'HWATCH="--exec --precise"'
+  '';
+}


### PR DESCRIPTION
### Description

This PR adds support for configuring [`hwatch`](https://github.com/blacknon/hwatch), a modern alternative to the `watch` command. `hwatch` is [available in Nixpkgs](https://search.nixos.org/packages?channel=24.11&type=packages&query=hwatch) and is configured [using the `HWATCH` environment variable](https://github.com/blacknon/hwatch?tab=readme-ov-file#configuration).

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).