### PR TITLE
git: difftastic: use 'option' attrset

### DIFF
--- a/tests/modules/programs/git/git-difftastic-expected.conf
+++ b/tests/modules/programs/git/git-difftastic-expected.conf
@@ -1,9 +1,9 @@
 [diff]
-	external = "@difftastic@/bin/difft --color always --background dark --display inline --context 5 --tab-width=8 --sort-paths"
+	external = "@difftastic@/bin/difft --background dark --color always --context 5 --display inline --sort-paths --tab-width 8"
 	tool = "difftastic"
 
 [difftool "difftastic"]
-	cmd = "@difftastic@/bin/difft --color always --background dark --display inline --context 5 --tab-width=8 --sort-paths $LOCAL $REMOTE"
+	cmd = "@difftastic@/bin/difft --background dark --color always --context 5 --display inline --sort-paths --tab-width 8 $LOCAL $REMOTE"
 
 [gpg]
 	format = "openpgp"

--- a/tests/modules/programs/git/git-difftastic.nix
+++ b/tests/modules/programs/git/git-difftastic.nix
@@ -5,14 +5,14 @@
     difftastic = {
       enable = true;
       enableAsDifftool = true;
-      background = "dark";
-      color = "always";
-      context = 5;
-      display = "inline";
-      extraArgs = [
-        "--tab-width=8"
-        "--sort-paths"
-      ];
+      options = {
+        background = "dark";
+        color = "always";
+        context = 5;
+        display = "inline";
+        tab-width = 8;
+        sort-paths = true;
+      };
     };
   };
 


### PR DESCRIPTION
### Description

I know #7911 was _just_ merged, but I do think we should try to move away from adding new options, and `toGNUCommandLine` should serve the same purpose as `extraArgs` but be more modular.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
