### PR TITLE
twitch-tui: add module

### DIFF
--- a/modules/programs/twitch-tui.nix
+++ b/modules/programs/twitch-tui.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.twitch-tui;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.twitch-tui = {
+    enable = mkEnableOption "twitch-tui";
+    package = mkPackageOption pkgs "twitch-tui" { nullable = true; };
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = {
+        twitch = {
+          username = "";
+          channel = "";
+          server = "wss://eventsub.wss.twitch.tv/ws";
+          token = "";
+        };
+
+        terminal = {
+          delay = 30;
+          maximum_messages = 500;
+          log_file = "";
+          log_level = "info";
+          first_state = "dashboard";
+        };
+      };
+      description = ''
+        Configuration settings for twitch-tui. All the available options
+        can be found here: <https://github.com/Xithrius/twitch-tui/blob/main/default-config.toml>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."twt/config.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "twitch-tui-config" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/twitch-tui/config.toml
+++ b/tests/modules/programs/twitch-tui/config.toml
@@ -1,0 +1,12 @@
+[terminal]
+delay = 30
+first_state = "dashboard"
+log_file = ""
+log_level = "info"
+maximum_messages = 500
+
+[twitch]
+channel = ""
+server = "wss://eventsub.wss.twitch.tv/ws"
+token = ""
+username = ""

--- a/tests/modules/programs/twitch-tui/default.nix
+++ b/tests/modules/programs/twitch-tui/default.nix
@@ -1,0 +1,1 @@
+{ twitch-tui-example = ./example-config.nix; }

--- a/tests/modules/programs/twitch-tui/example-config.nix
+++ b/tests/modules/programs/twitch-tui/example-config.nix
@@ -1,0 +1,27 @@
+{
+  programs.twitch-tui = {
+    enable = true;
+    settings = {
+      twitch = {
+        username = "";
+        channel = "";
+        server = "wss://eventsub.wss.twitch.tv/ws";
+        token = "";
+      };
+
+      terminal = {
+        delay = 30;
+        maximum_messages = 500;
+        log_file = "";
+        log_level = "info";
+        first_state = "dashboard";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/twt/config.toml
+    assertFileContent home-files/.config/twt/config.toml \
+    ${./config.toml}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This pull request adds a module for configuring [twitch-tui](https://github.com/Xithrius/twitch-tui).
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
