### PR TITLE
fontconfig: workaround KDE overwriting symlink

### DIFF
--- a/tests/modules/misc/fontconfig/default.nix
+++ b/tests/modules/misc/fontconfig/default.nix
@@ -1,3 +1,4 @@
+{ lib, pkgs, ... }:
 {
   fontconfig-no-font-package = ./no-font-package.nix;
   fontconfig-single-font-package = ./single-font-package.nix;
@@ -23,4 +24,7 @@
   fontconfig-default-rendering = ./default-rendering.nix;
   fontconfig-custom-rendering = ./custom-rendering.nix;
   fontconfig-extra-config-files = ./extra-config-files.nix;
+}
+// lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  fontconfig-mutable-placeholder = ./mutable-placeholder.nix;
 }

--- a/tests/modules/misc/fontconfig/mutable-placeholder.nix
+++ b/tests/modules/misc/fontconfig/mutable-placeholder.nix
@@ -1,0 +1,23 @@
+{ config, realPkgs, ... }:
+let
+  cfg = config.fonts.fontconfig.mutablePlaceholder;
+in
+{
+  fonts.fontconfig.enable = true;
+  fonts.fontconfig.mutablePlaceholder.enable = true;
+
+  nmt.script = ''
+    SYSTEMD_LOG_LEVEL=debug ${realPkgs.systemd}/bin/systemd-tmpfiles \
+      -E \
+      --root "$TEMPDIR/chroot" \
+      --create \
+      --remove \
+      --boot \
+      "$TESTED/home-files/.config/user-tmpfiles.d/home-manager.conf"
+
+    assertFileExists "$TEMPDIR/chroot/${cfg.file}"
+    assertFileNotRegex "$TEMPDIR/chroot/${cfg.file}" .
+  '';
+
+  test.stubs.systemd.outPath = null;
+}


### PR DESCRIPTION
### Description

Changing KDE font settings using GUI causes it to convert `$XDG_CONFIG_HOME/fontconfig/conf.d/10-hm-fonts.conf` to a plain file and then insert its own settings.

A bug was filed upstream[^1], however upstream does not appear receptive to making any changes.

Instead of patching KDE as suggested by upstream, we can simply work around the behavior by providing a mutable file for KDE to do what it wants with. Since it appears that KDE will always use the first file it finds[^2], we create the mutable file `00-aaa-local.conf`.

[^1]: https://bugs.kde.org/show_bug.cgi?id=498694
[^2]: https://github.com/KDE/plasma-workspace/blob/83bebc7896986eb27e0e1a8c62edaa98f567e2ce/kcms/fonts/kxftconfig.cpp#L192

Fixes: #5162


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
