### PR TITLE
restic: make sure pre and post hooks have interpreters

### DIFF
--- a/modules/services/restic.nix
+++ b/modules/services/restic.nix
@@ -491,7 +491,7 @@ in
                     set -x
 
                     ${lib.optionalString (backup.backupPrepareCommand != null) ''
-                      ${pkgs.writeScript "backupPrepareCommand" backup.backupPrepareCommand}
+                      ${pkgs.writeShellScript "backupPrepareCommand" backup.backupPrepareCommand}
                     ''}
 
                     ${lib.optionalString (backup.initialize) ''
@@ -508,7 +508,7 @@ in
                     ''}
 
                     ${lib.optionalString (backup.dynamicFilesFrom != null) ''
-                      ${pkgs.writeScript "dynamicFilesFromScript" backup.dynamicFilesFrom} >> ${filesFromTmpFile}
+                      ${pkgs.writeShellScript "dynamicFilesFromScript" backup.dynamicFilesFrom} >> ${filesFromTmpFile}
                     ''}
                   '';
                 }
@@ -522,7 +522,7 @@ in
                     set -x
 
                     ${lib.optionalString (backup.backupCleanupCommand != null) ''
-                      ${pkgs.writeScript "backupCleanupCommand" backup.backupCleanupCommand}
+                      ${pkgs.writeShellScript "backupCleanupCommand" backup.backupCleanupCommand}
                     ''}
                   '';
                 }


### PR DESCRIPTION
### Description
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
