### PR TITLE
discocss: fix discordPackage override

### DIFF
--- a/modules/programs/discocss.nix
+++ b/modules/programs/discocss.nix
@@ -42,10 +42,12 @@ in
     ];
 
     home.packages = lib.mkIf (cfg.package != null) [
-      (cfg.package.override {
-        discordAlias = cfg.discordAlias;
-        discord = lib.mkIf (cfg.discordPackage != null) cfg.discordPackage;
-      })
+      (cfg.package.override (
+        {
+          inherit (cfg) discordAlias;
+        }
+        // lib.optionalAttrs (cfg.discordPackage != null) { discord = cfg.discordPackage; }
+      ))
     ];
 
     xdg.configFile."discocss/custom.css".text = cfg.css;

--- a/modules/programs/discocss.nix
+++ b/modules/programs/discocss.nix
@@ -50,6 +50,8 @@ in
       ))
     ];
 
-    xdg.configFile."discocss/custom.css".text = cfg.css;
+    xdg.configFile."discocss/custom.css" = lib.mkIf (cfg.css != "") {
+      text = cfg.css;
+    };
   };
 }

--- a/tests/darwinScrublist.nix
+++ b/tests/darwinScrublist.nix
@@ -37,6 +37,8 @@ let
     "delta"
     "dircolors"
     "direnv"
+    "discord"
+    "discoss"
     "earthly"
     "element-desktop"
     "emacs"

--- a/tests/modules/programs/discocss/basic-configuration.nix
+++ b/tests/modules/programs/discocss/basic-configuration.nix
@@ -1,0 +1,34 @@
+{
+  config = {
+    programs.discocss = {
+      enable = true;
+      package = null;
+
+      discordAlias = false;
+
+      css = ''
+        /* Custom Discord theme */
+        .theme-dark {
+          --background-primary: #2f3136;
+          --background-secondary: #36393f;
+        }
+
+        .chat-3bRxxu {
+          background: var(--background-primary);
+        }
+
+        .content-yTz4x3:before {
+          content: "Custom CSS Loaded";
+          color: #43b581;
+        }
+      '';
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/discocss/custom.css
+      assertFileContent \
+        home-files/.config/discocss/custom.css \
+        ${./with-custom-css-expected.css}
+    '';
+  };
+}

--- a/tests/modules/programs/discocss/default.nix
+++ b/tests/modules/programs/discocss/default.nix
@@ -1,0 +1,5 @@
+{
+  discocss-basic-configuration = ./basic-configuration.nix;
+  discocss-no-packages = ./no-packages.nix;
+  discocss-no-css = ./no-css.nix;
+}

--- a/tests/modules/programs/discocss/no-css.nix
+++ b/tests/modules/programs/discocss/no-css.nix
@@ -1,0 +1,12 @@
+{
+  config = {
+    programs.discocss = {
+      enable = true;
+      discordAlias = false;
+    };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/discocss/custom.css
+    '';
+  };
+}

--- a/tests/modules/programs/discocss/no-packages.nix
+++ b/tests/modules/programs/discocss/no-packages.nix
@@ -1,0 +1,34 @@
+{
+  config = {
+    programs.discocss = {
+      enable = true;
+      package = null;
+      discordPackage = null;
+      discordAlias = false;
+
+      css = ''
+        /* Custom Discord theme */
+        .theme-dark {
+          --background-primary: #2f3136;
+          --background-secondary: #36393f;
+        }
+
+        .chat-3bRxxu {
+          background: var(--background-primary);
+        }
+
+        .content-yTz4x3:before {
+          content: "Custom CSS Loaded";
+          color: #43b581;
+        }
+      '';
+    };
+
+    nmt.script = ''
+      assertFileExists home-files/.config/discocss/custom.css
+      assertFileContent \
+        home-files/.config/discocss/custom.css \
+        ${./with-custom-css-expected.css}
+    '';
+  };
+}

--- a/tests/modules/programs/discocss/with-custom-css-expected.css
+++ b/tests/modules/programs/discocss/with-custom-css-expected.css
@@ -1,0 +1,14 @@
+/* Custom Discord theme */
+.theme-dark {
+  --background-primary: #2f3136;
+  --background-secondary: #36393f;
+}
+
+.chat-3bRxxu {
+  background: var(--background-primary);
+}
+
+.content-yTz4x3:before {
+  content: "Custom CSS Loaded";
+  color: #43b581;
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
