### PR TITLE
oh-my-posh: fix nushell with v26.0.0

### DIFF
--- a/modules/programs/oh-my-posh.nix
+++ b/modules/programs/oh-my-posh.nix
@@ -82,10 +82,15 @@ in
 
     programs.nushell = mkIf cfg.enableNushellIntegration {
       extraConfig = ''
-        source ${
-          pkgs.runCommand "oh-my-posh-nushell-config.nu" { } ''
-            ${lib.getExe cfg.package} init nu ${configArgument} --print >> "$out"
-          ''
+        ${
+          if lib.versionAtLeast (lib.versions.major cfg.package.version) "26" then
+            "${lib.getExe cfg.package} init nu ${configArgument}"
+          else
+            ''source ${
+              pkgs.runCommand "oh-my-posh-nushell-config.nu" { } ''
+                ${lib.getExe cfg.package} init nu ${configArgument} --print >> "$out"
+              ''
+            }''
         }
       '';
     };

--- a/tests/modules/programs/oh-my-posh/nushell.nix
+++ b/tests/modules/programs/oh-my-posh/nushell.nix
@@ -28,8 +28,18 @@
     in
     ''
       assertFileExists "${configFile}"
-      assertFileRegex \
-        "${configFile}" \
-        'source /nix/store/[^/]*-oh-my-posh-nushell-config.nu'
+      ${
+        if (lib.versionAtLeast (lib.versions.major config.programs.oh-my-posh.package.version) "26") then
+          ''
+            assertFileContains \
+                    "${configFile}" \
+                    "/bin/oh-my-posh init nu --config"''
+        else
+
+          ''
+            assertFileRegex \
+                    "${configFile}" \
+                    "source /nix/store/[^/]*-oh-my-posh-nushell-config.nu"''
+      }
     '';
 }


### PR DESCRIPTION
### Description
See #7336

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
