### PR TITLE
nix-gc: rename frequency to dates

### DIFF
--- a/tests/modules/services/nix-gc/darwin/basic.nix
+++ b/tests/modules/services/nix-gc/darwin/basic.nix
@@ -1,7 +1,7 @@
 {
   nix.gc = {
     automatic = true;
-    frequency = "monthly";
+    dates = "monthly";
     options = "--delete-older-than 30d";
   };
 

--- a/tests/modules/services/nix-gc/darwin/changed-options.nix
+++ b/tests/modules/services/nix-gc/darwin/changed-options.nix
@@ -1,0 +1,21 @@
+{ lib, options, ... }:
+
+{
+  nix.gc = {
+    automatic = true;
+    frequency = "monthly";
+    options = "--delete-older-than 30d";
+  };
+
+  test.asserts.warnings.expected = [
+    "The option `nix.gc.frequency' defined in ${lib.showFiles options.nix.gc.frequency.files} has been changed to `nix.gc.dates' that has a different type. Please read `nix.gc.dates' documentation and update your configuration accordingly."
+  ];
+
+  nmt.script = ''
+    serviceFile=LaunchAgents/org.nix-community.home.nix-gc.plist
+
+    assertFileExists "$serviceFile"
+
+    assertFileContent "$serviceFile" ${./expected-agent.plist}
+  '';
+}

--- a/tests/modules/services/nix-gc/darwin/darwin-nix-gc-interval-assertion.nix
+++ b/tests/modules/services/nix-gc/darwin/darwin-nix-gc-interval-assertion.nix
@@ -1,10 +1,10 @@
 {
   nix.gc = {
     automatic = true;
-    frequency = "00:02:03";
+    dates = "00:02:03";
   };
 
   test.asserts.assertions.expected = [
-    "On Darwin nix.gc.frequency must be one of: hourly, daily, weekly, monthly, semiannually, annually."
+    "On Darwin nix.gc.dates.* must be one of: hourly, daily, weekly, monthly, semiannually, annually."
   ];
 }

--- a/tests/modules/services/nix-gc/darwin/default.nix
+++ b/tests/modules/services/nix-gc/darwin/default.nix
@@ -1,4 +1,5 @@
 {
   nix-gc = ./basic.nix;
   nix-gc-interval-assertion = ./darwin-nix-gc-interval-assertion.nix;
+  nix-gc-changed-options = ./changed-options.nix;
 }

--- a/tests/modules/services/nix-gc/linux/changed-options.nix
+++ b/tests/modules/services/nix-gc/linux/changed-options.nix
@@ -1,10 +1,16 @@
+{ lib, options, ... }:
+
 {
   nix.gc = {
     automatic = true;
-    dates = [ "monthly" ];
+    frequency = "monthly";
     randomizedDelaySec = "42min";
     options = "--delete-older-than 30d --max-freed $((64 * 1024**3))";
   };
+
+  test.asserts.warnings.expected = [
+    "The option `nix.gc.frequency' defined in ${lib.showFiles options.nix.gc.frequency.files} has been changed to `nix.gc.dates' that has a different type. Please read `nix.gc.dates' documentation and update your configuration accordingly."
+  ];
 
   nmt.script = ''
     serviceFile=home-files/.config/systemd/user/nix-gc.service

--- a/tests/modules/services/nix-gc/linux/default.nix
+++ b/tests/modules/services/nix-gc/linux/default.nix
@@ -1,3 +1,4 @@
 {
   nix-gc = ./basic.nix;
+  nix-gc-changed-options = ./changed-options.nix;
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR renames the `nix.gc.frequency` option to `nix.gc.dates` to match upstream NixOS' module. Closes #5106.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See
      [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and
  [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See
        [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See
        [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See
        [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See
        [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
