### PR TITLE
Cursor: darwin extensions dirPath

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -59,8 +59,10 @@ let
 
   snippetDir = name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}snippets";
 
-  # TODO: On Darwin where are the extensions?
-  extensionPath = ".${extensionDir}/extensions";
+  extensionPath = if pkgs.stdenv.hostPlatform.isDarwin && vscodePname == "cursor" then
+    ".cursor/extensions"
+  else
+    ".${extensionDir}/extensions";
 
   extensionJson = ext: pkgs.vscode-utils.toExtensionJson ext;
   extensionJsonFile =


### PR DESCRIPTION
### Description

I am trying to add programs.vscode.extensions setting to work on darwin when using code-cursor package.

So I'm updating home-manager vscode.nix to add code-cursor's darwin extensions path.
on darwin, cursor doesn't look at `~.config/cursor/extensions/`..
it also doesn't look at `~/Application\ Support/Cursor/extensions/`.
Cursor only looks for extensions in the `~/.cursor/` directory.

I have not tested this change! I don't know *how*

EDIT/UPDATE: I was on 24.11. Now on nixpkgs 25.05. And, the home-manager option needs `programs.vscode.profiles.<profilename>.extensions` which appears to work out of the box.
I don't know why, but I guess so. meaning my PR seems pointless at the moment...?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
