### PR TITLE
element-desktop: combine configs

### DIFF
--- a/modules/programs/element-desktop.nix
+++ b/modules/programs/element-desktop.nix
@@ -124,7 +124,7 @@ in
           else
             (formatter.generate "element-desktop-default.json" cfg.settings);
         defaultConfig =
-          if (settings != { }) then
+          if (cfg.settings != { } || cfg.combineDefaultSettings) then
             {
               "${prefix}/Element/config.json".source = settings;
             }

--- a/modules/programs/element-desktop.nix
+++ b/modules/programs/element-desktop.nix
@@ -113,7 +113,7 @@ in
       let
         settings =
           if cfg.combineDefaultSettings then
-            (pkgs.runCommandLocal "element-desktop-default"
+            (pkgs.runCommandLocal "element-desktop-default.json"
               {
                 nativeBuildInputs = [ pkgs.jq ];
               }
@@ -122,7 +122,7 @@ in
               ''
             )
           else
-            (formatter.generate "element-desktop-default" cfg.settings);
+            (formatter.generate "element-desktop-default.json" cfg.settings);
         defaultConfig =
           if (settings != { }) then
             {
@@ -137,7 +137,7 @@ in
         let
           profile =
             if cfg.combineSettingsProfiles then
-              (pkgs.runCommandLocal "element-desktop-${name}"
+              (pkgs.runCommandLocal "element-desktop-${name}.json"
                 {
                   nativeBuildInputs = [ pkgs.jq ];
                 }
@@ -148,7 +148,7 @@ in
                 ''
               )
             else
-              (formatter.generate "element-desktop-${name}" cfg.profiles."${name}");
+              (formatter.generate "element-desktop-${name}.json" cfg.profiles."${name}");
         in
         lib.nameValuePair "${prefix}/Element-${name}/config.json" {
           source = profile;


### PR DESCRIPTION
### Description

This allow users to define element-desktop config as an override of the default one

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

cc @aguirre-matteo