### PR TITLE
oh-my-posh: added configFile option

### DIFF
--- a/modules/programs/oh-my-posh.nix
+++ b/modules/programs/oh-my-posh.nix
@@ -14,6 +14,8 @@ let
   configArgument =
     if cfg.settings != { } then
       "--config ${config.xdg.configHome}/oh-my-posh/config.json"
+    else if cfg.configFile != null then
+      "--config ${cfg.configFile}"
     else if cfg.useTheme != null then
       "--config ${cfg.package}/share/oh-my-posh/themes/${cfg.useTheme}.omp.json"
     else
@@ -38,6 +40,18 @@ in
         <https://ohmyposh.dev/docs/configuration/overview>
         for details. The `useTheme` option is ignored when this
         option is used.
+      '';
+    };
+
+    configFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Use a custom config file for oh-my-posh instead of the default theme.
+        This options corresponds to the `--config` option for the `oh-my-posh`
+        executable. See <https://ohmyposh.dev/docs/configuration/general> for
+        details. This option is ignored when the `settings` option is used. If
+        this option is set, `useTheme` will be ignored.
       '';
     };
 

--- a/tests/modules/programs/oh-my-posh/config-file.nix
+++ b/tests/modules/programs/oh-my-posh/config-file.nix
@@ -1,0 +1,17 @@
+{
+  programs = {
+    bash.enable = true;
+
+    oh-my-posh = {
+      enable = true;
+      configFile = "foo/bar/baz.yaml";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileContains \
+      home-files/.bashrc \
+      '/bin/oh-my-posh init bash --config foo/bar/baz.yaml'
+  '';
+}

--- a/tests/modules/programs/oh-my-posh/default.nix
+++ b/tests/modules/programs/oh-my-posh/default.nix
@@ -3,4 +3,5 @@
   oh-my-posh-zsh = ./zsh.nix;
   oh-my-posh-fish = ./fish.nix;
   oh-my-posh-nushell = ./nushell.nix;
+  oh-my-posh-config-file = ./config-file.nix;
 }


### PR DESCRIPTION
### Description

This option allows you to provide a custom config file for oh-my-posh as you would with the `--config` option. If set, `useTheme` will be ignored. If `settings` is provided, then this option will be ignored.


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@arjan-s 
@emilazy 
@khaneliman 