### PR TITLE
hyprland: update wiki domain name

### DIFF
--- a/modules/programs/hyprlock.nix
+++ b/modules/programs/hyprlock.nix
@@ -93,7 +93,7 @@ in
       description = ''
         Hyprlock configuration written in Nix. Entries with the same key should
         be written as lists. Variables' and colors' names should be quoted. See
-        <https://wiki.hyprland.org/Hypr-Ecosystem/hyprlock/> for more examples.
+        <https://wiki.hypr.land/Hypr-Ecosystem/hyprlock/> for more examples.
       '';
     };
 

--- a/modules/services/hypridle.nix
+++ b/modules/services/hypridle.nix
@@ -41,7 +41,7 @@ in
       description = ''
         Hypridle configuration written in Nix. Entries with the same key
         should be written as lists. Variables' and colors' names should be
-        quoted. See <https://wiki.hyprland.org/Hypr-Ecosystem/hypridle/> for more examples.
+        quoted. See <https://wiki.hypr.land/Hypr-Ecosystem/hypridle/> for more examples.
       '';
       example = lib.literalExpression ''
         {

--- a/modules/services/hyprpaper.nix
+++ b/modules/services/hyprpaper.nix
@@ -41,7 +41,7 @@ in
       description = ''
         hyprpaper configuration written in Nix. Entries with the same key
         should be written as lists. Variables' and colors' names should be
-        quoted. See <https://wiki.hyprland.org/Hypr-Ecosystem/hyprpaper/> for more examples.
+        quoted. See <https://wiki.hypr.land/Hypr-Ecosystem/hyprpaper/> for more examples.
       '';
       example = lib.literalExpression ''
         {

--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -32,7 +32,7 @@ in
 
     (lib.mkRemovedOptionModule # \
       [ "wayland" "windowManager" "hyprland" "xwayland" "hidpi" ]
-      "HiDPI patches are deprecated. Refer to https://wiki.hyprland.org/Configuring/XWayland"
+      "HiDPI patches are deprecated. Refer to https://wiki.hypr.land/Configuring/XWayland"
     )
 
     (lib.mkRemovedOptionModule # \
@@ -189,7 +189,7 @@ in
       description = ''
         Hyprland configuration written in Nix. Entries with the same key
         should be written as lists. Variables' and colors' names should be
-        quoted. See <https://wiki.hyprland.org> for more examples.
+        quoted. See <https://wiki.hypr.land> for more examples.
 
         ::: {.note}
         Use the [](#opt-wayland.windowManager.hyprland.plugins) option to


### PR DESCRIPTION
### Description

As I noticed in <https://github.com/nix-community/home-manager/pull/7277#issuecomment-2985781610>, it seems hyprland changed its domain name from `hyprland.org` to `hypr.land`. (The old domain redirects to the new one).

These changes are made by the following:
```
find . \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i 's/hyprland\.org/hypr.land/g'
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@fufexan
