### PR TITLE
msmtp: add new option to delegate use to `msmtpq`

### DIFF
--- a/modules/programs/aerc/accounts.nix
+++ b/modules/programs/aerc/accounts.nix
@@ -243,7 +243,7 @@ in
           // optPwCmd "outgoing" passwordCommand;
 
         msmtp = cfg: {
-          outgoing = "msmtpq --read-envelope-from --read-recipients";
+          outgoing = "${config.msmtp.msmtpCommand} --read-envelope-from --read-recipients";
         };
 
       };

--- a/modules/programs/alot/accounts.nix
+++ b/modules/programs/alot/accounts.nix
@@ -58,7 +58,10 @@ in
 
   config = lib.mkIf config.notmuch.enable {
     alot.sendMailCommand = lib.mkOptionDefault (
-      if config.msmtp.enable then "msmtpq --read-envelope-from --read-recipients" else null
+      if config.msmtp.enable then
+        "${config.msmtp.msmtpCommand} --read-envelope-from --read-recipients"
+      else
+        null
     );
   };
 }

--- a/modules/programs/astroid/accounts.nix
+++ b/modules/programs/astroid/accounts.nix
@@ -26,7 +26,7 @@
 
   config = lib.mkIf config.notmuch.enable {
     astroid.sendMailCommand = lib.mkIf config.msmtp.enable (
-      lib.mkOptionDefault "msmtpq --read-envelope-from --read-recipients"
+      lib.mkOptionDefault "${config.msmtp.msmtpCommand} --read-envelope-from --read-recipients"
     );
   };
 }

--- a/modules/programs/msmtp/default.nix
+++ b/modules/programs/msmtp/default.nix
@@ -114,6 +114,23 @@ in
           See <https://marlam.de/msmtp/msmtprc.txt> for examples.
         '';
       };
+
+      msmtpCommand = mkOption {
+        type = types.package;
+        internal = true;
+        readOnly = true;
+        default = if cfg.offlineSupport then "${pkgs.msmtp}/bin/msmtpq" else "${pkgs.msmtp}/bin/msmtp";
+      };
+
+      offlineSupport = lib.mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Use msmtpq script instead of msmtp. The script allows an offline
+          first workflow by adding all mails to a queue regardless of the
+          network status, and flushing them later.
+        '';
+      };
     };
 
     accounts.email.accounts = mkOption {
@@ -135,7 +152,7 @@ in
           (lib.mkIf (cfg.extraAccounts != "") (lib.mkAfter cfg.extraAccounts))
         ];
 
-        home.sessionVariables = {
+        home.sessionVariables = lib.optionalAttrs cfg.offlineSupport {
           MSMTPQ_Q = "${config.xdg.dataHome}/msmtp/queue";
           MSMTPQ_LOG = "${config.xdg.dataHome}/msmtp/queue.log";
         };

--- a/modules/programs/neomutt/accounts.nix
+++ b/modules/programs/neomutt/accounts.nix
@@ -61,7 +61,11 @@ in
 
     sendMailCommand = mkOption {
       type = types.nullOr types.str;
-      default = if config.msmtp.enable then "msmtpq --read-envelope-from --read-recipients" else null;
+      default =
+        if config.msmtp.enable then
+          "${config.msmtp.msmtpCommand} --read-envelope-from --read-recipients"
+        else
+          null;
       defaultText = lib.literalExpression ''
         if config.msmtp.enable then
           "msmtpq --read-envelope-from --read-recipients"


### PR DESCRIPTION
Add option `programs.msmtp.offlineSupport` which when enabled delegates the usage of `msmtp` to `msmtpq` script. This is achieved by an internal option `msmtpCommand` which should be called when `msmtp` is used by another module.

Resolves #2933.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
