### PR TITLE
Enable docker-cli in 25.05 release

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -95,6 +95,7 @@ let
       ./programs/direnv.nix
       ./programs/discocss.nix
       ./programs/distrobox.nix
+      ./programs/docker-cli.nix
       ./programs/earthly.nix
       ./programs/eclipse.nix
       ./programs/element-desktop.nix

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -192,6 +192,7 @@ import nmtSrc {
       ./modules/programs/darcs
       ./modules/programs/dircolors
       ./modules/programs/direnv
+      ./modules/programs/docker-cli
       ./modules/programs/earthly
       ./modules/programs/emacs
       ./modules/programs/eza


### PR DESCRIPTION
### Description

Enable both the docker-cli module and test in 25.05

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
