### PR TITLE
khard: support discover entries

### DIFF
--- a/modules/programs/khard.nix
+++ b/modules/programs/khard.nix
@@ -107,6 +107,26 @@ in
               default value will set the aforementioned path as a single vdir.
             '';
           };
+          options.khard.type = lib.mkOption {
+            type = types.enum [
+              "vdir"
+              "discover"
+            ];
+            default = "vdir";
+            description = ''
+              Either a single vdir located in [](#opt-accounts.contact.accounts._name_.local.path)
+              or multiple automatically discovered vdirs in
+              [](#opt-accounts.contact.accounts._name_.local.path)/[](#opt-accounts.contact.accounts._name_.khard.glob).
+            '';
+          };
+          options.khard.glob = lib.mkOption {
+            type = lib.types.str;
+            default = "*";
+            description = ''
+              The glob expansion to be searched for contacts when
+              type is set to discover.
+            '';
+          };
         }
       );
     };
@@ -131,11 +151,20 @@ in
           [[${makeName anAccount.name anAbook}]]
           path = ${makePath anAccount.local.path anAbook}
         '';
+        makeDiscoverEntry = anAccount: ''
+          [[${makeName anAccount.name ""}]]
+          path = ${anAccount.local.path}/${anAccount.khard.glob}
+          type = discover
+        '';
       in
       ''
         [addressbooks]
         ${lib.concatMapStringsSep "\n" (
-          acc: lib.concatMapStringsSep "\n" (makeEntry acc) acc.khard.addressbooks
+          acc:
+          if acc.khard.type == "discover" then
+            makeDiscoverEntry acc
+          else
+            lib.concatMapStringsSep "\n" (makeEntry acc) acc.khard.addressbooks
         ) (lib.attrValues accounts)}
 
         ${renderSettings cfg.settings}

--- a/tests/modules/programs/khard/default.nix
+++ b/tests/modules/programs/khard/default.nix
@@ -4,4 +4,5 @@
   khard_multiple_accounts = ./multiple_accounts.nix;
   khard_dirty_path = ./dirty_path.nix;
   khard_multiple_with_abooks = ./multiple_with_abooks.nix;
+  khard_discover_type = ./discover_type.nix;
 }

--- a/tests/modules/programs/khard/discover_type.nix
+++ b/tests/modules/programs/khard/discover_type.nix
@@ -1,0 +1,20 @@
+{
+  accounts.contact = {
+    basePath = ".contacts";
+    accounts.test = {
+      local.type = "filesystem";
+      khard = {
+        enable = true;
+        type = "discover";
+      };
+    };
+  };
+
+  programs.khard.enable = true;
+
+  nmt.script = ''
+    assertFileContent \
+      home-files/.config/khard/khard.conf \
+      ${./discover_type_expected}
+  '';
+}

--- a/tests/modules/programs/khard/discover_type_expected
+++ b/tests/modules/programs/khard/discover_type_expected
@@ -1,0 +1,9 @@
+[addressbooks]
+[[test]]
+path = /home/hm-user/.contacts/test/*
+type = discover
+
+
+[general]
+default_action=list
+


### PR DESCRIPTION
### Description
This adds support for discover type entries, which were introduced in khard 0.20.0, which work very similar to the equally-named khal feature.
<!--

Please provide a brief description of your change.
-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)