### PR TITLE
zed-editor: survive if previous files are not JSON5

### DIFF
--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -22,9 +22,9 @@ let
       # No file? Create it
       echo ${lib.escapeShellArg empty} > ${lib.escapeShellArg path}
     fi
-    dynamic="$(${lib.getExe json5} --as-json ${lib.escapeShellArg path})"
+    dynamic="$(${lib.getExe json5} --as-json ${lib.escapeShellArg path} 2>/dev/null || echo ${lib.escapeShellArg empty})"
     static="$(cat ${lib.escapeShellArg staticSettings})"
-    config="$(${lib.getExe pkgs.jq} -s ${lib.escapeShellArg jqOperation} --argjson dynamic "$dynamic" --argjson static "$static")"
+    config="$(${lib.getExe pkgs.jq} -n ${lib.escapeShellArg jqOperation} --argjson dynamic "$dynamic" --argjson static "$static")"
     printf '%s\n' "$config" > ${lib.escapeShellArg path}
     unset config
   '';

--- a/tests/modules/programs/zed-editor/default.nix
+++ b/tests/modules/programs/zed-editor/default.nix
@@ -2,6 +2,8 @@
   zed-extensions = ./extensions.nix;
   zed-install-remote-server = ./install-remote-server.nix;
   zed-keymap = ./keymap.nix;
+  zed-keymap-empty = ./keymap-empty.nix;
   zed-settings = ./settings.nix;
+  zed-settings-empty = ./settings-empty.nix;
   zed-themes = ./themes;
 }

--- a/tests/modules/programs/zed-editor/keymap-empty.nix
+++ b/tests/modules/programs/zed-editor/keymap-empty.nix
@@ -1,0 +1,74 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    userKeymaps = [
+      {
+        bindings = {
+          up = "menu::SelectPrev";
+        };
+      }
+      {
+        context = "Editor";
+        bindings = {
+          escape = "editor::Cancel";
+        };
+      }
+    ];
+  };
+
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  nmt.script =
+    let
+      # For some reason, the preexisting keymaps is an empty file
+      preexistingKeymaps = builtins.toFile "preexisting.json" "";
+
+      expectedContent = builtins.toFile "expected.json" ''
+        [
+          {
+            "bindings": {
+              "up": "menu::SelectPrev"
+            }
+          },
+          {
+            "bindings": {
+              "escape": "editor::Cancel"
+            },
+            "context": "Editor"
+          }
+        ]
+      '';
+
+      keymapPath = ".config/zed/keymap.json";
+      activationScript = pkgs.writeScript "activation" config.home.activation.zedKeymapActivation.data;
+    in
+    ''
+      export HOME=$TMPDIR/hm-user
+
+      # Simulate preexisting keymaps
+      mkdir -p $HOME/.config/zed
+      cat ${preexistingKeymaps} > $HOME/${keymapPath}
+
+      # Run the activation script
+      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+      chmod +x $TMPDIR/activate
+      $TMPDIR/activate
+
+      # Validate the merged keymaps
+      assertFileExists "$HOME/${keymapPath}"
+      assertFileContent "$HOME/${keymapPath}" "${expectedContent}"
+
+      # Test idempotency
+      $TMPDIR/activate
+      assertFileExists "$HOME/${keymapPath}"
+      assertFileContent "$HOME/${keymapPath}" "${expectedContent}"
+    '';
+}

--- a/tests/modules/programs/zed-editor/settings-empty.nix
+++ b/tests/modules/programs/zed-editor/settings-empty.nix
@@ -1,0 +1,67 @@
+# Test custom keymap functionality
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    userSettings = {
+      theme = "XY-Zed";
+      features = {
+        copilot = false;
+      };
+      vim_mode = false;
+      ui_font_size = 16;
+      buffer_font_size = 16;
+    };
+  };
+
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  nmt.script =
+    let
+      # For some reason, the preexisting settings is an empty file
+      preexistingSettings = builtins.toFile "preexisting.json" "";
+
+      expectedContent = builtins.toFile "expected.json" ''
+        {
+          "buffer_font_size": 16,
+          "features": {
+            "copilot": false
+          },
+          "theme": "XY-Zed",
+          "ui_font_size": 16,
+          "vim_mode": false
+        }
+      '';
+
+      settingsPath = ".config/zed/settings.json";
+      activationScript = pkgs.writeScript "activation" config.home.activation.zedSettingsActivation.data;
+    in
+    ''
+      export HOME=$TMPDIR/hm-user
+
+      # Simulate preexisting settings
+      mkdir -p $HOME/.config/zed
+      cat ${preexistingSettings} > $HOME/${settingsPath}
+
+      # Run the activation script
+      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+      chmod +x $TMPDIR/activate
+      $TMPDIR/activate
+
+      # Validate the merged settings
+      assertFileExists "$HOME/${settingsPath}"
+      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
+
+      # Test idempotency
+      $TMPDIR/activate
+      assertFileExists "$HOME/${settingsPath}"
+      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
+    '';
+}


### PR DESCRIPTION
Since the settings and keymap merging is done out of Nix, we cannot
guarantee preexisting files are properly-formated as JSON or JSON5.
Thus, here I'm adding a new fallback system in case json5 fails to parse
them.

I took this chance to also make sure dict keys are sorted in the end
result. This makes the output more reproducible, which will help
avoiding flaky tests. It is more important now that there's the extra
JSON5 step.

Fixes https://github.com/nix-community/home-manager/issues/7327
