### PR TITLE
superfile: add zoxide when zoxide_support enabled

### DIFF
--- a/modules/programs/superfile.nix
+++ b/modules/programs/superfile.nix
@@ -33,6 +33,7 @@ in
     package = mkPackageOption pkgs "superfile" { nullable = true; };
 
     metadataPackage = mkPackageOption pkgs "exiftool" { nullable = true; };
+    zoxidePackage = mkPackageOption pkgs "zoxide" { nullable = true; };
 
     settings = mkOption {
       type = tomlFormat.type;
@@ -150,6 +151,9 @@ in
         ++ optional (
           cfg.metadataPackage != null && cfg.settings ? metadata && cfg.settings.metadata
         ) cfg.metadataPackage
+        ++ optional (
+          cfg.zoxidePackage != null && cfg.settings ? zoxide_support && cfg.settings.zoxide_support
+        ) cfg.zoxidePackage
       );
 
       xdg.configFile = mkIf enableXdgConfig configFiles;


### PR DESCRIPTION
### Description

~~NixOS/nixpkgs#450661 has to be merged first~~

<https://superfile.netlify.app/list/plugin-list>

`zoxide_support` option requires `zoxide` to work.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
