### PR TITLE
davmail: enable access to the display server

### DIFF
--- a/modules/services/davmail.nix
+++ b/modules/services/davmail.nix
@@ -66,10 +66,7 @@ in
   config = mkIf cfg.enable {
 
     assertions = [
-      {
-        assertion = pkgs.stdenv.hostPlatform.isLinux;
-        message = "The DavMail service is only available on Linux.";
-      }
+      (lib.hm.assertions.assertPlatform "services.davmail" pkgs lib.platforms.linux)
     ];
 
     services.davmail.settings =
@@ -111,7 +108,7 @@ in
       };
       Install.WantedBy = [ "graphical-session.target" ];
       Service = {
-        Type = "simple";
+        Type = "exec";
         ExecStart = "${lib.getExe cfg.package} ${settingsFile}";
         Restart = "on-failure";
 
@@ -134,6 +131,7 @@ in
         RestrictAddressFamilies = [
           "AF_INET"
           "AF_INET6"
+          "AF_UNIX"
         ];
         RestrictNamespaces = true;
         RestrictRealtime = true;


### PR DESCRIPTION
### Description

Give davmail access to the display server, such that it can display its token request dialogue.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See
      [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and
  [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See
        [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See
        [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See
        [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See
        [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
