### PR TITLE
keepassxc: add autostart option

### DIFF
--- a/modules/programs/keepassxc.nix
+++ b/modules/programs/keepassxc.nix
@@ -46,16 +46,36 @@ in
         for the full list of options.
       '';
     };
+
+    autostart = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to start Keepassxc automatically on login through the XDG autostart mechanism.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
 
       {
-        xdg.configFile = {
-          "keepassxc/keepassxc.ini" = lib.mkIf (cfg.settings != { }) {
-            source = iniFormat.generate "keepassxc-settings" cfg.settings;
-          };
+        assertions = [
+          {
+            assertion = cfg.autostart -> config.xdg.autostart.enable;
+            message = ''
+              {option}`xdg.autostart.enable` has to be enabled in order for
+              {option}`programs.keepassxc.autostart` to be effective.
+            '';
+          }
+        ];
+
+        xdg.autostart.entries = lib.mkIf cfg.autostart [
+          "${cfg.package}/share/applications/org.keepassxc.KeePassXC.desktop"
+        ];
+        xdg.configFile."keepassxc/keepassxc.ini" = lib.mkIf (cfg.settings != { }) {
+          source = iniFormat.generate "keepassxc-settings" cfg.settings;
         };
       }
 

--- a/modules/programs/keepassxc.nix
+++ b/modules/programs/keepassxc.nix
@@ -11,7 +11,10 @@ let
   iniFormat = pkgs.formats.ini { };
 in
 {
-  meta.maintainers = [ lib.maintainers.d-brasher ];
+  meta.maintainers = with lib.maintainers; [
+    bmrips
+    d-brasher
+  ];
 
   options.programs.keepassxc = {
     enable = lib.mkEnableOption "keepassxc";

--- a/tests/modules/programs/keepassxc/autostart.nix
+++ b/tests/modules/programs/keepassxc/autostart.nix
@@ -1,0 +1,14 @@
+{
+  programs.keepassxc = {
+    enable = true;
+    autostart = true;
+  };
+  xdg.autostart.enable = false;
+
+  test.asserts.assertions.expected = [
+    ''
+      {option}`xdg.autostart.enable` has to be enabled in order for
+      {option}`programs.keepassxc.autostart` to be effective.
+    ''
+  ];
+}

--- a/tests/modules/programs/keepassxc/default.nix
+++ b/tests/modules/programs/keepassxc/default.nix
@@ -1,4 +1,5 @@
 {
+  keepassxc-autostart = ./autostart.nix;
   keepassxc-default-settings = ./default-settings.nix;
   keepassxc-example-settings = ./example-settings.nix;
 }


### PR DESCRIPTION
### Description

Add an option to automatically start KeePassXC on login.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
