### PR TITLE
opencode: add themes option

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -114,7 +114,7 @@ in
       description = ''
         Custom agents for opencode.
         The attribute name becomes the agent filename, and the value is either:
-        - Inline content as a string  
+        - Inline content as a string
         - A path to a file containing the agent content
         Agents are stored in ~/.config/opencode/agent/ directory.
       '';
@@ -137,6 +137,16 @@ in
       '';
     };
 
+    themes = mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      description = ''
+        Custom themes for opencode. The attribute name becomes the theme filename.
+        Themes are stored in {file}`$XDG_CONFIG_HOME/opencode/themes/` directory.
+        Set `programs.opencode.settings.theme` to enable the custom theme.
+        See <https://opencode.ai/docs/themes/> for the documentation.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -167,6 +177,17 @@ in
       lib.nameValuePair "opencode/agent/${name}.md" (
         if lib.isPath content then { source = content; } else { text = content; }
       )
-    ) cfg.agents;
+    ) cfg.agents
+    // lib.mapAttrs' (
+      name: content:
+      lib.nameValuePair "opencode/themes/${name}.json" {
+        source = jsonFormat.generate "opencode-${name}.json" (
+          {
+            "$schema" = "https://opencode.ai/theme.json";
+          }
+          // content
+        );
+      }
+    ) cfg.themes;
   };
 }

--- a/tests/modules/programs/opencode/default.nix
+++ b/tests/modules/programs/opencode/default.nix
@@ -8,4 +8,5 @@
   opencode-agents-path = ./agents-path.nix;
   opencode-commands-path = ./commands-path.nix;
   opencode-mixed-content = ./mixed-content.nix;
+  opencode-themes = ./themes.nix;
 }

--- a/tests/modules/programs/opencode/empty-themes.nix
+++ b/tests/modules/programs/opencode/empty-themes.nix
@@ -1,0 +1,9 @@
+{
+  programs.opencode = {
+    enable = true;
+    themes = { };
+  };
+  nmt.script = ''
+    assertPathNotExists home-files/.config/opencode/themes
+  '';
+}

