### PR TITLE
process-compose: Add programs.process-compose module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -501,6 +501,12 @@
     github = "silmarp";
     githubId = 67292496;
   };
+  stijnruts = {
+    name = "Stijn Ruts";
+    email = "nix@stijnruts.be";
+    github = "StijnRuts";
+    githubId = 1696566;
+  };
   swarsel = {
     name = "Leon Schwarzäugl";
     email = "leon@swarsel.win";

--- a/modules/misc/news/2025/08/2025-08-29_11-51-35.nix
+++ b/modules/misc/news/2025/08/2025-08-29_11-51-35.nix
@@ -1,0 +1,12 @@
+{
+  time = "2025-08-29T09:51:35+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.process-compose'
+
+    Process Compose, a simple and flexible scheduler and orchestrator
+    to manage non-containerized applications
+
+    The module supports configuring settings.yaml, theme.yaml, and shortcuts.yaml
+  '';
+}

--- a/modules/programs/process-compose.nix
+++ b/modules/programs/process-compose.nix
@@ -1,0 +1,162 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkOption;
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.stijnruts ];
+
+  options.programs.process-compose = {
+    enable = lib.mkEnableOption "Process Compose, a simple and flexible scheduler and orchestrator to manage non-containerized applications";
+
+    package = lib.mkPackageOption pkgs "process-compose" { nullable = true; };
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = {
+        theme = "Cobalt";
+        sort = {
+          by = "NAME";
+          isReversed = false;
+        };
+        disable_exit_confirmation = false;
+      };
+      description = ''
+        Written to {file}`$XDG_CONFIG_HOME/process-compose/settings.yaml`
+
+        See <https://f1bonacc1.github.io/process-compose/tui/#tui-state-settings>
+      '';
+    };
+
+    theme = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = {
+        body = {
+          fgColor = "white";
+          bgColor = "black";
+          secondaryTextColor = "yellow";
+          tertiaryTextColor = "green";
+          borderColor = "white";
+        };
+        stat_table = {
+          keyFgColor = "yellow";
+          valueFgColor = "white";
+          logoColor = "yellow";
+        };
+        proc_table = {
+          fgColor = "lightskyblue";
+          fgWarning = "yellow";
+          fgPending = "grey";
+          fgCompleted = "lightgreen";
+          fgError = "red";
+          headerFgColor = "white";
+        };
+        help = {
+          fgColor = "black";
+          keyColor = "white";
+          hlColor = "green";
+          categoryFgColor = "lightskyblue";
+        };
+        dialog = {
+          fgColor = "cadetblue";
+          bgColor = "black";
+          buttonFgColor = "black";
+          buttonBgColor = "lightskyblue";
+          buttonFocusFgColor = "black";
+          buttonFocusBgColor = "dodgerblue";
+          labelFgColor = "yellow";
+          fieldFgColor = "black";
+          fieldBgColor = "lightskyblue";
+        };
+      };
+      description = ''
+        Written to {file}`$XDG_CONFIG_HOME/process-compose/theme.yaml`
+
+        See <https://f1bonacc1.github.io/process-compose/tui/#tui-themes>
+      '';
+    };
+
+    shortcuts = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      example = {
+        log_follow = {
+          toggle_description = {
+            false = "Follow Off";
+            true = "Follow On";
+          };
+          shortcut = "F5";
+        };
+        log_screen = {
+          toggle_description = {
+            false = "Half Screen";
+            true = "Full Screen";
+          };
+          shortcut = "F4";
+        };
+        log_wrap = {
+          toggle_description = {
+            false = "Wrap Off";
+            true = "Wrap On";
+          };
+          shortcut = "F6";
+        };
+        process_restart = {
+          description = "Restart";
+          shortcut = "Ctrl-R";
+        };
+        process_screen = {
+          toggle_description = {
+            false = "Half Screen";
+            true = "Full Screen";
+          };
+          shortcut = "F8";
+        };
+        process_start = {
+          description = "Start";
+          shortcut = "F7";
+        };
+        process_stop = {
+          description = "Stop";
+          shortcut = "F9";
+        };
+        quit = {
+          description = "Quit";
+          shortcut = "F10";
+        };
+      };
+      description = ''
+        Written to {file}`$XDG_CONFIG_HOME/process-compose/shortcuts.yaml`
+
+        See <https://f1bonacc1.github.io/process-compose/tui/#shortcuts-configuration>
+      '';
+    };
+  };
+
+  config =
+    let
+      cfg = config.programs.process-compose;
+    in
+    lib.mkIf cfg.enable {
+      home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+      xdg.configFile = {
+        "process-compose/settings.yaml" = lib.mkIf (cfg.settings != { }) {
+          source = yamlFormat.generate "process-compose-settings" cfg.settings;
+        };
+        "process-compose/theme.yaml" = lib.mkIf (cfg.theme != { }) {
+          source = yamlFormat.generate "process-compose-theme" { style = cfg.theme; };
+        };
+        "process-compose/shortcuts.yaml" = lib.mkIf (cfg.shortcuts != { }) {
+          source = yamlFormat.generate "process-compose-shortcuts" { shortcuts = cfg.shortcuts; };
+        };
+      };
+    };
+}

--- a/tests/modules/programs/process-compose/default.nix
+++ b/tests/modules/programs/process-compose/default.nix
@@ -1,0 +1,1 @@
+{ process-compose = ./process-compose.nix; }

