### PR TITLE
Added: Extras to Claude Code to bring it to par with claude-code-nix-flake

### DIFF
--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -196,6 +196,16 @@ in
       example = lib.literalExpression "./agents";
     };
 
+    commandsDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a directory containing command files for Claude Code.
+        Command files from this directory will be symlinked to .claude/commands/.
+      '';
+      example = lib.literalExpression "./commands";
+    };
+
     mcpServers = lib.mkOption {
       type = lib.types.attrsOf jsonFormat.type;
       default = { };
@@ -251,6 +261,10 @@ in
         assertion = !(cfg.agents != { } && cfg.agentsDir != null);
         message = "Cannot specify both `programs.claude-code.agents` and `programs.claude-code.agentsDir`";
       }
+      {
+        assertion = !(cfg.commands != { } && cfg.commandsDir != null);
+        message = "Cannot specify both `programs.claude-code.commands` and `programs.claude-code.commandsDir`";
+      }
     ];
 
     programs.claude-code.finalPackage =
@@ -298,6 +312,11 @@ in
 
         ".claude/agents" = lib.mkIf (cfg.agentsDir != null) {
           source = cfg.agentsDir;
+          recursive = true;
+        };
+
+        ".claude/commands" = lib.mkIf (cfg.commandsDir != null) {
+          source = cfg.commandsDir;
           recursive = true;
         };
       }

--- a/modules/programs/claude-code.nix
+++ b/modules/programs/claude-code.nix
@@ -186,6 +186,16 @@ in
       };
     };
 
+    agentsDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a directory containing agent files for Claude Code.
+        Agent files from this directory will be symlinked to .claude/agents/.
+      '';
+      example = lib.literalExpression "./agents";
+    };
+
     mcpServers = lib.mkOption {
       type = lib.types.attrsOf jsonFormat.type;
       default = { };
@@ -237,6 +247,10 @@ in
         assertion = !(cfg.memory.text != null && cfg.memory.source != null);
         message = "Cannot specify both `programs.claude-code.memory.text` and `programs.claude-code.memory.source`";
       }
+      {
+        assertion = !(cfg.agents != { } && cfg.agentsDir != null);
+        message = "Cannot specify both `programs.claude-code.agents` and `programs.claude-code.agentsDir`";
+      }
     ];
 
     programs.claude-code.finalPackage =
@@ -281,6 +295,11 @@ in
         ".claude/CLAUDE.md" = lib.mkIf (cfg.memory.text != null || cfg.memory.source != null) (
           if cfg.memory.text != null then { text = cfg.memory.text; } else { source = cfg.memory.source; }
         );
+
+        ".claude/agents" = lib.mkIf (cfg.agentsDir != null) {
+          source = cfg.agentsDir;
+          recursive = true;
+        };
       }
       // lib.mapAttrs' (
         name: content:

--- a/tests/modules/programs/claude-code/agents-dir.nix
+++ b/tests/modules/programs/claude-code/agents-dir.nix
@@ -1,0 +1,14 @@
+{
+  programs.claude-code = {
+    enable = true;
+    agentsDir = ./agents;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.claude/agents/test-agent.md
+    assertLinkExists home-files/.claude/agents/test-agent.md
+    assertFileContent \
+      home-files/.claude/agents/test-agent.md \
+      ${./agents/test-agent.md}
+  '';
+}

--- a/tests/modules/programs/claude-code/agents/test-agent.md
+++ b/tests/modules/programs/claude-code/agents/test-agent.md
@@ -1,0 +1,6 @@
+---
+name: test-agent
+description: Test agent for agentsDir functionality
+---
+
+This is a test agent to verify that agentsDir works correctly.

--- a/tests/modules/programs/claude-code/assertion.nix
+++ b/tests/modules/programs/claude-code/assertion.nix
@@ -32,6 +32,12 @@
       test-command = "test content";
     };
     commandsDir = ./commands;
+
+    # assert fail: cannot set hooks and hooksDir at the same time.
+    hooks = {
+      test-hook = "test content";
+    };
+    hooksDir = ./hooks;
   };
 
   test.asserts.assertions.expected = [
@@ -39,5 +45,6 @@
     "Cannot specify both `programs.claude-code.memory.text` and `programs.claude-code.memory.source`"
     "Cannot specify both `programs.claude-code.agents` and `programs.claude-code.agentsDir`"
     "Cannot specify both `programs.claude-code.commands` and `programs.claude-code.commandsDir`"
+    "Cannot specify both `programs.claude-code.hooks` and `programs.claude-code.hooksDir`"
   ];
 }

--- a/tests/modules/programs/claude-code/assertion.nix
+++ b/tests/modules/programs/claude-code/assertion.nix
@@ -14,9 +14,16 @@
         ];
       };
     };
