### PR TITLE
jrnl: add module

### DIFF
--- a/modules/programs/jrnl.nix
+++ b/modules/programs/jrnl.nix
@@ -1,0 +1,36 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+let
+  cfg = config.programs.jrnl;
+  yamlFormat = pkgs.formats.yaml { };
+in
+with lib;
+{
+  options.programs.jrnl = {
+    enable = mkEnableOption "jrnl";
+
+    package = lib.mkPackageOption pkgs "jrnl" { nullable = true; };
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      description = ''
+        Configuration for the jrnl binary.
+        Available configuration options are described in the jrnl documentation:
+        <https://jrnl.sh/en/stable/reference-config-file/>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."jrnl/jrnl.yaml".source = yamlFormat.generate "jrnl.yaml" cfg.settings;
+  };
+
+  meta.maintainers = [ lib.maintainers.matthiasbeyer ];
+}


### PR DESCRIPTION
### Description

Adds a module for the `jrnl` program: https://jrnl.sh/

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
