### PR TITLE
nix.nix: use-sandbox -> sandbox

### DIFF
--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -314,7 +314,7 @@ in
       default = { };
       example = literalExpression ''
         {
-          use-sandbox = true;
+          sandbox = true;
           show-trace = true;
           system-features = [ "big-parallel" "kvm" "recursive-nix" ];
         }

--- a/tests/modules/misc/nix/example-settings-expected.conf
+++ b/tests/modules/misc/nix/example-settings-expected.conf
@@ -1,7 +1,7 @@
 # WARNING: this file is generated from the nix.settings option in
 # your Home Manager configuration at $XDG_CONFIG_HOME/nix/nix.conf.
 # Do not edit it!
+sandbox = true
 show-trace = true
 system-features = big-parallel kvm recursive-nix
-use-sandbox = true
 

--- a/tests/modules/misc/nix/example-settings.nix
+++ b/tests/modules/misc/nix/example-settings.nix
@@ -25,7 +25,7 @@
     ];
 
     settings = {
-      use-sandbox = true;
+      sandbox = true;
       show-trace = true;
       system-features = [
         "big-parallel"


### PR DESCRIPTION
### Description

The Nix configuration file sandbox setting is now "sandbox", not "use-sandbox".  Correct the documentation and tests that reference this setting.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

No obvious owners or maintainers