### PR TITLE
news: re-add dropped news entries

### DIFF
--- a/modules/misc/news/2024/12/2024-12-08_17-22-13.nix
+++ b/modules/misc/news/2024/12/2024-12-08_17-22-13.nix
@@ -1,0 +1,31 @@
+{ config, lib, ... }:
+
+{
+  time = "2024-12-08T17:22:13+00:00";
+  condition =
+    let
+      usingMbsync = lib.any (a: a.mbsync.enable) (lib.attrValues config.accounts.email.accounts);
+    in
+    usingMbsync;
+  message = ''
+    isync/mbsync 1.5.0 has changed several things.
+
+    isync gained support for using $XDG_CONFIG_HOME, and now places
+    its config file in '$XDG_CONFIG_HOME/isyncrc'.
+
+    isync changed the configuration options SSLType and SSLVersion to
+    TLSType and TLSVersion respectively.
+
+    All instances of
+    'accounts.email.accounts.<account-name>.mbsync.extraConfig.account'
+    that use 'SSLType' or 'SSLVersion' should be replaced with 'TLSType'
+    or 'TLSVersion', respectively.
+
+    TLSType options are unchanged.
+
+    TLSVersions has a new syntax, requiring a change to the Nix syntax.
+    Old Syntax: SSLVersions = [ "TLSv1.3" "TLSv1.2" ];
+    New Syntax: TLSVersions = [ "+1.3" "+1.2" "-1.1" ];
+    NOTE: The minus symbol means to NOT use that particular TLS version.
+  '';
+}

--- a/modules/misc/news/2024/12/2024-12-10_22-20-10.nix
+++ b/modules/misc/news/2024/12/2024-12-10_22-20-10.nix
@@ -1,0 +1,10 @@
+{ config, ... }:
+
+{
+  time = "2024-12-10T22:20:10+00:00";
+  condition = config.programs.nushell.enable;
+  message = ''
+    The module 'programs.nushell' can now manage the Nushell plugin
+    registry with the option 'programs.nushell.plugins'.
+  '';
+}

--- a/modules/misc/news/2024/12/2024-12-21_17-07-49.nix
+++ b/modules/misc/news/2024/12/2024-12-21_17-07-49.nix
@@ -1,0 +1,10 @@
+{
+  time = "2024-12-21T17:07:49+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.pay-respects'.
+
+    Pay Respects is a shell command suggestions tool and command-not-found
+    and thefuck replacement written in Rust.
+  '';
+}

--- a/modules/misc/news/2024/12/2024-12-22_08-24-29.nix
+++ b/modules/misc/news/2024/12/2024-12-22_08-24-29.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+{
+  time = "2024-12-22T08:24:29+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'programs.cavalier'.
+
+    Cavalier is a GUI wrapper around the Cava audio visualizer.
+  '';
+}

--- a/modules/misc/news/2025/01/2025-01-01_15-31-15.nix
+++ b/modules/misc/news/2025/01/2025-01-01_15-31-15.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+{
+  time = "2025-01-01T15:31:15+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    The 'systemd.user.startServices' option now defaults to 'true',
+    meaning that services will automatically be restarted as needed when
+    activating a configuration.
+
+    Further, the "legacy" alternative has been removed and will now result
+    in an evaluation error if used.
+
+    The "suggest" alternative will remain for a while longer but may also
+    be deprecated for removal in the future.
+  '';
+}

--- a/modules/misc/news/2025/01/2025-01-01_23-16-35.nix
+++ b/modules/misc/news/2025/01/2025-01-01_23-16-35.nix
@@ -1,0 +1,12 @@
+{
+  time = "2025-01-01T23:16:35+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.ghostty'.
+
+    Ghostty is a terminal emulator that differentiates itself by being
+    fast, feature-rich, and native. While there are many excellent
+    terminal emulators available, they all force you to choose between
+    speed, features, or native UIs. Ghostty provides all three.
+  '';
+}

--- a/modules/misc/news/2025/01/2025-01-02_11-21-19.nix
+++ b/modules/misc/news/2025/01/2025-01-02_11-21-19.nix
@@ -1,0 +1,10 @@
+{
+  time = "2025-01-02T11:21:19+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'services.mpdscribble'.
+
+    A MPD client which submits information about tracks being played to a
+    scrobbler (e.g. last.fm)
+  '';
+}

--- a/modules/misc/news/2025/01/2025-01-04_15-00-00.nix
+++ b/modules/misc/news/2025/01/2025-01-04_15-00-00.nix
@@ -1,0 +1,16 @@
+{ pkgs, ... }:
+
+{
+  time = "2025-01-04T15:00:00+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'wayland.windowManager.wayfire'.
+
+    Wayfire is a 3D Wayland compositor, inspired by Compiz and based on
+    wlroots. It aims to create a customizable, extendable and lightweight
+    environment without sacrificing its appearance.
+
+    This Home Manager module allows you to configure both wayfire itself,
+    as well as wf-shell.
+  '';
+}

