### PR TITLE
lib/strings: add PascalCase support for toCaseWithSeperator

### DIFF
--- a/modules/lib/strings.nix
+++ b/modules/lib/strings.nix
@@ -39,7 +39,7 @@ rec {
     "hm_" + safeName;
 
   /*
-    Convert a string from camelCase to another case format using a separator
+    Convert a string from camelCase or PascalCase to another case format using a separator
     Type: string -> string -> string
   */
   toCaseWithSeparator =
@@ -48,17 +48,18 @@ rec {
       splitByWords = builtins.split "([A-Z])";
       processWord = s: if lib.isString s then s else separator + lib.toLower (lib.elemAt s 0);
       words = splitByWords string;
+      converted = lib.concatStrings (map processWord words);
     in
-    lib.concatStrings (map processWord words);
+    lib.removePrefix separator converted;
 
   /*
-    Convert a string from camelCase to snake_case
+    Convert a string from camelCase or PascalCase to snake_case
     Type: string -> string
   */
   toSnakeCase = toCaseWithSeparator "_";
 
   /*
-    Convert a string from camelCase to kebab-case
+    Convert a string from camelCase or PascalCase to kebab-case
     Type: string -> string
   */
   toKebabCase = toCaseWithSeparator "-";


### PR DESCRIPTION
### Description

Added PascalCase support for lib.hm.strings.toCaseWithSeperator 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@khaneliman 
