### PR TITLE
nushell: fix broken direnv integration

### DIFF
--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -175,8 +175,7 @@ in
                             }
                           }
                           | merge ($env.ENV_CONVERSIONS? | default {})
-                          | get ([[value, optional, insensitive]; [$key, true, true]] | into cell-path)
-                          | get from_string?
+                          | get ([[value, optional, insensitive]; [$key, true, true] [from_string, true, false]] | into cell-path)
                           | if ($in | is-empty) { {|x| $x} } else { $in }
                       ) $value
                       return [ $key $value ]


### PR DESCRIPTION
### Description

Fixes #7497

After #7490, direnv integration broke for non-nightly nushell builds. I think the error that is triggered is a bug that got fixed and was not released yet:

```nushell
{} | get random_field? | get -i another_field # returns null/nothing as expected

# However
{} | get random_field? | get another_field? # ERROR: only table or record input data is supported. Input type: nothing
```

This PR joins the two `get` calls into a single one to avoid that error. This still avoids using potentially-breaking `-i` and `-o` flags. And this time, it was tested on both nightly and non-nightly (0.105.1).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@khaneliman @rycee @shikanime @Philipp-M @aidalgol
