### PR TITLE
{ci,lib}: remove 22.11 deprecations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,26 +11,21 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v31
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-        extra_nix_config: |
-          experimental-features = nix-command flakes
-    - run: |
-        if grep -R --exclude stdlib-extended.nix literalExample modules ; then
-          echo "Error: literalExample should be replaced by literalExpression" > /dev/stderr
-          exit 1
-        fi
-    - run: nix-build --show-trace -A docs.jsonModuleMaintainers
-    - run: nix fmt -- --ci
-    - run: nix-shell --show-trace . -A install
-    - run: yes | home-manager -I home-manager=. uninstall
-    - name: Run tests
-      run: nix-build -j auto --show-trace --arg enableBig false --pure --option allow-import-from-derivation false tests -A build.all
-      env:
-        GC_INITIAL_HEAP_SIZE: 4294967296
-    - name: Run tests (with IFD)
-      run: nix-build -j auto --show-trace --arg enableBig false --pure --arg enableLegacyIfd true tests -A build.all
-      env:
-        GC_INITIAL_HEAP_SIZE: 4294967296
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - run: nix-build --show-trace -A docs.jsonModuleMaintainers
+      - run: nix fmt -- --ci
+      - run: nix-shell --show-trace . -A install
+      - run: yes | home-manager -I home-manager=. uninstall
+      - name: Run tests
+        run: nix-build -j auto --show-trace --arg enableBig false --pure --option allow-import-from-derivation false tests -A build.all
+        env:
+          GC_INITIAL_HEAP_SIZE: 4294967296
+      - name: Run tests (with IFD)
+        run: nix-build -j auto --show-trace --arg enableBig false --pure --arg enableLegacyIfd true tests -A build.all
+        env:
+          GC_INITIAL_HEAP_SIZE: 4294967296

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,70 +1,32 @@
 { lib }:
 {
   hm = (import ../modules/lib/stdlib-extended.nix lib).hm;
+
   homeManagerConfiguration =
     {
+      check ? true,
+      extraSpecialArgs ? { },
+      lib ? pkgs.lib,
       modules ? [ ],
       pkgs,
-      lib ? pkgs.lib,
-      extraSpecialArgs ? { },
-      check ? true,
-      # Deprecated:
-      configuration ? null,
-    }@args:
-    let
-      msgForRemovedArg = ''
-        The 'homeManagerConfiguration' arguments
+    }:
+    import ../modules {
+      inherit
+        check
+        extraSpecialArgs
+        lib
+        pkgs
+        ;
+      configuration =
+        { ... }:
+        {
+          imports = modules ++ [ { programs.home-manager.path = "${../.}"; } ];
 
-          - 'configuration',
-          - 'username',
-          - 'homeDirectory'
-          - 'stateVersion',
-          - 'extraModules', and
-          - 'system'
+          nixpkgs = {
+            config = lib.mkDefault pkgs.config;
 
-        have been removed. Instead use the arguments 'pkgs' and
-        'modules'. See the 22.11 release notes for more: https://nix-community.github.io/home-manager/release-notes.xhtml#sec-release-22.11-highlights
-      '';
-
-      throwForRemovedArgs =
-        v:
-        let
-          used = builtins.filter (n: (args.${n} or null) != null) [
-            "configuration"
-            "username"
-            "homeDirectory"
-            "stateVersion"
-            "extraModules"
-            "system"
-          ];
-          msg =
-            msgForRemovedArg
-            + ''
-
-
-              Deprecated args passed: ''
-            + builtins.concatStringsSep " " used;
-        in
-        lib.throwIf (used != [ ]) msg v;
-
-    in
-    throwForRemovedArgs (
-      import ../modules {
-        inherit
-          pkgs
-          lib
-          check
-          extraSpecialArgs
-          ;
-        configuration =
-          { ... }:
-          {
-            imports = modules ++ [ { programs.home-manager.path = "${../.}"; } ];
-            nixpkgs = {
-              config = lib.mkDefault pkgs.config;
-              inherit (pkgs) overlays;
-            };
+            inherit (pkgs) overlays;
           };
-      }
-    );
+        };
+    };
 }

--- a/modules/lib/stdlib-extended.nix
+++ b/modules/lib/stdlib-extended.nix
@@ -9,9 +9,5 @@ in
 nixpkgsLib.extend (
   self: super: {
     hm = mkHmLib { lib = self; };
-
-    # For forward compatibility.
-    literalExpression = super.literalExpression or super.literalExample;
-    literalDocBook = super.literalDocBook or super.literalExample;
   }
 )


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
