### PR TITLE
nixos: improve description of enableLegacyProfileManagement

### DIFF
--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -116,12 +116,11 @@ in
       type = types.bool;
       default = false;
       description = ''
-        Whether to enable legacy profile (and garbage collection root)
-        management during activation. When enabled, the Home Manager activation
-        will produce a per-user `home-manager` Nix profile as well as a garbage
-        collection root, just like in the standalone installation of Home
-        Manager. Typically, this is not desired when Home Manager is embedded in
-        the system configuration.
+        Whether to enable legacy profile management during activation. When
+        enabled, the Home Manager activation will produce a per-user
+        `home-manager` Nix profile, just like in the standalone installation of
+        Home Manager. Typically, this is not desired when Home Manager is
+        embedded in the system configuration.
       '';
     };
 


### PR DESCRIPTION
### Description

Also applies to nix-darwin module.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.