### PR TITLE
hyprpanel: remove `dontAssertNotificationDaemons` option

### DIFF
--- a/modules/programs/hyprpanel/default.nix
+++ b/modules/programs/hyprpanel/default.nix
@@ -11,6 +11,13 @@ in
 {
   meta.maintainers = [ lib.maintainers.perchun ];
 
+  imports = [
+    (lib.mkRemovedOptionModule [ "programs" "hyprpanel" "dontAssertNotificationDaemons " ] ''
+      The hyprpanel never supported using it alongside other notification
+      daemons, so this option never truly worked.
+    '')
+  ];
+
   options.programs.hyprpanel = {
     enable = lib.mkEnableOption "HyprPanel";
 
@@ -52,42 +59,24 @@ in
     systemd.enable = lib.mkEnableOption "HyprPanel systemd integration" // {
       default = true;
     };
-
-    dontAssertNotificationDaemons = lib.mkOption {
-      default = false;
-      example = true;
-      description = ''
-        Whether to check for other notification daemons.
-
-        You might want to set this to false, because hyprpanel's notification
-        daemon is buggy and you may prefer something else.
-      '';
-      type = lib.types.bool;
-    };
   };
 
   config = lib.mkIf cfg.enable {
     assertions =
-      if !cfg.dontAssertNotificationDaemons then
-        let
-          notificationDaemons = [
-            "swaync"
-            "dunst"
-            "mako"
-          ];
-        in
-        builtins.map (name: {
-          assertion = !config.services.${name}.enable;
-          message = ''
-            Only one notification daemon can be enabled at once. You have enabled
-            ${name} and hyprpanel.
-
-            If you dont want to use hyprpanel's notification daemon, set
-            `programs.hyprpanel.dontAssertNotificationDaemons` to true.
-          '';
-        }) notificationDaemons
-      else
-        [ ];
+      let
+        notificationDaemons = [
+          "swaync"
+          "dunst"
+          "mako"
+        ];
+      in
+      builtins.map (name: {
+        assertion = !config.services.${name}.enable;
+        message = ''
+          Only one notification daemon can be enabled at once. You have enabled
+          ${name} and hyprpanel.
+        '';
+      }) notificationDaemons;
 
     home.packages = [ cfg.package ];
 


### PR DESCRIPTION
It didn't work anyway, and is now unnecessary as the upstream bugs were fixed

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
