### PR TITLE
Description

### DIFF
--- a/modules/services/pueue.nix
+++ b/modules/services/pueue.nix
@@ -5,11 +5,10 @@
   ...
 }:
 let
-
   cfg = config.services.pueue;
   yamlFormat = pkgs.formats.yaml { };
   configFile = yamlFormat.generate "pueue.yaml" ({ shared = { }; } // cfg.settings);
-
+  pueuedBin = "${cfg.package}/bin/pueued";
 in
 {
   meta.maintainers = [ lib.maintainers.AndersonTorres ];
@@ -36,28 +35,51 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    assertions = [
-      (lib.hm.assertions.assertPlatform "services.pueue" pkgs lib.platforms.linux)
-    ];
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+      }
+      (lib.mkIf pkgs.stdenv.isLinux {
+        xdg.configFile."pueue/pueue.yml".source = configFile;
+        systemd.user = lib.mkIf (cfg.package != null) {
+          services.pueued = {
+            Unit = {
+              Description = "Pueue Daemon - CLI process scheduler and manager";
+            };
 
-    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+            Service = {
+              Restart = "on-failure";
+              ExecStart = "${pueuedBin} -v -c ${configFile}";
+            };
 
-    xdg.configFile."pueue/pueue.yml".source = configFile;
-
-    systemd.user = lib.mkIf (cfg.package != null) {
-      services.pueued = {
-        Unit = {
-          Description = "Pueue Daemon - CLI process scheduler and manager";
+            Install.WantedBy = [ "default.target" ];
+          };
         };
+      })
+      (lib.mkIf pkgs.stdenv.isDarwin {
+        # This is the default configuration file location for pueue on
+        # darwin (https://github.com/Nukesor/pueue/wiki/Configuration)
+        home.file."Library/Application Support/pueue/pueue.yml".source = configFile;
+        launchd.agents.pueued = {
+          enable = true;
 
-        Service = {
-          Restart = "on-failure";
-          ExecStart = "${cfg.package}/bin/pueued -v -c ${configFile}";
+          config = {
+            ProgramArguments = [
+              pueuedBin
+              "-v"
+              "-c"
+              "${configFile}"
+            ];
+            KeepAlive = {
+              Crashed = true;
+              SuccessfulExit = false;
+            };
+            ProcessType = "Background";
+            RunAtLoad = true;
+          };
         };
-
-        Install.WantedBy = [ "default.target" ];
-      };
-    };
-  };
+      })
+    ]
+  );
 }


### PR DESCRIPTION
pueue: enable darwin configuration

This PR enables configuring pueue for darwin. pueue already builds fine for darwin and all that was needed was a `launchd` agent.

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {desciption}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC