### PR TITLE
home-manager: add flake support for repl command

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -212,6 +212,8 @@ function setFlakeAttribute() {
                 ;;
         esac
         export FLAKE_CONFIG_URI="$flake#homeConfigurations.\"$(printf %s "$name" | jq -sRr @uri)\""
+        export FLAKE_PATH="$flake"
+        export FLAKE_ATTR="homeConfigurations.\"$name\""
     fi
 }
 
@@ -639,9 +641,46 @@ function doBuild() {
 
 function doRepl() {
     setFlakeAttribute
+
     if [[ -v FLAKE_CONFIG_URI ]]; then
-        _i 'home-manager repl does not (yet) support flakes' >&2
-        return 1
+        printf -v bold '\033[1m'
+        printf -v blue '\033[34;1m'
+        printf -v reset '\033[0m'
+        exec nix repl --expr "
+            let
+                flake = builtins.getFlake ''$FLAKE_PATH'';
+                configuration = flake.$FLAKE_ATTR;
+                motd = ''
+
+
+                    Hello and welcome to the Home Manager configuration
+                        $FLAKE_ATTR
+                        in $FLAKE_PATH
+
+                    The following is loaded into nix repl's scope:
+
+                        - ${blue}config${reset}   All option values
+                        - ${blue}options${reset}  Option data and metadata
+                        - ${blue}pkgs${reset}     Nixpkgs package set
+                        - ${blue}lib${reset}      Nixpkgs library functions
+
+                        - ${blue}flake${reset}    Flake outputs, inputs and source info of $FLAKE_PATH
+
+                    Use tab completion to browse around ${blue}config${reset}.
+
+                    Use ${bold}:r${reset} to ${bold}reload${reset} everything after making a change in the flake.
+
+                    See ${bold}:?${reset} for more repl commands.
+                '';
+                scope =
+                    assert configuration.class or ''homeManager'' == ''homeManager'';
+                    {
+                        inherit (configuration) config options pkgs;
+                        inherit (configuration.pkgs) lib;
+                        inherit flake;
+                    };
+            in builtins.seq scope builtins.trace motd scope
+        " "${PASSTHROUGH_OPTS[@]}"
     fi
 
     setConfigFile


### PR DESCRIPTION
Extend the `home-manager repl` command to support flakes.  This is heavily based on the equivalent `nixos-rebuild repl` code.

### Description

I originally wrote the `home-manager repl` command without support for flakes, because I wasn't using them.  Now I am, and I wanted flake support, so I added it.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

No obvious maintainer, but tagging @khaneliman as the person who merged #5600