### PR TITLE
mkFirefox: add policy to accept added extensions

### DIFF
--- a/modules/programs/firefox/mkFirefoxModule.nix
+++ b/modules/programs/firefox/mkFirefoxModule.nix
@@ -254,6 +254,54 @@ in
       description = "Upstream release version used to fetch from `releases.mozilla.org`.";
     };
 
+    globalExtensions = mkOption {
+      type = types.listOf (
+        types.oneOf [
+          types.package
+          (types.submodule {
+            options = {
+              package = mkOption {
+                type = types.package;
+              };
+
+              settings = mkOption {
+                type = types.attrsOf jsonFormat.type;
+                default = { };
+                description = "Json formatted options for this extension.";
+              };
+            };
+          })
+        ]
+      );
+      default = [ ];
+      example = literalExpression ''
+        with pkgs.nur.repos.rycee.firefox-addons; [
+          privacy-badger
+          {
+            package = ublock-origin;
+            settings = {
+              private_browsing = true;
+            };
+          }
+        ]
+      '';
+      description = ''
+        Add-on package to install under policies.
+        For a package to work here it needs and addonId exposed in it's passthru.
+        This will be included in all add-ons accessible from the Nix User Repository.
+        Once you have NUR installed run
+
+        ```console
+        $ nix-env -f '<nixpkgs>' -qaP -A nur.repos.rycee.firefox-addons
+        ```
+
+        to list the available ${name} add-ons.
+
+        Installing extensions this way will automatically enable extensions
+        inside ${name} after the first installation.
+      '';
+    };
+
     languagePacks = mkOption {
       type = types.listOf types.str;
       default = [ ];
@@ -373,7 +421,11 @@ in
     profiles = mkOption {
       type = types.attrsOf (
         types.submodule (
-          { config, name, ... }:
+          {
+            config,
+            name,
+            ...
+          }:
           let
             profilePath = modulePath ++ [
               "profiles"
@@ -905,7 +957,10 @@ in
                 ]
               ) config.extensions.packages)
               ++ (builtins.concatMap (
-                { name, value }:
+                {
+                  name,
+                  value,
+                }:
                 let
                   packages = builtins.filter (pkg: (pkg.addonId or pkg.name) == name) config.extensions.packages;
                 in
@@ -1009,6 +1064,17 @@ in
           '';
         }
 
+        {
+          assertion = builtins.all (
+            elem:
+            let
+              package = elem.package or elem;
+            in
+            package ? addonId
+          ) cfg.globalExtensions;
+          message = "${moduleName}.globalExtensions requires each package to expose addonId in passthru.";
+        }
+
         (mkNoDuplicateAssertion cfg.profiles "profile")
       ]
       ++ (lib.concatMap (profile: profile.assertions) (attrValues cfg.profiles));
@@ -1078,7 +1144,6 @@ in
         );
       targets.darwin.defaults = (
         mkIf (cfg.darwinDefaultsId != null && isDarwin) {
-
           ${cfg.darwinDefaultsId} = {
             EnterprisePoliciesEnabled = true;
           }
@@ -1185,17 +1250,38 @@ in
         NoDefaultBookmarks = lib.mkIf (builtins.any (profile: profile.bookmarks.enable) (
           builtins.attrValues cfg.profiles
         )) false;
-        ExtensionSettings = lib.mkIf (cfg.languagePacks != [ ]) (
-          lib.listToAttrs (
-            map (
-              lang:
-              lib.nameValuePair "langpack-${lang}@firefox.mozilla.org" {
-                installation_mode = "normal_installed";
-                install_url = "https://releases.mozilla.org/pub/firefox/releases/${cfg.release}/linux-x86_64/xpi/${lang}.xpi";
-              }
-            ) cfg.languagePacks
-          )
-        );
+        ExtensionSettings = mkMerge [
+          (lib.mkIf (cfg.languagePacks != [ ]) (
+            lib.listToAttrs (
+              map (
+                lang:
+                lib.nameValuePair "langpack-${lang}@firefox.mozilla.org" {
+                  installation_mode = "normal_installed";
+                  install_url = "https://releases.mozilla.org/pub/firefox/releases/${cfg.release}/linux-x86_64/xpi/${lang}.xpi";
+                }
+              ) cfg.languagePacks
+            )
+          ))
+
+          (lib.mkIf (cfg.globalExtensions != [ ]) (
+            lib.listToAttrs (
+              map (
+                elem:
+                let
+                  package = elem.package or elem;
+                  settings = elem.settings or { };
+                in
+                lib.nameValuePair package.addonId (
+                  {
+                    installation_mode = "force_installed";
+                    install_url = "file://${package.outPath}/share/mozilla/${extensionPath}/${package.addonId}.xpi";
+                  }
+                  // settings
+                )
+              ) (builtins.filter (elem: (elem.package or elem) ? addonId) cfg.globalExtensions)
+            )
+          ))
+        ];
       };
     }
   );

--- a/tests/modules/programs/firefox/common.nix
+++ b/tests/modules/programs/firefox/common.nix
@@ -22,6 +22,7 @@ builtins.mapAttrs
     "${name}-deprecated-native-messenger" = ./deprecated-native-messenger.nix;
     "${name}-null-package" = ./null-package.nix;
     "${name}-final-package" = ./final-package.nix;
