### PR TITLE
command-not-found: sync with nixpkgs

### DIFF
--- a/modules/programs/command-not-found/command-not-found.pl
+++ b/modules/programs/command-not-found/command-not-found.pl
@@ -10,6 +10,24 @@ my $program = $ARGV[0];
 
 my $dbPath = "@dbPath@";
 
+if (! -e $dbPath) {
+    print STDERR "$program: command not found\n";
+    print STDERR "\n";
+    print STDERR "command-not-found: Missing package database\n";
+    print STDERR "command-not-found is a tool for searching for missing packages.\n";
+    print STDERR "No database was found, this likely means the database hasn't been generated yet.\n";
+    print STDERR "This tool requires nix-channels to generate the database for the `nixos` channel.\n";
+    print STDERR "\n";
+    print STDERR "If you are using nix-channels you can run:\n";
+    print STDERR "    sudo nix-channels --update\n";
+    print STDERR "\n";
+    print STDERR "If you are using flakes, see nix-index and nix-index-database.\n";
+    print STDERR "\n";
+    print STDERR "If you would like to disable this message you can set:\n";
+    print STDERR "    programs.command-not-found.enable = false;\n";
+    exit 127;
+}
+
 my $dbh = DBI->connect("dbi:SQLite:dbname=$dbPath", "", "")
     or die "cannot open database `$dbPath'";
 $dbh->{RaiseError} = 0;
@@ -21,11 +39,24 @@ my $res = $dbh->selectall_arrayref(
     "select package from Programs where system = ? and name = ?",
     { Slice => {} }, $system, $program);
 
-if (!defined $res || scalar @$res == 0) {
+my $len = !defined $res ? 0 : scalar @$res;
+
+if ($len == 0) {
     print STDERR "$program: command not found\n";
-} elsif (scalar @$res == 1) {
+} elsif ($len == 1) {
     my $package = @$res[0]->{package};
     if ($ENV{"NIX_AUTO_RUN"} // "") {
+        if ($ENV{"NIX_AUTO_RUN_INTERACTIVE"} // "") {
+            while (1) {
+                print STDERR "'$program' from package '$package' will be run, confirm? [yn]: ";
+                chomp(my $comfirm = <STDIN>);
+                if (lc $comfirm eq "n") {
+                    exit 0;
+                } elsif (lc $comfirm eq "y") {
+                    last;
+                }
+            }
+        }
         exec("nix-shell", "-p", $package, "--run", shell_quote("exec", @ARGV));
     } else {
         print STDERR <<EOF;
@@ -35,11 +66,30 @@ ephemeral shell by typing:
 EOF
     }
 } else {
-    print STDERR <<EOF;
+    if ($ENV{"NIX_AUTO_RUN"} // "") {
+        print STDERR "Select a package that provides '$program':\n";
+        for my $i (0 .. $len - 1) {
+            print STDERR "  [", $i + 1, "]: @$res[$i]->{package}\n";
+        }
+        my $choice = 0;
+        while (1) { # exec will break this loop
+            no warnings "numeric";
+            print STDERR "Your choice [1-${len}]: ";
+            # 0 can be invalid user input like non-number string
+            # so we start from 1
+            $choice = <STDIN> + 0;
+            if (1 <= $choice && $choice <= $len) {
+                exec("nix-shell", "-p", @$res[$choice - 1]->{package},
+                    "--run", shell_quote("exec", @ARGV));
+            }
+        }
+    } else {
+        print STDERR <<EOF;
 The program '$program' is not in your PATH. It is provided by several packages.
 You can make it available in an ephemeral shell by typing one of the following:
 EOF
-    print STDERR "  nix-shell -p $_->{package}\n" foreach @$res;
+        print STDERR "  nix-shell -p $_->{package}\n" foreach @$res;
+    }
 }
 
 exit 127;


### PR DESCRIPTION
### Description

Updates command-not-found.pl and adds fish compatibility.

I think nix-index needs to be updated since this adds fish compatibility, would appreciate some advice here.

https://github.com/nix-community/home-manager/blob/d0300c8808e41da81d6edfc202f3d3833c157daf/tests/modules/programs/nix-index/integrations.nix#L15-L18
https://github.com/nix-community/home-manager/blob/d0300c8808e41da81d6edfc202f3d3833c157daf/tests/modules/programs/nix-index/assert-on-command-not-found.nix#L10-L13

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@uvNikita @SuperSandro2000 
