### PR TITLE
qt: Remove Plasma 5 and related Qt5 packages

### DIFF
--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -215,6 +215,7 @@ in
                 "lxqt"
                 "qtct"
                 "kde"
+                "kde6"
               ]) (lib.types.submodule { options = newOption; })
             );
           default = null;
@@ -290,11 +291,22 @@ in
 
   config =
     let
+      deprecateKde6 =
+        name: optionPath:
+        if name == "kde6" then
+          lib.warn ''
+            The ${optionPath} value "kde6" has been deprecated and renamed to "kde".
+            Please update your configuration:
+              ${optionPath} = "kde";
+          '' "kde"
+        else
+          name;
+
       platformTheme =
         if (builtins.isString cfg.platformTheme) then
           {
             option = "qt.platformTheme";
-            name = cfg.platformTheme;
+            name = deprecateKde6 cfg.platformTheme "qt.platformTheme";
             package = null;
           }
         else if cfg.platformTheme == null then
@@ -306,7 +318,7 @@ in
         else
           {
             option = "qt.platformTheme.name";
-            name = cfg.platformTheme.name;
+            name = deprecateKde6 cfg.platformTheme.name "qt.platformTheme.name";
             package = cfg.platformTheme.package;
           };
 

--- a/modules/misc/qt.nix
+++ b/modules/misc/qt.nix
@@ -23,11 +23,6 @@ let
       qt6Packages.qt6gtk2
     ];
     kde = [
-      libsForQt5.kio
-      libsForQt5.plasma-integration
-      libsForQt5.systemsettings
-    ];
-    kde6 = [
       kdePackages.kio
       kdePackages.plasma-integration
       kdePackages.systemsettings
@@ -46,7 +41,6 @@ let
   styleNames = {
     gtk = "gtk2";
     qtct = "qt5ct";
-    kde6 = "kde";
   };
 
   # Maps known lowercase style names to style packages. Non-exhaustive.
@@ -79,7 +73,10 @@ let
       adwaita-qt6
     ];
 
-    breeze = libsForQt5.breeze-qt5;
+    breeze = [
+      kdePackages.breeze
+      kdePackages.breeze.qt5
+    ];
 
     kvantum = [
       libsForQt5.qtstyleplugin-kvantum
@@ -191,10 +188,7 @@ in
                   applications
 
                 `kde`
-                : Use Qt settings from Plasma 5
-
-                `kde6`
-                : Use Qt settings from Plasma 6
+                : Use Qt settings from Plasma
               '';
             };
             package = lib.mkOption {
@@ -221,7 +215,6 @@ in
                 "lxqt"
                 "qtct"
                 "kde"
-                "kde6"
               ]) (lib.types.submodule { options = newOption; })
             );
           default = null;

--- a/tests/modules/misc/qt/default.nix
+++ b/tests/modules/misc/qt/default.nix
@@ -3,4 +3,5 @@
   qt-platform-theme-gtk = ./qt-platform-theme-gtk.nix;
   qt-platform-theme-gtk3 = ./qt-platform-theme-gtk3.nix;
   qt-platform-theme-gnome = ./qt-platform-theme-gnome.nix;
+  qt-platform-theme-kde6-migration = ./qt-platform-theme-kde6-migration.nix;
 }

--- a/tests/modules/misc/qt/qt-platform-theme-kde6-migration.nix
+++ b/tests/modules/misc/qt/qt-platform-theme-kde6-migration.nix
@@ -1,0 +1,16 @@
+{
+  qt = {
+    enable = true;
+    platformTheme.name = "kde6"; # Should trigger warning and convert to "kde"
+  };
+
+  nmt.script = ''
+    # Verify that kde6 gets converted to kde in QT_QPA_PLATFORMTHEME
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'QT_QPA_PLATFORMTHEME="kde"'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'QT_PLUGIN_PATH'
+    assertFileRegex home-path/etc/profile.d/hm-session-vars.sh \
+      'QML2_IMPORT_PATH'
+  '';
+}


### PR DESCRIPTION
### Description

Modeled after the changes in Nixpkgs from https://github.com/NixOS/nixpkgs/pull/435823, platform `kde6` is removed and platform `kde` now means Plasma 6.

Also fixes evaluation error due to missing attribute `libsForQt5.breeze-qt5` (closes https://github.com/nix-community/home-manager/issues/7728).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.
  - This is a **breaking change**.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
