### PR TITLE
meli: move freeformat settings to example

### DIFF
--- a/modules/programs/meli.nix
+++ b/modules/programs/meli.nix
@@ -84,65 +84,36 @@ in
 
       settings = mkOption {
         type = types.submodule {
-          freeformType = (pkgs.formats.toml { }).type;
-          options = {
-            shortcuts = mkOption {
-              type = types.submodule {
-                options = {
-                  general = mkOption {
-                    type = types.attrsOf types.str;
-                    default = { };
-                    description = "general shortcut configuration";
-                    example = {
-                      scroll_up = "e";
-                      scroll_down = "n";
-                      next_page = "C-d";
-                    };
-                  };
-                  composing = mkOption {
-                    type = types.attrsOf types.str;
-                    default = { };
-                    description = "composing shortcut configuration";
-                    example = {
-                      edit = "m";
-                      scroll_up = "e";
-                      scroll_down = "n";
-                    };
-                  };
-                  contact-list = mkOption {
-                    type = types.attrsOf types.str;
-                    default = { };
-                    description = "contact-list shortcut configuration";
-                    example = {
+          freeformType = tomlFormat.type;
+        };
+        example = lib.literalExample ''
+          {
+          shortcuts = {
+          contact-list = {
                       create_contact = "c";
                       edit_contact = "m";
                     };
-                  };
-                  listing = mkOption {
-                    type = types.attrsOf types.str;
-                    default = { };
-                    description = "general shortcut configuration";
-                    example = {
-                      new_mail = "t";
-                      set_seen = "s";
-                    };
-                  };
-                  pager = mkOption {
-                    type = types.attrsOf types.str;
-                    default = { };
-                    description = "general shortcut configuration";
-                    example = {
+          general = {
+            edit = "m";
+            scroll_up = "e";
+            scroll_down = "n";
+          };
+          composing = {
+            edit = "m";
+            scroll_up = "e";
+            scroll_down = "n";
+          };
+          listing = {
+            new_mail = "t";
+            set_seen = "s";
+          };
+          pager = {
                       scroll_up = "e";
                       scroll_down = "n";
-                    };
-                  };
-                };
-              };
-              default = { };
-              description = "Shortcut Settings";
-            };
           };
-        };
+
+          }
+          }'';
         default = { };
         description = "Meli Configuration";
       };

--- a/tests/modules/programs/meli/expected.toml
+++ b/tests/modules/programs/meli/expected.toml
@@ -27,14 +27,6 @@ PRDR = true
 danger_accept_invalid_certs = false
 type = "tls"
 
-[shortcuts.composing]
-
-[shortcuts.contact-list]
-
 [shortcuts.general]
 scroll_down = "j"
 scroll_up = "k"
-
-[shortcuts.listing]
-
-[shortcuts.pager]


### PR DESCRIPTION
these hardcoded freeformat settings dont add anything over the default, worse they generate empty sections which can then clash with user included config (my usecase). It's best to move those to example.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
