### PR TITLE
fontconfig: add fonts.fontconfig.extraConfigFiles option

### DIFF
--- a/modules/misc/fontconfig.nix
+++ b/modules/misc/fontconfig.nix
@@ -15,37 +15,40 @@ let
 
   profileDirectory = config.home.profileDirectory;
 
-  fontconfigFileType = lib.types.submodule ({ name, ... }: {
-    options = {
-      enable = lib.mkEnableOption "Whether this font config file should be generated.";
-      text = lib.mkOption {
-        type = lib.types.nullOr lib.types.lines;
-        default = null;
-        description = "Verbatim contents of the config file. If this option is null then the 'source' option must be set.";
+  fontconfigFileType = lib.types.submodule (
+    { name, ... }:
+    {
+      options = {
+        enable = lib.mkEnableOption "Whether this font config file should be generated.";
+        text = lib.mkOption {
+          type = lib.types.nullOr lib.types.lines;
+          default = null;
+          description = "Verbatim contents of the config file. If this option is null then the 'source' option must be set.";
+        };
+        source = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "Config file to source. Alternatively, use the 'text' option instead.";
+        };
+        label = lib.mkOption {
+          type = lib.types.str;
+          default = "name";
+          description = "Label to use for the name of the config file.";
+        };
+        priority = lib.mkOption {
+          type = lib.types.addCheck lib.types.int (x: x >= 0 && x <= 99);
+          default = 90;
+          description = ''
+            Determines the order in which configs are loaded.
+            Must be a value within the range of 0-99, where priority 0 is the highest priority and 99 is the lowest.
+          '';
+        };
       };
-      source = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        default = null;
-        description = "Config file to source. Alternatively, use the 'text' option instead.";
+      config = {
+        label = lib.mkDefault name;
       };
-      label = lib.mkOption {
-        type = lib.types.str;
-        default = "name";
-        description = "Label to use for the name of the config file.";
-      };
-      priority = lib.mkOption {
-        type = lib.types.addCheck lib.types.int (x: x >= 0 && x <= 99);
-        default = 90;
-        description = ''
-          Determines the order in which configs are loaded.
-          Must be a value within the range of 0-99, where priority 0 is the highest priority and 99 is the lowest.
-        '';
-      };
-    };
-    config = {
-      label = lib.mkDefault name;
-    };
-  });
+    }
+  );
 
 in
 {
@@ -159,7 +162,7 @@ in
 
       extraConfigFiles = lib.mkOption {
         type = lib.types.attrsOf fontconfigFileType;
-        default = {};
+        default = { };
         description = ''
           Extra font config files that will be added to `~/.config/fontconfig/conf.d/`.
           Files are named like `fontconfig/conf.d/{priority}-{label}.conf`.
@@ -233,9 +236,12 @@ in
           </fontconfig>
         '';
 
-        fontconfigExtraConfs = lib.mapAttrs' (name: config:
-          lib.nameValuePair "fontconfig/conf.d/${builtins.toString config.priority}-${config.label}.conf"
-          { inherit (config) text; source = lib.mkIf (config.source != null) config.source; }
+        fontconfigExtraConfs = lib.mapAttrs' (
+          name: config:
+          lib.nameValuePair "fontconfig/conf.d/${builtins.toString config.priority}-${config.label}.conf" {
+            inherit (config) text;
+            source = lib.mkIf (config.source != null) config.source;
+          }
         ) cfg.extraConfigFiles;
       in
       {
@@ -313,6 +319,7 @@ in
             ${genDefault cfg.defaultFonts.monospace "monospace"}
             ${genDefault cfg.defaultFonts.emoji "emoji"}
           '';
-      } // fontconfigExtraConfs;
+      }
+      // fontconfigExtraConfs;
   };
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds a new option `fonts.fontconfig.extraConfigFiles`, which allows adding more config files to `.config/fontconfig/conf.d`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
