### PR TITLE
hyprshot: init module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -219,6 +219,12 @@
     github = "Janik-Haag";
     githubId = 80165193;
   };
+  joker9944 = {
+    name = "Felix von Arx";
+    email = "github@shroud.mozmail.com";
+    github = "Joker9944";
+    githubId = 9194199;
+  };
   jonringer = {
     email = "jonringer117@gmail.com";
     matrix = "@jonringer:matrix.org";

--- a/modules/misc/news/2025/08/2025-08-16_03-35-44.nix
+++ b/modules/misc/news/2025/08/2025-08-16_03-35-44.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+{
+  time = "2025-08-16T01:35:44+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'programs.hyprshot'
+
+    Hyprshot is an utility to easily take screenshot in Hyprland using your mouse.
+    It allows taking screenshots of windows, regions and monitors which are saved
+    to a folder of your choosing and copied to your clipboard.
+  '';
+}

--- a/modules/programs/hyprshot.nix
+++ b/modules/programs/hyprshot.nix
@@ -1,0 +1,38 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.hyprshot;
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [
+    joker9944
+  ];
+
+  options.programs.hyprshot = {
+    enable = lib.mkEnableOption "Hyprshot the Hyprland screenshot utility";
+    package = lib.mkPackageOption pkgs "hyprshot" { nullable = true; };
+    saveLocation = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "$HOME/Pictures/Screenshots";
+      description = ''
+        Set the `$HYPRSHOT_DIR` environment variable to the given location.
+
+        Hypershot will save screenshots to the first expression that resolves:
+         - `$HYPRSHOT_DIR`
+         - `$XDG_PICTURES_DIR`
+         - `$(xdg-user-dir PICTURES)`
+      '';
+    };
+  };
+
+  config.home = lib.mkIf cfg.enable {
+    packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    sessionVariables = lib.mkIf (cfg.saveLocation != null) { HYPRSHOT_DIR = cfg.saveLocation; };
+  };
+}


### PR DESCRIPTION
### Description

Add a new program module: Hyprshot the Hyprland screenshot utility.

A note on the tests. I ran all tests as instructed but they seem to be failing even on the `master` branch. The test I have written passes when run locally.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
