### PR TITLE
obsidian: add extraSettings

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -85,6 +85,12 @@
     github = "Avimitin";
     githubId = 30021675;
   };
+  azikx = {
+    name = "azikx";
+    email = "xfalwa@gmail.com";
+    github = "mctrxw";
+    githubId = 189107707;
+  };
   bamhm182 = {
     name = "bamhm182";
     email = "bamhm182@gmail.com";

--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -385,6 +385,12 @@ in
       );
       default = { };
     };
+
+    extraSettings = mkOption {
+      description = "Additional settings to include in obsidian.json.";
+      type = types.attrsOf types.anything;
+      default = { };
+    };
   };
 
   config =
@@ -536,21 +542,23 @@ in
           );
       };
 
-      xdg.configFile."obsidian/obsidian.json".source = (pkgs.formats.json { }).generate "obsidian.json" {
-        vaults = builtins.listToAttrs (
-          builtins.map (vault: {
-            name = builtins.hashString "md5" vault.target;
-            value =
-              {
-                path = "${config.home.homeDirectory}/${vault.target}";
-              }
-              // (lib.attrsets.optionalAttrs ((builtins.length vaults) == 1) {
-                open = true;
-              });
-          }) vaults
-        );
-        updateDisabled = true;
-      };
+      xdg.configFile."obsidian/obsidian.json".source =
+        (pkgs.formats.json { }).generate "obsidian.json" {
+          vaults = builtins.listToAttrs (
+            builtins.map (vault: {
+              name = builtins.hashString "md5" vault.target;
+              value =
+                {
+                  path = "${config.home.homeDirectory}/${vault.target}";
+                }
+                // (lib.attrsets.optionalAttrs ((builtins.length vaults) == 1) {
+                  open = true;
+                });
+            }) vaults
+          );
+          updateDisabled = true;
+        }
+        // cfg.extraSettings;
 
       assertions = [
         {
@@ -575,5 +583,8 @@ in
       ];
     };
 
-  meta.maintainers = [ lib.hm.maintainers.karaolidis ];
+  meta.maintainers = with lib.hm.maintainers; [
+    karaolidis
+    azikx
+  ];
 }


### PR DESCRIPTION
### Description

added extraSettings to obsidian module

### Example

```
programs.obsidian.extraSettings = {
  frame = "native";
};
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with nix fmt or
    nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt.

- [x] Code tested through nix-shell --pure tests -A run.all
    or nix build --reference-lock-file flake.lock ./tests#test-all using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    
    {component}: {description}

    {long description}
    

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@rycee @karaolidis