### PR TITLE
launchd+targets/darwin: Escape XML in plists

### DIFF
--- a/modules/launchd/default.nix
+++ b/modules/launchd/default.nix
@@ -43,7 +43,7 @@ let
       };
     };
 
-  toAgent = config: pkgs.writeText "${config.Label}.plist" (toPlist { } config);
+  toAgent = config: pkgs.writeText "${config.Label}.plist" (toPlist { escape = true; } config);
 
   agentPlists = lib.mapAttrs' (n: v: lib.nameValuePair "${v.config.Label}.plist" (toAgent v.config)) (
     lib.filterAttrs (n: v: v.enable) cfg.agents

--- a/modules/launchd/launchd.nix
+++ b/modules/launchd/launchd.nix
@@ -155,6 +155,18 @@ in
         This key maps to the second argument of `execvp(3)`.  This key is required in the absence of the Program
         key. Please note: many people are confused by this key. Please read `execvp(3)` very carefully!
       '';
+      # TODO: Remove this some time after 25.01.
+      apply =
+        value:
+        if value != null then
+          map (
+            item:
+            lib.warnIf (lib.hasInfix "&amp;" item)
+              "A value for `ProgramArguments` contains the literal string `&amp;`. This is no longer necessary and will lead to double-escaping, as home-manager now automatically escapes special characters."
+              item
+          ) value
+        else
+          value;
     };
 
     EnableGlobbing = mkOption {

--- a/modules/misc/news/2025/07/2025-07-01_22-15-34.nix
+++ b/modules/misc/news/2025/07/2025-07-01_22-15-34.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+{
+  time = "2025-07-01T20:15:34+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    XML characters are escaped for 'targets.darwin.keybindings' and 'launchd.agents.<name>'.
+
+    Special characters used in strings passed to  'targets.darwin.keybindings'
+    and 'launchd.agents.<name>' are now escaped before being included in the
+    generated plist files. If you were doing manual escaping you will need to
+    stop to avoid double escaping.
+  '';
+}

--- a/modules/targets/darwin/keybindings.nix
+++ b/modules/targets/darwin/keybindings.nix
@@ -8,7 +8,9 @@
 let
   cfg = config.targets.darwin;
   homeDir = config.home.homeDirectory;
-  confFile = pkgs.writeText "DefaultKeybinding.dict" (lib.generators.toPlist { } cfg.keybindings);
+  confFile = pkgs.writeText "DefaultKeybinding.dict" (
+    lib.generators.toPlist { escape = true; } cfg.keybindings
+  );
 in
 {
   options.targets.darwin.keybindings = lib.mkOption {

--- a/modules/targets/darwin/user-defaults/default.nix
+++ b/modules/targets/darwin/user-defaults/default.nix
@@ -11,7 +11,8 @@ let
   mkActivationCmds =
     isLocal: settings:
     let
-      toDefaultsFile = domain: attrs: pkgs.writeText "${domain}.plist" (lib.generators.toPlist { } attrs);
+      toDefaultsFile =
+        domain: attrs: pkgs.writeText "${domain}.plist" (lib.generators.toPlist { escape = true; } attrs);
 
       cliFlags = lib.optionalString isLocal "-currentHost";
 

--- a/tests/modules/launchd/agents.nix
+++ b/tests/modules/launchd/agents.nix
@@ -14,6 +14,7 @@
         };
         ProcessType = "Background";
         UnrecognizedByHomeManager = "should make it to the resulting plist";
+        "\"Special\" characters" = "<should be escaped>";
       };
     };
 

--- a/tests/modules/launchd/expected-agent.plist
+++ b/tests/modules/launchd/expected-agent.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>&quot;Special&quot; characters</key>
+	<string>&lt;should be escaped&gt;</string>
 	<key>KeepAlive</key>
 	<dict>
 		<key>Crashed</key>

--- a/tests/modules/services/macos-remap-keys/basic-agent.plist
+++ b/tests/modules/services/macos-remap-keys/basic-agent.plist
@@ -14,7 +14,7 @@
 		<string>/usr/bin/hidutil</string>
 		<string>property</string>
 		<string>--set</string>
-		<string>{ "UserKeyMapping": [ { "HIDKeyboardModifierMappingSrc": 0x700000039, "HIDKeyboardModifierMappingDst": 0x70000002A } ] }</string>
+		<string>{ &quot;UserKeyMapping&quot;: [ { &quot;HIDKeyboardModifierMappingSrc&quot;: 0x700000039, &quot;HIDKeyboardModifierMappingDst&quot;: 0x70000002A } ] }</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>


### PR DESCRIPTION


### Description

https://github.com/NixOS/nixpkgs/pull/356502 introduced an argument escape to lib.generators.toPlist which makes it escape special characters in the XML. This PR makes nix-darwin use it everywhere.

This is a breaking change, as https://github.com/nixos/nixpkgs/pull/356502#issuecomment-2480637115.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@midchildan
@khaneliman


