### PR TITLE
firefoxpwa: fix ULID length typo

### DIFF
--- a/modules/programs/firefoxpwa.nix
+++ b/modules/programs/firefoxpwa.nix
@@ -62,7 +62,7 @@ in
       default = { };
       description = ''
         Attribute set of profile options. The keys of that attribute set consist of
-        ULIDs. A ULID is made of 16 characters, each of which is one of
+        ULIDs. A ULID is made of 26 characters, each of which is one of
         '0123456789ABCDEFGHJKMNPQRSTVWXYZ' (Excluding I, L, O and U). See
         <https://github.com/ulid/spec?tab=readme-ov-file#canonical-string-representation>.
       '';
@@ -95,7 +95,7 @@ in
                 default = { };
                 description = ''
                   Attribute set of site options for this profile. The keys of that attribute set
-                  consist of ULIDs. A ULID is made of 16 characters, each of which is one of
+                  consist of ULIDs. A ULID is made of 26 characters, each of which is one of
                   '0123456789ABCDEFGHJKMNPQRSTVWXYZ' (Excluding I, L, O and U). See
                   <https://github.com/ulid/spec?tab=readme-ov-file#canonical-string-representation>.
                   Site ULIDs must be unique across profiles.


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

A ULID is 26 characters, not 16

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
    `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix-shell --pure tests -A run.all`
    or `nix build --reference-lock-file flake.lock ./tests#test-all` using Flakes.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
