### PR TITLE
oh-my-posh: add cache clearing on package version changes

### DIFF
--- a/modules/programs/oh-my-posh.nix
+++ b/modules/programs/oh-my-posh.nix
@@ -98,7 +98,7 @@ in
     # Clear oh-my-posh cache when the oh-my-posh package derivation changes
     home.activation.ohMyPoshClearCache = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       set -eu
-      nixver="${pkgs.oh-my-posh}"
+      nixver="${config.programs.oh-my-posh.package}"
       cache="${config.xdg.cacheHome}/oh-my-posh"
       state="$cache/pkg-path"
 

--- a/modules/programs/oh-my-posh.nix
+++ b/modules/programs/oh-my-posh.nix
@@ -94,5 +94,21 @@ in
         }
       '';
     };
+
+    # Clear oh-my-posh cache when the oh-my-posh package derivation changes
+    home.activation.ohMyPoshClearCache = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      set -eu
+      nixver="${pkgs.oh-my-posh}"
+      cache="${config.xdg.cacheHome}/oh-my-posh"
+      state="$cache/pkg-path"
+
+      if [ ! -f "$state" ] || [ "$(cat "$state")" != "$nixver" ]; then
+        rm -rf "$cache"
+      fi
+
+      mkdir -p "$cache"
+      printf '%s' "$nixver" > "$state"
+    '';
+
   };
 }


### PR DESCRIPTION
### Description

Fix an issue with `oh-my-posh` cached paths breaking during garbage collection.

`oh-my-posh` creates script files in `~/.cache/oh-my-posh` which include old derivation paths. Once the path is garbage collected, oh-my-posh stops working, preventing to successfully create new shells. With this error -

```
bash: /nix/store/5ddhz8nsahf1d03smzx2xpmynjspjfh8-oh-my-posh-26.8.0/bin/oh-my-posh: No such file or directory
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```