### PR TITLE
firefox: allow separators in bookmarks

### DIFF
--- a/modules/programs/firefox/profiles/bookmark-types.nix
+++ b/modules/programs/firefox/profiles/bookmark-types.nix
@@ -50,6 +50,8 @@ rec {
 
   bookmarkType = types.addCheck bookmarkSubmodule (x: x ? "url");
 
+  separatorType = types.enum [ "separator" ];
+
   directoryType =
     types.submodule (
       { name, ... }:
@@ -83,5 +85,9 @@ rec {
       description = "directory submodule";
     };
 
-  nodeType = types.either bookmarkType directoryType;
+  nodeType = types.oneOf [
+    bookmarkType
+    directoryType
+    separatorType
+  ];
 }

--- a/modules/programs/firefox/profiles/bookmarks.nix
+++ b/modules/programs/firefox/profiles/bookmarks.nix
@@ -45,9 +45,16 @@ let
         ${allItemsToHTML (indentLevel + 1) directory.bookmarks}
         ${indent indentLevel}</DL><p>'';
 
+      separatorToHTML = indentLevel: "${indent indentLevel}<HR>";
+
       itemToHTMLOrRecurse =
         indentLevel: item:
-        if item ? "url" then bookmarkToHTML indentLevel item else directoryToHTML indentLevel item;
+        if item ? "url" then
+          bookmarkToHTML indentLevel item
+        else if item == "separator" then
+          separatorToHTML indentLevel
+        else
+          directoryToHTML indentLevel item;
 
       allItemsToHTML =
         indentLevel: bookmarks: lib.concatStringsSep "\n" (map (itemToHTMLOrRecurse indentLevel) bookmarks);
@@ -106,6 +113,7 @@ in
             name = "kernel.org";
             url = "https://www.kernel.org";
           }
+          "separator"
           {
             name = "Nix sites";
             toolbar = true;

--- a/tests/modules/programs/firefox/profiles/bookmarks/default.nix
+++ b/tests/modules/programs/firefox/profiles/bookmarks/default.nix
@@ -38,6 +38,7 @@ in
               name = "kernel.org";
               url = "https://www.kernel.org";
             }
+            "separator"
             {
               name = "Nix sites";
               bookmarks = [

--- a/tests/modules/programs/firefox/profiles/bookmarks/expected-bookmarks.html
+++ b/tests/modules/programs/firefox/profiles/bookmarks/expected-bookmarks.html
@@ -11,6 +11,7 @@
     <DT><A HREF="https://wiki.nixos.org/wiki/Home_Manager" ADD_DATE="1" LAST_MODIFIED="1">Home Manager</A>
   </DL><p>
   <DT><A HREF="https://www.kernel.org" ADD_DATE="1" LAST_MODIFIED="1">kernel.org</A>
+  <HR>
   <DT><H3 ADD_DATE="1" LAST_MODIFIED="1">Nix sites</H3>
   <DL><p>
     <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>


### PR DESCRIPTION
### Description

Allow users to put separators in their bookmarks

Closes #6312

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->


- [X] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [X] Change is backwards compatible.
- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
