### PR TITLE
password-store: do not set non-default dir

### DIFF
--- a/docs/release-notes/rl-2511.md
+++ b/docs/release-notes/rl-2511.md
@@ -77,4 +77,7 @@ The state version in this release includes the changes below. These
 changes are only active if the `home.stateVersion` option is set to
 \"25.11\" or later.
 
-- No changes.
+- The `programs.password-store.settings` option does not set
+  `{ PASSWORD_STORE_DIR = $XDG_DATA_HOME/password-store; }` anymore by its
+  default value. This will revert to the default behaviour of the program,
+  namely `$HOME/.password-store` to be used as the store path.

--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -28,10 +28,11 @@ in
       defaultText = "$HOME/.password-store";
       example = "/home/user/.local/share/password-store";
       description = ''
-        Absolute path to password store. Defaults to
-        {file}`$HOME/.password-store` if the
-        {option}`programs.password-store` module is not enabled, and
-        {option}`programs.password-store.settings.PASSWORD_STORE_DIR` if it is.
+        Absolute path to password store, default upstream value of which is
+        {file}`$HOME/.password-store`. If the
+        {option}`programs.password-store` module is enabled and
+        {option}`programs.password-store.settings.PASSWORD_STORE_DIR` is set,
+        it will inherit the value from the latter.
       '';
     };
   };

--- a/modules/services/pass-secret-service.nix
+++ b/modules/services/pass-secret-service.nix
@@ -28,11 +28,10 @@ in
       defaultText = "$HOME/.password-store";
       example = "/home/user/.local/share/password-store";
       description = ''
-        Absolute path to password store, default upstream value of which is
-        {file}`$HOME/.password-store`. If the
-        {option}`programs.password-store` module is enabled and
-        {option}`programs.password-store.settings.PASSWORD_STORE_DIR` is set,
-        it will inherit the value from the latter.
+        Absolute path to the password store. If the
+        {option}`programs.password-store` module is enabled, the
+        {option}`programs.password-store.settings.PASSWORD_STORE_DIR` option
+        will be checked, if found it will be inherited as the default.
       '';
     };
   };
@@ -56,7 +55,7 @@ in
       in
       {
         Unit = {
-          AssertFileIsExecutable = "${binPath}";
+          AssertFileIsExecutable = binPath;
           Description = "Pass libsecret service";
           Documentation = "https://github.com/mdellweg/pass_secret_service";
           PartOf = [ "default.target" ];
@@ -64,7 +63,7 @@ in
 
         Service = {
           Type = "dbus";
-          ExecStart = "${binPath} ${lib.optionalString (cfg.storePath != null) "--path ${cfg.storePath}"}";
+          ExecStart = binPath + lib.optionalString (cfg.storePath != null) " --path ${cfg.storePath}";
           BusName = busName;
           Environment = [ "GNUPGHOME=${config.programs.gpg.homedir}" ];
         };

--- a/tests/modules/programs/password-store/default-path.nix
+++ b/tests/modules/programs/password-store/default-path.nix
@@ -1,0 +1,9 @@
+{
+  home.stateVersion = "25.11"; # Or any other newer version
+  programs.password-store.enable = true;
+
+  nmt.script = ''
+    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh \
+      '^export PASSWORD_STORE_DIR='
+  '';
+}

--- a/tests/modules/programs/password-store/default.nix
+++ b/tests/modules/programs/password-store/default.nix
@@ -1,0 +1,5 @@
+{
+  password-store-default-path = ./default-path.nix;
+  password-store-old-default-path = ./old-default-path.nix;
+  password-store-nondefault-path = ./nondefault-path.nix;
+}

--- a/tests/modules/programs/password-store/nondefault-path.nix
+++ b/tests/modules/programs/password-store/nondefault-path.nix
@@ -1,0 +1,15 @@
+let
+  somePath = "/some/random/path/I/store/pwds";
+in
+{
+  home.stateVersion = "25.11";
+  programs.password-store = {
+    enable = true;
+    settings.PASSWORD_STORE_DIR = somePath;
+  };
+
+  nmt.script = ''
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+      'export PASSWORD_STORE_DIR="${somePath}"'
+  '';
+}

--- a/tests/modules/programs/password-store/old-default-path.nix
+++ b/tests/modules/programs/password-store/old-default-path.nix
@@ -1,0 +1,10 @@
+{ config, ... }:
+{
+  home.stateVersion = "25.05"; # <= 25.11
+  programs.password-store.enable = true;
+
+  nmt.script = ''
+    assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+      'export PASSWORD_STORE_DIR="${config.xdg.dataHome}/password-store"'
+  '';
+}

--- a/tests/modules/services/pass-secret-service/default.nix
+++ b/tests/modules/services/pass-secret-service/default.nix
@@ -2,5 +2,7 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   pass-secret-service-default-configuration = ./default-configuration.nix;
+  pass-secret-service-old-default-path = ./old-default-path.nix;
+  pass-secret-service-nondefault-path = ./nondefault-path.nix;
   pass-secret-service-basic-configuration = ./basic-configuration.nix;
 }

--- a/tests/modules/services/pass-secret-service/nondefault-path.nix
+++ b/tests/modules/services/pass-secret-service/nondefault-path.nix
@@ -1,0 +1,20 @@
+{ config, ... }:
+let
+  somePath = "/some/random/path/I/store/pwds";
+in
+{
+  home.stateVersion = "25.11";
+  programs.password-store = {
+    enable = true;
+    settings.PASSWORD_STORE_DIR = somePath;
+  };
+  services.pass-secret-service = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+  };
+
+  nmt.script = ''
+    assertFileContains home-files/.config/systemd/user/pass-secret-service.service \
+      'ExecStart=${config.services.pass-secret-service.package}/bin/pass_secret_service --path ${somePath}'
+  '';
+}

--- a/tests/modules/services/pass-secret-service/old-default-path.nix
+++ b/tests/modules/services/pass-secret-service/old-default-path.nix
@@ -1,6 +1,8 @@
 { config, ... }:
 
 {
+  home.stateVersion = "25.05"; # <= 25.11
+  programs.password-store.enable = true;
   services.pass-secret-service = {
     enable = true;
     package = config.lib.test.mkStubPackage { };
@@ -10,6 +12,6 @@
     serviceFile=home-files/.config/systemd/user/pass-secret-service.service
 
     assertFileExists $serviceFile
-    assertFileRegex $serviceFile '^ExecStart=.*/bin/pass_secret_service$'
+    assertFileRegex $serviceFile '^ExecStart=.*/bin/pass_secret_service --path ${config.xdg.dataHome}/password-store$'
   '';
 }


### PR DESCRIPTION
### Description

Fixes #7832. 

I'm not sure if a news entry is required for such a change, but we can iterate on this PR.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
