### PR TITLE
thunderbird: support declaration of address books

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -488,7 +488,7 @@
   };
   zorrobert = {
     name = "zorrobert";
-    email = "zorrobert@mailbox.org";
+    email = "118135271+zorrobert@users.noreply.github.com";
     github = "zorrobert";
     githubId = 118135271;
   };

--- a/modules/misc/news/2025/07/2025-07-07_20-33-04.nix
+++ b/modules/misc/news/2025/07/2025-07-07_20-33-04.nix
@@ -1,0 +1,9 @@
+{ config, ... }:
+{
+  time = "2025-07-07T18:33:04+00:00";
+  condition = config.programs.thunderbird.enable;
+  message = ''
+    'programs.thunderbird' now supports declaration of address books using
+    'accounts.contact.accounts'.
+  '';
+}

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -41,6 +41,9 @@ let
   enabledCalendarAccounts = filterEnabled config.accounts.calendar.accounts;
   enabledCalendarAccountsWithId = addId enabledCalendarAccounts;
 
+  enabledContactAccounts = filterEnabled config.accounts.contact.accounts;
+  enabledContactAccountsWithId = addId enabledContactAccounts;
+
   thunderbirdConfigPath = if isDarwin then "Library/Thunderbird" else ".thunderbird";
 
   thunderbirdProfilesPath =
@@ -191,6 +194,27 @@ let
     // optionalAttrs (calendar.thunderbird.color != "") {
       "calendar.registry.calendar_${id}.color" = calendar.thunderbird.color;
     };
+
+  toThunderbirdContact =
+    contact: _:
+    let
+      inherit (contact) id;
+    in
+    lib.filterAttrs (n: v: v != null) (
+      {
+        "ldap_2.servers.contact_${id}.description" = contact.name;
+        "ldap_2.servers.contact_${id}.filename" = "contact_${id}.sqlite"; # this is needed for carddav to work
+      }
+      // optionalAttrs (contact.remote == null) {
+        "ldap_2.servers.contact_${id}.dirType" = 101; # dirType 101 for local address book
+      }
+      // optionalAttrs (contact.remote != null && contact.remote.type == "carddav") {
+        "ldap_2.servers.contact_${id}.dirType" = 102; # dirType 102 for CardDAV
+        "ldap_2.servers.contact_${id}.carddav.url" = contact.remote.url;
+        "ldap_2.servers.contact_${id}.carddav.username" = contact.remote.userName;
+        "ldap_2.servers.contact_${id}.carddav.token" = contact.thunderbird.token;
+      }
+    );
 
   toThunderbirdFeed =
     feed: profile:
@@ -379,6 +403,7 @@ in
                     ]
                   '';
                 };
+
                 calendarAccountsOrder = mkOption {
                   type = types.listOf types.str;
                   default = [ ];
@@ -661,6 +686,7 @@ in
         )
       );
     };
+
     accounts.calendar.accounts = mkOption {
       type =
         with types;
@@ -692,6 +718,38 @@ in
               default = "";
               example = "#dc8add";
               description = "Display color of the calendar in hex";
+            };
+          };
+        });
+    };
+
+    accounts.contact.accounts = mkOption {
+      type =
+        with types;
+        attrsOf (submodule {
+          options.thunderbird = {
+            enable = lib.mkEnableOption "the Thunderbird mail client for this account";
+
+            profiles = mkOption {
+              type = with types; listOf str;
+              default = [ ];
+              example = literalExpression ''
+                [ "profile1" "profile2" ]
+              '';
+              description = ''
+                List of Thunderbird profiles for which this account should be
+                enabled. If this list is empty (the default), this account will
+                be enabled for all declared profiles.
+              '';
+            };
+
+            token = mkOption {
+              type = nullOr str;
+              default = null;
+              example = "secret_token";
+              description = ''
+                A token is generated when adding an address book manually to Thunderbird, this can be entered here.
+              '';
             };
           };
         });
@@ -758,6 +816,44 @@ in
             '';
         }
       )
