### PR TITLE
zsh: generated plugin loading cleanup/improvements

### DIFF
--- a/modules/lib/shell.nix
+++ b/modules/lib/shell.nix
@@ -41,6 +41,59 @@ rec {
   # statement for each set entry.
   exportAll = vars: lib.concatStringsSep "\n" (lib.mapAttrsToList export vars);
 
+  # Wrap a list of strings to a given line width.
+  # Packs as many items as possible per line without exceeding maxWidth.
+  # Returns a list of strings, each representing a line.
+  #
+  # Example: wrapLines ["item1" "item2" "very-long-item" "item3"] 20
+  #   => ["item1 item2" "very-long-item" "item3"]
+  wrapLines =
+    items: maxWidth:
+    let
+      step =
+        acc: item:
+        let
+          potentialLine = if acc.currentLine == "" then item else "${acc.currentLine} ${item}";
+        in
+        if lib.stringLength potentialLine <= maxWidth then
+          acc // { currentLine = potentialLine; }
+        else
+          acc
+          // {
+            finishedLines = acc.finishedLines ++ [ acc.currentLine ];
+            currentLine = item;
+          };
+      foldResult = lib.foldl' step {
+        finishedLines = [ ];
+        currentLine = "";
+      } items;
+    in
+    foldResult.finishedLines ++ lib.optional (foldResult.currentLine != "") foldResult.currentLine;
+
+  # Formats a list of items for shell array content with intelligent width optimization.
+  # IMPORTANT: This formats the CONTENTS of an array (what goes inside parentheses),
+  # not a complete array definition. Use lib.hm.zsh.define for complete definitions.
+  #
+  # Uses lib.escapeShellArg for robust shell escaping (handles spaces, quotes, special chars).
+  # Packs multiple items per line to optimize terminal width (~78 chars per line).
+  # Short arrays (≤3 items, ≤80 chars total) use single-line format.
+  #
+  # Example outputs:
+  #   Empty:       ""
+  #   Simple:      item1 item2 item3
+  #   With spaces: 'item one' 'item two' 'item three'
+  #   Long arrays: \n  item1 item2 item3\n  item4 item5\n
+  #
+  # Built from composable helpers: wrapLines, formatMultiLine
+  formatShellArrayContent =
+    items:
+    let
+      quotedItems = lib.map lib.escapeShellArg items;
+      formatMultiLine = lines: "\n  ${lib.concatStringsSep "\n  " lines}\n";
+      wrapped = wrapLines quotedItems 78;
+    in
+    formatMultiLine wrapped;
+
   mkBashIntegrationOption = mkShellIntegrationOption "Bash";
   mkFishIntegrationOption = mkShellIntegrationOption "Fish";
   mkIonIntegrationOption = mkShellIntegrationOption "Ion";

