### PR TITLE
formatter: add deadnix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Also make sure to read the guidelines found at
 - [ ] Change is backwards compatible.
 
 - [ ] Code formatted with `nix fmt` or
-    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.
+    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.
 
 - [ ] Code tested through `nix-shell --pure tests -A run.all`
     or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ test-install:
 	HOME=$(shell mktemp -d) NIX_PATH=${NIX_PATH} nix-shell . -A install
 
 format:
-	nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run "treefmt --config-file ./treefmt.toml"
+	nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run "treefmt --config-file ./treefmt.toml"

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
           pkgs.treefmt.withConfig {
             runtimeInputs = with pkgs; [
               nixfmt-rfc-style
+              deadnix
               keep-sorted
             ];
             settings = pkgs.lib.importTOML ./treefmt.toml;

--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -187,28 +187,26 @@ in
 
                 corePlugins =
                   let
-                    corePluginsOptions =
-                      { config, ... }:
-                      {
-                        options = {
-                          enable = mkOption {
-                            type = types.bool;
-                            default = true;
-                            description = "Whether to enable the plugin.";
-                          };
+                    corePluginsOptions = {
+                      options = {
+                        enable = mkOption {
+                          type = types.bool;
+                          default = true;
+                          description = "Whether to enable the plugin.";
+                        };
 
-                          name = mkOption {
-                            type = types.enum corePlugins;
-                            description = "The plugin.";
-                          };
+                        name = mkOption {
+                          type = types.enum corePlugins;
+                          description = "The plugin.";
+                        };
 
-                          settings = mkOption {
-                            type = with types; attrsOf anything;
-                            description = "Plugin settings to include.";
-                            default = { };
-                          };
+                        settings = mkOption {
+                          type = with types; attrsOf anything;
+                          description = "Plugin settings to include.";
+                          default = { };
                         };
                       };
+                    };
                   in
                   mkOption {
                     description = "Core plugins to activate.";
@@ -220,28 +218,26 @@ in
 
                 communityPlugins =
                   let
-                    communityPluginsOptions =
-                      { config, ... }:
-                      {
-                        options = {
-                          enable = mkOption {
-                            type = types.bool;
-                            default = true;
-                            description = "Whether to enable the plugin.";
-                          };
+                    communityPluginsOptions = {
+                      options = {
+                        enable = mkOption {
+                          type = types.bool;
+                          default = true;
+                          description = "Whether to enable the plugin.";
+                        };
 
-                          pkg = mkOption {
-                            type = types.package;
-                            description = "The plugin package.";
-                          };
+                        pkg = mkOption {
+                          type = types.package;
+                          description = "The plugin package.";
+                        };
 
-                          settings = mkOption {
-                            type = with types; attrsOf anything;
-                            description = "Settings to include in the plugin's `data.json`.";
-                            default = { };
-                          };
+                        settings = mkOption {
+                          type = with types; attrsOf anything;
+                          description = "Settings to include in the plugin's `data.json`.";
+                          default = { };
                         };
                       };
+                    };
                   in
                   mkOption {
                     description = "Community plugins to install and activate.";
@@ -295,22 +291,20 @@ in
 
                 themes =
                   let
-                    themesOptions =
-                      { config, ... }:
-                      {
-                        options = {
-                          enable = mkOption {
-                            type = types.bool;
-                            default = true;
-                            description = "Whether to set the theme as active.";
-                          };
+                    themesOptions = {
+                      options = {
+                        enable = mkOption {
+                          type = types.bool;
+                          default = true;
+                          description = "Whether to set the theme as active.";
+                        };
 
-                          pkg = mkOption {
-                            type = types.package;
-                            description = "The theme package.";
-                          };
+                        pkg = mkOption {
+                          type = types.package;
+                          description = "The theme package.";
                         };
                       };
+                    };
                   in
                   mkOption {
                     description = "Themes to install.";
@@ -320,22 +314,20 @@ in
 
                 hotkeys =
                   let
-                    hotkeysOptions =
-                      { config, ... }:
-                      {
-                        options = {
-                          modifiers = mkOption {
-                            type = with types; listOf str;
-                            description = "The hotkey modifiers.";
-                            default = [ ];
-                          };
+                    hotkeysOptions = {
+                      options = {
+                        modifiers = mkOption {
+                          type = with types; listOf str;
+                          description = "The hotkey modifiers.";
+                          default = [ ];
+                        };
 
-                          key = mkOption {
-                            type = types.str;
-                            description = "The hotkey.";
-                          };
+                        key = mkOption {
+                          type = types.str;
+                          description = "The hotkey.";
                         };
                       };
+                    };
                   in
                   mkOption {
                     description = "Hotkeys to configure.";

--- a/modules/services/stalonetray.nix
+++ b/modules/services/stalonetray.nix
@@ -10,7 +10,6 @@ let
     mkIf
     mkOption
     types
-    literalExpression
     ;
 
   cfg = config.services.stalonetray;

--- a/tests/integration/standalone/alice-home-init.nix
+++ b/tests/integration/standalone/alice-home-init.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, ... }:
-
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.

--- a/tests/integration/standalone/home-with-symbols-init.nix
+++ b/tests/integration/standalone/home-with-symbols-init.nix
@@ -1,5 +1,3 @@
-{ config, pkgs, ... }:
-
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.

--- a/tests/modules/programs/helix/only-extraconfig.nix
+++ b/tests/modules/programs/helix/only-extraconfig.nix
@@ -1,4 +1,3 @@
-{ config, ... }:
 {
   programs.helix = {
     enable = true;

--- a/tests/modules/programs/lutris/empty.nix
+++ b/tests/modules/programs/lutris/empty.nix
@@ -1,4 +1,3 @@
-{ pkgs, lib, ... }:
 {
   programs.lutris.enable = true;
   nmt.script =

--- a/tests/modules/programs/mc/basic-configuration.nix
+++ b/tests/modules/programs/mc/basic-configuration.nix
@@ -1,5 +1,3 @@
-{ config, lib, ... }:
-
 {
   programs.mc = {
     enable = true;

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -5,6 +5,11 @@ tree-root-file = "release.json"
 command = "nixfmt"
 includes = [ "*.nix" ]
 
+[formatter.deadnix]
+command = "deadnix"
+options = [ "--edit", "--no-lambda-arg" ]
+includes = [ "*.nix" ]
+
 [formatter.keep-sorted]
 command = "keep-sorted"
 includes = [ "*" ]


### PR DESCRIPTION
### Description
follow up to https://github.com/nix-community/home-manager/pull/6985 and https://github.com/nix-community/home-manager/pull/7056
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
