### PR TITLE
niri: init module (playground for nixpkgs KDL format)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752950548,
-        "narHash": "sha256-NS6BLD0lxOrnCiEOcvQCDVPXafX1/ek1dfJHX1nUIzc=",
-        "owner": "NixOS",
+        "lastModified": 1753316869,
+        "narHash": "sha256-46I6xjQkZqk/Hvj5z6F/R69ppfs6KoRp3BL6mAwhkFY=",
+        "owner": "sodiboo",
         "repo": "nixpkgs",
-        "rev": "c87b95e25065c028d31a94f06a62927d18763fdf",
+        "rev": "88c9f09361a3591af14b1dd0d05d2f877c370cc3",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "owner": "sodiboo",
+        "ref": "ergonomic-kdl",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Home Manager for Nix";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:sodiboo/nixpkgs/ergonomic-kdl";
 
   outputs =
     {

--- a/modules/config/home-cursor.nix
+++ b/modules/config/home-cursor.nix
@@ -93,6 +93,8 @@ let
       sway = {
         enable = mkEnableOption "sway config generation for {option}`home.pointerCursor`";
       };
+
+      niri.enable = mkEnableOption "niri config generation for {option}`home.pointerCursor`";
     };
   };
 
@@ -253,6 +255,13 @@ in
                 };
               };
             };
+          };
+        })
+
+        (mkIf cfg.niri.enable {
+          wayland.windowManager.niri.cursor = {
+            xcursor-theme = cfg.name;
+            xcursor-size = cfg.size;
           };
         })
       ]))

--- a/modules/services/window-managers/default.nix
+++ b/modules/services/window-managers/default.nix
@@ -7,6 +7,7 @@
     ./hyprland.nix
     ./i3-sway
     ./labwc
+    ./niri
     ./river.nix
     ./spectrwm.nix
     ./wayfire.nix

--- a/modules/services/window-managers/niri/cursor.nix
+++ b/modules/services/window-managers/niri/cursor.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.wayland.windowManager.niri.cursor;
+
+  kdl = pkgs.formats.kdl { version = 1; };
+in
+{
+  options.wayland.windowManager.niri.cursor = {
+
+    # defaults from https://github.com/YaLTeR/niri/blob/fefc0bc0a71556eb75352e2b611e50eb5d3bf9c2/niri-config/src/lib.rs#L989-L992
+    xcursor-theme = lib.mkOption {
+      type = lib.types.str;
+      default = "default";
+    };
+    xcursor-size = lib.mkOption {
+      type = lib.types.int;
+      default = 24;
+    };
+
+    rendered = lib.mkOption {
+      type = kdl.type.nestedTypes.node;
+      visible = false;
+      internal = true;
+      readOnly = true;
+
+      default =
+        let
+          node =
+            name: args: children:
+            kdl.lib.node null name args { } children;
+
+          plain = name: children: node name [ ] children;
+          leaf = name: args: node name args [ ];
+        in
+        plain "cursor" [
+          (leaf "xcursor-theme" cfg.xcursor-theme)
+          (leaf "xcursor-size" cfg.xcursor-size)
+          cfg.extraConfig
+        ];
+    };
+
+    extraConfig = lib.mkOption {
+      type = kdl.type;
+      default = [ ];
+      description = ''
+        Extra configuration to append to the `cursor` section of niri's configuration file.
+      '';
+    };
+  };
+}

--- a/modules/services/window-managers/niri/default.nix
+++ b/modules/services/window-managers/niri/default.nix
@@ -27,6 +27,7 @@ in
   meta.maintainers = [ lib.maintainers.sodiboo ];
 
   imports = [
+    ./xwayland-satellite.nix
   ];
 
   options.wayland.windowManager.niri = {
@@ -54,6 +55,7 @@ in
       readOnly = true;
 
       default = [
+        cfg.xwayland-satellite.rendered
         cfg.extraConfig
       ];
     };

--- a/modules/services/window-managers/niri/default.nix
+++ b/modules/services/window-managers/niri/default.nix
@@ -27,6 +27,7 @@ in
   meta.maintainers = [ lib.maintainers.sodiboo ];
 
   imports = [
+    ./cursor.nix
     ./xwayland-satellite.nix
   ];
 
@@ -55,6 +56,7 @@ in
       readOnly = true;
 
       default = [
+        cfg.cursor.rendered
         cfg.xwayland-satellite.rendered
         cfg.extraConfig
       ];

