### PR TITLE
tmux: make package nullable

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -244,7 +244,7 @@ in
         '';
       };
 
-      package = lib.mkPackageOption pkgs "tmux" { };
+      package = lib.mkPackageOption pkgs "tmux" { nullable = true; };
 
       reverseSplit = mkOption {
         default = false;
@@ -351,11 +351,10 @@ in
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
-        home.packages = [
-          cfg.package
-        ]
-        ++ lib.optional cfg.tmuxinator.enable pkgs.tmuxinator
-        ++ lib.optional cfg.tmuxp.enable pkgs.tmuxp;
+        home.packages =
+          lib.optional (cfg.package != null) cfg.package
+          ++ lib.optional cfg.tmuxinator.enable pkgs.tmuxinator
+          ++ lib.optional cfg.tmuxp.enable pkgs.tmuxp;
       }
 
       { xdg.configFile."tmux/tmux.conf".text = lib.mkBefore tmuxConf; }


### PR DESCRIPTION
### Description

This makes the `program.tmux.package` argument nullable, allowing use of system `tmux`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
    - not required?

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
  - not applicable
 
- If this PR adds an exciting new feature or contains a breaking change.
  - not applicable