### PR TITLE
fix(service/gpg-agent): allow SSH ForwardAgent compatibility

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -372,7 +372,7 @@ in
 
         home.sessionVariablesExtra = optionalString cfg.enableSshSupport ''
           unset SSH_AGENT_PID
-          if [ "''${gnupg_SSH_AUTH_SOCK_by:-0}" -ne $$ ]; then
+          if [ -z "$SSH_CONNECTION" -o -z "$SSH_AUTH_SOCK" ] && [ "''${gnupg_SSH_AUTH_SOCK_by:-0}" -ne $$ ]; then
             export SSH_AUTH_SOCK="$(${gpgPkg}/bin/gpgconf --list-dirs agent-ssh-socket)"
           fi
         '';


### PR DESCRIPTION
https://github.com/nix-community/home-manager/pull/7117#issuecomment-3018582819
noted that #7117 broke compatibility with forwarding ssh-agents using
`ssh -A`/`ForwardAgent`. In order to continue supporting the fix for
the issue raised in #5997 and address the compatibility problem
mentioned by @euank, this commit introduces the solution described in
https://github.com/nix-community/home-manager/pull/7117#issuecomment-3025001779.

The code now checks the following:
1. is this shell part of an SSH connection and is `SSH_AUTH_SOCK` set?
   if so, assume the socket variable was set by sshd to point at a
   forwarded socket; bail out to skip setting `SSH_AUTH_SOCK".
1. is the current process a child of `gpg-agent --daemon`? if so, then
   bail out to skip setting `SSH_AUTH_SOCK`.
1. if we got this far, then set `SSH_AUTH_SOCK`.

I've tested this fix locally and can confirm that both #5997 as well as
the regression are fixed.

@euank, would you mind testing this patch out on your desktop and
confirming your old workflow once again works as expected?

Signed-off-by: squat <lserven@gmail.com>
