### PR TITLE
ssh-tpm-agent: act as ssh-agent proxy

### DIFF
--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -6,7 +6,6 @@
 }:
 
 let
-
   cfg = config.services.ssh-agent;
 
 in
@@ -16,11 +15,18 @@ in
     lib.hm.maintainers.lheckemann
   ];
 
-  options = {
-    services.ssh-agent = {
-      enable = lib.mkEnableOption "OpenSSH private key agent";
+  options.services.ssh-agent = {
+    enable = lib.mkEnableOption "OpenSSH private key agent";
 
-      package = lib.mkPackageOption pkgs "openssh" { };
+    package = lib.mkPackageOption pkgs "openssh" { };
+
+    socket = lib.mkOption {
+      type = lib.types.str;
+      default = "ssh-agent";
+      example = "ssh-agent/socket";
+      description = ''
+        The agent's socket; interpreted as a suffix to {env}`$XDG_RUNTIME_DIR`.
+      '';
     };
   };
 
@@ -31,21 +37,17 @@ in
 
     home.sessionVariablesExtra = ''
       if [ -z "$SSH_AUTH_SOCK" ]; then
-        export SSH_AUTH_SOCK=$XDG_RUNTIME_DIR/ssh-agent
+        export SSH_AUTH_SOCK=$XDG_RUNTIME_DIR/${cfg.socket}
       fi
     '';
 
     systemd.user.services.ssh-agent = {
       Install.WantedBy = [ "default.target" ];
-
       Unit = {
         Description = "SSH authentication agent";
         Documentation = "man:ssh-agent(1)";
       };
-
-      Service = {
-        ExecStart = "${lib.getExe' cfg.package "ssh-agent"} -D -a %t/ssh-agent";
-      };
+      Service.ExecStart = "${lib.getExe' cfg.package "ssh-agent"} -D -a %t/${cfg.socket}";
     };
   };
 }

--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -11,7 +11,10 @@ let
 
 in
 {
-  meta.maintainers = [ lib.hm.maintainers.lheckemann ];
+  meta.maintainers = [
+    lib.maintainers.bmrips
+    lib.hm.maintainers.lheckemann
+  ];
 
   options = {
     services.ssh-agent = {

--- a/modules/services/ssh-tpm-agent.nix
+++ b/modules/services/ssh-tpm-agent.nix
@@ -74,7 +74,6 @@ in
             Documentation = "https://github.com/Foxboron/ssh-tpm-agent";
             Requires = [ "ssh-tpm-agent.socket" ];
             After = [ "ssh-tpm-agent.socket" ];
-            RefuseManualStart = true;
           };
           Service = {
             Environment = "SSH_TPM_AUTH_SOCK=%t/ssh-tpm-agent.sock";
@@ -82,7 +81,7 @@ in
               let
                 inherit (config.services) ssh-agent;
               in
-              "${lib.getExe cfg.package} -l %t/ssh-tpm-agent.sock"
+              (lib.getExe cfg.package)
               + lib.optionalString (cfg.keyDir != null) " --key-dir ${cfg.keyDir}"
               + lib.optionalString ssh-agent.enable " -A %t/${ssh-agent.socket}";
             SuccessExitStatus = 2;
@@ -102,18 +101,12 @@ in
           Description = "SSH TPM agent socket";
           Documentation = "https://github.com/Foxboron/ssh-tpm-agent";
         };
-
         Socket = {
           ListenStream = "%t/ssh-tpm-agent.sock";
-          RuntimeDirectory = "ssh-tpm-agent";
-          SocketMode = "0600";
-          DirectoryMode = "0700";
           Service = "ssh-tpm-agent.service";
+          SocketMode = "0600";
         };
-
-        Install = {
-          WantedBy = [ "sockets.target" ];
-        };
+        Install.WantedBy = [ "sockets.target" ];
       };
     };
   };

