### PR TITLE
xdg.desktopEntries: Update outdated links in docs

### DIFF
--- a/modules/misc/xdg-desktop-entries.nix
+++ b/modules/misc/xdg-desktop-entries.nix
@@ -28,7 +28,7 @@ let
       # to match what's commonly used by other home manager modules.
 
       # Descriptions are taken from the desktop entry spec:
-      # https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys
+      # https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html
 
       type = mkOption {
         description = "The type of the desktop entry.";
@@ -208,7 +208,7 @@ in
 
       You can define entries for programs without entries or override existing entries.
 
-      See <https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys> for more information on options.
+      See <https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html> for more information on options.
     '';
     default = { };
     type = types.attrsOf (types.submodule desktopEntry);


### PR DESCRIPTION
### Description

The links were previously outdated, and even though they didn't 404, they did not point to the relevant section.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@cwyc 