### PR TITLE
nvchecker: add module

### DIFF
--- a/modules/misc/news/2025/09/2025-09-15_18-14-27.nix
+++ b/modules/misc/news/2025/09/2025-09-15_18-14-27.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-09-15T22:14:27+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.nvchecker`.
+
+    `nvchecker` checks if a new version of some software was released.
+  '';
+}

--- a/modules/programs/nvchecker.nix
+++ b/modules/programs/nvchecker.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  tomlFormat = pkgs.formats.toml { };
+  cfg = config.programs.nvchecker;
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "${config.home.homeDirectory}/Library/Application Support/nvchecker"
+    else
+      "${config.xdg.configHome}/nvchecker";
+in
+{
+  meta.maintainers = [ lib.maintainers.mdaniels5757 ];
+  options.programs.nvchecker = {
+    enable = lib.mkEnableOption "nvchecker";
+    package = lib.mkPackageOption pkgs "nvchecker" { nullable = true; };
+    settings =
+      let
+        envDocs = ''
+          Environment variables and `~` are expanded,
+          and relative paths are relative to
+          {file}`''${config.home.homeDirectory}/Library/Application Support/nvchecker/nvchecker/` (on Darwin)
+          or {file}`''${config.xdg.configHome}/nvchecker/` (otherwise).
+        '';
+      in
+      lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = tomlFormat.type;
+          options.__config__ = lib.mkOption {
+            type = lib.types.submodule {
+              freeformType = tomlFormat.type;
+              options = {
+                oldver = lib.mkOption {
+                  # doesn't matter if absolute/relative or (not) in store
+                  type = lib.types.pathWith { };
+                  default = "old_ver.json";
+                  description = ''
+                    The file to store 'old' (i.e. installed) version information in.
+
+                    ${envDocs}
+                  '';
+                };
+                newver = lib.mkOption {
+                  # doesn't matter if absolute/relative or (not) in store
+                  type = lib.types.pathWith { };
+                  default = "new_ver.json";
+                  description = ''
+                    The file to store 'new' (i.e. available) versions in.
+
+                    ${envDocs}
+                  '';
+                };
+              };
+            };
+            default = { };
+            defaultText = lib.literalExpression ''
+              {
+                oldver = "old_ver.json";
+                newver = "new_ver.json";
+              };
+            '';
+            description = ''
+              See <https://nvchecker.readthedocs.io/en/stable/usage.html#configuration-files>.
+
+              ${envDocs}
+            '';
+          };
+        };
+        default = { };
+        defaultText = lib.literalExpression ''
+          __config__ = {
+            oldver = "old_ver.json";
+            newver = "new_ver.json";
+          };
+        '';
+        example = lib.literalExpression ''
+          {
+            __config__ = {
+              oldver = "my_custom_oldver.json";
+              newver = "~/seperately_placed_newver.json";
+              keyfile = "keyfile.toml";
+            };
+
+            nvchecker = {
+              source = "github";
+              github = "lilydjwg/nvchecker";
+            };
+          }
+        '';
+        description = ''
+          Configuration written to
+          {file}`$HOME/Library/Application Support/nvchecker/nvchecker.toml` (on Darwin) or
+          {file}`$XDG_CONFIG_HOME/nvchecker/nvchecker.toml` (otherwise).
+          See <https://nvchecker.readthedocs.io/en/stable/usage.html#configuration-files>
+          for the full list of options.
+
+          ${envDocs}
+        '';
+      };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    home.file."${configDir}/nvchecker.toml".source = lib.mkIf (cfg.settings != { }) (
+      tomlFormat.generate "nvchecker.toml" cfg.settings
+    );
+  };
+}

--- a/tests/modules/programs/nvchecker/basic-config.nix
+++ b/tests/modules/programs/nvchecker/basic-config.nix
@@ -1,0 +1,27 @@
+{ pkgs, ... }:
+let
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/nvchecker"
+    else
+      ".config/nvchecker";
+in
+{
+  programs.nvchecker = {
+    enable = true;
+    settings = {
+      __config__ = {
+        keyfile = "keyfile.toml";
+      };
+      nvchecker = {
+        source = "github";
+        github = "lilydjwg/nvchecker";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/${configDir}/nvchecker.toml"
+    assertFileContent "home-files/${configDir}/nvchecker.toml" "${./basic-config.toml}"
+  '';
+}

--- a/tests/modules/programs/nvchecker/basic-config.toml
+++ b/tests/modules/programs/nvchecker/basic-config.toml
@@ -1,0 +1,8 @@
+[__config__]
+keyfile = "keyfile.toml"
+newver = "new_ver.json"
+oldver = "old_ver.json"
+
+[nvchecker]
+github = "lilydjwg/nvchecker"
+source = "github"

--- a/tests/modules/programs/nvchecker/default.nix
+++ b/tests/modules/programs/nvchecker/default.nix
@@ -1,0 +1,4 @@
+{
+  nvchecker-basic-config = ./basic-config.nix;
+  nvchecker-empty-config = ./empty-config.nix;
+}

--- a/tests/modules/programs/nvchecker/empty-config.nix
+++ b/tests/modules/programs/nvchecker/empty-config.nix
@@ -1,0 +1,16 @@
+{ pkgs, ... }:
+let
+  configDir =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "Library/Application Support/nvchecker"
+    else
+      ".config/nvchecker";
+in
+{
+  programs.nvchecker.enable = true;
+
+  nmt.script = ''
+    assertFileExists "home-files/${configDir}/nvchecker.toml"
+    assertFileContent "home-files/${configDir}/nvchecker.toml" "${./empty-config.toml}"
+  '';
+}

--- a/tests/modules/programs/nvchecker/empty-config.toml
+++ b/tests/modules/programs/nvchecker/empty-config.toml
@@ -1,0 +1,3 @@
+[__config__]
+newver = "new_ver.json"
+oldver = "old_ver.json"


### PR DESCRIPTION
### Description

`nvchecker` checks if a new version of some software was released.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
     
    These fail for me because of #7818. But the tests I added do pass on x86_64-linux and aarch64-darwin.


- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [X] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [X] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [X] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
