### PR TITLE
fix: ensure newline after vim.cmd[[source...]] in neovim init.lua

### DIFF
--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -472,7 +472,7 @@ in
                   luaRcContent =
                     lib.optionalString (
                       wrappedNeovim'.initRc != ""
-                    ) "vim.cmd [[source ${pkgs.writeText "nvim-init-home-manager.vim" wrappedNeovim'.initRc}]]"
+                    ) "vim.cmd [[source ${pkgs.writeText "nvim-init-home-manager.vim" wrappedNeovim'.initRc}]]\n"
                     + config.programs.neovim.extraLuaConfig
                     + lib.optionalString hasLuaConfig config.programs.neovim.generatedConfigs.lua;
                 in

--- a/tests/modules/programs/neovim/plugin-config.expected
+++ b/tests/modules/programs/neovim/plugin-config.expected
@@ -1,0 +1,3 @@
+vim.cmd [[source /nix/store/szdyh45rf0rgiq35zgy5b3z99f8lx8f2-nvim-init-home-manager.vim]]
+function HM_PLUGIN_LUA_CONFIG ()
+end

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -20,6 +20,14 @@ lib.mkIf config.test.enableBig {
           let g:hmPlugins='HM_PLUGINS_CONFIG'
         '';
       }
+      {
+        plugin = vim-nix;
+        type = "lua";
+        config = ''
+          function HM_PLUGIN_LUA_CONFIG ()
+          end
+        '';
+      }
     ];
     extraLuaPackages = ps: [ ps.luautf8 ];
   };
@@ -33,5 +41,13 @@ lib.mkIf config.test.enableBig {
       > "$vimout" || true
     assertFileContains "$vimout" "HM_EXTRA_CONFIG"
     assertFileContains "$vimout" "HM_PLUGINS_CONFIG"
+
+    initLua="$TESTED/home-files/.config/nvim/init.lua"
+    assertFileContains "$initLua" 'vim.cmd [[source '
+    assertFileContains "$initLua" 'function HM_PLUGIN_LUA_CONFIG ()'
+
+    flattened=$(mktemp)
+    sed ':a;N;$!ba;s/\n/__NL__/g' "$initLua" > "$flattened"
+    assertFileContains "$flattened" ']]__NL__function HM_PLUGIN_LUA_CONFIG ()__NL__end'
   '';
 }

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -43,8 +43,6 @@ lib.mkIf config.test.enableBig {
     assertFileContains "$vimout" "HM_PLUGINS_CONFIG"
 
     initLua="$TESTED/home-files/.config/nvim/init.lua"
-    assertFileContains "$initLua" 'vim.cmd [[source '
-    assertFileContains "$initLua" 'function HM_PLUGIN_LUA_CONFIG ()'
     assertFileContent "$initLua" ${./plugin-config.expected}
   '';
 }

--- a/tests/modules/programs/neovim/plugin-config.nix
+++ b/tests/modules/programs/neovim/plugin-config.nix
@@ -45,9 +45,6 @@ lib.mkIf config.test.enableBig {
     initLua="$TESTED/home-files/.config/nvim/init.lua"
     assertFileContains "$initLua" 'vim.cmd [[source '
     assertFileContains "$initLua" 'function HM_PLUGIN_LUA_CONFIG ()'
-
-    flattened=$(mktemp)
-    sed ':a;N;$!ba;s/\n/__NL__/g' "$initLua" > "$flattened"
-    assertFileContains "$flattened" ']]__NL__function HM_PLUGIN_LUA_CONFIG ()__NL__end'
+    assertFileContent "$initLua" ${./plugin-config.expected}
   '';
 }


### PR DESCRIPTION
### Description

Fix an issue where the generated `~/.config/nvim/init.lua` lacks a newline after the `vim.cmd [[source ...]]` directive. Without this newline, subsequent lua configuration is concatenated onto the same line, breaking lua syntax.

`init.lua` Before:

```
vim.cmd [[source /nix/store/...]]vim.opt.rtp:prepend(...)
```

After:

```
vim.cmd [[source /nix/store/...]]
vim.opt.rtp:prepend(...)
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix build --reference-lock-file flake.lock ./tests#test-all`

- [x] Test cases updated/added.


#### Maintainer CC

@khaneliman