### PR TITLE
treewide: Remove unwanted dependencies

### DIFF
--- a/modules/programs/alot/accounts.nix
+++ b/modules/programs/alot/accounts.nix
@@ -23,6 +23,15 @@ in
           "'\\[?{" + ''"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"'' + "}[,\\]]?'";
         shellcommand_external_filtering = "False";
       };
+      defaultText = lib.literalExpression ''
+        {
+          type = "shellcommand";
+          command = "''\'''${pkgs.notmuch}/bin/notmuch address --format=json --output=recipients  date:6M..'";
+          regexp =
+          "'\\[?{" + '''"name": "(?P<name>.*)", "address": "(?P<email>.+)", "name-addr": ".*"''' + "}[,\\]]?'";
+          shellcommand_external_filtering = "False";
+        }
+      '';
       example = lib.literalExpression ''
         {
           type = "shellcommand";

--- a/modules/programs/awscli.nix
+++ b/modules/programs/awscli.nix
@@ -41,7 +41,7 @@ in
       example = lib.literalExpression ''
         {
           "default" = {
-            "credential_process" = "${pkgs.pass}/bin/pass show aws";
+            "credential_process" = "''${pkgs.pass}/bin/pass show aws";
           };
         };
       '';

--- a/modules/programs/newsboat.nix
+++ b/modules/programs/newsboat.nix
@@ -122,6 +122,7 @@ in
       browser = mkOption {
         type = types.str;
         default = "${pkgs.xdg-utils}/bin/xdg-open";
+        defaultText = lib.literalExpression "\${pkgs.xdg-utils}/bin/xdg-open";
         description = "External browser to use.";
       };
 

--- a/modules/programs/ranger.nix
+++ b/modules/programs/ranger.nix
@@ -137,7 +137,7 @@ in
               description = ''
                 A command to run for the matching file.
               '';
-              example = literalExpression ''"${pkgs.vim}/bin/vim -- \"$@\""'';
+              example = literalExpression ''"''${pkgs.vim}/bin/vim -- \"$@\""'';
             };
           };
         }

--- a/modules/programs/swayr.nix
+++ b/modules/programs/swayr.nix
@@ -26,7 +26,7 @@ in
       default = { };
       example = lib.literalExpression ''
         menu = {
-          executable = "${pkgs.wofi}/bin/wofi";
+          executable = "''${pkgs.wofi}/bin/wofi";
           args = [
             "--show=dmenu"
             "--allow-markup"

--- a/modules/programs/termite.nix
+++ b/modules/programs/termite.nix
@@ -124,7 +124,7 @@ in
       browser = mkOption {
         default = null;
         type = types.nullOr types.str;
-        example = "${pkgs.xdg-utils}/xdg-open";
+        example = "\${pkgs.xdg-utils}/xdg-open";
         description = ''
           Set the default browser for opening links. If its not set, $BROWSER is read.
           If that's not set, url hints will be disabled.

--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -302,7 +302,7 @@ in
 
       shell = mkOption {
         default = defaultShell;
-        example = literalExpression "${pkgs.zsh}/bin/zsh";
+        example = literalExpression "\${pkgs.zsh}/bin/zsh";
         type = with types; nullOr str;
         description = "Set the default-shell tmux variable.";
       };

--- a/modules/services/fluidsynth.nix
+++ b/modules/services/fluidsynth.nix
@@ -20,6 +20,9 @@ in
       soundFont = mkOption {
         type = types.path;
         default = "${pkgs.soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2";
+        defaultText = lib.literalExpression ''
+          "''${pkgs.soundfont-fluid}/share/soundfonts/FluidR3_GM2-2.sf2";
+        '';
         description = ''
           The soundfont file to use, in SoundFont 2 format.
         '';

--- a/modules/services/grobi.nix
+++ b/modules/services/grobi.nix
@@ -43,8 +43,8 @@ in
               primary = true;
               atomic = true;
               execute_after = [
-                "${pkgs.xorg.xrandr}/bin/xrandr --dpi 96"
-                "${pkgs.xmonad-with-packages}/bin/xmonad --restart";
+                "''${pkgs.xorg.xrandr}/bin/xrandr --dpi 96"
+                "''${pkgs.xmonad-with-packages}/bin/xmonad --restart";
               ];
             }
             {
@@ -54,8 +54,8 @@ in
               primary = true;
               atomic = true;
               execute_after = [
-                "${pkgs.xorg.xrandr}/bin/xrandr --dpi 120"
-                "${pkgs.xmonad-with-packages}/bin/xmonad --restart";
+                "''${pkgs.xorg.xrandr}/bin/xrandr --dpi 120"
+                "''${pkgs.xmonad-with-packages}/bin/xmonad --restart";
               ];
             }
           ]

--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -76,8 +76,8 @@ in
         default = [ ];
         example = literalExpression ''
           [
-            { timeout = 60; command = "${pkgs.swaylock}/bin/swaylock -fF"; }
-            { timeout = 90; command = "${pkgs.systemd}/bin/systemctl suspend"; }
+            { timeout = 60; command = "''${pkgs.swaylock}/bin/swaylock -fF"; }
+            { timeout = 90; command = "''${pkgs.systemd}/bin/systemctl suspend"; }
           ]
         '';
         description = "List of commands to run after idle timeout.";
@@ -88,7 +88,7 @@ in
         default = [ ];
         example = literalExpression ''
           [
-            { event = "before-sleep"; command = "${pkgs.swaylock}/bin/swaylock -fF"; }
+            { event = "before-sleep"; command = "''${pkgs.swaylock}/bin/swaylock -fF"; }
             { event = "lock"; command = "lock"; }
           ]
         '';

--- a/modules/services/twmn.nix
+++ b/modules/services/twmn.nix
@@ -54,7 +54,7 @@ in
     extraConfig = mkOption {
       type = types.attrs;
       default = { };
-      example = literalExpression ''{ main.activation_command = "\${pkgs.hello}/bin/hello"; }'';
+      example = literalExpression ''{ main.activation_command = "''${pkgs.hello}/bin/hello"; }'';
       description = ''
         Extra configuration options to add to the twmnd config file. See
         <https://github.com/sboli/twmn/blob/master/README.md>

--- a/modules/services/unison.nix
+++ b/modules/services/unison.nix
@@ -42,6 +42,16 @@ let
           batch = "true";
           log = "false"; # don't log to file, handled by systemd
         };
+        defaultText = lib.literalExpression ''
+          {
+            repeat = "watch";
+            sshcmd = "''${pkgs.openssh}/bin/ssh";
+            ui = "text";
+            auto = "true";
+            batch = "true";
+            log = "false"; # don't log to file, handled by systemd
+          }
+        '';
         description = ''
           Additional command line options as a dictionary to pass to the
           `unison` program.

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -98,7 +98,6 @@ let
               defaultText = literalExpression ''
                 null for state version ≥ 20.09, as example otherwise
               '';
-              example = default;
             }
           );
       in
