### PR TITLE
treewide: remove config dependency on docs

### DIFF
--- a/modules/misc/nixgl.nix
+++ b/modules/misc/nixgl.nix
@@ -7,15 +7,16 @@
 
 let
   cfg = config.nixGL;
-  wrapperListMarkdown =
-    with builtins;
-    foldl' (
-      list: name:
-      list
-      + ''
-        - ${name}
-      ''
-    ) "" (attrNames config.lib.nixGL.wrappers);
+
+  wrapperAttrNames = [
+    "mesa"
+    "mesaPrime"
+    "nvidia"
+    "nvidiaPrime"
+  ];
+
+  wrapperListMarkdown = lib.concatMapStringsSep "\n" (v: "- ${v}") wrapperAttrNames;
+
 in
 {
   meta.maintainers = [ lib.maintainers.smona ];
@@ -42,7 +43,7 @@ in
     };
 
     defaultWrapper = lib.mkOption {
-      type = lib.types.enum (builtins.attrNames config.lib.nixGL.wrappers);
+      type = lib.types.enum wrapperAttrNames;
       default = "mesa";
       description = ''
         The package wrapper function available for use as `(config.lib.nixGL.wrap
@@ -58,7 +59,7 @@ in
     };
 
     offloadWrapper = lib.mkOption {
-      type = lib.types.enum (builtins.attrNames config.lib.nixGL.wrappers);
+      type = lib.types.enum wrapperAttrNames;
       default = "mesaPrime";
       description = ''
         The package wrapper function available for use as
@@ -124,7 +125,7 @@ in
     };
 
     installScripts = lib.mkOption {
-      type = with lib.types; nullOr (listOf (enum (builtins.attrNames config.lib.nixGL.wrappers)));
+      type = with lib.types; nullOr (listOf (enum wrapperAttrNames));
       default = null;
       example = [
         "mesa"
@@ -282,6 +283,8 @@ in
             override = args: makePackageWrapper vendor environment (pkg.override args);
           };
 
+      # Note, if you add/remove/alter attribute names here you need to make a
+      # corresponding change in the definition of `wrapperAttrNames`.
       wrappers = {
         mesa = makePackageWrapper "Intel" { };
         mesaPrime = makePackageWrapper "Intel" mesaOffloadEnv;

--- a/modules/programs/ashell.nix
+++ b/modules/programs/ashell.nix
@@ -33,7 +33,8 @@ in
     package = lib.mkPackageOption pkgs "ashell" { nullable = true; };
 
     settings = lib.mkOption {
-      inherit (settingsFormat) type;
+      # NOTE: `yaml` type supports null, using `nullOr` for backwards compatibility period
+      type = lib.types.nullOr tomlFormat.type;
       default = { };
       example = {
         modules = {

--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -77,30 +77,26 @@ let
 
                 updateUrl = mkOption {
                   type = str;
+                  default = "https://clients2.google.com/service/update2/crx";
                   description = ''
                     URL of the extension's update manifest XML file. Linux only.
                   '';
-                  default = "https://clients2.google.com/service/update2/crx";
-                  visible = pkgs.stdenv.isLinux;
-                  readOnly = pkgs.stdenv.isDarwin;
                 };
 
                 crxPath = mkOption {
                   type = nullOr path;
+                  default = null;
                   description = ''
                     Path to the extension's crx file. Linux only.
                   '';
-                  default = null;
-                  visible = pkgs.stdenv.isLinux;
                 };
 
                 version = mkOption {
                   type = nullOr str;
+                  default = null;
                   description = ''
                     The extension's version, required for local installation. Linux only.
                   '';
-                  default = null;
-                  visible = pkgs.stdenv.isLinux;
                 };
               };
             };

--- a/modules/programs/codex.nix
+++ b/modules/programs/codex.nix
@@ -28,7 +28,8 @@ in
     package = lib.mkPackageOption pkgs "codex" { nullable = true; };
 
     settings = lib.mkOption {
-      inherit (settingsFormat) type;
+      # NOTE: `yaml` type supports null, using `nullOr` for backwards compatibility period
+      type = lib.types.nullOr tomlFormat.type;
       description = ''
         Configuration written to {file}`~/.codex/config.toml` (0.2.0+) or {file}`~/.codex/config.yaml` (<0.2.0).
         See <https://github.com/openai/codex/blob/main/codex-rs/config.md> for supported values.

--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -297,6 +297,7 @@ in
       internal = true;
       type = with types; nullOr str;
       default = null;
+      defaultText = literalExpression "platform specific vendor path";
       example = ".mozilla";
       description = "Directory containing the native messaging hosts directory.";
     };

--- a/modules/programs/hyprlock.nix
+++ b/modules/programs/hyprlock.nix
@@ -105,24 +105,13 @@ in
       '';
     };
 
-    sourceFirst =
-      lib.mkEnableOption ''
-        putting source entries at the top of the configuration
-      ''
-      // {
-        default = true;
-      };
+    sourceFirst = lib.mkEnableOption "putting source entries at the top of the configuration" // {
+      default = true;
+    };
 
     importantPrefixes = lib.mkOption {
       type = with lib.types; listOf str;
       default = [
-        "$"
-        "bezier"
-        "monitor"
-        "size"
-      ]
-      ++ lib.optionals cfg.sourceFirst [ "source" ];
-      example = [
         "$"
         "bezier"
         "monitor"
@@ -146,7 +135,7 @@ in
           lib.optionalString (cfg.settings != { }) (
             lib.hm.generators.toHyprconf {
               attrs = cfg.settings;
-              inherit (cfg) importantPrefixes;
+              importantPrefixes = cfg.importantPrefixes ++ lib.optional cfg.sourceFirst "source";
             }
           )
           + lib.optionalString (cfg.extraConfig != null) cfg.extraConfig;

--- a/modules/programs/keychain.nix
+++ b/modules/programs/keychain.nix
@@ -75,7 +75,6 @@ in
     enableXsessionIntegration = mkOption {
       default = true;
       type = types.bool;
-      visible = pkgs.stdenv.hostPlatform.isLinux;
       description = ''
         Whether to run keychain from your {file}`~/.xsession`.
       '';

--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -177,12 +177,14 @@ in
                   description = "Settings to write to app.json.";
                   type = with types; attrsOf anything;
                   default = cfg.defaultSettings.app;
+                  defaultText = literalExpression "config.programs.obsidian.defaultSettings.app";
                 };
 
                 appearance = mkOption {
                   description = "Settings to write to appearance.json.";
                   type = with types; attrsOf anything;
                   default = cfg.defaultSettings.appearance;
+                  defaultText = literalExpression "config.programs.obsidian.defaultSettings.appearance";
                 };
 
                 corePlugins =
@@ -214,6 +216,7 @@ in
                       with types;
                       listOf (coercedTo (enum corePlugins) (p: { name = p; }) (submodule corePluginsOptions));
                     default = cfg.defaultSettings.corePlugins;
+                    defaultText = literalExpression "config.programs.obsidian.defaultSettings.corePlugins";
                   };
 
                 communityPlugins =
@@ -243,6 +246,7 @@ in
                     description = "Community plugins to install and activate.";
                     type = with types; listOf (coercedTo package (p: { pkg = p; }) (submodule communityPluginsOptions));
                     default = cfg.defaultSettings.communityPlugins;
+                    defaultText = literalExpression "config.programs.obsidian.defaultSettings.communityPlugins";
                   };
 
                 cssSnippets =
@@ -287,6 +291,7 @@ in
                       with types;
                       listOf (coercedTo (addCheck path checkCssPath) (p: { source = p; }) (submodule cssSnippetsOptions));
                     default = cfg.defaultSettings.cssSnippets;
+                    defaultText = literalExpression "config.programs.obsidian.defaultSettings.cssSnippets";
                   };
 
                 themes =
@@ -310,6 +315,7 @@ in
                     description = "Themes to install.";
                     type = with types; listOf (coercedTo package (p: { pkg = p; }) (submodule themesOptions));
                     default = cfg.defaultSettings.themes;
+                    defaultText = literalExpression "config.programs.obsidian.defaultSettings.themes";
                   };
 
                 hotkeys =
@@ -333,6 +339,7 @@ in
                     description = "Hotkeys to configure.";
                     type = with types; attrsOf (listOf (submodule hotkeysOptions));
                     default = cfg.defaultSettings.hotkeys;
+                    defaultText = literalExpression "config.programs.obsidian.defaultSettings.hotkeys";
                   };
 
                 extraFiles =
@@ -367,6 +374,7 @@ in
                     description = "Extra files to link to the vault directory.";
                     type = with types; attrsOf (submodule extraFilesOptions);
                     default = cfg.defaultSettings.extraFiles;
+                    defaultText = literalExpression "config.programs.obsidian.defaultSettings.extraFiles";
                   };
               };
             };

--- a/modules/programs/swayr.nix
+++ b/modules/programs/swayr.nix
@@ -98,6 +98,7 @@ in
     systemd.target = mkOption {
       type = types.str;
       default = config.wayland.systemd.target;
+      defaultText = lib.literalExpression "config.wayland.systemd.target";
       description = ''
         Systemd target to bind to.
       '';

--- a/modules/programs/vscode/default.nix
+++ b/modules/programs/vscode/default.nix
@@ -308,6 +308,7 @@ in
     mutableExtensionsDir = mkOption {
       type = types.bool;
       default = allProfilesExceptDefault == { };
+      defaultText = lib.literalExpression "(removeAttrs config.programs.vscode.profiles [ \"default\" ]) == { }";
       example = false;
       description = ''
         Whether extensions can be installed or updated manually

--- a/modules/programs/yambar.nix
+++ b/modules/programs/yambar.nix
@@ -51,6 +51,7 @@ in
       target = lib.mkOption {
         type = lib.types.str;
         default = config.wayland.systemd.target;
+        defaultText = lib.literalExpression "config.wayland.systemd.target";
         example = "sway-session.target";
         description = ''
           The systemd target that will automatically start the yambar service.

--- a/modules/services/cliphist.nix
+++ b/modules/services/cliphist.nix
@@ -53,6 +53,7 @@ in
     systemdTargets = lib.mkOption {
       type = with lib.types; either (listOf str) str;
       default = [ config.wayland.systemd.target ];
+      defaultText = lib.literalExpression "[ config.wayland.systemd.target ]";
       example = "sway-session.target";
       description = ''
         The systemd targets that will automatically start the cliphist service.

--- a/modules/services/hyprshell.nix
+++ b/modules/services/hyprshell.nix
@@ -50,6 +50,7 @@ in
       target = mkOption {
         type = types.str;
         default = config.wayland.systemd.target;
+        defaultText = lib.literalExpression "config.wayland.systemd.target";
         description = "The Systemd target that will start the hyprshell service";
       };
 

--- a/modules/services/window-managers/hyprland.nix
+++ b/modules/services/window-managers/hyprland.nix
@@ -250,8 +250,7 @@ in
         "$"
         "bezier"
         "name"
-      ]
-      ++ lib.optionals cfg.sourceFirst [ "source" ];
+      ];
       example = [
         "$"
         "bezier"
@@ -284,6 +283,8 @@ in
         shouldGenerate =
           cfg.systemd.enable || cfg.extraConfig != "" || cfg.settings != { } || cfg.plugins != [ ];
 
+        importantPrefixes = cfg.importantPrefixes ++ lib.optional cfg.sourceFirst "source";
+
         pluginsToHyprconf =
           plugins:
           lib.hm.generators.toHyprconf {
@@ -295,7 +296,7 @@ in
                 in
                 map (p: "hyprctl plugin load ${mkEntry p}") cfg.plugins;
             };
-            inherit (cfg) importantPrefixes;
+            inherit importantPrefixes;
           };
       in
       lib.mkIf shouldGenerate {
@@ -305,7 +306,7 @@ in
           + lib.optionalString (cfg.settings != { }) (
             lib.hm.generators.toHyprconf {
               attrs = cfg.settings;
-              inherit (cfg) importantPrefixes;
+              inherit importantPrefixes;
             }
           )
           + lib.optionalString (cfg.extraConfig != "") cfg.extraConfig;

--- a/modules/services/window-managers/i3-sway/lib/options.nix
+++ b/modules/services/window-managers/i3-sway/lib/options.nix
@@ -581,6 +581,13 @@ in
               sway = if cfg.config.focus.forceWrapping then "yes" else "no";
             }
             .${moduleName};
+          defaultText =
+            literalExpression
+              {
+                i3 = ''if focus.forceWrapping then "force" else "yes"'';
+                sway = ''if focus.forceWrapping then "yes" else "no"'';
+              }
+              .${moduleName};
           description = ''
             Whether the window focus commands automatically wrap around the edge of containers.
 

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -262,6 +262,26 @@ let
             "Return" = "mode default";
           };
         };
+        defaultText = lib.literalExpression ''
+          {
+            resize = {
+              # Binds arrow keys to resizing commands
+              ''${cfg.config.left}" = "resize shrink width 10 px";
+              ''${cfg.config.down}" = "resize grow height 10 px";
+              ''${cfg.config.up}" = "resize shrink height 10 px";
+              ''${cfg.config.right}" = "resize grow width 10 px";
+
+              "Left" = "resize shrink width 10 px";
+              "Down" = "resize grow height 10 px";
+              "Up" = "resize shrink height 10 px";
+              "Right" = "resize grow width 10 px";
+
+              # Exit resize mode
+              "Escape" = "mode default";
+              "Return" = "mode default";
+            };
+          }
+        '';
         description = ''
           An attribute set that defines binding modes and keybindings
           inside them

--- a/modules/services/wlsunset.nix
+++ b/modules/services/wlsunset.nix
@@ -99,6 +99,7 @@ in
     systemdTarget = mkOption {
       type = with types; str;
       default = config.wayland.systemd.target;
+      defaultText = lib.literalExpression "config.wayland.systemd.target";
       description = ''
         Systemd target to bind to.
       '';


### PR DESCRIPTION
Tested with rebased
https://github.com/nix-community/home-manager/pull/6411 so I could find all instances of config usage in docs.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