--- a/tests/modules/programs/process-compose/expected-settings.yaml
+++ b/tests/modules/programs/process-compose/expected-settings.yaml
@@ -1,0 +1,5 @@
+disable_exit_confirmation: false
+sort:
+  by: NAME
+  isReversed: false
+theme: Cobalt

--- a/tests/modules/programs/process-compose/expected-shortcuts.yaml
+++ b/tests/modules/programs/process-compose/expected-shortcuts.yaml
@@ -1,0 +1,33 @@
+shortcuts:
+  log_follow:
+    shortcut: F5
+    toggle_description:
+      'false': Follow Off
+      'true': Follow On
+  log_screen:
+    shortcut: F4
+    toggle_description:
+      'false': Half Screen
+      'true': Full Screen
+  log_wrap:
+    shortcut: F6
+    toggle_description:
+      'false': Wrap Off
+      'true': Wrap On
+  process_restart:
+    description: Restart
+    shortcut: Ctrl-R
+  process_screen:
+    shortcut: F8
+    toggle_description:
+      'false': Half Screen
+      'true': Full Screen
+  process_start:
+    description: Start
+    shortcut: F7
+  process_stop:
+    description: Stop
+    shortcut: F9
+  quit:
+    description: Quit
+    shortcut: F10

--- a/tests/modules/programs/process-compose/expected-theme.yaml
+++ b/tests/modules/programs/process-compose/expected-theme.yaml
@@ -1,0 +1,33 @@
+style:
+  body:
+    bgColor: black
+    borderColor: white
+    fgColor: white
+    secondaryTextColor: yellow
+    tertiaryTextColor: green
+  dialog:
+    bgColor: black
+    buttonBgColor: lightskyblue
+    buttonFgColor: black
+    buttonFocusBgColor: dodgerblue
+    buttonFocusFgColor: black
+    fgColor: cadetblue
+    fieldBgColor: lightskyblue
+    fieldFgColor: black
+    labelFgColor: yellow
+  help:
+    categoryFgColor: lightskyblue
+    fgColor: black
+    hlColor: green
+    keyColor: white
+  proc_table:
+    fgColor: lightskyblue
+    fgCompleted: lightgreen
+    fgError: red
+    fgPending: grey
+    fgWarning: yellow
+    headerFgColor: white
+  stat_table:
+    keyFgColor: yellow
+    logoColor: yellow
+    valueFgColor: white

--- a/tests/modules/programs/process-compose/process-compose.nix
+++ b/tests/modules/programs/process-compose/process-compose.nix
@@ -1,0 +1,109 @@
+{
+  programs.process-compose = {
+    enable = true;
+    settings = {
+      theme = "Cobalt";
+      sort = {
+        by = "NAME";
+        isReversed = false;
+      };
+      disable_exit_confirmation = false;
+    };
+    theme = {
+      body = {
+        fgColor = "white";
+        bgColor = "black";
+        secondaryTextColor = "yellow";
+        tertiaryTextColor = "green";
+        borderColor = "white";
+      };
+      stat_table = {
+        keyFgColor = "yellow";
+        valueFgColor = "white";
+        logoColor = "yellow";
+      };
+      proc_table = {
+        fgColor = "lightskyblue";
+        fgWarning = "yellow";
+        fgPending = "grey";
+        fgCompleted = "lightgreen";
+        fgError = "red";
+        headerFgColor = "white";
+      };
+      help = {
+        fgColor = "black";
+        keyColor = "white";
+        hlColor = "green";
+        categoryFgColor = "lightskyblue";
+      };
+      dialog = {
+        fgColor = "cadetblue";
+        bgColor = "black";
+        buttonFgColor = "black";
+        buttonBgColor = "lightskyblue";
+        buttonFocusFgColor = "black";
+        buttonFocusBgColor = "dodgerblue";
+        labelFgColor = "yellow";
+        fieldFgColor = "black";
+        fieldBgColor = "lightskyblue";
+      };
+    };
+    shortcuts = {
+      log_follow = {
+        toggle_description = {
+          false = "Follow Off";
+          true = "Follow On";
+        };
+        shortcut = "F5";
+      };
+      log_screen = {
+        toggle_description = {
+          false = "Half Screen";
+          true = "Full Screen";
+        };
+        shortcut = "F4";
+      };
+      log_wrap = {
+        toggle_description = {
+          false = "Wrap Off";
+          true = "Wrap On";
+        };
+        shortcut = "F6";
+      };
+      process_restart = {
+        description = "Restart";
+        shortcut = "Ctrl-R";
+      };
+      process_screen = {
+        toggle_description = {
+          false = "Half Screen";
+          true = "Full Screen";
+        };
+        shortcut = "F8";
+      };
+      process_start = {
+        description = "Start";
+        shortcut = "F7";
+      };
+      process_stop = {
+        description = "Stop";
+        shortcut = "F9";
+      };
+      quit = {
+        description = "Quit";
+        shortcut = "F10";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/process-compose/settings.yaml
+    assertFileContent home-files/.config/process-compose/settings.yaml ${./expected-settings.yaml}
+
+    assertFileExists home-files/.config/process-compose/theme.yaml
+    assertFileContent home-files/.config/process-compose/theme.yaml ${./expected-theme.yaml}
+
+    assertFileExists home-files/.config/process-compose/shortcuts.yaml
+    assertFileContent home-files/.config/process-compose/shortcuts.yaml ${./expected-shortcuts.yaml}
+  '';
+}


### PR DESCRIPTION
### Description

Allow configuring settings.yaml, theme.yaml, and shortcuts.yaml for Process Compose

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
