### PR TITLE
amoco: add module

### DIFF
--- a/modules/misc/news/2025/10/2025-10-07_09-39-32.nix
+++ b/modules/misc/news/2025/10/2025-10-07_09-39-32.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-10-07T12:39:32+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.amoco`
+
+    Amoco is a python package dedicated to symbolic analysis of binaries.
+  '';
+}

--- a/modules/programs/amoco.nix
+++ b/modules/programs/amoco.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  inherit (lib)
+    types
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+
+  cfg = config.programs.amoco;
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [ aguirre-matteo ];
+  options.programs.amoco = {
+    enable = mkEnableOption "amoco";
+    package = mkPackageOption pkgs "amoco" { nullable = true; };
+    config = mkOption {
+      type = with types; either str path;
+      default = "";
+      description = ''
+        Config file for amoco as a Python configuration module.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+    home.file.".config/amoco/config" = mkIf (cfg.config != "") {
+      source = if lib.isPath cfg.config then cfg.config else pkgs.writeText "amoco-config" cfg.config;
+    };
+  };
+}

--- a/tests/modules/programs/amoco/config
+++ b/tests/modules/programs/amoco/config
@@ -1,0 +1,1 @@
+print("No example config found!")

--- a/tests/modules/programs/amoco/default.nix
+++ b/tests/modules/programs/amoco/default.nix
@@ -1,0 +1,1 @@
+{ amoco-settings = ./settings.nix; }

--- a/tests/modules/programs/amoco/settings.nix
+++ b/tests/modules/programs/amoco/settings.nix
@@ -1,0 +1,14 @@
+{
+  programs.amoco = {
+    enable = true;
+    config = ''
+      print("No example config found!")
+    '';
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/amoco/config
+    assertFileContent home-files/.config/amoco/config \
+      ${./config}
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This PR adds a module for configuring [Amoco](https://github.com/bdcht/amoco). It supports a config file at `$HOME/.config/amoco/config` ([see](https://github.com/bdcht/amoco/blob/3e36c5247283a7abba57ce3c06910a7271ab1b9a/amoco/config.py#L256), especially lines 268 and 276), but I didn't find an example config file.
### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
