### PR TITLE
Fixed a typo in modules/programs/gurk-rs.nix

### DIFF
--- a/modules/programs/gurk-rs.nix
+++ b/modules/programs/gurk-rs.nix
@@ -45,7 +45,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.package = lib.mkIf (cfg.package != null) [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.file."${
       if pkgs.stdenv.hostPlatform.isDarwin then "Library/Application Support" else config.xdg.configHome


### PR DESCRIPTION
### Description

Fixed a typo in [modules/programs/gurk-rs.nix](https://github.com/nix-community/home-manager/commit/7969ed8baac8363b32775c5f55e132668bab8123#diff-4de6c4fbbe794a58c0f038e718d22042277ab5e89e465100126ae5f809794094). 
home.package is used instead of home.packages.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
