### PR TITLE
opencode: add support for global custom instructions via rules option and add empty settings test

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -41,13 +41,49 @@ in
         See <https://opencode.ai/docs/config/> for the documentation.
       '';
     };
+    rules = lib.mkOption {
+      type = lib.types.lines;
+      description = "You can provide global custom instructions to opencode; this value is written to {file}~/.config/opencode/AGENTS.md";
+      default = "";
+      example = lib.literalExpression ''
+        '''
+          # TypeScript Project Rules
+
+          ## External File Loading
+
+          CRITICAL: When you encounter a file reference (e.g., @rules/general.md), use your Read tool to load it on a need-to-know basis. They're relevant to the SPECIFIC task at hand.
+
+          Instructions:
+
+          - Do NOT preemptively load all references - use lazy loading based on actual need
+          - When loaded, treat content as mandatory instructions that override defaults
+          - Follow references recursively when needed
+
+          ## Development Guidelines
+
+          For TypeScript code style and best practices: @docs/typescript-guidelines.md
+          For React component architecture and hooks patterns: @docs/react-patterns.md
+          For REST API design and error handling: @docs/api-standards.md
+          For testing strategies and coverage requirements: @test/testing-guidelines.md
+
+          ## General Guidelines
+
+          Read the following file immediately as it's relevant to all workflows: @rules/general-guidelines.md.
+        '''
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
     home.packages = mkIf (cfg.package != null) [ cfg.package ];
 
-    xdg.configFile."opencode/config.json" = mkIf (cfg.settings != { }) {
-      source = jsonFormat.generate "config.json" cfg.settings;
+    xdg.configFile = {
+      "opencode/config.json" = mkIf (cfg.settings != { }) {
+        source = jsonFormat.generate "config.json" cfg.settings;
+      };
+      "opencode/AGENTS.md" = mkIf (cfg.rules != "") {
+        text = cfg.rules;
+      };
     };
   };
 }

--- a/tests/modules/programs/opencode/AGENTS.md
+++ b/tests/modules/programs/opencode/AGENTS.md
@@ -1,0 +1,22 @@
+# TypeScript Project Rules
+
+## External File Loading
+
+CRITICAL: When you encounter a file reference (e.g., @rules/general.md), use your Read tool to load it on a need-to-know basis. They're relevant to the SPECIFIC task at hand.
+
+Instructions:
+
+- Do NOT preemptively load all references - use lazy loading based on actual need
+- When loaded, treat content as mandatory instructions that override defaults
+- Follow references recursively when needed
+
+## Development Guidelines
+
+For TypeScript code style and best practices: @docs/typescript-guidelines.md
+For React component architecture and hooks patterns: @docs/react-patterns.md
+For REST API design and error handling: @docs/api-standards.md
+For testing strategies and coverage requirements: @test/testing-guidelines.md
+
+## General Guidelines
+
+Read the following file immediately as it's relevant to all workflows: @rules/general-guidelines.md.

--- a/tests/modules/programs/opencode/default.nix
+++ b/tests/modules/programs/opencode/default.nix
@@ -1,5 +1,6 @@
 {
   opencode-settings = ./settings.nix;
+  opencode-empty-settings = ./empty-settings.nix;
   opencode-rules = ./rules.nix;
   opencode-empty-rules = ./empty-rules.nix;
 }

--- a/tests/modules/programs/opencode/default.nix
+++ b/tests/modules/programs/opencode/default.nix
@@ -1,3 +1,5 @@
 {
   opencode-settings = ./settings.nix;
+  opencode-rules = ./rules.nix;
+  opencode-empty-rules = ./empty-rules.nix;
 }

--- a/tests/modules/programs/opencode/empty-rules.nix
+++ b/tests/modules/programs/opencode/empty-rules.nix
@@ -1,0 +1,9 @@
+{
+  programs.opencode = {
+    enable = true;
+    rules = "";
+  };
+  nmt.script = ''
+    assertPathNotExists home-files/.config/opencode/AGENTS.md
+  '';
+}

--- a/tests/modules/programs/opencode/empty-settings.nix
+++ b/tests/modules/programs/opencode/empty-settings.nix
@@ -1,0 +1,9 @@
+{
+  programs.opencode = {
+    enable = true;
+    settings = { };
+  };
+  nmt.script = ''
+    assertPathNotExists home-files/.config/opencode/config.json
+  '';
+}

--- a/tests/modules/programs/opencode/rules.nix
+++ b/tests/modules/programs/opencode/rules.nix
@@ -1,0 +1,34 @@
+{
+  programs.opencode = {
+    enable = true;
+    rules = ''
+      # TypeScript Project Rules
+
+      ## External File Loading
+
+      CRITICAL: When you encounter a file reference (e.g., @rules/general.md), use your Read tool to load it on a need-to-know basis. They're relevant to the SPECIFIC task at hand.
+
+      Instructions:
+
+      - Do NOT preemptively load all references - use lazy loading based on actual need
+      - When loaded, treat content as mandatory instructions that override defaults
+      - Follow references recursively when needed
+
+      ## Development Guidelines
+
+      For TypeScript code style and best practices: @docs/typescript-guidelines.md
+      For React component architecture and hooks patterns: @docs/react-patterns.md
+      For REST API design and error handling: @docs/api-standards.md
+      For testing strategies and coverage requirements: @test/testing-guidelines.md
+
+      ## General Guidelines
+
+      Read the following file immediately as it's relevant to all workflows: @rules/general-guidelines.md.
+    '';
+  };
+  nmt.script = ''
+    assertFileExists home-files/.config/opencode/AGENTS.md
+    assertFileContent home-files/.config/opencode/AGENTS.md \
+      ${./AGENTS.md}
+  '';
+}


### PR DESCRIPTION
### Description

- Introduce `rules` option to provide global custom instructions for opencode
- Update tests to cover presence and absence of `AGENTS.md` file with rules content
- Add `empty-settings` test to ensure the config file is **not** generated when no settings are provided

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
