### PR TITLE
waybar: use X-Reload-Triggers

### DIFF
--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -353,7 +353,7 @@ in
             ];
             After = [ cfg.systemd.target ];
             ConditionEnvironment = "WAYLAND_DISPLAY";
-            X-Restart-Triggers =
+            X-Reload-Triggers =
               optional (settings != [ ]) "${config.xdg.configFile."waybar/config".source}"
               ++ optional (cfg.style != null) "${config.xdg.configFile."waybar/style.css".source}";
           };


### PR DESCRIPTION
### Description

This causes the running waybar to be reloaded rather that fully restarted when only the configuration changes. Waiting for https://github.com/NixOS/nixpkgs/pull/441220.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```