+
+      (
+        let
+          foundContacts = filter (
+            a: a.remote != null && a.remote.type == "google_contacts"
+          ) enabledContactAccounts;
+        in
+        {
+          assertion = (length foundContacts == 0);
+          message =
+            '''accounts.contact.accounts.<name>.remote.type = "google_contacts";' is not directly supported by Thunderbird, ''
+            + "but declared for these address books: "
+            + (concatStringsSep ", " (lib.catAttrs "name" foundContacts))
+            + "\n"
+            + ''
+              To use google address books in Thunderbird choose 'type = "caldav"' instead.
+              The 'url' will be something like "https://www.googleapis.com/carddav/v1/principals/[YOUR-MAIL-ADDRESS]/lists/default/".
+              To get the exact URL, add the address book to Thunderbird manually and copy the URL from the "Advanced Preferences" section.
+            '';
+        }
+      )
+
+      (
+        let
+          foundContacts = filter (a: a.remote != null && a.remote.type == "http") enabledContactAccounts;
+        in
+        {
+          assertion = (length foundContacts == 0);
+          message =
+            '''accounts.contact.accounts.<name>.remote.type = "http";' is not supported by Thunderbird, ''
+            + "but declared for these address books: "
+            + (concatStringsSep ", " (lib.catAttrs "name" foundContacts))
+            + "\n"
+            + ''
+              Use a calendar of 'type = "caldav"' instead.
+            '';
+        }
+      )
     ];
 
     home.packages = [
@@ -790,6 +886,7 @@ in
             let
               emailAccounts = getAccountsForProfile name enabledEmailAccountsWithId;
               calendarAccounts = getAccountsForProfile name enabledCalendarAccountsWithId;
+              contactAccounts = getAccountsForProfile name enabledContactAccountsWithId;
 
               smtp = filter (a: a.smtp != null) emailAccounts;
 
@@ -858,8 +955,9 @@ in
                   profile.settings
                 ]
                 ++ (map (a: toThunderbirdAccount a profile) emailAccounts)
-                ++ (map (c: toThunderbirdCalendar c profile) calendarAccounts)
-                ++ (map (f: toThunderbirdFeed f profile) feedAccounts)
+                ++ (map (calendar: toThunderbirdCalendar calendar profile) calendarAccounts)
+                ++ (map (contact: toThunderbirdContact contact profile) contactAccounts)
+                ++ (map (feed: toThunderbirdFeed feed profile) feedAccounts)
               )) profile.extraConfig;
             };
 

