### PR TITLE
zsh: add option to disable history config in zshrc

### DIFF
--- a/modules/programs/zsh/history.nix
+++ b/modules/programs/zsh/history.nix
@@ -18,6 +18,12 @@ in
         { config, ... }:
         {
           options = {
+            enableConfig = lib.mkOption {
+              type = types.bool;
+              default = true;
+              description = "let home-manager configure history settings";
+            };
+
             append = mkOption {
               type = types.bool;
               default = false;
@@ -170,7 +176,7 @@ in
       };
     };
 
-  config = {
+  config = lib.mkIf cfg.history.enableConfig {
     warnings =
       lib.optionals (!lib.hasPrefix "/" cfg.history.path && !lib.hasInfix "$" cfg.history.path)
         [

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -5,6 +5,7 @@
   zsh-dotdir-default = import ./dotdir.nix "default";
   zsh-dotdir-relative = import ./dotdir.nix "relative";
   zsh-dotdir-shell-variable = import ./dotdir.nix "shell-variable";
+  zsh-history-disable-config = ./history-disable-config.nix;
   zsh-history-ignore-pattern = ./history-ignore-pattern.nix;
   zsh-history-path-absolute = import ./history-path.nix "absolute";
   zsh-history-path-default = import ./history-path.nix "default";

--- a/tests/modules/programs/zsh/history-disable-config.nix
+++ b/tests/modules/programs/zsh/history-disable-config.nix
@@ -5,6 +5,6 @@
   };
 
   nmt.script = ''
-    assertFileNotRegex home-files/.zshrc "setopt HIST_FCNTL_LOCK"
+    assertFileNotRegex home-files/.zshrc "setopt HIST_.*"
   '';
 }

--- a/tests/modules/programs/zsh/history-disable-config.nix
+++ b/tests/modules/programs/zsh/history-disable-config.nix
@@ -1,0 +1,10 @@
+{
+  programs.zsh = {
+    enable = true;
+    history.enableConfig = false;
+  };
+
+  nmt.script = ''
+    assertFileNotRegex home-files/.zshrc "setopt HIST_FCNTL_LOCK"
+  '';
+}


### PR DESCRIPTION
### Description

I have my history settings set via the NixOS module and I don't want to set those again for home-manager.

I admit this is a very specific usecase.

I'm open to suggestions on how to name that new option. I'm unsure myself.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
