### PR TITLE
home-manager: Document 'force = true' option in error output

### DIFF
--- a/modules/files/check-link-targets.sh
+++ b/modules/files/check-link-targets.sh
@@ -54,7 +54,10 @@ if [[ ${#collisionErrors[@]} -gt 0 ]] ; then
 " files automatically.
 - When used as a NixOS or nix-darwin module, set"\
 " 'home-manager.backupFileExtension'"\
-" to, for example, 'backup' and rebuild."
+" to, for example, 'backup' and rebuild.
+- Set 'force = true' on the related file options to forcefully overwrite"\
+" the files below. eg. 'xdg.configFile.\"mimeapps.list\".force = true'"
+
   for error in "${collisionErrors[@]}" ; do
     errorEcho "$error"
   done


### PR DESCRIPTION
### Description

Very minimal change to document the existence of 'force = true' as an option to address file overwrite errors. I've run into this problem multiple times and each time I have to remember how I worked around it. This change gives a clue what to search for to speed up the process.

Coincidentally, while adding this I noticed the recent #7887 perspective was to not document the new backup overwrite option, which I think is fair, but I also think noting how you could opt-in to overwriting single files is maybe more acceptable? Could add a bigger WARNING noting it's destructive or something too. 

I didn't see a previous PR/issue explicitly deciding not to document this, so apologies if I just missed it.

### Checklist

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

