### PR TITLE
radio-active: add module to create config files

### DIFF
--- a/modules/misc/news/2025/09/2025-09-28_06-57-30.nix
+++ b/modules/misc/news/2025/09/2025-09-28_06-57-30.nix
@@ -1,0 +1,12 @@
+{
+  time = "2025-09-28T06:57:30+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.radio-active'
+
+    `radio-active` is a TUI which enables playing of radio station streams.
+
+    This module allows for defining configuration file as well as favorites
+    list via Nix attribute sets.
+  '';
+}

--- a/modules/programs/radio-active.nix
+++ b/modules/programs/radio-active.nix
@@ -1,0 +1,148 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mapAttrsToList
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    ;
+
+  inherit (lib.attrsets)
+    attrByPath
+    ;
+
+  inherit (lib.types)
+    nonEmptyStr
+    attrsOf
+    oneOf
+    ;
+
+  inherit (lib.types.numbers)
+    nonnegative
+    ;
+
+  inherit (pkgs.formats)
+    ini
+    ;
+
+  iniFormat = ini { };
+
+  cfg = config.programs.radio-active;
+in
+{
+  meta.maintainers = [
+    lib.maintainers.S0AndS0
+  ];
+
+  options.programs.radio-active = {
+    enable = mkEnableOption "Enable installing radio-active and writing configuration file";
+
+    package = mkPackageOption pkgs "radio-active" {
+      nullable = true;
+    };
+
+    settings = mkOption {
+      type = attrsOf (
+        attrsOf (oneOf [
+          nonEmptyStr
+          nonnegative
+        ])
+      );
+      default = { };
+      example = {
+        loglevel = "debug";
+        limit = 41;
+        sort = "votes";
+        filter = "none";
+        volume = 68;
+        filepath = "/home/{user}/recordings/radioactive/";
+        filetype = "mp3";
+        player = "ffplay";
+      };
+      description = ''
+        Declare-able configurations for radio-active written to
+        {file}`$XDG_CONFIG_HOME/radio-active/configs.ini`.
+      '';
+    };
+
+    aliases = mkOption {
+      type = attrsOf nonEmptyStr;
+      default = { };
+      example = {
+        "Deep House Lounge" = "http://198.15.94.34:8006/stream";
+      };
+      description = ''
+        Key/value pairs where the key is name of radio station and value is URL.
+      '';
+    };
+  };
+
+  config =
+    let
+      player = attrByPath [ "settings" "AppConfig" "player" ] "ffplay" cfg;
+
+      knownPlayers = [
+        "ffplay"
+        "mpv"
+        "vlc"
+      ];
+    in
+    mkIf cfg.enable {
+      warnings = lib.optional (builtins.elem player knownPlayers == false) ''
+        Unknown player defined in `config.programs.radio-active.AppConfig.player`
+      '';
+
+      ## TODO: test that dependency `postPatch` modifications works at runtime
+      home.packages =
+        let
+          radio-active =
+            if player == "mpv" then
+              pkgs.radio-active.overrideAttrs (
+                finalAttrs: previousAttrs: {
+                  postPatch = ''
+                    ${previousAttrs.postPatch}
+
+                    substituteInPlace radioactive/mpv.py \
+                      --replace-fail 'self.exe_path = which(self.program_name)' \
+                      'self.exe_path = "${lib.getExe pkgs.mpv}"'
+                  '';
+                }
+              )
+            else if player == "vlc" then
+              pkgs.radio-active.overrideAttrs (
+                finalAttrs: previousAttrs: {
+                  postPatch = ''
+                    ${previousAttrs.postPatch}
+
+                    substituteInPlace radioactive/vlc.py \
+                      --replace-fail 'self.exe_path = which(self.program_name)' \
+                      'self.exe_path = "${lib.getExe pkgs.vlc}"'
+                  '';
+                }
+              )
+            else
+              pkgs.radio-active;
+        in
+        mkIf (cfg.package != null) [
+          radio-active
+        ];
+
+      xdg.configFile."radio-active/configs.ini" =
+        lib.mkIf (cfg.settings != { } && cfg.settings.AppConfig != { })
+          {
+            source = iniFormat.generate "radio-active-config" cfg.settings;
+          };
+
+      home.file.".radio-active-alias" = mkIf (cfg.aliases != { }) {
+        text = ''
+          ${builtins.concatStringsSep "\n" (mapAttrsToList (name: value: "${name}==${value}") cfg.aliases)}
+        '';
+      };
+    };
+}

