### PR TITLE
home-manager: re-enable gcroot handling for NixOS module

### DIFF
--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -36,12 +36,6 @@ in
 
               # Inherit glibcLocales setting from NixOS.
               i18n.glibcLocales = lib.mkDefault config.i18n.glibcLocales;
-
-              # Legacy profile management is when the activation script
-              # generates GC root and home-manager profile. The modern way
-              # simply relies on the GC root that the system maintains, which
-              # should also protect the Home Manager activation package outputs.
-              home.activationGenerateGcRoot = cfg.enableLegacyProfileManagement;
             };
           }
         ];

--- a/tests/integration/nixos/basics.nix
+++ b/tests/integration/nixos/basics.nix
@@ -82,16 +82,15 @@
 
       logout_alice()
 
-    with subtest("no GC root and profile"):
-      # There should be no GC root and Home Manager profile since we are not
+    with subtest("no profile management"):
+      # There should be no Home Manager profile since we are not
       # using legacy profile management.
-      hmState = "/home/alice/.local/state/home-manager"
-      machine.succeed(f"test ! -e {hmState}")
-
       hmProfile = "/home/alice/.local/state/nix/profiles/home-manager"
       machine.succeed(f"test ! -e {hmProfile}")
 
+      # There should be a gcroot, however since we want to keep track of which
+      # generation is currently enabled.
       hmGcroot = "/home/alice/.local/state/home-manager/gcroots/current-home"
-      machine.succeed(f"test ! -e {hmGcroot}")
+      machine.succeed(f"test -e {hmGcroot}")
   '';
 }


### PR DESCRIPTION


### Description

It was a bit too ambitious to also remove production of the gcroot, we need it to keep track of the currently active Home Manager configuration.

Fixes #7583

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
