### PR TITLE
alistral: add module

### DIFF
--- a/modules/misc/news/2025/10/2025-10-02_12-54-47.nix
+++ b/modules/misc/news/2025/10/2025-10-02_12-54-47.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-10-02T15:54:47+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.alistral`
+
+    Alistral is a collection of CLI based tools for Listenbrainz.
+  '';
+}

--- a/modules/programs/alistral.nix
+++ b/modules/programs/alistral.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.alistral;
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+  options.programs.alistral = {
+    enable = mkEnableOption "alistral";
+    package = mkPackageOption pkgs "alistral" { nullable = true; };
+    settings = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = {
+        default_user = "spanish_inquisition";
+        listenbrainz_url = "https://api.listenbrainz.org/1/";
+        musicbrainz_url = "http://musicbrainz.org/ws/2";
+      };
+      description = ''
+        Configuration settings for alistral. You can see the details here:
+        <https://rustynova016.github.io/Alistral/config/config.html>.
+      '';
+    };
+  };
+
+  config =
+    let
+      configDir =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "Library/Application Support/alistral"
+        else
+          ".config/alistral";
+    in
+    mkIf cfg.enable {
+      home.packages = mkIf (cfg.package != null) [ cfg.package ];
+      home.file."${configDir}/config.json" = mkIf (cfg.settings != { }) {
+        source = jsonFormat.generate "alistral-config.json" cfg.settings;
+      };
+    };
+}

--- a/tests/modules/programs/alistral/config.json
+++ b/tests/modules/programs/alistral/config.json
@@ -1,0 +1,5 @@
+{
+  "default_user": "spanish_inquisition",
+  "listenbrainz_url": "https://api.listenbrainz.org/1/",
+  "musicbrainz_url": "http://musicbrainz.org/ws/2"
+}

--- a/tests/modules/programs/alistral/default.nix
+++ b/tests/modules/programs/alistral/default.nix
@@ -1,0 +1,1 @@
+{ alistral-settings = ./settings.nix; }

--- a/tests/modules/programs/alistral/settings.nix
+++ b/tests/modules/programs/alistral/settings.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+
+{
+  programs.alistral = {
+    enable = true;
+    settings = {
+      default_user = "spanish_inquisition";
+      listenbrainz_url = "https://api.listenbrainz.org/1/";
+      musicbrainz_url = "http://musicbrainz.org/ws/2";
+    };
+  };
+
+  nmt.script =
+    let
+      configDir =
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "Library/Application Support/alistral"
+        else
+          ".config/alistral";
+    in
+    ''
+      assertFileExists "home-files/${configDir}/config.json"
+      assertFileContent "home-files/${configDir}/config.json" \
+        ${./config.json}
+    '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring [alistral](https://github.com/RustyNova016/Alistral).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
