### PR TITLE
ci: extract maintainers with single file eval

### DIFF
--- a/lib/nix/extract-maintainers.nix
+++ b/lib/nix/extract-maintainers.nix
@@ -1,73 +1,58 @@
 {
   lib ? import ../../modules/lib/stdlib-extended.nix (import <nixpkgs> { }).lib,
-  changedFilesJson ? throw "provide either changedFiles or changedFilesJson",
-  changedFiles ? builtins.fromJSON changedFilesJson,
+  file ? throw "provide file argument",
 }:
 let
   config = { };
   releaseInfo = lib.importJSON ../../release.json;
 
-  extractMaintainersFromFile =
-    file:
-    let
-      isNixFile = lib.hasSuffix ".nix" file;
-      filePath = ../../. + "/${file}";
-      fileExists = builtins.pathExists filePath;
+  isNixFile = lib.hasSuffix ".nix" file;
+  filePath = ../../. + "/${file}";
+  fileExists = builtins.pathExists filePath;
 
-      moduleResult =
-        if isNixFile && fileExists then
-          let
-            result = builtins.tryEval (
-              let
-                fileContent = import filePath;
+  maintainers =
+    if isNixFile && fileExists then
+      let
+        fileContent = import filePath;
 
-                module =
-                  if lib.isFunction fileContent then
-                    # TODO: Find a better way of handling this...
-                    if lib.hasPrefix "docs/" file then
-                      if lib.hasSuffix "home-manager-manual.nix" file then
-                        fileContent {
-                          stdenv = {
-                            mkDerivation = x: x;
-                          };
-                          inherit lib;
-                          documentation-highlighter = { };
-                          revision = "unknown";
-                          home-manager-options = {
-                            home-manager = { };
-                            nixos = { };
-                            nix-darwin = { };
-                          };
-                          nixos-render-docs = { };
-                        }
-                      else
-                        fileContent {
-                          inherit lib;
-                          pkgs = null;
-                          inherit (releaseInfo) release isReleaseBranch;
-                        }
-                    else if lib.hasPrefix "lib/" file then
-                      fileContent { inherit lib; }
-                    else
-                      fileContent {
-                        inherit lib config;
-                        pkgs = null;
-                      }
-                  else
-                    fileContent;
-              in
-              module.meta.maintainers or [ ]
-            );
-          in
-          if result.success then result.value else [ ]
-        else
-          [ ];
-    in
-    moduleResult;
+        module =
+          if lib.isFunction fileContent then
+            # TODO: Find a better way of handling this...
+            if lib.hasPrefix "docs/" file then
+              if lib.hasSuffix "home-manager-manual.nix" file then
+                fileContent {
+                  stdenv = {
+                    mkDerivation = x: x;
+                  };
+                  inherit lib;
+                  documentation-highlighter = { };
+                  revision = "unknown";
+                  home-manager-options = {
+                    home-manager = { };
+                    nixos = { };
+                    nix-darwin = { };
+                  };
+                  nixos-render-docs = { };
+                }
+              else
+                fileContent {
+                  inherit lib;
+                  pkgs = null;
+                  inherit (releaseInfo) release isReleaseBranch;
+                }
+            else if lib.hasPrefix "lib/" file then
+              fileContent { inherit lib; }
+            else
+              fileContent {
+                inherit lib config;
+                pkgs = null;
+              }
+          else
+            fileContent;
+      in
+      module.meta.maintainers or [ ]
+    else
+      [ ];
+
 in
-lib.pipe changedFiles [
-  (map extractMaintainersFromFile)
-  lib.concatLists
-  lib.unique
-  (map (maintainer: maintainer.github))
-]
+map (maintainer: maintainer.github) maintainers


### PR DESCRIPTION
Currently, we send all files as a list but it can be problematic with files that can't be evaluated properly. Instead of crashing the entire extraction process, we will send a file at a time for eval so we can just bypass files causing issues.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
