### PR TITLE
arduino: add module

### DIFF
--- a/modules/programs/arduino-cli.nix
+++ b/modules/programs/arduino-cli.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    ;
+
+  cfg = config.programs.arduino-cli;
+
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.arduino-cli = {
+    enable = mkEnableOption "arduino-cli";
+    package = mkPackageOption pkgs "arduino-cli" { nullable = true; };
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = { };
+      description = ''
+        Configuration settings for arduino-cli. All the available options
+        can be found here: <https://docs.arduino.cc/arduino-cli/configuration/>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    home.file.".arduino15/arduino-cli.yaml" = mkIf (cfg.settings != { }) {
+      source = yamlFormat.generate "arduino-cli-config" cfg.settings;
+    };
+  };
+}

--- a/modules/programs/arduino-cli.nix
+++ b/modules/programs/arduino-cli.nix
@@ -25,7 +25,14 @@ in
     settings = mkOption {
       type = yamlFormat.type;
       default = { };
-      example = { };
+      example = {
+        board_manager = {
+          enable_unsafe_install = true;
+          additional_urls = [
+            "https://downloads.arduino.cc/packages/package_staging_index.json"
+          ];
+        };
+      };
       description = ''
         Configuration settings for arduino-cli. All the available options
         can be found here: <https://docs.arduino.cc/arduino-cli/configuration/>.

--- a/modules/programs/arduino-ide.nix
+++ b/modules/programs/arduino-ide.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.arduino-ide;
+
+  yamlFormat = pkgs.formats.yaml { };
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.arduino-ide = {
+    enable = mkEnableOption "arduino-ide";
+    package = mkPackageOption pkgs "arduino-ide" { nullable = true; };
+    settings = mkOption {
+      type = jsonFormat.type;
+      default = { };
+      description = ''
+        Configuration settings for Arduino IDE.
+      '';
+    };
+
+    cliSettings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = {
+        board_manager = {
+          enable_unsafe_install = true;
+          additional_urls = [
+            "https://downloads.arduino.cc/packages/package_staging_index.json"
+          ];
+        };
+      };
+      description = ''
+        Configuration settings for the arduino-cli. All the available options
+        can be found here: <https://docs.arduino.cc/arduino-cli/configuration/>.
+      '';
+    };
+
+    keymaps = mkOption {
+      type = jsonFormat.type;
+      default = { };
+      description = ''
+        Keymaps declarations for Arduino IDE.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    home.file = {
+      ".arduinoIDE/arduino-cli.yaml" = mkIf (cfg.cliSettings != { }) {
+        source = yamlFormat.generate "arduino-ide-cli" cfg.cliSettings;
+      };
+      ".arduinoIDE/settings.json" = mkIf (cfg.settings != { }) {
+        source = jsonFormat.generate "arduino-ide-settings" cfg.settings;
+      };
+      ".arduinoIDE/keymaps.json" = mkIf (cfg.keymaps != { }) {
+        source = jsonFormat.generate "arduino-ide-keymaps" cfg.keymaps;
+      };
+    };
+  };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -11,6 +11,7 @@ let
     "alacritty"
     "alot"
     "antidote"
+    "arduino-ide"
     "aria2"
     "atuin"
     "autojump"

--- a/tests/modules/programs/arduino-cli/default.nix
+++ b/tests/modules/programs/arduino-cli/default.nix
@@ -1,0 +1,1 @@
+{ arduino-cli-example = ./example-config.nix; }

--- a/tests/modules/programs/arduino-cli/example-config.nix
+++ b/tests/modules/programs/arduino-cli/example-config.nix
@@ -1,0 +1,19 @@
+{
+  programs.arduino-cli = {
+    enable = true;
+    settings = {
+      board_manager = {
+        enable_unsafe_install = true;
+        additional_urls = [
+          "https://downloads.arduino.cc/packages/package_staging_index.json"
+        ];
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.arduino15/arduino-cli.yaml
+    assertFileContent home-files/.arduino15/arduino-cli.yaml \
+    ${./example-config.yaml}
+  '';
+}

--- a/tests/modules/programs/arduino-cli/example-config.yaml
+++ b/tests/modules/programs/arduino-cli/example-config.yaml
@@ -1,0 +1,4 @@
+board_manager:
+  additional_urls:
+  - https://downloads.arduino.cc/packages/package_staging_index.json
+  enable_unsafe_install: true

--- a/tests/modules/programs/arduino-ide/arduino-cli.yaml
+++ b/tests/modules/programs/arduino-ide/arduino-cli.yaml
@@ -1,0 +1,4 @@
+board_manager:
+  additional_urls:
+  - https://downloads.arduino.cc/packages/package_staging_index.json
+  enable_unsafe_install: true

--- a/tests/modules/programs/arduino-ide/default.nix
+++ b/tests/modules/programs/arduino-ide/default.nix
@@ -1,0 +1,1 @@
+{ arduino-ide-example = ./example-config.nix; }

--- a/tests/modules/programs/arduino-ide/example-config.nix
+++ b/tests/modules/programs/arduino-ide/example-config.nix
@@ -1,0 +1,19 @@
+{
+  programs.arduino-ide = {
+    enable = true;
+    cliSettings = {
+      board_manager = {
+        enable_unsafe_install = true;
+        additional_urls = [
+          "https://downloads.arduino.cc/packages/package_staging_index.json"
+        ];
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.arduinoIDE/arduino-cli.yaml
+    assertFileContent home-files/.arduinoIDE/arduino-cli.yaml \
+    ${./arduino-cli.yaml}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This pull request adds modules for configuring `arduino-cli` and `arduino-ide`. Closes #7387.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
