### PR TITLE
programs/hyprpanel: init

### DIFF
--- a/modules/programs/hyprpanel/default.nix
+++ b/modules/programs/hyprpanel/default.nix
@@ -1,0 +1,121 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.programs.hyprpanel;
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  meta.maintainers = [ lib.maintainers.perchun ];
+
+  options.programs.hyprpanel = {
+    enable = lib.mkEnableOption "HyprPanel";
+
+    package = lib.mkPackageOption pkgs "hyprpanel" { };
+
+    settings = lib.mkOption {
+      type = jsonFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        bar.battery.label = true;
+        bar.bluetooth.label = false;
+        bar.clock.format = "%H:%M:%S";
+        bar.layouts = {
+          "*" = {
+            left = [
+              "dashboard"
+              "workspaces"
+              "media"
+            ];
+            middle = [ "windowtitle" ];
+            right = [
+              "volume"
+              "network"
+              "bluetooth"
+              "notifications"
+            ];
+          };
+        };
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/hyprpanel/config.json`.
+
+        See <https://hyprpanel.com/configuration/settings.html#home-manager-module>
+        for the full list of options.
+      '';
+    };
+
+    systemd.enable = lib.mkEnableOption "HyprPanel systemd integration" // {
+      default = true;
+    };
+
+    dontAssertNotificationDaemons = lib.mkOption {
+      default = true;
+      example = false;
+      description = ''
+        Whether to check for other notification daemons.
+
+        You might want to set this to false, because hyprpanel's notification
+        daemon is buggy and you may prefer something else.
+      '';
+      type = lib.types.bool;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.dontAssertNotificationDaemons && !config.services.swaync.enable;
+        message = ''
+          Only one notification daemon can be enabled at once. You have enabled
+          swaync and hyprpanel at once.
+
+          If you dont want to use hyprpanel's notification daemon, set
+          `programs.hyprpanel.dontAssertNotificationDaemons` to true.
+        '';
+      }
+    ];
+
+    home.packages = [ cfg.package ];
+
+    programs.hyprpanel.settings = lib.mkIf config.services.hypridle.enable {
+      # fix hypridle module if user uses systemd service
+      bar.customModules.hypridle.startCommand = lib.mkDefault "systemctl --user start hypridle.service";
+      bar.customModules.hypridle.stopCommand = lib.mkDefault "systemctl --user stop hypridle.service";
+      bar.customModules.hypridle.isActiveCommand = lib.mkDefault "systemctl --user status hypridle.service | grep -q 'Active: active (running)' && echo 'yes' || echo 'no'";
+    };
+
+    xdg.configFile.hyprpanel = lib.mkIf (cfg.settings != { }) {
+      target = "hyprpanel/config.json";
+      source = jsonFormat.generate "hyprpanel-config" cfg.settings;
+      # hyprpanel replaces it with the same file, but without new line in the end
+      force = true;
+    };
+
+    systemd.user.services.hyprpanel = lib.mkIf cfg.systemd.enable {
+      Unit = {
+        Description = "Bar/Panel for Hyprland with extensive customizability";
+        Documentation = "https://hyprpanel.com/getting_started/hyprpanel.html";
+        PartOf = [ config.wayland.systemd.target ];
+        After = [ config.wayland.systemd.target ];
+        ConditionEnvironment = "WAYLAND_DISPLAY";
+        X-Restart-Triggers = lib.optional (cfg.settings != { }) "${config.xdg.configFile.hyprpanel.source}";
+      };
+
+      Service = {
+        ExecStart = "${cfg.package}/bin/hyprpanel";
+        ExecReload = "${pkgs.coreutils}/bin/kill -SIGUSR2 $MAINPID";
+        Restart = "on-failure";
+        KillMode = "mixed";
+      };
+
+      Install = {
+        WantedBy = [ config.wayland.systemd.target ];
+      };
+    };
+  };
+}

--- a/tests/modules/programs/hyprpanel/basic-config.json
+++ b/tests/modules/programs/hyprpanel/basic-config.json
@@ -1,0 +1,31 @@
+{
+  "bar": {
+    "battery": {
+      "label": true
+    },
+    "bluetooth": {
+      "label": false
+    },
+    "clock": {
+      "format": "%H:%M:%S"
+    },
+    "layouts": {
+      "*": {
+        "left": [
+          "dashboard",
+          "workspaces",
+          "media"
+        ],
+        "middle": [
+          "windowtitle"
+        ],
+        "right": [
+          "volume",
+          "network",
+          "bluetooth",
+          "notifications"
+        ]
+      }
+    }
+  }
+}

--- a/tests/modules/programs/hyprpanel/basic-config.nix
+++ b/tests/modules/programs/hyprpanel/basic-config.nix
@@ -1,0 +1,34 @@
+{ config, ... }:
+{
+  programs.hyprpanel = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "hyprpanel"; };
+    settings = {
+      bar.battery.label = true;
+      bar.bluetooth.label = false;
+      bar.clock.format = "%H:%M:%S";
+      bar.layouts = {
+        "*" = {
+          left = [
+            "dashboard"
+            "workspaces"
+            "media"
+          ];
+          middle = [ "windowtitle" ];
+          right = [
+            "volume"
+            "network"
+            "bluetooth"
+            "notifications"
+          ];
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      "home-files/.config/hyprpanel/config.json" \
+      ${./basic-config.json}
+  '';
+}

--- a/tests/modules/programs/hyprpanel/default.nix
+++ b/tests/modules/programs/hyprpanel/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  hyprpanel-basic-config = ./basic-config.nix;
+  hyprpanel-with-hypridle = ./with-hypridle.nix;
+}

--- a/tests/modules/programs/hyprpanel/with-hypridle.json
+++ b/tests/modules/programs/hyprpanel/with-hypridle.json
@@ -1,0 +1,38 @@
+{
+  "bar": {
+    "battery": {
+      "label": true
+    },
+    "bluetooth": {
+      "label": false
+    },
+    "clock": {
+      "format": "%H:%M:%S"
+    },
+    "customModules": {
+      "hypridle": {
+        "isActiveCommand": "systemctl --user status hypridle.service | grep -q 'Active: active (running)' && echo 'yes' || echo 'no'",
+        "startCommand": "systemctl --user start hypridle.service",
+        "stopCommand": "systemctl --user stop hypridle.service"
+      }
+    },
+    "layouts": {
+      "*": {
+        "left": [
+          "dashboard",
+          "workspaces",
+          "media"
+        ],
+        "middle": [
+          "windowtitle"
+        ],
+        "right": [
+          "volume",
+          "network",
+          "bluetooth",
+          "notifications"
+        ]
+      }
+    }
+  }
+}

--- a/tests/modules/programs/hyprpanel/with-hypridle.nix
+++ b/tests/modules/programs/hyprpanel/with-hypridle.nix
@@ -1,0 +1,35 @@
+{ config, ... }:
+{
+  services.hypridle.enable = true;
+  programs.hyprpanel = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { name = "hyprpanel"; };
+    settings = {
+      bar.battery.label = true;
+      bar.bluetooth.label = false;
+      bar.clock.format = "%H:%M:%S";
+      bar.layouts = {
+        "*" = {
+          left = [
+            "dashboard"
+            "workspaces"
+            "media"
+          ];
+          middle = [ "windowtitle" ];
+          right = [
+            "volume"
+            "network"
+            "bluetooth"
+            "notifications"
+          ];
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      "home-files/.config/hyprpanel/config.json" \
+      ${./with-hypridle.json}
+  '';
+}


### PR DESCRIPTION
### Description

https://github.com/Jas-SinghFSU/HyprPanel: Bar/Panel for Hyprland with extensive customizability (https://github.com/NixOS/nixpkgs/pull/379994)

I have been daily driving everything from this PR since the 2025 new year, so everything is pretty well tested

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

CC @JohnRTitor 
