### PR TITLE
anki: fix boolean options

### DIFF
--- a/modules/programs/anki/helper.nix
+++ b/modules/programs/anki/helper.nix
@@ -6,6 +6,16 @@
 }:
 let
   cfg = config.programs.anki;
+
+  # Convert Nix `nullOr bool` to Python types.
+  pyOptionalBool =
+    val:
+    if val == null then
+      "None"
+    else if val then
+      "True"
+    else
+      "False";
   # This script generates the Anki SQLite settings DB using the Anki Python API.
   # The configuration options in the SQLite database take the form of Python
   # Pickle data.
@@ -60,9 +70,9 @@ let
     if ui_scale_str:
       profile_manager.setUiScale(float(ui_scale_str))
 
-    hide_top_bar_str: str = "${toString cfg.hideTopBar}"
-    if hide_top_bar_str:
-      profile_manager.set_hide_top_bar(bool(hide_top_bar_str))
+    hide_top_bar: bool | None = ${pyOptionalBool cfg.hideTopBar}
+    if hide_top_bar is not None:
+      profile_manager.set_hide_top_bar(hide_top_bar)
 
     hide_top_bar_mode_str: str = "${toString cfg.hideTopBarMode}"
     if hide_top_bar_mode_str:
@@ -72,9 +82,9 @@ let
       }[hide_top_bar_mode_str]
       profile_manager.set_top_bar_hide_mode(hide_mode)
 
-    hide_bottom_bar_str: str = "${toString cfg.hideBottomBar}"
-    if hide_bottom_bar_str:
-      profile_manager.set_hide_bottom_bar(bool(hide_bottom_bar_str))
+    hide_bottom_bar: bool | None = ${pyOptionalBool cfg.hideBottomBar}
+    if hide_bottom_bar is not None:
+      profile_manager.set_hide_bottom_bar(hide_bottom_bar)
 
     hide_bottom_bar_mode_str: str = "${toString cfg.hideBottomBarMode}"
     if hide_bottom_bar_mode_str:
@@ -84,21 +94,21 @@ let
       }[hide_bottom_bar_mode_str]
       profile_manager.set_bottom_bar_hide_mode(hide_mode)
 
-    reduce_motion_str: str = "${toString cfg.reduceMotion}"
-    if reduce_motion_str:
-      profile_manager.set_reduce_motion(bool(reduce_motion_str))
+    reduce_motion: bool | None = ${pyOptionalBool cfg.reduceMotion}
+    if reduce_motion is not None:
+      profile_manager.set_reduce_motion(reduce_motion)
 
-    minimalist_mode_str: str = "${toString cfg.minimalistMode}"
-    if minimalist_mode_str:
-      profile_manager.set_minimalist_mode(bool(minimalist_mode_str))
+    minimalist_mode: bool | None = ${pyOptionalBool cfg.minimalistMode}
+    if minimalist_mode is not None:
+      profile_manager.set_minimalist_mode(minimalist_mode)
 
-    spacebar_rates_card_str: str = "${toString cfg.spacebarRatesCard}"
-    if spacebar_rates_card_str:
-      profile_manager.set_spacebar_rates_card(bool(spacebar_rates_card_str))
+    spacebar_rates_card: bool | None = ${pyOptionalBool cfg.spacebarRatesCard}
+    if spacebar_rates_card is not None:
+      profile_manager.set_spacebar_rates_card(spacebar_rates_card)
 
-    legacy_import_export_str: str = "${toString cfg.legacyImportExport}"
-    if legacy_import_export_str:
-      profile_manager.set_legacy_import_export(bool(legacy_import_export_str))
+    legacy_import_export: bool | None = ${pyOptionalBool cfg.legacyImportExport}
+    if legacy_import_export is not None:
+      profile_manager.set_legacy_import_export(legacy_import_export)
 
     answer_keys: tuple[tuple[int, str], ...] = (${
       lib.strings.concatMapStringsSep ", " (val: "(${toString val.ease}, '${val.key}')") cfg.answerKeys
@@ -114,13 +124,13 @@ let
     # Without this, the collection DB won't get automatically optimized.
     profile_manager.profile["lastOptimize"] = None
 
-    auto_sync_str: str = "${toString cfg.sync.autoSync}"
-    if auto_sync_str:
-      profile_manager.profile["autoSync"] = bool(auto_sync_str)
+    auto_sync: bool | None = ${pyOptionalBool cfg.sync.autoSync}
+    if auto_sync is not None:
+      profile_manager.profile["autoSync"] = auto_sync
 
-    sync_media_str: str = "${toString cfg.sync.syncMedia}"
-    if sync_media_str:
-      profile_manager.profile["syncMedia"] = bool(sync_media_str)
+    sync_media: bool | None = ${pyOptionalBool cfg.sync.syncMedia}
+    if sync_media is not None:
+      profile_manager.profile["syncMedia"] = sync_media
 
     media_sync_minutes_str: str = "${toString cfg.sync.autoSyncMediaMinutes}"
     if media_sync_minutes_str:


### PR DESCRIPTION
### Description

Previously, Anki boolean options only worked when they were `true` or `null`.

fixes #7992

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.