### PR TITLE
hypridle: add systemdTarget option

### DIFF
--- a/modules/services/hypridle.nix
+++ b/modules/services/hypridle.nix
@@ -74,6 +74,14 @@ in
         List of prefix of attributes to source at the top of the config.
       '';
     };
+
+    systemdTarget = lib.mkOption {
+      type = lib.types.str;
+      default = config.wayland.systemd.target;
+      defaultText = lib.literalExpression "config.wayland.systemd.target";
+      example = "hyprland-session.target";
+      description = "Systemd target to bind to.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -86,14 +94,14 @@ in
 
     systemd.user.services.hypridle = lib.mkIf (cfg.package != null) {
       Install = {
-        WantedBy = [ config.wayland.systemd.target ];
+        WantedBy = [ cfg.systemdTarget ];
       };
 
       Unit = {
         ConditionEnvironment = "WAYLAND_DISPLAY";
         Description = "hypridle";
-        After = [ config.wayland.systemd.target ];
-        PartOf = [ config.wayland.systemd.target ];
+        After = [ cfg.systemdTarget ];
+        PartOf = [ cfg.systemdTarget ];
         X-Restart-Triggers = lib.mkIf (cfg.settings != { }) [
           "${config.xdg.configFile."hypr/hypridle.conf".source}"
         ];


### PR DESCRIPTION
### Description

Added `systemdTarget` option to `hypridle`. It's the same as in neighbor module `swayidle`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@khaneliman @fufexan 
