### PR TITLE
keepassxc: note the native messaging hosts manifest installation conflict

### DIFF
--- a/modules/programs/keepassxc.nix
+++ b/modules/programs/keepassxc.nix
@@ -17,7 +17,27 @@ in
   ];
 
   options.programs.keepassxc = {
-    enable = lib.mkEnableOption "keepassxc";
+    enable = lib.mkEnableOption "keepassxc" // {
+      description = ''
+        Whether to enable KeePassXC.
+
+        ::: {.note}
+        When this flag is set, KeePassXC' builtin native messaging manifest for
+        communication with its browser extension is automatically installed.
+        This conflicts with KeePassXC' builtin installation mechanism. To
+        prevent error messages, either set
+        {option}`programs.keepassxc.settings.Browser.UpdateBinaryPath` to
+        `false`, or untick the checkbox
+
+          Application Settings/
+            Browser Integration/
+              Advanced/
+                Update native messaging manifest files at startup
+
+        in the GUI.
+        :::
+      '';
+    };
 
     package = lib.mkPackageOption pkgs "keepassxc" { nullable = true; };
 
@@ -52,7 +72,7 @@ in
       default = false;
       example = true;
       description = ''
-        Whether to start Keepassxc automatically on login through the XDG autostart mechanism.
+        Whether to start KeePassXC automatically on login through the XDG autostart mechanism.
       '';
     };
   };


### PR DESCRIPTION
### Description

Mention the problems that can occur when enabling the KeePassXC module and its possible fixes.

Closes #7298.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
