### PR TITLE
xdg-mime-apps: no spaces in default app entries

### DIFF
--- a/modules/misc/xdg-mime-apps.nix
+++ b/modules/misc/xdg-mime-apps.nix
@@ -161,7 +161,7 @@ in
 
               existing="$(crudini --get $out 'Default Applications' "$mime" 2>/dev/null || true)"
               local value="$existing''${existing:+;}''$name"
-              crudini --inplace --set $out 'Default Applications' "$mime" "$value"
+              crudini --ini-options=nospace --inplace --set $out 'Default Applications' "$mime" "$value"
             }
 
             install -m644 ${baseFile} $out

--- a/tests/modules/misc/xdg/mime-apps-basics-expected.ini
+++ b/tests/modules/misc/xdg/mime-apps-basics-expected.ini
@@ -4,7 +4,7 @@ image/png=foo1.desktop;foo2.desktop;foo3.desktop
 
 [Default Applications]
 image/png=default1.desktop;default2.desktop;test.desktop
-image/svg+xml = test.desktop
+image/svg+xml=test.desktop
 
 [Removed Associations]
 image/png=foo5.desktop


### PR DESCRIPTION
### Description

Fix https://github.com/nix-community/home-manager/commit/efcba687d355f4e46cb7754c385720ae454fe543#r166176427.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
