### PR TITLE
blueman-applet: Add option to change systemd targets

### DIFF
--- a/modules/services/blueman-applet.nix
+++ b/modules/services/blueman-applet.nix
@@ -24,6 +24,19 @@ in
       };
 
       package = lib.mkPackageOption pkgs "blueman" { };
+
+      systemdTargets = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [ "graphical-session.target" ];
+        example = [ "sway-session.target" ];
+        description = ''
+          The systemd targets that will automatically start the cliphist service.
+
+          When setting this value to `["sway-session.target"]`,
+          make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
+          otherwise the service may never be started.
+        '';
+      };
     };
   };
 
@@ -36,15 +49,12 @@ in
       Unit = {
         Description = "Blueman applet";
         Requires = [ "tray.target" ];
-        After = [
-          "graphical-session.target"
-          "tray.target"
-        ];
-        PartOf = [ "graphical-session.target" ];
+        After = cfg.systemdTargets ++ [ "tray.target" ];
+        PartOf = cfg.systemdTargets;
       };
 
       Install = {
-        WantedBy = [ "graphical-session.target" ];
+        WantedBy = cfg.systemdTargets;
       };
 
       Service = {


### PR DESCRIPTION
### Description

Introduce new option for a customizable systemd target to allow enabling the applet only in certain environments.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