--- a/modules/lib/zsh.nix
+++ b/modules/lib/zsh.nix
@@ -7,9 +7,12 @@ rec {
     if builtins.isBool v then
       if v then "true" else "false"
     else if builtins.isString v then
-      ''"${v}"''
+      lib.escapeShellArg v
     else if builtins.isList v then
-      "(${lib.concatStringsSep " " (map toZshValue v)})"
+      let
+        shell = import ./shell.nix { inherit lib; };
+      in
+      "(${shell.formatShellArrayContent (map toString v)})"
     else
       ''"${toString v}"'';
 

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -17,7 +17,6 @@ let
     ;
 
   cfg = config.programs.zsh;
-
   bindkeyCommands = {
     emacs = "bindkey -e";
     viins = "bindkey -v";
@@ -501,7 +500,12 @@ in
 
             (lib.mkIf (cfg.setOptions != [ ]) (
               mkOrder 950 ''
-                ${concatStringsSep "\n" (map (option: "setopt ${option}") cfg.setOptions)}
+                # Set shell options
+                ${lib.hm.zsh.define "set_opts" cfg.setOptions}
+                for opt in "''${set_opts[@]}"; do
+                  setopt "$opt"
+                done
+                unset opt set_opts
               ''
             ))
 

--- a/modules/programs/zsh/history.nix
+++ b/modules/programs/zsh/history.nix
@@ -199,16 +199,46 @@ in
         mkdir -p "$(dirname "$HISTFILE")"
 
         setopt HIST_FCNTL_LOCK
-        ${if cfg.history.append then "setopt" else "unsetopt"} APPEND_HISTORY
-        ${if cfg.history.ignoreDups then "setopt" else "unsetopt"} HIST_IGNORE_DUPS
-        ${if cfg.history.ignoreAllDups then "setopt" else "unsetopt"} HIST_IGNORE_ALL_DUPS
-        ${if cfg.history.saveNoDups then "setopt" else "unsetopt"} HIST_SAVE_NO_DUPS
-        ${if cfg.history.findNoDups then "setopt" else "unsetopt"} HIST_FIND_NO_DUPS
-        ${if cfg.history.ignoreSpace then "setopt" else "unsetopt"} HIST_IGNORE_SPACE
-        ${if cfg.history.expireDuplicatesFirst then "setopt" else "unsetopt"} HIST_EXPIRE_DUPS_FIRST
-        ${if cfg.history.share then "setopt" else "unsetopt"} SHARE_HISTORY
-        ${if cfg.history.extended then "setopt" else "unsetopt"} EXTENDED_HISTORY
-        ${if cfg.autocd != null then "${if cfg.autocd then "setopt" else "unsetopt"} autocd" else ""}
+
+        ${
+          let
+            historyOptions = {
+              APPEND_HISTORY = cfg.history.append;
+              HIST_IGNORE_DUPS = cfg.history.ignoreDups;
+              HIST_IGNORE_ALL_DUPS = cfg.history.ignoreAllDups;
+              HIST_SAVE_NO_DUPS = cfg.history.saveNoDups;
+              HIST_FIND_NO_DUPS = cfg.history.findNoDups;
+              HIST_IGNORE_SPACE = cfg.history.ignoreSpace;
+              HIST_EXPIRE_DUPS_FIRST = cfg.history.expireDuplicatesFirst;
+              SHARE_HISTORY = cfg.history.share;
+              EXTENDED_HISTORY = cfg.history.extended;
+            }
+            // lib.optionalAttrs (cfg.autocd != null) {
+              inherit (cfg) autocd;
+            };
+
+            enabledOpts = lib.filterAttrs (_: enabled: enabled) historyOptions;
+            disabledOpts = lib.filterAttrs (_: enabled: !enabled) historyOptions;
+          in
+          lib.concatStringsSep "\n\n" (
+            lib.filter (s: s != "") [
+              (lib.optionalString (enabledOpts != { }) ''
+                # Enabled history options
+                ${lib.hm.zsh.define "enabled_opts" (lib.mapAttrsToList (name: _: name) enabledOpts)}
+                for opt in "''${enabled_opts[@]}"; do
+                  setopt "$opt"
+                done
+                unset opt enabled_opts'')
+              (lib.optionalString (disabledOpts != { }) ''
+                # Disabled history options
+                ${lib.hm.zsh.define "disabled_opts" (lib.mapAttrsToList (name: _: name) disabledOpts)}
+                for opt in "''${disabled_opts[@]}"; do
+                  unsetopt "$opt"
+                done
+                unset opt disabled_opts'')
+            ]
+          )
+        }
       '')
 
       (lib.mkIf (cfg.historySubstringSearch.enable or false) (
@@ -217,12 +247,28 @@ in
           # https://github.com/zsh-users/zsh-history-substring-search#usage
           ''
             source ${pkgs.zsh-history-substring-search}/share/zsh-history-substring-search/zsh-history-substring-search.zsh
-            ${lib.concatMapStringsSep "\n" (upKey: ''bindkey "${upKey}" history-substring-search-up'') (
-              lib.toList cfg.historySubstringSearch.searchUpKey
-            )}
-            ${lib.concatMapStringsSep "\n" (downKey: ''bindkey "${downKey}" history-substring-search-down'') (
-              lib.toList cfg.historySubstringSearch.searchDownKey
-            )}
+
+            ${
+              let
+                upKeys = lib.toList cfg.historySubstringSearch.searchUpKey;
+                downKeys = lib.toList cfg.historySubstringSearch.searchDownKey;
+              in
+              ''
+                # Bind search up keys
+                ${lib.hm.zsh.define "search_up_keys" upKeys}
+                 for key in "''${search_up_keys[@]}"; do
+                   bindkey "$key" history-substring-search-up
+                 done
+                 unset key search_up_keys
+
+                # Bind search down keys
+                ${lib.hm.zsh.define "search_down_keys" downKeys}
+                 for key in "''${search_down_keys[@]}"; do
+                   bindkey "$key" history-substring-search-down
+                 done
+                 unset key search_down_keys
+              ''
+            }
           ''
       ))
     ];

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -179,6 +179,7 @@ let
     "zoxide"
     "zplug"
     "zsh"
