### PR TITLE
tests/news: add new test for news entries

### DIFF
--- a/modules/misc/news/2023/07/2023-07-25_07-16-09.nix
+++ b/modules/misc/news/2023/07/2023-07-25_07-16-09.nix
@@ -5,6 +5,6 @@
   condition = pkgs.stdenv.hostPlatform.isDarwin;
   message = ''
 
-    A new module is available: 'services.git-sync'.
+    The 'services.git-sync' module is now available on Darwin/macOS.
   '';
 }

--- a/modules/misc/news/2024/11/2024-11-14_18-16-21.nix
+++ b/modules/misc/news/2024/11/2024-11-14_18-16-21.nix
@@ -1,6 +1,6 @@
 { config, ... }:
 {
-  time = "2024-11-14T18:16:21+01:00";
+  time = "2024-11-14T17:16:21+00:00";
   condition = config.programs.feh.enable;
   message = ''
     The 'programs.feh' module now supports custom themes configuration.

--- a/modules/misc/news/2024/11/2024-11-24_21-15-57.nix
+++ b/modules/misc/news/2024/11/2024-11-24_21-15-57.nix
@@ -1,6 +1,6 @@
 { config, ... }:
 {
-  time = "2024-11-24T21:15:57+01:00";
+  time = "2024-11-24T20:15:57+00:00";
   condition = config.programs.zed-editor.enable;
   message = ''
     The 'programs.zed-editor' module now supports the 'extraPackages' option.

--- a/modules/misc/news/2025/03/2025-03-25_19-48-21.nix
+++ b/modules/misc/news/2025/03/2025-03-25_19-48-21.nix
@@ -1,5 +1,5 @@
 {
-  time = "2025-03-25T19:48:21-04:00";
+  time = "2025-03-25T23:48:21+00:00";
   condition = true;
   message = ''
     A new module is available: `programs.ripgrep-all`

--- a/modules/misc/news/2025/03/2025-03-25_20-44-04.nix
+++ b/modules/misc/news/2025/03/2025-03-25_20-44-04.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 {
-  time = "2025-03-25T20:44:04-06:00";
+  time = "2025-03-26T02:44:04+00:00";
   condition = pkgs.stdenv.hostPlatform.isLinux;
   message = ''
     A new module is available: `services.mpdscribble`

--- a/modules/misc/news/2025/03/2025-03-25_21-37-24.nix
+++ b/modules/misc/news/2025/03/2025-03-25_21-37-24.nix
@@ -1,5 +1,5 @@
 {
-  time = "2025-03-25T21:37:24+01:00";
+  time = "2025-03-25T20:37:24+00:00";
   condition = true;
   message = ''
     A new module is available: `programs.mergiraf`

--- a/modules/misc/news/2025/03/2025-03-29_23-32-11.nix
+++ b/modules/misc/news/2025/03/2025-03-29_23-32-11.nix
@@ -1,5 +1,5 @@
 {
-  time = "2025-03-29T23:32:11+09:00";
+  time = "2025-03-29T14:32:11+00:00";
   condition = true;
   message = ''
     A new module is available: `programs.sesh`

--- a/modules/misc/news/2025/05/2025-05-08_17-45-24.nix
+++ b/modules/misc/news/2025/05/2025-05-08_17-45-24.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 
 {
-  time = "2025-05-08T17:45:24+02:00";
+  time = "2025-05-08T15:45:24+00:00";
   condition = pkgs.stdenv.hostPlatform.isLinux;
   message = ''
     A new module is available: 'programs.wayprompt'.

--- a/modules/misc/news/2025/06/2025-06-27_18-53-10.nix
+++ b/modules/misc/news/2025/06/2025-06-27_18-53-10.nix
@@ -1,7 +1,7 @@
 { config, ... }:
 
 {
-  time = "2025-06-27T18-53-10+00:00";
+  time = "2025-06-27T18:53:10+00:00";
   condition = config.programs.ashell.enable && (config.programs.ashell.settings != { });
   message = ''
     ashell 0.5.0 changes the configuration file location and format.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -179,6 +179,7 @@ import nmtSrc {
           ./modules/home-environment
           ./modules/misc/fontconfig
           ./modules/misc/manual
+          ./modules/misc/news
           ./modules/misc/nix
           ./modules/misc/specialisation
           ./modules/misc/xdg

--- a/tests/modules/misc/news/default.nix
+++ b/tests/modules/misc/news/default.nix
@@ -1,0 +1,115 @@
+{
+  news-validation =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    {
+      home.file."news-test.json".source = config.news.json.output;
+
+      nmt.script = # Bash
+        ''
+          ALL_ERRORS=""
+          JQ_CMD="${pkgs.jq}/bin/jq"
+          news_json="$TESTED/home-files/news-test.json"
+
+          echo "Testing news validation..."
+          echo "Looking for news file at: $news_json"
+
+          if [[ ! -f "$news_json" ]]; then
+            fail "news-test.json file not found at $news_json"
+          fi
+
+          if ! "$JQ_CMD" . "$news_json" > /dev/null 2>&1; then
+            fail "news.json is not valid JSON"
+          fi
+
+          run_check() {
+            local description="$1"
+            local jq_filter="$2"
+            local fail_message="$3"
+
+            echo "--> Checking: $description"
+            local output
+            local exit_code=0
+
+            output=$("$JQ_CMD" -re "$jq_filter" "$news_json" 2>&1) || exit_code=$?
+
+            if [[ $exit_code -eq 3 ]]; then
+              echo "!!! JQ COMPILE ERROR in check: '$description'"
+              printf "Error details:\n%s\n" "$output"
+              fail "FATAL: Fix the jq filter for the check."
+            fi
+
+            if [[ -n "$output" ]]; then
+              local error_block
+              printf -v error_block '\n%s\nFAIL: %s\n%s\n%s' \
+                "=======================================================================" \
+                "$fail_message" \
+                "-----------------------------------------------------------------------" \
+                "$output"
+
+              ALL_ERRORS+="$error_block"
+            fi
+          }
+
+          echo "Validating JSON content..."
+
+          run_check \
+            "Entries array is not empty" \
+            'select((.entries | length) <= 0) | "Found only \(.entries | length) entries"' \
+            "news.entries should not be empty"
+
+          run_check \
+            "Required fields are present (time, message, condition, id)" \
+            '.entries[] | select(has("time", "message", "condition", "id") | not) | "ID: \(.id // "unknown") | Message: Missing one or more required fields."' \
+            "All news entries must have time, message,condition, and id fields"
+
+          run_check \
+           "Timestamps are valid, 4-digit year, ISO-8601 UTC dates" \
+           '
+             .entries[] | select(
+               # Condition 1: Check if the format is correct (4-digit year, etc.)
+               (.time | test("^20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\+00:00$") | not)
+               or
+               # Condition 2: Check if the date is logically valid (no Feb 30)
+               ((try (.time | sub("\\+00:00$"; "Z") | fromdateiso8601) catch null) == null)
+             ) | "Time: \(.time) | ID: \(.id // "unknown") | Message: Invalid format or non-existent date"' \
+           "All timestamps must be valid, well-formed ISO-8601 dates in UTC with a 4-digit year"
+
+          run_check \
+            "Message fields are non-empty strings" \
+            '.entries[] | select(.message == "" or (.message | type) != "string") | "ID: \(.id // "unknown") | Message: Message field is empty or not a string"' \
+            "All message fields must be non-empty strings"
+
+          run_check \
+            "ID fields are non-empty strings" \
+            '.entries[] | select(.id == "" or (.id | type) != "string") | "ID: \(.id // "undefined") | Message: ID field is empty or not a string"' \
+            "All id fields must be non-empty strings"
+
+          run_check \
+            "Condition fields are boolean" \
+            '.entries[] | select((.condition | type) != "boolean") | "ID: \(.id) | Message: Condition field is not a boolean (\(.condition | tostring))"' \
+            "All condition fields must be booleans"
+
+          run_check \
+            "IDs are unique" \
+            '.entries | group_by(.id)[] | select(length > 1) | "Duplicate ID: \(. [0].id) | Found at times: \([.[] | .time] | join(", "))"' \
+            "All news entry IDs must be unique"
+
+          if [[ -n "$ALL_ERRORS" ]]; then
+            echo ""
+            echo "##########################################"
+            echo "!!! VALIDATION FAILED - All issues found:"
+            echo "##########################################"
+            printf "%s\n" "$ALL_ERRORS"
+            echo "======================================================================="
+            fail "Please fix the validation issues listed above."
+          else
+            echo ""
+            echo "All news validation tests passed successfully!"
+          fi
+        '';
+    };
+}


### PR DESCRIPTION
### Description

Had a few issues recently with news eval. Create a test that will run to catch them. 

Example failure: 
https://buildbot.nix-community.org/#/builders/6042/builds/119/steps/1/logs/stdio
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
