### PR TITLE
zsh: option to define autoloadable site-functions

### DIFF
--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -12,6 +12,7 @@
   zsh-history-path-xdg-variable = import ./history-path.nix "xdg-variable";
   zsh-history-path-zdotdir-variable = import ./history-path.nix "zdotdir-variable";
   zsh-history-substring-search = ./history-substring-search.nix;
+  zsh-siteFunctions-mkcd = ./siteFunctions-mkcd.nix;
   zsh-plugins = ./plugins.nix;
   zsh-prezto = ./prezto.nix;
   zsh-session-variables = ./session-variables.nix;

--- a/tests/modules/programs/zsh/siteFunctions-mkcd.nix
+++ b/tests/modules/programs/zsh/siteFunctions-mkcd.nix
@@ -1,0 +1,17 @@
+let
+  body = ''
+    mkdir --parents "$1" && cd "$1"
+  '';
+in
+{
+  programs.zsh = {
+    enable = true;
+    siteFunctions.mkcd = body;
+  };
+
+  nmt.script = ''
+    assertFileExists home-path/share/zsh/site-functions/mkcd
+    assertFileContent home-path/share/zsh/site-functions/mkcd ${builtins.toFile "mkcd" body}
+    assertFileContains home-files/.zshrc "autoload -Uz mkcd"
+  '';
+}


### PR DESCRIPTION
### Description

Add an option to the Zsh module that allows defining autoloadable site functions.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
