### PR TITLE
ci: validate maintainers; update maintainer list on merge

### DIFF
--- a/.github/workflows/update-maintainers.yml
+++ b/.github/workflows/update-maintainers.yml
@@ -1,5 +1,8 @@
 name: Update maintainers list
 on:
+  push:
+    branches: ["master"]
+    paths: ["modules/lib/maintainers.nix"]
   schedule:
     # Update every Monday at 9 AM UTC
     - cron: "0 9 * * 1"
@@ -13,7 +16,7 @@ on:
 jobs:
   update-maintainers:
     runs-on: ubuntu-latest
-    if: github.event_name != 'schedule' || github.repository_owner == 'nix-community'
+    if: github.repository_owner == 'nix-community' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Create GitHub App token
         uses: actions/create-github-app-token@v2

--- a/.github/workflows/validate-maintainers.yml
+++ b/.github/workflows/validate-maintainers.yml
@@ -1,0 +1,91 @@
+name: Validate maintainers.nix
+on:
+  pull_request:
+    paths: ["modules/lib/maintainers.nix"]
+  workflow_dispatch:
+    inputs:
+      run_tests:
+        description: 'Run validation tests'
+        required: false
+        default: true
+        type: boolean
+jobs:
+  validate-maintainers:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'nix-community'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Get Nixpkgs revision from flake.lock
+        id: get-nixpkgs
+        run: |
+          echo "rev=$(jq -r '.nodes.nixpkgs.locked.rev' flake.lock)" >> "$GITHUB_OUTPUT"
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/${{ steps.get-nixpkgs.outputs.rev }}.tar.gz
+      - name: Validate Nix syntax
+        run: |
+          echo "🔍 Validating maintainers.nix syntax..."
+          if nix eval --file modules/lib/maintainers.nix --json > /dev/null; then
+            echo "✅ Valid Nix syntax"
+          else
+            echo "❌ Invalid Nix syntax"
+            exit 1
+          fi
+      - name: Validate maintainer entries
+        run: |
+          echo "🔍 Validating maintainer entries..."
+          python3 -c "
+          import json
+          import re
+          import subprocess
+          import sys
+
+          # Get the maintainers data from the Nix file
+          result = subprocess.run(['nix', 'eval', '--file', 'modules/lib/maintainers.nix', '--json'],
+                                 capture_output=True, text=True, check=True)
+          maintainers = json.loads(result.stdout)
+          errors = []
+
+          for name, data in maintainers.items():
+            # Check REQUIRED fields - github and githubId are mandatory
+            if 'github' not in data:
+              errors.append(f'{name}: Missing required field \"github\"')
+            if 'githubId' not in data:
+              errors.append(f'{name}: Missing required field \"githubId\"')
+
+            # Validate GitHub ID is a positive integer (NOT a string)
+            if 'githubId' in data:
+              github_id = data['githubId']
+              if not isinstance(github_id, int):
+                errors.append(f'{name}: githubId must be a number, not a string: {github_id} (type: {type(github_id).__name__})')
+              elif github_id <= 0:
+                errors.append(f'{name}: githubId must be positive: {github_id}')
+
+          if errors:
+            print('❌ Validation errors found:')
+            for error in errors:
+              print(f'  - {error}')
+            sys.exit(1)
+          else:
+            print('✅ All maintainer entries are valid')
+            print(f'✅ Validated {len(maintainers)} maintainer entries')
+          "
+      - name: Test generation
+        if: inputs.run_tests == true
+        run: |
+          echo "🔍 Testing all-maintainers.nix generation..."
+          ./lib/python/generate-all-maintainers.py
+
+          echo "🔍 Validating generated file..."
+          if nix eval --file ./all-maintainers.nix --json > /dev/null; then
+            echo "✅ Generated file has valid Nix syntax"
+          else
+            echo "❌ Generated file has invalid Nix syntax"
+            exit 1
+          fi
+      - name: Summary
+        run: |
+          echo "✅ All validation checks passed!"
+          echo "📋 The maintainers.nix file is ready for merge"


### PR DESCRIPTION
### Description
Tested in https://github.com/khaneliman/home-manager/pull/570

Wanted to make sure we are validating the entries people add against the known rules to prevent breaking our invite system. We can also update the master list after someone has merged a maintainer addition. 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
