### PR TITLE
systemd: Add user environment generator for session variables

### DIFF
--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -235,7 +235,7 @@ let
   hmSessionVarsUserEnvGenerator = {
     "systemd/user-environment-generators/05-home-manager.sh" = {
       text = ''
-        #!/bin/sh
+        #!${pkgs.bash}/bin/bash
 
         # Displays added or modified environment variables from sourcing one or more scripts.
         # Outputs in a clean KEY=VALUE format.
@@ -257,24 +257,12 @@ let
             before_env["$key"]="$value"
           done < <(env)
 
-          # Build the command to source all scripts and then print the env
-          local source_command=""
-          for script in "$@"; do
-            if [[ ! -f "$script" ]]; then
-              echo "Error: Script not found: $script" >&2
-              return 1
-            fi
-            source_command+=". '$script'; "
-          done
-          source_command+="env"
-
-          # Source scripts in a subshell and capture the "after" state
           declare -A after_env
           while IFS= read -r line; do
             local key="''${line%%=*}"
             local value="''${line#*=}"
             after_env["$key"]="$value"
-          done < <(bash -c "$source_command")
+          done < <(for f in "$@"; do source "$f"; done; env)
 
           # Compare maps and print added or modified variables
           for key in "''${!after_env[@]}"; do

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -9,6 +9,10 @@ let
 
   cfg = config.systemd.user;
 
+  nixPkg = if config.nix.package == null then pkgs.nix else config.nix.package;
+
+  profileDirectory = config.home.profileDirectory;
+
   inherit (lib)
     any
     attrValues
@@ -227,6 +231,17 @@ let
         };
       };
     '';
+
+  hmSessionVarsUserEnvGenerator = {
+    "systemd/user-environment-generators/05-home-manager.sh" = {
+      text = ''
+        . "${nixPkg}/etc/profile.d/nix.sh"
+        . "${profileDirectory}/etc/profile.d/hm-session-vars.sh"
+      '';
+      executable = true;
+      force = true;
+    };
+  };
 
   sessionVariables = mkIf (cfg.sessionVariables != { }) {
     "environment.d/10-home-manager.conf".text =
@@ -466,6 +481,8 @@ in
         ++ (buildServices "mount" cfg.mounts)
         ++ (buildServices "automount" cfg.automounts)
       ))
+
+      hmSessionVarsUserEnvGenerator
 
       sessionVariables
 

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -232,7 +232,14 @@ let
       };
     '';
 
