### PR TITLE
hyprshell: add module

### DIFF
--- a/modules/services/hyprshell.nix
+++ b/modules/services/hyprshell.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    types
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.services.hyprshell;
+
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.services.hyprshell = {
+    enable = mkEnableOption "hyprshell";
+    package = mkPackageOption pkgs "hyprshell" { nullable = true; };
+
+    settings = mkOption {
+      type = jsonFormat.type;
+      default = { };
+      description = ''
+        Configuration settings for hyprshell. All the avaiblable
+        options can be found here: <https://github.com/H3rmt/hyprshell/blob/hyprshell-release/CONFIGURE.md#config-options>
+      '';
+    };
+
+    style = mkOption {
+      type = with types; either path lines;
+      default = "";
+      description = ''
+        CSS file for customizing hyprshell. All the available
+        options can be found here: <https://github.com/H3rmt/hyprshell/blob/hyprshell-release/CONFIGURE.md#css>
+      '';
+    };
+
+    systemd = {
+      enable = mkEnableOption "the hyprshell Systemd service" // {
+        default = true;
+      };
+
+      target = mkOption {
+        type = types.str;
+        default = config.wayland.systemd.target;
+        description = "The Systemd target that will start the hyprshell service";
+      };
+
+      args = mkOption {
+        type = types.str;
+        default = "";
+        example = "-vv";
+        description = "Arguments to pass to the hyprshell service";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = if (cfg.package == null) then (if cfg.systemd.enable then false else true) else true;
+        message = "Can't set programs.hyprshell.systemd.enable with the package set to null.";
+      }
+    ];
+
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."hyprshell/config.json" = mkIf (cfg.settings != { }) {
+      source = jsonFormat.generate "hyprshell-config" cfg.settings;
+    };
+
+    xdg.configFile."hyprshell/style.css" = mkIf (cfg.style != "") {
+      source = if lib.isString cfg.style then pkgs.writeText "hyprshell-style" cfg.style else cfg.style;
+    };
+
+    systemd.user.services.hyprshell = mkIf (cfg.systemd.enable && (cfg.package != null)) {
+      Unit = {
+        Description = "Starts Hyprshell daemon";
+        After = [ cfg.systemd.target ];
+      };
+      Service = {
+        Type = "simple";
+        ExecStart = "${lib.getExe cfg.package} run ${cfg.systemd.args}";
+        Restart = "on-failure";
+      };
+      Install.WantedBy = [ cfg.systemd.target ];
+    };
+  };
+}

--- a/modules/services/hyprshell.nix
+++ b/modules/services/hyprshell.nix
@@ -64,6 +64,7 @@ in
 
   config = mkIf cfg.enable {
     assertions = [
+      (lib.hm.assertions.assertPlatform "services.hyprshell" pkgs lib.platforms.linux)
       {
         assertion = if (cfg.package == null) then (if cfg.systemd.enable then false else true) else true;
         message = "Can't set programs.hyprshell.systemd.enable with the package set to null.";

--- a/tests/modules/services/hyprshell/config.json
+++ b/tests/modules/services/hyprshell/config.json
@@ -1,0 +1,9 @@
+{
+  "kill_bind": "ctrl+shift+alt, h",
+  "layerrules": true,
+  "version": 1,
+  "windows": {
+    "items_per_row": 5,
+    "scale": 8.5
+  }
+}

--- a/tests/modules/services/hyprshell/default.nix
+++ b/tests/modules/services/hyprshell/default.nix
@@ -1,0 +1,1 @@
+{ hyprshell-example = ./example-config.nix; }

--- a/tests/modules/services/hyprshell/default.nix
+++ b/tests/modules/services/hyprshell/default.nix
@@ -1,1 +1,5 @@
-{ hyprshell-example = ./example-config.nix; }
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  hyprshell-example = ./example-config.nix;
+}

--- a/tests/modules/services/hyprshell/example-config.nix
+++ b/tests/modules/services/hyprshell/example-config.nix
@@ -1,0 +1,26 @@
+{
+  services.hyprshell = {
+    enable = true;
+    settings = {
+      layerrules = true;
+      kill_bind = "ctrl+shift+alt, h";
+      version = 1;
+      windows = {
+        scale = 8.5;
+        items_per_row = 5;
+      };
+    };
+    style = ./style.css;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/hyprshell/config.json
+    assertFileExists home-files/.config/hyprshell/style.css
+
+    assertFileContent home-files/.config/hyprshell/config.json \
+    ${./config.json}
+
+    assertFileContent home-files/.config/hyprshell/style.css \
+    ${./style.css}
+  '';
+}

--- a/tests/modules/services/hyprshell/style.css
+++ b/tests/modules/services/hyprshell/style.css
@@ -1,0 +1,57 @@
+:root {
+    --border-color: rgba(90, 90, 120, 0.4);
+    --border-color-active: rgba(239, 9, 9, 0.9);
+
+    --bg-color: rgba(20, 20, 20, 0.9);
+    --bg-color-hover: rgba(40, 40, 50, 1);
+
+    --border-radius: 12px;
+    --border-size: 3px;
+    --border-style: solid;
+    --border-style-secondary: dashed;
+
+    --text-color: rgba(245, 245, 245, 1);
+
+    --window-padding: 2px;
+}
+
+.window {
+}
+
+
+.monitor {
+}
+
+.workspace {
+}
+
+.client {
+}
+
+.client-image {
+}
+
+
+.launcher {
+}
+
+.launcher-input {
+}
+
+.launcher-results {
+}
+
+.launcher-item {
+}
+
+.launcher-exec {
+}
+
+.launcher-key {
+}
+
+.launcher-plugins {
+}
+
+.launcher-plugin {
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This pull request adds a module for configuring Hyprshell. Closes #7290.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
