### PR TITLE
restic: add platform assertion (linux)

### DIFF
--- a/modules/services/restic.nix
+++ b/modules/services/restic.nix
@@ -327,10 +327,17 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    assertions = lib.mapAttrsToList (n: v: {
-      assertion = lib.xor (v.repository == null) (v.repositoryFile == null);
-      message = "services.restic.backups.${n}: exactly one of repository or repositoryFile should be set";
-    }) cfg.backups;
+    assertions = lib.flatten [
+      (lib.mapAttrsToList (n: v: {
+        assertion = lib.xor (v.repository == null) (v.repositoryFile == null);
+        message = "services.restic.backups.${n}: exactly one of repository or repositoryFile should be set";
+      }) cfg.backups)
+
+      {
+        assertion = pkgs.stdenv.hostPlatform.isLinux;
+        message = "services.restic: linux is currently the only supported platform";
+      }
+    ];
 
     systemd.user.services = lib.mapAttrs' (
       name: backup:


### PR DESCRIPTION
### Description
#7923
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
