### PR TITLE
ci: fix update-maintainers indentation

### DIFF
--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -120,24 +120,24 @@ jobs:
 
             ---
             🤖 *This PR was automatically created by the [update-maintainers workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})*
-          run: |
-            # Create a new branch for the update
-            branch_name="maintainers/update-$(date +%Y%m%d%H%M%S)"
-            git checkout -b "$branch_name"
+        run: |
+          # Create a new branch for the update
+          branch_name="maintainers/update-$(date +%Y%m%d%H%M%S)"
+          git checkout -b "$branch_name"
 
-            # Commit the changes
-            git add all-maintainers.nix
-            git commit -m "$title" -m "$commit_body"
+          # Commit the changes
+          git add all-maintainers.nix
+          git commit -m "$title" -m "$commit_body"
 
-            # Push the branch
-            git push origin "$branch_name"
+          # Push the branch
+          git push origin "$branch_name"
 
-            # Create the pull request
-            gh pr create \
-              --title "$title" \
-              --body "$pr_body" \
-              --label "dependencies" \
-              --label "maintainers"
+          # Create the pull request
+          gh pr create \
+            --title "$title" \
+            --body "$pr_body" \
+            --label "dependencies" \
+            --label "maintainers"
       - name: Summary
         env:
           has_changes: ${{ steps.check-changes.outputs.has_changes }}


### PR DESCRIPTION
### Description

Fixes a regression from be8f7e100f285167793f7ff77ce8e5b60ab48e26 https://github.com/nix-community/home-manager/pull/7371#issuecomment-3028498429

Done some _limited_ testing on my fork, as I don't have an app set up. This should validate that there are no syntax issues at least: https://github.com/MattSturgeon/home-manager/actions/runs/16030766755/job/45230480595

<!--

Please provide a brief description of your change.

-->


### Checklist

- [ ] Change is backwards compatible

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested (kinda)

- [x] Commit messages are formatted correctly

#### Maintainer CC

@khaneliman
