### PR TITLE
nh: Add options for specific flakes

### DIFF
--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -29,6 +29,42 @@ in
       '';
     };
 
+    osFlake = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        The string that will be used for the {env}`NH_OS_FLAKE` environment variable.
+
+        {env}`NH_OS_FLAKE` is used by nh as the default flake for performing {command}`nh os`
+        actions, such as {command}`nh os switch`.
+        Setting this will take priority over the `flake` option.
+      '';
+    };
+
+    homeFlake = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        The string that will be used for the {env}`NH_HOME_FLAKE` environment variable.
+
+        {env}`NH_HOME_FLAKE` is used by nh as the default flake for performing {command}`nh home`
+        actions, such as {command}`nh home switch`.
+        Setting this will take priority over the `flake` option.
+      '';
+    };
+
+    darwinFlake = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        The string that will be used for the {env}`NH_DARWIN_FLAKE` environment variable.
+
+        {env}`NH_DARWIN_FLAKE` is used by nh as the default flake for performing
+        {command}`nh darwin` actions, such as {command}`nh darwin switch`.
+        Setting this will take priority over the `flake` option.
+      '';
+    };
+
     clean = {
       enable = lib.mkEnableOption ''
         periodic garbage collection for user profile and nix store with nh clean
@@ -64,19 +100,45 @@ in
       lib.optional (cfg.clean.enable && config.nix.gc.automatic)
         "programs.nh.clean.enable and nix.gc.automatic (Home-Manager) are both enabled. Please use one or the other to avoid conflict.";
 
-    assertions = lib.optionals pkgs.stdenv.isDarwin [
-      (lib.hm.darwin.assertInterval "programs.nh.clean.dates" cfg.clean.dates pkgs)
-    ];
+    assertions =
+      (lib.optionals pkgs.stdenv.isDarwin [
+        (lib.hm.darwin.assertInterval "programs.nh.clean.dates" cfg.clean.dates pkgs)
+      ])
+      ++ [
+        {
+          assertion = (cfg.osFlake != null) -> !(lib.hasSuffix ".nix" cfg.osFlake);
+          message = "nh.osFlake must be a directory, not a nix file";
+        }
+        {
+          assertion = (cfg.homeFlake != null) -> !(lib.hasSuffix ".nix" cfg.homeFlake);
+          message = "nh.homeFlake must be a directory, not a nix file";
+        }
+        {
+          assertion = (cfg.darwinFlake != null) -> !(lib.hasSuffix ".nix" cfg.darwinFlake);
+          message = "nh.darwinFlake must be a directory, not a nix file";
+        }
+      ];
 
     home = lib.mkIf cfg.enable {
       packages = [ cfg.package ];
-      sessionVariables = lib.mkIf (cfg.flake != null) (
-        let
-          packageVersion = lib.getVersion cfg.package;
-          isVersion4OrHigher = lib.versionAtLeast packageVersion "4.0.0";
-        in
-        if isVersion4OrHigher then { NH_FLAKE = cfg.flake; } else { FLAKE = cfg.flake; }
-      );
+      sessionVariables = lib.attrsets.mergeAttrsList [
+        (lib.mkIf (cfg.flake != null) (
+          let
+            packageVersion = lib.getVersion cfg.package;
+            isVersion4OrHigher = lib.versionAtLeast packageVersion "4.0.0";
+          in
+          if isVersion4OrHigher then { NH_FLAKE = cfg.flake; } else { FLAKE = cfg.flake; }
+        ))
+        (lib.mkIf (cfg.osFlake != null) {
+          NH_OS_FLAKE = cfg.osFlake;
+        })
+        (lib.mkIf (cfg.homeFlake != null) {
+          NH_HOME_FLAKE = cfg.homeFlake;
+        })
+        (lib.mkIf (cfg.darwinFlake != null) {
+          NH_DARWIN_FLAKE = cfg.darwinFlake;
+        })
+      ];
     };
 
     systemd.user = lib.mkIf (cfg.clean.enable && pkgs.stdenv.isLinux) {

--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -121,7 +121,7 @@ in
 
     home = lib.mkIf cfg.enable {
       packages = [ cfg.package ];
-      sessionVariables = lib.attrsets.mergeAttrsList [
+      sessionVariables = lib.mkMerge [
         (lib.mkIf (cfg.flake != null) (
           let
             packageVersion = lib.getVersion cfg.package;

--- a/tests/modules/programs/nh/darwin/config.nix
+++ b/tests/modules/programs/nh/darwin/config.nix
@@ -3,6 +3,9 @@
     enable = true;
 
     flake = "/path/to/flake";
+    osFlake = "/path/to/osFlake";
+    homeFlake = "/path/to/homeFlake";
+    darwinFlake = "/path/to/darwinFlake";
 
     clean = {
       enable = true;
@@ -18,5 +21,8 @@
     assertFileContent $serviceFileNormalized ${./launchd.plist}
 
     assertFileRegex home-path/etc/profile.d/hm-session-vars.sh 'NH_FLAKE="/path/to/flake"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh 'NH_OS_FLAKE="/path/to/osFlake"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh 'NH_HOME_FLAKE="/path/to/homeFlake"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh 'NH_DARWIN_FLAKE="/path/to/darwinFlake"'
   '';
 }

--- a/tests/modules/programs/nh/linux/config.nix
+++ b/tests/modules/programs/nh/linux/config.nix
@@ -5,6 +5,9 @@
     package = config.lib.test.mkStubPackage { version = "4.0.0"; };
 
     flake = "/path/to/flake";
+    osFlake = "/path/to/osFlake";
+    homeFlake = "/path/to/homeFlake";
+    darwinFlake = "/path/to/darwinFlake";
 
     clean = {
       enable = true;
@@ -31,5 +34,8 @@
     assertFileExists $unitDir/timers.target.wants/nh-clean.timer
 
     assertFileRegex home-path/etc/profile.d/hm-session-vars.sh 'NH_FLAKE="/path/to/flake"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh 'NH_OS_FLAKE="/path/to/osFlake"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh 'NH_HOME_FLAKE="/path/to/homeFlake"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh 'NH_DARWIN_FLAKE="/path/to/darwinFlake"'
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

nh provides an environment variable setting for defining the default flake, which is available as the programs.nh.flake setting. However, nh also provides three environment-specific settings for OS, home-manager, and Darwin. These are useful when, for one reason or another, different flakes are used for configuring the OS and the user's environment (e.g. on a shared machine).

This PR makes the other three settings available in a similar manner.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [N/A] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
@johnrtitor @a-jay98