### PR TITLE
zsh: fix zsh history substring search generation

### DIFF
--- a/modules/programs/zsh/history.nix
+++ b/modules/programs/zsh/history.nix
@@ -247,28 +247,12 @@ in
           # https://github.com/zsh-users/zsh-history-substring-search#usage
           ''
             source ${pkgs.zsh-history-substring-search}/share/zsh-history-substring-search/zsh-history-substring-search.zsh
-
-            ${
-              let
-                upKeys = lib.toList cfg.historySubstringSearch.searchUpKey;
-                downKeys = lib.toList cfg.historySubstringSearch.searchDownKey;
-              in
-              ''
-                # Bind search up keys
-                ${lib.hm.zsh.define "search_up_keys" upKeys}
-                 for key in "''${search_up_keys[@]}"; do
-                   bindkey "$key" history-substring-search-up
-                 done
-                 unset key search_up_keys
-
-                # Bind search down keys
-                ${lib.hm.zsh.define "search_down_keys" downKeys}
-                 for key in "''${search_down_keys[@]}"; do
-                   bindkey "$key" history-substring-search-down
-                 done
-                 unset key search_down_keys
-              ''
-            }
+            ${lib.concatMapStringsSep "\n" (upKey: ''bindkey "${upKey}" history-substring-search-up'') (
+              lib.toList cfg.historySubstringSearch.searchUpKey
+            )}
+            ${lib.concatMapStringsSep "\n" (downKey: ''bindkey "${downKey}" history-substring-search-down'') (
+              lib.toList cfg.historySubstringSearch.searchDownKey
+            )}
           ''
       ))
     ];

--- a/tests/modules/programs/zsh/history-substring-search-expected.zshrc
+++ b/tests/modules/programs/zsh/history-substring-search-expected.zshrc
@@ -36,22 +36,6 @@ done
 unset opt disabled_opts
 
 source @zsh-history-substring-search@/share/zsh-history-substring-search/zsh-history-substring-search.zsh
-
-# Bind search up keys
-search_up_keys=(
-  '^[[A' '\eOA'
-)
- for key in "${search_up_keys[@]}"; do
-   bindkey "$key" history-substring-search-up
- done
- unset key search_up_keys
-
-# Bind search down keys
-search_down_keys=(
-  '^[[B'
-)
- for key in "${search_down_keys[@]}"; do
-   bindkey "$key" history-substring-search-down
- done
- unset key search_down_keys
-
+bindkey "^[[A" history-substring-search-up
+bindkey "\eOA" history-substring-search-up
+bindkey "^[[B" history-substring-search-down


### PR DESCRIPTION
### Description
Closes https://github.com/nix-community/home-manager/issues/7968
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
