### PR TITLE
grep: init module

### DIFF
--- a/modules/programs/grep.nix
+++ b/modules/programs/grep.nix
@@ -1,0 +1,37 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.grep;
+
+in
+{
+
+  meta.maintainers = [ lib.maintainers.bmrips ];
+
+  options.programs.grep = {
+    enable = lib.mkEnableOption "{command}`grep`.";
+    package = lib.mkPackageOption pkgs "grep" {
+      default = "gnugrep";
+      nullable = true;
+    };
+    colors = lib.mkOption {
+      type = with lib.types; attrsOf str;
+      default = { };
+      description = "Settings for {env}`GREP_COLORS`";
+      example.error = "01;31";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+    home.sessionVariables.GREP_COLORS = lib.mkIf (cfg.colors != { }) (
+      lib.concatStringsSep ":" (lib.mapAttrsToList (n: v: "${n}=${v}") cfg.colors)
+    );
+  };
+
+}


### PR DESCRIPTION
### Description

Add a module for grep, mainly to configure its colours through `$$GREP_COLORS`>

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
