### PR TITLE
fzf: prefer `source` for Zsh integration

### DIFF
--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -40,7 +40,7 @@ let
     if hasShellIntegrationEmbedded then
       ''
         if [[ $options[zle] = on ]]; then
-          eval "$(${getExe cfg.package} --zsh)"
+          source <(${getExe cfg.package} --zsh)
         fi
       ''
     else


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

fzf version 0.53.0 and later now prefers using `source` for its Zsh integration. - https://github.com/junegunn/fzf/pull/3794

Also updated in homebrew. - https://github.com/Homebrew/homebrew-core/pull/172980

This PR only updates the Zsh part of 0.48.0 integrations - https://github.com/nix-community/home-manager/pull/5239

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.: As far as I know, there is no reason to keep `eval` even in 0.48.0~0.52.x

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@khaneliman
