### PR TITLE
opencode: init

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    ;
+
+  cfg = config.programs.opencode;
+
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ delafthi ];
+
+  options.programs.opencode = {
+    enable = mkEnableOption "opencode";
+
+    package = mkPackageOption pkgs "opencode" { nullable = true; };
+
+    settings = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = literalExpression ''
+        {
+          theme = "opencode";
+          model = "anthropic/claude-sonnet-4-20250514";
+          autoshare = false;
+          autoupdate = true;
+        }
+      '';
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/opencode/config.json`.
+        See <https://opencode.ai/docs/config/> for the documentation.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."opencode/config.json" = mkIf (cfg.settings != { }) {
+      source = jsonFormat.generate "config.json" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/opencode/config.json
+++ b/tests/modules/programs/opencode/config.json
@@ -1,0 +1,6 @@
+{
+  "autoshare": false,
+  "autoupdate": true,
+  "model": "anthropic/claude-sonnet-4-20250514",
+  "theme": "opencode"
+}

--- a/tests/modules/programs/opencode/default.nix
+++ b/tests/modules/programs/opencode/default.nix
@@ -1,0 +1,3 @@
+{
+  opencode-settings = ./settings.nix;
+}

--- a/tests/modules/programs/opencode/settings.nix
+++ b/tests/modules/programs/opencode/settings.nix
@@ -1,0 +1,16 @@
+{
+  programs.opencode = {
+    enable = true;
+    settings = {
+      theme = "opencode";
+      model = "anthropic/claude-sonnet-4-20250514";
+      autoshare = false;
+      autoupdate = true;
+    };
+  };
+  nmt.script = ''
+    assertFileExists home-files/.config/opencode/config.json
+    assertFileContent home-files/.config/opencode/config.json \
+      ${./config.json}
+  '';
+}


### PR DESCRIPTION
### Description

This PR adds an opencode module that is compatible with opencode v0.1.194.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
