### PR TITLE
Add Justfile listing common commands

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,16 @@
+# Common commands
+#
+# Contributing manual:
+# - https://nix-community.github.io/home-manager/#ch-contributing
+
+# List tests matching a pattern `pattern`
+list *pattern:
+  nix run .#tests -- -l {{pattern}}
+
+# Run all tests matching a pattern `pattern`
+test *pattern:
+  nix run .#tests -- {{pattern}}
+
+# Run integration tests
+integration_tests:
+  nix run .#tests -- -t -l


### PR DESCRIPTION
### Description

This just lists the commands in the Contributing manual

### Checklist

- [x] Change is backwards compatible.
  - Trivially

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.
  - Doesn't apply, but it passed on my pre-commit hook

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
  - I don't think this is necessary

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  - Not necessary

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
  - N/A

- If this PR adds an exciting new feature or contains a breaking change.
  - N/A