### PR TITLE
Improve error when failing to build Neomutt config

### DIFF
--- a/modules/programs/neomutt/default.nix
+++ b/modules/programs/neomutt/default.nix
@@ -23,18 +23,15 @@ let
 
   accountCommandNeeded = lib.any (
     a:
-    a.neomutt.enable
-    && (
-      a.neomutt.mailboxType == "imap"
-      || (lib.any (m: !isString m && m.type == "imap") a.neomutt.extraMailboxes)
-    )
-  ) (attrValues config.accounts.email.accounts);
+    a.neomutt.mailboxType == "imap"
+    || (lib.any (m: !isString m && m.type == "imap") a.neomutt.extraMailboxes)
+  ) neomuttAccounts;
 
   accountCommand =
     let
       imapAccounts = filter (
-        a: a.neomutt.enable && a.imap.host != null && a.userName != null && a.passwordCommand != null
-      ) (attrValues config.accounts.email.accounts);
+        a: a.imap.host != null && a.userName != null && a.passwordCommand != null
+      ) neomuttAccounts;
       accountCase =
         account:
         let


### PR DESCRIPTION
### Description

If there's an account under `accounts.email.accounts` with `neomutt.enable` set to true but neither `passwordCommand` nor `neomutt.sendMailCommand` set, then building the Neomutt rc file will fail.  Ensure that failure has a useful error message, rather than a confusing type error.

While we're here, make the module code slightly less repetitious by just building the set of email accounts that have Neomutt enabled once, rather than multiple times in multiple contexts.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes. (See #7412 for failures with the non-flake test, and #7413 for failures on aarch64-linux, but flake test passes on x86_64-linux.)

- ~[ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~ No changes required

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - ~[ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).~

#### Maintainer CC

No obvious maintainers.
