### PR TITLE
swayosd: Remove non-existing `display` arg option

### DIFF
--- a/modules/misc/news/2025/09/2025-09-01_14-57-54.nix
+++ b/modules/misc/news/2025/09/2025-09-01_14-57-54.nix
@@ -1,0 +1,7 @@
+{
+  time = "2025-09-01T12:57:54+00:00";
+  condition = true;
+  message = ''
+    The option 'services.swayosd.display' has been removed, it had no impact.
+  '';
+}

--- a/modules/misc/news/2025/09/2025-09-01_14-57-54.nix
+++ b/modules/misc/news/2025/09/2025-09-01_14-57-54.nix
@@ -1,7 +1,0 @@
-{
-  time = "2025-09-01T12:57:54+00:00";
-  condition = true;
-  message = ''
-    The option 'services.swayosd.display' has been removed, since the --display flag is no longer available in swayosd-server.".
-  '';
-}

--- a/modules/misc/news/2025/09/2025-09-01_14-57-54.nix
+++ b/modules/misc/news/2025/09/2025-09-01_14-57-54.nix
@@ -2,6 +2,6 @@
   time = "2025-09-01T12:57:54+00:00";
   condition = true;
   message = ''
-    The option 'services.swayosd.display' has been removed, it had no impact.
+    The option 'services.swayosd.display' has been removed, since the --display flag is no longer available in swayosd-server.".
   '';
 }

--- a/modules/services/swayosd.nix
+++ b/modules/services/swayosd.nix
@@ -45,15 +45,6 @@ in
         Use a custom Stylesheet file instead of looking for one.
       '';
     };
-
-    display = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "eDP-1";
-      description = ''
-        X display to use.
-      '';
-    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -79,7 +70,6 @@ in
           Type = "simple";
           ExecStart =
             "${cfg.package}/bin/swayosd-server"
-            + (optionalString (cfg.display != null) " --display ${cfg.display}")
             + (optionalString (cfg.stylePath != null) " --style ${lib.escapeShellArg cfg.stylePath}")
             + (optionalString (cfg.topMargin != null) " --top-margin ${toString cfg.topMargin}");
           Restart = "always";

--- a/modules/services/swayosd.nix
+++ b/modules/services/swayosd.nix
@@ -18,6 +18,14 @@ in
 {
   meta.maintainers = [ lib.hm.maintainers.pltanton ];
 
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "services"
+      "swayosd"
+      "display"
+    ] "This option had no impact.")
+  ];
+
   options.services.swayosd = {
     enable = lib.mkEnableOption ''
       swayosd, a GTK based on screen display for keyboard shortcuts like

--- a/modules/services/swayosd.nix
+++ b/modules/services/swayosd.nix
@@ -23,7 +23,7 @@ in
       "services"
       "swayosd"
       "display"
-    ] "This option had no impact.")
+    ] "The --display flag is no longer available in swayosd-server.")
   ];
 
   options.services.swayosd = {

--- a/tests/modules/services/swayosd/default.nix
+++ b/tests/modules/services/swayosd/default.nix
@@ -2,4 +2,5 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   swayosd = ./swayosd.nix;
+  swayosd-with-deprecated-options = ./deprecated-options.nix;
 }

--- a/tests/modules/services/swayosd/deprecated-options.nix
+++ b/tests/modules/services/swayosd/deprecated-options.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  config,
+  options,
+  ...
+}:
+
+{
+  services.swayosd = {
+    enable = true;
+    package = config.lib.test.mkStubPackage {
+      name = "swayosd";
+      outPath = "@swayosd@";
+    };
+    display = "DISPLAY";
+    stylePath = "/etc/xdg/swayosd/style.css";
+    topMargin = 0.1;
+  };
+
+  test.asserts.assertions.expected = [
+    ''
+      The option definition `services.swayosd.display' in ${lib.showFiles options.services.swayosd.display.files} no longer has any effect; please remove it.
+      The --display flag is no longer available in swayosd-server.
+    ''
+  ];
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/systemd/user/swayosd.service \
+      ${builtins.toFile "swayosd.service" ''
+        [Install]
+        WantedBy=graphical-session.target
+
+        [Service]
+        ExecStart=@swayosd@/bin/swayosd-server --style /etc/xdg/swayosd/style.css --top-margin 0.100000
+        Restart=always
+        RestartSec=2s
+        Type=simple
+
+        [Unit]
+        After=graphical-session.target
+        ConditionEnvironment=WAYLAND_DISPLAY
+        Description=Volume/backlight OSD indicator
+        Documentation=man:swayosd(1)
+        PartOf=graphical-session.target
+        StartLimitBurst=5
+        StartLimitIntervalSec=10
+      ''}
+  '';
+}

--- a/tests/modules/services/swayosd/swayosd.nix
+++ b/tests/modules/services/swayosd/swayosd.nix
@@ -7,7 +7,6 @@
       name = "swayosd";
       outPath = "@swayosd@";
     };
-    display = "DISPLAY";
     stylePath = "/etc/xdg/swayosd/style.css";
     topMargin = 0.1;
   };
@@ -20,7 +19,7 @@
         WantedBy=graphical-session.target
 
         [Service]
-        ExecStart=@swayosd@/bin/swayosd-server --display DISPLAY --style /etc/xdg/swayosd/style.css --top-margin 0.100000
+        ExecStart=@swayosd@/bin/swayosd-server --style /etc/xdg/swayosd/style.css --top-margin 0.100000
         Restart=always
         RestartSec=2s
         Type=simple


### PR DESCRIPTION
### Description

Fixes #7750 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
