### PR TITLE
mpd: fix typo

### DIFF
--- a/modules/services/mpd.nix
+++ b/modules/services/mpd.nix
@@ -53,7 +53,7 @@ in
         type = types.lines;
         default = "";
         description = ''
-          Extra directives added to to the end of MPD's configuration
+          Extra directives added to the end of MPD's configuration
           file, {file}`mpd.conf`. Basic configuration
           like file location and uid/gid is added automatically to the
           beginning of the file. For available options see


### PR DESCRIPTION
### Description

fixed a typo

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).