### PR TITLE
conky: add support for multiple instances

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -114,12 +114,10 @@
     github = "d-dervishi";
     githubId = 61125355;
     name = "David Dervishi";
-    keys = [
-      {
-        longKeyId = "rsa4096/0xB1C012F0E7697195";
-        fingerprint = "4C92 E3B0 21B5 5562 A1E0  CE3D B1C0 12F0 E769 7195";
-      }
-    ];
+    keys = [{
+      longKeyId = "rsa4096/0xB1C012F0E7697195";
+      fingerprint = "4C92 E3B0 21B5 5562 A1E0  CE3D B1C0 12F0 E769 7195";
+    }];
   };
   danjujan = {
     name = "Jan Schmitz";
@@ -203,19 +201,18 @@
     matrix = "@hey2022:matrix.org";
     github = "hey2022";
     githubId = 48553457;
-    keys = [ { fingerprint = "128E 09C0 6F73 D678 6BB5  E551 5EA5 3C75 F7BE 3EDE"; } ];
+    keys =
+      [{ fingerprint = "128E 09C0 6F73 D678 6BB5  E551 5EA5 3C75 F7BE 3EDE"; }];
   };
   HPsaucii = {
     name = "Holly Powell";
     email = "me@hpsaucii.dev";
     github = "HPsaucii";
     githubId = 126502193;
-    keys = [
-      {
-        longkeyid = "rsa4096/0xEDB2C634166AE6AD";
-        fingerprint = "AD32 73D4 5E0E 9478 E826  543F EDB2 C634 166A E6AD";
-      }
-    ];
+    keys = [{
+      longkeyid = "rsa4096/0xEDB2C634166AE6AD";
+      fingerprint = "AD32 73D4 5E0E 9478 E826  543F EDB2 C634 166A E6AD";
+    }];
   };
   ipsavitsky = {
     name = "Ilya Savitsky";
@@ -254,6 +251,12 @@
     email = "contact@joygnu.org";
     github = "joygnu";
     githubId = 152063003;
+  };
+  jpoage = {
+    name = "Jason Poage";
+    email = "jpoage@jasonpoage.com";
+    github = "jpoage1";
+    githubId = 29345692;
   };
   jrobsonchase = {
     email = "josh@robsonchase.com";
@@ -380,12 +383,10 @@
     github = "msfjarvis";
     githubId = 13348378;
     name = "Harsh Shandilya";
-    keys = [
-      {
-        longkeyid = "rsa4096/0xB7843F823355E9B9";
-        fingerprint = "8F87 050B 0F9C B841 1515  7399 B784 3F82 3355 E9B9";
-      }
-    ];
+    keys = [{
+      longkeyid = "rsa4096/0xB7843F823355E9B9";
+      fingerprint = "8F87 050B 0F9C B841 1515  7399 B784 3F82 3355 E9B9";
+    }];
   };
   msyds = {
     name = "Madeleine Sydney Ślaga";
@@ -470,12 +471,10 @@
     email = "88944439+rcerc@users.noreply.github.com";
     github = "rcerc";
     githubId = 88944439;
-    keys = [
-      {
-        longkeyid = "ed25519/0x3F98EC7EC2B87ED1";
-        fingerprint = "D5D6 FD1F 0D9A 3284 FB9B  C26D 3F98 EC7E C2B8 7ED1";
-      }
-    ];
+    keys = [{
+      longkeyid = "ed25519/0x3F98EC7EC2B87ED1";
+      fingerprint = "D5D6 FD1F 0D9A 3284 FB9B  C26D 3F98 EC7E C2B8 7ED1";
+    }];
   };
   rosuavio = {
     name = "Rosario Pulella";
@@ -506,12 +505,10 @@
     email = "leon@swarsel.win";
     github = "Swarsel";
     githubId = 32304731;
-    keys = [
-      {
-        longkeyid = "rsa4096/0x76FD3810215AE097";
-        fingerprint = "4BE7 9252 6228 9B47 6DBB  C17B 76FD 3810 215A E097";
-      }
-    ];
+    keys = [{
+      longkeyid = "rsa4096/0x76FD3810215AE097";
+      fingerprint = "4BE7 9252 6228 9B47 6DBB  C17B 76FD 3810 215A E097";
+    }];
   };
   vortriz = {
     name = "Rishi Vora";

--- a/modules/misc/news/2025/08/2025-08-25_15-07-31.nix
+++ b/modules/misc/news/2025/08/2025-08-25_15-07-31.nix
@@ -1,0 +1,11 @@
+{
+  time = "2025-08-25T20:07:31+00:00";
+  condition = true;
+  message = ''
+      The `services.conky` module now supports running multiple instances. A new
+    option, `services.conky.configs`, allows you to define a set of named
+    Conky configurations. Each configuration can specify its own config
+    file/text, package, and whether it should start automatically. The old
+    `extraConfig` option is preserved for backwards compatibility.
+  '';
+}

--- a/modules/services/conky.nix
+++ b/modules/services/conky.nix
@@ -1,17 +1,11 @@
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+{ config, lib, pkgs, ... }:
 
 let
 
   cfg = config.services.conky;
 
-in
-{
-  meta.maintainers = [ lib.hm.maintainers.kaleo ];
+in {
+  meta.maintainers = with lib.hm.maintainers; [ jpoage kaleo ];
 
   options = {
     services.conky = {
@@ -33,7 +27,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    assertions = [ (lib.hm.assertions.assertPlatform "services.conky" pkgs lib.platforms.linux) ];
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.conky" pkgs
+        lib.platforms.linux)
+    ];
 
     home.packages = [ cfg.package ];
 
@@ -46,10 +43,9 @@ in
       Service = {
         Restart = "always";
         RestartSec = "3";
-        ExecStart = toString (
-          [ "${cfg.package}/bin/conky" ]
-          ++ lib.optional (cfg.extraConfig != "") "--config ${pkgs.writeText "conky.conf" cfg.extraConfig}"
-        );
+        ExecStart = toString ([ "${cfg.package}/bin/conky" ]
+          ++ lib.optional (cfg.extraConfig != "")
+          "--config ${pkgs.writeText "conky.conf" cfg.extraConfig}");
       };
 
       Install.WantedBy = [ "graphical-session.target" ];

--- a/modules/services/conky.nix
+++ b/modules/services/conky.nix
@@ -4,8 +4,9 @@ let
 
   cfg = config.services.conky;
 
-in {
-  meta.maintainers = with lib.hm.maintainers; [ jpoage kaleo ];
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ kaleo jpoage ];
 
   options = {
     services.conky = {
@@ -23,32 +24,129 @@ in {
           {command}`conky --print-config`, will be used.
         '';
       };
+      autoStart = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Start Conky automatically at login";
+      };
+      configs = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.submodule ({ name, ... }: {
+          options = {
+            enable = lib.mkEnableOption "this conky instance" // {
+              default = true;
+            };
+
+            autoStart = lib.mkOption {
+              type = with lib.types; nullOr bool;
+              default = null;
+              defaultText =
+                lib.literalExpression "config.services.conky.autoStart";
+              description = "Start this conky instance automatically at login.";
+            };
+
+            config = lib.mkOption {
+              type = lib.types.either lib.types.path lib.types.lines;
+              description =
+                "The conky configuration content as a string or a path to the config file.";
+              example = ''
+                conky.config = {
+                  alignment = "top_right",
+                  ...
+                };
+              '';
+            };
+
+            package = lib.mkPackageOption pkgs "conky" { };
+
+          };
+        }));
+        default = { };
+        description =
+          "A set of named Conky configurations for running multiple instances.";
+        example = lib.literalExpression ''
+          {
+            main = {
+              autoStart = true;
+              config = /path/to/main.conf;
+            };
+            stats = {
+              autoStart = false;
+              config = '''
+                conky.config = { ... };
+              ''';
+              package = pkgs.conky-lua;
+            };
+          }
+        '';
+      };
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = {
     assertions = [
       (lib.hm.assertions.assertPlatform "services.conky" pkgs
         lib.platforms.linux)
     ];
 
-    home.packages = [ cfg.package ];
+    home.packages = lib.unique ([ cfg.package ] ++ (lib.map (conf: conf.package)
+      (lib.attrValues
+        (lib.filterAttrs (name: conf: conf.enable) cfg.configs))));
 
-    systemd.user.services.conky = {
-      Unit = {
-        Description = "Conky - Lightweight system monitor";
-        After = [ "graphical-session.target" ];
-      };
+    systemd.user.services =
+      let
+        enabledConfigs = lib.filterAttrs (name: conf: conf.enable) cfg.configs;
+        manyConky = lib.mapAttrs'
+          (name: conf:
+            let
+              maybeConf = conf.config;
+              isPath = lib.isPath maybeConf;
+              configFile =
+                if isPath then
+                  maybeConf
+                else
+                  pkgs.writeText "conky-${name}.conf" maybeConf;
+            in
+            {
+              name = "conky@${name}";
+              value = {
+                Unit = lib.mkIf conf.autoStart {
+                  Description = "Conky - Lightweight system monitor (${name})";
+                  After = [ "graphical-session.target" ];
+                  PartOf = [ "graphical-session.target" ];
+                };
+                Service = {
+                  Restart = "always";
+                  RestartSec = "3";
+                  ExecStart = "${conf.package}/bin/conky --config ${configFile}";
+                };
+                Install = lib.mkIf conf.autoStart {
+                  WantedBy = [ "graphical-session.target" ];
+                };
+              };
+            })
+          enabledConfigs;
 
-      Service = {
-        Restart = "always";
-        RestartSec = "3";
-        ExecStart = toString ([ "${cfg.package}/bin/conky" ]
-          ++ lib.optional (cfg.extraConfig != "")
-          "--config ${pkgs.writeText "conky.conf" cfg.extraConfig}");
-      };
+        basicConky = lib.attrsets.optionalAttrs cfg.enable {
+          conky = {
+            Unit = {
+              Description = "Conky - Lightweight system monitor";
+              After = [ "graphical-session.target" ];
+            };
 
-      Install.WantedBy = [ "graphical-session.target" ];
-    };
+            Service = {
+              Restart = "always";
+              RestartSec = "3";
+              ExecStart = toString ([ "${cfg.package}/bin/conky" ]
+                ++ lib.optional (cfg.extraConfig != "")
+                "--config ${pkgs.writeText "conky.conf" cfg.extraConfig}");
+            };
+
+            Install = lib.mkIf cfg.autoStart {
+              WantedBy = [ "graphical-session.target" ];
+            };
+          };
+        };
+      in
+      basicConky // manyConky;
   };
 }

