### PR TITLE
nix-darwin: redirect output to stderr

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -23,13 +23,13 @@ in
             driverVersion = if cfg.enableLegacyProfileManagement then "0" else "1";
           in
           ''
-            echo Activating home-manager configuration for ${usercfg.home.username}
+            echo Activating home-manager configuration for ${usercfg.home.username} >&2
             launchctl asuser "$(id -u ${usercfg.home.username})" sudo -u ${usercfg.home.username} --set-home ${pkgs.writeShellScript "activation-${usercfg.home.username}" ''
               ${lib.optionalString (
                 cfg.backupFileExtension != null
               ) "export HOME_MANAGER_BACKUP_EXT=${lib.escapeShellArg cfg.backupFileExtension}"}
               ${lib.optionalString cfg.verbose "export VERBOSE=1"}
-              exec ${usercfg.home.activationPackage}/activate --driver-version ${driverVersion}
+              exec ${usercfg.home.activationPackage}/activate --driver-version ${driverVersion} >&2
             ''}
           ''
         ) cfg.users


### PR DESCRIPTION
### Description

Redirects activation output to stderr on Nix-Darwin. Every other activation script on Darwin does this and some tools like `nh` only print stderr and not stdout, so when using those the output wasn't shown before.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
