### PR TITLE
macos-remap-keys: add japanese Kana and Eisuu keycodes

### DIFF
--- a/modules/services/macos-remap-keys/keytables.nix
+++ b/modules/services/macos-remap-keys/keytables.nix
@@ -147,7 +147,9 @@ let
   page7Keys = mapToInt (lib.fromHexString "700000000") (
     letters // numbers // specialKeys // fKeys1To12 // fKeys13To24 // navigationKeys // modifierKeys
   );
-  pageFFKeys = mapToInt (lib.fromHexString "FF00000000") { Fn = "0x3"; };
+  pageFFKeys = mapToInt (lib.fromHexString "FF00000000") {
+    Fn = "0x3";
+  };
 in
 {
   keyboard = page7Keys // pageFFKeys;


### PR DESCRIPTION
### Description

Adds key codes for Japanese-specific MacBook layout keys: Kana and Eisuu as well as a keycode for Fn (I was surprised that it even existed)

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
