### PR TITLE
dunst: Add option to change systemd targets

### DIFF
--- a/modules/services/dunst.nix
+++ b/modules/services/dunst.nix
@@ -59,7 +59,6 @@ let
     name = "hicolor";
     size = "32x32";
   };
-
 in
 {
   meta.maintainers = [ lib.maintainers.rycee ];
@@ -126,6 +125,16 @@ in
               timeout = 10;
             };
           };
+        '';
+      };
+
+      systemdTargets = mkOption {
+        type = with types; listOf str;
+        default = [ config.wayland.systemd.target ];
+        defaultText = literalExpression "config.wayland.systemd.target";
+        example = [ "sway-session.target" ];
+        description = ''
+          The systemd targets that will automatically start the dunst service.
         '';
       };
     };
@@ -198,8 +207,8 @@ in
         systemd.user.services.dunst = {
           Unit = {
             Description = "Dunst notification daemon";
-            After = [ config.wayland.systemd.target ];
-            PartOf = [ config.wayland.systemd.target ];
+            After = cfg.systemdTargets;
+            PartOf = cfg.systemdTargets;
           };
 
           Service = {


### PR DESCRIPTION
### Description

Introduce new option for a customizable systemd targets to allow enabling
the service only in certain environments.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
