### PR TITLE
nh: allow absolute flake paths

### DIFF
--- a/modules/programs/nh.nix
+++ b/modules/programs/nh.nix
@@ -30,7 +30,7 @@ in
     };
 
     osFlake = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = with lib.types; nullOr (either singleLineStr path);
       default = null;
       description = ''
         The string that will be used for the {env}`NH_OS_FLAKE` environment variable.
@@ -42,7 +42,7 @@ in
     };
 
     homeFlake = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = with lib.types; nullOr (either singleLineStr path);
       default = null;
       description = ''
         The string that will be used for the {env}`NH_HOME_FLAKE` environment variable.
@@ -54,7 +54,7 @@ in
     };
 
     darwinFlake = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+      type = with lib.types; nullOr (either singleLineStr path);
       default = null;
       description = ''
         The string that will be used for the {env}`NH_DARWIN_FLAKE` environment variable.


### PR DESCRIPTION
### Description
Changed `osFlake`, `darwinFlake` and `homeFlake` option types to allow either an absolute path or `singleLineStr`, aligning their behavior with the existing `flake` option.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