+    "zsh-history-substring-search"
     # keep-sorted end
   ];
 

--- a/tests/modules/programs/fabric-ai/zshrc
+++ b/tests/modules/programs/fabric-ai/zshrc
@@ -15,16 +15,25 @@ HISTFILE="/home/hm-user/.zsh_history"
 mkdir -p "$(dirname "$HISTFILE")"
 
 setopt HIST_FCNTL_LOCK
-unsetopt APPEND_HISTORY
-setopt HIST_IGNORE_DUPS
-unsetopt HIST_IGNORE_ALL_DUPS
-unsetopt HIST_SAVE_NO_DUPS
-unsetopt HIST_FIND_NO_DUPS
-setopt HIST_IGNORE_SPACE
-unsetopt HIST_EXPIRE_DUPS_FIRST
-setopt SHARE_HISTORY
-unsetopt EXTENDED_HISTORY
 
+# Enabled history options
+enabled_opts=(
+  HIST_IGNORE_DUPS HIST_IGNORE_SPACE SHARE_HISTORY
+)
+for opt in "${enabled_opts[@]}"; do
+  setopt "$opt"
+done
+unset opt enabled_opts
+
+# Disabled history options
+disabled_opts=(
+  APPEND_HISTORY EXTENDED_HISTORY HIST_EXPIRE_DUPS_FIRST HIST_FIND_NO_DUPS
+  HIST_IGNORE_ALL_DUPS HIST_SAVE_NO_DUPS
+)
+for opt in "${disabled_opts[@]}"; do
+  unsetopt "$opt"
+done
+unset opt disabled_opts
 
 
 

--- a/tests/modules/programs/zsh/aliases.nix
+++ b/tests/modules/programs/zsh/aliases.nix
@@ -32,16 +32,25 @@
       mkdir -p "$(dirname "$HISTFILE")"
 
       setopt HIST_FCNTL_LOCK
-      unsetopt APPEND_HISTORY
-      setopt HIST_IGNORE_DUPS
-      unsetopt HIST_IGNORE_ALL_DUPS
-      unsetopt HIST_SAVE_NO_DUPS
-      unsetopt HIST_FIND_NO_DUPS
-      setopt HIST_IGNORE_SPACE
-      unsetopt HIST_EXPIRE_DUPS_FIRST
-      setopt SHARE_HISTORY
-      unsetopt EXTENDED_HISTORY
 
+      # Enabled history options
+      enabled_opts=(
+        HIST_IGNORE_DUPS HIST_IGNORE_SPACE SHARE_HISTORY
+      )
+      for opt in "''${enabled_opts[@]}"; do
+        setopt "$opt"
+      done
+      unset opt enabled_opts
+
+      # Disabled history options
+      disabled_opts=(
+        APPEND_HISTORY EXTENDED_HISTORY HIST_EXPIRE_DUPS_FIRST HIST_FIND_NO_DUPS
+        HIST_IGNORE_ALL_DUPS HIST_SAVE_NO_DUPS
+      )
+      for opt in "''${disabled_opts[@]}"; do
+        unsetopt "$opt"
+      done
+      unset opt disabled_opts
 
       alias -- test1=alias
       alias -- test2=alias2

