### PR TITLE
doc: add a missing subcommand

### DIFF
--- a/docs/home-manager.1
+++ b/docs/home-manager.1
@@ -27,6 +27,7 @@
 .Cm | option Ar option.name
 .Cm | packages
 .Cm | remove-generations Ar ID \&...
+.Cm | switch
 .Cm | uninstall
 .Brc
 .Op Fl A Ar attrPath


### PR DESCRIPTION
Add the missing subcommand (`switch`) to the home-manager's manpage.