### PR TITLE
Numbat: add initFile

### DIFF
--- a/modules/programs/numbat.nix
+++ b/modules/programs/numbat.nix
@@ -40,13 +40,14 @@ in
     };
 
     initFile = lib.mkOption {
-      type = lib.types.nullOr lib.types.lines;
+      type = lib.types.nullOr (lib.types.either lib.types.lines lib.types.path);
       default = null;
       example = ''
         unit kohm: ElectricResistance = kV/A
       '';
       description = ''
-        User initialization file ({file}`init.nbt`) contents.
+        User initialization file ({file}`init.nbt`) contents. May be specified
+        inline or as a path to a source file.
       '';
     };
   };
@@ -55,7 +56,7 @@ in
     home.packages = mkIf (cfg.package != null) [ cfg.package ];
 
     home.file."${configDir}/init.nbt" = mkIf (cfg.initFile != null) {
-      text = cfg.initFile;
+      source = if lib.isString cfg.initFile then pkgs.writeText "init.nbt" cfg.initFile else cfg.initFile;
     };
 
     home.file."${configDir}/config.toml" = mkIf (cfg.settings != { }) {

--- a/modules/programs/numbat.nix
+++ b/modules/programs/numbat.nix
@@ -38,10 +38,25 @@ in
         <https://numbat.dev/doc/cli-customization.html#configuration> for options.
       '';
     };
+
+    initFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.lines;
+      default = null;
+      example = ''
+        unit kohm: ElectricResistance = kV/A
+      '';
+      description = ''
+        User initialization file ({file}`init.nbt`) contents.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
     home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    home.file."${configDir}/init.nbt" = mkIf (cfg.initFile != null) {
+      text = cfg.initFile;
+    };
 
     home.file."${configDir}/config.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "numbat-config" cfg.settings;

--- a/tests/modules/programs/numbat/default.nix
+++ b/tests/modules/programs/numbat/default.nix
@@ -1,4 +1,5 @@
 {
   numbat-example-config = ./example-config.nix;
   numbat-empty-config = ./empty-config.nix;
+  numbat-external-initfile = ./external-initfile.nix;
 }

--- a/tests/modules/programs/numbat/empty-config.nix
+++ b/tests/modules/programs/numbat/empty-config.nix
@@ -14,5 +14,6 @@ in
 
   nmt.script = ''
     assertPathNotExists 'home-files/${configDir}/config.toml'
+    assertPathNotExists 'home-files/${configDir}/init.nbt'
   '';
 }

--- a/tests/modules/programs/numbat/example-config.nix
+++ b/tests/modules/programs/numbat/example-config.nix
@@ -19,6 +19,9 @@ in
       prompt = "> ";
       exchange-rates.fetching-policy = "on-first-use";
     };
+    initFile = ''
+      unit kohm: ElectricResistance = kV/A
+    '';
   };
 
   nmt.script = ''
@@ -30,6 +33,11 @@ in
 
         [exchange-rates]
         fetching-policy = "on-first-use"
+      ''}
+    assertFileExists 'home-files/${configDir}/init.nbt'
+    assertFileContent $(normalizeStorePaths 'home-files/${configDir}/init.nbt') \
+      ${builtins.toFile "expected-init.nbt" ''
+        unit kohm: ElectricResistance = kV/A
       ''}
   '';
 }

--- a/tests/modules/programs/numbat/external-initfile.nix
+++ b/tests/modules/programs/numbat/external-initfile.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/numbat"
+    else
+      ".config/numbat";
+in
+{
+  programs.numbat = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    initFile = ./init.nbt;
+  };
+
+  nmt.script = ''
+    assertFileExists 'home-files/${configDir}/init.nbt'
+    assertFileContent $(normalizeStorePaths 'home-files/${configDir}/init.nbt') \
+      ${builtins.toFile "expected-init.nbt" ''
+        unit kohm: ElectricResistance = kV/A
+      ''}
+  '';
+}

--- a/tests/modules/programs/numbat/init.nbt
+++ b/tests/modules/programs/numbat/init.nbt
@@ -1,0 +1,1 @@
+unit kohm: ElectricResistance = kV/A


### PR DESCRIPTION
### Description

This PR picks up where #7159 left off, providing an `initFile` option for `programs.numbat` to allow the user to supply custom units, functions, and constants for Numbat to use.

The first commit in this PR implements this using just (`lib.types.nullOr`) `lib.types.lines`; the second additionally allows specifying a path to the `init.nbt` file to use as a source. Though I was drawn to `lib.hm.types.sourceFileOrLines` initially, it has some extra logic around directories that is unnecessary (and perhaps confusing) for this.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
