### PR TITLE
oh-my-posh: added option to supply config path

### DIFF
--- a/modules/programs/oh-my-posh.nix
+++ b/modules/programs/oh-my-posh.nix
@@ -16,6 +16,8 @@ let
       "--config ${config.xdg.configHome}/oh-my-posh/config.json"
     else if cfg.useTheme != null then
       "--config ${cfg.package}/share/oh-my-posh/themes/${cfg.useTheme}.omp.json"
+    else if cfg.configFile != null then
+      "--config ${cfg.configFile}"
     else
       "";
 
@@ -49,6 +51,14 @@ in
         <https://ohmyposh.dev/docs/themes>. Because a theme
         is essentially a configuration file, this option is not used when a
         `configFile` is set.
+      '';
+    };
+
+    configFile = lib.mkOption {
+      type = with lib.types; nullOr (either str path);
+      default = null;
+      description = ''
+        Path to a custom configuration path, can be json, yaml or toml.
       '';
     };
 

--- a/modules/programs/oh-my-posh.nix
+++ b/modules/programs/oh-my-posh.nix
@@ -72,6 +72,18 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          lib.count (x: x) [
+            (cfg.settings != { })
+            (cfg.useTheme != null)
+            (cfg.configFile != null)
+          ] <= 1;
+        message = "oh-my-posh: Only one of 'settings', 'useTheme', or 'configFile' can be configured at a time.";
+      }
+    ];
+
     home.packages = [ cfg.package ];
 
     xdg.configFile."oh-my-posh/config.json" = mkIf (cfg.settings != { }) {

--- a/tests/modules/programs/oh-my-posh/assertion-all-three.nix
+++ b/tests/modules/programs/oh-my-posh/assertion-all-three.nix
@@ -1,0 +1,14 @@
+{
+  programs.oh-my-posh = {
+    enable = true;
+    settings = {
+      version = 2;
+    };
+    useTheme = "jandedobbeleer";
+    configFile = "/etc/oh-my-posh/custom.json";
+  };
+
+  test.asserts.assertions.expected = [
+    "oh-my-posh: Only one of 'settings', 'useTheme', or 'configFile' can be configured at a time."
+  ];
+}

--- a/tests/modules/programs/oh-my-posh/assertion-settings-config-file.nix
+++ b/tests/modules/programs/oh-my-posh/assertion-settings-config-file.nix
@@ -1,0 +1,13 @@
+{
+  programs.oh-my-posh = {
+    enable = true;
+    settings = {
+      version = 2;
+    };
+    configFile = "/etc/oh-my-posh/custom.json";
+  };
+
+  test.asserts.assertions.expected = [
+    "oh-my-posh: Only one of 'settings', 'useTheme', or 'configFile' can be configured at a time."
+  ];
+}

--- a/tests/modules/programs/oh-my-posh/assertion-settings-theme.nix
+++ b/tests/modules/programs/oh-my-posh/assertion-settings-theme.nix
@@ -1,0 +1,13 @@
+{
+  programs.oh-my-posh = {
+    enable = true;
+    settings = {
+      version = 2;
+    };
+    useTheme = "jandedobbeleer";
+  };
+
+  test.asserts.assertions.expected = [
+    "oh-my-posh: Only one of 'settings', 'useTheme', or 'configFile' can be configured at a time."
+  ];
+}

--- a/tests/modules/programs/oh-my-posh/assertion-theme-config-file.nix
+++ b/tests/modules/programs/oh-my-posh/assertion-theme-config-file.nix
@@ -1,0 +1,11 @@
+{
+  programs.oh-my-posh = {
+    enable = true;
+    useTheme = "jandedobbeleer";
+    configFile = "/etc/oh-my-posh/custom.json";
+  };
+
+  test.asserts.assertions.expected = [
+    "oh-my-posh: Only one of 'settings', 'useTheme', or 'configFile' can be configured at a time."
+  ];
+}

--- a/tests/modules/programs/oh-my-posh/config-file.nix
+++ b/tests/modules/programs/oh-my-posh/config-file.nix
@@ -1,0 +1,17 @@
+{
+  programs = {
+    bash.enable = true;
+
+    oh-my-posh = {
+      enable = true;
+      configFile = "/etc/oh-my-posh/custom.json";
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.bashrc
+    assertFileContains \
+      home-files/.bashrc \
+      '/bin/oh-my-posh init bash --config /etc/oh-my-posh/custom.json'
+  '';
+}

--- a/tests/modules/programs/oh-my-posh/default.nix
+++ b/tests/modules/programs/oh-my-posh/default.nix
@@ -3,4 +3,10 @@
   oh-my-posh-zsh = ./zsh.nix;
   oh-my-posh-fish = ./fish.nix;
   oh-my-posh-nushell = ./nushell.nix;
+  oh-my-posh-settings = ./settings.nix;
+  oh-my-posh-config-file = ./config-file.nix;
+  oh-my-posh-assertion-settings-theme = ./assertion-settings-theme.nix;
+  oh-my-posh-assertion-settings-config-file = ./assertion-settings-config-file.nix;
+  oh-my-posh-assertion-theme-config-file = ./assertion-theme-config-file.nix;
+  oh-my-posh-assertion-all-three = ./assertion-all-three.nix;
 }

--- a/tests/modules/programs/oh-my-posh/settings.nix
+++ b/tests/modules/programs/oh-my-posh/settings.nix
@@ -1,0 +1,39 @@
+{
+  programs = {
+    bash.enable = true;
+
+    oh-my-posh = {
+      enable = true;
+      settings = {
+        version = 2;
+        final_space = true;
+        blocks = [
+          {
+            type = "prompt";
+            alignment = "left";
+            segments = [
+              {
+                type = "shell";
+                style = "plain";
+                template = "{{ .Name }} ";
+              }
+            ];
+          }
+        ];
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/oh-my-posh/config.json
+    assertFileContains \
+      home-files/.config/oh-my-posh/config.json \
+      '"version": 2'
+    assertFileContains \
+      home-files/.config/oh-my-posh/config.json \
+      '"final_space": true'
+    assertFileContains \
+      home-files/.bashrc \
+      '/bin/oh-my-posh init bash --config /home/hm-user/.config/oh-my-posh/config.json'
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Closes https://github.com/nix-community/home-manager/pull/6108
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