--- a/tests/modules/programs/radio-active/AppConfig.nix
+++ b/tests/modules/programs/radio-active/AppConfig.nix
@@ -1,0 +1,32 @@
+{
+  programs.radio-active = {
+    enable = true;
+
+    settings.AppConfig = {
+      filepath = "/mnt/{user}/recordings/radioactive/";
+      filetype = "auto";
+      filter = "name=shows";
+      limit = 41;
+      loglevel = "debug";
+      player = "ffplay";
+      sort = "random";
+      volume = 68;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/radio-active/configs.ini
+    assertFileContent home-files/.config/radio-active/configs.ini \
+    ${builtins.toFile "expected.radio-active_configs.ini" ''
+      [AppConfig]
+      filepath=/mnt/{user}/recordings/radioactive/
+      filetype=auto
+      filter=name=shows
+      limit=41
+      loglevel=debug
+      player=ffplay
+      sort=random
+      volume=68
+    ''}
+  '';
+}

--- a/tests/modules/programs/radio-active/AppConfig_all.nix
+++ b/tests/modules/programs/radio-active/AppConfig_all.nix
@@ -1,0 +1,32 @@
+{
+  programs.radio-active = {
+    enable = true;
+
+    settings.AppConfig = {
+      filepath = "/home/{user}/recordings/radioactive/";
+      filetype = "mp3";
+      filter = "none";
+      limit = 41;
+      loglevel = "debug";
+      player = "ffplay";
+      sort = "votes";
+      volume = 68;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/radio-active/configs.ini
+    assertFileContent home-files/.config/radio-active/configs.ini \
+    ${builtins.toFile "expected.all.radio-active_configs.ini" ''
+      [AppConfig]
+      filepath=/home/{user}/recordings/radioactive/
+      filetype=mp3
+      filter=none
+      limit=41
+      loglevel=debug
+      player=ffplay
+      sort=votes
+      volume=68
+    ''}
+  '';
+}

--- a/tests/modules/programs/radio-active/AppConfig_player_mpv.nix
+++ b/tests/modules/programs/radio-active/AppConfig_player_mpv.nix
@@ -1,0 +1,16 @@
+{
+  programs.radio-active = {
+    enable = true;
+
+    settings.AppConfig.player = "mpv";
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/radio-active/configs.ini
+    assertFileContent home-files/.config/radio-active/configs.ini \
+    ${builtins.toFile "expected.player_mpv.radio-active_configs.ini" ''
+      [AppConfig]
+      player=mpv
+    ''}
+  '';
+}

--- a/tests/modules/programs/radio-active/AppConfig_player_vlc.nix
+++ b/tests/modules/programs/radio-active/AppConfig_player_vlc.nix
@@ -1,0 +1,16 @@
+{
+  programs.radio-active = {
+    enable = true;
+
+    settings.AppConfig.player = "vlc";
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/radio-active/configs.ini
+    assertFileContent home-files/.config/radio-active/configs.ini \
+    ${builtins.toFile "expected.player_mpv.radio-active_configs.ini" ''
+      [AppConfig]
+      player=vlc
+    ''}
+  '';
+}

--- a/tests/modules/programs/radio-active/aliases.nix
+++ b/tests/modules/programs/radio-active/aliases.nix
@@ -1,0 +1,17 @@
+{
+  programs.radio-active = {
+    enable = true;
+
+    aliases = {
+      "Deep House Lounge" = "http://198.15.94.34:8006/stream";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.radio-active-alias
+    assertFileContent home-files/.radio-active-alias \
+    ${builtins.toFile "expected.radio-active_aliases.ini" ''
+      Deep House Lounge==http://198.15.94.34:8006/stream
+    ''}
+  '';
+}

--- a/tests/modules/programs/radio-active/default.nix
+++ b/tests/modules/programs/radio-active/default.nix
@@ -1,0 +1,11 @@
+{ lib, pkgs, ... }:
+
+{
+  radio-active-aliases = ./aliases.nix;
+  radio-active-AppConfig = ./AppConfig.nix;
+  radio-active-AppConfig_all = ./AppConfig_all.nix;
+  radio-active-AppConfig_player_mpv = ./AppConfig_player_mpv.nix;
+}
+// lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin != true) {
+  radio-active-AppConfig_player_vlc = ./AppConfig_player_vlc.nix;
+}


### PR DESCRIPTION
**WARN:**

- must be applied after https://github.com/NixOS/nixpkgs/pull/441029
- requires update of `flake.lock` too

### Description

Configuration entry similar to;

```nix
programs.radio-active.enable = true;
```

...  will produce default configuration `~/.radio-active-configs.ini`

```
[AppConfig]
filepath = /home/{user}/recordings/radioactive/
filetype = mp3
filter = none
limit = 100
loglevel = info
player = ffplay
sort = name
volume = 80
```

By default `ffplay` is used for recording/playback, but that can be changed by applying either of the following;

```nix
programs.radio-active.appConfig.player = "vlc";
programs.radio-active.appConfig.player = "mpv";
```

All other configuration options documented by;
https://github.com/deep5050/radio-active?tab=readme-ov-file#default-configs maybe applied under the `AppConfig` attribute set.

Finally, the `aliases` attribute set allows for defining key/value pares that will generate a `~/.radio-active-alias` of bookmarked stations, for example something like;

```nix
programs.radio-active.aliases = {
  "Deep House Lounge" = "http://198.15.94.34:8006/stream";
};
```

... will result in;

```
Deep House Lounge==http://198.15.94.34:8006/stream
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.
   > Nope

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
   > Note; had to do `--impure` and import local `pkgs` due to pending PR over at [NixOS/nixpkgs#441029](https://github.com/NixOS/nixpkgs/pull/441029), but _should_ work once that's accepted and `flake.lock` is updated here ;-)

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