+
+    # assert fail: cannot set text and source at the same time.
+    memory = {
+      text = "Some text content";
+      source = ./expected-memory.md;
+    };
   };
 
   test.asserts.assertions.expected = [
     "`programs.claude-code.package` cannot be null when `mcpServers` is configured"
+    "Cannot specify both `programs.claude-code.memory.text` and `programs.claude-code.memory.source`"
   ];
 }

--- a/tests/modules/programs/claude-code/assertion.nix
+++ b/tests/modules/programs/claude-code/assertion.nix
@@ -26,11 +26,18 @@
       test-agent = "test content";
     };
     agentsDir = ./agents;
+
+    # assert fail: cannot set commands and commandsDir at the same time.
+    commands = {
+      test-command = "test content";
+    };
+    commandsDir = ./commands;
   };
 
   test.asserts.assertions.expected = [
     "`programs.claude-code.package` cannot be null when `mcpServers` is configured"
     "Cannot specify both `programs.claude-code.memory.text` and `programs.claude-code.memory.source`"
     "Cannot specify both `programs.claude-code.agents` and `programs.claude-code.agentsDir`"
+    "Cannot specify both `programs.claude-code.commands` and `programs.claude-code.commandsDir`"
   ];
 }

--- a/tests/modules/programs/claude-code/assertion.nix
+++ b/tests/modules/programs/claude-code/assertion.nix
@@ -20,10 +20,17 @@
       text = "Some text content";
       source = ./expected-memory.md;
     };
+
+    # assert fail: cannot set agents and agentsDir at the same time.
+    agents = {
+      test-agent = "test content";
+    };
+    agentsDir = ./agents;
   };
 
   test.asserts.assertions.expected = [
     "`programs.claude-code.package` cannot be null when `mcpServers` is configured"
     "Cannot specify both `programs.claude-code.memory.text` and `programs.claude-code.memory.source`"
+    "Cannot specify both `programs.claude-code.agents` and `programs.claude-code.agentsDir`"
   ];
 }

--- a/tests/modules/programs/claude-code/commands-dir.nix
+++ b/tests/modules/programs/claude-code/commands-dir.nix
@@ -1,0 +1,14 @@
+{
+  programs.claude-code = {
+    enable = true;
+    commandsDir = ./commands;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.claude/commands/test-command.md
+    assertLinkExists home-files/.claude/commands/test-command.md
+    assertFileContent \
+      home-files/.claude/commands/test-command.md \
+      ${./commands/test-command.md}
+  '';
+}

--- a/tests/modules/programs/claude-code/commands/test-command.md
+++ b/tests/modules/programs/claude-code/commands/test-command.md
@@ -1,0 +1,6 @@
+---
+allowed-tools: Bash(echo:*)
+description: Test command for commandsDir functionality
+---
+
+This is a test command to verify that commandsDir works correctly.

--- a/tests/modules/programs/claude-code/default.nix
+++ b/tests/modules/programs/claude-code/default.nix
@@ -6,4 +6,5 @@
   claude-code-memory-management = ./memory-management.nix;
   claude-code-memory-from-source = ./memory-from-source.nix;
   claude-code-agents-dir = ./agents-dir.nix;
+  claude-code-commands-dir = ./commands-dir.nix;
 }

--- a/tests/modules/programs/claude-code/default.nix
+++ b/tests/modules/programs/claude-code/default.nix
@@ -3,4 +3,6 @@
   claude-code-full-config = ./full-config.nix;
   claude-code-mcp = ./mcp.nix;
   claude-code-assertion = ./assertion.nix;
+  claude-code-memory-management = ./memory-management.nix;
+  claude-code-memory-from-source = ./memory-from-source.nix;
 }

--- a/tests/modules/programs/claude-code/default.nix
+++ b/tests/modules/programs/claude-code/default.nix
@@ -7,4 +7,5 @@
   claude-code-memory-from-source = ./memory-from-source.nix;
   claude-code-agents-dir = ./agents-dir.nix;
   claude-code-commands-dir = ./commands-dir.nix;
+  claude-code-hooks-dir = ./hooks-dir.nix;
 }

--- a/tests/modules/programs/claude-code/default.nix
+++ b/tests/modules/programs/claude-code/default.nix
@@ -5,4 +5,5 @@
   claude-code-assertion = ./assertion.nix;
   claude-code-memory-management = ./memory-management.nix;
   claude-code-memory-from-source = ./memory-from-source.nix;
+  claude-code-agents-dir = ./agents-dir.nix;
 }

