### PR TITLE
desktoppr: init module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758427187,
-        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
         "type": "github"
       },
       "original": {

--- a/modules/misc/news/2025/09/2025-09-25_17-32-18.nix
+++ b/modules/misc/news/2025/09/2025-09-25_17-32-18.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+
+{
+  time = "2025-09-25T17:32:18+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    A new module is available: `programs.desktoppr`
+
+    The module allows declaratively configuring the desktop picture/wallpaper
+    on macOS, either once, or on every activation (default), using the
+    desktoppr command-line tool.
+  '';
+}

--- a/modules/programs/desktoppr.nix
+++ b/modules/programs/desktoppr.nix
@@ -1,0 +1,105 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.desktoppr;
+in
+
+{
+  options.programs.desktoppr = {
+    enable = lib.mkEnableOption "managing the desktop picture/wallpaper on macOS using desktoppr";
+    package = lib.mkPackageOption pkgs "desktoppr" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = with lib.types; attrsOf anything;
+
+        options = {
+          picture = lib.mkOption {
+            type = with lib.types; nullOr (either path (strMatching "^http(s)?:\/\/.*$"));
+            default = null;
+            example = "/System/Library/Desktop Pictures/Solid Colors/Stone.png";
+            description = ''
+              The path to the desktop picture/wallpaper to set. Can also be an HTTP
+              or HTTPS URL to retrieve the picture from a remote URL at runtime.
+            '';
+          };
+
+          sha256 = lib.mkOption {
+            type = with lib.types; nullOr (strMatching "^[a-f0-9]{64}$");
+            default = null;
+            example = "e1e594dec9343b721005a6bf06c48e0aac34ac9a77090e42b543bae9e1e0354a";
+            description = ''
+              An optional SHA256 checksum of the desktop picture/wallpaper. If the
+              specified file does not match the checksum, it will not be set.
+            '';
+          };
+
+          color = lib.mkOption {
+            type = lib.types.strMatching "[0-9a-fA-F]{6}";
+            default = "000000";
+            example = "2E2E2E";
+            description = ''
+              The background color that will be used behind the chosen picture when
+              it does not fill the screen.
+            '';
+          };
+
+          scale = lib.mkOption {
+            type = lib.types.enum [
+              "fill"
+              "stretch"
+              "center"
+              "fit"
+            ];
+            default = "fill";
+            example = "fit";
+            description = ''
+              The scaling behavior to use when using an image.
+            '';
+          };
+
+          setOnlyOnce = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            example = true;
+            description = ''
+              If false (the default), the desktop picture/wallpaper will be reset
+              to the configured parameters on every system configuration change.
+
+              If true, the desktop picture/wallpaper will only be set when it
+              differs from the one previously set. This allows the user to manually
+              change the desktop picture/wallpaper after it has been set.
+            '';
+          };
+        };
+      };
+      default = { };
+      example = {
+        picture = "/System/Library/Desktop Pictures/Solid Colors/Stone.png";
+      };
+      description = ''
+        The settings to set for desktoppr.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.desktoppr" pkgs lib.platforms.darwin)
+    ];
+
+    targets.darwin.defaults.desktoppr = cfg.settings;
+
+    home.activation.desktoppr = lib.hm.dag.entryAfter [ "setDarwinDefaults" ] ''
+      verboseEcho "Setting the desktop picture/wallpaper"
+      run "${lib.getExe cfg.package}" manage
+    '';
+  };
+
+  meta.maintainers = with lib.maintainers; [ andre4ik3 ];
+}


### PR DESCRIPTION
### Description

Adds a module for [desktoppr](https://github.com/scriptingosx/desktoppr), a small utility to manage the desktop picture (macOS < 13) / wallpaper (macOS >= 13).

I'm not sure how I would create tests for this module. I tried to create tests where it would set the desktop picture and color, then read it to ensure it was set, but it seems like the tests run in the build sandbox, so the picture/color never gets set and reading the picture/color always returns an empty string. So I don't think it's possible to test it inside the sandbox.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
