### PR TITLE
files: show better error when file would be clobbered

### DIFF
--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -40,7 +40,7 @@ for sourcePath in "$@" ; do
       fi
     else
       # Fail if nothing else works
-      collisionErrors+=("Existing file '$backup' would be clobbered by backing up '$targetPath'")
+      collisionErrors+=("Existing file '$targetPath' would be clobbered")
     fi
   fi
 done


### PR DESCRIPTION
### Description

Before:

> Existing file '' would be clobbered by backing up '/home/winter/.config/fish/config.fish'

After:

> Existing file '/home/winter/.config/fish/config.fish' would be clobbered

---

**Note:** This work is funded by Antithesis.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

(It looks like some tests are broken-ish, e.g. `/build/.attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90: line 6: @hjson-go@/bin/hjson-cli: No such file or directory`)

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
