### PR TITLE
hyprland: add support for submaps (#6062)

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -316,7 +316,7 @@ in
         ) cfg.submaps;
 
         submapWarnings = lib.mapAttrsToList (submapName: nonBinds: ''
-          wayland.windowManager.hyprland.submaps."${submapName}".settings: found non-bind entries: [${builtins.toString nonBinds}], which probably will have no effect in a submap
+          wayland.windowManager.hyprland.submaps."${submapName}".settings: found non-bind entries: [${builtins.toString nonBinds}], which will have no effect in a submap
         '') (lib.filterAttrs (n: v: v != [ ]) submapWarningsAttrset);
       in
       submapWarnings ++ lib.optional inconsistent warning;

--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -217,7 +217,11 @@ in
     };
 
     submaps = lib.mkOption {
-      description = "Attribute set of Hyprland submaps";
+      description = ''
+        Attribute set of Hyprland submaps.
+
+        See <https://wiki.hypr.land/Configuring/Binds#submaps> to learn about submaps
+      '';
       default = { };
       type = lib.types.attrsOf (
         lib.types.submodule (

--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -234,8 +234,15 @@ in
                 '';
                 example = lib.literalExpression ''
                   {
+                    binde = [
+                     ", right, resizeactive, 10 0"
+                     ", left, resizeactive, -10 0"
+                     ", up, resizeactive, 0 -10"
+                     ", down, resizeactive, 0 10"
+                    ];
+
                     bind = [
-                      ", q, exec $terminal"
+                      ", escape, submap, reset"
                     ];
                   }
                 '';
@@ -244,6 +251,29 @@ in
           }
         )
       );
+      example = lib.literalExpression ''
+        {
+          # submap to change window focus with vim keys
+          move_focus = {
+            settings = {
+              bind = [
+                ", h, movefocus, l"
+                ", j, movefocus, d"
+                ", k, movefocus, u"
+                ", l, movefocus, r"
+
+                ", escape, submap, reset"
+              ];
+            };
+          };
+
+          other_submap = {
+            settings = {
+              # ...
+            };
+          };
+        }
+      '';
     };
 
     extraConfig = lib.mkOption {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds support for [hyprland submaps](https://wiki.hypr.land/Configuring/Binds/#submaps) in the Hyprland HM module.

This is my first PR here, and this implementation is aimed to be basic, submap support could be extended in the future. The only "flashy" things in this PR are an assertion for submap name `reset` and warnings for non-binds in submaps.

Still slightly WIP : the added features seem to function all as expected (as far as my testing went), but there are still some things to do (I'm open for advice on how to get these done):
- [ ] Writing tests for the submap support
- [ ] Documentation
  - [x] Double-checking/improving `description`s and `example`s
  - [ ] Checking the rendered docs look right

I'm also all open for discussion on the implementation details and option structure, formatting or any comment really

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@fufexan 
