### PR TITLE
mpvpaper: fix eval if no settings are defined

### DIFF
--- a/modules/programs/mpvpaper.nix
+++ b/modules/programs/mpvpaper.nix
@@ -55,7 +55,11 @@ in
     ];
 
     home.packages = mkIf (cfg.package != null) [ cfg.package ];
-    xdg.configFile."mpvpaper/pauselist".text = mkIf (cfg.pauseList != "") cfg.pauseList;
-    xdg.configFile."mpvpaper/stoplist".text = mkIf (cfg.stopList != "") cfg.stopList;
+    xdg.configFile."mpvpaper/pauselist" = mkIf (cfg.pauseList != "") {
+      text = cfg.pauseList;
+    };
+    xdg.configFile."mpvpaper/stoplist" = mkIf (cfg.stopList != "") {
+      text = cfg.stopList;
+    };
   };
 }


### PR DESCRIPTION
### Description

Currently just enabling the module with `programs.mpvpaper.enable = true;` will cause an error:
```
error: The option `xdg.configFile."mpvpaper/pauselist".source' was accessed but has no value defined. Try setting the option.
```

The fix will not attempt to evaluate the config files if no settings for stopList and pauseList are set.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC
@aguirre-matteo 

