### PR TITLE
hyprsunset: fixed evaluation when hyprland package is null

### DIFF
--- a/modules/services/hyprsunset.nix
+++ b/modules/services/hyprsunset.nix
@@ -200,28 +200,30 @@ in
           };
         };
       }
-      // lib.optionalAttrs (config.wayland.windowManager.hyprland.package != null) lib.mapAttrs' (
-        name: transitionCfg:
-        lib.nameValuePair "hyprsunset-${name}" {
-          Install = { };
+      // lib.optionalAttrs (config.wayland.windowManager.hyprland.package != null) (
+        lib.mapAttrs' (
+          name: transitionCfg:
+          lib.nameValuePair "hyprsunset-${name}" {
+            Install = { };
 
-          Unit = {
-            ConditionEnvironment = "WAYLAND_DISPLAY";
-            Description = "hyprsunset transition for ${name}";
-            After = [ "hyprsunset.service" ];
-            Requires = [ "hyprsunset.service" ];
-          };
+            Unit = {
+              ConditionEnvironment = "WAYLAND_DISPLAY";
+              Description = "hyprsunset transition for ${name}";
+              After = [ "hyprsunset.service" ];
+              Requires = [ "hyprsunset.service" ];
+            };
 
-          Service = {
-            Type = "oneshot";
-            # Execute multiple requests sequentially
-            ExecStart = lib.concatMapStringsSep " && " (
-              cmd:
-              "${lib.getExe' config.wayland.windowManager.hyprland.package "hyprctl"} hyprsunset ${lib.escapeShellArgs cmd}"
-            ) transitionCfg.requests;
-          };
-        }
-      ) cfg.transitions;
+            Service = {
+              Type = "oneshot";
+              # Execute multiple requests sequentially
+              ExecStart = lib.concatMapStringsSep " && " (
+                cmd:
+                "${lib.getExe' config.wayland.windowManager.hyprland.package "hyprctl"} hyprsunset ${lib.escapeShellArgs cmd}"
+              ) transitionCfg.requests;
+            };
+          }
+        ) cfg.transitions
+      );
 
       timers = lib.mapAttrs' (
         name: transitionCfg:


### PR DESCRIPTION
### Issue

Hyprsunset does not evaluate when hyprsunset package is set to `null`

```
       error: attempt to call something which is not a function but a set: { }
       at /nix/store/g1jaiwcamlaxia17xhhww0s63iyns1xv-source/modules/services/hyprsunset.nix:203:10:
          202|       }
          203|       // lib.optionalAttrs (config.wayland.windowManager.hyprland.package != null) lib.mapAttrs' (
             |          ^
          204|         name: transitionCfg:
```

### Changes made

I wrapped `lib.mapAttrs' (...) cfg.transitions` in brackets to fix this issue.

### Minimal reproduction

```nix
{
  wayland.windowManager.hyprland = {
    enable = true;
    package = null;
    portalPackage = null;
  };

  services.hyprsunset = {
    enable = true;
    settings = {
      profile = [
        {
          time = "6:00";
          identity = true;
        }
        {
          time = "00:00";
          temperature = 3500;
          gamma = 0.4;
        }
      ];
    };
  };
}
```

### Note

I wonder if the `config.wayland.windowManager.hyprland.package != null` condition should be also wrapped around the timers. Now if i'm correct, i think it just produces an empty set but its still doing some useless evaluation.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
