### PR TITLE
ci: set env variables for flake update

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -4,11 +4,16 @@ on:
     # Update every Sunday and Wednesday
     - cron: "51 3 * * 0,3"
   workflow_dispatch:
-
 jobs:
   update:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.repository_owner == 'nix-community'
+    env:
+      repo: ${{ github.repository }}
+      base_branch: ${{ github.ref_name }}
+      pr_branch: update/${{ github.ref_name }}
+      workflow_run_id: ${{ github.run_id }}
+      workflow_run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     strategy:
       matrix:
         branch: [master, release-25.05]


### PR DESCRIPTION
Help with allowing multiple Prs from actions to different branches.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
