### PR TITLE
tmux: shortcut and prefix settings

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -84,23 +84,17 @@ let
     ''}
 
     ${
-      if cfg.prefix != null then
-        ''
-          # rebind main key: ${cfg.prefix}
-          unbind C-${defaultShortcut}
-          set -g prefix ${cfg.prefix}
-          bind -N "Send the prefix key through to the application" \
-            ${cfg.prefix} send-prefix
-        ''
-      else
-        optionalString (cfg.shortcut != defaultShortcut) ''
-          # rebind main key: C-${cfg.shortcut}
-          unbind C-${defaultShortcut}
-          set -g prefix C-${cfg.shortcut}
-          bind -N "Send the prefix key through to the application" \
-            ${cfg.shortcut} send-prefix
-          bind C-${cfg.shortcut} last-window
-        ''
+      let
+        defaultPrefix = "C-${defaultShortcut}";
+        prefix = if cfg.prefix != null then cfg.prefix else "C-${cfg.shortcut}";
+      in
+      optionalString (prefix != defaultPrefix) ''
+        # rebind main key: ${prefix}
+        unbind ${defaultPrefix}
+        set -g prefix ${prefix}
+        bind -n -N "Send the prefix key through to the application" \
+          ${prefix} send-prefix
+      ''
     }
 
     ${optionalString cfg.disableConfirmationPrompt ''

--- a/tests/modules/programs/tmux/prefix.conf
+++ b/tests/modules/programs/tmux/prefix.conf
@@ -15,7 +15,7 @@ set -g mode-keys   emacs
 # rebind main key: C-a
 unbind C-b
 set -g prefix C-a
-bind -N "Send the prefix key through to the application" \
+bind -n -N "Send the prefix key through to the application" \
   C-a send-prefix
 
 

--- a/tests/modules/programs/tmux/shortcut-without-prefix.conf
+++ b/tests/modules/programs/tmux/shortcut-without-prefix.conf
@@ -15,9 +15,8 @@ set -g mode-keys   emacs
 # rebind main key: C-a
 unbind C-b
 set -g prefix C-a
-bind -N "Send the prefix key through to the application" \
-  a send-prefix
-bind C-a last-window
+bind -n -N "Send the prefix key through to the application" \
+  C-a send-prefix
 
 
 


### PR DESCRIPTION
### Description

adjusting the tmux lines for setting the prefix.
previously the prefix option would be set in the prefix key table, causing it to not register correctly.

the settings for the shortcut option would set an unrelated keybinding for the prefix.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
