### PR TITLE
ci: alternative fix for backport if condition

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,7 +16,7 @@ jobs:
   backport:
     name: Backport Pull Request
     if: >
-      secrets.GH_TOKEN_FOR_UPDATES
+      github.repository_owner == 'nix-community'
       && github.event.pull_request.merged == true
       && (
         github.event.action != 'labeled'

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,19 +16,15 @@ jobs:
   backport:
     name: Backport Pull Request
     if: >
-      github.event.pull_request.merged == true &&
-      ( github.event.action != 'labeled'
+      secrets.GH_TOKEN_FOR_UPDATES
+      && github.event.pull_request.merged == true
+      && (
+        github.event.action != 'labeled'
         || startsWith(github.event.label.name, 'backport')
       )
 
     runs-on: ubuntu-24.04-arm
     steps:
-      - name: Check token
-        run: |
-          if [ -z "${{ secrets.GH_TOKEN_FOR_UPDATES }}" ]; then
-            echo "GH_TOKEN_FOR_UPDATES secret is not set"
-            exit 1
-          fi
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}


### PR DESCRIPTION
### Description

Followup to:

- #7167
- #7165

Ideally, the if condition checks that the necessary vars are available. This allows testing workflows on a fork of the repo, by first configuring required vars and secrets.

However it that's not possible, due to _secrets_ always being "falsy" and not having any _vars_, we can explicitly check this is not a fork using `github.repository_owner == 'nix-community'`.

This is a better solution than dynamically checking in a step, as it avoids running any jobs at all. This also avoids a "failure" if the workflow is accidentally run on a fork, because `if` conditions are considered neutral.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@khaneliman 
