### PR TITLE
aichat: add agents option

### DIFF
--- a/modules/misc/news/2025/09/2025-09-25_19-15-33.nix
+++ b/modules/misc/news/2025/09/2025-09-25_19-15-33.nix
@@ -1,0 +1,11 @@
+{ config, ... }:
+
+{
+  time = "2025-09-25T22:15:33+00:00";
+  condition = config.programs.aichat.enable;
+  message = ''
+    A new option is available: `programs.aichat.agents`
+
+    This option allows you to set agent-specific settings for aichat.
+  '';
+}

--- a/tests/modules/programs/aichat/llama.yaml
+++ b/tests/modules/programs/aichat/llama.yaml
@@ -1,0 +1,3 @@
+model: llama3.2:latest
+temperature: 0.5
+use_tools: web_search

--- a/tests/modules/programs/aichat/openai.yaml
+++ b/tests/modules/programs/aichat/openai.yaml
@@ -1,0 +1,5 @@
+agent_prelude: default
+model: openai:gpt-4o
+temperature: 0.5
+top_p: 0.7
+use_tools: fs,web_search

--- a/tests/modules/programs/aichat/settings.nix
+++ b/tests/modules/programs/aichat/settings.nix
@@ -1,4 +1,3 @@
-{ ... }:
 {
   programs.aichat = {
     enable = true;
@@ -18,10 +17,34 @@
         }
       ];
     };
+
+    agents = {
+      openai = {
+        model = "openai:gpt-4o";
+        temperature = 0.5;
+        top_p = 0.7;
+        use_tools = "fs,web_search";
+        agent_prelude = "default";
+      };
+
+      llama = {
+        model = "llama3.2:latest";
+        temperature = 0.5;
+        use_tools = "web_search";
+      };
+    };
   };
+
   nmt.script = ''
     assertFileExists home-files/.config/aichat/config.yaml
     assertFileContent home-files/.config/aichat/config.yaml \
       ${./settings.yml}
+
+    assertFileExists home-files/.config/aichat/agents/openai/config.yaml
+    assertFileExists home-files/.config/aichat/agents/llama/config.yaml
+    assertFileContent home-files/.config/aichat/agents/openai/config.yaml \
+      ${./openai.yaml}
+    assertFileContent home-files/.config/aichat/agents/llama/config.yaml \
+      ${./llama.yaml}
   '';
 }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds the `programs.aichat.agents` option to allow users to declare agent-specific settings for Aichat as described [here](https://github.com/sigoden/aichat/wiki/Configuration-Guide#agent-specific). 

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
