### PR TITLE
Backport nullable programs.zed-editor.package

### DIFF
--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -31,7 +31,7 @@ in
     programs.zed-editor = {
       enable = lib.mkEnableOption "Zed, the high performance, multiplayer code editor from the creators of Atom and Tree-sitter";
 
-      package = lib.mkPackageOption pkgs "zed-editor" { };
+      package = lib.mkPackageOption pkgs "zed-editor" { nullable = true; };
 
       extraPackages = mkOption {
         type = with types; listOf package;
@@ -128,7 +128,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    home.packages =
+    home.packages = mkIf (cfg.package != null) (
       if cfg.extraPackages != [ ] then
         [
           (pkgs.symlinkJoin {
@@ -143,7 +143,8 @@ in
           })
         ]
       else
-        [ cfg.package ];
+        [ cfg.package ]
+    );
 
     home.file = mkIf (cfg.installRemoteServer && (cfg.package ? remote_server)) (
       let
@@ -184,5 +185,12 @@ in
             }
           ) cfg.themes
         );
+
+    assertions = [
+      {
+        assertion = cfg.extraPackages != [ ] -> cfg.package != null;
+        message = "{option}programs.zed-editor.extraPackages requires non null {option}programs.zed-editor.package";
+      }
+    ];
   };
 }


### PR DESCRIPTION
### Description

This is a backport of https://github.com/nix-community/home-manager/pull/7220 to 25.05.

Apologies if this is dumb, I couldn't see anything in the guidelines about how it's decided what is allowed to be backported or how to send backports. I'm also fuzzy on whether this commit counts as a bug fix or a feature.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`. [Running, will update].

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
