### PR TITLE
lib: Add ordered children and no children to `lib.hm.generators.toKDL`

### DIFF
--- a/tests/lib/generators/tokdl-result.txt
+++ b/tests/lib/generators/tokdl-result.txt
@@ -1,7 +1,12 @@
 a 1
+argsAndProps 1 2 a=3
 b "string"
 bigFlatItems 23847590283751 1.239000 "multiline \" \" \"\nstring\n" null
 c "multiline string\nwith special characters:\n\t \n \\" \"\n"
+duplicateChildren {
+	child 2
+	child 1
+}
 extraAttrs 2 true arg1=1 arg2=false {
 	nested {
 		a 1

--- a/tests/lib/generators/tokdl.nix
+++ b/tests/lib/generators/tokdl.nix
@@ -38,6 +38,10 @@
       [ ]
       [ null ]
     ];
+    duplicateChildren._children = [
+      { child = [ 2 ]; }
+      { child = [ 1 ]; }
+    ];
     extraAttrs = {
       _args = [
         2
@@ -50,6 +54,15 @@
       nested = {
         a = 1;
         b = null;
+      };
+    };
+    argsAndProps = {
+      _args = [
+        1
+        2
+      ];
+      _props = {
+        a = 3;
       };
     };
     listInAttrsInList = {


### PR DESCRIPTION
### Description

The current `toKDL` generator doesn't allow the generation of Zellij keybinding configuration because it requires ordered children. For example, the following KDL:

```kdl
keybinds clear-defaults=true {
    pane {
        bind "e" { TogglePaneEmbedOrFloating; SwitchToMode "locked"; }
        bind "left" { MoveFocus "left"; }
    }
}
```

cannot be generated with the current `toKDL` generator.

There are a few previous attempts to fix this (#5272, #4614, #5706), but they all involve non-backwards-compatible changes to the existing mapping.

This PR extends the existing syntax to add an `_children` attr (like the already-existing `_args` and `_props` attrs) that can be used to pass a list of ordered children for a node, which means that the above KDL can be generated with:

```nix
keybinds._props.clear-defaults = true;
keybinds.pane._children = [
  {
    bind = {
      _args = ["e"];
      _children = [
        { TogglePaneEmbedOrFloating = {}; }
        { SwitchToMode._args = ["locked"]; }
      ];
    };
  }
  {
    bind = {
      _args = ["left"];
      MoveFocus = ["left"];
    };
  }
];
```

It's probably worth adding a higher-level interface to assign keybindings to the zellij module, but I think that should be a separate PR.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@khaneliman @mainrs for the zellij module