--- a/modules/misc/news/2025/01/2025-01-21_17-28-13.nix
+++ b/modules/misc/news/2025/01/2025-01-21_17-28-13.nix
@@ -1,0 +1,13 @@
+{ config, ... }:
+
+{
+  time = "2025-01-21T17:28:13+00:00";
+  condition = with config.programs.yazi; enable && enableFishIntegration;
+  message = ''
+    Yazi's fish shell integration wrapper now calls the 'yazi' executable
+    directly, ignoring any shell aliases with the same name.
+
+    Your configuration may break if you rely on the wrapper calling a
+    'yazi' alias.
+  '';
+}

--- a/modules/misc/news/2025/01/2025-01-26_16-40-00.nix
+++ b/modules/misc/news/2025/01/2025-01-26_16-40-00.nix
@@ -1,0 +1,11 @@
+{
+  time = "2025-01-26T16:40:00+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.mods'
+
+    mods is a command line AI tool that is highly configurable and allows
+    querying AI models hosted locally or by other services (OpenAI,
+    Cohere, Groq).
+  '';
+}

--- a/modules/misc/news/2025/01/2025-01-29_17-34-53.nix
+++ b/modules/misc/news/2025/01/2025-01-29_17-34-53.nix
@@ -1,0 +1,14 @@
+{ config, ... }:
+
+{
+  time = "2025-01-29T17:34:53+00:00";
+  condition = config.programs.firefox.enable;
+  message = ''
+    The Firefox module now provides a
+    'programs.firefox.profiles.<name>.preConfig' option.
+
+    It allows extra preferences to be added to 'user.js' before the
+    options specified in 'programs.firefox.profiles.<name>.settings', so
+    that they can be overwritten.
+  '';
+}

--- a/modules/misc/news/2025/01/2025-01-29_19-11-20.nix
+++ b/modules/misc/news/2025/01/2025-01-29_19-11-20.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+
+{
+  time = "2025-01-29T19:11:20+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    A new module is available: 'programs.aerospace'.
+
+    AeroSpace is an i3-like tiling window manager for macOS.
+    See https://github.com/nikitabobko/AeroSpace for more.
+  '';
+}

--- a/modules/misc/news/2025/01/2025-01-30_09-18-55.nix
+++ b/modules/misc/news/2025/01/2025-01-30_09-18-55.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+
+{
+  time = "2025-01-30T09:18:55+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'services.linux-wallpaperengine'.
+
+    Reproduce the background functionality of Wallpaper Engine on Linux
+    systems.
+  '';
+}

--- a/modules/misc/news/2025/02/2025-02-07_22-31-45.nix
+++ b/modules/misc/news/2025/02/2025-02-07_22-31-45.nix
@@ -1,0 +1,16 @@
+{
+  time = "2025-02-07T22:31:45+00:00";
+  condition = true;
+  message = ''
+    All 'programs.<PROGRAM>.enable<SHELL>Integration' values now default
+    to the new 'home.shell.enable<SHELL>Integration' options, which
+    inherit from the new the 'home.shell.enableShellIntegration' option.
+
+    The following inconsistent default values change from 'false' to
+    'true':
+
+    - programs.zellij.enableBashIntegration
+    - programs.zellij.enableFishIntegration
+    - programs.zellij.enableZshIntegration
+  '';
+}

--- a/modules/misc/news/2025/02/2025-02-11_15-25-26.nix
+++ b/modules/misc/news/2025/02/2025-02-11_15-25-26.nix
@@ -1,0 +1,11 @@
+{
+  time = "2025-02-11T15:25:26+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.git-worktree-switcher'.
+
+    git-worktree-switcher allows you to quickly switch git worktrees.
+    It includes shell completions for Bash, Fish and Zsh.
+    See https://github.com/mateusauler/git-worktree-switcher for more.
+  '';
+}

--- a/modules/misc/news/2025/02/2025-02-12_15-56-00.nix
+++ b/modules/misc/news/2025/02/2025-02-12_15-56-00.nix
@@ -1,0 +1,10 @@
+{
+  time = "2025-02-12T15:56:00+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.tex-fmt'.
+
+    tex-fmt is a LaTeX formatter written in Rust.
+    See https://github.com/WGUNDERWOOD/tex-fmt for more information.
+  '';
+}

--- a/modules/misc/news/2025/02/2025-02-16_17-00-00.nix
+++ b/modules/misc/news/2025/02/2025-02-16_17-00-00.nix
@@ -1,0 +1,10 @@
+{
+  time = "2025-02-16T17:00:00+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'services.wluma'.
+
+    Wluma is a tool for Wayland compositors to automatically adjust
+    screen brightness based on the screen contents and amount of ambient light around you.
+  '';
+}

