### PR TITLE
lutris: make module x86_64-linux only

### DIFF
--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -137,6 +137,7 @@ in
   config = mkIf cfg.enable {
     assertions = [
       (lib.hm.assertions.assertPlatform "programs.lutris" pkgs lib.platforms.linux)
+      (lib.hm.assertions.assertPlatform "programs.lutris" pkgs lib.platforms.x86_64)
     ];
     warnings =
       let

--- a/tests/modules/programs/lutris/default.nix
+++ b/tests/modules/programs/lutris/default.nix
@@ -1,5 +1,5 @@
 { lib, pkgs, ... }:
-lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+lib.optionalAttrs (pkgs.stdenv.hostPlatform.isx86_64 && pkgs.stdenv.hostPlatform.isLinux) {
   lutris-runners = ./runners-configuration.nix;
   # lutris-wine = ./wine-configuration.nix;
   lutris-empty = ./empty.nix;


### PR DESCRIPTION
### Description

Marked the lutris module as x86_64-linux only for now since the upstream package uses many x86_64 only applications.
I'm unsure if this is the right way to do this, I couldn't find any references.

Should fix #7413.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
