### PR TITLE
git-credential-keepassxc: init module

### DIFF
--- a/modules/programs/git-credential-keepassxc.nix
+++ b/modules/programs/git-credential-keepassxc.nix
@@ -1,0 +1,58 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.git-credential-keepassxc;
+in
+{
+
+  meta.maintainer = [ lib.maintainers.bmrips ];
+
+  options.programs.git-credential-keepassxc = {
+    enable = lib.mkEnableOption "{command}`git-credential-keepassxc`.";
+    package = lib.mkPackageOption pkgs "git-credential-keepassxc" { };
+    groups = lib.mkOption {
+      type = with lib.types; nullOr (listOf str);
+      default = null;
+      example = "Git";
+      description = ''
+        The KeePassXC groups used for storing and fetching of credentials. By
+        default, the groups created by
+        {command}`git-credential-keepassxc configure [--group <GROUP>]` are used.
+      '';
+    };
+    hosts = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      example = [ "https://github.com" ];
+      description = "Hosts for which {command}`git-credential-keepassxc` is enabled.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    programs.git.extraConfig.credential =
+      let
+        helperConfig =
+          let
+            groups =
+              if cfg.groups == null then
+                "--git-groups"
+              else
+                lib.concatStringsSep " " (map (g: "--group ${g}") cfg.groups);
+          in
+          {
+            helper = "${cfg.package}/bin/git-credential-keepassxc ${groups}";
+          };
+      in
+      if cfg.hosts == [ ] then
+        helperConfig
+      else
+        lib.listToAttrs (map (host: lib.nameValuePair host helperConfig)) cfg.hosts;
+  };
+
+}

--- a/tests/modules/programs/git-credential-keepassxc/custom-groups.nix
+++ b/tests/modules/programs/git-credential-keepassxc/custom-groups.nix
@@ -1,0 +1,15 @@
+{
+  programs.git.enable = true;
+  programs.git-credential-keepassxc = {
+    enable = true;
+    groups = [
+      "A"
+      "B"
+    ];
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileRegex home-files/.config/git/config 'helper = "\S*/bin/git-credential-keepassxc --group A --group B"'
+  '';
+}

--- a/tests/modules/programs/git-credential-keepassxc/default-config.nix
+++ b/tests/modules/programs/git-credential-keepassxc/default-config.nix
@@ -1,0 +1,9 @@
+{
+  programs.git.enable = true;
+  programs.git-credential-keepassxc.enable = true;
+
+  nmt.script = ''
+    assertFileExists home-files/.config/git/config
+    assertFileRegex home-files/.config/git/config 'helper = "\S*/bin/git-credential-keepassxc --git-groups"'
+  '';
+}

--- a/tests/modules/programs/git-credential-keepassxc/default.nix
+++ b/tests/modules/programs/git-credential-keepassxc/default.nix
@@ -1,0 +1,4 @@
+{
+  git-credential-keepassxc-default-config = ./default-config.nix;
+  git-credential-keepassxc-custom-groups = ./custom-groups.nix;
+}


### PR DESCRIPTION
### Description

Add a module for [git-credential-keepassxc](https://github.com/Frederick888/git-credential-keepassxc).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
