### PR TITLE
jellyfin-mpv-shim: make sure the config file is read properly

### DIFF
--- a/modules/services/jellyfin-mpv-shim.nix
+++ b/modules/services/jellyfin-mpv-shim.nix
@@ -107,8 +107,20 @@ in
     ];
 
     xdg.configFile = {
+      # jellyfin-mpv-shim errors if the config file isn't writeable
+      # so, as a temporary workaround, we generate a hidden file (.conf.json)
+      # and make a writeable copy.
       "jellyfin-mpv-shim/conf.json" = lib.mkIf (cfg.settings != { }) {
         source = jsonFormat.generate "jellyfin-mpv-shim-conf" cfg.settings;
+        target = "jellyfin-mpv-shim/.conf.json";
+        onChange =
+          let
+            dir = "${config.xdg.configHome}/jellyfin-mpv-shim";
+          in
+          ''
+            cp --dereference ${dir}/.conf.json ${dir}/conf.json
+            chmod u+w ${dir}/conf.json
+          '';
       };
 
       "jellyfin-mpv-shim/mpv.conf" = lib.mkIf (cfg.mpvConfig != null) {


### PR DESCRIPTION
### Description

jellyfin-mpv-shim can't read its configuration file if it's not writeable (see https://github.com/nix-community/home-manager/pull/7129#issuecomment-2925542595).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.  
    I can't run the tests on my platform (`aarch64-linux`).

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@repparw 