### PR TITLE
home-environment: change runCommand to runCommandLocal

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -694,7 +694,7 @@ in
     lib.bash.initHomeManagerLib =
       let
         domainDir =
-          pkgs.runCommand "hm-modules-messages"
+          pkgs.runCommandLocal "hm-modules-messages"
             {
               nativeBuildInputs = [ pkgs.buildPackages.gettext ];
             }
@@ -786,7 +786,7 @@ in
           ''}
         '';
       in
-      pkgs.runCommand "home-manager-generation"
+      pkgs.runCommandLocal "home-manager-generation"
         {
           preferLocalBuild = true;
           passAsFile = [ "extraDependencies" ];


### PR DESCRIPTION
Change runCommand to runCommandLocal so that config changes can build offline without unnecessarily consulting substituters.

A fresh `home-manager-generation` runCommand derivation is created for each config change, but it should really be runCommandLocal, as it is exceedingly improbable that my config will be cached. Furthermore, this causes NixOS rebuilds to fail offline even if only text config changes are applied, as runCommand causes home-manager to ask Nix to always try consulting substituters and fail if it is unreachable.

A number of other `runCommand`s are also in this module; can someone review if they should also be changed to runCommandLocal?

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
