### PR TITLE
gemini-cli: init module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -460,6 +460,12 @@
     github = "Rosuavio";
     githubId = 7164552;
   };
+  rrvsh = {
+    name = "Mohammad Rafiq";
+    email = "rafiq@rrv.sh";
+    github = "rrvsh";
+    githubId = 20300874;
+  };
   rszamszur = {
     name = "Radosław Szamszur";
     email = "radoslawszamszur@gmail.com";

--- a/modules/programs/gemini-cli.nix
+++ b/modules/programs/gemini-cli.nix
@@ -1,0 +1,117 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.gemini-cli;
+
+  jsonFormat = pkgs.formats.json { };
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.rrvsh ];
+
+  options.programs.gemini-cli = {
+    enable = lib.mkEnableOption "gemini-cli";
+
+    package = lib.mkPackageOption pkgs "gemini-cli" { nullable = true; };
+
+    settings = lib.mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "theme": "Default",
+          "vimMode": true,
+          "preferredEditor": "nvim",
+          "autoAccept": true
+        }
+      '';
+      description = "JSON config for gemini-cli";
+    };
+
+    commands =
+      let
+        commandType = lib.types.submodule {
+          freeformType = lib.types.str;
+          options = {
+            prompt = lib.mkOption {
+              type = lib.types.str;
+              description = ''
+                The prompt that will be sent to the Gemini model when the command is executed.
+                This can be a single-line or multi-line string.
+                The special placeholder {{args}} will be replaced with the text the user typed after the command name.
+              '';
+            };
+            description = lib.mkOption {
+              type = lib.types.str;
+              description = ''
+                A brief, one-line description of what the command does.
+                This text will be displayed next to your command in the /help menu.
+                If you omit this field, a generic description will be generated from the filename.
+              '';
+            };
+          };
+        };
+      in
+      lib.mkOption {
+        type = lib.types.attrsOf commandType;
+        default = { };
+        description = ''
+          An attribute set of custom commands that will be globally available.
+          The name of the attribute set will be the name of each command.
+          You may use subdirectories to create namespaced commands, such as `git/fix` becoming `/git:fix`.
+          See https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/commands.md#custom-commands for more information.
+        '';
+        example = lib.literalExpression ''
+          changelog = {
+            prompt =
+              '''
+              Your task is to parse the `<version>`, `<change_type>`, and `<message>` from their input and use the `write_file` tool to correctly update the `CHANGELOG.md` file.
+              ''';
+            description = "Adds a new entry to the project's CHANGELOG.md file.";
+          };
+          "git/fix" = { # Becomes /git:fix
+            prompt = "Please analyze the staged git changes and provide a code fix for the issue described here: {{args}}.";
+            description = "Generates a fix for a given GitHub issue.";
+          };
+        '';
+      };
+
+    defaultModel = lib.mkOption {
+      type = lib.types.str;
+      default = "gemini-2.5-pro";
+      example = "gemini-2.5-flash";
+      description = ''
+        The default model to use for the CLI.
+        Will be set as $GEMINI_MODEL.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        home = {
+          packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+          file.".gemini/settings.json" = lib.mkIf (cfg.settings != { }) {
+            source = jsonFormat.generate "gemini-cli-settings.json" cfg.settings;
+          };
+          sessionVariables.GEMINI_MODEL = cfg.defaultModel;
+        };
+      }
+      {
+        home.file = lib.mapAttrs' (
+          n: v:
+          lib.nameValuePair ".gemini/commands/${n}.toml" {
+            source = tomlFormat.generate "gemini-cli-command-${n}.toml" {
+              inherit (v) description prompt;
+            };
+          }
+        ) cfg.commands;
+      }
+    ]
+  );
+}

--- a/tests/modules/programs/gemini-cli/changelog.toml
+++ b/tests/modules/programs/gemini-cli/changelog.toml
@@ -1,0 +1,2 @@
+description = "Adds a new entry to the project's CHANGELOG.md file."
+prompt = "Your task is to parse the `<version>`, `<change_type>`, and `<message>` from their input and use the `write_file` tool to correctly update the `CHANGELOG.md` file.\n"

--- a/tests/modules/programs/gemini-cli/default.nix
+++ b/tests/modules/programs/gemini-cli/default.nix
@@ -1,0 +1,3 @@
+{
+  gemini-cli-settings = ./settings.nix;
+}

--- a/tests/modules/programs/gemini-cli/fix.toml
+++ b/tests/modules/programs/gemini-cli/fix.toml
@@ -1,0 +1,2 @@
+description = "Generates a fix for a given GitHub issue."
+prompt = "Please analyze the staged git changes and provide a code fix for the issue described here: {{args}}."

--- a/tests/modules/programs/gemini-cli/settings.json
+++ b/tests/modules/programs/gemini-cli/settings.json
@@ -1,0 +1,6 @@
+{
+  "autoAccept": true,
+  "preferredEditor": "nvim",
+  "theme": "Default",
+  "vimMode": true
+}

--- a/tests/modules/programs/gemini-cli/settings.nix
+++ b/tests/modules/programs/gemini-cli/settings.nix
@@ -1,0 +1,32 @@
+{
+  programs.gemini-cli = {
+    enable = true;
+    settings = {
+      theme = "Default";
+      vimMode = true;
+      preferredEditor = "nvim";
+      autoAccept = true;
+    };
+    commands = {
+      changelog = {
+        prompt = ''
+          Your task is to parse the `<version>`, `<change_type>`, and `<message>` from their input and use the `write_file` tool to correctly update the `CHANGELOG.md` file.
+        '';
+        description = "Adds a new entry to the project's CHANGELOG.md file.";
+      };
+      "git/fix" = {
+        prompt = "Please analyze the staged git changes and provide a code fix for the issue described here: {{args}}.";
+        description = "Generates a fix for a given GitHub issue.";
+      };
+    };
+  };
+  nmt.script = ''
+    assertFileExists home-files/.gemini/settings.json
+    assertFileContent home-files/.gemini/settings.json \
+      ${./settings.json}
+    assertFileContent home-files/.gemini/commands/changelog.toml \
+      ${./changelog.toml}
+    assertFileContent home-files/.gemini/commands/git/fix.toml \
+      ${./fix.toml}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This module adds the (gemini-cli)[https://github.com/google-gemini/gemini-cli] `programs.gemini-cli` option. I've configured the `settings.json` and `commands/**/*.toml` using the `*.settings` and `*.commands` options. 

Note: unfortunately I was unable to find a way to have the `commands` option take an arbitrarily nested attribute set, which would have been ideal to model the intended directory structure (`git.file` becomes `git/file.toml`) so instead I've just gone with specifying the path in the attribute set name to have custom namespaced commands. If anyone has any input on how to solve the infinite recursion problem when adding a recursive type for an option, im all ears.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See
      [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and
  [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See
        [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See
        [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See
        [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See
        [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
