### PR TITLE
gtk: add color scheme option

### DIFF
--- a/modules/misc/gtk.nix
+++ b/modules/misc/gtk.nix
@@ -73,6 +73,17 @@ in
       default = null;
       description = "Default cursor theme for all GTK versions.";
     };
+
+    colorScheme = mkOption {
+      type = types.nullOr (
+        types.enum [
+          "dark"
+          "light"
+        ]
+      );
+      default = null;
+      description = "Default color scheme for all GTK versions";
+    };
   };
 
   config = mkIf cfg.enable {

--- a/modules/misc/gtk/gtk2.nix
+++ b/modules/misc/gtk/gtk2.nix
@@ -103,12 +103,14 @@ in
       text =
         let
           settings = gtkLib.mkGtkSettings {
+            gtkVersion = 2;
             inherit (cfg2)
               font
               theme
               iconTheme
               cursorTheme
               ;
+            colorScheme = null;
           };
           settingsText = lib.concatMapStrings (n: "${formatGtk2Option n settings.${n}}\n") (
             lib.attrNames settings

--- a/modules/misc/gtk/gtk3.nix
+++ b/modules/misc/gtk/gtk3.nix
@@ -76,6 +76,18 @@ in
       description = "Cursor theme for GTK 3 applications.";
     };
 
+    colorScheme = mkOption {
+      type = types.nullOr (
+        types.enum [
+          "dark"
+          "light"
+        ]
+      );
+      default = cfg.colorScheme;
+      defaultText = literalExpression "config.gtk.colorScheme";
+      description = "Color scheme for GTK 3 applications.";
+    };
+
     extraConfig = mkOption {
       type =
         with types;
@@ -112,11 +124,13 @@ in
         text = toIni {
           Settings =
             gtkLib.mkGtkSettings {
+              gtkVersion = 3;
               inherit (cfg3)
                 font
                 theme
                 iconTheme
                 cursorTheme
+                colorScheme
                 ;
             }
             // cfg3.extraConfig;
@@ -134,11 +148,13 @@ in
     dconf.settings."org/gnome/desktop/interface" =
       let
         settings = gtkLib.mkGtkSettings {
+          gtkVersion = 3;
           inherit (cfg3)
             font
             theme
             iconTheme
             cursorTheme
+            colorScheme
             ;
         };
       in
@@ -148,6 +164,7 @@ in
         "icon-theme" = settings."gtk-icon-theme-name" or null;
         "cursor-theme" = settings."gtk-cursor-theme-name" or null;
         "cursor-size" = settings."gtk-cursor-theme-size" or null;
+        "color-scheme" = if cfg3.colorScheme != null then "prefer-${cfg3.colorScheme}" else null;
       };
   };
 }

--- a/modules/misc/gtk/gtk4.nix
+++ b/modules/misc/gtk/gtk4.nix
@@ -76,6 +76,18 @@ in
       description = "Cursor theme for GTK 4 applications.";
     };
 