--- a/tests/modules/programs/opencode/my-theme.json
+++ b/tests/modules/programs/opencode/my-theme.json
@@ -1,0 +1,223 @@
+{
+  "$schema": "https://opencode.ai/theme.json",
+  "defs": {
+    "nord0": "#2E3440",
+    "nord1": "#3B4252",
+    "nord10": "#5E81AC",
+    "nord11": "#BF616A",
+    "nord12": "#D08770",
+    "nord13": "#EBCB8B",
+    "nord14": "#A3BE8C",
+    "nord15": "#B48EAD",
+    "nord2": "#434C5E",
+    "nord3": "#4C566A",
+    "nord4": "#D8DEE9",
+    "nord5": "#E5E9F0",
+    "nord6": "#ECEFF4",
+    "nord7": "#8FBCBB",
+    "nord8": "#88C0D0",
+    "nord9": "#81A1C1"
+  },
+  "theme": {
+    "accent": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "background": {
+      "dark": "nord0",
+      "light": "nord6"
+    },
+    "backgroundElement": {
+      "dark": "nord1",
+      "light": "nord4"
+    },
+    "backgroundPanel": {
+      "dark": "nord1",
+      "light": "nord5"
+    },
+    "border": {
+      "dark": "nord2",
+      "light": "nord3"
+    },
+    "borderActive": {
+      "dark": "nord3",
+      "light": "nord2"
+    },
+    "borderSubtle": {
+      "dark": "nord2",
+      "light": "nord3"
+    },
+    "diffAdded": {
+      "dark": "nord14",
+      "light": "nord14"
+    },
+    "diffAddedBg": {
+      "dark": "#3B4252",
+      "light": "#E5E9F0"
+    },
+    "diffAddedLineNumberBg": {
+      "dark": "#3B4252",
+      "light": "#E5E9F0"
+    },
+    "diffContext": {
+      "dark": "nord3",
+      "light": "nord3"
+    },
+    "diffContextBg": {
+      "dark": "nord1",
+      "light": "nord5"
+    },
+    "diffHighlightAdded": {
+      "dark": "nord14",
+      "light": "nord14"
+    },
+    "diffHighlightRemoved": {
+      "dark": "nord11",
+      "light": "nord11"
+    },
+    "diffHunkHeader": {
+      "dark": "nord3",
+      "light": "nord3"
+    },
+    "diffLineNumber": {
+      "dark": "nord2",
+      "light": "nord4"
+    },
+    "diffRemoved": {
+      "dark": "nord11",
+      "light": "nord11"
+    },
+    "diffRemovedBg": {
+      "dark": "#3B4252",
+      "light": "#E5E9F0"
+    },
+    "diffRemovedLineNumberBg": {
+      "dark": "#3B4252",
+      "light": "#E5E9F0"
+    },
+    "error": {
+      "dark": "nord11",
+      "light": "nord11"
+    },
+    "info": {
+      "dark": "nord8",
+      "light": "nord10"
+    },
+    "markdownBlockQuote": {
+      "dark": "nord3",
+      "light": "nord3"
+    },
+    "markdownCode": {
+      "dark": "nord14",
+      "light": "nord14"
+    },
+    "markdownCodeBlock": {
+      "dark": "nord4",
+      "light": "nord0"
+    },
+    "markdownEmph": {
+      "dark": "nord12",
+      "light": "nord12"
+    },
+    "markdownHeading": {
+      "dark": "nord8",
+      "light": "nord10"
+    },
+    "markdownHorizontalRule": {
+      "dark": "nord3",
+      "light": "nord3"
+    },
+    "markdownImage": {
+      "dark": "nord9",
+      "light": "nord9"
+    },
+    "markdownImageText": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "markdownLink": {
+      "dark": "nord9",
+      "light": "nord9"
+    },
+    "markdownLinkText": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "markdownListEnumeration": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "markdownListItem": {
+      "dark": "nord8",
+      "light": "nord10"
+    },
+    "markdownStrong": {
+      "dark": "nord13",
+      "light": "nord13"
+    },
+    "markdownText": {
+      "dark": "nord4",
+      "light": "nord0"
+    },
+    "primary": {
+      "dark": "nord8",
+      "light": "nord10"
+    },
+    "secondary": {
+      "dark": "nord9",
+      "light": "nord9"
+    },
+    "success": {
+      "dark": "nord14",
+      "light": "nord14"
+    },
+    "syntaxComment": {
+      "dark": "nord3",
+      "light": "nord3"
+    },
+    "syntaxFunction": {
+      "dark": "nord8",
+      "light": "nord8"
+    },
+    "syntaxKeyword": {
+      "dark": "nord9",
+      "light": "nord9"
+    },
+    "syntaxNumber": {
+      "dark": "nord15",
+      "light": "nord15"
+    },
+    "syntaxOperator": {
+      "dark": "nord9",
+      "light": "nord9"
+    },
+    "syntaxPunctuation": {
+      "dark": "nord4",
+      "light": "nord0"
+    },
+    "syntaxString": {
+      "dark": "nord14",
+      "light": "nord14"
+    },
+    "syntaxType": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "syntaxVariable": {
+      "dark": "nord7",
+      "light": "nord7"
+    },
+    "text": {
+      "dark": "nord4",
+      "light": "nord0"
+    },
+    "textMuted": {
+      "dark": "nord3",
+      "light": "nord1"
+    },
+    "warning": {
+      "dark": "nord12",
+      "light": "nord12"
+    }
+  }
+}

