### PR TITLE
direnv: fix `get -i` nushell deprecation

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -193,8 +193,8 @@ in
                           }
                         }
                         | merge ($env.ENV_CONVERSIONS? | default {})
-                        | get -i ([[value, optional, insensitive]; [$key, false, true]] | into cell-path)
-                        | get -i from_string
+                        | get ([[value, optional, insensitive]; [$key, true, true]] | into cell-path)
+                        | get from_string?
                         | if ($in | is-empty) { {|x| $x} } else { $in }
                     ) $value
                     return [ $key $value ]


### PR DESCRIPTION
Since https://github.com/nushell/nushell/pull/16007, the recommended flag is `--optional`. To avoid compatibility issues, the builtin optional access syntax is used instead, which is backwards-compatible.

A bunch of other nushell integrations are breaking as well, I could add hotfixes for those but I rather target the upstream. In the meantime, this fixed all the warnings  I got if anyone's getting annoyed by them:

```nix
programs.mise.enableNushellIntegration = false;
programs.nushell.extraConfig = lib.mkMerge [
    (lib.mkBefore ''
      def --wrapped 'get -i' [path, ...rest] { get -o $path ...$rest }
      def --wrapped 'get --ignore-errors' [path, ...rest] { get -o $path ...$rest }
    '')
    # mise is the only integration I found that uses `get $path -i`, which doesn't go through the wrapper
    (lib.mkIf config.programs.mise.enable ''
      use ${
        pkgs.runCommand "mise-nushell-config.nu" { } ''
          ${lib.getExe config.programs.mise.package} activate nu | sed 's|--ignore-errors|--optional|g' | sed 's|get -i|get -o|g' > "$out"
        ''
      }
    '')
  ];
```

As this is a 2 day-old change it's probably not affecting a lot of users yet, I just happened to update my nightly build today.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@khaneliman @rycee @shikanime @Philipp-M @aidalgol 
