### PR TITLE
sway: print hint when checking the config file fails

### DIFF
--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -430,7 +430,7 @@ let
       ${pkgs.xvfb-run}/bin/xvfb-run ${cfg.package}/bin/sway --config "$target" --validate --unsupported-gpu || {
         echo "Checking the sway config file failed. Normally, this happens because there are errors in the config file."
         echo "But the check can also fail if the sway config file has dependencies on configuration that is not available in the Nix build sandbox (e.g. custom keyboard layouts defined in the NixOS configuration; background images in the user's home directory)."
-        echo "In that case, it may be necessary to set 'config.wayland.windowManager.sway.checkConfig = false;'."
+        echo "In that case, it may be necessary to set 'wayland.windowManager.sway.checkConfig = false;'."
         exit 1
       }
     '';


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This is meant to address https://github.com/nix-community/home-manager/issues/5311.

I've felt compelled to do something about this after reading a comment by a user who said they've nearly given up transitioning from Arch to NixOS + home-manager because of it.

While it does not fix the issue of the check failing because of run-time dependencies not being available in the `checkPhase`; it should make it easier for users to understand what is going on and how to work around it.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`. _some unrelated anki test is currently failing?_

- [ ] Test cases updated/added. See
      [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef). _I don't think this needs a test_

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and
  [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See
        [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See
        [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See
        [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See
        [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
