### PR TITLE
mkFirefoxModule: policies option work for darwin

### DIFF
--- a/modules/programs/firefox/default.nix
+++ b/modules/programs/firefox/default.nix
@@ -33,6 +33,7 @@ in
       };
       platforms.darwin = {
         configPath = "Library/Application Support/Firefox";
+        defaultsId = "org.mozilla.firefox.plist";
       };
     })
 

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -274,6 +274,12 @@ in
       default = wrappedPackageName;
       description = "Name of the wrapped browser package.";
     };
+    darwinDefaultsId = mkOption rec {
+      type = types.nullOr types.str;
+      default = if platforms.darwin ? "defaultsId" then platforms.darwin.defaultsId else null;
+      example = if default != null then default else "com.developer.app";
+      description = ''The id for the darwin defaults in order to set policies'';
+    };
 
     darwinAppName = mkOption {
       internal = true;
@@ -914,7 +920,15 @@ in
           Using '${moduleName}.vendorPath' has been deprecated and
           will be removed in the future. Native messaging hosts will function normally without specifying this path.
         '';
+      targets.darwin.defaults = (
+        mkIf (cfg.darwinDefaultsId != null && isDarwin) {
 
+          ${cfg.darwinDefaultsId} = {
+            EnterprisePoliciesEnabled = true;
+          }
+          // cfg.policies;
+        }
+      );
       home.packages = lib.optional (cfg.finalPackage != null) cfg.finalPackage;
 
       home.file = mkMerge (


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC
@rycee 
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
