### PR TITLE
ci: use flake lock for tests 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
         with:
+          # TODO: Adjust uninstall to not need channel
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - run: nix-build --show-trace -A docs.jsonModuleMaintainers
+      - run: nix build --show-trace .#docs-jsonModuleMaintainers
       - run: nix fmt -- --ci
-      - run: nix-shell --show-trace . -A install
-      - run: yes | home-manager -I home-manager=. uninstall
+      - run: nix run .#home-manager -- init --switch
+      - run: yes | nix run . -- uninstall
       - name: Run tests
-        run: nix-build -j auto --show-trace --arg enableBig false --pure --option allow-import-from-derivation false tests -A build.all
+        run: nix build -j auto --show-trace --option allow-import-from-derivation false --reference-lock-file flake.lock "./tests#test-all-no-big"
         env:
           GC_INITIAL_HEAP_SIZE: 4294967296
       - name: Run tests (with IFD)
-        run: nix-build -j auto --show-trace --arg enableBig false --pure --arg enableLegacyIfd true tests -A build.all
+        run: nix build -j auto --show-trace --reference-lock-file flake.lock "./tests#test-all-no-big"
         env:
           GC_INITIAL_HEAP_SIZE: 4294967296

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,6 +1,7 @@
 {
   pkgs ? import <nixpkgs> { },
   enableBig ? true,
+  enableLegacyIfd ? false,
 }:
 
 let
@@ -142,6 +143,7 @@ let
           ];
 
           test.enableBig = enableBig;
+          test.enableLegacyIfd = enableLegacyIfd;
         }
       )
     ];

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -51,8 +51,32 @@
               renameTestPkg = n: lib.nameValuePair "integration-test-${n}";
             in
             lib.mapAttrs' renameTestPkg tests;
+
+          testAllNoBig =
+            let
+              tests = import ./. {
+                inherit pkgs;
+                enableBig = false;
+              };
+            in
+            lib.nameValuePair "test-all-no-big" tests.build.all;
+
+          testAllNoBigIfd =
+            let
+              tests = import ./. {
+                inherit pkgs;
+                enableBig = false;
+                enableLegacyIfd = true;
+              };
+            in
+            lib.nameValuePair "test-all-no-big-ifd" tests.build.all;
         in
-        testPackages // integrationTestPackages
+        testPackages
+        // integrationTestPackages
+        // (lib.listToAttrs [
+          testAllNoBig
+          testAllNoBigIfd
+        ])
       );
     };
 }


### PR DESCRIPTION
### Description
Talked about in matrix a while back, kept forgetting to implement. Annoying to have unexpected CI failures before a flake lock update. 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