--- a/modules/services/window-managers/niri/default.nix
+++ b/modules/services/window-managers/niri/default.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.wayland.windowManager.niri;
+
+  kdl = pkgs.formats.kdl { version = 1; };
+
+  validated-config =
+    pkgs.runCommandLocal "config.kdl"
+      {
+        config = cfg.configFile;
+        nativeBuildInputs = [
+          cfg.package
+        ];
+      }
+      ''
+        niri validate -c $config
+        cp $config $out
+      '';
+in
+{
+  meta.maintainers = [ lib.maintainers.sodiboo ];
+
+  imports = [
+  ];
+
+  options.wayland.windowManager.niri = {
+    enable = lib.mkEnableOption "niri, a scrollable-tiling Wayland compositor";
+
+    package = lib.mkPackageOption pkgs "niri" { };
+
+    configFile = lib.mkOption {
+      description = ''
+        The config file to place in your home directory.
+
+        Takes priority over all other configuration options.
+      '';
+      type = lib.types.path;
+      default = kdl.generate "config.kdl" cfg.rendered;
+      defaultText = lib.literalExpression ''
+        Generated from the rest of this module.
+      '';
+    };
+
+    rendered = lib.mkOption {
+      type = kdl.type;
+      visible = false;
+      internal = true;
+      readOnly = true;
+
+      default = [
+        cfg.extraConfig
+      ];
+    };
+
+    extraConfig = lib.mkOption {
+      type = kdl.type;
+      default = [ ];
+      description = ''
+        Extra toplevel configuration to append to niri's config file.
+
+        See https://github.com/NixOS/nixpkgs/pull/426828
+      '';
+
+      example = lib.literalExpression ''
+        [
+          (node null "input" [] {} [
+            (node null "keyboard" [] {} [
+              (node null "xkb" [] {} [
+                (node null "layout" ["no"] {} [])
+              ])
+            ])
+          ])
+          (node null "output" ["eDP-1"] {} [
+            (node null "mode" ["2560x1440"] {} [])
+          ])
+          (node null "output" ["HDMI-A-1"] {} [
+            (node null "mode" ["1920x1080"] {} [])
+          ])
+        ]
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    xdg.configFile."niri/config.kdl".source = validated-config;
+  };
+}

--- a/modules/services/window-managers/niri/xwayland-satellite.nix
+++ b/modules/services/window-managers/niri/xwayland-satellite.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.wayland.windowManager.niri.xwayland-satellite;
+
+  kdl = pkgs.formats.kdl { version = 1; };
+in
+{
+  meta.maintainers = [ lib.maintainers.sodiboo ];
+
+  options.wayland.windowManager.niri.xwayland-satellite = {
+    enable = lib.mkEnableOption "xwayland-satellite integration for niri" // {
+      default = true;
+    };
+
+    package = lib.mkPackageOption pkgs "xwayland-satellite" { };
+
+    rendered = lib.mkOption {
+      type = kdl.type.nestedTypes.node;
+      visible = false;
+      internal = true;
+      readOnly = true;
+
+      default =
+        let
+          node =
+            name: args: children:
+            kdl.lib.node null name args { } children;
+
+          plain = name: children: node name [ ] children;
+          leaf = name: args: node name args [ ];
+        in
+        plain "xwayland-satellite" [
+          (lib.mkIf (!cfg.enable) [ (leaf "off" [ ]) ])
+          (lib.mkIf (cfg.enable) [
+            (leaf "path" [ (lib.getExe cfg.package) ])
+            cfg.extraConfig
+          ])
+        ];
+    };
+
+    extraConfig = lib.mkOption {
+      type = kdl.type;
+      default = [ ];
+      description = ''
+        Extra configuration to append to the `xwayland-satellite` section of niri's configuration file, if xwayland-satellite integration is enabled.
+      '';
+    };
+  };
+}


### PR DESCRIPTION
### Description

- This is a playground for testing https://github.com/NixOS/nixpkgs/pull/426828.
- It's an example of what i'd consider to be a minimal and idiomatic KDL-configured module.

It is subject to change as the nixpkgs KDL format evolves. As i open this PR; i have *not* considered the implications of compatibility with niri-flake, because `wayland.windowManagers.niri` is a totally different namespace from the `programs.niri` i use. Realistically, i guess i can just stub out `wayland.windowManagers.niri` with aliases to my own modules.

Note that `xwayland-satellite` is one of the primary things we'd want to set a default for (letting niri locate it, *without* including that in `$PATH`), but this option does not exist in stable niri. It requires the latest git. The config is expected to fail validation, unless you use a newer niri package.

---

This should probably not be merged. I want to get the "KDL style" down first; *then* i think there should be a separate PR where i focus on just how to apply that to niri. In particular, a future PR can discuss which parts are worth including in such a niri module (and maybe naming of some options like `xcursor-size`, which i deviate from in niri-flake but not in this PR). For now, just accept the general set of options i expose and their naming.

Please focus on the *general structure of the KDL-related parts of the module*:
- The naming of `extraConfig`, `rendered`, `configFile`.
- The way i'm doing the rendering (it's much inspired by niri-flake at this moment).
- Does this kind of file hierarchy make sense? I like the idea of separating it into sections like this, with each one outputting a `rendered` option.

### Related

This doesn't close any of the following issues, but it's related enough that i want to create backlinks:

- https://github.com/NixOS/nixpkgs/issues/198655
- #7250
- https://github.com/sodiboo/niri-flake/issues/480
- https://github.com/nix-community/stylix/issues/1746

Also, a reminder for myself to cc ironbar on the "real" PR later on. They want a `niri-session.target`, i believe:

- https://github.com/JakeStanger/ironbar/pull/953#discussion_r2074117855

The semantics of installation and service management are *entirely out of scope* for this PR.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
