### PR TITLE
glance: restart service when settings file changes

### DIFF
--- a/modules/services/glance.nix
+++ b/modules/services/glance.nix
@@ -86,6 +86,9 @@ in
       Unit = {
         Description = "Glance feed dashboard server";
         PartOf = [ "graphical-session.target" ];
+        X-Restart-Triggers = [
+          settingsFile
+        ];
       };
 
       Install.WantedBy = [ "graphical-session.target" ];

--- a/tests/modules/services/glance/default-settings.nix
+++ b/tests/modules/services/glance/default-settings.nix
@@ -4,6 +4,7 @@
   nmt.script = ''
     configFile=home-files/.config/glance/glance.yml
     serviceFile=home-files/.config/systemd/user/glance.service
+    serviceFile=$(normalizeStorePaths $serviceFile)
 
     assertFileContent $configFile ${./glance-default-config.yml}
     assertFileContent $serviceFile ${./glance.service}

--- a/tests/modules/services/glance/example-settings.nix
+++ b/tests/modules/services/glance/example-settings.nix
@@ -26,6 +26,7 @@
   nmt.script = ''
     configFile=home-files/.config/glance/glance.yml
     serviceFile=home-files/.config/systemd/user/glance.service
+    serviceFile=$(normalizeStorePaths $serviceFile)
 
     assertFileContent $configFile ${./glance-example-config.yml}
     assertFileContent $serviceFile ${./glance.service}

--- a/tests/modules/services/glance/glance.service
+++ b/tests/modules/services/glance/glance.service
@@ -7,3 +7,4 @@ ExecStart=@glance@/bin/glance --config /home/hm-user/.config/glance/glance.yml
 [Unit]
 Description=Glance feed dashboard server
 PartOf=graphical-session.target
+X-Restart-Triggers=/nix/store/00000000000000000000000000000000-glance.yml


### PR DESCRIPTION
### Description

Fixes https://github.com/nix-community/home-manager/issues/7667

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See
      [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and
  [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