--- a/tests/modules/programs/zsh/default.nix
+++ b/tests/modules/programs/zsh/default.nix
@@ -16,6 +16,7 @@
   zsh-plugins = ./plugins.nix;
   zsh-prezto = ./prezto.nix;
   zsh-session-variables = ./session-variables.nix;
+  zsh-smart-formatting = ./smart-formatting.nix;
   zsh-syntax-highlighting = ./syntax-highlighting.nix;
   zsh-zprof = ./zprof.nix;
   zshrc-contents-priorities = ./zshrc-content-priorities.nix;

--- a/tests/modules/programs/zsh/history-substring-search-expected.zshrc
+++ b/tests/modules/programs/zsh/history-substring-search-expected.zshrc
@@ -1,0 +1,57 @@
+typeset -U path cdpath fpath manpath
+for profile in ${(z)NIX_PROFILES}; do
+  fpath+=($profile/share/zsh/site-functions $profile/share/zsh/$ZSH_VERSION/functions $profile/share/zsh/vendor-completions)
+done
+
+HELPDIR="@zsh@/share/zsh/$ZSH_VERSION/help"
+
+autoload -U compinit && compinit
+# History options should be set in .zshrc and after oh-my-zsh sourcing.
+# See https://github.com/nix-community/home-manager/issues/177.
+HISTSIZE="10000"
+SAVEHIST="10000"
+
+HISTFILE="/home/hm-user/.zsh_history"
+mkdir -p "$(dirname "$HISTFILE")"
+
+setopt HIST_FCNTL_LOCK
+
+# Enabled history options
+enabled_opts=(
+  HIST_IGNORE_DUPS HIST_IGNORE_SPACE SHARE_HISTORY
+)
+for opt in "${enabled_opts[@]}"; do
+  setopt "$opt"
+done
+unset opt enabled_opts
+
+# Disabled history options
+disabled_opts=(
+  APPEND_HISTORY EXTENDED_HISTORY HIST_EXPIRE_DUPS_FIRST HIST_FIND_NO_DUPS
+  HIST_IGNORE_ALL_DUPS HIST_SAVE_NO_DUPS
+)
+for opt in "${disabled_opts[@]}"; do
+  unsetopt "$opt"
+done
+unset opt disabled_opts
+
+source @zsh-history-substring-search@/share/zsh-history-substring-search/zsh-history-substring-search.zsh
+
+# Bind search up keys
+search_up_keys=(
+  '^[[A' '\eOA'
+)
+ for key in "${search_up_keys[@]}"; do
+   bindkey "$key" history-substring-search-up
+ done
+ unset key search_up_keys
+
+# Bind search down keys
+search_down_keys=(
+  '^[[B'
+)
+ for key in "${search_down_keys[@]}"; do
+   bindkey "$key" history-substring-search-down
+ done
+ unset key search_down_keys
+

--- a/tests/modules/programs/zsh/history-substring-search.nix
+++ b/tests/modules/programs/zsh/history-substring-search.nix
@@ -11,10 +11,8 @@
     };
   };
 
-  # Written with regex to ensure we don't end up missing newlines in the future
   nmt.script = ''
-    assertFileRegex home-files/.zshrc "^bindkey \"\^\[\[B\" history-substring-search-down$"
-    assertFileRegex home-files/.zshrc "^bindkey \"\^\[\[A\" history-substring-search-up$"
-    assertFileRegex home-files/.zshrc "^bindkey \"\\\\eOA\" history-substring-search-up$"
+    assertFileExists home-files/.zshrc
+    assertFileContent $(normalizeStorePaths home-files/.zshrc) ${./history-substring-search-expected.zshrc}
   '';
 }

