### PR TITLE
lutris: add defaultWinePackage option

### DIFF
--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -224,8 +224,7 @@ in
         nameValuePair "lutris/runners/${runner_name}.yml" {
           source = settingsFormat.generate "${runner_name}.yml" (buildRunnerConfig runner_name runner_config);
         }
-      )
-      (recursiveUpdate wine_extra cfg.runners);
+      ) (recursiveUpdate wine_extra cfg.runners);
 
     xdg.dataFile =
       let

--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -15,6 +15,7 @@ let
     nameValuePair
     mapAttrs'
     filterAttrs
+    filterAttrsRecursive
     attrNames
     concatStringsSep
     toLower
@@ -170,18 +171,13 @@ in
       let
         buildRunnerConfig = (
           runner_name: runner_config:
-          {
+          filterAttrsRecursive (name: value: value != { } && value != null && value != "") {
             "${runner_name}" =
-              (optionalAttrs (runner_config.settings.runner != { }) runner_config.settings.runner)
-              // (optionalAttrs
-                (runner_config.package != null && runner_config.settings.runner.runner_executable == "")
-                {
-                  runner_executable = getExe runner_config.package;
-                }
-              );
-          }
-          // optionalAttrs (runner_config.settings.system != { }) {
-            system = runner_config.settings.system;
+              runner_config.settings.runner
+              // (optionalAttrs (runner_config.package != null) {
+                runner_executable = getExe runner_config.package;
+              });
+            inherit (runner_config.settings) system;
           }
         );
       in

--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -12,18 +12,22 @@ let
     types
     optional
     optionalAttrs
+    optionalString
     nameValuePair
     mapAttrs'
+    filter
     filterAttrs
     filterAttrsRecursive
     attrNames
     concatStringsSep
     toLower
+    recursiveUpdate
     listToAttrs
     getExe
     ;
   cfg = config.programs.lutris;
   settingsFormat = pkgs.formats.yaml { };
+  formatWineName = (package: toLower package.name);
 in
 {
   options.programs.lutris = {
@@ -47,6 +51,16 @@ in
       '';
       type = types.listOf types.package;
     };
+    defaultWinePackage = mkOption {
+      default = null;
+      example = "pkgs.proton-ge-bin";
+      description = ''
+        The wine/proton package to set as the default for lutris.
+        It must still be set under proton/winePackages.
+      '';
+      type = types.nullOr types.package;
+    };
+
     protonPackages = mkOption {
       default = [ ];
       example = "[ pkgs.proton-ge-bin ]";
@@ -88,6 +102,7 @@ in
               description = ''
                 The package to use for this runner, nix will try to find the executable for this package.
                 A more specific path can be set by using settings.runner.runner_executable instead.
+                Uncompatible with certain runners, such as wine.
               '';
               type = types.nullOr types.package;
             };
@@ -112,6 +127,7 @@ in
                           default = "";
                           description = ''
                             Specific option to point to a runner executable directly, don't set runner.package if you set this.
+                            Uncompatible with certain runners such as wine.
                           '';
                         };
                       };
@@ -149,13 +165,23 @@ in
           ) cfg.runners
         );
       in
-      mkIf (redundantRunners != [ ]) [
-        ''
+      filter (e: e != "") [
+        (optionalString (redundantRunners != [ ]) ''
           Under programs.lutris.runners, the following lutris runners had both a
           <runner>.package and <runner>.settings.runner.runner_executable options set:
             - ${concatStringsSep ", " redundantRunners}
           Note that runner_executable overrides package, setting both is pointless.
-        ''
+        '')
+        (optionalString ((cfg.runners.wine.package or null) != null) ''
+          Setting programs.lutris.runners.wine.package does nothing.
+          Use the respective options, proton/winePackages and defaultWinePackage.
+        '')
+        (optionalString ((cfg ? runners.wine.settings.runner.version) && (cfg.defaultWinePackage != null))
+          ''
+            Found conflicting options under programs.lutris, both runners.wine.settings.version and defaultWinePackage
+            were set.
+          ''
+        )
       ];
     home.packages =
       let
@@ -171,22 +197,35 @@ in
       let
         buildRunnerConfig = (
           runner_name: runner_config:
+          # Remove the unset values so they don't end up on the final config.
           filterAttrsRecursive (name: value: value != { } && value != null && value != "") {
             "${runner_name}" =
               runner_config.settings.runner
+              # If set translate .package to runner_executable
               // (optionalAttrs (runner_config.package != null) {
                 runner_executable = getExe runner_config.package;
               });
             inherit (runner_config.settings) system;
           }
         );
+        # Extra default config for wine if defaultWinePackage was set
+        wine_extra = optionalAttrs (cfg.defaultWinePackage != null) {
+          wine = {
+            package = null;
+            settings = {
+              runner.version = formatWineName cfg.defaultWinePackage;
+              system = { };
+            };
+          };
+        };
       in
       mapAttrs' (
         runner_name: runner_config:
         nameValuePair "lutris/runners/${runner_name}.yml" {
           source = settingsFormat.generate "${runner_name}.yml" (buildRunnerConfig runner_name runner_config);
         }
-      ) cfg.runners;
+      )
+      (recursiveUpdate wine_extra cfg.runners);
 
     xdg.dataFile =
       let
@@ -195,7 +234,7 @@ in
           map (
             # lutris seems to not detect wine/proton if the name has some caps
             package:
-            (nameValuePair "lutris/runners/${type}/${toLower package.name}" {
+            (nameValuePair "lutris/runners/${type}/${formatWineName package}" {
               source = package;
             })
           ) packages;

--- a/tests/modules/programs/lutris/runners-configuration.nix
+++ b/tests/modules/programs/lutris/runners-configuration.nix
@@ -2,7 +2,12 @@
 {
   programs.lutris = {
     enable = true;
+    defaultWinePackage = pkgs.proton-ge-bin;
     runners = {
+      wine.settings = {
+        runner.system_winetricks = true;
+        system.disable_runtime = true;
+      };
       cemu.package = pkgs.cemu;
       pcsx2.settings = {
         system.disable_screen_saver = true;
@@ -38,6 +43,13 @@
         system:
           disable_screen_saver: true
       '';
+      expectedWine = builtins.toFile "wine.yml" ''
+        system:
+          disable_runtime: true
+        wine:
+          system_winetricks: true
+          version: ${lib.toLower pkgs.proton-ge-bin.name}
+      '';
     in
     ''
       assertFileExists ${runnersDir}/cemu.yml
@@ -46,5 +58,7 @@
       assertFileContent ${runnersDir}/pcsx2.yml ${expectedPcsx2}
       assertFileExists ${runnersDir}/rpcs3.yml
       assertFileContent ${runnersDir}/rpcs3.yml ${expectedRpcs3}
+      assertFileExists ${runnersDir}/wine.yml
+      assertFileContent ${runnersDir}/wine.yml ${expectedWine}
     '';
 }


### PR DESCRIPTION
### Description
- Add a defaultWinePackage option, a convenient way for users to specify to lutris which wine package to use by default.
- Make it clearer that runners.package is not compatible with all runners, warn those who try to set it for wine.

Should close #7764 
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
