### PR TITLE
systemd: make unit definitions freeform modules

### DIFF
--- a/tests/modules/services/ssh-tpm-agent/as-ssh-agent-proxy.nix
+++ b/tests/modules/services/ssh-tpm-agent/as-ssh-agent-proxy.nix
@@ -22,8 +22,8 @@
       Type=simple
 
       [Unit]
-      After=ssh-tpm-agent.socket
       After=ssh-agent.service
+      After=ssh-tpm-agent.socket
       BindsTo=ssh-agent.service
       Description=ssh-tpm-agent service
       Documentation=https://github.com/Foxboron/ssh-tpm-agent


### PR DESCRIPTION
### Description

This is some experiments in making the systemd unit descriptions more typed by using freeform modules.

### Checklist

- [ ] Change is backwards compatible.

     _Technically no, with this change we would, for example, reject `ExecStart = 42` (which is nonsense) but quite possibly also valid configurations._

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

       _Will do this if leaving draft._