### PR TITLE
Add ghidra module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -121,14 +121,6 @@
     github = "danjujan";
     githubId = 44864658;
   };
-  delafthi = {
-    name = "Thierry Delafontaine";
-    email = "delafthi@pm.me";
-    matrix = "@delafthi:matrix.org";
-    github = "delafthi";
-    githubId = 50531499;
-    keys = [ { fingerprint = "6DBB 0BB9 AEE6 2C2A 8059  7E1C 0092 6686 9818 63CB"; } ];
-  };
   Dines97 = {
     name = "Denis Kaynar";
     email = "19364873+Dines97@users.noreply.github.com";
@@ -329,12 +321,6 @@
     email = "lunab08@proton.me";
     github = "miku4k";
     githubId = 89653242;
-  };
-  m0nsterrr = {
-    name = "Ludovic Ortega";
-    email = "nix@mail.adminafk.fr";
-    github = "M0NsTeRRR";
-    githubId = 37785089;
   };
   mager = {
     email = "andreas@mager.eu";

--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -147,6 +147,12 @@
     githubId = 32838899;
     name = "Daniel Wagenknecht";
   };
+  ErrorTeaPot = {
+    name = "ErrorTeaPot";
+    email = "home-manager.u7iqn@simplelogin.com";
+    github = "ErrorTeaPot";
+    githubId = 98967114;
+  };
   fendse = {
     email = "46252070+Fendse@users.noreply.github.com";
     github = "Fendse";

--- a/modules/programs/ghidra.nix
+++ b/modules/programs/ghidra.nix
@@ -1,0 +1,45 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.ghidra;
+in
+{
+  options.programs.ghidra = {
+    enable = lib.mkEnableOption "Ghidra, a software reverse engineering (SRE) suite of tools";
+
+    gdb = lib.mkOption {
+      default = true;
+      type = lib.types.bool;
+      description = ''
+        Whether to add to gdbinit the python modules required to make Ghidra's debugger work.
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "ghidra" { example = "ghidra-bin"; };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile = lib.mkIf cfg.gdb {
+      "gdb/gdbinit.d/ghidra-modules.gdb".text = with pkgs.python3.pkgs; ''
+        python
+        import sys
+        [sys.path.append(p) for p in "${
+          (makePythonPath [
+            psutil
+            protobuf
+          ])
+        }".split(":")]
+        end
+      '';
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ ErrorTeaPot ];
+}

--- a/modules/programs/ghidra.nix
+++ b/modules/programs/ghidra.nix
@@ -41,5 +41,5 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ ErrorTeaPot ];
+  meta.maintainers = with lib.hm.maintainers; [ ErrorTeaPot ];
 }

--- a/tests/modules/programs/ghidra/basic-configuration.nix
+++ b/tests/modules/programs/ghidra/basic-configuration.nix
@@ -9,7 +9,7 @@
 
     nmt.script = ''
       gdbConfigDir=home-files/.config/gdb
-      assertFileExists $configDir/gdbinit.d/ghidra-modules.gdb
+      assertFileExists $gdbConfigDir/gdbinit.d/ghidra-modules.gdb
     '';
   };
 }

--- a/tests/modules/programs/ghidra/basic-configuration.nix
+++ b/tests/modules/programs/ghidra/basic-configuration.nix
@@ -1,0 +1,15 @@
+{ config, ... }:
+
+{
+  config = {
+    programs.ghidra = {
+      enable = true;
+      gdb = true;
+    };
+
+    nmt.script = ''
+      gdbConfigDir=home-files/.config/gdb
+      assertFileExists $configDir/gdbinit.d/ghidra-modules.gdb
+    '';
+  };
+}

--- a/tests/modules/programs/ghidra/default.nix
+++ b/tests/modules/programs/ghidra/default.nix
@@ -1,0 +1,4 @@
+{ lib, pkgs, ... }:
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  ghidra-basic-configuration = ./basic-configuration.nix;
+}


### PR DESCRIPTION
### Description

I am adding a Ghidra module. I have ported the nixpkgs one to home-manager with some changes for user-level compatibility.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC
