### PR TITLE
news:  `fontconfig` is under `config.fonts`, not `config`

### DIFF
--- a/modules/misc/news/2025/08/2025-08-05_14-17-36.nix
+++ b/modules/misc/news/2025/08/2025-08-05_14-17-36.nix
@@ -1,7 +1,7 @@
-{ fonts, ... }:
+{ config, ... }:
 {
   time = "2025-08-05T19:17:36+00:00";
-  condition = fonts.fontconfig.enable;
+  condition = config.fonts.fontconfig.enable;
   message = ''
     The 'fontconfig' module now supports font rendering configuration.
 


### PR DESCRIPTION
### Description

According to:
https://github.com/nix-community/home-manager/blob/fc3add429f21450359369af74c2375cb34a2d204/modules/misc/fontconfig.nix#L33-L45

`fontconfig` is under `config.fonts`, not `config`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
