### PR TITLE
fix(zellij): Allow using extraConfig without settings

### DIFF
--- a/modules/programs/zellij.nix
+++ b/modules/programs/zellij.nix
@@ -274,12 +274,15 @@ in
         {
 
           "zellij/config.yaml" =
-            mkIf (cfg.settings != { } && (lib.versionOlder cfg.package.version "0.32.0"))
+            mkIf ((lib.versionOlder cfg.package.version "0.32.0") && cfg.settings != { })
               {
                 source = yamlFormat.generate "zellij.yaml" cfg.settings;
               };
           "zellij/config.kdl" =
-            mkIf (cfg.settings != { } && (lib.versionAtLeast cfg.package.version "0.32.0"))
+            mkIf
+              (
+                (lib.versionAtLeast cfg.package.version "0.32.0") && (cfg.settings != { } || cfg.extraConfig != "")
+              )
               {
                 text =
                   (lib.hm.generators.toKDL { } cfg.settings)

--- a/tests/modules/programs/zellij/config-extra_config.nix
+++ b/tests/modules/programs/zellij/config-extra_config.nix
@@ -1,0 +1,29 @@
+{
+  programs = {
+    zellij = {
+      enable = true;
+
+      # No `settings`
+      extraConfig = ''
+        This_could_have_been_json {
+        }
+      '';
+    };
+  };
+
+  test.stubs = {
+    zellij = { };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/zellij/config.kdl
+
+    assertFileContains \
+      home-files/.config/zellij/config.kdl \
+      '// extraConfig'
+
+    assertFileContains \
+      home-files/.config/zellij/config.kdl \
+      'This_could_have_been_json'
+  '';
+}

--- a/tests/modules/programs/zellij/config-mixed.nix
+++ b/tests/modules/programs/zellij/config-mixed.nix
@@ -1,0 +1,35 @@
+{
+  programs = {
+    zellij = {
+      enable = true;
+
+      settings = {
+        default_layout = "welcome";
+      };
+      extraConfig = ''
+        This_could_have_been_json {
+        }
+      '';
+    };
+  };
+
+  test.stubs = {
+    zellij = { };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/zellij/config.kdl
+
+    assertFileContains \
+      home-files/.config/zellij/config.kdl \
+      'default_layout "welcome"'
+
+    assertFileContains \
+      home-files/.config/zellij/config.kdl \
+      '// extraConfig'
+
+    assertFileContains \
+      home-files/.config/zellij/config.kdl \
+      'This_could_have_been_json'
+  '';
+}

--- a/tests/modules/programs/zellij/config-settings.nix
+++ b/tests/modules/programs/zellij/config-settings.nix
@@ -1,5 +1,3 @@
-{ lib, ... }:
-
 {
   programs = {
     zellij = {
@@ -8,10 +6,7 @@
       settings = {
         default_layout = "welcome";
       };
-      extraConfig = ''
-        This_could_have_been_json {
-        }
-      '';
+      # No extraConfig
     };
   };
 
@@ -25,13 +20,5 @@
     assertFileContains \
       home-files/.config/zellij/config.kdl \
       'default_layout "welcome"'
-
-    assertFileContains \
-      home-files/.config/zellij/config.kdl \
-      '// extraConfig'
-
-    assertFileContains \
-      home-files/.config/zellij/config.kdl \
-      'This_could_have_been_json'
   '';
 }

--- a/tests/modules/programs/zellij/default.nix
+++ b/tests/modules/programs/zellij/default.nix
@@ -1,5 +1,7 @@
 {
-  zellij-config = ./config.nix;
+  zellij-config-mixed = ./config-mixed.nix;
+  zellij-config-settings = ./config-settings.nix;
+  zellij-config-extra_config = ./config-extra_config.nix;
   zellij-enable-shells = ./enable-shells.nix;
   zellij-layout = ./layout.nix;
   zellij-theme = ./theme.nix;


### PR DESCRIPTION
### Description

Fixes issue where `extraConfig` isn't applied if `settings` isn't specified.

See https://github.com/nix-community/home-manager/issues/8015 

### Checklist

- [x] Change is backwards compatible.
  - Sans keeping broken setups.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.
  - passed on pre-commit

- [-] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
  - All zellij tests pass. Didn't test the rest.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
  - Forked test to consider only `settings`, only `extraConfig`and both.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
  - It doesn't 

- If this PR adds an exciting new feature or contains a breaking change.
  - It doesn't
