### PR TITLE
gh: insert empty helper when using credential helper

### DIFF
--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -193,7 +193,10 @@ in
         map (
           host:
           lib.nameValuePair host {
-            helper = "${cfg.package}/bin/gh auth git-credential";
+            helper = [
+              ""
+              "${cfg.package}/bin/gh auth git-credential"
+            ];
           }
         ) cfg.gitCredentialHelper.hosts
       )

--- a/tests/modules/programs/gh/credential-helper.git.conf
+++ b/tests/modules/programs/gh/credential-helper.git.conf
@@ -1,7 +1,9 @@
 [credential "https://github.com"]
+	helper = ""
 	helper = "@gh@/bin/gh auth git-credential"
 
 [credential "https://github.example.com"]
+	helper = ""
 	helper = "@gh@/bin/gh auth git-credential"
 
 [gpg]


### PR DESCRIPTION
Resets previous helpers so the only one being used is the `gh` cli

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
