### PR TITLE
sesh: fix assumption

### DIFF
--- a/modules/programs/sesh.nix
+++ b/modules/programs/sesh.nix
@@ -92,7 +92,7 @@ in
         home.packages = lib.mkIf (cfg.zoxidePackage != null) [ cfg.zoxidePackage ];
 
         programs.tmux.extraConfig = ''
-          bind-key "${cfg.tmuxKey}" run-shell "sesh connect \"$(
+          bind-key "${cfg.tmuxKey}" run-shell " bash -c 'sesh connect \"$(
             sesh list ${args} | fzf-tmux -p 55%,60% \
               --no-sort --ansi --border-label ' sesh ' --prompt '⚡  ' \
               --header '  ^a all ^t tmux ^g configs ^x zoxide ^d tmux kill ^f find' \
@@ -104,7 +104,7 @@ in
               --bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
               --bind 'ctrl-d:execute(tmux kill-session -t {})+change-prompt(⚡  )+reload(sesh list ${args})' \
               -- ${fzf-args}
-          )\""
+          )\"'"
         '';
       })
     ]);


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Fixes an assumtion on which shell is executing the command in tmux. in fish shell this causes the key to not work. Closes:
- https://github.com/nix-community/home-manager/issues/7192
- https://github.com/nix-community/home-manager/issues/7313
- https://github.com/joshmedeski/sesh/issues/267
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC
 @michaelvanstraten
<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
