### PR TITLE
mods: get ipsavitsky from Nixpkgs maintainers list

### DIFF
--- a/modules/programs/mods.nix
+++ b/modules/programs/mods.nix
@@ -11,7 +11,7 @@ let
   yamlFormat = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = [ lib.hm.maintainers.ipsavitsky ];
+  meta.maintainers = [ lib.maintainers.ipsavitsky ];
 
   options.programs.mods = {
     enable = lib.mkEnableOption "mods";


### PR DESCRIPTION
### Description

No need to use the HM list since @ipsavitsky is now in the Nixpkgs maintainers list.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```