### PR TITLE
vscode: fix version checks when using Windsurf

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -438,7 +438,16 @@ in
             lib.concatMap toPaths (flatten (mapAttrsToList (n: v: v.extensions) cfg.profiles))
             ++
               lib.optional
-                ((lib.versionAtLeast vscodeVersion "1.74.0" || vscodePname == "cursor") && defaultProfile != { })
+                (
+                  (
+                    lib.versionAtLeast vscodeVersion "1.74.0"
+                    || builtins.elem vscodePname [
+                      "cursor"
+                      "windsurf"
+                    ]
+                  )
+                  && defaultProfile != { }
+                )
                 {
                   # Whenever our immutable extensions.json changes, force VSCode to regenerate
                   # extensions.json with both mutable and immutable extensions.
@@ -461,7 +470,14 @@ in
                   paths =
                     (flatten (mapAttrsToList (n: v: v.extensions) cfg.profiles))
                     ++ lib.optional (
-                      (lib.versionAtLeast vscodeVersion "1.74.0" || vscodePname == "cursor") && defaultProfile != { }
+                      (
+                        lib.versionAtLeast vscodeVersion "1.74.0"
+                        || builtins.elem vscodePname [
+                          "cursor"
+                          "windsurf"
+                        ]
+                      )
+                      && defaultProfile != { }
                     ) (extensionJsonFile "default" (extensionJson defaultProfile.extensions));
                 };
               in


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Windsurf versions do not match VSCode versions, causing `extensions.json` to not be created. This MR fixes that in the same way https://github.com/nix-community/home-manager/pull/6680 did for Cursor.

No idea if there's a minimum version of Windsurf that should be validated here.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@Reputable2772 @HyunggyuJang

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
