### PR TITLE
am2rlauncher: add module

### DIFF
--- a/modules/misc/news/2025/10/2025-10-05_14-55-44.nix
+++ b/modules/misc/news/2025/10/2025-10-05_14-55-44.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+
+{
+  time = "2025-10-05T17:55:44+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: `programs.am2rlauncher`
+
+    AM2RLauncher is a front-end application that simplifies installing the
+    latest AM2R-Community-Updates, creating APKs for Android use, as well as
+    Mods for AM2R. It supports Windows (x86/x64) as well as Linux (x64).
+  '';
+}

--- a/modules/programs/am2rlauncher.nix
+++ b/modules/programs/am2rlauncher.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    types
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.am2rlauncher;
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+  options.programs.am2rlauncher = {
+    enable = mkEnableOption "am2rlauncher";
+    package = mkPackageOption pkgs "am2rlauncher" { nullable = true; };
+    config = mkOption {
+      type = with types; either str path;
+      default = "";
+      example = ''
+        <?xml version="1.0" encoding="utf-8"?>
+        <settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" AutoUpdateAM2R="false" AutoUpdateLauncher="true" Language="English" MusicHQPC="false" MusicHQAndroid="false" MirrorIndex="0" ProfileIndex="null" CustomMirrorEnabled="false" CustomMirrorText="" ProfileDebugLog="true" Width="600" Height="600" IsMaximized="false" />
+      '';
+      description = ''
+        Config file for am2rlauncher in XML format. You can see the available options
+        by modifying the settings in the GUI and looking at $XDG_CONFIG_HOME/AM2RLauncher/config.xml.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.am2rlauncher" pkgs lib.platforms.linux)
+    ];
+
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    xdg.configFile."AM2RLauncher/config.xml" = mkIf (cfg.config != "") {
+      source =
+        if lib.isPath cfg.config then cfg.config else pkgs.writeText "am2rlauncher-config.xml" cfg.config;
+    };
+  };
+}

--- a/tests/modules/programs/am2rlauncher/config.xml
+++ b/tests/modules/programs/am2rlauncher/config.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" AutoUpdateAM2R="false" AutoUpdateLauncher="true" Language="English" MusicHQPC="false" MusicHQAndroid="false" MirrorIndex="0" ProfileIndex="null" CustomMirrorEnabled="false" CustomMirrorText="" ProfileDebugLog="true" Width="600" Height="600" IsMaximized="false" />

--- a/tests/modules/programs/am2rlauncher/default.nix
+++ b/tests/modules/programs/am2rlauncher/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  am2rlauncher-settings = ./settings.nix;
+}

--- a/tests/modules/programs/am2rlauncher/settings.nix
+++ b/tests/modules/programs/am2rlauncher/settings.nix
@@ -1,0 +1,12 @@
+{
+  programs.am2rlauncher = {
+    enable = true;
+    config = ./config.xml;
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/AM2RLauncher/config.xml
+    assertFileContent home-files/.config/AM2RLauncher/config.xml \
+      ${./config.xml}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring [AM2RLauncher](https://github.com/AM2R-Community-Developers/AM2RLauncher).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
