### PR TITLE
zed: add option to override settings

### DIFF
--- a/tests/modules/programs/zed-editor/default.nix
+++ b/tests/modules/programs/zed-editor/default.nix
@@ -3,9 +3,12 @@
   zed-install-remote-server = ./install-remote-server.nix;
   zed-keymap = ./keymap.nix;
   zed-keymap-empty = ./keymap-empty.nix;
+  zed-keymap-override = ./keymap-override.nix;
   zed-settings = ./settings.nix;
   zed-settings-empty = ./settings-empty.nix;
+  zed-settings-override = ./settings-override.nix;
   zed-tasks = ./tasks.nix;
   zed-tasks-empty = ./tasks-empty.nix;
+  zed-tasks-override = ./tasks-override.nix;
   zed-themes = ./themes;
 }

--- a/tests/modules/programs/zed-editor/keymap-override.nix
+++ b/tests/modules/programs/zed-editor/keymap-override.nix
@@ -1,0 +1,75 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    userKeymaps = [
+      {
+        context = "Editor";
+        bindings = {
+          escape = "editor::Cancel";
+        };
+      }
+    ];
+    preserveUserKeymaps = false;
+  };
+
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  nmt.script =
+    let
+      preexistingKeymaps = builtins.toFile "preexisting.json" ''
+        [
+          {
+            "context": "Workspace",
+            "bindings": {
+              "ctrl-shift-t": "workspace::NewTerminal"
+            }
+          }
+        ]
+      '';
+
+      expectedContent = builtins.toFile "expected.json" ''
+        [
+          {
+            "bindings": {
+              "escape": "editor::Cancel"
+            },
+            "context": "Editor"
+          }
+        ]
+      '';
+
+      keymapPath = ".config/zed/keymap.json";
+      activationScript = pkgs.writeScript "activation" config.home.activation.zedKeymapActivation.data;
+    in
+    ''
+      export HOME=$TMPDIR/hm-user
+
+      # Simulate preexisting keymaps
+      mkdir -p $HOME/.config/zed
+      cat ${preexistingKeymaps} > $HOME/${keymapPath}
+
+      # Run the activation script
+      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+      chmod +x $TMPDIR/activate
+      $TMPDIR/activate
+
+      # Validate the merged keymaps
+      assertFileExists "$HOME/${keymapPath}"
+      assertFileContent "$HOME/${keymapPath}" "${expectedContent}"
+
+      # Test idempotency
+      $TMPDIR/activate
+      assertFileExists "$HOME/${keymapPath}"
+      assertFileContent "$HOME/${keymapPath}" "${expectedContent}"
+
+      echo not-readonly >> $HOME/${keymapPath}
+    '';
+}

--- a/tests/modules/programs/zed-editor/settings-override.nix
+++ b/tests/modules/programs/zed-editor/settings-override.nix
@@ -1,0 +1,77 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    userSettings = {
+      theme = "XY-Zed";
+      features = {
+        copilot = false;
+      };
+      vim_mode = false;
+      ui_font_size = 16;
+      buffer_font_size = 16;
+    };
+    preserveUserSettings = false;
+  };
+
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  nmt.script =
+    let
+      preexistingSettings = builtins.toFile "preexisting.json" ''
+        {
+          "theme": "Default",
+          "features": {
+            "copilot": true,
+            "ai_assist": true
+          },
+          "vim_mode": true
+        }
+      '';
+
+      expectedContent = builtins.toFile "expected.json" ''
+        {
+          "buffer_font_size": 16,
+          "features": {
+            "copilot": false
+          },
+          "theme": "XY-Zed",
+          "ui_font_size": 16,
+          "vim_mode": false
+        }
+      '';
+
+      settingsPath = ".config/zed/settings.json";
+      activationScript = pkgs.writeScript "activation" config.home.activation.zedSettingsActivation.data;
+    in
+    ''
+      export HOME=$TMPDIR/hm-user
+
+      # Simulate preexisting settings
+      mkdir -p $HOME/.config/zed
+      cat ${preexistingSettings} > $HOME/${settingsPath}
+
+      # Run the activation script
+      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+      chmod +x $TMPDIR/activate
+      $TMPDIR/activate
+
+      # Validate the merged settings
+      assertFileExists "$HOME/${settingsPath}"
+      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
+
+      # Test idempotency
+      $TMPDIR/activate
+      assertFileExists "$HOME/${settingsPath}"
+      assertFileContent "$HOME/${settingsPath}" "${expectedContent}"
+
+      echo not-readonly >> $HOME/${settingsPath}
+    '';
+}

--- a/tests/modules/programs/zed-editor/tasks-override.nix
+++ b/tests/modules/programs/zed-editor/tasks-override.nix
@@ -1,0 +1,79 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    userTasks = [
+      {
+        label = "Format Code";
+        command = "nix";
+        args = [
+          "fmt"
+          "$ZED_WORKTREE_ROOT"
+        ];
+        allow_concurrent_runs = false;
+      }
+    ];
+    preserveUserTasks = false;
+  };
+
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  nmt.script =
+    let
+      preexistingTasks = builtins.toFile "preexisting.json" ''
+        [
+          {
+            "label": "Compile",
+            "command": "make"
+          }
+        ]
+      '';
+
+      expectedContent = builtins.toFile "expected.json" ''
+        [
+          {
+            "allow_concurrent_runs": false,
+            "args": [
+              "fmt",
+              "$ZED_WORKTREE_ROOT"
+            ],
+            "command": "nix",
+            "label": "Format Code"
+          }
+        ]
+      '';
+
+      taskPath = ".config/zed/tasks.json";
+      activationScript = pkgs.writeScript "activation" config.home.activation.zedTasksActivation.data;
+    in
+    ''
+      export HOME=$TMPDIR/hm-user
+
+      # Simulate preexisting tasks
+      mkdir -p $HOME/.config/zed
+      cat ${preexistingTasks} > $HOME/${taskPath}
+
+      # Run the activation script
+      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+      chmod +x $TMPDIR/activate
+      $TMPDIR/activate
+
+      # Validate the merged tasks
+      assertFileExists "$HOME/${taskPath}"
+      assertFileContent "$HOME/${taskPath}" "${expectedContent}"
+
+      # Test idempotency
+      $TMPDIR/activate
+      assertFileExists "$HOME/${taskPath}"
+      assertFileContent "$HOME/${taskPath}" "${expectedContent}"
+
+      echo not-readonly >> $HOME/${taskPath}
+    '';
+}


### PR DESCRIPTION
### Description
It's great to be able to merge the config and for the settings files not to be read only, so that we can use all of Zed's features.
However, it can make it a pain when wanting to configure 100% declaratively.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
