### PR TITLE
dunst: UWSM compatibility

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -218,6 +218,9 @@ in
                 ]
             );
             Environment = lib.optionalString (cfg.waylandDisplay != "") "WAYLAND_DISPLAY=${cfg.waylandDisplay}";
+            Install = {
+              WantedBy = config.wayland.systemd.target;
+            };
           };
         };
       }


### PR DESCRIPTION
Added Install field for systemd service, which is needed for autostart to work properly under compositors launched under UWSM

### Description

<!--

UWSM-managed compositors (e.g. Hyprland) had issues with autostarting dunst service, [since Install field was not set ](https://wiki.hypr.land/Useful-Utilities/Systemd-start/#autostart). 

I could solve this issue locally in my home-manager configuration by extending existing config with 

```
  services.dunst = {
    enable = true;
  };
  systemd.user.services.dunst = lib.mkMerge [
    {
      Install.WantedBy = [config.wayland.systemd.target];
    }
  ];
```

My addition basically replicates this fix.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
