### PR TITLE
cleanup: Cleanup helper text for systemd target

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -241,10 +241,6 @@ in
         example = "sway-session.target";
         description = ''
           The systemd target that will automatically start the Waybar service.
-
-          When setting this value to `"sway-session.target"`,
-          make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
-          otherwise the service may never be started.
         '';
       };
     };

--- a/modules/programs/yambar.nix
+++ b/modules/programs/yambar.nix
@@ -55,10 +55,6 @@ in
         example = "sway-session.target";
         description = ''
           The systemd target that will automatically start the yambar service.
-
-          When setting this value to `"sway-session.target"`,
-          make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
-          otherwise the service may never be started.
         '';
       };
     };

--- a/modules/services/blueman-applet.nix
+++ b/modules/services/blueman-applet.nix
@@ -31,10 +31,6 @@ in
         example = [ "sway-session.target" ];
         description = ''
           The systemd targets that will automatically start the cliphist service.
-
-          When setting this value to `["sway-session.target"]`,
-          make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
-          otherwise the service may never be started.
         '';
       };
     };

--- a/modules/services/cliphist.nix
+++ b/modules/services/cliphist.nix
@@ -58,10 +58,6 @@ in
       description = ''
         The systemd targets that will automatically start the cliphist service.
 
-        When setting this value to `["sway-session.target"]`,
-        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
-        otherwise the service may never be started.
-
         Note: A single string value is deprecated, please use a list.
       '';
     };

--- a/modules/services/clipman.nix
+++ b/modules/services/clipman.nix
@@ -22,10 +22,6 @@ in
       example = "sway-session.target";
       description = ''
         The systemd target that will automatically start the clipman service.
-
-        When setting this value to `"sway-session.target"`,
-        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
-        otherwise the service may never be started.
       '';
     };
   };

--- a/modules/services/clipse.nix
+++ b/modules/services/clipse.nix
@@ -22,10 +22,6 @@ in
       example = "sway-session.target";
       description = ''
         The systemd target that will automatically start the clipse service.
-
-        When setting this value to `"sway-session.target"`,
-        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
-        otherwise the service may never be started.
       '';
     };
 

--- a/modules/services/copyq.nix
+++ b/modules/services/copyq.nix
@@ -24,10 +24,6 @@ in
       example = "sway-session.target";
       description = ''
         The systemd target that will automatically start the CopyQ service.
-
-        When setting this value to `"sway-session.target"`,
-        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
-        otherwise the service may never be started.
       '';
     };
 

--- a/modules/services/wluma.nix
+++ b/modules/services/wluma.nix
@@ -53,10 +53,6 @@ in
       example = "sway-session.target";
       description = ''
         The systemd target that will automatically start the Wluma service.
-
-        When setting this value to `"sway-session.target"`,
-        make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
-        otherwise the service may never be started.
       '';
     };
   };

--- a/modules/wayland.nix
+++ b/modules/wayland.nix
@@ -13,10 +13,6 @@
           The systemd target that will automatically start the graphical Wayland services.
           This option is a generalization of individual `systemd.target` or `systemdTarget`,
           and affect all Wayland services by default.
-
-          When setting this value to `"sway-session.target"`,
-          make sure to also enable {option}`wayland.windowManager.sway.systemd.enable`,
-          otherwise the service may never be started.
         '';
       };
     };


### PR DESCRIPTION

### Description

Remove helper text about sway for systemd target options

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
