### PR TITLE
trippy: add forceUserConfig option

### DIFF
--- a/modules/programs/trippy.nix
+++ b/modules/programs/trippy.nix
@@ -6,6 +6,7 @@
 }:
 let
   inherit (lib)
+    types
     mkIf
     mkEnableOption
     mkPackageOption
@@ -46,12 +47,27 @@ in
         here: <https://trippy.rs/reference/configuration/>
       '';
     };
+    forceUserConfig = mkOption {
+      type = types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whatever to force trippy to use user's config through the -c flag.
+        This will prevent certain commands such as 'sudo' ignoring
+        the configured settings. This will only work if you have
+        'programs.<shell>.enable' (bash, zsh, fish, ...), depending
+        on your shell.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
     home.packages = mkIf (cfg.package != null) [ cfg.package ];
     xdg.configFile."trippy/trippy.toml" = mkIf (cfg.settings != { }) {
       source = tomlFormat.generate "trippy-config" cfg.settings;
+    };
+    home.shellAliases = mkIf cfg.forceUserConfig {
+      trip = "trip -c ${config.xdg.configHome}/trippy/trippy.toml";
     };
   };
 }

--- a/tests/modules/programs/trippy/example-config.nix
+++ b/tests/modules/programs/trippy/example-config.nix
@@ -1,5 +1,4 @@
 {
-
   programs.trippy = {
     enable = true;
     settings = {

--- a/tests/modules/programs/trippy/example-config.nix
+++ b/tests/modules/programs/trippy/example-config.nix
@@ -1,4 +1,5 @@
 {
+
   programs.trippy = {
     enable = true;
     settings = {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This pull request adds the option `programs.trippy.forceUserConfig`. Closes #7471.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
