### PR TITLE
zoxide: move zsh priority

### DIFF
--- a/modules/programs/zoxide.nix
+++ b/modules/programs/zoxide.nix
@@ -45,7 +45,8 @@ in
     );
 
     programs.zsh.initContent = lib.mkIf cfg.enableZshIntegration (
-      lib.mkOrder 2000 ''
+      # After `compInit` in `zsh`
+      lib.mkOrder 600 ''
         eval "$(${lib.getExe cfg.package} init zsh ${cfgOptions})"
       ''
     );


### PR DESCRIPTION
According to upstream documentation, they recommend at end of file. But, realistically just needs to be after compinit.

### Description
Originally moved to bottom of file because of this note in upstream documentation: 

>Add this to the end of your config file (usually ~/.zshrc):
>
>eval "$(zoxide init zsh)"
>
>For completions to work, the above line must be added after compinit is called. You may have to rebuild your completions cache by running rm ~/.zcompdump*; compinit.

Closes https://github.com/nix-community/home-manager/issues/7592
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
