### PR TITLE
cudatext: add module

### DIFF
--- a/modules/misc/news/2025/09/2025-09-13_13-36-15.nix
+++ b/modules/misc/news/2025/09/2025-09-13_13-36-15.nix
@@ -1,0 +1,13 @@
+{
+  time = "2025-09-13T16:36:15+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.cudatext`
+
+    CudaText is a cross-platform text editor, written in Object Pascal.
+    It is open source project and can be used free of charge, even for business.
+    It starts quite fast: ~0.3 sec with ~30 plugins, on Linux on CPU Intel Core
+    i3 3GHz. It is extensible by Python add-ons: plugins, linters, code tree parsers,
+    external tools. Syntax parser is feature-rich, from EControl engine.
+  '';
+}

--- a/modules/programs/cudatext.nix
+++ b/modules/programs/cudatext.nix
@@ -1,0 +1,163 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    types
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    nameValuePair
+    mapAttrs'
+    ;
+
+  cfg = config.programs.cudatext;
+
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+  options.programs.cudatext = {
+    enable = mkEnableOption "cudatext";
+    package = mkPackageOption pkgs "cudatext" { nullable = true; };
+    hotkeys = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = {
+        "2823" = {
+          name = "code tree: clear filter";
+          s1 = [ "Home" ];
+        };
+
+        "153" = {
+          name = "delete char right (delete)";
+          s1 = [ "End" ];
+        };
+
+        "655465" = {
+          name = "caret to line end";
+          s1 = [ ];
+        };
+
+        "116" = {
+          name = "column select: page up";
+          s1 = [ ];
+        };
+
+        "655464" = {
+          name = "caret to line begin";
+          s1 = [ ];
+        };
+      };
+      description = ''
+        Hotkeys for Cudatext. To see the available options, change
+        the settings in the dialog "Help | Command palette" and
+        look at the changes in `settings/keys.json`.
+      '';
+    };
+
+    userSettings = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = {
+        numbers_style = 2;
+        numbers_center = false;
+        numbers_for_carets = true;
+      };
+      description = ''
+        User configuration for Cudatext.
+      '';
+    };
+
+    lexerSettings = mkOption {
+      type = types.attrsOf jsonFormat.type;
+      default = { };
+      example = {
+        C = {
+          numbers_style = 2;
+        };
+        Python = {
+          numbers_style = 1;
+          numbers_center = false;
+        };
+        Rust = {
+          numbers_style = 2;
+          numbers_center = false;
+          numbers_for_carets = true;
+        };
+      };
+      description = ''
+        User configuration settings specific to each lexer.
+      '';
+    };
+
+    lexerHotkeys = mkOption {
+      type = types.attrsOf jsonFormat.type;
+      default = { };
+      example = {
+        C = {
+          "153" = {
+            name = "delete char right (delete)";
+            s1 = [ "End" ];
+          };
+
+          "655465" = {
+            name = "caret to line end";
+            s1 = [ ];
+          };
+        };
+
+        Python = {
+          "2823" = {
+            name = "code tree: clear filter";
+            s1 = [ "Home" ];
+          };
+
+          "655464" = {
+            name = "caret to line begin";
+            s1 = [ ];
+          };
+        };
+      };
+      description = ''
+        Hotkeys settings specific to each lexer.
+      '';
+    };
+  };
+
+  config =
+    let
+      settingsPath =
+        if pkgs.stdenv.isDarwin then
+          "Library/Application Support/CudaText/settings"
+        else
+          "${lib.removePrefix config.home.homeDirectory config.xdg.configHome}/cudatext/settings";
+    in
+    mkIf cfg.enable {
+      home.packages = mkIf (cfg.package != null) [ cfg.package ];
+      home.file = {
+        "${settingsPath}/keys.json" = mkIf (cfg.hotkeys != { }) {
+          source = jsonFormat.generate "cudatext-keys.json" cfg.hotkeys;
+        };
+        "${settingsPath}/user.json" = mkIf (cfg.userSettings != { }) {
+          source = jsonFormat.generate "cudatext-user.json" cfg.userSettings;
+        };
+      }
+      // (mapAttrs' (
+        k: v:
+        nameValuePair "${settingsPath}/lexer ${k}.json" {
+          source = jsonFormat.generate "cudatext-lexer-${k}" v;
+        }
+      ) cfg.lexerSettings)
+      // (mapAttrs' (
+        k: v:
+        nameValuePair "${settingsPath}/keys lexer ${k}.json" {
+          source = jsonFormat.generate "cudatext-lexer-keys-${k}" v;
+        }
+      ) cfg.lexerHotkeys);
+    };
+}

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -32,6 +32,7 @@ let
     "cmus"
     "codex"
     "comodoro"
+    "cudatext"
     "darcs"
     "delta"
     "dircolors"

--- a/tests/modules/programs/cudatext/default.nix
+++ b/tests/modules/programs/cudatext/default.nix
@@ -1,0 +1,1 @@
+{ cudatext-example-config = ./example-config.nix; }

