### PR TITLE
obsidian: open last used vault on startup & update

### DIFF
--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -537,7 +537,7 @@ in
           let
             template = (pkgs.formats.json { }).generate "obsidian.json" {
               vaults = builtins.listToAttrs (
-                builtins.map (vault: {
+                map (vault: {
                   name = builtins.substring 0 16 (builtins.hashString "md5" vault.target);
                   value = {
                     path = "${config.home.homeDirectory}/${vault.target}";


### PR DESCRIPTION
### Description

Resolves #7406 and updates some obsidian configurations to the latest upstream defaults.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```