### PR TITLE
fix meli eval warning 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -209,7 +209,6 @@
           - modules/programs/kubecolor.nix
           - modules/programs/lazydocker.nix
           - modules/programs/matplotlib.nix
-          - modules/programs/meli.nix
           - modules/programs/mercurial.nix
           - modules/programs/mergiraf.nix
           - modules/programs/mise.nix
@@ -303,6 +302,7 @@
           - modules/programs/getmail*
           - modules/programs/himalaya.nix
           - modules/programs/lieer.nix
+          - modules/programs/meli.nix
           - modules/programs/msmtp*
           - modules/programs/mu.nix
           - modules/programs/mujmap.nix

--- a/modules/programs/meli.nix
+++ b/modules/programs/meli.nix
@@ -86,7 +86,7 @@ in
         type = types.submodule {
           freeformType = tomlFormat.type;
         };
-        example = lib.literalExample ''
+        example = lib.literalExpression ''
           {
           shortcuts = {
           contact-list = {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Fixes https://github.com/nix-community/home-manager/issues/7261

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
