### PR TITLE
gpg-agent: write nushell initialization to config file

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -377,7 +377,7 @@ in
         programs.zsh.initContent = mkIf cfg.enableZshIntegration gpgZshInitStr;
         programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration gpgFishInitStr;
 
-        programs.nushell.extraEnv = mkIf cfg.enableNushellIntegration gpgNushellInitStr;
+        programs.nushell.extraConfig = mkIf cfg.enableNushellIntegration gpgNushellInitStr;
       }
 
       (mkIf (cfg.sshKeys != null) {


### PR DESCRIPTION
### Description

According to the [nushell docs](https://www.nushell.sh/book/configuration.html#configuration-overview):

> The first file loaded is env.nu, which was historically used to override environment variables. However, the current "best-practice" recommendation is to set all environment variables (and other configuration) using config.nu and the autoload directories below.

We already do this for all variables in the `environmentVariables` option.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
