### PR TITLE
yarn: add module

### DIFF
--- a/modules/programs/yarn/default.nix
+++ b/modules/programs/yarn/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    ;
+
+  cfg = config.programs.yarn;
+
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = [ lib.maintainers.friedrichaltheide ];
+
+  options.programs.yarn = {
+    enable = mkEnableOption "management of yarn config";
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = ''
+        {
+          httpProxy = "http://proxy.example.org:3128";
+          httpsProxy = "http://proxy.example.org:3128";
+        }
+      '';
+      description = ''
+        Available configuration options for yarn see:
+        <https://yarnpkg.com/configuration/yarnrc>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home = {
+      file =
+        let
+          yarnRcFileName = ".yarnrc.yml";
+        in
+        {
+          "${yarnRcFileName}" = {
+            source = yamlFormat.generate "${yarnRcFileName}" cfg.settings;
+          };
+        };
+    };
+  };
+}

--- a/tests/modules/programs/yarn/default.nix
+++ b/tests/modules/programs/yarn/default.nix
@@ -1,0 +1,4 @@
+{
+  yarn = ./example-config.nix;
+  yarn-empty-config = ./empty-config.nix;
+}

--- a/tests/modules/programs/yarn/empty-config.nix
+++ b/tests/modules/programs/yarn/empty-config.nix
@@ -1,0 +1,12 @@
+{
+  programs.yarn = {
+    settings = {
+      httpProxy = "http://proxy.example.org:3128";
+      httpsProxy = "http://proxy.example.org:3128";
+    };
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.yarnrc.yml
+  '';
+}

--- a/tests/modules/programs/yarn/example-config.nix
+++ b/tests/modules/programs/yarn/example-config.nix
@@ -1,0 +1,20 @@
+{
+  programs.yarn = {
+    enable = true;
+
+    settings = {
+      httpProxy = "http://proxy.example.org:3128";
+      httpsProxy = "http://proxy.example.org:3128";
+    };
+  };
+
+  nmt.script =
+    let
+      configPath = "home-files/.yarnrc.yml";
+    in
+    ''
+      assertFileExists ${configPath}
+      assertFileContent ${configPath} \
+        ${./example-config.yml}
+    '';
+}

--- a/tests/modules/programs/yarn/example-config.yml
+++ b/tests/modules/programs/yarn/example-config.yml
@@ -1,0 +1,2 @@
+httpProxy: http://proxy.example.org:3128
+httpsProxy: http://proxy.example.org:3128


### PR DESCRIPTION
### Description

This PR adds a yarn module allowing to write the .yarnrc file in the home directory of a user

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