--- a/modules/services/ssh-tpm-agent.nix
+++ b/modules/services/ssh-tpm-agent.nix
@@ -17,7 +17,10 @@ let
 
 in
 {
-  meta.maintainers = [ lib.maintainers.yethal ];
+  meta.maintainers = with lib.maintainers; [
+    bmrips
+    yethal
+  ];
 
   options.services.ssh-tpm-agent = {
     enable = mkEnableOption "SSH agent for TPMs";

--- a/tests/modules/services/ssh-agent/basic-service-expected.service
+++ b/tests/modules/services/ssh-agent/basic-service-expected.service
@@ -2,7 +2,7 @@
 WantedBy=default.target
 
 [Service]
-ExecStart=@openssh@/bin/ssh-agent -D -a %t/ssh-agent
+ExecStart=@openssh@/bin/ssh-agent -D -a %t/ssh-agent/socket
 
 [Unit]
 Description=SSH authentication agent

--- a/tests/modules/services/ssh-agent/basic-service.nix
+++ b/tests/modules/services/ssh-agent/basic-service.nix
@@ -1,15 +1,12 @@
-{ config, ... }:
-
 {
-  config = {
-    services.ssh-agent = {
-      enable = true;
-    };
-
-    nmt.script = ''
-      assertFileContent \
-        home-files/.config/systemd/user/ssh-agent.service \
-        ${./basic-service-expected.service}
-    '';
+  services.ssh-agent = {
+    enable = true;
+    socket = "ssh-agent/socket";
   };
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/systemd/user/ssh-agent.service \
+      ${./basic-service-expected.service}
+  '';
 }

--- a/tests/modules/services/ssh-tpm-agent/as-ssh-agent-proxy.nix
+++ b/tests/modules/services/ssh-tpm-agent/as-ssh-agent-proxy.nix
@@ -1,6 +1,7 @@
 { config, ... }:
 
 {
+  services.ssh-agent.enable = true;
   services.ssh-tpm-agent = {
     enable = true;
     package = config.lib.test.mkStubPackage { outPath = "@ssh-tpm-agent@"; };
@@ -16,16 +17,17 @@
     assertFileContent $serviceFile ${builtins.toFile "expected-service" ''
       [Service]
       Environment=SSH_TPM_AUTH_SOCK=%t/ssh-tpm-agent.sock
-      ExecStart=@ssh-tpm-agent@/bin/dummy -l %t/ssh-tpm-agent.sock
-      PassEnvironment=SSH_AGENT_PID
+      ExecStart=@ssh-tpm-agent@/bin/dummy -l %t/ssh-tpm-agent.sock -A %t/ssh-agent
       SuccessExitStatus=2
       Type=simple
 
       [Unit]
       After=ssh-tpm-agent.socket
+      After=ssh-agent.service
+      BindsTo=ssh-agent.service
       Description=ssh-tpm-agent service
       Documentation=https://github.com/Foxboron/ssh-tpm-agent
-      RefuseManualStart=true
+      RefuseManualStart=yes
       Requires=ssh-tpm-agent.socket
     ''}
 

--- a/tests/modules/services/ssh-tpm-agent/as-ssh-agent-proxy.nix
+++ b/tests/modules/services/ssh-tpm-agent/as-ssh-agent-proxy.nix
@@ -17,7 +17,7 @@
     assertFileContent $serviceFile ${builtins.toFile "expected-service" ''
       [Service]
       Environment=SSH_TPM_AUTH_SOCK=%t/ssh-tpm-agent.sock
-      ExecStart=@ssh-tpm-agent@/bin/dummy -l %t/ssh-tpm-agent.sock -A %t/ssh-agent
+      ExecStart=@ssh-tpm-agent@/bin/dummy -A %t/ssh-agent
       SuccessExitStatus=2
       Type=simple
 
@@ -27,7 +27,6 @@
       BindsTo=ssh-agent.service
       Description=ssh-tpm-agent service
       Documentation=https://github.com/Foxboron/ssh-tpm-agent
-      RefuseManualStart=yes
       Requires=ssh-tpm-agent.socket
     ''}
 
@@ -36,9 +35,7 @@
       WantedBy=sockets.target
 
       [Socket]
-      DirectoryMode=0700
       ListenStream=%t/ssh-tpm-agent.sock
-      RuntimeDirectory=ssh-tpm-agent
       Service=ssh-tpm-agent.service
       SocketMode=0600
 

--- a/tests/modules/services/ssh-tpm-agent/default.nix
+++ b/tests/modules/services/ssh-tpm-agent/default.nix
@@ -1,5 +1,6 @@
 { lib, pkgs, ... }:
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-  ssh-tpm-agent = ./service.nix;
+  ssh-tpm-agent-standalone = ./standalone.nix;
+  ssh-tpm-agent-as-ssh-agent-proxy = ./as-ssh-agent-proxy.nix;
 }

--- a/tests/modules/services/ssh-tpm-agent/standalone.nix
+++ b/tests/modules/services/ssh-tpm-agent/standalone.nix
@@ -1,0 +1,47 @@
+{ config, ... }:
+
+{
+  services.ssh-tpm-agent = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@ssh-tpm-agent@"; };
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/ssh-tpm-agent.service
+    socketFile=home-files/.config/systemd/user/ssh-tpm-agent.socket
+
+    assertFileExists $serviceFile
+    assertFileExists $socketFile
+
+    assertFileContent $serviceFile ${builtins.toFile "expected-service" ''
+      [Service]
+      Environment=SSH_TPM_AUTH_SOCK=%t/ssh-tpm-agent.sock
+      ExecStart=@ssh-tpm-agent@/bin/dummy -l %t/ssh-tpm-agent.sock
+      SuccessExitStatus=2
+      Type=simple
+
+      [Unit]
+      After=ssh-tpm-agent.socket
+      Description=ssh-tpm-agent service
+      Documentation=https://github.com/Foxboron/ssh-tpm-agent
+      RefuseManualStart=true
+      Requires=ssh-tpm-agent.socket
+    ''}
+
+    assertFileContent $socketFile ${builtins.toFile "expected-socket" ''
+      [Install]
+      WantedBy=sockets.target
+
+      [Socket]
+      DirectoryMode=0700
+      ListenStream=%t/ssh-tpm-agent.sock
+      RuntimeDirectory=ssh-tpm-agent
+      Service=ssh-tpm-agent.service
+      SocketMode=0600
+
+      [Unit]
+      Description=SSH TPM agent socket
+      Documentation=https://github.com/Foxboron/ssh-tpm-agent
+    ''}
+  '';
+}

--- a/tests/modules/services/ssh-tpm-agent/standalone.nix
+++ b/tests/modules/services/ssh-tpm-agent/standalone.nix
@@ -16,7 +16,7 @@
     assertFileContent $serviceFile ${builtins.toFile "expected-service" ''
       [Service]
       Environment=SSH_TPM_AUTH_SOCK=%t/ssh-tpm-agent.sock
-      ExecStart=@ssh-tpm-agent@/bin/dummy -l %t/ssh-tpm-agent.sock
+      ExecStart=@ssh-tpm-agent@/bin/dummy
       SuccessExitStatus=2
       Type=simple
 
@@ -24,7 +24,6 @@
       After=ssh-tpm-agent.socket
       Description=ssh-tpm-agent service
       Documentation=https://github.com/Foxboron/ssh-tpm-agent
-      RefuseManualStart=true
       Requires=ssh-tpm-agent.socket
     ''}
 
@@ -33,9 +32,7 @@
       WantedBy=sockets.target
 
       [Socket]
-      DirectoryMode=0700
       ListenStream=%t/ssh-tpm-agent.sock
-      RuntimeDirectory=ssh-tpm-agent
       Service=ssh-tpm-agent.service
       SocketMode=0600
 


### PR DESCRIPTION
### Description

This PR fixes a bug in the ssh-tpm-agent module. `ssh-tpm-agent` can act as proxy to `ssh-agent` as showcased in its [README](https://github.com/Foxboron/ssh-tpm-agent#proxy-support). In contrast to the solution shown in the README, the [systemd unit shipped by upstream](https://github.com/Foxboron/ssh-tpm-agent/blob/master/contrib/services/user/ssh-tpm-agent.service) does not connect to a running ssh-agent through the `-A <socket>` option but through the `$SSH_AGENT_PID` environment variable that is set when the ssh-agent is initialized by `eval "$(ssh-agent)"`.

However, when the ssh-agent is started through systemd, like in its corresponding HM module, `$SSH_AGENT_PID` is not set, such that `ssh-tpm-agent` fails to connect to `ssh-agent`. You can verify this by trying to add a regular (non-TPM-guarded) SSH key; it will not show up in `ssh-add -l`.

This PR resolves this issue by

- declaring `ssh-agent.service` as a requirement for `ssh-tpm-agent.service`, and
- adding the `-A <ssh-agent-socket>` flag to `ssh-tpm-agent`,

_if_ `services.ssh-agent` is enabled. To communicate ssh-agent's socket path across these modules, I added an internal `services.ssh-agent.socket` option.

Other changes contained in this PR:

- On NixOS, check that `security.tpm2` is enabled and that the user is a member of `security.tpm2.tssGroup`.
- Remove options from the `ssh-tpm-agent` systemd units to match their upstream units.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
  `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
  `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See
  [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and
  [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See
    [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See
    [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See
    [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.

  - [ ] Generate a news entry. See
    [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
