### PR TITLE
podman: support mounts configuration

### DIFF
--- a/modules/services/podman-linux/default.nix
+++ b/modules/services/podman-linux/default.nix
@@ -84,6 +84,12 @@ in
           `skopeo` will be used.
         '';
       };
+
+      mounts = lib.mkOption {
+        default = [ ];
+        type = lib.types.listOf lib.types.str;
+        description = "mounts.conf configuration";
+      };
     };
   };
 
@@ -107,6 +113,9 @@ in
       };
       "containers/storage.conf".source = toml.generate "storage.conf" cfg.settings.storage;
       "containers/containers.conf".source = toml.generate "containers.conf" cfg.settings.containers;
+      "containers/mounts.conf" = lib.mkIf (cfg.settings.mounts != [ ]) {
+        text = builtins.concatStringsSep "\n" cfg.settings.mounts;
+      };
     };
   };
 }

--- a/tests/modules/services/podman-linux/configuration-mounts-expected.conf
+++ b/tests/modules/services/podman-linux/configuration-mounts-expected.conf
@@ -1,0 +1,1 @@
+/usr/share/secrets:/run/secrets

--- a/tests/modules/services/podman-linux/configuration.nix
+++ b/tests/modules/services/podman-linux/configuration.nix
@@ -34,6 +34,7 @@
       policy = {
         default = [ { type = "insecureAcceptAnything"; } ];
       };
+      mounts = [ "/usr/share/secrets:/run/secrets" ];
     };
   };
 
@@ -43,20 +44,24 @@
     policyFile=$configPath/policy.json
     registriesFile=$configPath/registries.conf
     storageFile=$configPath/storage.conf
+    mountsFile=$configPath/mounts.conf
 
     assertFileExists $containersFile
     assertFileExists $policyFile
     assertFileExists $registriesFile
     assertFileExists $storageFile
+    assertFileExists $mountsFile
 
     containersFile=$(normalizeStorePaths $containersFile)
     policyFile=$(normalizeStorePaths $policyFile)
     registriesFile=$(normalizeStorePaths $registriesFile)
     storageFile=$(normalizeStorePaths $storageFile)
+    mountsFile=$(normalizeStorePaths $mountsFile)
 
     assertFileContent $containersFile ${./configuration-containers-expected.conf}
     assertFileContent $policyFile ${./configuration-policy-expected.json}
     assertFileContent $registriesFile ${./configuration-registries-expected.conf}
     assertFileContent $storageFile ${./configuration-storage-expected.conf}
+    assertFileContent $mountsFile ${./configuration-mounts-expected.conf}
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
