### PR TITLE
nix-your-shell: Allow passing `--nom` parameter to nix-your-shell

### DIFF
--- a/tests/modules/programs/nix-your-shell/enable-shells.nix
+++ b/tests/modules/programs/nix-your-shell/enable-shells.nix
@@ -13,6 +13,7 @@
       enableFishIntegration = true;
       enableNushellIntegration = true;
       enableZshIntegration = true;
+      nix-output-monitor.enable = true;
     };
     fish.enable = true;
     nushell.enable = true;
@@ -33,7 +34,7 @@
       assertFileExists home-files/.config/fish/config.fish
       assertFileRegex \
         home-files/.config/fish/config.fish \
-        '/nix/store/[^/]*-nix-your-shell-[^/]*/bin/nix-your-shell fish | source'
+        '/nix/store/[^/]*-nix-your-shell-[^/]*/bin/nix-your-shell --nom fish | source'
 
       assertFileExists ${nushellConfigDir}/config.nu
       assertFileRegex \
@@ -43,6 +44,6 @@
       assertFileExists home-files/.zshrc
       assertFileRegex \
         home-files/.zshrc \
-        '/nix/store/[^/]*-nix-your-shell-[^/]*/bin/nix-your-shell zsh | source /dev/stdin'
+        '/nix/store/[^/]*-nix-your-shell-[^/]*/bin/nix-your-shell --nom zsh | source /dev/stdin'
     '';
 }


### PR DESCRIPTION
This PR allows passing `--nom` parameter to `nix-your-shell` program.

### Questions
- Should the `nom` package be added to the installed user packages? Is there a better approach (a wrapper over `nix-your-shell` with its own `nom` version, perhaps)?

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.