### PR TITLE
superfile: add pinned folder and first use option

### DIFF
--- a/modules/programs/superfile.nix
+++ b/modules/programs/superfile.nix
@@ -7,7 +7,10 @@
 
 let
   cfg = config.programs.superfile;
+
   tomlFormat = pkgs.formats.toml { };
+  jsonFormat = pkgs.formats.json { };
+
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
   inherit (lib)
     literalExpression
@@ -23,6 +26,29 @@ let
     types
     hm
     ;
+
+  pinnedFolderModule = types.submodule {
+    freeformType = jsonFormat.type;
+
+    options = {
+      name = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "Nix Store";
+        description = ''
+          Name that will be shown.
+        '';
+      };
+
+      location = mkOption {
+        type = types.path;
+        example = "/nix/store";
+        description = ''
+          Location of the pinned entry.
+        '';
+      };
+    };
+  };
 in
 {
   meta.maintainers = [ hm.maintainers.LucasWagler ];
@@ -106,11 +132,38 @@ in
         };
       '';
     };
+
+    firstUseCheck = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Enables the first time use popup.
+      '';
+    };
+
+    pinnedFolders = mkOption {
+      type = types.listOf pinnedFolderModule;
+      default = [ ];
+      example = literalExpression ''
+        [
+          {
+            name = "Nix Store";
+            location = "/nix/store";
+          }
+        ];
+      '';
+      description = ''
+        Entries that get added to the pinned panel.
+      '';
+    };
   };
 
   config =
     let
       enableXdgConfig = !isDarwin || config.xdg.enable;
+      baseConfigPath = if enableXdgConfig then "superfile" else "Library/Application Support/superfile";
+      baseDataPath = if enableXdgConfig then "superfile" else "Library/Application Support/superfile";
+
       themeSetting =
         if (!(cfg.settings ? theme) && cfg.themes != { }) then
           {
@@ -118,7 +171,6 @@ in
           }
         else
           { };
-      baseConfigPath = if enableXdgConfig then "superfile" else "Library/Application Support/superfile";
       configFile = mkIf (cfg.settings != { }) {
         "${baseConfigPath}/config.toml".source = tomlFormat.generate "superfile-config.toml" (
           recursiveUpdate themeSetting cfg.settings
@@ -139,24 +191,48 @@ in
               (tomlFormat.generate "superfile-theme-${name}.toml" value);
         }
       ) cfg.themes;
+
+      firstUseCheckFile = mkIf (!cfg.firstUseCheck) { "${baseDataPath}/firstUseCheck".text = ""; };
+      pinnedFile = mkIf (cfg.pinnedFolders != [ ]) {
+        "${baseDataPath}/pinned.json".source = jsonFormat.generate "pinned.json" cfg.pinnedFolders;
+      };
+
+      files = mkMerge [
+        configFile
+        hotkeysFile
+        themeFiles
+
+        firstUseCheckFile
+        pinnedFile
+      ];
       configFiles = mkMerge [
         configFile
         hotkeysFile
         themeFiles
       ];
+      dataFiles = mkMerge [
+        firstUseCheckFile
+        pinnedFile
+      ];
     in
     mkIf cfg.enable {
-      home.packages = mkIf (cfg.package != null) (
-        [ cfg.package ]
-        ++ optional (
-          cfg.metadataPackage != null && cfg.settings ? metadata && cfg.settings.metadata
-        ) cfg.metadataPackage
-        ++ optional (
-          cfg.zoxidePackage != null && cfg.settings ? zoxide_support && cfg.settings.zoxide_support
-        ) cfg.zoxidePackage
-      );
+      home = {
+        packages = mkIf (cfg.package != null) (
+          [ cfg.package ]
+          ++ optional (
+            cfg.metadataPackage != null && cfg.settings ? metadata && cfg.settings.metadata
+          ) cfg.metadataPackage
+          ++ optional (
+            cfg.zoxidePackage != null && cfg.settings ? zoxide_support && cfg.settings.zoxide_support
+          ) cfg.zoxidePackage
+        );
 
-      xdg.configFile = mkIf enableXdgConfig configFiles;
-      home.file = mkIf (!enableXdgConfig) configFiles;
+        file = mkIf (!enableXdgConfig) files;
+      };
+
+      xdg = {
+        configFile = mkIf enableXdgConfig configFiles;
+        dataFile = mkIf enableXdgConfig dataFiles;
+      };
     };
 }

--- a/tests/modules/programs/superfile/example-pinned-folders.json
+++ b/tests/modules/programs/superfile/example-pinned-folders.json
@@ -1,0 +1,6 @@
+[
+  {
+    "location": "/nix/store",
+    "name": "Nix Store"
+  }
+]

--- a/tests/modules/programs/superfile/example-settings.nix
+++ b/tests/modules/programs/superfile/example-settings.nix
@@ -53,6 +53,13 @@
         ];
       };
     };
+    firstUseCheck = false;
+    pinnedFolders = [
+      {
+        name = "Nix Store";
+        location = "/nix/store";
+      }
+    ];
   };
 
   nmt.script =
@@ -60,6 +67,10 @@
       configSubPath =
         if !pkgs.stdenv.isDarwin then ".config/superfile" else "Library/Application Support/superfile";
       configBasePath = "home-files/" + configSubPath;
+
+      dataSubPath =
+        if !pkgs.stdenv.isDarwin then ".local/share/superfile" else "Library/Application Support/superfile";
+      dataBasePath = "home-files/" + dataSubPath;
     in
     ''
       assertFileExists "${configBasePath}/config.toml"
@@ -82,5 +93,10 @@
       assertFileContent \
         "${configBasePath}/theme/test2.toml" \
         ${./example-theme2-expected.toml}
+      assertFileExists "${dataBasePath}/firstUseCheck"
+      assertFileExists "${dataBasePath}/pinned.json"
+      assertFileContent \
+        "${dataBasePath}/pinned.json" \
+        ${./example-pinned-folders.json}
     '';
 }


### PR DESCRIPTION
### Description

Code can be found [here](https://github.com/yorukot/superfile/blob/8b31697b7435e4530c66a08527a25ce54105b427/src/config/fixed_variable.go#L45-L46).

- Add an option to configure the pinned directories that get shown on the left panel
- Add an option to disable the first-use pop-up

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
