### PR TITLE
syncthing: assert tray service content in test

### DIFF
--- a/tests/modules/services/syncthing/linux/tray.nix
+++ b/tests/modules/services/syncthing/linux/tray.nix
@@ -3,5 +3,21 @@
 
   nmt.script = ''
     assertFileExists home-files/.config/systemd/user/syncthingtray.service
+    assertFileContent \
+      home-files/.config/systemd/user/syncthingtray.service \
+      ${builtins.toFile "syncthingtray-expected.service" ''
+        [Install]
+        WantedBy=graphical-session.target
+
+        [Service]
+        ExecStart=@syncthingtray@/bin/syncthingtray --wait
+
+        [Unit]
+        After=graphical-session.target
+        After=tray.target
+        Description=syncthingtray
+        PartOf=graphical-session.target
+        Requires=tray.target
+      ''}
   '';
 }


### PR DESCRIPTION
### Description

Make the test a bit more valid.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```