### PR TITLE
starship: set `STARSHIP_CONFIG` var and add option to set config path

### DIFF
--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -82,13 +82,26 @@ in
         https://starship.rs/advanced-config/#transientprompt-and-transientrightprompt-in-cmd
       '';
     };
+
+    configPath = mkOption {
+      type = lib.types.str;
+      default = "${config.xdg.configHome}/starship.toml";
+      defaultText = lib.literalExpression "\${config.xdg.configHome}/starship.toml";
+      description = ''
+        Relative path to the user's home directory where the Starship config should be stored.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home = {
+      packages = [ cfg.package ];
 
-    xdg.configFile."starship.toml" = mkIf (cfg.settings != { }) {
-      source = tomlFormat.generate "starship-config" cfg.settings;
+      sessionVariables.STARSHIP_CONFIG = cfg.configPath;
+
+      file.${cfg.configPath} = mkIf (cfg.settings != { }) {
+        source = tomlFormat.generate "starship-config" cfg.settings;
+      };
     };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''

--- a/tests/modules/programs/starship/settings.nix
+++ b/tests/modules/programs/starship/settings.nix
@@ -46,6 +46,11 @@
   };
 
   nmt.script = ''
+    sessionVarsFile=home-path/etc/profile.d/hm-session-vars.sh
+    assertFileExists $sessionVarsFile
+    assertFileContains $sessionVarsFile \
+        'export STARSHIP_CONFIG="/home/hm-user/.config/starship.toml"'
+
     assertFileContent \
       home-files/.config/starship.toml \
       ${./settings-expected.toml}


### PR DESCRIPTION
### Description

The reason for doing this is so that when you use `sudo su`, you can pass that env variable to the root shell to have the same terminal prompt as the current user.

Docs: <https://starship.rs/config/#config-file-location>

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
