### PR TITLE
nixgl: fix wrapper name typo

### DIFF
--- a/modules/misc/nixgl.nix
+++ b/modules/misc/nixgl.nix
@@ -346,7 +346,7 @@ in
             ''
           ))
 
-          (lib.mkIf (wantsWrapper "nvidia") (
+          (lib.mkIf (wantsWrapper "nvidiaPrime") (
             pkgs.writeShellScriptBin "nixGLNvidiaPrime" ''
               ${envVarsAsScript nvOffloadEnv}
               exec ${getWrapperExe "Nvidia"} "$@"


### PR DESCRIPTION
### Description

Acknowledge nvidiaPrime when it is one of the wrappers in cfg.installScripts