### PR TITLE
trippy: add module

### DIFF
--- a/modules/programs/trippy.nix
+++ b/modules/programs/trippy.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.trippy;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.trippy = {
+    enable = mkEnableOption "trippy";
+    package = mkPackageOption pkgs "trippy" { nullable = true; };
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = {
+        theme-colors = {
+          bg-color = "black";
+          border-color = "gray";
+          text-color = "gray";
+          tab-text-color = "green";
+        };
+        bindings = {
+          toggle-help = "h";
+          toggle-help-alt = "?";
+          toggle-settings = "s";
+          toggle-settings-tui = "1";
+          toggle-settings-trace = "2";
+          toggle-settings-dns = "3";
+          toggle-settings-geoip = "4";
+        };
+      };
+      description = ''
+        Configuration settings for trippy. All the available options can be found
+        here: <https://trippy.rs/reference/configuration/>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."trippy/trippy.toml" = mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "trippy-config" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/trippy/default.nix
+++ b/tests/modules/programs/trippy/default.nix
@@ -1,0 +1,1 @@
+{ trippy-example = ./example-config.nix; }

--- a/tests/modules/programs/trippy/example-config.nix
+++ b/tests/modules/programs/trippy/example-config.nix
@@ -1,0 +1,28 @@
+{
+  programs.trippy = {
+    enable = true;
+    settings = {
+      theme-colors = {
+        bg-color = "black";
+        border-color = "gray";
+        text-color = "gray";
+        tab-text-color = "green";
+      };
+      bindings = {
+        toggle-help = "h";
+        toggle-help-alt = "?";
+        toggle-settings = "s";
+        toggle-settings-tui = "1";
+        toggle-settings-trace = "2";
+        toggle-settings-dns = "3";
+        toggle-settings-geoip = "4";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/trippy/trippy.toml
+    assertFileContent home-files/.config/trippy/trippy.toml \
+    ${./trippy.toml}
+  '';
+}

--- a/tests/modules/programs/trippy/trippy.toml
+++ b/tests/modules/programs/trippy/trippy.toml
@@ -1,0 +1,14 @@
+[bindings]
+toggle-help = "h"
+toggle-help-alt = "?"
+toggle-settings = "s"
+toggle-settings-dns = "3"
+toggle-settings-geoip = "4"
+toggle-settings-trace = "2"
+toggle-settings-tui = "1"
+
+[theme-colors]
+bg-color = "black"
+border-color = "gray"
+tab-text-color = "green"
+text-color = "gray"


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This pull request adds a module for configuring [trippy](https://github.com/fujiapple852/trippy).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
