### PR TITLE
hyprland: Add `"output"` to `importantPrefixes` option default

### DIFF
--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -250,6 +250,7 @@ in
         "$"
         "bezier"
         "name"
+        "output"
       ];
       example = [
         "$"

--- a/tests/modules/services/hyprland/simple-config.conf
+++ b/tests/modules/services/hyprland/simple-config.conf
@@ -32,6 +32,14 @@ input {
   kb_layout=ro
 }
 
+monitorv2 {
+  output=desc:Monitor
+  mode=highres
+  position=auto-right
+  scale=1
+  vrr=1
+}
+
 plugin {
   plugin1 {
     section {

--- a/tests/modules/services/hyprland/simple-config.nix
+++ b/tests/modules/services/hyprland/simple-config.nix
@@ -10,6 +10,16 @@
     settings = {
       source = [ "sourced.conf" ];
 
+      monitorv2 = [
+        {
+          output = "desc:Monitor";
+          mode = "highres";
+          position = "auto-right";
+          scale = 1;
+          vrr = 1;
+        }
+      ];
+
       decoration = {
         shadow_offset = "0 5";
         "col.shadow" = "rgba(00000099)";


### PR DESCRIPTION
### Description

Add "output" to `importantPrefixes` option default to support `monitorv2` Hyprland syntax.
Fixes #7230.
Expand `test-hyprland-simple-config` to include a `monitorv2` option.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@fufexan 
