### PR TITLE
programs.rclone: various fixes

### DIFF
--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -259,7 +259,7 @@ in
 
               if ! ${lib.getExe cfg.package} config update \
                      ${remote.name} config_refresh_token=false \
-                     ${secret} "$(cat "${secretFile}")" \
+                     ${secret}="$(cat "${secretFile}")" \
                      --non-interactive; then
                 echo "Failed to inject secret \"${secretFile}\""
                 cleanup

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -63,7 +63,7 @@ in
                 description = ''
                   Regular configuration options as described in rclone's documentation
                   <https://rclone.org/docs/>. When specifying options follow the formatting
-                  process outlined here <https://rclone.org/docs/#config-config-file>, namley:
+                  process outlined here <https://rclone.org/docs/#config-config-file>, namely:
                    - Remove the leading double-dash (--) from the rclone option name
                    - Replace hyphens (-) with underscores (_)
                    - Convert to lowercase

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -344,6 +344,7 @@ in
                   };
 
                   Service = {
+                    Type = "notify";
                     Environment = [
                       # fusermount/fusermount3
                       "PATH=/run/wrappers/bin"

--- a/tests/integration/standalone/rclone/default.nix
+++ b/tests/integration/standalone/rclone/default.nix
@@ -21,7 +21,7 @@ in
   imports = [
     ./no-secrets.nix
     ./with-secrets-in-store.nix
-    ./secrets-with-whitespace.nix
+    ./secrets-arbitrary-characters.nix
     ./no-type.nix
     ./mount.nix
     ./shell.nix

--- a/tests/integration/standalone/rclone/secrets-arbitrary-characters.nix
+++ b/tests/integration/standalone/rclone/secrets-arbitrary-characters.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 let
-  module = pkgs.writeText "secrets-with-whitespace-module" ''
+  module = pkgs.writeText "secrets-arbitrary-characters-module" ''
     {
       programs.rclone.remotes = {
         alices-cool-remote-v3 = {
@@ -8,25 +8,29 @@ let
             type = "memory";
             description = "alices speeedy remote";
           };
-          secrets.spaces-secret = "${pkgs.writeText "secret" ''
-            This is a secret with spaces, it has single spaces,        and lots of spaces :3
-          ''}";
+          secrets = {
+            spaces-secret = "${pkgs.writeText "secret" ''
+              This is a secret with spaces, it has single spaces,        and lots of spaces :3
+            ''}";
+            symbols-secret = "${pkgs.writeText "secret" "-x'$$*>\"+:&#{!@'"}";
+          };
         };
       };
     }
   '';
 
-  expected = pkgs.writeText "secrets-with-whitespace-expected" ''
+  expected = pkgs.writeText "secrets-arbitrary-characters-expected" ''
     [alices-cool-remote-v3]
     description = alices speeedy remote
     type = memory
     spaces-secret = This is a secret with spaces, it has single spaces,        and lots of spaces :3
+    symbols-secret = -x'$$*>"+:&#{!@'
 
   '';
 in
 {
   script = ''
-    with subtest("Secrets with spaces"):
+    with subtest("Secrets with arbitrary characters"):
       succeed_as_alice("install -m644 ${module} /home/alice/.config/home-manager/test-remote.nix")
 
       actual = succeed_as_alice("home-manager switch")


### PR DESCRIPTION
### Description

rclone-mount services are changed to be `Type=notify`; according to <https://rclone.org/commands/rclone_mount/#systemd>, it should be possible to set `Type=notify` to ensure that the service is not marked as started until the mountpoint has actually been successfully mounted, and this is what the project recommends when using as a systemd service.

Furthermore, the `key=value` syntax is used in `rclone config update` to ensure that the secret value cannot be interpreted as a flag (which could happen if the secret value begins with `-`). I don't know if tests really ought to be added for this, but I was kinda struggling to run the tests for `rclone` tbh. I'm open to adding a test though (or maybe making the `secrets-with-whitespace` test scope a bit broader).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
