### PR TITLE
aerospace: Add launchd agent and enhance configuration

### DIFF
--- a/tests/modules/programs/aerospace/aerospace-service-expected.plist
+++ b/tests/modules/programs/aerospace/aerospace-service-expected.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Label</key>
+	<string>org.nix-community.home.aerospace</string>
+	<key>Program</key>
+	<string>/nix/store/00000000000000000000000000000000-aerospace/Applications/AeroSpace.app/Contents/MacOS/AeroSpace</string>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/tmp/aerospace.err.log</string>
+	<key>StandardOutPath</key>
+	<string>/tmp/aerospace.log</string>
+</dict>
+</plist>

--- a/tests/modules/programs/aerospace/aerospace.nix
+++ b/tests/modules/programs/aerospace/aerospace.nix
@@ -1,6 +1,9 @@
 {
   programs.aerospace = {
     enable = true;
+
+    launchd.enable = true;
+
     userSettings = {
       gaps = {
         outer.left = 8;

--- a/tests/modules/programs/aerospace/aerospace.nix
+++ b/tests/modules/programs/aerospace/aerospace.nix
@@ -1,6 +1,22 @@
+{ config, pkgs, ... }:
+let
+  hmPkgs = pkgs.extend (
+    self: super: {
+      aerospace = config.lib.test.mkStubPackage {
+        name = "aerospace";
+        buildScript = ''
+          mkdir -p $out/bin
+          touch $out/bin/aerospace
+          chmod 755 $out/bin/aerospace
+        '';
+      };
+    }
+  );
+in
 {
   programs.aerospace = {
     enable = true;
+    package = hmPkgs.aerospace;
 
     launchd.enable = true;
 
@@ -22,5 +38,9 @@
 
   nmt.script = ''
     assertFileContent home-files/.config/aerospace/aerospace.toml ${./settings-expected.toml}
+
+    serviceFile=$(normalizeStorePaths LaunchAgents/org.nix-community.home.aerospace.plist)
+    assertFileExists $serviceFile
+    assertFileContent "$serviceFile" ${./aerospace-service-expected.plist}
   '';
 }


### PR DESCRIPTION
### Description
This commit introduces a `launchd` agent to automatically start AeroSpace at login, significantly improving its integration.

Solve issue #6725 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
