### PR TITLE
zsh: add plugins.*.completions paths to fpath

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -183,15 +183,22 @@ in
               type = types.str;
               description = ''
                 The name of the plugin.
-
-                Don't forget to add {option}`file`
-                if the script name does not follow convention.
               '';
             };
 
             file = mkOption {
               type = types.str;
-              description = "The plugin script to source.";
+              description = ''
+                The plugin script to source.
+                Required if the script name does not match {file}`name.plugin.zsh`
+                using the plugin {option}`name` from the plugin {option}`src`.
+              '';
+            };
+
+            completions = mkOption {
+              default = [ ];
+              type = types.listOf types.str;
+              description = "Paths of additional functions to add to {env}`fpath`.";
             };
           };
 
@@ -606,16 +613,6 @@ in
           example = literalExpression ''
             [
               {
-                # will source zsh-autosuggestions.plugin.zsh
-                name = "zsh-autosuggestions";
-                src = pkgs.fetchFromGitHub {
-                  owner = "zsh-users";
-                  repo = "zsh-autosuggestions";
-                  rev = "v0.4.0";
-                  sha256 = "0z6i9wjjklb4lvr7zjhbphibsyx51psv50gm07mbb0kj9058j6kc";
-                };
-              }
-              {
                 name = "enhancd";
                 file = "init.sh";
                 src = pkgs.fetchFromGitHub {
@@ -625,6 +622,12 @@ in
                   sha256 = "0iqa9j09fwm6nj5rpip87x3hnvbbz9w9ajgm6wkrd5fls8fn8i5g";
                 };
               }
+            {
+              name = "wd";
+              src = pkgs.zsh-wd;
+              file = "share/wd/wd.plugin.zsh";
+              completions = [ "share/zsh/site-functions" ];
+            }
             ]
           '';
           description = "Plugins to source in {file}`.zshrc`.";
@@ -773,6 +776,15 @@ in
                   map (plugin: ''
                     path+="$HOME/${pluginsDir}/${plugin.name}"
                     fpath+="$HOME/${pluginsDir}/${plugin.name}"
+                    ${
+                      (optionalString (plugin.completions != [ ]) ''
+                        fpath+=(${
+                          lib.concatMapStringsSep " " (
+                            completion: "\"$HOME/${pluginsDir}/${plugin.name}/${completion}\""
+                          ) plugin.completions
+                        })
+                      '')
+                    }
                   '') cfg.plugins
                 )
               )

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -7,6 +7,7 @@
   zsh-history-path-old-custom = ./history-path-old-custom.nix;
   zsh-history-path-old-default = ./history-path-old-default.nix;
   zsh-history-substring-search = ./history-substring-search.nix;
+  zsh-plugins = ./plugins.nix;
   zsh-prezto = ./prezto.nix;
   zsh-session-variables = ./session-variables.nix;
   zsh-syntax-highlighting = ./syntax-highlighting.nix;

--- a/tests/modules/programs/zsh/plugins.nix
+++ b/tests/modules/programs/zsh/plugins.nix
@@ -1,0 +1,31 @@
+{ pkgs, ... }:
+
+let
+  mockZshPluginSrc = pkgs.writeText "mockZshPluginSrc" "echo example";
+in
+{
+  config = {
+    programs.zsh = {
+      enable = true;
+      plugins = [
+        {
+          name = "mockPlugin";
+          file = "share/mockPlugin/mockPlugin.plugin.zsh";
+          src = mockZshPluginSrc;
+          completions = [
+            "share/zsh/site-functions"
+            "share/zsh/vendor-completions"
+          ];
+        }
+      ];
+    };
+
+    test.stubs.zsh = { };
+
+    nmt.script = ''
+      assertFileRegex home-files/.zshrc '^path+="$HOME/.zsh/plugins/mockPlugin"$'
+      assertFileRegex home-files/.zshrc '^fpath+="$HOME/.zsh/plugins/mockPlugin"$'
+      assertFileRegex home-files/.zshrc '^fpath+=("$HOME/.zsh/plugins/mockPlugin/share/zsh/site-functions" "$HOME/.zsh/plugins/mockPlugin/share/zsh/vendor-completions")$'
+    '';
+  };
+}


### PR DESCRIPTION
Autocompletion scripts and additional plugin functions are located in specific directories that might not match the plugin source script but need to be included in fpath before calling compinit.

An option to provide a path to these scripts is added to add the paths to fpath before calling completionInit.

### Description
Closes https://github.com/nix-community/home-manager/pull/5458
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
