### PR TITLE
neomutt: allow default email sending behaviour

### DIFF
--- a/modules/programs/neomutt/default.nix
+++ b/modules/programs/neomutt/default.nix
@@ -223,7 +223,7 @@ let
       {
         sendmail = "'${neomutt.sendMailCommand}'";
       }
-    else
+    else if passwordCommand != null then
       let
         smtpProto = if smtp.tls.enable && !smtp.tls.useStartTls then "smtps" else "smtp";
         smtpPort = if smtp.port != null then ":${toString smtp.port}" else "";
@@ -232,7 +232,9 @@ let
       {
         smtp_url = "'${smtpBaseUrl}'";
         smtp_pass = ''"`${passCmd}`"'';
-      };
+      }
+    else
+      { };
 
   genAccountConfig =
     account:
@@ -537,17 +539,12 @@ in
         );
     };
 
-    assertions =
-      [
-        {
-          assertion = ((filter (b: (lib.length (lib.toList b.map)) == 0) (cfg.binds ++ cfg.macros)) == [ ]);
-          message = "The 'programs.neomutt.(binds|macros).map' list must contain at least one element.";
-        }
-      ]
-      ++ lib.mapAttrsToList (n: a: {
-        assertion = a.neomutt.sendMailCommand != null || a.passwordCommand != null;
-        message = "'accounts.email.accounts.${n}' needs either 'neomutt.sendMailCommand' or 'passwordCommand' set.";
-      }) neomuttAccountsCfg;
+    assertions = [
+      {
+        assertion = ((filter (b: (lib.length (lib.toList b.map)) == 0) (cfg.binds ++ cfg.macros)) == [ ]);
+        message = "The 'programs.neomutt.(binds|macros).map' list must contain at least one element.";
+      }
+    ];
 
     warnings =
       let


### PR DESCRIPTION


### Description

If neither neomutt.sendMailCommand nor passCmd are set, leave configuration for sending emails unset.  This will leave neomutt to manage sending emails itself, which matches the existing description of the `accounts.email.accounts.<name>.neomutt.sendMailCommand` configuration option.

This also removes the assertion added in #7414 / bd680a8c (neomutt: allow default email sending behaviour, 2025-07-12), since it is now valid to have neither passCmd nor neomutt.sendMailCommand on an account.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- ~[ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~ There are no existing tests for `neomutt.sendMailCommand`; there probably ought to be some, but I don't want to delay this fix for writing those.

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

Paging @teto as the person who looked at #7414