### PR TITLE
xdg-terminal-exec: init

### DIFF
--- a/modules/misc/xdg-terminal-exec.nix
+++ b/modules/misc/xdg-terminal-exec.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.xdg.terminal-exec;
+in
+{
+  options = {
+    xdg.terminal-exec = {
+      enable = lib.mkEnableOption "xdg-terminal-exec, the [proposed](https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/46) Default Terminal Execution Specification";
+      package = lib.mkPackageOption pkgs "xdg-terminal-exec" { };
+      settings = lib.mkOption {
+        type = with lib.types; attrsOf (listOf str);
+        default = { };
+        description = ''
+          Configuration options for the Default Terminal Execution Specification.
+
+          The keys are the desktop environments that are matched (case-insensitively) against `$XDG_CURRENT_DESKTOP`,
+          or `default` which is used when the current desktop environment is not found in the configuration.
+          The values are a list of terminals' [desktop file IDs](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s02.html#desktop-file-id) to try in order of decreasing priority.
+        '';
+        example = {
+          default = [ "kitty.desktop" ];
+          GNOME = [
+            "com.raggesilver.BlackBox.desktop"
+            "org.gnome.Terminal.desktop"
+          ];
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = lib.mapAttrs' (
+      desktop: terminals:
+      # map desktop name such as GNOME to `.config/gnome-xdg-terminals.list`, default to `.config/xdg-terminals.list`
+      lib.nameValuePair (
+        "${if desktop == "default" then "" else "${lib.toLower desktop}-"}xdg-terminals.list"
+      ) { text = lib.concatLines terminals; }
+    ) cfg.settings;
+  };
+
+  meta.maintainers = with lib.maintainers; [ nukdokplex ];
+}

--- a/modules/misc/xdg-terminal-exec.nix
+++ b/modules/misc/xdg-terminal-exec.nix
@@ -11,7 +11,7 @@ in
   options = {
     xdg.terminal-exec = {
       enable = lib.mkEnableOption "xdg-terminal-exec, the [proposed](https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/46) Default Terminal Execution Specification";
-      package = lib.mkPackageOption pkgs "xdg-terminal-exec" { };
+      package = lib.mkPackageOption pkgs "xdg-terminal-exec" { nullable = true; };
       settings = lib.mkOption {
         type = with lib.types; attrsOf (listOf str);
         default = { };
@@ -34,7 +34,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile = lib.mapAttrs' (
       desktop: terminals:


### PR DESCRIPTION
port xdg.terminal-exec from nixos to hm

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
