### PR TITLE
ci: conditional test step runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,44 @@ on:
   schedule:
     - cron: "30 2 * * *"
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      docs: ${{ steps.changes.outputs.docs }}
+      format: ${{ steps.changes.outputs.format }}
+      hm: ${{ steps.changes.outputs.hm }}
+      tests: ${{ steps.changes.outputs.tests }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            tests:
+              - 'flake.lock'
+              - 'flake.nix'
+              - 'modules/**'
+              - 'nix-darwin/**'
+              - 'nixos/**'
+              - 'tests/**'
+            docs:
+              - '**.md'
+              - 'docs/**'
+              - 'flake.lock'
+              - 'flake.nix'
+              - 'modules/**'
+            format:
+              - '**/*.nix'
+            hm:
+              - 'flake.lock'
+              - 'flake.nix'
+              - 'home-manager/**'
   tests:
+    needs: changes
+    # This job MUST always run to satisfy branch protection rules.
+    # The `always()` function ensures it runs even if `changes` is skipped (on a schedule).
+    if: always()
     strategy:
       fail-fast: false
       matrix:
@@ -13,29 +50,69 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
+        if: github.event_name == 'schedule' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.tests == 'true' || needs.changes.outputs.hm == 'true' || needs.changes.outputs.format == 'true'
         with:
           # TODO: Adjust uninstall to not need channel
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
-      - run: nix build --show-trace .#docs-jsonModuleMaintainers
-      - run: nix fmt -- --ci
+      - name: Build docs
+        if: github.event_name == 'schedule' || needs.changes.outputs.docs == 'true'
+        run: nix build --show-trace .#docs-jsonModuleMaintainers
+      - name: Format Check
+        if: github.event_name == 'schedule' || needs.changes.outputs.format == 'true'
+        run: nix fmt -- --ci
       - name: Test init --switch with locked inputs
+        # FIXME: nix broken on darwin on unstable
+        if: matrix.os != 'macos-latest' && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
         run: |
           # Copy lock file to home directory for consistent testing
           mkdir -p ~/.config/home-manager
           cp flake.lock ~/.config/home-manager/
           nix run .#home-manager -- init --switch --override-input home-manager .
+      - name: Uninstall
         # FIXME: nix broken on darwin on unstable
-        if: matrix.os != 'macos-latest'
-      - run: yes | nix run . -- uninstall
-        # FIXME: nix broken on darwin on unstable
-        if: matrix.os != 'macos-latest'
+        if: matrix.os != 'macos-latest' && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
+        run: yes | nix run . -- uninstall
       - name: Run tests
+        if: github.event_name == 'schedule' || needs.changes.outputs.tests == 'true'
         run: nix build -j auto --show-trace --option allow-import-from-derivation false --reference-lock-file flake.lock "./tests#test-all-no-big"
         env:
           GC_INITIAL_HEAP_SIZE: 4294967296
       - name: Run tests (with IFD)
+        if: github.event_name == 'schedule' || needs.changes.outputs.tests == 'true'
         run: nix build -j auto --show-trace --reference-lock-file flake.lock "./tests#test-all-no-big"
         env:
           GC_INITIAL_HEAP_SIZE: 4294967296
+      - name: Generate Job Summary
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          echo "### Test Job Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "A summary of tasks triggered by file changes in this PR:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "${{ needs.changes.outputs.docs }}" == "true" ]]; then
+            echo "- ✅ **Docs Build:** Triggered" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ☑️ **Docs Build:** Skipped (no relevant files changed)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [[ "${{ needs.changes.outputs.format }}" == "true" ]]; then
+            echo "- ✅ **Format Check:** Triggered" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ☑️ **Format Check:** Skipped (no relevant files changed)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [[ "${{ needs.changes.outputs.hm }}" == "true" ]]; then
+            echo "- ✅ **Home Manager Tests:** Triggered" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ☑️ **Home Manager Tests:** Skipped (no relevant files changed)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [[ "${{ needs.changes.outputs.tests }}" == "true" ]]; then
+            echo "- ✅ **General Tests:** Triggered" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ☑️ **General Tests:** Skipped (no relevant files changed)" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
Not every PR requires the overhead of spinning up runners and running our entire test suite. Filter on paths affected and only run the relevant steps/jobs.

Would rather just split up into multiple jobs ala https://github.com/nix-community/home-manager/pull/6539 but I can't change the checks on repo so just doing conditional steps. 

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
