### PR TITLE
lorri: make notifications service auto-start if enabled

### DIFF
--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -133,6 +133,10 @@ in
             in
             "PATH=${path}";
         };
+
+        Install = {
+          WantedBy = [ "lorri.service" ];
+        };
       };
     };
   };


### PR DESCRIPTION
Without this fix, the notifications service would need to start by hand
every time.

@moduon MT-1075