--- a/tests/modules/services/conky/default.nix
+++ b/tests/modules/services/conky/default.nix
@@ -2,4 +2,5 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   conky-basic-configuration = ./basic-configuration.nix;
+  conky-dynamic-configuration = ./dynamic-configuration.nix;
 }

--- a/tests/modules/services/conky/dynamic-configuration.nix
+++ b/tests/modules/services/conky/dynamic-configuration.nix
@@ -1,0 +1,68 @@
+{ config, pkgs, lib, ... }:
+
+let
+  homeDirectory = config.home.homeDirectory;
+  exampleConfig = ''
+    conky.text = [[
+      S Y S T E M    I N F O
+      $hr
+      Host:$alignr $nodename
+      Uptime:$alignr $uptime
+      RAM:$alignr $mem/$memmax
+    ]]
+  '';
+in {
+  services.conky = {
+    configs = {
+      withFile = {
+        enable = true;
+        autoStart = true;
+        config = "${homeDirectory}/.config/conky/my-conky.conf";
+        package = pkgs.conky;
+      };
+
+      withConfig = {
+        enable = true;
+        autoStart = false;
+        config = exampleConfig;
+        package = pkgs.conky;
+      };
+      shouldBeDisabled = { enable = false; };
+    };
+  };
+
+  home.file.".config/conky/my-conky.conf".text = "dummy conky file content";
+
+  nmt.script = ''
+    # --- Test the 'withFile' instance ---
+    serviceFile1="$TESTED/home-files/.config/systemd/user/conky@withFile.service"
+
+    assertFileExists "$serviceFile1"
+
+    assertFileRegex "$serviceFile1" \
+      "ExecStart=.*/bin/conky --config /nix/store/.*-conky-withFile.conf"
+
+    assertFileRegex "$serviceFile1" "ExecStart=${pkgs.conky}/bin/conky --config .*"
+
+    assertFileContains "$serviceFile1" "[Install]"
+    assertFileContains "$serviceFile1" "WantedBy=graphical-session.target"
+
+    # --- Test the 'withConfig' instance ---
+    serviceFile2="$TESTED/home-files/.config/systemd/user/conky@withConfig.service"
+
+    assertFileExists "$serviceFile2"
+
+    assertFileRegex "$serviceFile2" \
+      "ExecStart=.*/bin/conky --config /nix/store/.*-conky-withConfig.conf"
+
+    assertFileNotRegex "$serviceFile2" "\[Install\]"
+
+    generatedConfigFile="$(grep -o '/nix/store/.*-conky-withConfig.conf' "$serviceFile2")"
+
+    assertFileContent "$generatedConfigFile" ${./basic-configuration.conf}
+
+    # --- Test the 'shouldBeDisabled' instance ---
+    serviceFile3="$TESTED/home-files/.config/systemd/user/conky@shouldBeDisabled.service"
+    assertPathNotExists "$serviceFile3"
+  '';
+}


### PR DESCRIPTION
### Description

This PR enhances the services.conky module to support running multiple, named Conky instances simultaneously.

The primary change is the introduction of a new option, services.conky.configs. This allows users to define an attribute set where each entry represents a unique Conky instance, complete with its own configuration, package, and auto-start setting.

For example:

```Nix

services.conky.configs = {
  main = {
    config = /path/to/main.conf;
    package = pkgs.conky;
  };

  stats = {
    autoStart = false;
    config = ''
      conky.config = {
        alignment = 'top_right',
        ...
      };
    '';
    package = pkgs.conky-lua; # Use a different package
  };
};```

This implementation generates a separate systemd user service for each instance (e.g., conky@main.service and conky@stats.service), providing more granular control.

The module remains fully backwards-compatible. Existing configurations using services.conky.enable and services.conky.extraConfig will continue to function as before for managing a single instance. An autoStart option has also been added to the top-level service for consistency.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
