### PR TITLE
pistol: change config path for macOS

### DIFF
--- a/modules/programs/pistol.nix
+++ b/modules/programs/pistol.nix
@@ -94,7 +94,7 @@ in
       }
 
       (mkIf (cfg.associations != [ ] && pkgs.stdenv.hostPlatform.isDarwin) {
-        home.file."Library/Application Support/pistol/pistol.conf".text = configFile;
+        home.file."Library/Preferences/pistol/pistol.conf".text = configFile;
       })
 
       (mkIf (cfg.associations != [ ] && !pkgs.stdenv.hostPlatform.isDarwin) {

--- a/tests/modules/programs/pistol/associations.nix
+++ b/tests/modules/programs/pistol/associations.nix
@@ -27,7 +27,7 @@
         fpath .*.md$ sh: bat --paging=never --color=always %pistol-filename% | head -8'';
       path =
         if pkgs.stdenv.hostPlatform.isDarwin then
-          "home-files/Library/Application Support/pistol/pistol.conf"
+          "home-files/Library/Preferences/pistol/pistol.conf"
         else
           "home-files/.config/pistol/pistol.conf";
     in


### PR DESCRIPTION
### Description
Changed pistol's config path from `Library/Application Support/pistol` to `Library/Preferences/pistol` as per the documentation: https://github.com/doronbehar/pistol/blob/64a5bf1afe3ca72241bdadf7199b5b8abf01e04a/README.adoc?plain=1#L275-L276

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
