### PR TITLE
ci: split tests into chunks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,37 +39,12 @@ jobs:
               - 'flake.lock'
               - 'flake.nix'
               - 'home-manager/**'
-  get-test-chunks:
-    runs-on: ubuntu-latest
-    outputs:
-      test-matrix: ${{ steps.chunks.outputs.test-matrix }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-      - name: Get test chunks
-        id: chunks
-        run: |
-          linux_chunks=$(nix eval --json ./tests#packages.x86_64-linux --apply 'pkgs: builtins.attrNames (builtins.removeAttrs pkgs ["metadata"])' | jq -r '[.[] | select(startswith("test-chunk-")) | sub("test-chunk-"; "") | tonumber] | sort')
-          echo "Found Linux chunks: $linux_chunks"
-
-          darwin_chunks=$(nix eval --json ./tests#packages.aarch64-darwin --apply 'pkgs: builtins.attrNames (builtins.removeAttrs pkgs ["metadata"])' | jq -r '[.[] | select(startswith("test-chunk-")) | sub("test-chunk-"; "") | tonumber] | sort')
-          echo "Found Darwin chunks: $darwin_chunks"
-
-          matrix=$(jq -n -c \
-            --argjson linux_chunks "$linux_chunks" \
-            --argjson darwin_chunks "$darwin_chunks" \
-            '{include: [($linux_chunks[] | {os: "ubuntu-latest", test_chunk: .}), ($darwin_chunks[] | {os: "macos-latest", test_chunk: .})]}')
-
-          echo "test-matrix=$matrix" >> $GITHUB_OUTPUT
-          echo "Generated matrix: $matrix"
   tests:
-    needs: [changes, get-test-chunks]
+    needs: changes
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.get-test-chunks.outputs.test-matrix) }}
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -86,14 +61,14 @@ jobs:
             max-jobs = auto
             cores = 0
       - name: Build docs
-        if: matrix.os == 'ubuntu-latest' && matrix.test_chunk == 1 && (github.event_name == 'schedule' || needs.changes.outputs.docs == 'true')
+        if: github.event_name == 'schedule' || needs.changes.outputs.docs == 'true'
         run: nix build --show-trace .#docs-jsonModuleMaintainers
       - name: Format Check
-        if: matrix.os == 'ubuntu-latest' && matrix.test_chunk == 1 && (github.event_name == 'schedule' || needs.changes.outputs.format == 'true')
+        if: github.event_name == 'schedule' || needs.changes.outputs.format == 'true'
         run: nix fmt -- --ci
       - name: Test init --switch with locked inputs
         # FIXME: nix broken on darwin on unstable
-        if: matrix.os == 'ubuntu-latest' && matrix.test_chunk == 1 && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
+        if: matrix.os != 'macos-latest' && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
         run: |
           # Copy lock file to home directory for consistent testing
           mkdir -p ~/.config/home-manager
@@ -101,20 +76,8 @@ jobs:
           nix run .#home-manager -- init --switch --override-input home-manager .
       - name: Uninstall
         # FIXME: nix broken on darwin on unstable
-        if: matrix.os == 'ubuntu-latest' && matrix.test_chunk == 1 && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
+        if: matrix.os != 'macos-latest' && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
         run: yes | nix run . -- uninstall
-      - name: Run tests (chunk ${{ matrix.test_chunk }})
-        if: github.event_name == 'schedule' || needs.changes.outputs.tests == 'true'
-        run: |
-          nix build -j auto --show-trace --option allow-import-from-derivation false --reference-lock-file flake.lock "./tests#test-chunk-${{ matrix.test_chunk }}"
-        env:
-          GC_INITIAL_HEAP_SIZE: 4294967296
-      - name: Run tests with IFD (chunk ${{ matrix.test_chunk }})
-        if: github.event_name == 'schedule' || needs.changes.outputs.tests == 'true'
-        run: |
-          nix build -j auto --show-trace --reference-lock-file flake.lock "./tests#test-chunk-${{ matrix.test_chunk }}"
-        env:
-          GC_INITIAL_HEAP_SIZE: 4294967296
       - name: Generate Job Summary
         if: github.event_name == 'pull_request'
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,6 @@ jobs:
         if: github.event_name == 'schedule' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.tests == 'true' || needs.changes.outputs.hm == 'true' || needs.changes.outputs.format == 'true'
         with:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/${{ steps.get-nixpkgs.outputs.rev }}.tar.gz
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            max-jobs = auto
-            cores = 0
       - name: Build docs
         if: github.event_name == 'schedule' || needs.changes.outputs.docs == 'true'
         run: nix build --show-trace .#docs-jsonModuleMaintainers
