### PR TITLE
programs/nix-search-tv: add quotes to fix shell misinterpretation 

### DIFF
--- a/modules/programs/nix-search-tv.nix
+++ b/modules/programs/nix-search-tv.nix
@@ -72,7 +72,7 @@ in
         };
 
         source.command = "${path} print";
-        preview.command = "${path} preview {}";
+        preview.command = ''${path} preview "{}"'';
       }
     );
 

--- a/tests/modules/programs/nix-search-tv/television.nix
+++ b/tests/modules/programs/nix-search-tv/television.nix
@@ -13,7 +13,7 @@
         name = "nix-search-tv"
 
         [preview]
-        command = "${lib.getExe pkgs.nix-search-tv} preview {}"
+        command = "${lib.getExe pkgs.nix-search-tv} preview \"{}\""
 
         [source]
         command = "${lib.getExe pkgs.nix-search-tv} print"


### PR DESCRIPTION
Add quotes to the preview command in television integration to prevent the shell from interpreting options with `<name>` as writing the output of the command `name` to a file with the name of the remainder of the option name. 

For example, when running the command to preview `accounts.calendar.<name>.remote` (`nix-search-tv preview ...`), the shell  would interpret this as `name > .remote`, create the file `.remote`, and error out because the command `name` was not found.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
