### PR TITLE
helix: don't ignore extraConfig when no other settings

### DIFF
--- a/tests/modules/programs/helix/default.nix
+++ b/tests/modules/programs/helix/default.nix
@@ -1,1 +1,4 @@
-{ helix-example-settings = ./example-settings.nix; }
+{
+  helix-example-settings = ./example-settings.nix;
+  helix-only-extraconfig = ./only-extraconfig.nix;
+}

--- a/tests/modules/programs/helix/only-extraconfig-expected.toml
+++ b/tests/modules/programs/helix/only-extraconfig-expected.toml
@@ -1,0 +1,2 @@
+[editor]
+auto-pairs = false

--- a/tests/modules/programs/helix/only-extraconfig.nix
+++ b/tests/modules/programs/helix/only-extraconfig.nix
@@ -1,0 +1,16 @@
+{ config, ... }:
+{
+  programs.helix = {
+    enable = true;
+    extraConfig = ''
+      [editor]
+      auto-pairs = false
+    '';
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/helix/config.toml \
+      ${./only-extraconfig-expected.toml}
+  '';
+}


### PR DESCRIPTION
### Description

Fix so that you can still generate `programs.helix.extraConfig` without using `programs.helix.settings`. Useful particularly in the case of `extraConfig = lib.readFile ./config.toml;`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt`

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

My test code passes:
```
/aux/code/home-manager> nix build --reference-lock-file flake.lock "./tests#test-helix-only-extraconfig"
```

I get an unrelated error trying to run the entire test suite.
```
error: builder for '/nix/store/0ahpc06wbspycw9ih4i0r2kg8p7khh88-nmt-test-firefox-profiles-bookmarks-attrset.drv' failed with exit code 1;
       last 11 log lines:
       > Expected /nix/store/j2avbbv232xh00ldmd9ycl0dbpik5hqn-bookmarks.html to be same as /nix/store/iiz9myl298nqpm9hbidr8p6hmqvkzapb-expected-bookmarks.html but were different:
       > --- actual
       > +++ expected
       > @@ -11,6 +11,7 @@
       >      <DT><A HREF="https://wiki.nixos.org/wiki/Home_Manager" ADD_DATE="1" LAST_MODIFIED="1">Home Manager</A>
       >    </DL><p>
       >    <DT><A HREF="https://www.kernel.org" ADD_DATE="1" LAST_MODIFIED="1">kernel.org</A>
       > +  <HR>
       >    <DT><H3 ADD_DATE="1" LAST_MODIFIED="1">Nix sites</H3>
       >    <DL><p>
       >      <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>
       For full logs, run:
         nix log /nix/store/0ahpc06wbspycw9ih4i0r2kg8p7khh88-nmt-test-firefox-profiles-bookmarks-attrset.drv
error: 1 dependencies of derivation '/nix/store/5cd4yrncnhfs4wny15mc6c9vgwz6j0ys-nmt-all-tests.drv' failed to build
Exception: nix exited with 1
  [tty 63]:1:1-61: nix build --reference-lock-file flake.lock "./tests#test-all"
```

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

#### Maintainer CC

@Philipp-M 
