### PR TITLE
Add guiAddress to syncthing configuration

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -199,6 +199,9 @@ let
       syncthing_password=$(${cat} ${cfg.passwordFile})
       curl -X PATCH -d '{"password": "'$syncthing_password'"}' ${curlAddressArgs "/rest/config/gui"}
     ''
+    + lib.optionalString (cfg.guiAddress != null) ''
+      curl -X PATCH -d '{"address": "'${cfg.guiAddress}'"}' ${curlAddressArgs "/rest/config/gui"}
+    ''
     + ''
       # restart Syncthing if required
       if curl ${curlAddressArgs "/rest/config/restart-required"} |


### PR DESCRIPTION
### Description

We have a configuration option `services.syncthing.guiAddress` which is an explicit option because we need it in the syncthing-init service, but why not _also_ set it in the actual syncthing config as well as (or instead of?) the current CLI override? This way other software that parses the config file / REST API like syncthingtray just works with it instead of erroring out and unexpectedly requesting user interaction.

I guess we could actually also scrap the explicit `services.syncthing.guiAddress` option in favor of the syncthing-native `services.syncthing.settings.gui.address` because these two (valid!) options conflict otherwise.

Also, a next PR (or addition to this one) could be to make sure the `syncthing-init` service treats `services.syncthing.settings.gui` differently by not PUTting but PATCHing the configuration as PUTting triggers an API key regeneration, again breaking REST API access for other tools.

### Checklist

- [x] Change is backwards compatible.
      Though it could overwrite previously set GUI addresses and thus interfere with non-home-manager configurations.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
#### Maintainer CC

@rycee
