### PR TITLE
retext: add module

### DIFF
--- a/modules/misc/news/2025/09/2025-09-18_07-58-37.nix
+++ b/modules/misc/news/2025/09/2025-09-18_07-58-37.nix
@@ -1,0 +1,11 @@
+{
+  time = "2025-09-18T14:46:18+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.retext`
+
+    ReText is a simple but powerful editor for markup languages. It is based on
+    Markups module which supports Markdown, reStructuredText, Textile and
+    AsciiDoc. One can also add support for custom markups using Python modules.
+  '';
+}

--- a/modules/programs/retext.nix
+++ b/modules/programs/retext.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.retext;
+  iniFormat = pkgs.formats.ini { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+  options.programs.retext = {
+    enable = mkEnableOption "retext";
+    package = mkPackageOption pkgs "retext" { nullable = true; };
+    settings = mkOption {
+      inherit (iniFormat) type;
+      default = { };
+      example = {
+        General = {
+          documentStatsEnabled = true;
+          lineNumbersEnabled = true;
+          relativeLineNumbers = true;
+          useWebEngine = true;
+        };
+
+        ColorScheme = {
+          htmlTags = "green";
+          htmlSymbols = "#ff8800";
+          htmlComments = "#abc";
+        };
+      };
+      description = ''
+        Configuration settings for retext. All the available options can be found
+        here: <https://github.com/retext-project/retext/blob/master/configuration.md>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."ReText Project/ReText.conf" = mkIf (cfg.settings != { }) {
+      source = iniFormat.generate "ReText.conf" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/retext/ReText.conf
+++ b/tests/modules/programs/retext/ReText.conf
@@ -1,0 +1,10 @@
+[ColorScheme]
+htmlComments=#abc
+htmlSymbols=#ff8800
+htmlTags=green
+
+[General]
+documentStatsEnabled=true
+lineNumbersEnabled=true
+relativeLineNumbers=true
+useWebEngine=true

--- a/tests/modules/programs/retext/default.nix
+++ b/tests/modules/programs/retext/default.nix
@@ -1,0 +1,1 @@
+{ retext-example-config = ./example-config.nix; }

--- a/tests/modules/programs/retext/example-config.nix
+++ b/tests/modules/programs/retext/example-config.nix
@@ -1,0 +1,25 @@
+{
+  programs.retext = {
+    enable = true;
+    settings = {
+      General = {
+        documentStatsEnabled = true;
+        lineNumbersEnabled = true;
+        relativeLineNumbers = true;
+        useWebEngine = true;
+      };
+
+      ColorScheme = {
+        htmlTags = "green";
+        htmlSymbols = "#ff8800";
+        htmlComments = "#abc";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/.config/ReText Project/ReText.conf"
+    assertFileContent "home-files/.config/ReText Project/ReText.conf" \
+      ${./ReText.conf}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring [ReText](https://github.com/retext-project/retext).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
