### PR TITLE
mergiraf: enable jujutsu integration

### DIFF
--- a/modules/programs/mergiraf.nix
+++ b/modules/programs/mergiraf.nix
@@ -27,14 +27,18 @@ in
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    programs.git = {
-      attributes = [ "* merge=mergiraf" ];
-      extraConfig = {
-        merge.mergiraf = {
-          name = "mergiraf";
-          driver = "${mergiraf} merge --git %O %A %B -s %S -x %X -y %Y -p %P -l %L";
+    programs = {
+      git = {
+        attributes = [ "* merge=mergiraf" ];
+        extraConfig = {
+          merge.mergiraf = {
+            name = "mergiraf";
+            driver = "${mergiraf} merge --git %O %A %B -s %S -x %X -y %Y -p %P -l %L";
+          };
         };
       };
+
+      jujutsu.settings.ui.merge-editor = "mergiraf";
     };
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Set up jujutsu to use mergiraf to resolve merge conflicts.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@bobvanderlinden