### PR TITLE
smug: add new option introduced by v0.3.7

### DIFF
--- a/modules/programs/smug.nix
+++ b/modules/programs/smug.nix
@@ -63,7 +63,7 @@ in
                           type = lib.types.nullOr lib.types.bool;
                           default = null;
                           description = ''
-                            Whether this windows should be selected by default at session start.
+                            Whether this window should be selected by default at session start.
                           '';
                         };
 

--- a/modules/programs/smug.nix
+++ b/modules/programs/smug.nix
@@ -59,6 +59,14 @@ in
                           '';
                         };
 
+                        selected = lib.mkOption {
+                          type = lib.types.nullOr lib.types.bool;
+                          default = null;
+                          description = ''
+                            Whether this windows should be selected by default at session start.
+                          '';
+                        };
+
                         root = mkOptionRoot "Root path of window. This is relative to the path of the smug project.";
 
                         commands = mkOptionCommands "Commands to execute when window starts.";


### PR DESCRIPTION


### Description

<!--

    

-->
Adds 'selected' option for tmux windows
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
