### PR TITLE
ssh: provide code snippet in enableDefaultConfig description

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -559,6 +559,21 @@ in
       description = ''
         Whether to enable or not the old default config values.
         This option will become deprecated in the future.
+        For an equivalent, copy and paste the following
+        code snippet in your config:
+
+        programs.ssh.matchBlocks."*" = {
+          forwardAgent = false;
+          addKeysToAgent = "no";
+          compression = false;
+          serverAliveInterval = 0;
+          serverAliveCountMax = 3;
+          hashKnownHosts = false;
+          userKnownHostsFile = "~/.ssh/known_hosts";
+          controlMaster = "no";
+          controlPath = "~/.ssh/master-%r@%n:%p";
+          controlPersist = "no";
+        };
       '';
     };
   };


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Provide a code snippet of the equivalent of `enableDefaultConfig` to `matchBlocks."*"` in the option description.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
