### PR TITLE
mkFirefoxModule: set NoDefaultBookmarks when bookmarks are enabled; librewolf: allow bookmark configuration

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -964,6 +964,9 @@ in
       release = mkOptionDefault (builtins.head (lib.splitString "-" cfg.package.version));
 
       policies = {
+        NoDefaultBookmarks = lib.mkIf (builtins.any (profile: profile.bookmarks.enable) (
+          builtins.attrValues cfg.profiles
+        )) false;
         ExtensionSettings = lib.mkIf (cfg.languagePacks != [ ]) (
           lib.listToAttrs (
             map (

--- a/modules/programs/librewolf.nix
+++ b/modules/programs/librewolf.nix
@@ -42,8 +42,6 @@ in
       platforms.darwin = {
         configPath = "Library/Application Support/LibreWolf";
       };
-
-      enableBookmarks = false;
     })
   ];
 


### PR DESCRIPTION
### Description
Closes https://github.com/nix-community/home-manager/issues/5821
Closes https://github.com/nix-community/home-manager/issues/6852

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
