### PR TITLE
radio-cli: add module

### DIFF
--- a/modules/programs/radio-cli.nix
+++ b/modules/programs/radio-cli.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.radio-cli;
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+
+  options.programs.radio-cli = {
+    enable = mkEnableOption "radio-cli";
+    package = mkPackageOption pkgs "radio-cli" { nullable = true; };
+    settings = mkOption {
+      type = jsonFormat.type;
+      default = { };
+      example = {
+        config_version = "2.3.0";
+        max_lines = 7;
+        country = "ES";
+        data = [
+          {
+            station = "lofi";
+            url = "https://www.youtube.com/live/jfKfPfyJRdk?si=WDl-XdfuhxBfe6XN";
+          }
+        ];
+      };
+      description = ''
+        Configuration settings for radio-cli. For an example config,
+        refer to: <https://github.com/margual56/radio-cli/blob/main/config.json>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."radio-cli/config.json" = mkIf (cfg.settings != { }) {
+      source = jsonFormat.generate "radio-cli-config" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/radio-cli/config.json
+++ b/tests/modules/programs/radio-cli/config.json
@@ -1,0 +1,11 @@
+{
+  "config_version": "2.3.0",
+  "country": "ES",
+  "data": [
+    {
+      "station": "lofi",
+      "url": "https://www.youtube.com/live/jfKfPfyJRdk?si=WDl-XdfuhxBfe6XN"
+    }
+  ],
+  "max_lines": 7
+}

--- a/tests/modules/programs/radio-cli/default.nix
+++ b/tests/modules/programs/radio-cli/default.nix
@@ -1,0 +1,1 @@
+{ radio-cli-example = ./example-config.nix; }

--- a/tests/modules/programs/radio-cli/example-config.nix
+++ b/tests/modules/programs/radio-cli/example-config.nix
@@ -1,0 +1,22 @@
+{
+  programs.radio-cli = {
+    enable = true;
+    settings = {
+      config_version = "2.3.0";
+      max_lines = 7;
+      country = "ES";
+      data = [
+        {
+          station = "lofi";
+          url = "https://www.youtube.com/live/jfKfPfyJRdk?si=WDl-XdfuhxBfe6XN";
+        }
+      ];
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/radio-cli/config.json
+    assertFileContent home-files/.config/radio-cli/config.json \
+    ${./config.json}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring [radio-cli](https://github.com/margual56/radio-cli).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