--- a/tests/modules/programs/claude-code/expected-agents-readme.md
+++ b/tests/modules/programs/claude-code/expected-agents-readme.md
@@ -1,0 +1,8 @@
+# Claude Code Agents
+
+## Current Configuration
+Test implementation of agents directory management.
+
+## Available Agents
+- This is a test configuration
+- AgentsDir should be created at ~/.claude/agents/README.md

--- a/tests/modules/programs/claude-code/expected-memory.md
+++ b/tests/modules/programs/claude-code/expected-memory.md
@@ -1,0 +1,8 @@
+# Project Memory
+
+## Current Task
+Test implementation of memory management.
+
+## Key Context
+- This is a test configuration
+- Memory should be created at ~/.claude/CLAUDE.md

--- a/tests/modules/programs/claude-code/full-config.nix
+++ b/tests/modules/programs/claude-code/full-config.nix
@@ -104,6 +104,17 @@
         Focus on user-friendly explanations and examples.
       '';
     };
+
+    hooks = {
+      pre-edit = ''
+        #!/usr/bin/env bash
+        echo "About to edit file: $1"
+      '';
+      post-commit = ''
+        #!/usr/bin/env bash
+        echo "Committed with message: $1"
+      '';
+    };
   };
 
   nmt.script = ''
@@ -122,5 +133,11 @@
 
     assertFileExists home-files/.claude/commands/commit.md
     assertFileContent home-files/.claude/commands/commit.md ${./expected-commit}
+
+    assertFileExists home-files/.claude/hooks/pre-edit
+    assertFileRegex home-files/.claude/hooks/pre-edit "About to edit file"
+
+    assertFileExists home-files/.claude/hooks/post-commit
+    assertFileRegex home-files/.claude/hooks/post-commit "Committed with message"
   '';
 }

--- a/tests/modules/programs/claude-code/hooks-dir.nix
+++ b/tests/modules/programs/claude-code/hooks-dir.nix
@@ -1,0 +1,14 @@
+{
+  programs.claude-code = {
+    enable = true;
+    hooksDir = ./hooks;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.claude/hooks/test-hook
+    assertLinkExists home-files/.claude/hooks/test-hook
+    assertFileContent \
+      home-files/.claude/hooks/test-hook \
+      ${./hooks/test-hook}
+  '';
+}

--- a/tests/modules/programs/claude-code/hooks/test-hook
+++ b/tests/modules/programs/claude-code/hooks/test-hook
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Test hook for claude-code
+echo "Test hook executed with: $@"

--- a/tests/modules/programs/claude-code/memory-from-source.nix
+++ b/tests/modules/programs/claude-code/memory-from-source.nix
@@ -1,0 +1,13 @@
+{
+  programs.claude-code = {
+    enable = true;
+    memory = {
+      source = ./expected-memory.md;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.claude/CLAUDE.md
+    assertFileContent home-files/.claude/CLAUDE.md ${./expected-memory.md}
+  '';
+}

--- a/tests/modules/programs/claude-code/memory-management.nix
+++ b/tests/modules/programs/claude-code/memory-management.nix
@@ -1,0 +1,22 @@
+{
+  programs.claude-code = {
+    enable = true;
+    memory = {
+      text = ''
+        # Project Memory
+
+        ## Current Task
+        Test implementation of memory management.
+
+        ## Key Context
+        - This is a test configuration
+        - Memory should be created at ~/.claude/CLAUDE.md
+      '';
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.claude/CLAUDE.md
+    assertFileContent home-files/.claude/CLAUDE.md ${./expected-memory.md}
+  '';
+}


### PR DESCRIPTION
### Description

This brings the new `claude-code` home-manager settings on par in functionality with [claude-code-nix-flake](https://github.com/Sewer56/claude-code-nix-flake).

Originally `claude-code-nix-flake` was built in mind with upstreaming to `home-manager`; it's just that I've waited till `claude-code` worked with symlinks, since that was broken for a long time. Now, this can be upstreamed.

In this case, I've merged the additional settings from the above flake of mine into upstream claude-code.

PS. This is easier to review commit by commit,

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

-----

CC. @khaneliman 

What do you think we should do with `claude.json`? It does have some tunable options a person may want to touch such as:

```json
"autoUpdates": false,
"theme": "dark-daltonized",
"isQualifiedForDataSharing": false,
"hasCompletedOnboarding": true,
"bypassPermissionsModeAccepted": true,
"hasUsedBackslashReturn": true,
"hasOpusPlanDefault": false,
```

Which a user may want to touch.
(Also `mcpServers`, but we found a way around this one by wrapping the CLI).

Problem is, claude-code mutates this file, so we can't really symlink it into read-only nix store.
In [claude-code-nix-flake](https://github.com/Sewer56/claude-code-nix-flake); I would merge settings into the existing file; just like I did with others until claude code fixed symlinks. However, I'm not sure how acceptable that is by upstream home-manager standards.