### PR TITLE
ci: tag-maintainers fix fetching maintainers

### DIFF
--- a/.github/workflows/tag-maintainers.yml
+++ b/.github/workflows/tag-maintainers.yml
@@ -42,16 +42,15 @@ jobs:
           echo "module_files<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      - name: Build module maintainers lookup
-        run: nix build --show-trace .#docs-jsonModuleMaintainers
+      - name: Setup maintainer evaluation
+        run: |
+          echo "Setting up dynamic maintainer evaluation..."
       - name: Find and Request Reviewers
         id: find-maintainers
         if: steps.changed-files.outputs.module_files != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
-          MODULE_MAINTAINERS=$(cat ./result)
-
           declare -A MAINTAINERS_TO_NOTIFY
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
 
@@ -61,14 +60,28 @@ jobs:
             fi
 
             echo "Processing file: $FILE"
-            MATCHING_KEY=$(jq -r 'keys[] | select(endswith($path))' --arg path "$FILE" <<< "$MODULE_MAINTAINERS")
-            MAINTAINERS=""
-            if [[ -n "$MATCHING_KEY" ]]; then
-              echo "Found matching key in maintainer list: $MATCHING_KEY"
-              MAINTAINERS=$(jq -r "(.[\"$MATCHING_KEY\"][] | .github) // empty" <<< "$MODULE_MAINTAINERS")
-            else
-              echo "Could not find a matching key for $FILE in the maintainer list."
+
+            # Dynamically evaluate meta.maintainers for this specific file
+            MAINTAINERS_JSON=$(nix eval --impure --expr "
+              let
+                nixpkgs = import <nixpkgs> {};
+                lib = import ./modules/lib/stdlib-extended.nix nixpkgs.lib;
+                pkgs = nixpkgs;
+                config = {};
+                module = import ./$FILE { inherit lib pkgs config; };
+              in
+                module.meta.maintainers or []
+            " --json 2>/dev/null || echo "[]")
+
+            if [[ "$MAINTAINERS_JSON" == "[]" ]]; then
+              echo "No maintainers found for $FILE"
+              continue
             fi
+
+            echo "Found maintainers JSON for $FILE: $MAINTAINERS_JSON"
+
+            # Extract GitHub usernames from the maintainers
+            MAINTAINERS=$(echo "$MAINTAINERS_JSON" | jq -r '.[] | .github // empty' 2>/dev/null || echo "")
 
             for MAINTAINER in $MAINTAINERS; do
               if [[ "$MAINTAINER" != "$PR_AUTHOR" ]]; then


### PR DESCRIPTION
Was relying on flawed logic and fragile parsing to identify maintainers on changed files. Rework to use nix eval to grab the `meta.maintainers` to use when requesting a review.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
