### PR TITLE
linux-wallpaperengine: Fix evaluation error when passing null as options

### DIFF
--- a/modules/services/linux-wallpaperengine.nix
+++ b/modules/services/linux-wallpaperengine.nix
@@ -19,7 +19,8 @@ in
     package = lib.mkPackageOption pkgs "linux-wallpaperengine" { };
 
     assetsPath = mkOption {
-      type = types.path;
+      type = types.nullOr types.path;
+      default = null;
       description = "Path to the assets directory.";
     };
 
@@ -104,6 +105,10 @@ in
   config = lib.mkIf cfg.enable {
     assertions = [
       (lib.hm.assertions.assertPlatform "services.linux-wallpaperengine" pkgs lib.platforms.linux)
+      ({
+        assertion = cfg.wallpapers != null;
+        message = "linux-wallpaperengine: You must set at least one wallpaper";
+      })
     ];
 
     home.packages = [ cfg.package ];
@@ -135,8 +140,8 @@ in
         Service = {
           ExecStart =
             lib.getExe cfg.package
-            + " --assets-dir ${cfg.assetsPath} "
-            + "--clamping ${cfg.clamping} "
+            + (lib.optionalString (cfg.assetsPath != null) " --assets-dir ${cfg.assetsPath} ")
+            + (lib.optionalString (cfg.clamping != null) "--clamping ${cfg.clamping} ")
             + (lib.strings.concatStringsSep " " args);
           Restart = "on-failure";
         };

--- a/tests/modules/services/linux-wallpaperengine/default.nix
+++ b/tests/modules/services/linux-wallpaperengine/default.nix
@@ -1,1 +1,4 @@
-{ linux-wallpaperengine-basic-configuration = ./basic-configuration.nix; }
+{
+  linux-wallpaperengine-basic-configuration = ./basic-configuration.nix;
+  linux-wallpaperengine-null-options = ./null-options.nix;
+}

--- a/tests/modules/services/linux-wallpaperengine/null-options-expected.service
+++ b/tests/modules/services/linux-wallpaperengine/null-options-expected.service
@@ -1,0 +1,11 @@
+[Install]
+WantedBy=graphical-session.target
+
+[Service]
+ExecStart=@linux-wallpaperengine@/bin/linux-wallpaperengine
+Restart=on-failure
+
+[Unit]
+After=graphical-session.target
+Description=Implementation of Wallpaper Engine on Linux
+PartOf=graphical-session.target

--- a/tests/modules/services/linux-wallpaperengine/null-options.nix
+++ b/tests/modules/services/linux-wallpaperengine/null-options.nix
@@ -1,0 +1,11 @@
+{
+  services.linux-wallpaperengine = {
+    enable = true;
+  };
+
+  nmt.script = ''
+    assertFileContent \
+        home-files/.config/systemd/user/linux-wallpaperengine.service \
+        ${./null-options-expected.service}
+  '';
+}


### PR DESCRIPTION
### Description

This fixes evaluation error "cannot coerce null to a string" when setting either `services.linux-wallpaperengine.clamping` or `assetsPath` to null or leave as default.   

I received an email notification from @ccalhoun1999 from my mailbox, but I didn't see their comment on the original pull request, so I'll mention them here for reference.   

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

myself
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
