### PR TITLE
add stop and restart settings to the nextcloud-client service

### DIFF
--- a/modules/services/nextcloud-client.nix
+++ b/modules/services/nextcloud-client.nix
@@ -40,6 +40,12 @@ in
         Environment = [ "PATH=${config.home.profileDirectory}/bin" ];
         ExecStart =
           "${cfg.package}/bin/nextcloud" + (lib.optionalString cfg.startInBackground " --background");
+        ExecStop = "${cfg.package}/bin/nextcloud --quit";
+        KillMode = "process";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        NoNewPrivileges = true;
+        RestrictRealtime = true;
       };
 
       Install = {


### PR DESCRIPTION
The service fails on `home-manager switch` every now and then, so I suggest adding stop and restart settings to it.
See also [this issue](https://github.com/nextcloud/desktop/issues/728).

It might even be worth adding `RestartSec` with a value of e.g. `5` to ensure the client really has stopped before restarting, but I am not sure whether that is how it is done properly :sweat_smile: 