--- a/tests/modules/programs/opencode/themes.nix
+++ b/tests/modules/programs/opencode/themes.nix
@@ -1,0 +1,232 @@
+{
+  nmt.script = ''
+    assertFileExists home-files/.config/opencode/themes/my-theme.json
+    assertFileContent home-files/.config/opencode/themes/my-theme.json \
+      ${./my-theme.json}
+  '';
+  programs.opencode = {
+    enable = true;
+    themes.my-theme = {
+      defs = {
+        nord0 = "#2E3440";
+        nord1 = "#3B4252";
+        nord10 = "#5E81AC";
+        nord11 = "#BF616A";
+        nord12 = "#D08770";
+        nord13 = "#EBCB8B";
+        nord14 = "#A3BE8C";
+        nord15 = "#B48EAD";
+        nord2 = "#434C5E";
+        nord3 = "#4C566A";
+        nord4 = "#D8DEE9";
+        nord5 = "#E5E9F0";
+        nord6 = "#ECEFF4";
+        nord7 = "#8FBCBB";
+        nord8 = "#88C0D0";
+        nord9 = "#81A1C1";
+      };
+      theme = {
+        accent = {
+          dark = "nord7";
+          light = "nord7";
+        };
+        background = {
+          dark = "nord0";
+          light = "nord6";
+        };
+        backgroundElement = {
+          dark = "nord1";
+          light = "nord4";
+        };
+        backgroundPanel = {
+          dark = "nord1";
+          light = "nord5";
+        };
+        border = {
+          dark = "nord2";
+          light = "nord3";
+        };
+        borderActive = {
+          dark = "nord3";
+          light = "nord2";
+        };
+        borderSubtle = {
+          dark = "nord2";
+          light = "nord3";
+        };
+        diffAdded = {
+          dark = "nord14";
+          light = "nord14";
+        };
+        diffAddedBg = {
+          dark = "#3B4252";
+          light = "#E5E9F0";
+        };
+        diffAddedLineNumberBg = {
+          dark = "#3B4252";
+          light = "#E5E9F0";
+        };
+        diffContext = {
+          dark = "nord3";
+          light = "nord3";
+        };
+        diffContextBg = {
+          dark = "nord1";
+          light = "nord5";
+        };
+        diffHighlightAdded = {
+          dark = "nord14";
+          light = "nord14";
+        };
+        diffHighlightRemoved = {
+          dark = "nord11";
+          light = "nord11";
+        };
+        diffHunkHeader = {
+          dark = "nord3";
+          light = "nord3";
+        };
+        diffLineNumber = {
+          dark = "nord2";
+          light = "nord4";
+        };
+        diffRemoved = {
+          dark = "nord11";
+          light = "nord11";
+        };
+        diffRemovedBg = {
+          dark = "#3B4252";
+          light = "#E5E9F0";
+        };
+        diffRemovedLineNumberBg = {
+          dark = "#3B4252";
+          light = "#E5E9F0";
+        };
+        error = {
+          dark = "nord11";
+          light = "nord11";
+        };
+        info = {
+          dark = "nord8";
+          light = "nord10";
+        };
+        markdownBlockQuote = {
+          dark = "nord3";
+          light = "nord3";
+        };
+        markdownCode = {
+          dark = "nord14";
+          light = "nord14";
+        };
+        markdownCodeBlock = {
+          dark = "nord4";
+          light = "nord0";
+        };
+        markdownEmph = {
+          dark = "nord12";
+          light = "nord12";
+        };
+        markdownHeading = {
+          dark = "nord8";
+          light = "nord10";
+        };
+        markdownHorizontalRule = {
+          dark = "nord3";
+          light = "nord3";
+        };
+        markdownImage = {
+          dark = "nord9";
+          light = "nord9";
+        };
+        markdownImageText = {
+          dark = "nord7";
+          light = "nord7";
+        };
+        markdownLink = {
+          dark = "nord9";
+          light = "nord9";
+        };
+        markdownLinkText = {
+          dark = "nord7";
+          light = "nord7";
+        };
+        markdownListEnumeration = {
+          dark = "nord7";
+          light = "nord7";
+        };
+        markdownListItem = {
+          dark = "nord8";
+          light = "nord10";
+        };
+        markdownStrong = {
+          dark = "nord13";
+          light = "nord13";
+        };
+        markdownText = {
+          dark = "nord4";
+          light = "nord0";
+        };
+        primary = {
+          dark = "nord8";
+          light = "nord10";
+        };
+        secondary = {
+          dark = "nord9";
+          light = "nord9";
+        };
+        success = {
+          dark = "nord14";
+          light = "nord14";
+        };
+        syntaxComment = {
+          dark = "nord3";
+          light = "nord3";
+        };
+        syntaxFunction = {
+          dark = "nord8";
+          light = "nord8";
+        };
+        syntaxKeyword = {
+          dark = "nord9";
+          light = "nord9";
+        };
+        syntaxNumber = {
+          dark = "nord15";
+          light = "nord15";
+        };
+        syntaxOperator = {
+          dark = "nord9";
+          light = "nord9";
+        };
+        syntaxPunctuation = {
+          dark = "nord4";
+          light = "nord0";
+        };
+        syntaxString = {
+          dark = "nord14";
+          light = "nord14";
+        };
+        syntaxType = {
+          dark = "nord7";
+          light = "nord7";
+        };
+        syntaxVariable = {
+          dark = "nord7";
+          light = "nord7";
+        };
+        text = {
+          dark = "nord4";
+          light = "nord0";
+        };
+        textMuted = {
+          dark = "nord3";
+          light = "nord1";
+        };
+        warning = {
+          dark = "nord12";
+          light = "nord12";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Add themes option to configure custom themes through nix. Define a submodule for the settings option, to give the `theme` setting a description.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)

@delafthi 