### PR TITLE
iamb: use correct config directory on macOS

### DIFF
--- a/modules/programs/iamb.nix
+++ b/modules/programs/iamb.nix
@@ -7,6 +7,11 @@
 let
   cfg = config.programs.iamb;
   tomlFormat = pkgs.formats.toml { };
+  configDir =
+    if pkgs.stdenv.isDarwin && !config.xdg.enable then
+      "Library/Application Support"
+    else
+      config.xdg.configHome;
 in
 {
   options.programs.iamb = {
@@ -46,7 +51,7 @@ in
   config = lib.mkIf cfg.enable {
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-    xdg.configFile."iamb/config.toml" = lib.mkIf (cfg.settings != { }) {
+    home.file."${configDir}/iamb/config.toml" = lib.mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "iamb-config" cfg.settings;
     };
   };


### PR DESCRIPTION
On macOS, configuration files are stored in the platform-standard directory `~/Library/Application Support/` by default. However, if the user enables the XDG Base Directory specification by setting `xdg.enable = true`, iamb should respect the `XDG_CONFIG_HOME` environment variable (along with other related XDG variables). Currently, this behavior is not implemented in iamb, a PR has been opened to fix that -> https://github.com/ulyssa/iamb/pull/478.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
