### PR TITLE
television: put channel configs in correct location and cleanup

### DIFF
--- a/tests/modules/programs/television/basic-config.nix
+++ b/tests/modules/programs/television/basic-config.nix
@@ -10,19 +10,21 @@
         input_bar_position = "top";
       };
     };
-    channels.my-custom = {
-      cable_channel = [
-        {
+    channels = {
+      git-log = {
+        metadata = {
           name = "git-log";
-          source_command = ''git log --oneline --date=short --pretty="format:%h %s %an %cd" "$@"'';
-          preview_command = "git show -p --stat --pretty=fuller --color=always {0}";
-        }
-        {
-          name = "my-dotfiles";
-          source_command = "fd -t f . $HOME/.config";
-          preview_command = "bat -n --color=always {0}";
-        }
-      ];
+          description = "A channel to select from git log entries";
+          requirements = [ "git" ];
+        };
+        source = {
+          command = "git log --oneline --date=short --pretty=\"format:%h %s %an %cd\" \"$@\"";
+          output = "{split: :0}";
+        };
+        preview = {
+          command = "git show -p --stat --pretty=fuller --color=always '{0}'";
+        };
+      };
     };
   };
 
@@ -37,18 +39,20 @@
         show_preview_panel = true
         use_nerd_font_icons = false
       ''}
-    assertFileExists home-files/.config/television/my-custom-channels.toml
-    assertFileContent home-files/.config/television/my-custom-channels.toml \
+    assertFileExists home-files/.config/television/cable/git-log.toml
+    assertFileContent home-files/.config/television/cable/git-log.toml \
       ${pkgs.writeText "channels-expected" ''
-        [[cable_channel]]
+        [metadata]
+        description = "A channel to select from git log entries"
         name = "git-log"
-        preview_command = "git show -p --stat --pretty=fuller --color=always {0}"
-        source_command = "git log --oneline --date=short --pretty=\"format:%h %s %an %cd\" \"$@\""
+        requirements = ["git"]
 
-        [[cable_channel]]
-        name = "my-dotfiles"
-        preview_command = "bat -n --color=always {0}"
-        source_command = "fd -t f . $HOME/.config"
+        [preview]
+        command = "git show -p --stat --pretty=fuller --color=always '{0}'"
+
+        [source]
+        command = "git log --oneline --date=short --pretty=\"format:%h %s %an %cd\" \"$@\""
+        output = "{split: :0}"
       ''}
   '';
 }


### PR DESCRIPTION
### Description

Channel configurations are now supposed to live in `~/.config/television/cable/<NAME>.toml`. I also cleaned up the derivation a bit to make it more readable.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).

#### Maintainer CC

@awwpotato
