### PR TITLE
kakoune: implement a final package option

### DIFF
--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -688,6 +688,12 @@ in
 
       package = lib.mkPackageOption pkgs "kakoune-unwrapped" { nullable = true; };
 
+      finalPackage = mkOption {
+        type = types.nullOr types.package;
+        readOnly = true;
+        description = "Resulting customized kakoune package.";
+      };
+
       config = mkOption {
         type = types.nullOr configModule;
         default = { };
@@ -746,7 +752,9 @@ in
       The listed plugins will not be installed.
     '';
 
-    home.packages = lib.mkIf (cfg.package != null) [ kakouneWithPlugins ];
+    programs.kakoune.finalPackage = lib.mkIf (cfg.package != null) kakouneWithPlugins;
+
+    home.packages = lib.mkIf (cfg.finalPackage != null) [ cfg.finalPackage ];
     home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "kak"; };
     xdg.configFile = lib.mkMerge [
       { "kak/kakrc".source = configFile; }


### PR DESCRIPTION
### Description

This adds a "final-package" option to kakoune options, similar to `programs.neovim.finalPackage`.

This is useful for writing scrips, creating aliases etc.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
The module doesn't have a maintainers, @philipwilk you were the last person to have edited it, would you mind leaving a review?