+    "${name}-global-extensions-assertions" = ./global-extensions-assertions.nix;
     "${name}-policies" = ./policies.nix;
     "${name}-profiles-bookmarks" = ./profiles/bookmarks;
     "${name}-profiles-bookmarks-attrset" = ./profiles/bookmarks/attrset.nix;

--- a/tests/modules/programs/firefox/global-extensions-assertions.nix
+++ b/tests/modules/programs/firefox/global-extensions-assertions.nix
@@ -1,0 +1,25 @@
+modulePath:
+{ config, lib, ... }:
+
+let
+  firefoxMockOverlay = import ./setup-firefox-mock-overlay.nix modulePath;
+
+  extensionWithoutAddonId = config.lib.test.mkStubPackage {
+    name = "extension-without-addon-id";
+  };
+in
+{
+  imports = [ firefoxMockOverlay ];
+
+  config = lib.mkIf config.test.enableBig (
+    lib.setAttrByPath modulePath {
+      enable = true;
+      globalExtensions = [ extensionWithoutAddonId ];
+    }
+    // {
+      test.asserts.assertions.expected = [
+        "${lib.showOption modulePath}.globalExtensions requires each package to expose addonId in passthru."
+      ];
+    }
+  );
+}

--- a/tests/modules/programs/firefox/policies.nix
+++ b/tests/modules/programs/firefox/policies.nix
@@ -11,6 +11,16 @@ let
   firefoxMockOverlay = import ./setup-firefox-mock-overlay.nix modulePath;
 
   darwinPath = "Applications/${cfg.darwinAppName}.app/Contents/Resources";
+
+  uBlockStubPkg = config.lib.test.mkStubPackage {
+    name = "ublock-origin-dummy";
+    extraAttrs.addonId = "uBlock0@raymondhill.net";
+  };
+
+  privacyBadgerStubPkg = config.lib.test.mkStubPackage {
+    name = "privacy-badger-dummy";
+    extraAttrs.addonId = "jid1-MnnxcxisBPnSXQ@jetpack";
+  };
 in
 {
   imports = [ firefoxMockOverlay ];
@@ -22,6 +32,16 @@ in
       policies = {
         BlockAboutConfig = true;
       };
+      globalExtensions = [
+        uBlockStubPkg
+        {
+          package = privacyBadgerStubPkg;
+          settings = {
+            default_area = "menupanel";
+            private_browsing = true;
+          };
+        }
+      ];
       package = pkgs.${cfg.wrappedPackageName}.override {
         extraPolicies = {
           DownloadDirectory = "/foo";
@@ -61,6 +81,31 @@ in
 
           if [[ $downloadDirectory_actual_value != "\"/foo\"" ]]; then
             fail "Expected '${config_file}' to set 'policies.DownloadDirectory' to \"/foo\""
+          fi
+
+          ublock_installation_mode="$($jq --arg extid "${uBlockStubPkg.addonId}" ".policies.ExtensionSettings[\$extid].installation_mode" ${config_file})"
+
+          if [[ $ublock_installation_mode != "\"force_installed\"" ]]; then
+            fail "Expected '${config_file}' to force-install ${uBlockStubPkg.addonId}"
+          fi
+
+          ublock_install_url="$($jq --arg extid "${uBlockStubPkg.addonId}" ".policies.ExtensionSettings[\$extid].install_url" ${config_file})"
+          expected_ublock_install_url="\"file://${uBlockStubPkg}/share/mozilla/extensions/{ec8030f7-c20a-464f-9b0e-13a3a9e97384}/${uBlockStubPkg.addonId}.xpi\""
+
+          if [[ $ublock_install_url != "$expected_ublock_install_url" ]]; then
+            fail "Expected '${config_file}' to set install_url for ${uBlockStubPkg.addonId}"
+          fi
+
+          privacy_badger_private_browsing="$($jq --arg extid "${privacyBadgerStubPkg.addonId}" ".policies.ExtensionSettings[\$extid].private_browsing" ${config_file})"
+
+          if [[ $privacy_badger_private_browsing != "true" ]]; then
+            fail "Expected '${config_file}' to preserve custom settings for ${privacyBadgerStubPkg.addonId}"
+          fi
+
+          privacy_badger_default_area="$($jq --arg extid "${privacyBadgerStubPkg.addonId}" ".policies.ExtensionSettings[\$extid].default_area" ${config_file})"
+
+          if [[ $privacy_badger_default_area != "\"menupanel\"" ]]; then
+            fail "Expected '${config_file}' to preserve default_area for ${privacyBadgerStubPkg.addonId}"
           fi
         '';
     }


### PR DESCRIPTION
This commit adds extensions added via
profiles.<name>.extensions.packages to the policy. In consequence, the extensions are added without complaint and don't need to be enabled manually.

### Description

While switching browser, I noticed that the current method of installing extensions, does not enable them. This is because the only firefox is allowed to install extensions, and it only provides one way to do so automatically.
As such, I have improved the method of installing extensions by using the intended way by mozilla to do this, without sacrificing reproducibility. This is achieved by "downloading" extensions from the nix store.

### NOTE:
- The extensionPath uuid constant became obsolete through this because extensions don't need to be bundled anymore.
This involves @rycee to change his convenient output derivations for firefox modules.
- This change relies on the fact that firefox modules from @rycee NUR repository expose a addonId. This needs to be documented somewhere
- `nix fmt .` made some unnecessary changes.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef). (not applicable)

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```
  Maintainers and Involved:
  @chayleaf
  @onny
  @brckd 
  @kira-bruneau 