### PR TITLE
opencode: change tilde (~) to `XDG_CONFIG_DIR` for command and agent paths

### DIFF
--- a/modules/programs/opencode.nix
+++ b/modules/programs/opencode.nix
@@ -87,7 +87,7 @@ in
         The attribute name becomes the command filename, and the value is either:
         - Inline content as a string
         - A path to a file containing the command content
-        Commands are stored in ~/.config/opencode/command/ directory.
+        Commands are stored in {file}`$XDG_CONFIG_HOME/.config/opencode/command/` directory.
       '';
       example = lib.literalExpression ''
         {
@@ -114,9 +114,9 @@ in
       description = ''
         Custom agents for opencode.
         The attribute name becomes the agent filename, and the value is either:
-        - Inline content as a string  
+        - Inline content as a string
         - A path to a file containing the agent content
-        Agents are stored in ~/.config/opencode/agent/ directory.
+        Agents are stored in {file}`$XDG_CONFIG_HOME/.config/opencode/agent/` directory.
       '';
       example = lib.literalExpression ''
         {


### PR DESCRIPTION
Replace the use of `~` in the documentation for the command and agent settings with the `XDG_CONFIG_DIR` environment variable to avoid ambiguity about the config directory. Also switch to the `{file}` path macro so paths render correctly in the docs and tooling.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
