### PR TITLE
zellij: add support for layouts generation

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -30,6 +30,116 @@ in
 
     package = lib.mkPackageOption pkgs "zellij" { };
 
+    layouts = lib.mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          yamlFormat.type
+          types.path
+          types.lines
+        ]
+      );
+      default = { };
+      example = lib.literalExpression ''
+        {
+          dev = {
+            layout = {
+              _children = [
+                {
+                  default_tab_template = {
+                    _children = [
+                      {
+                        pane = {
+                          size = 1;
+                          borderless = true;
+                          plugin = {
+                            location = "zellij:tab-bar";
+                          };
+                        };
+                      }
+                      { "children" = { }; }
+                      {
+                        pane = {
+                          size = 2;
+                          borderless = true;
+                          plugin = {
+                            location = "zellij:status-bar";
+                          };
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Project";
+                      focus = true;
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "nvim";
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Git";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "lazygit";
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Files";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "yazi";
+                        };
+                      }
+                    ];
+                  };
+                }
+                {
+                  tab = {
+                    _props = {
+                      name = "Shell";
+                    };
+                    _children = [
+                      {
+                        pane = {
+                          command = "zsh";
+                        };
+                      }
+                    ];
+                  };
+                }
+              ];
+            };
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/zellij/layouts/<layout>.kdl`.
+
+        See <https://zellij.dev/documentation> for the full
+        list of options.
+      '';
+    };
+
     settings = lib.mkOption {
       type = yamlFormat.type;
       default = { };
@@ -123,6 +233,20 @@ in
                 text = lib.hm.generators.toKDL { } cfg.settings;
               };
         }
+
+        (lib.mapAttrs' (
+          name: value:
+          lib.nameValuePair "zellij/layouts/${name}.kdl" {
+            source =
+              if builtins.isPath value || lib.isStorePath value then
+                value
+              else
+                pkgs.writeText "zellij-layout-${name}" (
+                  if lib.isString value then value else lib.hm.generators.toKDL { } value
+                );
+          }
+        ) cfg.layouts)
+
         (lib.mapAttrs' (
           name: value:
           lib.nameValuePair "zellij/themes/${name}.kdl" {

--- a/tests/modules/programs/zellij/default.nix
+++ b/tests/modules/programs/zellij/default.nix
@@ -1,4 +1,5 @@
 {
   zellij-enable-shells = ./enable-shells.nix;
+  zellij-layout = ./layout.nix;
   zellij-theme = ./theme.nix;
 }

--- a/tests/modules/programs/zellij/layout.nix
+++ b/tests/modules/programs/zellij/layout.nix
@@ -1,0 +1,142 @@
+{ pkgs, ... }:
+{
+  programs.zellij = {
+    enable = true;
+    layouts = {
+      dev = {
+        layout = {
+          _children = [
+            {
+              default_tab_template = {
+                _children = [
+                  {
+                    pane = {
+                      size = 1;
+                      borderless = true;
+                      plugin = {
+                        location = "zellij:tab-bar";
+                      };
+                    };
+                  }
+                  { "children" = { }; }
+                  {
+                    pane = {
+                      size = 2;
+                      borderless = true;
+                      plugin = {
+                        location = "zellij:status-bar";
+                      };
+                    };
+                  }
+                ];
+              };
+            }
+            {
+              tab = {
+                _props = {
+                  name = "Project";
+                  focus = true;
+                };
+                _children = [
+                  {
+                    pane = {
+                      command = "nvim";
+                    };
+                  }
+                ];
+              };
+            }
+            {
+              tab = {
+                _props = {
+                  name = "Git";
+                };
+                _children = [
+                  {
+                    pane = {
+                      command = "lazygit";
+                    };
+                  }
+                ];
+              };
+            }
+            {
+              tab = {
+                _props = {
+                  name = "Files";
+                };
+                _children = [
+                  {
+                    pane = {
+                      command = "yazi";
+                    };
+                  }
+                ];
+              };
+            }
+            {
+              tab = {
+                _props = {
+                  name = "Shell";
+                };
+                _children = [
+                  {
+                    pane = {
+                      command = "zsh";
+                    };
+                  }
+                ];
+              };
+            }
+          ];
+        };
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/zellij/layouts/dev.kdl
+    assertFileContent home-files/.config/zellij/layouts/dev.kdl \
+      ${pkgs.writeText "layout-dev-expected" ''
+        layout {
+        	default_tab_template {
+        		pane {
+        			borderless true
+        			plugin {
+        				location "zellij:tab-bar"
+        			}
+        			size 1
+        		}
+        		children
+        		pane {
+        			borderless true
+        			plugin {
+        				location "zellij:status-bar"
+        			}
+        			size 2
+        		}
+        	}
+        	tab focus=true name="Project" {
+        		pane {
+        			command "nvim"
+        		}
+        	}
+        	tab name="Git" {
+        		pane {
+        			command "lazygit"
+        		}
+        	}
+        	tab name="Files" {
+        		pane {
+        			command "yazi"
+        		}
+        	}
+        	tab name="Shell" {
+        		pane {
+        			command "zsh"
+        		}
+        	}
+        }
+      ''}
+  '';
+}


### PR DESCRIPTION
Adds a layouts option to support generating layout files for zellij to use.

closes https://github.com/nix-community/home-manager/issues/4485
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
