### PR TITLE
fix(zed): support preexisting JSON5 settings

### DIFF
--- a/tests/modules/programs/zed-editor/keymap.nix
+++ b/tests/modules/programs/zed-editor/keymap.nix
@@ -30,6 +30,7 @@
     let
       preexistingKeymaps = builtins.toFile "preexisting.json" ''
         [
+          // Things changed interactively
           {
             "bindings": {
               "down": "menu::SelectNext"
@@ -41,12 +42,14 @@
             },
             "context": "Terminal"
           },
+
+          /* Manually changed */
           {
             "bindings": {
               "enter": "newline"
             },
-            "context": "Editor"
-          }
+            "context": "Editor",
+          },
         ]
       '';
 

--- a/tests/modules/programs/zed-editor/settings.nix
+++ b/tests/modules/programs/zed-editor/settings.nix
@@ -27,7 +27,10 @@
     let
       preexistingSettings = builtins.toFile "preexisting.json" ''
         {
+          // I chose this theme interactively
           "theme": "Default",
+
+          /* I change AI settings interactively */
           "features": {
             "copilot": true,
             "ai_assist": true


### PR DESCRIPTION
Zed uses JSON5 for settings files. JQ doesn't understand that format and
fails if found, when merging with preexisting settings.

Here I add a conversion step that converts JSON5 to JSON before handling
the contents to JQ.

Besides, I changed the arguments in the jq function, so instead of using
`[0]` and `[1]`, we now use `$dynamic` and `$static` respectively. This
should make scripts more readable.

Fixes https://github.com/nix-community/home-manager/issues/7247
Fixes https://github.com/nix-community/home-manager/issues/7226
