### PR TITLE
wayfire: fix broken configuration.ini test

### DIFF
--- a/tests/modules/services/wayfire/configuration.ini
+++ b/tests/modules/services/wayfire/configuration.ini
@@ -10,4 +10,4 @@ plugins=command expo cube autostart
 xwayland=true
 
 [cube]
-skydome_texture=/nix/store/yk5hl40w5254k2xkicn32l8ky8sfm9va-dummy
+skydome_texture=/nix/store/00000000000000000000000000000000-dummy

--- a/tests/modules/services/wayfire/configuration.nix
+++ b/tests/modules/services/wayfire/configuration.nix
@@ -14,9 +14,7 @@
   };
 
   nmt.script = ''
-    wayfireConfig=home-files/.config/wayfire.ini
-
-    assertFileExists "$wayfireConfig"
-    assertFileContent "$wayfireConfig" "${./configuration.ini}"
+    assertFileExists home-files/.config/wayfire.ini
+    assertFileContent "$(normalizeStorePaths home-files/.config/wayfire.ini)" "${./configuration.ini}"
   '';
 }


### PR DESCRIPTION
### Description
The `configuration.nix` test was failing on aarch-64. ~~I'm not sure this is the cleanest way to fix this, wavnc seems to get the `/nix/store/00000000000000000000000000000000-dummy` by default? See [here](https://github.com/nix-community/home-manager/blob/master/tests/modules/services/wayvnc/simple.nix#L5) and [here](https://github.com/nix-community/home-manager/blob/master/tests/modules/services/wayvnc/simple.service#L5)~~

Closes #7477

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
