### PR TITLE
arrpc: assert linux; tests/arrpc: enhance service module test coverage

### DIFF
--- a/modules/services/arrpc.nix
+++ b/modules/services/arrpc.nix
@@ -33,6 +33,11 @@ in
   };
 
   config = mkIf cfg.enable {
+    # NOTE: Currently only systemd implemented
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.arrpc" pkgs lib.platforms.linux)
+    ];
+
     systemd.user.services.arRPC = {
       Unit = {
         Description = "Discord Rich Presence for browsers, and some custom clients";

--- a/tests/modules/services/arrpc/custom-target-expected.service
+++ b/tests/modules/services/arrpc/custom-target-expected.service
@@ -1,0 +1,10 @@
+[Install]
+WantedBy=sway-session.target
+
+[Service]
+ExecStart=@arrpc@/bin/arrpc
+Restart=always
+
+[Unit]
+Description=Discord Rich Presence for browsers, and some custom clients
+PartOf=graphical-session.target

--- a/tests/modules/services/arrpc/custom-target.nix
+++ b/tests/modules/services/arrpc/custom-target.nix
@@ -1,0 +1,14 @@
+{
+  config = {
+    services.arrpc = {
+      enable = true;
+      systemdTarget = "sway-session.target";
+    };
+
+    nmt.script = ''
+      assertFileContent \
+        home-files/.config/systemd/user/arRPC.service \
+        ${./custom-target-expected.service}
+    '';
+  };
+}

--- a/tests/modules/services/arrpc/default.nix
+++ b/tests/modules/services/arrpc/default.nix
@@ -1,0 +1,4 @@
+{ lib, pkgs, ... }:
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  arrpc-custom-target = ./custom-target.nix;
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt-rfc-style deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