--- a/modules/misc/news/2025/02/2025-02-20_18-39-31.nix
+++ b/modules/misc/news/2025/02/2025-02-20_18-39-31.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+
+{
+  time = "2025-02-20T18:39:31+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'programs.swayimg'.
+
+    swayimg is a fully customizable and lightweight image viewer for
+    Wayland based display servers.
+    See https://github.com/artemsen/swayimg for more.
+  '';
+}

--- a/modules/misc/news/2025/02/2025-02-21_16-53-20.nix
+++ b/modules/misc/news/2025/02/2025-02-21_16-53-20.nix
@@ -1,0 +1,10 @@
+{
+  time = "2025-02-21T16:53:20+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.earthly'.
+
+    Earthly is a build configuration framework utilizing buildkit and
+    Dockerfile-like syntax for fast builds and simplicity.
+  '';
+}

--- a/modules/misc/news/2025/02/2025-02-22_16-46-56.nix
+++ b/modules/misc/news/2025/02/2025-02-22_16-46-56.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+
+{
+  time = "2025-02-22T16:46:56+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'services.wpaperd'.
+
+    This replaces the existing module, 'programs.wpaperd', and adds a
+    systemd service to ensure its execution.
+  '';
+}

--- a/modules/misc/news/2025/02/2025-02-22_16-53-20.nix
+++ b/modules/misc/news/2025/02/2025-02-22_16-53-20.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-02-22T16:53:20+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.jqp'.
+
+    A TUI playground for experimenting with `jq`.
+  '';
+}

--- a/modules/misc/news/2025/03/2025-03-11_02-34-43.nix
+++ b/modules/misc/news/2025/03/2025-03-11_02-34-43.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+
+{
+  time = "2025-03-11T02:34:43+00:00";
+  condition = config.programs.zsh.enable;
+  message = ''
+    A new module is available: 'programs.zsh.initContent'.
+
+    initContent option allows you to set the content of the zshrc file,
+    you can use `lib.mkOrder` to specify the order of the content you want to insert.
+  '';
+}

--- a/modules/misc/news/2025/03/2025-03-19_18-10-56.nix
+++ b/modules/misc/news/2025/03/2025-03-19_18-10-56.nix
@@ -1,0 +1,10 @@
+{ config, ... }:
+
+{
+  time = "2025-03-19T18:10:56+00:00";
+  condition = config.services.easyeffects.enable;
+  message = ''
+    The Easyeffects module now supports adding json formatted presets
+    under '$XDG_CONFIG_HOME/easyeffects/{input,output}/'.
+  '';
+}

--- a/modules/misc/news/2025/03/2025-03-24_15-29-33.nix
+++ b/modules/misc/news/2025/03/2025-03-24_15-29-33.nix
@@ -1,0 +1,10 @@
+{
+  time = "2025-03-24T15:29:33+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.smug'.
+
+    Session manager and task runner for tmux written in Go.
+    See https://github.com/ivaaaan/smug for more information.
+  '';
+}

--- a/modules/misc/news/2025/03/2025-03-24_22-31-45.nix
+++ b/modules/misc/news/2025/03/2025-03-24_22-31-45.nix
@@ -1,0 +1,12 @@
+{
+  time = "2025-03-24T22:31:45+00:00";
+  condition = true;
+  message = ''
+    The following default values change from 'true' to
+    'false':
+
+    - programs.zellij.enableBashIntegration
+    - programs.zellij.enableFishIntegration
+    - programs.zellij.enableZshIntegration
+  '';
+}

--- a/modules/misc/news/2025/03/2025-03-29_04-16-57.nix
+++ b/modules/misc/news/2025/03/2025-03-29_04-16-57.nix
@@ -1,0 +1,10 @@
+{
+  time = "2025-03-29T04:16:57+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.streamlink'.
+
+    Streamlink is a CLI utility which pipes video streams from various
+    services into a video player.
+  '';
+}

--- a/modules/misc/news/2025/03/2025-03-31_16-39-41.nix
+++ b/modules/misc/news/2025/03/2025-03-31_16-39-41.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+
+{
+  time = "2025-03-31T16:39:41+00:00";
+  condition = config.programs.jq.enable;
+  message = ''
+    Jq module now supports color for object keys
+
+    Your configuration will break if you have defined the "programs.jq.colors" option.
+    To resolve this, please add `objectKeys` to your assignment of `programs.jq.colors`.
+  '';
+}

--- a/modules/misc/news/2025/04/2025-04-02_00-00-00.nix
+++ b/modules/misc/news/2025/04/2025-04-02_00-00-00.nix
@@ -1,0 +1,10 @@
+{
+  time = "2025-04-02T00:00:00+00:00";
+  condition = true;
+  message = ''
+    A new service is available: 'services.home-manager.autoExpire'.
+
+    A service that allow to automatically expire (and optionally clean-up
+    Nix's store) old Home-Manager generations.
+  '';
+}


### PR DESCRIPTION
During migration to new format and removing from the inline files. We lost some entries.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
