### PR TITLE
macos-remap-keys: add NonUSBackslash keycode

### DIFF
--- a/modules/services/macos-remap-keys/keytables.nix
+++ b/modules/services/macos-remap-keys/keytables.nix
@@ -45,6 +45,8 @@ let
     Dot = "0x37";
     Slash = "0x38";
     Capslock = "0x39";
+    # Section ('§') -- key below Escape on the non-US keyboards
+    NonUSBackslash = "0x64";
   };
 
   fKeys1To12 = {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Adds a key code for NonUSBackslash (`§/±`) present in non-US keyboards (EU variants in particular).

This allows to move the backtick (GraveAccent/Tilde) key to the "usual" location, below `Escape` key, for example:

```nix
  services.macos-remap-keys = {
    enable = true;
    keyboard = {
      NonUSBackslash = "GraveAccent";
      # Preserve a way to type the section/plusminus symbols with the key between `Shift` & `Z`
      GraveAccent = "NonUSBackslash";
    };
```

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

**N.B.** I believe this should not impact any tests, so I've skipped the two steps below
- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