--- a/tests/modules/programs/zsh/plugins.nix
+++ b/tests/modules/programs/zsh/plugins.nix
@@ -23,9 +23,29 @@ in
     test.stubs.zsh = { };
 
     nmt.script = ''
-      assertFileRegex home-files/.zshrc '^path+="/home/hm-user/.zsh/plugins/mockPlugin"$'
-      assertFileRegex home-files/.zshrc '^fpath+="/home/hm-user/.zsh/plugins/mockPlugin"$'
-      assertFileRegex home-files/.zshrc '^fpath+=("/home/hm-user/.zsh/plugins/mockPlugin/share/zsh/site-functions" "/home/hm-user/.zsh/plugins/mockPlugin/share/zsh/vendor-completions")$'
+      # Test the plugin directories loop structure
+      assertFileContains home-files/.zshrc '# Add plugin directories to PATH and fpath'
+      assertFileContains home-files/.zshrc 'plugin_dirs=('
+      assertFileContains home-files/.zshrc 'mockPlugin'
+      assertFileContains home-files/.zshrc 'for plugin_dir in "''${plugin_dirs[@]}"; do'
+      assertFileContains home-files/.zshrc 'path+="/home/hm-user/.zsh/plugins/$plugin_dir"'
+      assertFileContains home-files/.zshrc 'fpath+="/home/hm-user/.zsh/plugins/$plugin_dir"'
+
+      # Test the completion paths loop structure
+      assertFileContains home-files/.zshrc '# Add completion paths to fpath'
+      assertFileContains home-files/.zshrc 'completion_paths=('
+      assertFileContains home-files/.zshrc 'mockPlugin/share/zsh/site-functions'
+      assertFileContains home-files/.zshrc 'mockPlugin/share/zsh/vendor-completions'
+      assertFileContains home-files/.zshrc 'for completion_path in "''${completion_paths[@]}"; do'
+      assertFileContains home-files/.zshrc 'fpath+="/home/hm-user/.zsh/plugins/$completion_path"'
+
+      # Test the plugin loading structure
+      assertFileContains home-files/.zshrc '# Source plugins'
+      assertFileContains home-files/.zshrc 'plugins=('
+      assertFileContains home-files/.zshrc 'mockPlugin/share/mockPlugin/mockPlugin.plugin.zsh'
+      assertFileContains home-files/.zshrc 'for plugin in "''${plugins[@]}"; do'
+      assertFileContains home-files/.zshrc '[[ -f "/home/hm-user/.zsh/plugins/$plugin" ]] && source "/home/hm-user/.zsh/plugins/$plugin"'
+      assertFileContains home-files/.zshrc 'done'
     '';
   };
 }

--- a/tests/modules/programs/zsh/prezto.nix
+++ b/tests/modules/programs/zsh/prezto.nix
@@ -36,6 +36,6 @@
     assertFileContains home-files/.zshenv \
       '. "/home/hm-user/.nix-profile/etc/profile.d/hm-session-vars.sh"'
     assertFileContains home-files/.zshenv \
-      'export FOO="bar"'
+      'export FOO=bar'
   '';
 }

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -12,7 +12,7 @@
 
   nmt.script = ''
     assertFileExists home-files/.zshenv
-    assertFileRegex home-files/.zshenv 'export V1="v1"'
-    assertFileRegex home-files/.zshenv 'export V2="v2-v1"'
+    assertFileRegex home-files/.zshenv 'export V1=v1'
+    assertFileRegex home-files/.zshenv 'export V2=v2-v1'
   '';
 }

