### PR TITLE
mergiraf: add merge.conflictStyle git configuration

### DIFF
--- a/modules/programs/mergiraf.nix
+++ b/modules/programs/mergiraf.nix
@@ -30,9 +30,12 @@ in
     programs.git = {
       attributes = [ "* merge=mergiraf" ];
       extraConfig = {
-        merge.mergiraf = {
-          name = "mergiraf";
-          driver = "${mergiraf} merge --git %O %A %B -s %S -x %X -y %Y -p %P -l %L";
+        merge = {
+          mergiraf = {
+            name = "mergiraf";
+            driver = "${mergiraf} merge --git %O %A %B -s %S -x %X -y %Y -p %P -l %L";
+          };
+          conflictStyle = "diff3";
         };
       };
     };

--- a/tests/modules/programs/mergiraf/mergiraf-git.conf
+++ b/tests/modules/programs/mergiraf/mergiraf-git.conf
@@ -4,6 +4,9 @@
 [gpg "openpgp"]
 	program = "@gnupg@/bin/gpg"
 
+[merge]
+	conflictStyle = "diff3"
+
 [merge "mergiraf"]
 	driver = "@mergiraf@/bin/mergiraf merge --git %O %A %B -s %S -x %X -y %Y -p %P -l %L"
 	name = "mergiraf"


### PR DESCRIPTION
### Description

Fixes https://github.com/nix-community/home-manager/issues/7993

Before this change people had to know to change `merge.conflictStyle = "diff3"` in git's configuration. This is documented by mergiraf here: https://github.com/nix-community/home-manager/issues/7993

Now this configuration is set by enabling mergiraf in home-manager. Whenever someone has set this to something else, a conflict arises, forcing the user to choose whether to override this value or disable mergiraf. So in that sense it isn't backwards compatible: it will show a configuration error when mergiraf wouldn't have been able to operate correctly, while previously this was ignored.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [-] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
