### PR TITLE
mise: statically generate nushell config

### DIFF
--- a/modules/programs/mise.nix
+++ b/modules/programs/mise.nix
@@ -129,12 +129,12 @@ in
       '';
 
       nushell = mkIf (cfg.enableNushellIntegration && cfg.package != null) {
-        extraEnv = ''
-          let mise_path = $nu.default-config-dir | path join mise.nu
-          ^mise activate nu | save $mise_path --force
-        '';
         extraConfig = ''
-          use ($nu.default-config-dir | path join mise.nu)
+          use ${
+            pkgs.runCommand "mise-nushell-config.nu" { } ''
+              ${lib.getExe cfg.package} activate nu > $out
+            ''
+          }
         '';
       };
     };

--- a/modules/programs/mise.nix
+++ b/modules/programs/mise.nix
@@ -116,19 +116,19 @@ in
     };
 
     programs = {
-      bash.initExtra = mkIf cfg.enableBashIntegration ''
+      bash.initExtra = mkIf (cfg.enableBashIntegration && cfg.package != null) ''
         eval "$(${getExe cfg.package} activate bash)"
       '';
 
-      zsh.initContent = mkIf cfg.enableZshIntegration ''
+      zsh.initContent = mkIf (cfg.enableZshIntegration && cfg.package != null) ''
         eval "$(${getExe cfg.package} activate zsh)"
       '';
 
-      fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
+      fish.interactiveShellInit = mkIf (cfg.enableFishIntegration && cfg.package != null) ''
         ${getExe cfg.package} activate fish | source
       '';
 
-      nushell = mkIf cfg.enableNushellIntegration {
+      nushell = mkIf (cfg.enableNushellIntegration && cfg.package != null) {
         extraEnv = ''
           let mise_path = $nu.default-config-dir | path join mise.nu
           ^mise activate nu | save $mise_path --force

--- a/tests/modules/programs/mise/nushell-integration.nix
+++ b/tests/modules/programs/mise/nushell-integration.nix
@@ -2,7 +2,14 @@
 {
   programs = {
     mise = {
-      package = config.lib.test.mkStubPackage { name = "mise"; };
+      package = config.lib.test.mkStubPackage {
+        name = "mise";
+        buildScript = ''
+          mkdir -p $out/bin
+          touch $out/bin/mise
+          chmod +x $out/bin/mise
+        '';
+      };
       enable = true;
       enableNushellIntegration = true;
     };
@@ -11,12 +18,7 @@
   };
 
   nmt.script = ''
-    assertFileContains home-files/.config/nushell/env.nu \
-      '
-      let mise_path = $nu.default-config-dir | path join mise.nu
-      ^mise activate nu | save $mise_path --force
-      '
-    assertFileContains home-files/.config/nushell/config.nu \
-      'use ($nu.default-config-dir | path join mise.nu)'
+    assertFileRegex home-files/.config/nushell/config.nu \
+      'use \/nix\/store\/.*-mise-nushell-config.nu'
   '';
 }


### PR DESCRIPTION
### Description

Generating the nushell config at build-time has a bunch of advantages:

- It saves ~10ms of shell startup time in my system

  | Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
  |:---|---:|---:|---:|---:|
  | `mise activate nu` | 9.8 ± 1.0 | 7.9 | 13.2 | 1.00 |

- It is pure, as it doesn't depend on a file outside of the store
- It follows the existing convention with nushell integrations as far as I can see

Static generation is added to nushell mostly because it lacks `eval` support, but this change could be applied to all the other shells as well, for some of the above reasons.

As a bonus, I added checks for `cfg.package != null` to all the integrations. When the package is null, we emit a warning telling the user that the shell integration won't be added. Which is true, because the build straight up fails. The integration is skipped now when that's the case.


### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
