### PR TITLE
ci: add backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,40 @@
+# Based on
+# https://github.com/NixOS/nixpkgs/blob/2566f9dc/.github/workflows/backport.yml
+#
+# NOTE: this uses the GH_TOKEN_FOR_UPDATES because pushing a backport PR using
+# GITHUB_TOKEN does not trigger CI.
+# TODO: consider switching to a GitHub App
+name: Backport
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport Pull Request
+    if: >
+      secrets.GH_TOKEN_FOR_UPDATES
+      && github.event.pull_request.merged == true
+      && (
+        github.event.action != 'labeled'
+        || startsWith(github.event.label.name, 'backport')
+      )
+
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Create backport PRs
+        id: backport
+        uses: korthout/backport-action@v3
+        with:
+          # See https://github.com/korthout/backport-action#inputs
+          github_token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          branch_name: backport/${target_branch}/${pull_number}
+          copy_labels_pattern: .*

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -17,5 +17,8 @@ jobs:
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v25
         with:
+          # NOTE: this uses the GH_TOKEN_FOR_UPDATES because pushing a flake
+          # update PR using GITHUB_TOKEN does not trigger CI.
+          # TODO: consider switching to a GitHub App
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           pr-labels: dependencies


### PR DESCRIPTION
### Description

As I was recently adding this workflow to Nixvim, I figured home-manager would benefit too.

Adds a GitHub workflow to create backport PRs when merged PRs have a "backport" label.

This uses the very flexible https://github.com/korthout/backport-action and is based on the [workflow used by nixpkgs](https://github.com/NixOS/nixpkgs/blob/2566f9dc/.github/workflows/backport.yml), which is also [used by Stylix](https://github.com/nix-community/stylix/blob/0512b0f/.github/workflows/backport.yml) and [most recently, Nixvim](https://github.com/nix-community/nixvim/pull/3411). See [how it works](https://github.com/korthout/backport-action#how-it-works).

Currently, the workflow [will assume](https://github.com/korthout/backport-action#label_pattern) that backport labels follow the regex `backport ([^ ]+)$` (e.g. `backport nixos-25.05`), however it could be customised by assigning a different regex to `with: label_pattern`.

In order to trigger CI workflows to run on PRs created by the backport workflow, I've configured it to use `GH_TOKEN_FOR_UPDATES`. Ideally both the backport workflow and the update workflow would migrate to using a GitHub App with the [create-github-app-token](https://github.com/actions/create-github-app-token) action. I've added some TODO comments, however I don't want to distract from the crux of this PR by tackling such a migration now.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@khaneliman

