### PR TITLE
tests: re-add module argument

### DIFF
--- a/tests/integration/standalone/alice-home-init.nix
+++ b/tests/integration/standalone/alice-home-init.nix
@@ -1,3 +1,5 @@
+{ config, pkgs, ... }:
+
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.

--- a/tests/integration/standalone/home-with-symbols-init.nix
+++ b/tests/integration/standalone/home-with-symbols-init.nix
@@ -1,3 +1,5 @@
+{ config, pkgs, ... }:
+
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -9,6 +9,10 @@ includes = [ "*.nix" ]
 command = "deadnix"
 options = [ "--edit", "--no-lambda-arg" ]
 includes = [ "*.nix" ]
+excludes = [
+  "tests/integration/standalone/alice-home-init.nix",
+  "tests/integration/standalone/home-with-symbols-init.nix"
+]
 
 [formatter.keep-sorted]
 command = "keep-sorted"


### PR DESCRIPTION
### Description

These were removed as part of dead code removal, but they are actually needed in the integration tests for comparing with the configuration generated by the installation.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
