### PR TITLE
vscode: enable defining `mcp.json` separate from `settings.json`

### DIFF
--- a/modules/programs/vscode/default.nix
+++ b/modules/programs/vscode/default.nix
@@ -54,6 +54,7 @@ let
     name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}settings.json";
   tasksFilePath =
     name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}tasks.json";
+  mcpFilePath = name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}mcp.json";
   keybindingsFilePath =
     name: "${userDir}/${optionalString (name != "default") "profiles/${name}/"}keybindings.json";
 
@@ -119,6 +120,25 @@ let
         description = ''
           Configuration written to Visual Studio Code's
           {file}`tasks.json`.
+          This can be a JSON object or a path to a custom JSON file.
+        '';
+      };
+
+      userMcp = mkOption {
+        type = types.either types.path jsonFormat.type;
+        default = { };
+        example = literalExpression ''
+          {
+            "servers": {
+              "Github": {
+                "url": "https://api.githubcopilot.com/mcp/"
+              }
+            }
+          }
+        '';
+        description = ''
+          Configuration written to Visual Studio Code's
+          {file}`mcp.json`.
           This can be a JSON object or a path to a custom JSON file.
         '';
       };
@@ -270,6 +290,7 @@ in
         "enableExtensionUpdateCheck"
         "userSettings"
         "userTasks"
+        "userMcp"
         "keybindings"
         "extensions"
         "languageSnippets"
@@ -381,6 +402,11 @@ in
         (mkIf (v.userTasks != { }) {
           "${tasksFilePath n}".source =
             if isPath v.userTasks then v.userTasks else jsonFormat.generate "vscode-user-tasks" v.userTasks;
+        })
+
+        (mkIf (v.userMcp != { }) {
+          "${mcpFilePath n}".source =
+            if isPath v.userMcp then v.userMcp else jsonFormat.generate "vscode-user-mcp" v.userMcp;
         })
 
         (mkIf (v.keybindings != [ ]) {

--- a/tests/modules/programs/vscode/default.nix
+++ b/tests/modules/programs/vscode/default.nix
@@ -1,6 +1,7 @@
 {
   vscode-keybindings = ./keybindings.nix;
   vscode-tasks = ./tasks.nix;
+  vscode-mcp = ./mcp.nix;
   vscode-update-checks = ./update-checks.nix;
   vscode-snippets = ./snippets.nix;
 }

--- a/tests/modules/programs/vscode/mcp.nix
+++ b/tests/modules/programs/vscode/mcp.nix
@@ -1,0 +1,71 @@
+{ pkgs, lib, ... }:
+
+let
+
+  mcpFilePath =
+    name:
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/Code/User/${
+        lib.optionalString (name != "default") "profiles/${name}/"
+      }mcp.json"
+    else
+      ".config/Code/User/${lib.optionalString (name != "default") "profiles/${name}/"}mcp.json";
+
+  content = ''
+    {
+      "servers": {
+        "Github": {
+          "url": "https://api.githubcopilot.com/mcp/"
+        }
+      }
+    }
+  '';
+
+  mcp = {
+    servers = {
+      Github = {
+        url = "https://api.githubcopilot.com/mcp/";
+      };
+    };
+  };
+
+  customMcpPath = pkgs.writeText "custom.json" content;
+
+  expectedMcp = pkgs.writeText "mcp-expected.json" ''
+    {
+      "servers": {
+        "Github": {
+          "url": "https://api.githubcopilot.com/mcp/"
+        }
+      }
+    }
+  '';
+
+  expectedCustomMcp = pkgs.writeText "custom-expected.json" content;
+
+in
+{
+  programs.vscode = {
+    enable = true;
+    package = pkgs.writeScriptBin "vscode" "" // {
+      pname = "vscode";
+      version = "1.75.0";
+    };
+    profiles = {
+      default.userMcp = mcp;
+      test.userMcp = mcp;
+      custom.userMcp = customMcpPath;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/${mcpFilePath "default"}"
+    assertFileContent "home-files/${mcpFilePath "default"}" "${expectedMcp}"
+
+    assertFileExists "home-files/${mcpFilePath "test"}"
+    assertFileContent "home-files/${mcpFilePath "test"}" "${expectedMcp}"
+
+    assertFileExists "home-files/${mcpFilePath "custom"}"
+    assertFileContent "home-files/${mcpFilePath "custom"}" "${expectedCustomMcp}"
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add an option to define mcp configuration in it's own file (separate from settings) as [required by VS Code 1.102](https://code.visualstudio.com/updates/v1_102#_mcp-migration-support).

VS Code 1.102 separates MCP configuration from `settings.json` to a profile-specific `mcp.json`. VS Code automatically performs this separation if MCP configuration is detected inside `settings.json` which conflicts with the immutability of the settings.json that home-manager supplies.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->

@hall 