### PR TITLE
autotiling: init module

### DIFF
--- a/modules/misc/news/2025/10/2025-10-11_14-06-00.nix
+++ b/modules/misc/news/2025/10/2025-10-11_14-06-00.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+{
+  time = "2025-10-11T14:06:00+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new service is available: 'services.autotiling'.
+    autotiling is a script for Sway and i3 to automatically switch the horizontal / vertical window split orientation.
+  '';
+}

--- a/modules/services/autotiling.nix
+++ b/modules/services/autotiling.nix
@@ -1,0 +1,70 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkOption
+    types
+    ;
+
+  cfg = config.services.autotiling;
+
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.swarsel ];
+
+  options.services.autotiling = {
+    enable = lib.mkEnableOption "enable autotiling service";
+    package = lib.mkPackageOption pkgs "autotiling" { };
+
+    extraArgs = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      example = [
+        "--workspaces"
+        "8"
+        "9"
+      ];
+      description = ''
+        Extra arguments to pass to autotiling.
+      '';
+    };
+
+    systemdTarget = mkOption {
+      type = types.str;
+      default = "graphical-session.target";
+      description = ''
+        Systemd target to bind to.
+      '';
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.autotiling" pkgs lib.platforms.linux)
+    ];
+
+    systemd.user.services.autotiling = {
+      Unit = {
+        Description = "Split orientation manager";
+        PartOf = [ cfg.systemdTarget ];
+        After = [ cfg.systemdTarget ];
+      };
+
+      Service = {
+        Type = "simple";
+        Restart = "always";
+        ExecStart = "${lib.getExe cfg.package} ${lib.escapeShellArgs cfg.extraArgs}";
+      };
+
+      Install = {
+        WantedBy = [ cfg.systemdTarget ];
+      };
+    };
+  };
+}

--- a/tests/flake.lock
+++ b/tests/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1760038930,
+        "narHash": "sha256-Oncbh0UmHjSlxO7ErQDM3KM0A5/Znfofj2BSzlHLeVw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0b4defa2584313f3b781240b29d61f6f9f7e0df3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/modules/services/autotiling/autotiling-basic-config.nix
+++ b/tests/modules/services/autotiling/autotiling-basic-config.nix
@@ -1,0 +1,40 @@
+{ config, ... }:
+
+{
+  services.autotiling = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = "@autotiling@"; };
+    extraArgs = [
+      "--outputs"
+      "DP-1"
+      "--workspaces"
+      "8"
+      "9"
+      "--limit"
+      "2"
+    ];
+  };
+
+  nmt.script = ''
+    serviceFile=home-files/.config/systemd/user/autotiling.service
+
+    assertFileExists "$serviceFile"
+
+    serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+
+    assertFileContent "$serviceFileNormalized" ${builtins.toFile "expected.service" ''
+      [Install]
+      WantedBy=graphical-session.target
+
+      [Service]
+      ExecStart=@autotiling@/bin/dummy --outputs DP-1 --workspaces 8 9 --limit 2
+      Restart=always
+      Type=simple
+
+      [Unit]
+      After=graphical-session.target
+      Description=Split orientation manager
+      PartOf=graphical-session.target
+    ''}
+  '';
+}

--- a/tests/modules/services/autotiling/default.nix
+++ b/tests/modules/services/autotiling/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  autotiling-basic-config = ./autotiling-basic-config.nix;
+}


### PR DESCRIPTION
### Description

Adds a module for [autotiling](https://github.com/nwg-piotr/autotiling).
<!--


-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
