### PR TITLE
bash: source session variable file directly

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -265,7 +265,7 @@ in
       );
 
       home.file.".profile".source = writeBashScript "profile" ''
-        . "${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
+        . "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh"
 
         ${sessionVarsStr}
 

--- a/tests/modules/programs/bash/session-variables.nix
+++ b/tests/modules/programs/bash/session-variables.nix
@@ -14,9 +14,9 @@
   nmt.script = ''
     assertFileExists home-files/.profile
     assertFileContent \
-      home-files/.profile \
+      "$(normalizeStorePaths home-files/.profile)" \
       ${builtins.toFile "session-variables-expected" ''
-        . "/home/hm-user/.nix-profile/etc/profile.d/hm-session-vars.sh"
+        . "/nix/store/00000000000000000000000000000000-hm-session-vars.sh/etc/profile.d/hm-session-vars.sh"
 
         export V1="v1"
         export V2="v2-v1"


### PR DESCRIPTION
### Description

Make the Bash `.profile` path refer to the Nix store path of `hm-session-vars.sh`. This may help in the case where you are using HM as a NixOS module and your profile directory path has changed since the previous activation. I.e., may fix the issue in #7647.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.