### PR TITLE
docker-cli and yarn: fixups

### DIFF
--- a/modules/programs/docker-cli.nix
+++ b/modules/programs/docker-cli.nix
@@ -21,18 +21,18 @@ in
   options.programs.docker-cli = {
     enable = mkEnableOption "management of docker client config";
 
-    configPath = mkOption {
+    configDir = mkOption {
       type = lib.types.str;
-      default = ".docker/config.json";
+      default = ".docker";
       description = ''
-        Relative path to the user's home directory where the Docker CLI settings should be stored.
+        Folder relative to the user's home directory where the Docker CLI settings should be stored.
       '';
     };
 
     settings = mkOption {
       type = jsonFormat.type;
       default = { };
-      example = ''
+      example = lib.literalExpression ''
         {
           "proxies" = {
             "default" = {
@@ -52,11 +52,11 @@ in
   config = mkIf cfg.enable {
     home = {
       sessionVariables = {
-        DOCKER_CONFIG = "${config.home.homeDirectory}/${cfg.configPath}";
+        DOCKER_CONFIG = "${config.home.homeDirectory}/${cfg.configDir}";
       };
 
       file = {
-        "${cfg.configPath}" = {
+        "${cfg.configDir}/config.json" = {
           source = jsonFormat.generate "config.json" cfg.settings;
         };
       };

--- a/modules/programs/yarn/default.nix
+++ b/modules/programs/yarn/default.nix
@@ -24,7 +24,7 @@ in
     settings = mkOption {
       type = yamlFormat.type;
       default = { };
-      example = ''
+      example = lib.literalExpression ''
         {
           httpProxy = "http://proxy.example.org:3128";
           httpsProxy = "http://proxy.example.org:3128";

--- a/tests/modules/programs/docker-cli/empty-config.nix
+++ b/tests/modules/programs/docker-cli/empty-config.nix
@@ -7,12 +7,11 @@ let
 in
 {
   programs.docker-cli = {
-    configPath = ".docker/empty.json";
+    configDir = ".docker2";
   };
 
   nmt.script = ''
     assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'DOCKER_CONFIG'
-    assertPathNotExists home-files/.docker/config.json
-    assertPathNotExists home-files/${cfgDocker.configPath}
+    assertPathNotExists home-files/${cfgDocker.configDir}
   '';
 }

--- a/tests/modules/programs/docker-cli/example-config.nix
+++ b/tests/modules/programs/docker-cli/example-config.nix
@@ -6,7 +6,7 @@
   programs.docker-cli = {
     enable = true;
 
-    configPath = ".docker/config2.json";
+    configDir = ".docker2";
 
     settings = {
       "proxies" = {
@@ -22,8 +22,8 @@
   nmt.script =
     let
       cfgDocker = config.programs.docker-cli;
-      configTestPath = "home-files/${cfgDocker.configPath}";
-      configHomePath = "/home/hm-user/${cfgDocker.configPath}";
+      configTestPath = "home-files/${cfgDocker.configDir}/config.json";
+      configHomePath = "/home/hm-user/${cfgDocker.configDir}";
     in
     ''
       assertFileContains home-path/etc/profile.d/hm-session-vars.sh \


### PR DESCRIPTION
### Description

- docker-cli and yaar: Fix example text
- docker-cli: Set DOCKER_CONFIG env to the path of the config files instead of a single file
- docker-cli: Separate path to folder and config name
- docker-cli: Update tests

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
