### PR TITLE
ci: switch to a GitHub App

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,9 +1,5 @@
 # Based on
 # https://github.com/NixOS/nixpkgs/blob/2566f9dc/.github/workflows/backport.yml
-#
-# NOTE: this uses the GH_TOKEN_FOR_UPDATES because pushing a backport PR using
-# GITHUB_TOKEN does not trigger CI.
-# TODO: consider switching to a GitHub App
 name: Backport
 
 on:
@@ -16,7 +12,7 @@ jobs:
   backport:
     name: Backport Pull Request
     if: >
-      github.repository_owner == 'nix-community'
+      vars.CI_APP_ID
       && github.event.pull_request.merged == true
       && (
         github.event.action != 'labeled'
@@ -25,9 +21,16 @@ jobs:
 
     runs-on: ubuntu-24.04-arm
     steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Create backport PRs
@@ -35,6 +38,6 @@ jobs:
         uses: korthout/backport-action@v3
         with:
           # See https://github.com/korthout/backport-action#inputs
-          github_token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          github_token: ${{ steps.app-token.outputs.token }}
           branch_name: backport/${target_branch}/${pull_number}
           copy_labels_pattern: .*

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -42,3 +42,14 @@ jobs:
           git-author-name: ${{ steps.user-info.outputs.name }}
           git-author-email: ${{ steps.user-info.outputs.email }}
           pr-labels: dependencies
+          pr-body: |
+            Automated update by the [update-flake-lock] GitHub Action.
+
+            ```
+            {{ env.GIT_COMMIT_MESSAGE }}
+            ```
+
+            This PR was most recently updated by workflow run [${{ github.run_id }}].
+
+            [update-flake-lock]: https://github.com/DeterminateSystems/update-flake-lock
+            [${{ github.run_id }}]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -10,6 +10,25 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository_owner == 'nix-community'
     steps:
+      - name: Create GitHub App token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+      - name: Get GitHub App user info
+        id: user-info
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          slug: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          name="$slug[bot]"
+          id=$(gh api "/users/$name" --jq .id)
+          {
+            echo "id=$id"
+            echo "name=$name"
+            echo "email=$id+$name@users.noreply.github.com"
+          } >> "$GITHUB_OUTPUT"
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Nix
@@ -17,8 +36,9 @@ jobs:
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v25
         with:
-          # NOTE: this uses the GH_TOKEN_FOR_UPDATES because pushing a flake
-          # update PR using GITHUB_TOKEN does not trigger CI.
-          # TODO: consider switching to a GitHub App
-          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          token: ${{ steps.app-token.outputs.token }}
+          git-committer-name: ${{ steps.user-info.outputs.name }}
+          git-committer-email: ${{ steps.user-info.outputs.email }}
+          git-author-name: ${{ steps.user-info.outputs.name }}
+          git-author-email: ${{ steps.user-info.outputs.email }}
           pr-labels: dependencies


### PR DESCRIPTION
### Description

Followup to #7165.

Workflows will now push to PRs as a "bot user" (GitHub App), which will still trigger CI. This is more idiomatic than a "machine" user which is in reality a normal user account.

Its tokens are short lived, so more secure than a PAT that doesn't expire.

This PR is **blocked** by a GitHub App being created for Home Manager and the relevant APP ID and PRIVATE KEY being added to the repo's vars and secrets respectively. A nix-community admin will be able to do this, see [previous matrix thread](https://matrix.to/#/!PbtOpdWBSRFbEZRLIf:numtide.com/$copbS2S4-Jk8Cqvp-DFkZtxfdwmUUPWV1edITMvSnIA?via=matrix.org&via=envs.net&via=nixos.dev) for an example.

Additionally, I've improved the PR body for the update workflow.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@khaneliman
