### PR TITLE
ci: maintainer pings refactor

### DIFF
--- a/.github/workflows/tag-maintainers.yml
+++ b/.github/workflows/tag-maintainers.yml
@@ -2,6 +2,9 @@ name: Tag Module Maintainers
 on:
   pull_request_target:
     types: [opened, ready_for_review, reopened, synchronize]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  cancel-in-progress: true
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/tag-maintainers.yml
+++ b/.github/workflows/tag-maintainers.yml
@@ -45,15 +45,37 @@ jobs:
           echo "module_files<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      - name: Setup maintainer evaluation
-        run: |
-          echo "Setting up dynamic maintainer evaluation..."
-      - name: Find and Request Reviewers
-        id: find-maintainers
-        if: steps.changed-files.outputs.module_files != ''
+      - name: Manage Reviewers
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
+          remove_reviewers() {
+            local reviewers_to_remove="$1"
+            local reason="$2"
+
+            if [[ -n "$reviewers_to_remove" ]]; then
+              for REVIEWER in $reviewers_to_remove; do
+                echo "Removing review request from $REVIEWER ($reason)"
+                gh api --method DELETE "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers" \
+                  --input - <<< "{\"reviewers\": [\"$REVIEWER\"]}"
+              done
+            fi
+          }
+
+          # Check if no module files changed - remove all reviewers
+          if [[ '${{ steps.changed-files.outputs.module_files }}' == '' ]]; then
+            echo "No module files changed, checking for outdated reviewers to remove..."
+            PENDING_REVIEWERS=$(gh pr view ${{ github.event.pull_request.number }} --json reviewRequests --jq '.reviewRequests[].login')
+            if [[ -n "$PENDING_REVIEWERS" ]]; then
+              echo "Found pending reviewers to remove: $PENDING_REVIEWERS"
+              remove_reviewers "$PENDING_REVIEWERS" "no module files changed"
+            else
+              echo "No pending reviewers to remove."
+            fi
+            exit 0
+          fi
+
+          # Process module files to find current maintainers
           declare -A MAINTAINERS_TO_NOTIFY
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
 
@@ -64,7 +86,6 @@ jobs:
 
             echo "Processing file: $FILE"
 
-            # Dynamically evaluate meta.maintainers for this specific file
             MAINTAINERS_JSON=$(nix eval --impure --expr "
               let
                 nixpkgs = import <nixpkgs> {};
@@ -100,6 +121,11 @@ jobs:
             USERS_TO_EXCLUDE=$(printf "%s\n%s" "$PENDING_REVIEWERS" "$PAST_REVIEWERS" | sort -u)
             echo "Complete list of users to exclude:"
             echo "$USERS_TO_EXCLUDE"
+
+            # Remove outdated review requests
+            CURRENT_MAINTAINERS=$(printf "%s\n" "${!MAINTAINERS_TO_NOTIFY[@]}" | sort -u)
+            OUTDATED_REVIEWERS=$(comm -23 <(echo "$PENDING_REVIEWERS" | sort) <(echo "$CURRENT_MAINTAINERS" | sort))
+            remove_reviewers "$OUTDATED_REVIEWERS" "no longer a maintainer of changed files"
 
             # Check if maintainers are collaborators and not already reviewers
             REPO="${{ github.repository }}"

--- a/.github/workflows/tag-maintainers.yml
+++ b/.github/workflows/tag-maintainers.yml
@@ -1,14 +1,17 @@
 name: Tag Module Maintainers
 on:
   pull_request_target:
-    types: [ready_for_review]
+    types: [opened, ready_for_review, reopened, synchronize]
 permissions:
   contents: read
   pull-requests: write
 jobs:
   tag-maintainers:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'nix-community'
+    if: |
+      github.repository_owner == 'nix-community' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.state == 'open'
     steps:
       - name: Create GitHub App token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
### Description
Tested https://github.com/khaneliman/home-manager/pull/575

Make sure we properly request reviews on PR opening, reopening, changes made to files, etc. Also remove reviewers that are no longer relevant. Fixes issue where a PR that opens doesn't tag reviewers and requires toggling between draft and reopening again. 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
