### PR TITLE
syncthing: Fix for syncthing v2 (#7762)

### DIFF
--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -213,11 +213,11 @@ let
 
   defaultSyncthingArgs = [
     "${syncthing}"
-    "-no-browser"
-    "-no-restart"
-    "-no-upgrade"
-    "-gui-address=${if isUnixGui then "unix://" else ""}${cfg.guiAddress}"
-    "-logflags=0"
+    "serve"
+    "--no-browser"
+    "--no-restart"
+    "--no-upgrade"
+    "--gui-address=${if isUnixGui then "unix://" else ""}${cfg.guiAddress}"
   ];
 
   syncthingArgs = defaultSyncthingArgs ++ cfg.extraOptions;

--- a/tests/modules/services/syncthing/extra-options.nix
+++ b/tests/modules/services/syncthing/extra-options.nix
@@ -19,7 +19,7 @@ lib.mkMerge [
     nmt.script = ''
       assertFileExists home-files/.config/systemd/user/syncthing.service
       assertFileContains home-files/.config/systemd/user/syncthing.service \
-      "ExecStart=@syncthing@/bin/syncthing -no-browser -no-restart -no-upgrade '-gui-address=127.0.0.1:8384' '-logflags=0' -foo '-bar \"baz\"'"
+      "ExecStart=@syncthing@/bin/syncthing serve --no-browser --no-restart --no-upgrade '--gui-address=127.0.0.1:8384' -foo '-bar \"baz\"'"
     '';
   })
 


### PR DESCRIPTION
syncthing v2 changed its CLI API.

https://github.com/syncthing/syncthing/releases/tag/v2.0.0

### Checklist


- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)