### PR TITLE
home-environment: add `home.checks`

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -389,6 +389,22 @@ in
       description = ''
         A list of paths that should be included in the home
         closure but generally not visible.
+
+        For built-time checks the `home.checks` option is more appropriate
+        for that purpose as checks should not leave a trace in the built
+        home configuration.
+      '';
+    };
+
+    home.checks = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      description = ''
+        Packages that are added as dependencies of the home's build, usually
+        for the purpose of validating some part of the configuration.
+
+        Unlike `home.extraDependencies`, these store paths do not
+        become part of the built home configuration.
       '';
     };
 
@@ -791,6 +807,15 @@ in
           preferLocalBuild = true;
           passAsFile = [ "extraDependencies" ];
           inherit (config.home) extraDependencies;
+
+          # Not actually used in the builder. `passedChecks` is just here to create
+          # the build dependencies. Checks are similar to build dependencies in the
+          # sense that if they fail, the home build fails. However, checks do not
+          # produce any output of value, so they are not used by the system builder.
+          # In fact, using them runs the risk of accidentally adding unneeded paths
+          # to the system closure, which defeats the purpose of the `home.checks`
+          # option, as opposed to `home.extraDependencies`.
+          passedChecks = lib.concatStringsSep " " config.home.checks;
         }
         ''
           mkdir -p $out


### PR DESCRIPTION
### Note

I do not fully understand how dependency tracking (build time vs "runtime") works but this implementation copied the nixpkgs mechanism so should be fine *if* `home.activationPackage` is the analogue of `baseSystem` in nixos/modules/system/activation/top-level.nix. (https://github.com/NixOS/nixpkgs/blob/f859c5d293108245d6a364ce679f6f3cf15c1f4c/nixos/modules/system/activation/top-level.nix#L57-L77)

Note for nixpkgs implementation: `system.checks` becomes part of `system.systemBuilderArgs` which is passed as an argument to `baseSystem = pkgs.stdenvNoCC.mkDerivation ...`.

### Description

This should have the same effect `system.checks` has in nixpkgs: adds paths to the build closure without being becoming part of the generated configuration.

This is useful for built-time checks as these should not leave a trace in the built home configuration.

The implementation mirrors nixpkgs: add an unused argument to the home-manager-generation derivation.

Fixes #7390

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.


#### Maintainer CC

@rycee