### PR TITLE
feat(tmux): move config file `~/.config/tmux.conf` -> `~/.tmux.conf`

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -132,7 +132,7 @@ let
       )
     ];
 
-    xdg.configFile."tmux/tmux.conf".text = ''
+    home.file.".tmux.conf".text = ''
       # ============================================= #
       # Load plugins with Home Manager                #
       # --------------------------------------------- #
@@ -209,7 +209,7 @@ in
         default = "";
         description = ''
           Additional configuration to add to
-          {file}`tmux.conf`.
+          {file}`.tmux.conf`.
         '';
       };
 
@@ -363,8 +363,8 @@ in
           ++ lib.optional cfg.tmuxp.enable pkgs.tmuxp;
       }
 
-      { xdg.configFile."tmux/tmux.conf".text = lib.mkBefore tmuxConf; }
-      { xdg.configFile."tmux/tmux.conf".text = lib.mkAfter cfg.extraConfig; }
+      { home.file.".tmux.conf".text = lib.mkBefore tmuxConf; }
+      { home.file.".tmux.conf".text = lib.mkAfter cfg.extraConfig; }
 
       (lib.mkIf cfg.secureSocket {
         home.sessionVariables = {


### PR DESCRIPTION
## Why this change?
- Plugin auto-loading issue: On macOS, tmux does not automatically source ~/.config/tmux/tmux.conf. As a result, plugin don’t work unless the config is manually sourced with:
```
tmux source ~/.config/tmux/tmux.conf
```

- Platform consistency: While ~/.config/tmux/tmux.conf is XDG-compliant, tmux on macOS does not follow this behavior reliably. The move aligns with tmux’s default expectations and common practice.

## ✅ Result
- Tmux plugins now load correctly on startup.
- Manual sourcing is no longer needed.
- Configuration becomes more portable and idiomatic, especially for macOS users.