### PR TITLE
atuin: fix docs url

### DIFF
--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -84,7 +84,7 @@ in
         Configuration written to
         {file}`$XDG_CONFIG_HOME/atuin/config.toml`.
 
-        See <https://atuin.sh/docs/config/> for the full list
+        See <https://docs.atuin.sh/configuration/config//> for the full list
         of options.
       '';
     };
@@ -102,7 +102,7 @@ in
         {file}`$XDG_CONFIG_HOME/atuin/themes/theme-name.toml`
         where the name of each attribute is the theme-name
 
-        See <https://atuin.sh/guide/theming/> for the full list
+        See <https://docs.atuin.sh/guide/theming/> for the full list
         of options.
       '';
       default = { };

--- a/modules/programs/atuin.nix
+++ b/modules/programs/atuin.nix
@@ -84,7 +84,7 @@ in
         Configuration written to
         {file}`$XDG_CONFIG_HOME/atuin/config.toml`.
 
-        See <https://docs.atuin.sh/configuration/config//> for the full list
+        See <https://docs.atuin.sh/configuration/config/> for the full list
         of options.
       '';
     };


### PR DESCRIPTION
### Description

This change fixes the URLs for the atuin docs since the old ones either redirect or land on a 404 page.
It only touches option descriptions and does not include any functional changes.

### Maintainers

@hawkw
@water-sucks 