### PR TITLE
way-displays: fix `systemd.variables` regression

### DIFF
--- a/modules/services/way-displays.nix
+++ b/modules/services/way-displays.nix
@@ -89,7 +89,7 @@ in
     home.packages = [ cfg.package ];
 
     wayland.windowManager = lib.mapAttrs (name: _: {
-      systemd.variables = [ "XDG_VTNR" ];
+      systemd.variables = lib.mkOptionDefault [ "XDG_VTNR" ];
     }) options.wayland.windowManager;
 
     xdg.configFile."way-displays/cfg.yaml" = mkIf (cfg.settings != null) {


### PR DESCRIPTION


### Description

Commit 04672588 mistakenly set the systemd.variables option list value to only `[ "XDG_VTNR" ]` for every `wayland.windowManager` which breaks autogenerated dbus-update-activation-environment commands. Fixed by using `lib.mkOptionDefault` to merge into the default value instead of taking precedence over it.

Fixes #7296

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@jolars @mightyiam 
