### PR TITLE
home-manager: fix option subcommand

### DIFF
--- a/docs/home-manager.1
+++ b/docs/home-manager.1
@@ -24,7 +24,7 @@
 .Cm | generations
 .Cm | help
 .Cm | news
-.Cm | option Ar option.name
+.Cm | option Oo Fl -recursive Oc Ar option.name
 .Cm | packages
 .Cm | remove-generations Ar ID \&...
 .Cm | switch
@@ -138,10 +138,14 @@ Show news entries in a pager.
 .RE
 .PP
 
-.It Cm option Ar option.name
+.It Cm option Oo Fl -recursive Oc Ar option.name
 .RS 4
 Inspect the given option name in the home configuration, like
 \fBnixos-option\fR(8)\&.
+.sp
+If the
+.Fl -recursive
+option is given, print all the values at or below the option name recursively\&.
 .RE
 .Pp
 

--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -232,7 +232,29 @@ function doInspectOption() {
     fi
     setConfigFile
 
-    local extraArgs=("$@")
+    local paths=()
+    local recursive=false
+
+    while (( $# > 0 )); do
+        local opt="$1"
+        shift
+
+        case $opt in
+            --recursive)
+                recursive=true;;
+            *)
+                # Remove trailing dot if exists, match the behavior of
+                # old nixos-option and make shell completions happy
+                paths+=("${opt%.}")
+                ;;
+        esac
+    done
+
+    if [[ ${#paths[@]} -eq 0 ]]; then
+        paths=("")
+    fi
+
+    local extraArgs=()
 
     for p in "${EXTRA_NIX_PATH[@]}"; do
         extraArgs=("${extraArgs[@]}" "-I" "$p")
@@ -256,11 +278,24 @@ function doInspectOption() {
     modulesExpr+=" configuration = if confAttr == \"\" then confPath else (import confPath).\${confAttr};"
     modulesExpr+=" pkgs = import <nixpkgs> {}; check = true; })"
 
-    nixos-option \
-        --options_expr "$modulesExpr.options" \
-        --config_expr "$modulesExpr.config" \
-        "${extraArgs[@]}" \
-        "${PASSTHROUGH_OPTS[@]}"
+    local NIXOS_OPTION_CMD NIXOS_OPTION_REAL NIXOS_OPTION_DIR NIXOS_OPTION_NIX
+    NIXOS_OPTION_CMD=$(command -v nixos-option)
+    NIXOS_OPTION_REAL=$(realpath "${NIXOS_OPTION_CMD}")
+    NIXOS_OPTION_NIX=$(nix-store -q --references "${NIXOS_OPTION_REAL}" | grep 'nixos-option\.nix$')
+
+    if [[ ! -f "$NIXOS_OPTION_NIX" ]]; then
+        _iError "nixos-option.nix not found."
+        exit 1
+    fi
+
+    for path in "${paths[@]}"; do
+        nix-instantiate --eval --json \
+            --arg nixos "$modulesExpr" \
+            --argstr path "$path" \
+            --arg recursive "$recursive" \
+            "$NIXOS_OPTION_NIX" \
+        | jq -r
+    done
 }
 
 function doInit() {
@@ -1063,8 +1098,10 @@ function doHelp() {
     echo
     echo "  edit         Open the home configuration in \$VISUAL or \$EDITOR"
     echo
-    echo "  option OPTION.NAME"
+    echo "  option [--recursive] OPTION.NAME"
     echo "               Inspect configuration option named OPTION.NAME."
+    echo
+    echo "      --recursive   Print all the values at or below the option name recursively."
     echo
     echo "  build        Build configuration into result directory"
     echo
@@ -1203,6 +1240,16 @@ while [[ $# -gt 0 ]]; do
                     ;;
                 *)
                     errTopLevelSubcommandOpt "--specialisation" "switch"
+                    ;;
+            esac
+            ;;
+        --recursive)
+            case $COMMAND in
+                option)
+                    COMMAND_ARGS+=("$opt")
+                    ;;
+                *)
+                    errTopLevelSubcommandOpt "--recursive" "option"
                     ;;
             esac
             ;;


### PR DESCRIPTION
- calls nix-instatiate instead of nixos-option (using nix-option's underlying nix script).
- loops over options to display since nixos-option can only process a single option.
- passes through the --recursive flag from nixos-option. and includes --help and man page for the flag.

details:

nixos-option was changed from a C++ command to a shell script that feeds a nix script (with arguments) to nix-instatiate. in the process, the --config_expr and --options_expr we once passed to nixos-option were removed.

without changing the nixos-option shell script, we have no may to override the arguments to the nixos-option nix script.

luckily, we can use our modulesExpr as a direct argument to the new nixos-option nix script.

unluckily, the nix script does not accept multiple options per instantiation. so we are also looping through the given options ourselves and feeding them each to nixos-option's nix script.

the nixos-option shell and nix scripts are in different places in the nix store, so we have to search the store for the nix script given the location of the shell script.

also, the nixos-option nix script wants a 'recursive' flag, so we now honor that flag for the home-manager option subcommand.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