@@ -67,16 +63,14 @@ jobs:
         if: github.event_name == 'schedule' || needs.changes.outputs.format == 'true'
         run: nix fmt -- --ci
       - name: Test init --switch with locked inputs
-        # FIXME: nix broken on darwin on unstable
-        if: matrix.os != 'macos-latest' && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
+        if: github.event_name == 'schedule' || needs.changes.outputs.hm == 'true'
         run: |
           # Copy lock file to home directory for consistent testing
           mkdir -p ~/.config/home-manager
           cp flake.lock ~/.config/home-manager/
           nix run .#home-manager -- init --switch --override-input home-manager .
       - name: Uninstall
-        # FIXME: nix broken on darwin on unstable
-        if: matrix.os != 'macos-latest' && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
+        if: github.event_name == 'schedule' || needs.changes.outputs.hm == 'true'
         run: yes | nix run . -- uninstall
       - name: Generate Job Summary
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,37 @@ jobs:
               - 'flake.lock'
               - 'flake.nix'
               - 'home-manager/**'
+  get-test-chunks:
+    runs-on: ubuntu-latest
+    outputs:
+      test-matrix: ${{ steps.chunks.outputs.test-matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Get test chunks
+        id: chunks
+        run: |
+          linux_chunks=$(nix eval --json ./tests#packages.x86_64-linux --apply 'pkgs: builtins.attrNames (builtins.removeAttrs pkgs ["metadata"])' | jq -r '[.[] | select(startswith("test-chunk-")) | sub("test-chunk-"; "") | tonumber] | sort')
+          echo "Found Linux chunks: $linux_chunks"
+
+          darwin_chunks=$(nix eval --json ./tests#packages.aarch64-darwin --apply 'pkgs: builtins.attrNames (builtins.removeAttrs pkgs ["metadata"])' | jq -r '[.[] | select(startswith("test-chunk-")) | sub("test-chunk-"; "") | tonumber] | sort')
+          echo "Found Darwin chunks: $darwin_chunks"
+
+          matrix=$(jq -n -c \
+            --argjson linux_chunks "$linux_chunks" \
+            --argjson darwin_chunks "$darwin_chunks" \
+            '{include: [($linux_chunks[] | {os: "ubuntu-latest", test_chunk: .}), ($darwin_chunks[] | {os: "macos-latest", test_chunk: .})]}')
+
+          echo "test-matrix=$matrix" >> $GITHUB_OUTPUT
+          echo "Generated matrix: $matrix"
   tests:
-    needs: changes
+    needs: [changes, get-test-chunks]
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+      matrix: ${{ fromJson(needs.get-test-chunks.outputs.test-matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -58,15 +83,17 @@ jobs:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/${{ steps.get-nixpkgs.outputs.rev }}.tar.gz
           extra_nix_config: |
             experimental-features = nix-command flakes
+            max-jobs = auto
+            cores = 0
       - name: Build docs
-        if: github.event_name == 'schedule' || needs.changes.outputs.docs == 'true'
+        if: matrix.os == 'ubuntu-latest' && matrix.test_chunk == 1 && (github.event_name == 'schedule' || needs.changes.outputs.docs == 'true')
         run: nix build --show-trace .#docs-jsonModuleMaintainers
       - name: Format Check
-        if: github.event_name == 'schedule' || needs.changes.outputs.format == 'true'
+        if: matrix.os == 'ubuntu-latest' && matrix.test_chunk == 1 && (github.event_name == 'schedule' || needs.changes.outputs.format == 'true')
         run: nix fmt -- --ci
       - name: Test init --switch with locked inputs
         # FIXME: nix broken on darwin on unstable
-        if: matrix.os != 'macos-latest' && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
+        if: matrix.os == 'ubuntu-latest' && matrix.test_chunk == 1 && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
         run: |
           # Copy lock file to home directory for consistent testing
           mkdir -p ~/.config/home-manager
@@ -74,16 +101,18 @@ jobs:
           nix run .#home-manager -- init --switch --override-input home-manager .
       - name: Uninstall
         # FIXME: nix broken on darwin on unstable
-        if: matrix.os != 'macos-latest' && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
+        if: matrix.os == 'ubuntu-latest' && matrix.test_chunk == 1 && (github.event_name == 'schedule' || needs.changes.outputs.hm == 'true')
         run: yes | nix run . -- uninstall
-      - name: Run tests
+      - name: Run tests (chunk ${{ matrix.test_chunk }})
         if: github.event_name == 'schedule' || needs.changes.outputs.tests == 'true'
-        run: nix build -j auto --show-trace --option allow-import-from-derivation false --reference-lock-file flake.lock "./tests#test-all-no-big"
+        run: |
+          nix build -j auto --show-trace --option allow-import-from-derivation false --reference-lock-file flake.lock "./tests#test-chunk-${{ matrix.test_chunk }}"
         env:
           GC_INITIAL_HEAP_SIZE: 4294967296
-      - name: Run tests (with IFD)
+      - name: Run tests with IFD (chunk ${{ matrix.test_chunk }})
         if: github.event_name == 'schedule' || needs.changes.outputs.tests == 'true'
-        run: nix build -j auto --show-trace --reference-lock-file flake.lock "./tests#test-all-no-big"
+        run: |
+          nix build -j auto --show-trace --reference-lock-file flake.lock "./tests#test-chunk-${{ matrix.test_chunk }}"
         env:
           GC_INITIAL_HEAP_SIZE: 4294967296
       - name: Generate Job Summary

--- a/buildbot-nix.toml
+++ b/buildbot-nix.toml
@@ -1,0 +1,3 @@
+attribute = "buildbot"
+flake_dir = "./tests"
+lock_file = "./flake.lock"

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -34,7 +34,10 @@
 
           integrationTestPackages =
             let
-              tests = import ./integration { inherit pkgs; };
+              tests = import ./integration {
+                inherit pkgs;
+                inherit (pkgs) lib;
+              };
               renameTestPkg = n: lib.nameValuePair "integration-test-${n}";
             in
             lib.mapAttrs' renameTestPkg tests;

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -70,9 +70,47 @@
               };
             in
             lib.nameValuePair "test-all-no-big-ifd" tests.build.all;
+
+          # Create chunked test packages for better CI parallelization
+          testChunks =
+            let
+              tests = import ./. {
+                inherit pkgs;
+                # Disable big tests since this is only used for CI
+                enableBig = false;
+              };
+              allTests = lib.attrNames tests.build;
+              # Remove 'all' from the test list as it's a meta-package
+              filteredTests = lib.filter (name: name != "all") allTests;
+              # NOTE: Just a starting value, we can tweak this to find a good value.
+              targetTestsPerChunk = 250;
+              numChunks = lib.max 1 (
+                builtins.ceil ((builtins.length filteredTests) / (targetTestsPerChunk * 1.0))
+              );
+              chunkSize = builtins.ceil ((builtins.length filteredTests) / (numChunks * 1.0));
+
+              makeChunk =
+                chunkNum: testList:
+                let
+                  start = (chunkNum - 1) * chunkSize;
+                  end = lib.min (start + chunkSize) (builtins.length testList);
+                  chunkTests = lib.sublist start (end - start) testList;
+                  chunkAttrs = lib.genAttrs chunkTests (name: tests.build.${name});
+                in
+                pkgs.symlinkJoin {
+                  name = "test-chunk-${toString chunkNum}";
+                  paths = lib.attrValues chunkAttrs;
+                };
+            in
+            lib.listToAttrs (
+              lib.genList (
+                i: lib.nameValuePair "test-chunk-${toString (i + 1)}" (makeChunk (i + 1) filteredTests)
+              ) numChunks
+            );
         in
         testPackages
         // integrationTestPackages
+        // testChunks
         // (lib.listToAttrs [
           testAllNoBig
           testAllNoBigIfd

--- a/tests/integration/default.nix
+++ b/tests/integration/default.nix
@@ -1,4 +1,4 @@
-{ pkgs }:
+{ lib, pkgs }:
 
 let
   nixosLib = import "${pkgs.path}/nixos/lib" { };
@@ -13,7 +13,7 @@ let
       hostPkgs = pkgs; # the Nixpkgs package set used outside the VMs
     };
 
-  tests = {
+  tests = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
     home-with-symbols = runTest ./standalone/home-with-symbols.nix;
     kitty = runTest ./standalone/kitty.nix;
     mu = runTest ./standalone/mu;


### PR DESCRIPTION
Similar goal of https://github.com/nix-community/home-manager/pull/6539 but applying it to the actual tests themselves for parallelization. Again, blocked by being able to change our checks ( I can't do that )

We have lots of tests and would like to add more. However, adding more testing coverage comes at the cost of a slower CI when we run them sequentially. This adds test outputs that are chunked however we'd like to tune for batch sizes. Allowing us to create a parallelized CI workflow.

Been testing in my fork and seems to cut time in half https://github.com/khaneliman/home-manager/actions/runs/16084828656

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
