### PR TITLE
drop google-chrome-{beta,dev} as it was dropped by nixpkgs

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -10,8 +10,6 @@ let
   supportedBrowsers = {
     chromium = "Chromium";
     google-chrome = "Google Chrome";
-    google-chrome-beta = "Google Chrome Beta";
-    google-chrome-dev = "Google Chrome Dev";
     brave = "Brave Browser";
     vivaldi = "Vivaldi Browser";
   };
@@ -166,8 +164,6 @@ let
       darwinDirs = {
         chromium = "Chromium";
         google-chrome = "Google/Chrome";
-        google-chrome-beta = "Google/Chrome Beta";
-        google-chrome-dev = "Google/Chrome Dev";
         brave = "BraveSoftware/Brave-Browser";
       };
 
@@ -244,16 +240,6 @@ in
         [
           "programs"
           "google-chrome"
-          "extensions"
-        ]
-        [
-          "programs"
-          "google-chrome-beta"
-          "extensions"
-        ]
-        [
-          "programs"
-          "google-chrome-dev"
           "extensions"
         ]
       ];


### PR DESCRIPTION


### Description

<!--


-->
https://github.com/NixOS/nixpkgs/pull/261870
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.
it should be because `config.programs.google-chrome-{beta,dev}.package` fails to evaluate 
- [ ] Code formatted with `nix fmt` or
`nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
