### PR TITLE
helix: fix configuration file creation logic

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -232,7 +232,7 @@ in
         settings =
           let
             hasSettings = cfg.settings != { };
-            hasExtraConfig = cfg.extraConfig != null;
+            hasExtraConfig = cfg.extraConfig != "";
           in
           {
             "helix/config.toml" = mkIf (hasSettings || hasExtraConfig) {


### PR DESCRIPTION
### Description

Fixes the logic that determines if the helix editor config files should be created. See https://github.com/nix-community/home-manager/issues/7310

Take 2 after an unfortunate git mishap on https://github.com/nix-community/home-manager/pull/7311

@Philipp-M 