### PR TITLE
jjui: init module

### DIFF
--- a/modules/misc/news/2025/09/2025-09-12_10-02-45.nix
+++ b/modules/misc/news/2025/09/2025-09-12_10-02-45.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-09-12T15:02:45+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.jjui'
+
+    jjui is a terminal user interface for jujutsu version control system.
+  '';
+}

--- a/modules/programs/jjui.nix
+++ b/modules/programs/jjui.nix
@@ -11,7 +11,10 @@ let
   tomlFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = [ lib.maintainers.khaneliman ];
+  meta.maintainers = with lib.maintainers; [
+    adda
+    khaneliman
+  ];
 
   options.programs.jjui = {
     enable = lib.mkEnableOption "jjui - A terminal user interface for jujutsu";

--- a/modules/programs/jjui.nix
+++ b/modules/programs/jjui.nix
@@ -1,0 +1,65 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkIf mkOption;
+
+  cfg = config.programs.jjui;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = [ lib.maintainers.khaneliman ];
+
+  options.programs.jjui = {
+    enable = lib.mkEnableOption "jjui - A terminal user interface for jujutsu";
+
+    package = lib.mkPackageOption pkgs "jjui" { nullable = true; };
+
+    configDir = mkOption {
+      type = lib.types.str;
+      default =
+        let
+          dir = if pkgs.stdenv.isDarwin then "Library/Application Support" else config.xdg.configHome;
+        in
+        "${dir}/jjui";
+      defaultText = lib.literalExpression "Darwin: \"Library/Application Support/jjui\" \nLinux: \${config.xdg.configHome}/jjui";
+      example = lib.literalExpression "\${config.home.homeDirectory}/.jjui";
+      description = ''
+        The directory to contain jjui configuration files.
+      '';
+    };
+
+    settings = mkOption {
+      inherit (tomlFormat) type;
+      default = { };
+      example = {
+        revisions = {
+          template = "builtin_log_compact";
+          revset = "";
+        };
+      };
+      description = ''
+        Options to add to the {file}`config.toml` file. See
+        <https://github.com/idursun/jjui/wiki/Configuration>
+        for options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home = {
+      packages = mkIf (cfg.package != null) [ cfg.package ];
+
+      file."${cfg.configDir}/config.toml" = mkIf (cfg.settings != { }) {
+        source = tomlFormat.generate "jjui-config" cfg.settings;
+      };
+
+      sessionVariables = {
+        JJUI_CONFIG_DIR = cfg.configDir;
+      };
+    };
+  };
+}

--- a/tests/modules/programs/jjui/default.nix
+++ b/tests/modules/programs/jjui/default.nix
@@ -1,0 +1,5 @@
+{
+  jjui-empty-settings = ./empty-settings.nix;
+  jjui-example-settings = ./example-settings.nix;
+  jjui-null-package = ./null-package.nix;
+}

--- a/tests/modules/programs/jjui/empty-settings.nix
+++ b/tests/modules/programs/jjui/empty-settings.nix
@@ -1,0 +1,9 @@
+{
+  config = {
+    programs.jjui.enable = true;
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/jjui
+    '';
+  };
+}

--- a/tests/modules/programs/jjui/example-settings-expected.toml
+++ b/tests/modules/programs/jjui/example-settings-expected.toml
@@ -1,0 +1,3 @@
+[revisions]
+revset = "ancestors(@ | heads(remote_branches())) ~ empty()"
+template = "builtin_log_compact"

--- a/tests/modules/programs/jjui/example-settings.nix
+++ b/tests/modules/programs/jjui/example-settings.nix
@@ -1,0 +1,29 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+
+{
+  config = {
+    programs.jjui = {
+      enable = true;
+      settings = {
+        revisions = {
+          template = "builtin_log_compact";
+          revset = "ancestors(@ | heads(remote_branches())) ~ empty()";
+        };
+      };
+    };
+
+    nmt.script =
+      let
+        configDir = if !pkgs.stdenv.isDarwin then ".config/jjui" else "Library/Application Support/jjui";
+      in
+      ''
+        assertFileContent \
+          "home-files/${configDir}/config.toml" \
+          ${./example-settings-expected.toml}
+      '';
+  };
+}

--- a/tests/modules/programs/jjui/null-package.nix
+++ b/tests/modules/programs/jjui/null-package.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+
+{
+  config = {
+    programs.jjui = {
+      enable = true;
+      package = null;
+      settings = {
+        revisions.template = "builtin_log_oneline";
+      };
+    };
+
+    nmt.script =
+      let
+        configDir = if !pkgs.stdenv.isDarwin then ".config/jjui" else "Library/Application Support/jjui";
+      in
+      ''
+        assertFileContent \
+          "home-files/${configDir}/config.toml" \
+          ${pkgs.writeText "expected" ''
+            [revisions]
+            template = "builtin_log_oneline"
+          ''}
+      '';
+  };
+}


### PR DESCRIPTION
Add a module for configuring the jjui program.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
