### PR TITLE
home-manager: add backup overwrite option

### DIFF
--- a/modules/files.nix
+++ b/modules/files.nix
@@ -149,6 +149,9 @@ in
             if [[ -e "$targetPath" && ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
               # The target exists, back it up
               backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
+              if [[ -e "$backup" && -n "$HOME_MANAGER_BACKUP_OVERWRITE" ]]; then
+                run rm $VERBOSE_ARG "$backup"
+              fi
               run mv $VERBOSE_ARG "$targetPath" "$backup" || errorEcho "Moving '$targetPath' failed!"
             fi
 

--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -33,8 +33,10 @@ for sourcePath in "$@" ; do
     elif [[ ! -L "$targetPath" && -n "$HOME_MANAGER_BACKUP_EXT" ]] ; then
       # Next, try to move the file to a backup location if configured and possible
       backup="$targetPath.$HOME_MANAGER_BACKUP_EXT"
-      if [[ -e "$backup" ]]; then
+      if [[ -e "$backup" && -z "$HOME_MANAGER_BACKUP_OVERWRITE" ]] ; then
         collisionErrors+=("Existing file '$backup' would be clobbered by backing up '$targetPath'")
+      elif [[ -e "$backup" && -n "$HOME_MANAGER_BACKUP_OVERWRITE" ]] ; then
+        warnEcho "Existing file '$targetPath' is in the way of '$sourcePath' and '$backup' exists. Backup will be clobbered due to HOME_MANAGER_BACKUP_OVERWRITE=1"
       else
         warnEcho "Existing file '$targetPath' is in the way of '$sourcePath', will be moved to '$backup'"
       fi

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -28,6 +28,7 @@ in
               ${lib.optionalString (
                 cfg.backupFileExtension != null
               ) "export HOME_MANAGER_BACKUP_EXT=${lib.escapeShellArg cfg.backupFileExtension}"}
+              ${lib.optionalString cfg.overwriteBackup "export HOME_MANAGER_BACKUP_OVERWRITE=1"}
               ${lib.optionalString cfg.verbose "export VERBOSE=1"}
               exec ${usercfg.home.activationPackage}/activate --driver-version ${driverVersion} >&2
             ''}

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -91,6 +91,10 @@ in
       '';
     };
 
+    overwriteBackup = mkEnableOption ''
+      forced overwriting of existing backup files when using `backupFileExtension`
+    '';
+
     extraSpecialArgs = mkOption {
       type = types.attrs;
       default = { };

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -7,15 +7,18 @@
 }:
 
 let
-
+  inherit (lib) mkIf;
   cfg = config.home-manager;
 
-  serviceEnvironment =
-    lib.optionalAttrs (cfg.backupFileExtension != null) {
-      HOME_MANAGER_BACKUP_EXT = cfg.backupFileExtension;
-    }
-    // lib.optionalAttrs cfg.verbose { VERBOSE = "1"; };
+  serviceEnvironment = lib.mkMerge [
+    (mkIf cfg.verbose { VERBOSE = "1"; })
 
+    (mkIf (cfg.backupFileExtension != null) {
+      HOME_MANAGER_BACKUP_EXT = cfg.backupFileExtension;
+    })
+
+    (mkIf cfg.overwriteBackup { HOME_MANAGER_BACKUP_OVERWRITE = "1"; })
+  ];
 in
 {
   imports = [ ./common.nix ];
@@ -41,7 +44,7 @@ in
         ];
       };
     }
-    (lib.mkIf (cfg.users != { }) {
+    (mkIf (cfg.users != { }) {
       systemd.services = lib.mapAttrs' (
         _: usercfg:
         let


### PR DESCRIPTION
### Description

Closes https://github.com/nix-community/home-manager/issues/4199.

When using the `backupFileExtension` option, if the backup file exists, the activation process fails. This adds an opt in option to instead overwrite the old backup instead of failing.

This feature is highly requested, the issue above is the 6th most liked issue on the tracker.

I have not added a help text mentioning this option on collision to be conservative. This setting removes data, so I don't think suggesting it for any collision is responsible.

There was a previous attempt at implementing this here https://github.com/nix-community/home-manager/pull/4971 but the contributor gave up due to opposition to overwriting data. Since then [Hjem](https://github.com/feel-co/hjem) (A minimal home-manager alternative) has implemented a very similar feature  https://hjem.feel-co.org/options.html#option-hjem-clobberByDefault.

With [Hjem](https://github.com/feel-co/hjem) setting the precedent, and it being one of the most requested features (judging by reactions) I hope this change can receive more favorable second look.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
      *(It was taking too long due to my slow connection)*

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