--- a/tests/modules/programs/zsh/smart-formatting-expected.zshrc
+++ b/tests/modules/programs/zsh/smart-formatting-expected.zshrc
@@ -1,0 +1,40 @@
+typeset -U path cdpath fpath manpath
+for profile in ${(z)NIX_PROFILES}; do
+  fpath+=($profile/share/zsh/site-functions $profile/share/zsh/$ZSH_VERSION/functions $profile/share/zsh/vendor-completions)
+done
+
+HELPDIR="@zsh@/share/zsh/$ZSH_VERSION/help"
+
+autoload -U compinit && compinit
+# History options should be set in .zshrc and after oh-my-zsh sourcing.
+# See https://github.com/nix-community/home-manager/issues/177.
+HISTSIZE="50000"
+SAVEHIST="50000"
+
+HISTFILE="/home/hm-user/.zsh_history"
+mkdir -p "$(dirname "$HISTFILE")"
+
+setopt HIST_FCNTL_LOCK
+
+# Disabled history options
+disabled_opts=(
+  APPEND_HISTORY EXTENDED_HISTORY HIST_EXPIRE_DUPS_FIRST HIST_FIND_NO_DUPS
+  HIST_IGNORE_ALL_DUPS HIST_IGNORE_DUPS HIST_IGNORE_SPACE HIST_SAVE_NO_DUPS
+  SHARE_HISTORY
+)
+for opt in "${disabled_opts[@]}"; do
+  unsetopt "$opt"
+done
+unset opt disabled_opts
+
+# Set shell options
+set_opts=(
+  AUTO_LIST AUTO_PARAM_SLASH AUTO_PUSHD ALWAYS_TO_END CORRECT HIST_FCNTL_LOCK
+  HIST_VERIFY INTERACTIVE_COMMENTS MENU_COMPLETE PUSHD_IGNORE_DUPS PUSHD_TO_HOME
+  PUSHD_SILENT NOTIFY PROMPT_SUBST MULTIOS NOFLOWCONTROL NO_CORRECT_ALL
+  NO_HIST_BEEP NO_NOMATCH
+)
+for opt in "${set_opts[@]}"; do
+  setopt "$opt"
+done
+unset opt set_opts

