### PR TITLE
cleanup: Move home.stateVersion to end of default home.nix

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -361,14 +361,6 @@ function doInit() {
   home.username = "$(escapeForNix "$USER")";
   home.homeDirectory = "$(escapeForNix "$HOME")";
 $xdgVars
-  # This value determines the Home Manager release that your configuration is
-  # compatible with. This helps avoid breakage when a new Home Manager release
-  # introduces backwards incompatible changes.
-  #
-  # You should not change this value, even if you update Home Manager. If you do
-  # want to update the value, then make sure to first check the Home Manager
-  # release notes.
-  home.stateVersion = "25.05"; # Please read the comment before changing.
 
   # The home.packages option allows you to install Nix packages into your
   # environment.
@@ -428,6 +420,15 @@ $xdgVars
 
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;
+
+  # This value determines the Home Manager release that your configuration is
+  # compatible with. This helps avoid breakage when a new Home Manager release
+  # introduces backwards incompatible changes.
+  #
+  # You should not change this value, even if you update Home Manager. If you do
+  # want to update the value, then make sure to first check the Home Manager
+  # release notes.
+  home.stateVersion = "25.05"; # Please read the comment before changing.
 }
 EOF
     fi


### PR DESCRIPTION
### Description

As a new user, I prefer seeing what I'm most interested in (home.packages) first; more technical home-manager internal configuration like this can go to the end.

### Checklist

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted