### PR TITLE
anki: sync, documentation fixes

### DIFF
--- a/modules/programs/anki/default.nix
+++ b/modules/programs/anki/default.nix
@@ -17,6 +17,13 @@ in
 {
   meta.maintainers = [ lib.maintainers.junestepp ];
 
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "programs" "anki" "sync" "passwordFile" ]
+      [ "programs" "anki" "sync" "keyFile" ]
+    )
+  ];
+
   options.programs.anki = {
     enable = lib.mkEnableOption "Anki";
 
@@ -208,10 +215,23 @@ in
         description = "Path to a file containing the sync account username.";
       };
 
-      passwordFile = lib.mkOption {
+      keyFile = lib.mkOption {
         type = with lib.types; nullOr path;
         default = null;
-        description = "Path to a file containing the sync account password.";
+        description = ''
+          Path to a file containing the sync account sync key. This is different from
+          the account password.
+
+          To get the sync key, follow these steps:
+
+          - Enable this Home Manager module: `programs.anki.enable = true`
+          - Open Anki.
+          - Navigate to the sync settings page. (Tools > Preferences > Syncing)
+          - Log in to your AnkiWeb account.
+          - Select "Yes" to the prompt about saving preferences and syncing.
+          - A Home Manager warning prompt will show. Select "Show details...".
+          - Get your sync key from the message: "syncKey changed from \`None\` to \`<YOUR SYNC KEY WILL BE HERE>\`"
+        '';
       };
 
       url = lib.mkOption {

--- a/modules/programs/anki/helper.nix
+++ b/modules/programs/anki/helper.nix
@@ -164,7 +164,7 @@ in
         if cfg.sync.usernameFile == null then "None" else "Path('${cfg.sync.usernameFile}')"
       }
       key_file: Path | None = ${
-        if cfg.sync.passwordFile == null then "None" else "Path('${cfg.sync.passwordFile}')"
+        if cfg.sync.keyFile == null then "None" else "Path('${cfg.sync.keyFile}')"
       }
       custom_sync_url: str | None = ${if cfg.sync.url == null then "None" else "'${cfg.sync.url}'"}
 

--- a/tests/modules/programs/anki/full-config.nix
+++ b/tests/modules/programs/anki/full-config.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 let
   # This would normally not be a file in the store for security reasons.
-  testPasswordFile = pkgs.writeText "test-password-file" "password";
+  testKeyFile = pkgs.writeText "test-key-file" "a-sync-key";
 in
 {
   programs.anki = {
@@ -37,7 +37,7 @@ in
       networkTimeout = 60;
       url = "http://example.com/anki-sync/";
       username = "lovelearning@email.com";
-      passwordFile = testPasswordFile;
+      keyFile = testKeyFile;
     };
   };
 


### PR DESCRIPTION
### Description

See commits.

fixes #7562

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```