### PR TITLE
intelli-shell: fix config file location on macos

### DIFF
--- a/modules/programs/intelli-shell.nix
+++ b/modules/programs/intelli-shell.nix
@@ -80,7 +80,7 @@ in
     let
       configPath =
         if pkgs.stdenv.hostPlatform.isDarwin then
-          "Library/Preferences/org.IntelliShell.Intelli-Shell"
+          "Library/Application Support/org.IntelliShell.Intelli-Shell"
         else
           ".config/intelli-shell";
     in

--- a/tests/modules/programs/intelli-shell/settings.nix
+++ b/tests/modules/programs/intelli-shell/settings.nix
@@ -27,13 +27,13 @@
     let
       configPath =
         if pkgs.stdenv.hostPlatform.isDarwin then
-          "Library/Preferences/org.IntelliShell.Intelli-Shell"
+          "Library/Application Support/org.IntelliShell.Intelli-Shell"
         else
           ".config/intelli-shell";
     in
     ''
-      assertFileExists home-files/${configPath}/config.toml
-      assertFileContent home-files/${configPath}/config.toml \
+      assertFileExists 'home-files/${configPath}/config.toml'
+      assertFileContent 'home-files/${configPath}/config.toml' \
         ${./config.toml}
     '';
 }


### PR DESCRIPTION
### Description

intelli-shel default location for _config.toml_ on macOS is `~/Library/Application Support/org.IntelliShell.Intelli-Shell/config.toml` according to the [doc](https://lasantosr.github.io/intelli-shell/configuration/index.html). 

Update the module to put the config in the right folder.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
