### PR TITLE
zsh: only apply plugins when zsh is enabled

### DIFF
--- a/modules/programs/zsh/plugins/default.nix
+++ b/modules/programs/zsh/plugins/default.nix
@@ -89,8 +89,10 @@ in
     };
 
   config = lib.mkIf (cfg.plugins != [ ]) {
-    home.file = lib.foldl' (a: b: a // b) { } (
-      map (plugin: { "${pluginsDir}/${plugin.name}".source = plugin.src; }) cfg.plugins
+    home.file = lib.mkIf cfg.enable (
+      lib.foldl' (a: b: a // b) { } (
+        map (plugin: { "${pluginsDir}/${plugin.name}".source = plugin.src; }) cfg.plugins
+      )
     );
 
     programs.zsh = {


### PR DESCRIPTION
### Description

Fixes a regression from https://github.com/nix-community/home-manager/pull/7442 that caused plugins to be deployed to the home directory even if zsh itself wasn't actually enabled

I kept this `cfg.enable` guard scoped to the `home.file` definition, as the other `programs.zsh` options touched here are already guarded correctly

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@khaneliman (not listed, but is the OP of the original PR and seems active on it recently :p)

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
