### PR TITLE
fish: support theme plugins

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -765,6 +765,30 @@ in
           }) cfg.plugins
         );
       })
+      (
+        let
+          themes = lib.foldl (
+            themeList: plugin:
+            if lib.pathIsDirectory "${plugin.src}/themes" then
+              themeList ++ lib.filesystem.listFilesRecursive "${plugin.src}/themes"
+            else
+              themeList
+          ) [ ] cfg.plugins;
+        in
+        (mkIf (lib.length themes > 0) {
+          xdg.configFile = lib.mkMerge (
+            map (
+              theme:
+              let
+                basename = lib.last (builtins.split "/" (toString theme));
+              in
+              {
+                "fish/themes/${basename}".source = theme;
+              }
+            ) themes
+          );
+        })
+      )
     ]
   );
 }

--- a/tests/modules/programs/fish/default.nix
+++ b/tests/modules/programs/fish/default.nix
@@ -6,4 +6,5 @@
   fish-plugins = ./plugins.nix;
   fish-manpage = ./manpage.nix;
   fish-binds = ./binds.nix;
+  fish-themes = ./themes.nix;
 }

--- a/tests/modules/programs/fish/themes.nix
+++ b/tests/modules/programs/fish/themes.nix
@@ -1,0 +1,38 @@
+{ lib, pkgs, ... }:
+let
+  dummy-theme-plugin = pkgs.runCommandLocal "theme" { } ''
+    mkdir -p "$out"/themes
+    echo "fish_color_normal 575279" > "$out/themes/dummy-theme-plugin.theme"
+  '';
+
+  copied-theme = pkgs.writeText "theme.theme" ''
+    fish_color_normal 575279
+  '';
+in
+{
+  config = {
+    programs.fish = {
+      enable = true;
+      plugins = [
+        {
+          name = "foo";
+          src = dummy-theme-plugin;
+        }
+      ];
+    };
+
+    # Needed to avoid error with dummy fish package.
+    xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+      builtins.toFile "empty" ""
+    );
+
+    nmt = {
+      description = "if fish plugin contains themes directory copy the themes";
+      script = ''
+        assertDirectoryExists home-files/.config/fish/themes
+        assertFileExists home-files/.config/fish/themes/dummy-theme-plugin.theme
+        assertFileContent home-files/.config/fish/themes/dummy-theme-plugin.theme ${copied-theme}
+      '';
+    };
+  };
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->
Supersedes #5394
Allows for linking fish plugin theme files to [fish's themes folder](https://fishshell.com/docs/current/cmds/fish_config.html#theme-files). Fully allowing for theme plugins to properly be installed declaratively. Fixes #3724

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
