### PR TITLE
sqlite: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -169,6 +169,22 @@
     githubId = 46252070;
     name = "Sara Johnsson";
   };
+  fk29g = {
+    name = "nicknb";
+    email = "nicknb@posteo.com";
+    github = "fk29g";
+    githubId = 205353326;
+    keys = [
+      {
+        longKeyId = "ed25519/0xD90384C807BC1FE6";
+        fingerprint = "8FF0 1BEE BCBF 1D20 ECD3  5FFA D903 84C8 07BC 1FE6";
+      }
+      {
+        longKeyId = "ed25519/0x2BF0FBB405AD6A7C";
+        fingerprint = "6F9B 47B6 FFB0 823D 2ACF  9ED8 2BF0 FBB4 05AD 6A7C";
+      }
+    ];
+  };
   florpe = {
     email = "jens.krewald@gmail.com";
     github = "florpe";

--- a/modules/misc/news/2025/10/2025-10-12_18-29-08.nix
+++ b/modules/misc/news/2025/10/2025-10-12_18-29-08.nix
@@ -1,0 +1,7 @@
+{
+  time = "2025-10-12T16:29:08+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.sqlite`.
+  '';
+}

--- a/modules/programs/sqlite.nix
+++ b/modules/programs/sqlite.nix
@@ -1,0 +1,136 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.sqlite;
+  defaultColSeparator = "|";
+  defaultPrompt = "sqlite> ";
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.fk29g ];
+
+  options.programs.sqlite = {
+    enable = lib.mkEnableOption "sqlite";
+
+    package = lib.mkPackageOption pkgs "sqlite-interactive" {
+      nullable = true;
+      example = [ "sqlite" ];
+    };
+
+    mode = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "ascii"
+          "box"
+          "column"
+          "csv"
+          "html"
+          "insert"
+          "json"
+          "line"
+          "list"
+          "markdown"
+          "qbox"
+          "quote"
+          "table"
+          "tabs"
+          "tcl"
+        ]
+      );
+      default = null;
+      description = ''
+        Output format for query results.
+
+        If set to `null`, SQLite uses "list".
+      '';
+    };
+
+    separator = {
+      column = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = " | ";
+        description = ''
+          Column separator.
+
+          If set to `null`, SQLite uses "${defaultColSeparator}".
+        '';
+      };
+
+      row = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "\\n\\n";
+        description = ''
+          Row separator.
+
+          If set to `null`, SQLite uses "\n".
+        '';
+      };
+    };
+
+    prompt = {
+      main = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "❯ ";
+        description = ''
+          Main shell prompt.
+
+          If set to `null`, SQLite uses `${defaultPrompt}`.
+        '';
+      };
+
+      continue = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Shell prompt for continuing lines of multi-line queries.
+
+          If set to `null`, SQLite uses `   ...> `.
+        '';
+      };
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = ''
+        Extra lines added to {file}`sqliterc`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."sqlite3/sqliterc".text = lib.concatStringsSep "\n" (
+      lib.filter (x: x != "") [
+        (lib.optionalString (cfg.mode != null) ".mode ${cfg.mode}")
+        (lib.optionalString (
+          cfg.separator.column != null && cfg.separator.row != null
+        ) ".separator \"${cfg.separator.column}\" \"${cfg.separator.row}\"")
+        (lib.optionalString (
+          cfg.separator.column != null && cfg.separator.row == null
+        ) ".separator \"${cfg.separator.column}\"")
+        (lib.optionalString (
+          cfg.separator.column == null && cfg.separator.row != null
+        ) ".separator \"${defaultColSeparator}\" \"${cfg.separator.row}\"")
+        (lib.optionalString (
+          cfg.prompt.main != null && cfg.prompt.continue != null
+        ) ".prompt \"${cfg.prompt.main}\" \"${cfg.prompt.continue}\"")
+        (lib.optionalString (
+          cfg.prompt.main != null && cfg.prompt.continue == null
+        ) ".prompt \"${cfg.prompt.main}\"")
+        (lib.optionalString (
+          cfg.prompt.main == null && cfg.prompt.continue != null
+        ) ".prompt \"${defaultPrompt}\" \"${cfg.prompt.continue}\"")
+        (lib.optionalString (cfg.extraConfig != "") (cfg.extraConfig))
+      ]
+    );
+  };
+}

--- a/tests/modules/programs/sqlite/basic-configuration-expected
+++ b/tests/modules/programs/sqlite/basic-configuration-expected
@@ -1,0 +1,4 @@
+.mode box
+.separator " | " "\n\n"
+.prompt "> " "..> "
+.help

--- a/tests/modules/programs/sqlite/basic-configuration.nix
+++ b/tests/modules/programs/sqlite/basic-configuration.nix
@@ -1,0 +1,26 @@
+{
+  programs.sqlite = {
+    enable = true;
+    mode = "box";
+    separator = {
+      column = " | ";
+      row = "\\n\\n";
+    };
+    prompt = {
+      main = "> ";
+      continue = "..> ";
+    };
+    extraConfig = ''
+      .help
+    '';
+  };
+
+  nmt.script =
+    let
+      configFile = "home-files/.config/sqlite3/sqliterc";
+    in
+    ''
+      assertFileExists "${configFile}"
+      assertFileContent "${configFile}" ${./basic-configuration-expected}
+    '';
+}

--- a/tests/modules/programs/sqlite/default.nix
+++ b/tests/modules/programs/sqlite/default.nix
@@ -1,0 +1,4 @@
+{
+  sqlite-basic-configuration = ./basic-configuration.nix;
+  sqlite-empty-settings = ./empty-settings.nix;
+}

--- a/tests/modules/programs/sqlite/empty-settings.nix
+++ b/tests/modules/programs/sqlite/empty-settings.nix
@@ -1,0 +1,7 @@
+{
+  programs.sqlite.enable = false;
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/sqlite
+  '';
+}


### PR DESCRIPTION
### Description

Adds a module for configuring SQLite.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)