+    colorScheme = mkOption {
+      type = types.nullOr (
+        types.enum [
+          "dark"
+          "light"
+        ]
+      );
+      default = cfg.colorScheme;
+      defaultText = literalExpression "config.gtk.colorScheme";
+      description = "Color scheme for GTK 4 applications.";
+    };
+
     extraConfig = mkOption {
       type =
         with types;
@@ -105,11 +117,13 @@ in
         text = toIni {
           Settings =
             gtkLib.mkGtkSettings {
+              gtkVersion = 4;
               inherit (cfg4)
                 font
                 theme
                 iconTheme
                 cursorTheme
+                colorScheme
                 ;
             }
             // cfg4.extraConfig;

--- a/modules/misc/gtk/lib.nix
+++ b/modules/misc/gtk/lib.nix
@@ -55,10 +55,12 @@ in
   # Helper function to generate the settings attribute set for a given version
   mkGtkSettings =
     {
+      gtkVersion,
       font,
       theme,
       iconTheme,
       cursorTheme,
+      colorScheme,
     }:
     optionalAttrs (font != null) {
       gtk-font-name =
@@ -72,7 +74,10 @@ in
     // optionalAttrs (cursorTheme != null) { "gtk-cursor-theme-name" = cursorTheme.name; }
     // optionalAttrs (cursorTheme != null && cursorTheme.size != null) {
       "gtk-cursor-theme-size" = cursorTheme.size;
-    };
+    }
+    // optionalAttrs (colorScheme == "dark") { "gtk-application-prefer-dark-theme" = true; }
+    // optionalAttrs (gtkVersion == 4 && colorScheme == "dark") { "gtk-interface-color-scheme" = 2; }
+    // optionalAttrs (gtkVersion == 4 && colorScheme == "light") { "gtk-interface-color-scheme" = 3; };
 
   # Package collection helper for all GTK versions
   collectGtkPackages =

--- a/tests/modules/misc/gtk/default.nix
+++ b/tests/modules/misc/gtk/default.nix
@@ -3,6 +3,9 @@
   gtk-per-version-override = ./gtk-per-version-override.nix;
   gtk-selective-enable = ./gtk-selective-enable.nix;
 
+  # ColorScheme tests
+  gtk-colorscheme = ./gtk-colorscheme.nix;
+
   # GTK2
   gtk2-basic-config = ./gtk2/gtk2-basic-config.nix;
   gtk2-config-file-location = ./gtk2/gtk2-config-file-location.nix;

--- a/tests/modules/misc/gtk/gtk-colorscheme.nix
+++ b/tests/modules/misc/gtk/gtk-colorscheme.nix
@@ -1,0 +1,30 @@
+{ pkgs, ... }:
+{
+  gtk = {
+    enable = true;
+    theme.name = "Adwaita";
+    iconTheme.name = "Adwaita";
+
+    # Global dark colorScheme
+    colorScheme = "dark";
+
+    # GTK3 overrides to light
+    gtk3.colorScheme = "light";
+  };
+
+  nmt.script = ''
+    # GTK3's settings should be untouched
+    assertFileExists home-files/.config/gtk-3.0/settings.ini
+    assertFileNotRegex home-files/.config/gtk-3.0/settings.ini \
+      'gtk-application-prefer-dark-theme'
+
+    # GTK4 should inherit global dark colorScheme
+    assertFileExists home-files/.config/gtk-4.0/settings.ini
+    assertFileContains home-files/.config/gtk-4.0/settings.ini \
+      'gtk-application-prefer-dark-theme=true'
+    assertFileContains home-files/.config/gtk-4.0/settings.ini \
+      'gtk-interface-color-scheme=2'
+
+    echo "ColorScheme test completed successfully"
+  '';
+}

--- a/tests/modules/misc/gtk/gtk-global-inheritance-gtk3-expected.ini
+++ b/tests/modules/misc/gtk/gtk-global-inheritance-gtk3-expected.ini
@@ -1,4 +1,5 @@
 [Settings]
+gtk-application-prefer-dark-theme=true
 gtk-cursor-theme-name=Adwaita
 gtk-cursor-theme-size=24
 gtk-font-name=Ubuntu 12

--- a/tests/modules/misc/gtk/gtk-global-inheritance-gtk4-expected.ini
+++ b/tests/modules/misc/gtk/gtk-global-inheritance-gtk4-expected.ini
@@ -1,6 +1,8 @@
 [Settings]
+gtk-application-prefer-dark-theme=true
 gtk-cursor-theme-name=Adwaita
 gtk-cursor-theme-size=24
 gtk-font-name=Ubuntu 12
 gtk-icon-theme-name=Adwaita
+gtk-interface-color-scheme=2
 gtk-theme-name=Adwaita-dark

--- a/tests/modules/misc/gtk/gtk-global-inheritance.nix
+++ b/tests/modules/misc/gtk/gtk-global-inheritance.nix
@@ -19,6 +19,7 @@
       name = "Adwaita";
       size = 24;
     };
+    colorScheme = "dark";
   };
 
   nmt.script = ''


### PR DESCRIPTION
### Description

Fixes https://github.com/nix-community/home-manager/issues/7154
Provide an option to specify gtk's `prefer-dark` or `prefer-light`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
