### PR TITLE
podman: add nftables to default container path

### DIFF
--- a/modules/services/podman-linux/containers.nix
+++ b/modules/services/podman-linux/containers.nix
@@ -121,6 +121,7 @@ let
                 builtins.concatStringsSep ":" [
                   "/run/wrappers/bin"
                   "/run/current-system/sw/bin"
+                  "${pkgs.nftables}/bin"
                   "${config.home.homeDirectory}/.nix-profile/bin"
                   "${pkgs.systemd}/bin"
                 ]


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Newer versions of Podman with some Netavark configurations expect nftables to be on PATH. Adding it explicitly here to ensure its available.

Will resolve issues with Podman 5.6.0 containers not starting and journal logs similar to:

```
Error: netavark: nftables error: unable to execute "nft": No such file or directory (os error 2)
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

cc @bamhm182 