### PR TITLE
Various minor fixes

### DIFF
--- a/modules/misc/xdg-terminal-exec.nix
+++ b/modules/misc/xdg-terminal-exec.nix
@@ -10,18 +10,16 @@ in
 {
   options = {
     xdg.terminal-exec = {
-      enable = lib.mkEnableOption "xdg-terminal-exec, the [proposed](https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/46) Default Terminal Execution Specification";
+      enable = lib.mkEnableOption ''
+        xdg-terminal-exec, the
+        [proposed](https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/46)
+        Default Terminal Execution Specification'';
+
       package = lib.mkPackageOption pkgs "xdg-terminal-exec" { nullable = true; };
+
       settings = lib.mkOption {
         type = with lib.types; attrsOf (listOf str);
         default = { };
-        description = ''
-          Configuration options for the Default Terminal Execution Specification.
-
-          The keys are the desktop environments that are matched (case-insensitively) against `$XDG_CURRENT_DESKTOP`,
-          or `default` which is used when the current desktop environment is not found in the configuration.
-          The values are a list of terminals' [desktop file IDs](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s02.html#desktop-file-id) to try in order of decreasing priority.
-        '';
         example = {
           default = [ "kitty.desktop" ];
           GNOME = [
@@ -29,6 +27,13 @@ in
             "org.gnome.Terminal.desktop"
           ];
         };
+        description = ''
+          Configuration options for the Default Terminal Execution Specification.
+
+          The keys are the desktop environments that are matched (case-insensitively) against {env}`XDG_CURRENT_DESKTOP`,
+          or `default` which is used when the current desktop environment is not found in the configuration.
+          The values are a list of terminals' [desktop file IDs](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s02.html#desktop-file-id) to try in order of decreasing priority.
+        '';
       };
     };
   };
@@ -38,7 +43,8 @@ in
 
     xdg.configFile = lib.mapAttrs' (
       desktop: terminals:
-      # map desktop name such as GNOME to `.config/gnome-xdg-terminals.list`, default to `.config/xdg-terminals.list`
+      # Map desktop name such as GNOME to `.config/gnome-xdg-terminals.list`,
+      # default to `.config/xdg-terminals.list`.
       lib.nameValuePair (
         "${if desktop == "default" then "" else "${lib.toLower desktop}-"}xdg-terminals.list"
       ) { text = lib.concatLines terminals; }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -53,6 +53,7 @@ let
     ./misc/xdg-mime.nix
     ./misc/xdg-portal.nix
     ./misc/xdg-system-dirs.nix
+    ./misc/xdg-terminal-exec.nix
     ./misc/xdg-user-dirs.nix
     ./misc/xdg.nix
     ./misc/xfconf.nix

--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -39,12 +39,13 @@ in
       description = ''
         Configuration written to {file}`$XDG_CONFIG_HOME/opencode/config.json`.
         See <https://opencode.ai/docs/config/> for the documentation.
-        '"$schema": "https://opencode.ai/config.json"' is automatically added to the config.
+
+        Note, `"$schema": "https://opencode.ai/config.json"` is automatically added to the configuration.
       '';
     };
+
     rules = lib.mkOption {
       type = lib.types.lines;
-      description = "You can provide global custom instructions to opencode; this value is written to {file}~/.config/opencode/AGENTS.md";
       default = "";
       example = lib.literalExpression ''
         '''
@@ -71,6 +72,10 @@ in
 
           Read the following file immediately as it's relevant to all workflows: @rules/general-guidelines.md.
         '''
+      '';
+      description = ''
+        You can provide global custom instructions to opencode; this value is
+        written to {file}`$XDG_CONFIG_HOME/opencode/AGENTS.md`.
       '';
     };
   };


### PR DESCRIPTION
### Description

Make sure xdg-terminal-exec module is imported (see #7527). Also minor option description fixes.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@nukdokplex