### PR TITLE
home-manager: fix integration tests

### DIFF
--- a/tests/integration/standalone/alice-home-init.nix
+++ b/tests/integration/standalone/alice-home-init.nix
@@ -1,3 +1,5 @@
+{ config, pkgs, ... }:
+
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.
@@ -11,7 +13,7 @@
   # You should not change this value, even if you update Home Manager. If you do
   # want to update the value, then make sure to first check the Home Manager
   # release notes.
-  home.stateVersion = "24.11"; # Please read the comment before changing.
+  home.stateVersion = "25.05"; # Please read the comment before changing.
 
   # The home.packages option allows you to install Nix packages into your
   # environment.

--- a/tests/integration/standalone/home-with-symbols-init.nix
+++ b/tests/integration/standalone/home-with-symbols-init.nix
@@ -1,3 +1,5 @@
+{ config, pkgs, ... }:
+
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.
@@ -11,7 +13,7 @@
   # You should not change this value, even if you update Home Manager. If you do
   # want to update the value, then make sure to first check the Home Manager
   # release notes.
-  home.stateVersion = "24.11"; # Please read the comment before changing.
+  home.stateVersion = "25.05"; # Please read the comment before changing.
 
   # The home.packages option allows you to install Nix packages into your
   # environment.

--- a/tests/integration/standalone/nh.nix
+++ b/tests/integration/standalone/nh.nix
@@ -80,8 +80,11 @@ in
         "cp -v ${./alice-home-next.nix} ${home}/.config/home-manager/home.nix"
       ]))
 
+      # The default configuration creates this link on activation.
+      machine.fail("test -L '${home}/.cache/.keep'")
+
       actual = succeed_as_alice("nh home switch --no-nom '${home}/.config/home-manager'")
-      expected = "Starting Home Manager activation"
+      expected = "home-manager-generation.drv"
       assert expected in actual, \
         f"expected nh home switch to contain {expected}, but got {actual}"
 


### PR DESCRIPTION
### Description

They previously failed. I'm not sure why the nh test no longer picks up the activation script output but at least it seems to get activated.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```