### PR TITLE
files: improve collision error message formatting for readability

### DIFF
--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -48,11 +48,11 @@ done
 if [[ ${#collisionErrors[@]} -gt 0 ]] ; then
   errorEcho "Please do one of the following:
 - Move or remove the files below and try again.
-- In standalone mode, use 'home-manager switch -b backup' to back up
-  files automatically.
-- When used as a NixOS or nix-darwin module, set
-    'home-manager.backupFileExtension'
-  to, for example, 'backup' and rebuild."
+- In standalone mode, use 'home-manager switch -b backup' to back up"\
+" files automatically.
+- When used as a NixOS or nix-darwin module, set"\
+" 'home-manager.backupFileExtension'"\
+" to, for example, 'backup' and rebuild."
   for error in "${collisionErrors[@]}" ; do
     errorEcho "$error"
   done


### PR DESCRIPTION
### Description

#### Summary

This change improves the formatting of the collision error message in `modules/files/check-link-targets.sh`.

Previously, the error message was wrapped across multiple lines mid-sentence due to 80-character source formatting. When rendered through systemd logs, this wrapping caused important lines — **specifically the file path responsible for the collision** — to be truncated. Users often had to run `journalctl` to retrieve the missing context.

This update restructures the string concatenation so that each bullet point is rendered on a single line at runtime, while still respecting source formatting guidelines. As a result, the collision error message now displays the full file path directly in the standard log output.

#### Benefits

- Ensures file path information is immediately visible in service logs.
- Improves readability of error messages without altering functionality.
- Reduces the need for users to run additional commands (`journalctl`) to diagnose collisions.

#### Example Output

Before:
```bash
Sep 30 16:03:15 hostname hm-activate-x71c9[5046]: Please do one of the following:
Sep 30 16:03:15 hostname hm-activate-x71c9[5046]: - Move or remove the above files and try again.
Sep 30 16:03:15 hostname hm-activate-x71c9[5046]: - In standalone mode, use 'home-manager switch -b backup' to back up
Sep 30 16:03:15 hostname hm-activate-x71c9[5046]:   files automatically.
Sep 30 16:03:15 hostname hm-activate-x71c9[5046]: - When used as a NixOS or nix-darwin module, set
Sep 30 16:03:15 hostname hm-activate-x71c9[5046]:     'home-manager.backupFileExtension'
Sep 30 16:03:15 hostname hm-activate-x71c9[5046]:   to, for example, 'backup' and rebuild.
```

After
```bash
Sep 30 15:50:30 hostname hm-activate-x71c9[4537]: Activating checkFilesChanged
Sep 30 15:50:30 hostname hm-activate-x71c9[4537]: Activating checkLinkTargets
Sep 30 15:50:30 hostname hm-activate-x71c9[4660]: Existing file '/home/x71c9/.config/lazygit/config.yml' is in the way of '/nix/store/...'
Sep 30 16:03:15 hostname hm-activate-x71c9[5046]: Please do one of the following:
Sep 30 16:03:15 hostname hm-activate-x71c9[5046]: - Move or remove the above files and try again.
Sep 30 16:03:15 hostname hm-activate-x71c9[5046]: - In standalone mode, use 'home-manager switch -b backup' to back up files automatically.
Sep 30 16:03:15 hostname hm-activate-x71c9[5046]: - When used as a NixOS or nix-darwin module, set 'home-manager.backupFileExtension' to, for example, 'backup' and rebuild.
```

The key improvement is the visibility of this line, which was previously hidden in truncated logs:

```bash
Existing file '/home/x71c9/.config/lazygit/config.yml' is in the way of '/nix/store/...'
```

#### Notes

- No changelog entry required for this message-only improvement.
- No functional or behavioral changes beyond output formatting.

---

### Checklist

- [x] Change is backwards compatible.
- [x] Code formatted with `nix fmt`.
- [x] Code tested through `nix run .#tests -- test-all`
- [ ] Test cases updated/added. *No need for new test*
- [x] Commit messages are formatted

- No new module added
- No breaking changes
