### PR TITLE
gurk-rs: remove references to deprecated 'data_path' option from documentation

### DIFF
--- a/modules/programs/gurk-rs.nix
+++ b/modules/programs/gurk-rs.nix
@@ -22,11 +22,10 @@ in
         Configuration written to {file}`$XDG_CONFIG_HOME/.config/gurk/gurk.toml`
         or {file}`Library/Application Support/gurk/gurk.toml`. Options are
         declared at <https://github.com/boxdot/gurk-rs/blob/main/src/config.rs>.
-        Note that `data_path` and `signal_db_path` should be set.
+        Note that `signal_db_path` should be set.
       '';
       example = lib.literalExpression ''
         {
-          data_path = "/home/USERNAME/.local/share/gurk/gurk.data.json";
           signal_db_path = "/home/USERNAME/.local/share/gurk/signal-db";
           first_name_only = false;
           show_receipts = true;


### PR DESCRIPTION
The 'data_path' key was deprecated upstream a while ago.
See commit d9b538d0 (https://github.com/boxdot/gurk-rs/commit/d9b538d0)
for details.