-  hmSessionVarsUserEnvGenerator = {
+  systemdConfig = {
+    "systemd/user.conf".text = ''
+      [Manager]
+      ManagerEnvironment=SYSTEMD_ENVIRONMENT_GENERATOR_PATH=%h/.config/systemd/user-environment-generators:/run/systemd/user-environment-generators:/etc/systemd/user-environment-generators:/usr/local/lib/systemd/user-environment-generators:/usr/lib/systemd/user-environment-generators
+    '';
+  };
+
+  systemdSessionVarsUserEnvGenerator = {
     "systemd/user-environment-generators/05-home-manager.sh" = {
       text = ''
         #!${pkgs.bash}/bin/bash
@@ -521,11 +528,13 @@ in
         ++ (buildServices "automount" cfg.automounts)
       ))
 
-      hmSessionVarsUserEnvGenerator
-
       sessionVariables
 
       settings
+
+      systemdConfig
+
+      systemdSessionVarsUserEnvGenerator
     ];
 
     xdg.dataFile = lib.mkIf (cfg.packages != [ ]) {

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -235,8 +235,59 @@ let
   hmSessionVarsUserEnvGenerator = {
     "systemd/user-environment-generators/05-home-manager.sh" = {
       text = ''
-        . "${nixPkg}/etc/profile.d/nix.sh"
-        . "${profileDirectory}/etc/profile.d/hm-session-vars.sh"
+        #!/bin/sh
+
+        # Displays added or modified environment variables from sourcing one or more scripts.
+        # Outputs in a clean KEY=VALUE format.
+        #
+        # Usage:
+        #   diff_env <script1.sh> [script2.sh ...]
+        #
+        diff_env() {
+          if [[ "$#" -eq 0 ]]; then
+            echo "Usage: diff_env <script1.sh> [script2.sh ...]" >&2
+            return 1
+          fi
+
+          # Capture the "before" environment into a map
+          declare -A before_env
+          while IFS= read -r line; do
+            local key="''${line%%=*}"
+            local value="''${line#*=}"
+            before_env["$key"]="$value"
+          done < <(env)
+
+          # Build the command to source all scripts and then print the env
+          local source_command=""
+          for script in "$@"; do
+            if [[ ! -f "$script" ]]; then
+              echo "Error: Script not found: $script" >&2
+              return 1
+            fi
+            source_command+=". '$script'; "
+          done
+          source_command+="env"
+
+          # Source scripts in a subshell and capture the "after" state
+          declare -A after_env
+          while IFS= read -r line; do
+            local key="''${line%%=*}"
+            local value="''${line#*=}"
+            after_env["$key"]="$value"
+          done < <(bash -c "$source_command")
+
+          # Compare maps and print added or modified variables
+          for key in "''${!after_env[@]}"; do
+            # Print if the key is new OR if the value for an existing key has changed.
+            if ! [[ -v before_env["$key"] ]] || [[ "''${before_env[$key]}" != "''${after_env[$key]}" ]]; then
+              echo "$key=''${after_env[$key]}"
+            fi
+          done
+        }
+
+        diff_env \
+          "${nixPkg}/etc/profile.d/nix.sh" \
+          "${profileDirectory}/etc/profile.d/hm-session-vars.sh"
       '';
       executable = true;
       force = true;

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -232,14 +232,7 @@ let
       };
     '';
 
-  systemdConfig = {
-    "systemd/user.conf".text = ''
-      [Manager]
-      ManagerEnvironment=SYSTEMD_ENVIRONMENT_GENERATOR_PATH=%h/.config/systemd/user-environment-generators:/run/systemd/user-environment-generators:/etc/systemd/user-environment-generators:/usr/local/lib/systemd/user-environment-generators:/usr/lib/systemd/user-environment-generators
-    '';
-  };
-
-  systemdSessionVarsUserEnvGenerator = {
+  hmSessionVarsUserEnvGenerator = {
     "systemd/user-environment-generators/05-home-manager.sh" = {
       text = ''
         #!${pkgs.bash}/bin/bash
@@ -445,12 +438,20 @@ in
       settings = mkOption {
         apply =
           sections:
+          let
+            generatorPath = "SYSTEMD_ENVIRONMENT_GENERATOR_PATH=%h/.config/systemd/user-environment-generators:/run/systemd/user-environment-generators:/etc/systemd/user-environment-generators:/usr/local/lib/systemd/user-environment-generators:/usr/lib/systemd/user-environment-generators";
+            managerEnv = sections.Manager.ManagerEnvironment or "";
+            finalManagerEnv = generatorPath + (if managerEnv == "" then "" else " " + managerEnv);
+            newManager = (sections.Manager or { }) // {
+              ManagerEnvironment = finalManagerEnv;
+            };
+          in
           sections
           // {
             # Setting one of these to an empty value would reset any
             # previous settings, so we’ll remove them instead if they
             # are not explicitly set.
-            Manager = removeIfEmpty sections.Manager [
+            Manager = removeIfEmpty newManager [
               "ManagerEnvironment"
               "DefaultEnvironment"
             ];
@@ -528,13 +529,11 @@ in
         ++ (buildServices "automount" cfg.automounts)
       ))
 
+      hmSessionVarsUserEnvGenerator
+
       sessionVariables
 
       settings
-
-      systemdConfig
-
-      systemdSessionVarsUserEnvGenerator
     ];
 
     xdg.dataFile = lib.mkIf (cfg.packages != [ ]) {

--- a/modules/systemd.nix
+++ b/modules/systemd.nix
@@ -278,7 +278,6 @@ let
           "${profileDirectory}/etc/profile.d/hm-session-vars.sh"
       '';
       executable = true;
-      force = true;
     };
   };
 

--- a/tests/modules/systemd/default-user-config.nix
+++ b/tests/modules/systemd/default-user-config.nix
@@ -1,23 +1,11 @@
 { pkgs, ... }:
 
 {
-  systemd.user.settings.Manager = {
-    LogLevel = "debug";
-    DefaultCPUAccounting = true;
-    DefaultEnvironment = {
-      TEST = "abc";
-      PATH = "/bin:/sbin:/some where";
-    };
-  };
-
   nmt.script = ''
     userConf=home-files/.config/systemd/user.conf
     assertFileExists $userConf
     assertFileContent $userConf ${pkgs.writeText "expected" ''
       [Manager]
-      DefaultCPUAccounting=true
-      DefaultEnvironment=PATH='/bin:/sbin:/some where' TEST=abc
-      LogLevel=debug
       ManagerEnvironment=SYSTEMD_ENVIRONMENT_GENERATOR_PATH=%h/.config/systemd/user-environment-generators:/run/systemd/user-environment-generators:/etc/systemd/user-environment-generators:/usr/local/lib/systemd/user-environment-generators:/usr/lib/systemd/user-environment-generators
     ''}
   '';

--- a/tests/modules/systemd/default.nix
+++ b/tests/modules/systemd/default.nix
@@ -6,4 +6,5 @@
   systemd-empty-user-config = ./empty-user-config.nix;
   systemd-slices = ./slices.nix;
   systemd-timers = ./timers.nix;
+  systemd-user-environment-generators = ./user-environment-generators.nix;
 }

--- a/tests/modules/systemd/default.nix
+++ b/tests/modules/systemd/default.nix
@@ -3,7 +3,7 @@
   systemd-packages = ./packages.nix;
   systemd-session-variables = ./session-variables.nix;
   systemd-user-config = ./user-config.nix;
-  systemd-empty-user-config = ./empty-user-config.nix;
+  systemd-default-user-config = ./default-user-config.nix;
   systemd-slices = ./slices.nix;
   systemd-timers = ./timers.nix;
   systemd-user-environment-generators = ./user-environment-generators.nix;

--- a/tests/modules/systemd/empty-user-config.nix
+++ b/tests/modules/systemd/empty-user-config.nix
@@ -1,6 +1,0 @@
-{
-  nmt.script = ''
-    userConf=home-files/.config/systemd/user.conf
-    assertPathNotExists $userConf
-  '';
-}

--- a/tests/modules/systemd/user-environment-generators.nix
+++ b/tests/modules/systemd/user-environment-generators.nix
@@ -1,12 +1,6 @@
-{ pkgs, ... }:
-
 {
   nmt.script = ''
     hmSessionVarsUserEnvGenerator=home-files/.config/systemd/user-environment-generators/05-home-manager.sh
     assertFileExists $hmSessionVarsUserEnvGenerator
-    assertFileContent $hmSessionVarsUserEnvGenerator ${pkgs.writeText "expected" ''
-      . "@nix@/etc/profile.d/nix.sh"
-      . "/home/hm-user/.nix-profile/etc/profile.d/hm-session-vars.sh"
-    ''}
   '';
 }

--- a/tests/modules/systemd/user-environment-generators.nix
+++ b/tests/modules/systemd/user-environment-generators.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+
+{
+  nmt.script = ''
+    hmSessionVarsUserEnvGenerator=home-files/.config/systemd/user-environment-generators/05-home-manager.sh
+    assertFileExists $hmSessionVarsUserEnvGenerator
+    assertFileContent $hmSessionVarsUserEnvGenerator ${pkgs.writeText "expected" ''
+      . "@nix@/etc/profile.d/nix.sh"
+      . "/home/hm-user/.nix-profile/etc/profile.d/hm-session-vars.sh"
+    ''}
+  '';
+}


### PR DESCRIPTION
### Description

On systems where graphical sessions like GNOME are started by the systemd user manager, the session environment is not sourced from a traditional shell profile. This results in an incomplete `PATH` environment variable. Consequently, `.desktop` files for applications installed by Home Manager are considered invalid because their `Exec=` target cannot be found in the `PATH`, and the applications do not appear in menus.

While `systemd.user.sessionVariables` can set simple variables, it is not well-suited for dynamically constructing `PATH`. Systemd provides a more suitable mechanism for this task: an environment generator.

This commit implements this solution by adding a script to `~/.config/systemd/user-environment-generators/`. This script is executed by the systemd user manager on startup and sources:
  - The main Nix profile script (`nix.sh`)
  - The Home Manager session variables script (`hm-session-vars.sh`)

This correctly populates the environment for all services and applications managed by the user instance. While the primary motivation is fixing the `PATH`, this approach also ensures all other environment variables from the profile scripts are set. This makes the systemd session environment consistent with that of an interactive shell profile, providing a more predictable experience regardless of how the user session is initiated.

A test is included to validate the generator's creation and content.

Fixes: #1439

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
