### PR TITLE
swww: add extraArgs for swww-daemon

### DIFF
--- a/modules/services/swww.nix
+++ b/modules/services/swww.nix
@@ -13,6 +13,20 @@ in
   options.services.swww = {
     enable = lib.mkEnableOption "swww, a Solution to your Wayland Wallpaper Woes";
     package = lib.mkPackageOption pkgs "swww" { };
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "--no-cache"
+        "--layer"
+        "bottom"
+      ];
+      description = ''
+        Options given to swww-daemon when the service is run.
+
+        See `swww-daemon --help` for more information.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -35,7 +49,7 @@ in
       };
 
       Service = {
-        ExecStart = "${lib.getExe' cfg.package "swww-daemon"}";
+        ExecStart = "${lib.getExe' cfg.package "swww-daemon"} ${lib.escapeShellArgs cfg.extraArgs}";
         Restart = "always";
         RestartSec = 10;
       };

--- a/tests/modules/services/swww/swww-graphical-session-target.nix
+++ b/tests/modules/services/swww/swww-graphical-session-target.nix
@@ -3,6 +3,11 @@
   services.swww = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@swww@"; };
+    extraArgs = [
+      "--no-cache"
+      "--layer"
+      "bottom"
+    ];
   };
 
   nmt.script = ''

--- a/tests/modules/services/swww/swww-graphical-session-target.service
+++ b/tests/modules/services/swww/swww-graphical-session-target.service
@@ -2,7 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
-ExecStart=@swww@/bin/swww-daemon
+ExecStart=@swww@/bin/swww-daemon --no-cache --layer bottom
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Allows passing of arguments when initializing swww-daemon, such as `--no-cache` or `--format`

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See
      [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See
  [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style)
  for more information and
  [recent commit messages](https://github.com/nix-community/home-manager/commits/master)
  for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See
        [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
