### PR TITLE
aichat: init

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -61,6 +61,7 @@ let
       ./programs/aerc.nix
       ./programs/aerospace.nix
       ./programs/afew.nix
+      ./programs/aichat.nix
       ./programs/alacritty.nix
       ./programs/alot.nix
       ./programs/antidote.nix

--- a/modules/programs/aichat.nix
+++ b/modules/programs/aichat.nix
@@ -1,0 +1,72 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkIf;
+
+  cfg = config.programs.aichat;
+
+  settingsFormat = pkgs.formats.yaml { };
+
+  inherit (pkgs.stdenv.hostPlatform) isLinux isDarwin;
+in
+{
+  meta.maintainers = [
+    lib.maintainers.jaredmontoya
+  ];
+
+  options.programs.aichat = {
+    enable = lib.mkEnableOption "aichat, an All-in-one LLM CLI tool";
+
+    package = lib.mkPackageOption pkgs "aichat" { nullable = true; };
+
+    settings = lib.mkOption {
+      inherit (settingsFormat) type;
+      default = { };
+      defaultText = lib.literalExpression "{ }";
+      example = lib.literalExpression ''
+        {
+          model = "Ollama:mistral-small:latest";
+          clients = [
+            {
+              type = "openai-compatible";
+              name = "Ollama";
+              api_base = "http://localhost:11434/v1";
+              models = [
+                {
+                  name = "llama3.2:latest";
+                }
+              ];
+            }
+          ];
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/aichat/config.yaml`
+        on Linux or on Darwin if [](#opt-xdg.enable) is set, otherwise
+        {file}`~/Library/Application Support/aichat/config.yaml`.
+        See
+        <https://github.com/sigoden/aichat/blob/main/config.example.yaml>
+        for supported values.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    home.file."Library/Application Support/aichat/config.yaml" =
+      mkIf (cfg.settings != { } && (isDarwin && !config.xdg.enable))
+        {
+          source = settingsFormat.generate "aichat-config" cfg.settings;
+        };
+
+    xdg.configFile."aichat/config.yaml" = mkIf (cfg.settings != { } && (isLinux || config.xdg.enable)) {
+      source = settingsFormat.generate "aichat-config" cfg.settings;
+    };
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -7,6 +7,7 @@ let
     # keep-sorted start case=no numeric=yes
     "aerc"
     "aerospace"
+    "aichat"
     "alacritty"
     "alot"
     "antidote"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -171,6 +171,7 @@ import nmtSrc {
       ./modules/misc/specialisation
       ./modules/misc/xdg
       ./modules/programs/aerc
+      ./modules/programs/aichat
       ./modules/programs/alacritty
       ./modules/programs/alot
       ./modules/programs/antidote

--- a/tests/modules/programs/aichat/default.nix
+++ b/tests/modules/programs/aichat/default.nix
@@ -1,0 +1,3 @@
+{
+  aichat-settings = ./settings.nix;
+}

--- a/tests/modules/programs/aichat/settings.nix
+++ b/tests/modules/programs/aichat/settings.nix
@@ -1,0 +1,26 @@
+{ ... }:
+{
+  programs.aichat = {
+    enable = true;
+    settings = {
+      model = "Ollama:mistral-small:latest";
+      clients = [
+        {
+          type = "openai-compatible";
+          name = "Ollama";
+          api_base = "http://localhost:11434/v1";
+          models = [
+            {
+              name = "llama3.2:latest";
+            }
+          ];
+        }
+      ];
+    };
+  };
+  nmt.script = ''
+    assertFileExists home-files/.config/aichat/config.yaml
+    assertFileContent home-files/.config/aichat/config.yaml \
+      ${./settings.yml}
+  '';
+}

--- a/tests/modules/programs/aichat/settings.yml
+++ b/tests/modules/programs/aichat/settings.yml
@@ -1,0 +1,7 @@
+clients:
+- api_base: http://localhost:11434/v1
+  models:
+  - name: llama3.2:latest
+  name: Ollama
+  type: openai-compatible
+model: Ollama:mistral-small:latest


### PR DESCRIPTION
### Description
[aichat](https://github.com/sigoden/aichat) is an all in one CLI tool for AI interactions.
On first run it prompts you to create a config so I made a home manager module to do this declaratively.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
