### PR TITLE
pizauth: reload on change and fix option type

### DIFF
--- a/modules/services/pizauth.nix
+++ b/modules/services/pizauth.nix
@@ -60,7 +60,8 @@ in
             };
 
             clientSecret = mkOption {
-              type = types.str;
+              type = types.nullOr types.str;
+              default = null;
               description = ''
                 The OAuth2 client secret.
               '';
@@ -128,6 +129,8 @@ in
             ${indent}auth_uri = "${acc.authUri}";
             ${indent}token_uri = "${acc.tokenUri}";
             ${indent}client_id = "${acc.clientId}";
+          ''
+          + lib.optionalString (acc.clientSecret != "" && acc.clientSecret != null) ''
             ${indent}client_secret = "${acc.clientSecret}";
           ''
           + lib.optionalString (acc.scopes != [ ] && acc.scopes != null) ''
@@ -164,6 +167,7 @@ in
       Unit = {
         Description = "Pizauth OAuth2 token manager";
         After = [ "network.target" ];
+        X-Restart-Triggers = [ "${config.xdg.configFile."pizauth.conf".source}" ];
       };
 
       Service = {

--- a/tests/modules/services/pizauth/basic-config.nix
+++ b/tests/modules/services/pizauth/basic-config.nix
@@ -28,6 +28,13 @@
             "offline_access"
           ];
         };
+        test3 = {
+          authUri = "authUri3";
+          tokenUri = "tokenUri3";
+          clientId = "clientId3";
+          scopes = [
+          ];
+        };
       };
     };
 
@@ -63,6 +70,12 @@
               "scope1",
               "offline_access"
             ];
+          }
+
+          account "test3" {
+            auth_uri = "authUri3";
+            token_uri = "tokenUri3";
+            client_id = "clientId3";
           }
         ''}
     '';


### PR DESCRIPTION

### Description

- added onChange pizauth reload for config file

- clientSecret is not required for outlook365 so should be nullable

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
