### PR TITLE
direnv: fix nushell cell-path handling

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -187,13 +187,13 @@ in
                 | items {|key, value|
                     let value = do (
                         {
-                          "path": {
+                          "PATH": {
                             from_string: {|s| $s | split row (char esep) | path expand --no-symlink }
                             to_string: {|v| $v | path expand --no-symlink | str join (char esep) }
                           }
                         }
                         | merge ($env.ENV_CONVERSIONS? | default {})
-                        | get -i $key
+                        | get -i ([[value, optional, insensitive]; [$key, false, true]] | into cell-path)
                         | get -i from_string
                         | if ($in | is-empty) { {|x| $x} } else { $in }
                     ) $value


### PR DESCRIPTION
### Description
Since version 0.105.0, cell-paths are case-sensitive by default, since the record we are using is lowercase it doesn't convert `$env.PATH`.

Alternatively, instead of making it uppercase, we could build an actual `cell-path` value instead of relying on the string value of `$key`, which would comply with `$env` remaining a case-insensitive record (this also seems backwards compatible).
```nu
let key_path = [ # becomes $.<key>!
	[value, optional, insensitive];
	[$key, false, true]
]
get -i $key_path
```
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@khaneliman, @rycee, @shikanime 