### PR TITLE
sway: drop oxalica from maintainer

### DIFF
--- a/all-maintainers.nix
+++ b/all-maintainers.nix
@@ -1801,18 +1801,6 @@
     name = "Owen McGrath";
     source = "home-manager";
   };
-  oxalica = {
-    email = "oxalicc@pm.me";
-    github = "oxalica";
-    githubId = 14816024;
-    keys = [
-      {
-        fingerprint = "F90F FD6D 585C 2BA1 F13D  E8A9 7571 654C F88E 31C2";
-      }
-    ];
-    name = "oxalica";
-    source = "nixpkgs";
-  };
   pacien = {
     email = "r9uhdi.nixpkgs@euxane.net";
     github = "pacien";

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -497,7 +497,6 @@ in
     Scrumplex
     alexarice
     sumnerevans
-    oxalica
   ];
 
   imports =


### PR DESCRIPTION
### Description

I do not use sway anymore. It seems no other module is maintained by me, thus also remove me from `all-maintainers.nix`.

The commit is signed by (the signing subkey of) the GPG key touched in the diff.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.


- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
