### PR TITLE
aerospace: allow colemak on key-mapping

### DIFF
--- a/modules/programs/aerospace.nix
+++ b/modules/programs/aerospace.nix
@@ -263,6 +263,7 @@ in
             type = types.enum [
               "qwerty"
               "dvorak"
+              "colemak"
             ];
             default = "qwerty";
             description = "Keymapping preset.";

--- a/tests/modules/programs/aerospace/aerospace-colemak.nix
+++ b/tests/modules/programs/aerospace/aerospace-colemak.nix
@@ -1,0 +1,41 @@
+{ config, pkgs, ... }:
+let
+  hmPkgs = pkgs.extend (
+    self: super: {
+      aerospace = config.lib.test.mkStubPackage {
+        name = "aerospace";
+        buildScript = ''
+          mkdir -p $out/bin
+          touch $out/bin/aerospace
+          chmod 755 $out/bin/aerospace
+        '';
+      };
+    }
+  );
+in
+{
+  programs.aerospace = {
+    enable = true;
+    package = hmPkgs.aerospace;
+
+    userSettings = {
+      gaps = {
+        outer.left = 8;
+        outer.bottom = 8;
+        outer.top = 8;
+        outer.right = 8;
+      };
+      mode.main.binding = {
+        alt-h = "focus left";
+        alt-j = "focus down";
+        alt-k = "focus up";
+        alt-l = "focus right";
+      };
+      key-mapping.preset = "colemak";
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent home-files/.config/aerospace/aerospace.toml ${./colemak-settings-expected.toml}
+  '';
+}

--- a/tests/modules/programs/aerospace/colemak-settings-expected.toml
+++ b/tests/modules/programs/aerospace/colemak-settings-expected.toml
@@ -1,0 +1,25 @@
+accordion-padding = 30
+after-startup-command = []
+default-root-container-layout = "tiles"
+default-root-container-orientation = "auto"
+enable-normalization-flatten-containers = true
+enable-normalization-opposite-orientation-for-nested-containers = true
+exec-on-workspace-change = []
+on-focus-changed = []
+on-focused-monitor-changed = ["move-mouse monitor-lazy-center"]
+on-window-detected = []
+
+[gaps.outer]
+bottom = 8
+left = 8
+right = 8
+top = 8
+
+[key-mapping]
+preset = "colemak"
+
+[mode.main.binding]
+alt-h = "focus left"
+alt-j = "focus down"
+alt-k = "focus up"
+alt-l = "focus right"

--- a/tests/modules/programs/aerospace/default.nix
+++ b/tests/modules/programs/aerospace/default.nix
@@ -2,4 +2,5 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
   aerospace = ./aerospace.nix;
+  aerospace-colemak = ./aerospace-colemak.nix;
 }


### PR DESCRIPTION
### Description

Allow colemak as value for key-mapping.presets.
See https://github.com/nikitabobko/AeroSpace/commit/a8cd536ca182996ceffc04ebec55c4e3ac54f27a

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
