### PR TITLE
jq: make `colors` and `package` nullable

### DIFF
--- a/modules/programs/jq.nix
+++ b/modules/programs/jq.nix
@@ -35,11 +35,11 @@ in
     programs.jq = {
       enable = lib.mkEnableOption "the jq command-line JSON processor";
 
-      package = lib.mkPackageOption pkgs "jq" { };
+      package = lib.mkPackageOption pkgs "jq" { nullable = true; };
 
       colors = mkOption {
         description = ''
-          The colors used in colored JSON output.
+          The colors used in colored JSON output, or null to use the defaults.
 
           See the [Colors section](https://jqlang.github.io/jq/manual/#Colors)
           of the jq manual.
@@ -58,30 +58,21 @@ in
           }
         '';
 
-        default = {
-          null = "1;30";
-          false = "0;37";
-          true = "0;37";
-          numbers = "0;37";
-          strings = "0;32";
-          arrays = "1;37";
-          objects = "1;37";
-          objectKeys = "1;34";
-        };
+        default = null;
 
-        type = colorsType;
+        type = types.nullOr colorsType;
       };
     };
   };
 
   config = mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     home.sessionVariables =
       let
         c = cfg.colors;
       in
-      {
+      lib.mkIf (c != null) {
         JQ_COLORS = "${c.null}:${c.false}:${c.true}:${c.numbers}:${c.strings}:${c.arrays}:${c.objects}:${c.objectKeys}";
       };
   };


### PR DESCRIPTION
### Description

Make `colors` and `package` nullable, and since according to commit
f9b5172d956c79add5f6c8acccea2c7ca7f904c9 the defaults are the upstream values, default `colors` to null.

Setting JQ_COLORS is just unnecessary environment clutter when using the default colors.

Although the module now does nothing besides (optionally) installing `jq` when `colors` is left at its default value, that is still useful: from a flake with multiple home-manager configurations, some of which have `jq` provided through other means, setting/forcing `programs.jq.package` to null is more convenient than conditionally adding `jq` to `home.packages`.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

`nix run .#tests -- test-all` fails for reasons that look unrelated to my change (`test-all-no-big-ifd` fails to build `/nix/store/18p2c978b28w4qfdw8c445rhng2ag2ij-home-build-podman-my-bld.drv` with `/nix/store/nbrif411qgsj1h5r7rlgxxm140aj58dz-stdenv-linux/setup: line 1773: @podman@/lib/systemd/user-generators/podman-user-generator: No such file or directory`).

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

Please let me know if this warrants a test (the module doesn't have one yet, and I'll need to figure out the unrelated failure mentioned above first).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
