### PR TITLE
nh: remove .nix suffix check for flake paths

### DIFF
--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -100,22 +100,9 @@ in
       lib.optional (cfg.clean.enable && config.nix.gc.automatic)
         "programs.nh.clean.enable and nix.gc.automatic (Home-Manager) are both enabled. Please use one or the other to avoid conflict.";
 
-    assertions =
-      (lib.optionals pkgs.stdenv.isDarwin [
-        (lib.hm.darwin.assertInterval "programs.nh.clean.dates" cfg.clean.dates pkgs)
-      ])
-      ++
-        map
-          (name: {
-            assertion = (cfg.${name} != null) -> !(lib.hasSuffix ".nix" cfg.${name});
-            message = "nh.${name} must be a directory, not a nix file";
-          })
-          [
-            "darwinFlake"
-            "flake"
-            "homeFlake"
-            "osFlake"
-          ];
+    assertions = lib.optionals pkgs.stdenv.isDarwin [
+      (lib.hm.darwin.assertInterval "programs.nh.clean.dates" cfg.clean.dates pkgs)
+    ];
 
     home = lib.mkIf cfg.enable {
       packages = [ cfg.package ];


### PR DESCRIPTION
### Description
see https://github.com/nix-community/home-manager/pull/7566#discussion_r2249211538

cc @girlpunk @pedorich-n 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