--- a/tests/modules/programs/cudatext/example-config.nix
+++ b/tests/modules/programs/cudatext/example-config.nix
@@ -1,0 +1,112 @@
+{ pkgs, ... }:
+
+{
+  programs.cudatext = {
+    enable = true;
+    userSettings = {
+      numbers_style = 2;
+      numbers_center = false;
+      numbers_for_carets = true;
+    };
+
+    hotkeys = {
+      "2823" = {
+        name = "code tree: clear filter";
+        s1 = [ "Home" ];
+      };
+
+      "153" = {
+        name = "delete char right (delete)";
+        s1 = [ "End" ];
+      };
+
+      "655465" = {
+        name = "caret to line end";
+        s1 = [ ];
+      };
+
+      "116" = {
+        name = "column select: page up";
+        s1 = [ ];
+      };
+
+      "655464" = {
+        name = "caret to line begin";
+        s1 = [ ];
+      };
+    };
+
+    lexerSettings = {
+      C = {
+        numbers_style = 2;
+      };
+      Python = {
+        numbers_style = 1;
+        numbers_center = false;
+      };
+      Rust = {
+        numbers_style = 2;
+        numbers_center = false;
+        numbers_for_carets = true;
+      };
+    };
+
+    lexerHotkeys = {
+      C = {
+        "153" = {
+          name = "delete char right (delete)";
+          s1 = [ "End" ];
+        };
+
+        "655465" = {
+          name = "caret to line end";
+          s1 = [ ];
+        };
+      };
+
+      Python = {
+        "2823" = {
+          name = "code tree: clear filter";
+          s1 = [ "Home" ];
+        };
+
+        "655464" = {
+          name = "caret to line begin";
+          s1 = [ ];
+        };
+      };
+    };
+  };
+
+  nmt.script =
+    let
+      settingsPath =
+        if pkgs.stdenv.isDarwin then
+          "home-files/Library/Application Support/CudaText/settings"
+        else
+          "home-files/.config/cudatext/settings";
+    in
+    ''
+      assertFileExists "${settingsPath}/user.json"
+      assertFileExists "${settingsPath}/keys.json"
+
+      assertFileExists "${settingsPath}/lexer C.json"
+      assertFileExists "${settingsPath}/lexer Python.json"
+      assertFileExists "${settingsPath}/lexer Rust.json"
+
+      assertFileExists "${settingsPath}/keys lexer C.json"
+      assertFileExists "${settingsPath}/keys lexer Python.json"
+
+
+
+      assertFileContent "${settingsPath}/user.json" ${./user.json}
+      assertFileContent "${settingsPath}/keys.json" ${./keys.json}
+
+      assertFileContent "${settingsPath}/lexer C.json" ${./lexerC.json}
+      assertFileContent "${settingsPath}/lexer Python.json" ${./lexerPython.json}
+      assertFileContent "${settingsPath}/lexer Rust.json" ${./lexerRust.json}
+
+      assertFileContent "${settingsPath}/keys lexer C.json" ${./keysLexerC.json}
+      assertFileContent "${settingsPath}/keys lexer Python.json" ${./keysLexerPython.json}
+    '';
+}

--- a/tests/modules/programs/cudatext/keys.json
+++ b/tests/modules/programs/cudatext/keys.json
@@ -1,0 +1,26 @@
+{
+  "116": {
+    "name": "column select: page up",
+    "s1": []
+  },
+  "153": {
+    "name": "delete char right (delete)",
+    "s1": [
+      "End"
+    ]
+  },
+  "2823": {
+    "name": "code tree: clear filter",
+    "s1": [
+      "Home"
+    ]
+  },
+  "655464": {
+    "name": "caret to line begin",
+    "s1": []
+  },
+  "655465": {
+    "name": "caret to line end",
+    "s1": []
+  }
+}

--- a/tests/modules/programs/cudatext/keysLexerC.json
+++ b/tests/modules/programs/cudatext/keysLexerC.json
@@ -1,0 +1,12 @@
+{
+  "153": {
+    "name": "delete char right (delete)",
+    "s1": [
+      "End"
+    ]
+  },
+  "655465": {
+    "name": "caret to line end",
+    "s1": []
+  }
+}

--- a/tests/modules/programs/cudatext/keysLexerPython.json
+++ b/tests/modules/programs/cudatext/keysLexerPython.json
@@ -1,0 +1,12 @@
+{
+  "2823": {
+    "name": "code tree: clear filter",
+    "s1": [
+      "Home"
+    ]
+  },
+  "655464": {
+    "name": "caret to line begin",
+    "s1": []
+  }
+}

--- a/tests/modules/programs/cudatext/lexerC.json
+++ b/tests/modules/programs/cudatext/lexerC.json
@@ -1,0 +1,3 @@
+{
+  "numbers_style": 2
+}

--- a/tests/modules/programs/cudatext/lexerPython.json
+++ b/tests/modules/programs/cudatext/lexerPython.json
@@ -1,0 +1,4 @@
+{
+  "numbers_center": false,
+  "numbers_style": 1
+}

--- a/tests/modules/programs/cudatext/lexerRust.json
+++ b/tests/modules/programs/cudatext/lexerRust.json
@@ -1,0 +1,5 @@
+{
+  "numbers_center": false,
+  "numbers_for_carets": true,
+  "numbers_style": 2
+}

--- a/tests/modules/programs/cudatext/user.json
+++ b/tests/modules/programs/cudatext/user.json
@@ -1,0 +1,5 @@
+{
+  "numbers_center": false,
+  "numbers_for_carets": true,
+  "numbers_style": 2
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring [CudaText](https://cudatext.github.io/).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
