### PR TITLE
watcher example typo windows

### DIFF
--- a/modules/services/activitywatch.nix
+++ b/modules/services/activitywatch.nix
@@ -210,7 +210,7 @@ in
             };
           };
 
-          aw-watcher-windows = {
+          aw-watcher-window = {
             package = pkgs.activitywatch;
             settings = {
               poll_time = 1;


### PR DESCRIPTION
the example config has a stray s 