### PR TITLE
codex: support XDG Base Directory specification

### DIFF
--- a/tests/modules/programs/codex/custom-instructions-prefer-xdg-directories.nix
+++ b/tests/modules/programs/codex/custom-instructions-prefer-xdg-directories.nix
@@ -1,0 +1,17 @@
+{
+  home.preferXdgDirectories = true;
+  programs.codex = {
+    enable = true;
+    custom-instructions = ''
+      - Always respond with emojis
+      - Only use git commands when explicitly requested
+    '';
+  };
+  nmt.script = ''
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+      'export CODEX_HOME="/home/hm-user/.config/codex"'
+    assertFileExists home-files/.config/codex/AGENTS.md
+    assertFileContent home-files/.config/codex/AGENTS.md \
+      ${./AGENTS.md}
+  '';
+}

--- a/tests/modules/programs/codex/default.nix
+++ b/tests/modules/programs/codex/default.nix
@@ -1,7 +1,9 @@
 {
   codex-settings-toml = ./settings-toml.nix;
+  codex-settings-toml-prefer-xdg-directories = ./settings-toml-prefer-xdg-directories.nix;
   codex-settings-yaml = ./settings-yaml.nix;
   codex-empty-settings = ./empty-settings.nix;
   codex-custom-instructions = ./custom-instructions.nix;
+  codex-custom-instructions-prefer-xdg-directories = ./custom-instructions-prefer-xdg-directories.nix;
   codex-empty-custom-instructions = ./empty-custom-instructions.nix;
 }

--- a/tests/modules/programs/codex/empty-settings.nix
+++ b/tests/modules/programs/codex/empty-settings.nix
@@ -6,5 +6,6 @@
   nmt.script = ''
     assertPathNotExists home-files/.codex/config.toml
     assertPathNotExists home-files/.codex/config.yaml
+    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'CODEX_HOME'
   '';
 }

--- a/tests/modules/programs/codex/settings-toml-prefer-xdg-directories.nix
+++ b/tests/modules/programs/codex/settings-toml-prefer-xdg-directories.nix
@@ -7,6 +7,7 @@ let
   '';
 in
 {
+  home.preferXdgDirectories = true;
   programs.codex = {
     enable = true;
     package = codexPackage;
@@ -23,9 +24,10 @@ in
     };
   };
   nmt.script = ''
-    assertFileExists home-files/.codex/config.toml
-    assertFileContent home-files/.codex/config.toml \
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+      'export CODEX_HOME="/home/hm-user/.config/codex"'
+    assertFileExists home-files/.config/codex/config.toml
+    assertFileContent home-files/.config/codex/config.toml \
       ${./config.toml}
-    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh 'CODEX_HOME'
   '';
 }


### PR DESCRIPTION
- Configuration file is now placed in XDG_CONFIG_HOME/codex/config.toml by default for versions >=0.2.0 when preferXdgDirectories is enabled.
- Falls back to ~/.codex/config.yaml for versions <0.2.0 and to ~/.codex/config.toml when preferXdgDirectories is disabled
- Sets CODEX_HOME environment variable to $XDG_CONFIG_HOME/codex when using XDG directories.
- Updated tests to verify XDG directory behavior and environment variable presence.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
