### PR TITLE
restic: fix integration test

### DIFF
--- a/tests/integration/standalone/restic.nix
+++ b/tests/integration/standalone/restic.nix
@@ -152,7 +152,7 @@ in
         f"Paths containing \"*exclude*\" got backed up incorrectly. output: {actual}"
 
     with subtest("Using an rclone backend"):
-      systemctl_succeed_as_alice("start restic-backups-rclone.service")
+      systemctl_succeed_as_alice("start rclone-config.service restic-backups-rclone.service")
       actual = succeed_as_alice("restic-rclone ls latest")
       assert_list("restic-rclone ls latest", expectedIncluded, actual)
 


### PR DESCRIPTION
### Description

Seems to have broken due to the change in #7688. This change is just to unbreak the integration test suite, a proper solution would have to establish a requires/after dependency between the restic and rclone services.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

CC: @ttrssreal