### PR TITLE
timewarrior: init

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -293,6 +293,7 @@ let
       ./programs/texlive.nix
       ./programs/thefuck.nix
       ./programs/thunderbird.nix
+      ./programs/timewarrior.nix
       ./programs/timidity.nix
       ./programs/tint2.nix
       ./programs/tiny.nix

--- a/modules/programs/timewarrior.nix
+++ b/modules/programs/timewarrior.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.timewarrior;
+  taskCfg = config.programs.taskwarrior;
+in
+{
+  options.programs.timewarrior = {
+    enable = lib.mkEnableOption "Timewarrior";
+    package = lib.mkPackageOption pkgs "timewarrior" { };
+    taskwarrior.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = taskCfg.enable;
+      description = ''
+        Whether to enable the on-modify hook for Taskwarrior.
+        See <https://timewarrior.net/docs/taskwarrior/>.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.file."${taskCfg.dataLocation}/hooks/on-modify.timewarrior" = lib.mkIf cfg.taskwarrior.enable {
+      executable = true;
+      source = "${cfg.package}/share/doc/timew/ext/on-modify.timewarrior";
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ prince213 ];
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -307,6 +307,7 @@ import nmtSrc {
       ./modules/programs/texlive
       ./modules/programs/thefuck
       ./modules/programs/thunderbird
+      ./modules/programs/timewarrior
       ./modules/programs/tmate
       ./modules/programs/tmux
       ./modules/programs/topgrade

--- a/tests/modules/programs/timewarrior/default.nix
+++ b/tests/modules/programs/timewarrior/default.nix
@@ -1,0 +1,1 @@
+{ timewarrior = ./timewarrior.nix; }

--- a/tests/modules/programs/timewarrior/timewarrior.nix
+++ b/tests/modules/programs/timewarrior/timewarrior.nix
@@ -1,0 +1,21 @@
+{ realPkgs, ... }:
+{
+  test.unstubs = [
+    (_: _: { inherit (realPkgs) timewarrior; })
+  ];
+
+  programs.taskwarrior = {
+    enable = true;
+    package = realPkgs.taskwarrior3;
+  };
+
+  programs.timewarrior = {
+    enable = true;
+    taskwarrior.enable = true;
+  };
+
+  nmt.script = ''
+    assertLinkExists home-files/.local/share/task/hooks/on-modify.timewarrior
+    assertFileIsExecutable home-files/.local/share/task/hooks/on-modify.timewarrior
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
