### PR TITLE
ssh-agent: Allow other systemd units access to $SSH_AUTH_SOCK

### DIFF
--- a/tests/modules/services/ssh-agent/basic-service-expected.service
+++ b/tests/modules/services/ssh-agent/basic-service-expected.service
@@ -3,6 +3,7 @@ WantedBy=default.target
 
 [Service]
 ExecStart=@openssh@/bin/ssh-agent -D -a %t/ssh-agent/socket
+ExecStartPost=/nix/store/00000000000000000000000000000000-update-ssh-agent-env SSH_AUTH_SOCK=%t/ssh-agent/socket
 
 [Unit]
 Description=SSH authentication agent

--- a/tests/modules/services/ssh-agent/basic-service.nix
+++ b/tests/modules/services/ssh-agent/basic-service.nix
@@ -6,7 +6,7 @@
 
   nmt.script = ''
     assertFileContent \
-      home-files/.config/systemd/user/ssh-agent.service \
+      $(normalizeStorePaths home-files/.config/systemd/user/ssh-agent.service) \
       ${./basic-service-expected.service}
   '';
 }

--- a/tests/modules/services/ssh-agent/timeout-service-expected.service
+++ b/tests/modules/services/ssh-agent/timeout-service-expected.service
@@ -3,6 +3,7 @@ WantedBy=default.target
 
 [Service]
 ExecStart=@openssh@/bin/ssh-agent -D -a %t/ssh-agent -t 1337
+ExecStartPost=/nix/store/00000000000000000000000000000000-update-ssh-agent-env SSH_AUTH_SOCK=%t/ssh-agent
 
 [Unit]
 Description=SSH authentication agent

--- a/tests/modules/services/ssh-agent/timeout-service.nix
+++ b/tests/modules/services/ssh-agent/timeout-service.nix
@@ -6,7 +6,7 @@
 
   nmt.script = ''
     assertFileContent \
-      home-files/.config/systemd/user/ssh-agent.service \
+      $(normalizeStorePaths home-files/.config/systemd/user/ssh-agent.service) \
       ${./timeout-service-expected.service}
   '';
 }


### PR DESCRIPTION
### Description

If another systemd unit wants to talk to the ssh-agent service, they need to know the SSH_AUTH_SOCK variable to do so.

### Checklist

- [X] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

The tests are broken at HEAD:

 - `nix-shell --pure tests -A run.all`

   <details>
   <summary>Errors</summary>

       error:
              … while calling the 'derivationStrict' builtin
                at <nix/derivation-internal.nix>:37:12:
                  36|
                  37|   strict = derivationStrict drvAttrs;
                    |            ^
                  38|
       
              … while evaluating derivation 'nmt-run-all-tests'
                whose name attribute is located at /nix/store/ka13k2zhk09q32ip9aidyd20v48g90jk-source/pkgs/stdenv/generic/make-derivation.nix:480:13
       
              … while evaluating attribute 'shellHook' of derivation 'nmt-run-all-tests'
                at /nix/store/fm1dwqb08lxr1gk02niyvb1j7v4181c0-source/default.nix:38:41:
                  37|   runShellOnlyCommand = name: shellHook:
                  38|     pkgs.runCommandLocal name { inherit shellHook; } ''
                    |                                         ^
                  39|       echo This derivation is only useful when run through nix-shell.
       
              … while evaluating the option `nmt.result.success':
       
              … while evaluating definitions from `/nix/store/fm1dwqb08lxr1gk02niyvb1j7v4181c0-source/nmt.nix':
       
              … while evaluating the option `home.activation.installPackages.data':
       
              … while evaluating definitions from `/home/.../home-manager/modules/home-environment.nix':
       
              … while evaluating the option `home.packages':
       
              … while evaluating definitions from `/home/.../home-manager/modules/programs/anki':
       
              (stack trace truncated; use '--show-trace' to show the full, detailed trace)
       
              error: attribute 'withAddons' missing
              at /home/.../home-manager/modules/programs/anki/default.nix:334:8:
                 333|     home.packages = [
                 334|       (cfg.package.withAddons (
                    |        ^
                 335|         [
   </details>

 - `nix run .#tests`

   <details>
   <summary>Errors</summary>
   ```
   ℹ️ Discovering tests...
   ❌ Error: Command 'fzf' not found. Is it in your PATH?
   ℹ️ No tests selected to run.
   ```
   </details>

I'll let GitHub Actions run the tests.