### PR TITLE
papis: allow libraries to not to be defined

### DIFF
--- a/modules/programs/papis.nix
+++ b/modules/programs/papis.nix
@@ -14,9 +14,11 @@ let
   );
 
   settingsIni = (lib.mapAttrs (n: v: v.settings) cfg.libraries) // {
-    settings = cfg.settings // {
-      "default-library" = lib.head defaultLibraries;
-    };
+    settings =
+      cfg.settings
+      // lib.optionalAttrs (cfg.libraries != { }) {
+        "default-library" = lib.head defaultLibraries;
+      };
   };
 
 in
@@ -97,6 +99,7 @@ in
           }
         )
       );
+      default = { };
       description = "Attribute set of papis libraries.";
     };
   };
@@ -116,8 +119,6 @@ in
 
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-    xdg.configFile."papis/config" = lib.mkIf (cfg.libraries != { }) {
-      text = lib.generators.toINI { } settingsIni;
-    };
+    xdg.configFile."papis/config".text = lib.generators.toINI { } settingsIni;
   };
 }


### PR DESCRIPTION
papis allows setting configuration via local [1] or via a python file [2]. A user can decide to define libraries via these methods, which home-manager module won't allow. Shift where the check is done to allow a config file without library definitions.

[1]: https://papis.readthedocs.io/en/latest/configuration.html#local-configuration-files
[2]: https://papis.readthedocs.io/en/latest/configuration.html#python-configuration-file

### Description

papis doesn't enforce library definitions, contrary to what is done in this module. This struck me when I wanted to set libraries on local papis config files, and only use the global config file for settings. 

This change works around the issue. Since I don't understand the reasoning of this assertion [1] fully, I'm unsure whether or not to remove it. Maybe this PR can start the discussion.

[1]: https://github.com/nix-community/home-manager/pull/3626

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@marsam @rycee 
