### PR TITLE
i3-sway/lib: modifier accepts any string

### DIFF
--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -639,7 +639,7 @@ in
   };
 
   modifier = mkOption {
-    type = types.enum [
+    type = types.either (types.enum [
       "Shift"
       "Control"
       "Mod1"
@@ -647,7 +647,7 @@ in
       "Mod3"
       "Mod4"
       "Mod5"
-    ];
+    ]) types.str;
     default = "Mod1";
     description = "Modifier key that is used for all default keybindings.";
     example = "Mod4";


### PR DESCRIPTION
Currently, we aggressively limit what modifier can be used in the module system that blocks valid configurations. Allow any strings to unblock these configs. But, could be refactored further to support list of modifiers and automatically convert to a config string.

### Description
Closes https://github.com/nix-community/home-manager/issues/4838
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
