### PR TITLE
rclone: check existence of file rather than using `cat`

### DIFF
--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -252,7 +252,7 @@ in
           injectSecret =
             remote:
             lib.mapAttrsToList (secret: secretFile: ''
-              if ! cat "${secretFile}"; then
+              if [[ ! -r "${secretFile}" ]]; then
                 echo "Secret \"${secretFile}\" not found"
                 cleanup
               fi


### PR DESCRIPTION
It's not really clear why this was done in the first place, and furthermore it means that the secrets are being printed to stdout and appearing in the user's journal.
