### PR TITLE
zsh: fix sessionVariables variable expansion

### DIFF
--- a/modules/lib/zsh.nix
+++ b/modules/lib/zsh.nix
@@ -30,5 +30,13 @@ rec {
   # Given an attribute set containing shell variable names and their
   # assignments, this function produces a string containing an export
   # statement for each set entry.
-  exportAll = vars: lib.concatStringsSep "\n" (lib.mapAttrsToList export vars);
+  exportAll =
+    vars:
+    {
+      indent ? "",
+    }:
+    let
+      separator = if indent == "" then "\n" else "\n" + indent;
+    in
+    lib.concatStringsSep separator (lib.mapAttrsToList export vars);
 }

--- a/modules/lib/zsh.nix
+++ b/modules/lib/zsh.nix
@@ -7,7 +7,7 @@ rec {
     if builtins.isBool v then
       if v then "true" else "false"
     else if builtins.isString v then
-      lib.escapeShellArg v
+      ''"${v}"''
     else if builtins.isList v then
       let
         shell = import ./shell.nix { inherit lib; };

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -346,7 +346,7 @@ in
 
   config =
     let
-      envVarsStr = config.lib.zsh.exportAll cfg.sessionVariables;
+      envVarsStr = config.lib.zsh.exportAll cfg.sessionVariables { indent = "  "; };
       localVarsStr = config.lib.zsh.defineAll cfg.localVariables;
 
       aliasesStr = concatStringsSep "\n" (

--- a/tests/modules/programs/zsh/prezto.nix
+++ b/tests/modules/programs/zsh/prezto.nix
@@ -36,6 +36,6 @@
     assertFileContains home-files/.zshenv \
       '. "/home/hm-user/.nix-profile/etc/profile.d/hm-session-vars.sh"'
     assertFileContains home-files/.zshenv \
-      'export FOO=bar'
+      'export FOO="bar"'
   '';
 }

--- a/tests/modules/programs/zsh/session-variables.nix
+++ b/tests/modules/programs/zsh/session-variables.nix
@@ -1,10 +1,11 @@
-{ config, ... }:
+{ config, lib, ... }:
 
 {
   programs.zsh = {
     enable = true;
 
     sessionVariables = {
+      PATH = "$HOME/bin:$PATH";
       V1 = "v1";
       V2 = "v2-${config.programs.zsh.sessionVariables.V1}";
     };
@@ -12,7 +13,6 @@
 
   nmt.script = ''
     assertFileExists home-files/.zshenv
-    assertFileRegex home-files/.zshenv 'export V1=v1'
-    assertFileRegex home-files/.zshenv 'export V2=v2-v1'
+    assertFileContent home-files/.zshenv ${./session-variables.zshenv}
   '';
 }

--- a/tests/modules/programs/zsh/session-variables.zshenv
+++ b/tests/modules/programs/zsh/session-variables.zshenv
@@ -5,6 +5,6 @@
 if [[ -z "$__HM_ZSH_SESS_VARS_SOURCED" ]]; then
   export __HM_ZSH_SESS_VARS_SOURCED=1
   export PATH="$HOME/bin:$PATH"
-export V1="v1"
-export V2="v2-v1"
+  export V1="v1"
+  export V2="v2-v1"
 fi

--- a/tests/modules/programs/zsh/session-variables.zshenv
+++ b/tests/modules/programs/zsh/session-variables.zshenv
@@ -1,0 +1,10 @@
+# Environment variables
+. "/home/hm-user/.nix-profile/etc/profile.d/hm-session-vars.sh"
+
+# Only source this once
+if [[ -z "$__HM_ZSH_SESS_VARS_SOURCED" ]]; then
+  export __HM_ZSH_SESS_VARS_SOURCED=1
+  export PATH="$HOME/bin:$PATH"
+export V1="v1"
+export V2="v2-v1"
+fi


### PR DESCRIPTION
### Description
Follow up to https://github.com/nix-community/home-manager/pull/7849
Closes https://github.com/nix-community/home-manager/issues/7896
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
