### PR TITLE
wpaperd: handle empty settings properly 

### DIFF
--- a/modules/services/wpaperd.nix
+++ b/modules/services/wpaperd.nix
@@ -86,7 +86,9 @@ in
         Description = "wpaperd";
         PartOf = [ config.wayland.systemd.target ];
         After = [ config.wayland.systemd.target ];
-        X-Restart-Triggers = [ "${config.xdg.configFile."wpaperd/wallpaper.toml".source}" ];
+        X-Restart-Triggers = lib.mkIf (cfg.settings != { }) [
+          "${config.xdg.configFile."wpaperd/wallpaper.toml".source}"
+        ];
       };
 
       Service = {

--- a/tests/modules/services/wpaperd/default.nix
+++ b/tests/modules/services/wpaperd/default.nix
@@ -1,5 +1,6 @@
 { lib, pkgs, ... }:
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  wpaperd-no-settings = ./wpaperd-no-settings.nix;
   wpaperd-example-settings = ./wpaperd-example-settings.nix;
 }

--- a/tests/modules/services/wpaperd/wpaperd-example-settings.nix
+++ b/tests/modules/services/wpaperd/wpaperd-example-settings.nix
@@ -15,6 +15,7 @@
   };
 
   nmt.script = ''
+    assertFileExists home-files/.config/wpaperd/wallpaper.toml
     assertFileContent home-files/.config/wpaperd/wallpaper.toml \
       ${./wpaperd-expected-settings.toml}
   '';

--- a/tests/modules/services/wpaperd/wpaperd-no-settings.nix
+++ b/tests/modules/services/wpaperd/wpaperd-no-settings.nix
@@ -1,0 +1,9 @@
+{
+  services.wpaperd = {
+    enable = true;
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/wpaperd/wallpaper.toml
+  '';
+}


### PR DESCRIPTION
### Description
Closes https://github.com/nix-community/home-manager/issues/7423
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
