### PR TITLE
lsd: allow specifying a path type value for `icons` and `colors` options

### DIFF
--- a/modules/programs/lsd.nix
+++ b/modules/programs/lsd.nix
@@ -54,7 +54,7 @@ in
     };
 
     colors = lib.mkOption {
-      type = yamlFormat.type;
+      type = lib.types.either yamlFormat.type lib.types.path;
       default = { };
       example = {
         size = {
@@ -74,7 +74,7 @@ in
     };
 
     icons = lib.mkOption {
-      type = yamlFormat.type;
+      type = lib.types.either yamlFormat.type lib.types.path;
       default = { };
       example = {
         name = {
@@ -132,7 +132,8 @@ in
 
     xdg.configFile = {
       "lsd/colors.yaml" = lib.mkIf (cfg.colors != { }) {
-        source = yamlFormat.generate "lsd-colors" cfg.colors;
+        source =
+          if lib.types.path.check cfg.colors then cfg.colors else yamlFormat.generate "lsd-colors" cfg.colors;
       };
 
       "lsd/config.yaml" = lib.mkIf (cfg.settings != { }) {
@@ -140,7 +141,8 @@ in
       };
 
       "lsd/icons.yaml" = lib.mkIf (cfg.icons != { }) {
-        source = yamlFormat.generate "lsd-icons" cfg.icons;
+        source =
+          if lib.types.path.check cfg.icons then cfg.icons else yamlFormat.generate "lsd-icons" cfg.icons;
       };
     };
   };

--- a/tests/modules/programs/lsd/default.nix
+++ b/tests/modules/programs/lsd/default.nix
@@ -1,1 +1,4 @@
-{ lsd-example-settings = ./example-settings.nix; }
+{
+  lsd-example-settings = ./example-settings.nix;
+  lsd-example-settings-using-paths = ./example-settings-using-paths.nix;
+}

--- a/tests/modules/programs/lsd/example-settings-using-paths.nix
+++ b/tests/modules/programs/lsd/example-settings-using-paths.nix
@@ -1,0 +1,37 @@
+{
+  programs.lsd = {
+    enable = true;
+    settings = {
+      date = "relative";
+      blocks = [
+        "date"
+        "size"
+        "name"
+      ];
+      layout = "oneline";
+      sorting.dir-grouping = "first";
+      ignore-globs = [
+        ".git"
+        ".hg"
+        ".bsp"
+      ];
+    };
+    colors = ./example-colors-expected.yaml;
+    icons = ./example-icons-expected.yaml;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/lsd/config.yaml
+    assertFileExists home-files/.config/lsd/colors.yaml
+    assertFileExists home-files/.config/lsd/icons.yaml
+    assertFileContent \
+      home-files/.config/lsd/config.yaml \
+      ${./example-settings-expected.yaml}
+    assertFileContent \
+      home-files/.config/lsd/colors.yaml \
+      ${./example-colors-expected.yaml}
+    assertFileContent \
+      home-files/.config/lsd/icons.yaml \
+      ${./example-icons-expected.yaml}
+  '';
+}


### PR DESCRIPTION
### Description

This allows users to use an icons or colors theme file taken from GitHub directly without the YAML -> Nix translation in the configuration.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
