### PR TITLE
syncthing: install tray package when `syncthing.tray` is enabled

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -61,6 +61,12 @@
     github = "aheaume";
     githubId = 13830042;
   };
+  aionescu = {
+    name = "Alex Ionescu";
+    email = "github@ionescu.sh";
+    github = "aionescu";
+    githubId = 48064242;
+  };
   austreelis = {
     email = "github@accounts.austreelis.net";
     github = "Austreelis";

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -866,6 +866,8 @@ in
         (lib.hm.assertions.assertPlatform "services.syncthing.tray" pkgs lib.platforms.linux)
       ];
 
+      home.packages = [ cfg.tray.package ];
+
       systemd.user.services = {
         ${cfg.tray.package.pname} = {
           Unit = {

--- a/modules/services/syncthing.nix
+++ b/modules/services/syncthing.nix
@@ -293,7 +293,10 @@ let
   syncthingArgs = defaultSyncthingArgs ++ cfg.extraOptions;
 in
 {
-  meta.maintainers = [ lib.maintainers.rycee ];
+  meta.maintainers = [
+    lib.maintainers.rycee
+    lib.hm.maintainers.aionescu
+  ];
 
   options = {
     services.syncthing = {


### PR DESCRIPTION
### Description

Adds `syncthing.tray.package` to `home.packages` if `syncthing.tray.enable` is `true`, or adds `pkgs.syncthingtray-minimal` if the deprecated `syncthing.tray = true` is used.

Also adds me as maintainer for the Syncthing module.

Closes #4309.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.
  - Does adding an extra package to existing installations count as a breaking change?

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
