### PR TITLE
WIP ssh: add match block glob order tests

### DIFF
--- a/tests/modules/programs/ssh/default.nix
+++ b/tests/modules/programs/ssh/default.nix
@@ -5,6 +5,7 @@
   ssh-renamed-options = ./renamed-options.nix;
   ssh-includes = ./includes.nix;
   ssh-match-blocks = ./match-blocks-attrs.nix;
+  ssh-match-blocks-attrs-glob-order = ./match-blocks-attrs-glob-order.nix;
   ssh-match-blocks-match-and-hosts = ./match-blocks-match-and-hosts.nix;
   ssh-forwards-dynamic-valid-bind-no-asserts = ./forwards-dynamic-valid-bind-no-asserts.nix;
   ssh-forwards-dynamic-bind-path-with-port-asserts = ./forwards-dynamic-bind-path-with-port-asserts.nix;

--- a/tests/modules/programs/ssh/match-blocks-attrs-glob-order-expected.conf
+++ b/tests/modules/programs/ssh/match-blocks-attrs-glob-order-expected.conf
@@ -1,0 +1,22 @@
+Host *
+  ForwardAgent no
+  IdentitiesOnly yes
+  ServerAliveInterval 0
+  ServerAliveCountMax 3
+  Compression no
+  AddKeysToAgent no
+  HashKnownHosts no
+  UserKnownHostsFile ~/.ssh/known_hosts
+  ControlMaster no
+  ControlPath ~/.ssh/master-%r@%n:%p
+  ControlPersist no
+  StrictHostKeyChecking accept-new
+
+Host tor-*
+  ProxyCommand socat STDIO SOCKS4A:127.0.0.1:%h:%p,socksport=9050
+  AddressFamily inet
+  Compression yes
+
+Host *-screen
+  RemoteCommand screen -RD ssh
+  RequestTTY yes

--- a/tests/modules/programs/ssh/match-blocks-attrs-glob-order.nix
+++ b/tests/modules/programs/ssh/match-blocks-attrs-glob-order.nix
@@ -1,0 +1,53 @@
+{ config, lib, ... }:
+{
+  config = {
+    programs.ssh = {
+      enable = true;
+      enableDefaultConfig = false;
+      matchBlocks = {
+        "*" = {
+          forwardAgent = false;
+          serverAliveInterval = 0;
+          serverAliveCountMax = 3;
+          compression = false;
+          addKeysToAgent = "no";
+          hashKnownHosts = false;
+          userKnownHostsFile = "~/.ssh/known_hosts";
+          controlMaster = "no";
+          controlPath = "~/.ssh/master-%r@%n:%p";
+          controlPersist = "no";
+
+          identitiesOnly = true;
+          extraOptions = {
+            StrictHostKeyChecking = "accept-new";
+          };
+        };
+
+        "tor-*" = lib.hm.dag.entryBefore [ "*-screen" ] {
+          proxyCommand = "socat STDIO SOCKS4A:127.0.0.1:%h:%p,socksport=9050";
+          addressFamily = "inet";
+          compression = true;
+        };
+
+        "*-screen" = lib.hm.dag.entryAfter [ "*" ] {
+          extraOptions = {
+            RemoteCommand = "screen -RD ssh";
+            RequestTTY = "yes";
+          };
+        };
+      };
+    };
+
+    home.file.assertions.text = builtins.toJSON (
+      map (a: a.message) (lib.filter (a: !a.assertion) config.assertions)
+    );
+
+    nmt.script = ''
+      assertFileExists home-files/.ssh/config
+      assertFileContent \
+        home-files/.ssh/config \
+        ${./match-blocks-attrs-glob-order-expected.conf}
+      assertFileContent home-files/assertions ${./no-assertions.json}
+    '';
+  };
+}


### PR DESCRIPTION
Demonstrates Issue [nix-community/home-manager#7781](https://github.com/nix-community/home-manager/issues/7781)

### Description

Add tests to aid in addressing order issue reported where `dag.entryBefore` and `dag.entryAfter` do not behave when glob (`"*"`) strings are involved.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- ~~[ ] Change is backwards compatible.~~
   > Nope, certain SSH config options were added recently which prevents tests from running on non-`master` branch.  Most recent commit that these tests do run on is `b08f8737776f10920c330657bee8b95834b7a70f`

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
