### PR TITLE
zsh: fix trailing slash breaking zshenv

### DIFF
--- a/modules/programs/zsh/lib.nix
+++ b/modules/programs/zsh/lib.nix
@@ -3,7 +3,7 @@ let
   cfg = config.programs.zsh;
 in
 rec {
-  homeDir = config.home.homeDirectory;
+  homeDir = cleanPathStr config.home.homeDirectory;
 
   /*
     Escape a path string for shell usage and remove trailing slashes.


### PR DESCRIPTION
### Description

If a user has a trailing `/` in their `user.users.<user>.home` value with the zsh enabled the module fails to properly check the equality of dotDir and the home path.

The libs.nix module is stripping the trailing `/` from the `dotDirAbs` and `dotDirRel` and not for homeDir.

You can see the how the values are evaluated by running this script:
```
nix eval --json --impure --expr '
let
  flake   = builtins.getFlake ("path:" + toString ./.);
  libPkgs = if flake.inputs ? nixpkgs then flake.inputs.nixpkgs.lib else import <nixpkgs/lib> {};
  user    = builtins.getEnv "USER";
  host    = builtins.getEnv "HOSTNAME";

  hmCfg =
    if flake ? darwinConfigurations then
      let
        dcs = flake.darwinConfigurations;
        machineKey =
          if host != "" && builtins.hasAttr host dcs
          then host
          else builtins.head (builtins.attrNames dcs);
        hmUsers = dcs.${machineKey}.config.home-manager.users;
      in
        if builtins.hasAttr user hmUsers
        then hmUsers.${user}
        else throw "User ${user} not found in home-manager.users for ${machineKey}"
    else
      let
        hcs = flake.homeConfigurations;
        keys = builtins.attrNames hcs;
        matches = builtins.filter (k: (hcs.${k}.config.home.username or "") == user) keys;
        key = if matches != [] then builtins.head matches else builtins.head keys;
      in
        hcs.${key}.config;

  hmSrc = flake.inputs.home-manager.outPath;
  vals  = import (hmSrc + "/modules/programs/zsh/lib.nix") { config = hmCfg; lib = libPkgs; };
in { inherit (vals) homeDir dotDirAbs dotDirRel; }
' | jq
```

@lzpreslav actually mentioned this on the PR a few months back.
https://github.com/nix-community/home-manager/pull/6089#issuecomment-3185007895

Relevant LOC:
https://github.com/nix-community/home-manager/blob/master/modules/programs/zsh/lib.nix#L6
https://github.com/nix-community/home-manager/blob/master/modules/programs/zsh/lib.nix#L69
https://github.com/nix-community/home-manager/blob/master/modules/programs/zsh/lib.nix#L99-L100
https://github.com/nix-community/home-manager/blob/master/modules/programs/zsh/default.nix#L415

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.