### PR TITLE
aerc: change stylesets option to reflect the structure aerc expects

### DIFF
--- a/modules/programs/aerc/default.nix
+++ b/modules/programs/aerc/default.nix
@@ -104,10 +104,10 @@ in
     };
 
     stylesets = mkOption {
-      type = with types; attrsOf (either confSection lines);
+      type = with types; attrsOf (sectionsOrLines);
       default = { };
       example = literalExpression ''
-        { default = { ui = { "tab.selected.reverse" = toggle; }; }; };
+        { default = { ui = { "tab.selected.reverse" = "toggle"; }; }; };
       '';
       description = ''
         Stylesets added to {file}`$HOME/.config/aerc/stylesets/`.
@@ -166,7 +166,7 @@ in
       mkStyleset = attrsets.mapAttrs' (
         k: v:
         let
-          value = if lib.isString v then v else sectionsToINI { global = v; };
+          value = if lib.isString v then v else sectionsToINI v;
         in
         {
           name = "${configDir}/stylesets/${k}";

--- a/tests/modules/programs/aerc/settings.nix
+++ b/tests/modules/programs/aerc/settings.nix
@@ -94,14 +94,20 @@
           error.fg = red
           header.bold = true
           title.reverse = true
+
+          [ui]
+          tab.selected.reverse = toggle
         '';
         default = {
-          "*.default" = "true";
-          "*error.bold" = "true";
-          "error.fg" = "red";
-          "header.bold" = "true";
-          "*.selected.reverse" = "toggle";
-          "title.reverse" = "true";
+          global = {
+            "*.default" = "true";
+            "*error.bold" = "true";
+            "error.fg" = "red";
+            "header.bold" = "true";
+            "*.selected.reverse" = "toggle";
+            "title.reverse" = "true";
+          };
+          ui."tab.selected.reverse" = "toggle";
         };
       };
 

--- a/tests/modules/programs/aerc/stylesets.expected
+++ b/tests/modules/programs/aerc/stylesets.expected
@@ -6,3 +6,6 @@
 error.fg = red
 header.bold = true
 title.reverse = true
+
+[ui]
+tab.selected.reverse = toggle


### PR DESCRIPTION
### Description

Updates the `programs.aerc.stylesets` option to reflect the structure aerc expects, as well as what appears to be the intention judging from the example, which, aside from the unquoted string, currently produces an error (see #4037).

I suppose this change isn't backwards compatible, since it now expects you to set your styles under sections instead of putting everything into global, but I can't imagine this was the intended behavior since defining stylesets relies on the ability to use other sections. The only way I can see this option would have worked previously is by providing lines rather than attrsets, which works the same as before.

Before this change the example results in:
```
error: A definition for option `home-manager.users.chris.programs.aerc.stylesets.default.ui' is not of type `values (null, bool, int, string, or float) or a list of values, that will be joined with a comma'. TypeError: The option `home-manager.users.chris.programs.aerc.stylesets.default.ui` is neither a value of type `null or string or signed integer or boolean or floating point number` nor `list of (null or string or signed integer or boolean or floating point number)`, Definition values:
       - In `/nix/store/fv70cicj7jb8z65z3h6n9447zr2bqxis-source/modules/aerc':
           {
             "tab.selected.reverse" = "toggle";
           }
```
and the only way to achieve what it attempts to achieve would be:
```nix
stylesets.default = ''
  [ui]
  tab.selected.reverse = toggle
'';
```
with this PR
```nix
stylesets = {
  default = { ui = { "tab.selected.reverse" = "toggle"; }; };
  default2 = ''
    [ui]
    tab.selected.reverse = toggle
  '';
};
```
produces two identical files.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
