### PR TITLE
codex: init

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -194,6 +194,14 @@
     github = "danjujan";
     githubId = 44864658;
   };
+  delafthi = {
+    name = "Thierry Delafontaine";
+    email = "delafthi@pm.me";
+    matrix = "@delafthi:matrix.org";
+    github = "delafthi";
+    githubId = 50531499;
+    keys = [ { fingerprint = "6DBB 0BB9 AEE6 2C2A 8059  7E1C 0092 6686 9818 63CB"; } ];
+  };
   Dines97 = {
     name = "Denis Kaynar";
     email = "19364873+Dines97@users.noreply.github.com";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -92,6 +92,7 @@ let
       ./programs/chromium.nix
       ./programs/clock-rs.nix
       ./programs/cmus.nix
+      ./programs/codex.nix
       ./programs/command-not-found/command-not-found.nix
       ./programs/comodoro.nix
       ./programs/darcs.nix

--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -1,0 +1,67 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkIf;
+
+  cfg = config.programs.codex;
+
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = [
+    lib.hm.maintainers.delafthi
+  ];
+
+  options.programs.codex = {
+    enable = lib.mkEnableOption "Lightweight coding agent that runs in your terminal";
+
+    package = lib.mkPackageOption pkgs "codex" { nullable = true; };
+
+    settings = lib.mkOption {
+      inherit (settingsFormat) type;
+      description = ''
+        Configuration written to {file}`~/.codex/config.yaml`.
+        See <https://github.com/openai/codex#configuration-guide> for supported values.
+      '';
+      default = { };
+      defaultText = lib.literalExpression "{ }";
+      example = lib.literalExpression ''
+        {
+          model = "gemma3:latest";
+          provider = "ollama";
+          providers = {
+            ollama = {
+              name = "Ollama";
+              baseURL = "http://localhost:11434/v1";
+              envKey = "OLLAMA_API_KEY";
+            };
+          };
+        }
+      '';
+    };
+    custom-instructions = lib.mkOption {
+      type = lib.types.lines;
+      description = "Define custom guidance for the agents; this value is written to {file}~/.codex/AGENTS.md";
+      default = "";
+      example = lib.literalExpression ''
+        '''
+          - Always respond with emojis
+          - Only use git commands when explicitly requested
+        '''
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    home.file = {
+      ".codex/config.yaml".source = settingsFormat.generate "codex-config" cfg.settings;
+      ".codex/AGENTS.md".text = cfg.custom-instructions;
+    };
+  };
+
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -29,6 +29,7 @@ let
     "cava"
     "clock-rs"
     "cmus"
+    "codex"
     "comodoro"
     "darcs"
     "delta"

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -190,6 +190,7 @@ import nmtSrc {
       ./modules/programs/cava
       ./modules/programs/clock-rs
       ./modules/programs/cmus
+      ./modules/programs/codex
       ./modules/programs/comodoro
       ./modules/programs/darcs
       ./modules/programs/dircolors

--- a/tests/modules/programs/codex/custom-instructions.md
+++ b/tests/modules/programs/codex/custom-instructions.md
@@ -1,0 +1,2 @@
+- Always respond with emojis
+- Only use git commands when explicitly requested

--- a/tests/modules/programs/codex/custom-instructions.nix
+++ b/tests/modules/programs/codex/custom-instructions.nix
@@ -1,0 +1,14 @@
+{
+  programs.codex = {
+    enable = true;
+    custom-instructions = ''
+      - Always respond with emojis
+      - Only use git commands when explicitly requested
+    '';
+  };
+  nmt.script = ''
+    assertFileExists home-files/.codex/AGENTS.md
+    assertFileContent home-files/.codex/AGENTS.md \
+      ${./custom-instructions.md}
+  '';
+}

--- a/tests/modules/programs/codex/default.nix
+++ b/tests/modules/programs/codex/default.nix
@@ -1,0 +1,4 @@
+{
+  codex-settings = ./settings.nix;
+  codex-custom-instructions = ./custom-instructions.nix;
+}

--- a/tests/modules/programs/codex/settings.nix
+++ b/tests/modules/programs/codex/settings.nix
@@ -1,0 +1,21 @@
+{
+  programs.codex = {
+    enable = true;
+    settings = {
+      model = "gemma3:latest";
+      provider = "ollama";
+      providers = {
+        ollama = {
+          name = "Ollama";
+          baseURL = "http://localhost:11434/v1";
+          envKey = "OLLAMA_API_KEY";
+        };
+      };
+    };
+  };
+  nmt.script = ''
+    assertFileExists home-files/.codex/config.yaml
+    assertFileContent home-files/.codex/config.yaml \
+      ${./settings.yml}
+  '';
+}

--- a/tests/modules/programs/codex/settings.yml
+++ b/tests/modules/programs/codex/settings.yml
@@ -1,0 +1,7 @@
+model: gemma3:latest
+provider: ollama
+providers:
+  ollama:
+    baseURL: http://localhost:11434/v1
+    envKey: OLLAMA_API_KEY
+    name: Ollama


### PR DESCRIPTION
### Description

This PR adds a new Home Manager module for [Codex](https://github.com/openai/codex), providing an easy way to install and configure Codex through Nix Home Manager.

Please note that Codex is still in early development:

> Codex CLI is an experimental project under active development. It is not yet stable, may contain bugs, incomplete features, or undergo breaking changes.

Additionally, Codex currently uses `~/.codex` as its configuration directory and does not yet follow the XDG Base Directory specification. An [open pull request](https://github.com/openai/codex/pull/172) aims to address this, but it has not been merged as of this writing.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
