### PR TITLE
hyprland: add direct support for animation configuration

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -290,6 +290,43 @@ in
       '';
     };
 
+    animations = lib.mkOption {
+      type = with lib.types; attrsOf str;
+      default = { };
+      description = ''
+        Hyprland animations configuration. This option is an alternative to
+        {option}`programs.hyprland.settings.animation` which can help avoiding
+        repetition of animations, in case you want to pass an animation to
+        a bind to hyprctl for example.
+
+        ::: {.note}
+        This option has an `apply` function which prepends the attribute
+        values with their corresponding names. This is so that to write
+        a call to `hyprctl animation`, you only have to write
+        ```nix
+        "hyprctl animation ''${config.programs.hyprland.animations.''${animName}}"
+        ```
+        instead of having to repeat the animation name (which would look like this:)
+        ```nix
+        "hyprctl animation ''${animName}, ''${config.programs.hyprland.animations.''${animName}}"
+        ```
+        :::
+      '';
+      example = lib.literalExpression ''
+        {
+          ## This produces the example from the Hyprland documentation example:
+          # animation = workspaces, 1, 8, default
+          # animation = windows, 1, 10, myepiccurve, slide
+          # animation = fade, 0
+
+          workspaces = "1, 8, default";
+          windows = "1, 10, myepiccurve, slide";
+          fade = "0";
+        }
+      '';
+      apply = builtins.mapAttrs (n: v: "${n}, ${v}");
+    };
+
     extraConfig = lib.mkOption {
       type = lib.types.lines;
       default = "";
@@ -413,6 +450,7 @@ in
             }
           )
           + lib.optionalString (cfg.submaps != { }) (submapsToHyprConf cfg.submaps)
+          + lib.concatMapAttrsStringSep "" (n: v: "animation=${v}\n") cfg.animations
           + lib.optionalString (cfg.extraConfig != "") cfg.extraConfig;
 
         onChange = lib.mkIf (cfg.package != null) ''

--- a/tests/modules/services/hyprland/simple-config.conf
+++ b/tests/modules/services/hyprland/simple-config.conf
@@ -7,9 +7,6 @@ bezier=smoothIn, 0.25, 1, 0.5, 1
 bezier=overshot, 0.4,0.8,0.2,1.2
 source=sourced.conf
 animations {
-  animation=border, 1, 2, smoothIn
-  animation=fade, 1, 4, smoothOut
-  animation=windows, 1, 3, overshot, popin 80%
   enabled=true
 }
 
@@ -52,6 +49,9 @@ plugin {
     dummy=plugin setting
   }
 }
+animation=border, 1, 2, smoothIn
+animation=fade, 1, 4, smoothOut
+animation=windows, 1, 3, overshot, popin 80%
 # window resize
 bind = $mod, S, submap, resize
 

--- a/tests/modules/services/hyprland/simple-config.nix
+++ b/tests/modules/services/hyprland/simple-config.nix
@@ -7,6 +7,11 @@
       "/path/to/plugin1"
       (config.lib.test.mkStubPackage { name = "foo"; })
     ];
+    animations = {
+      border = "1, 2, smoothIn";
+      fade = "1, 4, smoothOut";
+      windows = "1, 3, overshot, popin 80%";
+    };
     settings = {
       source = [ "sourced.conf" ];
 
@@ -29,11 +34,6 @@
 
       animations = {
         enabled = true;
-        animation = [
-          "border, 1, 2, smoothIn"
-          "fade, 1, 4, smoothOut"
-          "windows, 1, 3, overshot, popin 80%"
-        ];
       };
 
       bezier = [


### PR DESCRIPTION
### Description

This PR adds a specific support for Hyprland animation configuration.

Note it is already possible to configure animations through `programs.services.window-managers.hyprland.settings`, but I recently found a use case which I described in my added option's example in which it would be useful to have a dedicated option.

I'm not sure we want this change or not: it has the advantage of covering my niche use case and provides a more readable, less repetitive configuration option; but has the disadvantage of proposing several ways of achieving the same thing, potentially making it harder to understand for the module users. Whether or not this is considered valuable for HM, I still need something for my use case, so I would just use it as a custom module in my config if it does not land here.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@fufexan