@@ -181,7 +180,7 @@ let
               pkg = if isSway && isNull cfg.package then pkgs.sway else cfg.package;
             in
             "${pkg}/bin/${moduleName}bar";
-          defaultText = "i3bar";
+          defaultText = literalExpression "i3bar";
           description = "Command that will be used to start a bar.";
           example = if isI3 then "\${pkgs.i3}/bin/i3bar -t" else "\${pkgs.waybar}/bin/waybar";
         };
@@ -189,6 +188,7 @@ let
         statusCommand = mkNullableOption {
           type = types.str;
           default = "${pkgs.i3status}/bin/i3status";
+          defaultText = literalExpression "\${pkgs.i3status}/bin/i3status";
           description = "Command that will be used to get status lines.";
         };
 
@@ -959,6 +959,9 @@ in
   terminal = mkOption {
     type = types.str;
     default = if isI3 then "i3-sensible-terminal" else "${pkgs.foot}/bin/foot";
+    defaultText = literalExpression (
+      if isI3 then ''"i3-sensible-terminal"'' else "\${pkgs.foot}/bin/foot"
+    );
     description = "Default terminal to run.";
     example = "alacritty";
   };
@@ -970,6 +973,12 @@ in
         "${pkgs.dmenu}/bin/dmenu_path | ${pkgs.dmenu}/bin/dmenu | ${pkgs.findutils}/bin/xargs swaymsg exec --"
       else
         "${pkgs.dmenu}/bin/dmenu_run";
+    defaultText = literalExpression (
+      if isSway then
+        "\${pkgs.dmenu}/bin/dmenu_path | \${pkgs.dmenu}/bin/dmenu | \${pkgs.findutils}/bin/xargs swaymsg exec --"
+      else
+        "\${pkgs.dmenu}/bin/dmenu_run"
+    );
     description = "Default launcher to use.";
     example = "bemenu-run";
   };

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -155,9 +155,9 @@ let
           let
             modifier = config.wayland.windowManager.sway.config.modifier;
           in lib.mkOptionDefault {
-            "''${modifier}+Return" = "exec ${cfg.config.terminal}";
+            "''${modifier}+Return" = "exec ''${cfg.config.terminal}";
             "''${modifier}+Shift+q" = "kill";
-            "''${modifier}+d" = "exec ${cfg.config.menu}";
+            "''${modifier}+d" = "exec ''${cfg.config.menu}";
           }
         '';
       };
@@ -509,7 +509,7 @@ in
         withBaseWrapper = cfg.wrapperFeatures.base;
         withGtkWrapper = cfg.wrapperFeatures.gtk;
       };
-      defaultText = lib.literalExpression "${pkgs.sway}";
+      defaultText = lib.literalExpression "\${pkgs.sway}";
       description = ''
         Sway package to use. Will override the options
         'wrapperFeatures', 'extraSessionCommands', and 'extraOptions'.


### PR DESCRIPTION
### Description

Fixes interpolation of packages in the default and example texts.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
