### PR TITLE
firefox: add extension permissions

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -729,7 +729,11 @@ in
                                     default = null;
                                     example = [ "activeTab" ];
                                     defaultText = "Any permissions";
-                                    description = "Allowed permissions for this extension.";
+                                    description = ''
+                                      Allowed permissions for this extension. See
+                                      https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions
+                                      for a list of relevant permissions.
+                                    '';
                                   };
                                   force = mkOption {
                                     type = types.bool;

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -731,7 +731,7 @@ in
                                     defaultText = "Any permissions";
                                     description = ''
                                       Allowed permissions for this extension. See
-                                      https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions
+                                      <https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions>
                                       for a list of relevant permissions.
                                     '';
                                   };

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -356,6 +356,12 @@ in
       type = types.attrsOf (
         types.submodule (
           { config, name, ... }:
+          let
+            profilePath = modulePath ++ [
+              "profiles"
+              name
+            ];
+          in
           {
             imports = [ (pkgs.path + "/nixos/modules/misc/assertions.nix") ];
 
@@ -783,28 +789,9 @@ in
                       builtins.all (ext: ext.settings == { }) (attrValues config.extensions.settings)
                       || config.extensions.force;
                     message = ''
-                      Using '${
-                        lib.showAttrPath (
-                          modulePath
-                          ++ [
-                            "profiles"
-                            config.name
-                            "extensions"
-                            "settings"
-                          ]
-                        )
-                      }' will override all previous extensions settings.
-                      Enable '${
-                        lib.showAttrPath (
-                          modulePath
-                          ++ [
-                            "profiles"
-                            config.name
-                            "extensions"
-                            "force"
-                          ]
-                        )
-                      }' to acknowledge this.
+                      Using '${lib.showOption profilePath}.extensions.settings' will override all
+                      previous extensions settings. Enable
+                      '${lib.showOption profilePath}.extensions.force' to acknowledge this.
                     '';
                   }
                 ]
@@ -820,8 +807,7 @@ in
                       assertion = value.permissions == null || length packages == 1;
                       message = ''
                         Must have exactly one extension with addonId '${name}'
-                        in '${moduleName}.extensions.packages' but found
-                        ${toString (length packages)}.
+                        in '${lib.showOption profilePath}.extensions.packages' but found ${toString (length packages)}.
                       '';
                     }
 
@@ -833,14 +819,13 @@ in
                         Consider adding the missing permissions to
                         '${
                           lib.showAttrPath (
-                            modulePath
+                            profilePath
                             ++ [
                               "extensions"
                               name
-                              "permissions"
                             ]
                           )
-                        }'.
+                        }.permissions'.
                       '';
                     }
                   ]

--- a/tests/modules/programs/firefox/common.nix
+++ b/tests/modules/programs/firefox/common.nix
@@ -19,6 +19,7 @@ builtins.mapAttrs
     "${name}-profiles-containers-id-out-of-range" = ./profiles/containers/id-out-of-range.nix;
     "${name}-profiles-duplicate-ids" = ./profiles/duplicate-ids.nix;
     "${name}-profiles-extensions" = ./profiles/extensions;
+    "${name}-profiles-extensions-assertions" = ./profiles/extensions/assertions.nix;
     "${name}-profiles-overwrite" = ./profiles/overwrite;
     "${name}-profiles-search" = ./profiles/search;
     "${name}-profiles-settings" = ./profiles/settings;

--- a/tests/modules/programs/firefox/profiles/extensions/assertions.nix
+++ b/tests/modules/programs/firefox/profiles/extensions/assertions.nix
@@ -1,0 +1,74 @@
+modulePath:
+{ config, lib, ... }:
+
+let
+
+  firefoxMockOverlay = import ../../setup-firefox-mock-overlay.nix modulePath;
+
+  uBlockStubPkg = config.lib.test.mkStubPackage {
+    name = "ublock-origin-dummy";
+    extraAttrs = {
+      addonId = "uBlock0@raymondhill.net";
+      meta.mozPermissions = [
+        "privacy"
+        "storage"
+        "tabs"
+        "<all_urls>"
+        "http://*/*"
+        "https://github.com/*"
+      ];
+    };
+  };
+in
+{
+  imports = [ firefoxMockOverlay ];
+
+  config = lib.mkIf config.test.enableBig (
+    lib.setAttrByPath modulePath {
+      enable = true;
+      profiles.extensions = {
+        extensions = {
+          packages = [ uBlockStubPkg ];
+          settings = {
+            "uBlock0@raymondhill.net" = {
+              settings = {
+                selectedFilterLists = [
+                  "ublock-filters"
+                  "ublock-badware"
+                  "ublock-privacy"
+                  "ublock-unbreak"
+                  "ublock-quick-fixes"
+                ];
+              };
+              permissions = [
+                "alarms"
+                "tabs"
+                "https://github.com/*"
+              ];
+            };
+            "unknown@example.com".permissions = [ ];
+          };
+        };
+      };
+    }
+    // {
+      test.asserts.assertions.expected = [
+        ''
+          Using '${lib.showOption modulePath}.profiles.extensions.extensions.settings' will override all
+          previous extensions settings. Enable
+          '${lib.showOption modulePath}.profiles.extensions.extensions.force' to acknowledge this.
+        ''
+        ''
+          Extension uBlock0@raymondhill.net requests permissions that weren't
+          authorized: ["privacy","storage","<all_urls>","http://*/*"].
+          Consider adding the missing permissions to
+          '${lib.showOption modulePath}.profiles.extensions.extensions."uBlock0@raymondhill.net".permissions'.
+        ''
+        ''
+          Must have exactly one extension with addonId 'unknown@example.com'
+          in '${lib.showOption modulePath}.profiles.extensions.extensions.packages' but found 0.
+        ''
+      ];
+    }
+  );
+}


### PR DESCRIPTION
Adds extension permissions as suggested in #7001. Adds the 'profiles.<name>.extensions.settings.<name>.permissions' to Firefox derivatives. If set, this option adds an assertion that fails if an extension package requests permissions that weren't added to the permissions option. In order to not require 'profiles.<name>.extensions.force' to be set when only permissions, but no extension settings were defined, the relevant assertions were changed. They now check whether any 'extensions.settings.<name>.settings' was set instead of checking whether 'extensions.settings' was set. Closes #7001.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@bricked @rycee @HPsaucii