--- a/tests/modules/programs/zsh/smart-formatting.nix
+++ b/tests/modules/programs/zsh/smart-formatting.nix
@@ -1,0 +1,47 @@
+{
+  programs.zsh = {
+    enable = true;
+    # Add many setOptions to trigger multi-line formatting
+    setOptions = [
+      "AUTO_LIST"
+      "AUTO_PARAM_SLASH"
+      "AUTO_PUSHD"
+      "ALWAYS_TO_END"
+      "CORRECT"
+      "HIST_FCNTL_LOCK"
+      "HIST_VERIFY"
+      "INTERACTIVE_COMMENTS"
+      "MENU_COMPLETE"
+      "PUSHD_IGNORE_DUPS"
+      "PUSHD_TO_HOME"
+      "PUSHD_SILENT"
+      "NOTIFY"
+      "PROMPT_SUBST"
+      "MULTIOS"
+      "NOFLOWCONTROL"
+      "NO_CORRECT_ALL"
+      "NO_HIST_BEEP"
+      "NO_NOMATCH"
+    ];
+    # This should also show intelligent formatting for history options
+    history = {
+      size = 50000;
+      save = 50000;
+      # These will create many disabled options
+      append = false;
+      ignoreDups = false;
+      ignoreAllDups = false;
+      saveNoDups = false;
+      findNoDups = false;
+      ignoreSpace = false;
+      expireDuplicatesFirst = false;
+      extended = false;
+      share = false;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.zshrc
+    assertFileContent home-files/.zshrc ${./smart-formatting-expected.zshrc}
+  '';
+}

--- a/tests/modules/programs/zsh/zshrc-content-priorities.nix
+++ b/tests/modules/programs/zsh/zshrc-content-priorities.nix
@@ -50,16 +50,25 @@
           mkdir -p "$(dirname "$HISTFILE")"
 
           setopt HIST_FCNTL_LOCK
-          unsetopt APPEND_HISTORY
-          setopt HIST_IGNORE_DUPS
-          unsetopt HIST_IGNORE_ALL_DUPS
-          unsetopt HIST_SAVE_NO_DUPS
-          unsetopt HIST_FIND_NO_DUPS
-          setopt HIST_IGNORE_SPACE
-          unsetopt HIST_EXPIRE_DUPS_FIRST
-          setopt SHARE_HISTORY
-          unsetopt EXTENDED_HISTORY
 
+          # Enabled history options
+          enabled_opts=(
+            HIST_IGNORE_DUPS HIST_IGNORE_SPACE SHARE_HISTORY
+          )
+          for opt in "''${enabled_opts[@]}"; do
+            setopt "$opt"
+          done
+          unset opt enabled_opts
+
+          # Disabled history options
+          disabled_opts=(
+            APPEND_HISTORY EXTENDED_HISTORY HIST_EXPIRE_DUPS_FIRST HIST_FIND_NO_DUPS
+            HIST_IGNORE_ALL_DUPS HIST_SAVE_NO_DUPS
+          )
+          for opt in "''${disabled_opts[@]}"; do
+            unsetopt "$opt"
+          done
+          unset opt disabled_opts
 
           # Default priority
           echo "Default priority content"


### PR DESCRIPTION
### Description
Just doing some loops for adding to path and sourcing to clean up the generated code. 

Plugin path: 
```bash
path+="/Users/khaneliman/.config/zsh/plugins/fzf-tab"
fpath+="/Users/khaneliman/.config/zsh/plugins/fzf-tab"

path+="/Users/khaneliman/.config/zsh/plugins/zsh-nix-shell"
fpath+="/Users/khaneliman/.config/zsh/plugins/zsh-nix-shell"

path+="/Users/khaneliman/.config/zsh/plugins/zsh-vi-mode"
fpath+="/Users/khaneliman/.config/zsh/plugins/zsh-vi-mode"

path+="/Users/khaneliman/.config/zsh/plugins/fast-syntax-highlighting"
fpath+="/Users/khaneliman/.config/zsh/plugins/fast-syntax-highlighting"

path+="/Users/khaneliman/.config/zsh/plugins/zsh-autosuggestions"
fpath+="/Users/khaneliman/.config/zsh/plugins/zsh-autosuggestions"

path+="/Users/khaneliman/.config/zsh/plugins/zsh-better-npm-completion"
fpath+="/Users/khaneliman/.config/zsh/plugins/zsh-better-npm-completion"

path+="/Users/khaneliman/.config/zsh/plugins/zsh-you-should-use"
fpath+="/Users/khaneliman/.config/zsh/plugins/zsh-you-should-use"
```
->
```bash
# Add plugin directories to PATH and fpath
plugin_dirs=(
  "fzf-tab" "zsh-nix-shell" "zsh-vi-mode" "fast-syntax-highlighting"
  "zsh-autosuggestions" "zsh-better-npm-completion" "zsh-you-should-use"
)
for plugin_dir in "${plugin_dirs[@]}"; do
  path+="/Users/khaneliman/.config/zsh/plugins/$plugin_dir"
  fpath+="/Users/khaneliman/.config/zsh/plugins/$plugin_dir"
done
```

Plugin sourcing:
```bash
if [[ -f "/Users/khaneliman/.config/zsh/plugins/fzf-tab/share/fzf-tab/fzf-tab.plugin.zsh" ]]; then
  source "/Users/khaneliman/.config/zsh/plugins/fzf-tab/share/fzf-tab/fzf-tab.plugin.zsh"
fi
if [[ -f "/Users/khaneliman/.config/zsh/plugins/zsh-nix-shell/share/zsh-nix-shell/nix-shell.plugin.zsh" ]]; then
  source "/Users/khaneliman/.config/zsh/plugins/zsh-nix-shell/share/zsh-nix-shell/nix-shell.plugin.zsh"
fi
if [[ -f "/Users/khaneliman/.config/zsh/plugins/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh" ]]; then
  source "/Users/khaneliman/.config/zsh/plugins/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh"
fi
if [[ -f "/Users/khaneliman/.config/zsh/plugins/fast-syntax-highlighting/share/zsh/site-functions/fast-syntax-highlighting.plugin.zsh" ]]; then
  source "/Users/khaneliman/.config/zsh/plugins/fast-syntax-highlighting/share/zsh/site-functions/fast-syntax-highlighting.plugin.zsh"
fi
if [[ -f "/Users/khaneliman/.config/zsh/plugins/zsh-autosuggestions/share/zsh-autosuggestions/zsh-autosuggestions.zsh" ]]; then
  source "/Users/khaneliman/.config/zsh/plugins/zsh-autosuggestions/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
fi
if [[ -f "/Users/khaneliman/.config/zsh/plugins/zsh-better-npm-completion/share/zsh-better-npm-completion" ]]; then
  source "/Users/khaneliman/.config/zsh/plugins/zsh-better-npm-completion/share/zsh-better-npm-completion"
fi
if [[ -f "/Users/khaneliman/.config/zsh/plugins/zsh-you-should-use/share/zsh/plugins/you-should-use/you-should-use.plugin.zsh" ]]; then
  source "/Users/khaneliman/.config/zsh/plugins/zsh-you-should-use/share/zsh/plugins/you-should-use/you-should-use.plugin.zsh"
fi
```
->
```bash
# Source plugins
plugins=(
  "fzf-tab/share/fzf-tab/fzf-tab.plugin.zsh"
  "zsh-nix-shell/share/zsh-nix-shell/nix-shell.plugin.zsh"
  "zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh"
  "fast-syntax-highlighting/share/zsh/site-functions/fast-syntax-highlighting.plugin.zsh"
  "zsh-autosuggestions/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
  "zsh-better-npm-completion/share/zsh-better-npm-completion"
  "zsh-you-should-use/share/zsh/plugins/you-should-use/you-should-use.plugin.zsh"
)
for plugin in "${plugins[@]}"; do
  [[ -f "/Users/khaneliman/.config/zsh/plugins/$plugin" ]] && source "/Users/khaneliman/.config/zsh/plugins/$plugin"
d
```

Hist:
```bash
setopt HIST_FCNTL_LOCK
unsetopt APPEND_HISTORY
setopt HIST_IGNORE_DUPS
unsetopt HIST_IGNORE_ALL_DUPS
setopt HIST_SAVE_NO_DUPS
setopt HIST_FIND_NO_DUPS
setopt HIST_IGNORE_SPACE
setopt HIST_EXPIRE_DUPS_FIRST
setopt SHARE_HISTORY
setopt EXTENDED_HISTORY
setopt autocd

source '/nix/store/i1q7kjxqmfwi4h2kdl18wyidqsxx3yp0-catppuccin-zsh-syntax-highlighting-0-unstable-2024-07-20/catppuccin_macchiato-zsh-syntax-highlighting.zsh'

setopt AUTO_LIST
setopt AUTO_PARAM_SLASH
setopt AUTO_PUSHD
setopt ALWAYS_TO_END
setopt CORRECT
setopt HIST_FCNTL_LOCK
setopt HIST_VERIFY
setopt INTERACTIVE_COMMENTS
setopt MENU_COMPLETE
setopt PUSHD_IGNORE_DUPS
setopt PUSHD_TO_HOME
setopt PUSHD_SILENT
setopt NOTIFY
setopt PROMPT_SUBST
setopt MULTIOS
setopt NOFLOWCONTROL
setopt NO_CORRECT_ALL
setopt NO_HIST_BEEP
setopt NO_NOMATCH
```
->
```bash
setopt HIST_FCNTL_LOCK

# Enabled history options
enabled_opts=(
  "EXTENDED_HISTORY" "HIST_EXPIRE_DUPS_FIRST" "HIST_FIND_NO_DUPS"
  "HIST_IGNORE_DUPS" "HIST_IGNORE_SPACE" "HIST_SAVE_NO_DUPS" "SHARE_HISTORY"
  "autocd"
)
for opt in "${enabled_opts[@]}"; do
  setopt "$opt"
done

# Disabled history options
disabled_opts=("APPEND_HISTORY" "HIST_IGNORE_ALL_DUPS")
for opt in "${disabled_opts[@]}"; do
  unsetopt "$opt"
done

```


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