--- a/tests/modules/programs/thunderbird/thunderbird-expected-first-darwin.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-first-darwin.js
@@ -16,6 +16,14 @@ user_pref("calendar.registry.calendar_5152790e278eb89039f8bfaa354b944ec1b44c5d3f
 user_pref("calendar.registry.calendar_5152790e278eb89039f8bfaa354b944ec1b44c5d3fc144edc5720c3edc045c73.uri", "https://my.caldav.server/calendar");
 user_pref("calendar.registry.calendar_5152790e278eb89039f8bfaa354b944ec1b44c5d3fc144edc5720c3edc045c73.username", "testuser");
 user_pref("general.useragent.override", "");
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.description", "shared");
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.dirType", 101);
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.filename", "contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.sqlite");
+user_pref("ldap_2.servers.contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.carddav.url", "https://my.caldav.server/contact/");
+user_pref("ldap_2.servers.contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.carddav.username", "home-manager@example.com");
+user_pref("ldap_2.servers.contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.description", "family");
+user_pref("ldap_2.servers.contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.dirType", 102);
+user_pref("ldap_2.servers.contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.filename", "contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.sqlite");
 user_pref("mail.account.account_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.identities", "id_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.account.account_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.server", "server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.account.account_c6cc42837ed0a8041f93ff12c579a4af0dbe702461c97eef069f9f5f8dc4bfab.server", "server_c6cc42837ed0a8041f93ff12c579a4af0dbe702461c97eef069f9f5f8dc4bfab");

--- a/tests/modules/programs/thunderbird/thunderbird-expected-first-linux.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-first-linux.js
@@ -16,6 +16,14 @@ user_pref("calendar.registry.calendar_5152790e278eb89039f8bfaa354b944ec1b44c5d3f
 user_pref("calendar.registry.calendar_5152790e278eb89039f8bfaa354b944ec1b44c5d3fc144edc5720c3edc045c73.uri", "https://my.caldav.server/calendar");
 user_pref("calendar.registry.calendar_5152790e278eb89039f8bfaa354b944ec1b44c5d3fc144edc5720c3edc045c73.username", "testuser");
 user_pref("general.useragent.override", "");
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.description", "shared");
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.dirType", 101);
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.filename", "contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.sqlite");
+user_pref("ldap_2.servers.contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.carddav.url", "https://my.caldav.server/contact/");
+user_pref("ldap_2.servers.contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.carddav.username", "home-manager@example.com");
+user_pref("ldap_2.servers.contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.description", "family");
+user_pref("ldap_2.servers.contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.dirType", 102);
+user_pref("ldap_2.servers.contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.filename", "contact_d34a569ab7aaa54dacd715ae64953455d86b768846cd0085ef4e9e7471489b7b.sqlite");
 user_pref("mail.account.account_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.identities", "id_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.account.account_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.server", "server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.account.account_c6cc42837ed0a8041f93ff12c579a4af0dbe702461c97eef069f9f5f8dc4bfab.server", "server_c6cc42837ed0a8041f93ff12c579a4af0dbe702461c97eef069f9f5f8dc4bfab");

--- a/tests/modules/programs/thunderbird/thunderbird-expected-second-darwin.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-second-darwin.js
@@ -14,6 +14,12 @@ user_pref("calendar.registry.calendar_474c12b01f4f765680ac3bb3e0b670b7ac817c9f71
 user_pref("calendar.registry.calendar_474c12b01f4f765680ac3bb3e0b670b7ac817c9f717997577cac3f12f1b5013a.uri", "https://www.thunderbird.net/media/caldata/autogen/GermanHolidays.ics");
 user_pref("calendar.registry.calendar_474c12b01f4f765680ac3bb3e0b670b7ac817c9f717997577cac3f12f1b5013a.username", null);
 user_pref("general.useragent.override", "");
+user_pref("ldap_2.servers.contact_00e13ed7af55b27622f1d6eab5bec0147e68efe28dc2b12461117afa1a5ed40e.description", "work");
+user_pref("ldap_2.servers.contact_00e13ed7af55b27622f1d6eab5bec0147e68efe28dc2b12461117afa1a5ed40e.dirType", 101);
+user_pref("ldap_2.servers.contact_00e13ed7af55b27622f1d6eab5bec0147e68efe28dc2b12461117afa1a5ed40e.filename", "contact_00e13ed7af55b27622f1d6eab5bec0147e68efe28dc2b12461117afa1a5ed40e.sqlite");
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.description", "shared");
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.dirType", 101);
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.filename", "contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.sqlite");
 user_pref("mail.account.account_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.identities", "id_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.account.account_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.server", "server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.accountmanager.accounts", "account1,account_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");

--- a/tests/modules/programs/thunderbird/thunderbird-expected-second-linux.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-second-linux.js
@@ -14,6 +14,12 @@ user_pref("calendar.registry.calendar_474c12b01f4f765680ac3bb3e0b670b7ac817c9f71
 user_pref("calendar.registry.calendar_474c12b01f4f765680ac3bb3e0b670b7ac817c9f717997577cac3f12f1b5013a.uri", "https://www.thunderbird.net/media/caldata/autogen/GermanHolidays.ics");
 user_pref("calendar.registry.calendar_474c12b01f4f765680ac3bb3e0b670b7ac817c9f717997577cac3f12f1b5013a.username", null);
 user_pref("general.useragent.override", "");
+user_pref("ldap_2.servers.contact_00e13ed7af55b27622f1d6eab5bec0147e68efe28dc2b12461117afa1a5ed40e.description", "work");
+user_pref("ldap_2.servers.contact_00e13ed7af55b27622f1d6eab5bec0147e68efe28dc2b12461117afa1a5ed40e.dirType", 101);
+user_pref("ldap_2.servers.contact_00e13ed7af55b27622f1d6eab5bec0147e68efe28dc2b12461117afa1a5ed40e.filename", "contact_00e13ed7af55b27622f1d6eab5bec0147e68efe28dc2b12461117afa1a5ed40e.sqlite");
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.description", "shared");
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.dirType", 101);
+user_pref("ldap_2.servers.contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.filename", "contact_a4d26868017c0ccffe2efe50944ef4211834660cca834c6e9f86dec6a88246fa.sqlite");
 user_pref("mail.account.account_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.identities", "id_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.account.account_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc.server", "server_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");
 user_pref("mail.accountmanager.accounts", "account1,account_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc");

--- a/tests/modules/programs/thunderbird/thunderbird.nix
+++ b/tests/modules/programs/thunderbird/thunderbird.nix
@@ -89,6 +89,29 @@
     };
   };
 
+  accounts.contact.accounts = {
+    family = {
+      remote = {
+        type = "carddav";
+        url = "https://my.caldav.server/contact/";
+        userName = "home-manager@example.com";
+      };
+      thunderbird = {
+        enable = true;
+        profiles = [ "first" ];
+      };
+    };
+    work = {
+      thunderbird = {
+        enable = true;
+        profiles = [ "second" ];
+      };
+    };
+    shared = {
+      thunderbird.enable = true;
+    };
+  };
+
   programs.thunderbird = {
     enable = true;
     package = config.lib.test.mkStubPackage {


### PR DESCRIPTION
### Description

Adds support for address books using the `accounts.contact.accounts.*` options. 

This is based on a module I wrote for my personal config to set calendars and address books before #5484 was merged. I was able to reuse many of the sections @DerRockWolf added for calendars and adapt them to work with address books as the structure is very similar.

Resolves #5933 

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@d-dervishi @jkarlson