### PR TITLE
vivid: modify `themes` option with custom nix entries

### DIFF
--- a/tests/modules/programs/vivid/example-config.nix
+++ b/tests/modules/programs/vivid/example-config.nix
@@ -26,6 +26,7 @@
     themes = {
       ayu = ./themes/ayu.yml;
       mocha = ./themes/mocha.yml;
+      tiny = import ./themes/tiny.nix;
     };
   };
 
@@ -41,5 +42,9 @@
     assertFileExists home-files/.config/vivid/themes/mocha.yml
     assertFileContent home-files/.config/vivid/themes/mocha.yml \
     ${./themes/mocha.yml}
+
+    assertFileExists home-files/.config/vivid/themes/tiny.yml
+    assertFileContent home-files/.config/vivid/themes/tiny.yml \
+    ${./themes/tiny.yml}
   '';
 }

--- a/tests/modules/programs/vivid/themes/tiny.nix
+++ b/tests/modules/programs/vivid/themes/tiny.nix
@@ -1,0 +1,15 @@
+{
+  colors = {
+    primary = "00aaff";
+    secondary = "ff00aa";
+  };
+  core = {
+    directory = {
+      foreground = "primary";
+    };
+    "executable-file" = {
+      foreground = "secondary";
+      "font-style" = "bold";
+    };
+  };
+}

--- a/tests/modules/programs/vivid/themes/tiny.yml
+++ b/tests/modules/programs/vivid/themes/tiny.yml
@@ -1,0 +1,9 @@
+colors:
+  primary: 00aaff
+  secondary: ff00aa
+core:
+  directory:
+    foreground: primary
+  executable-file:
+    font-style: bold
+    foreground: secondary


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

The current `themes` option only allows for downloading external YAML themes, and not for generating custom ones with Nix code. This will be useful when styling NixOS and home-manager uniformly with [stylix](https://nix-community.github.io/stylix/), but nonetheless, it is a helpful option to have, in my opinion.

@aguirre-matteo would be glad to get some feedback on this!

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
