### PR TITLE
lib/default.nix: remove inefficient second copy

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -20,7 +20,14 @@
       configuration =
         { ... }:
         {
-          imports = modules ++ [ { programs.home-manager.path = "${../.}"; } ];
+          imports = modules ++ [
+            {
+              programs.home-manager.path = builtins.path {
+                path = ../.;
+                name = "source";
+              };
+            }
+          ];
 
           nixpkgs = {
             config = lib.mkDefault pkgs.config;


### PR DESCRIPTION
### Description

Using ./. forces Nix to copy the flake to the store a second time. Using builtins.path like this, forcing the name to be "source", reduces the extraneous copy.

ref:

```
warning: Copying '/nix/store/b3sj22x9pqf3dyw0409dhpzwi9vswwx7-source' to the store again
You can make Nix evaluate faster and copy fewer files by replacing `./.` with the `self` flake input, or `builtins.path { path = ./.; name = "source"; }`

Location: /nix/store/b3sj22x9pqf3dyw0409dhpzwi9vswwx7-source/lib/default.nix:23:68
```


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

cc @khaneliman

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
