### PR TITLE
maintainers: update out-of-date github info

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -221,7 +221,7 @@
   };
   jkarlson = {
     email = "jekarlson@gmail.com";
-    github = "jkarlson";
+    github = "ethorsoe";
     githubId = 1204734;
     name = "Emil Karlson";
   };

--- a/modules/programs/yambar.nix
+++ b/modules/programs/yambar.nix
@@ -12,7 +12,7 @@ let
 
 in
 {
-  meta.maintainers = [ lib.maintainers.carpinchomug ];
+  meta.maintainers = [ ];
 
   options.programs.yambar = {
     enable = lib.mkEnableOption "Yambar";


### PR DESCRIPTION

### Description

As per https://github.com/orgs/nix-community/discussions/1908#discussioncomment-13972992

> * home-manager
>   * `carpinchomug` -> [api.github.com/user/101536256](https://api.github.com/user/101536256) -> account deleted
>   * `jkarlson` -> [api.github.com/user/1204734](https://api.github.com/user/1204734) -> `ethorsoe`
>   * `seylerius` -> [api.github.com/user/1145981](https://api.github.com/user/1145981) -> `sableseyler`

`seylerius` and `carpinchomug` are inherited from the nixpkgs maintainers list, so I'll update/remove them in nixpkgs. In this PR, I updated @ethorsoe (`jkarlson`)'s maintainers entry and removed usage of `carpinchomug`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and
  [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

