### PR TITLE
zed-editor: option to generate immutable settings

### DIFF
--- a/tests/modules/programs/zed-editor/default.nix
+++ b/tests/modules/programs/zed-editor/default.nix
@@ -1,11 +1,15 @@
 {
   zed-extensions = ./extensions.nix;
+  zed-extensions-immutable = ./extensions-immutable.nix;
   zed-install-remote-server = ./install-remote-server.nix;
   zed-keymap = ./keymap.nix;
+  zed-keymap-immutable = ./keymap-immutable.nix;
   zed-keymap-empty = ./keymap-empty.nix;
   zed-settings = ./settings.nix;
+  zed-settings-immutable = ./settings-immutable.nix;
   zed-settings-empty = ./settings-empty.nix;
   zed-tasks = ./tasks.nix;
+  zed-tasks-immutable = ./tasks-immutable.nix;
   zed-tasks-empty = ./tasks-empty.nix;
   zed-themes = ./themes;
 }

--- a/tests/modules/programs/zed-editor/extensions-immutable.nix
+++ b/tests/modules/programs/zed-editor/extensions-immutable.nix
@@ -1,0 +1,31 @@
+{ config, ... }:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    mutableUserSettings = false;
+    extensions = [
+      "swift"
+      "html"
+      "xy-zed"
+    ];
+  };
+
+  nmt.script =
+    let
+      expectedContent = builtins.toFile "expected.json" ''
+        {
+          "auto_install_extensions": {
+            "html": true,
+            "swift": true,
+            "xy-zed": true
+          }
+        }
+      '';
+    in
+    ''
+      assertFileExists "home-files/.config/zed/settings.json"
+      assertFileContent "home-files/.config/zed/settings.json" "${expectedContent}"
+    '';
+}

--- a/tests/modules/programs/zed-editor/keymap-immutable.nix
+++ b/tests/modules/programs/zed-editor/keymap-immutable.nix
@@ -1,0 +1,48 @@
+# Test custom keymap functionality
+{ config, ... }:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    mutableUserKeymaps = false;
+    userKeymaps = [
+      {
+        bindings = {
+          up = "menu::SelectPrev";
+        };
+      }
+      {
+        context = "Editor";
+        bindings = {
+          escape = "editor::Cancel";
+        };
+      }
+    ];
+  };
+
+  nmt.script =
+    let
+      expectedContent = builtins.toFile "expected.json" ''
+        [
+          {
+            "bindings": {
+              "up": "menu::SelectPrev"
+            }
+          },
+          {
+            "bindings": {
+              "escape": "editor::Cancel"
+            },
+            "context": "Editor"
+          }
+        ]
+      '';
+
+      keymapPath = ".config/zed/keymap.json";
+    in
+    ''
+      assertFileExists "home-files/${keymapPath}"
+      assertFileContent "home-files/${keymapPath}" "${expectedContent}"
+    '';
+}

--- a/tests/modules/programs/zed-editor/settings-immutable.nix
+++ b/tests/modules/programs/zed-editor/settings-immutable.nix
@@ -1,0 +1,40 @@
+# Test custom keymap functionality
+{ config, ... }:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    mutableUserSettings = false;
+    userSettings = {
+      theme = "XY-Zed";
+      features = {
+        copilot = false;
+      };
+      vim_mode = false;
+      ui_font_size = 16;
+      buffer_font_size = 16;
+    };
+  };
+
+  nmt.script =
+    let
+      expectedContent = builtins.toFile "expected.json" ''
+        {
+          "buffer_font_size": 16,
+          "features": {
+            "copilot": false
+          },
+          "theme": "XY-Zed",
+          "ui_font_size": 16,
+          "vim_mode": false
+        }
+      '';
+
+      settingsPath = ".config/zed/settings.json";
+    in
+    ''
+      assertFileExists "home-files/${settingsPath}"
+      assertFileContent "home-files/${settingsPath}" "${expectedContent}"
+    '';
+}

--- a/tests/modules/programs/zed-editor/tasks-immutable.nix
+++ b/tests/modules/programs/zed-editor/tasks-immutable.nix
@@ -1,0 +1,44 @@
+# Test custom keymap functionality
+{ config, ... }:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    mutableUserTasks = false;
+    userTasks = [
+      {
+        label = "Format Code";
+        command = "nix";
+        args = [
+          "fmt"
+          "$ZED_WORKTREE_ROOT"
+        ];
+        allow_concurrent_runs = false;
+      }
+    ];
+  };
+
+  nmt.script =
+    let
+      expectedContent = builtins.toFile "expected.json" ''
+        [
+          {
+            "allow_concurrent_runs": false,
+            "args": [
+              "fmt",
+              "$ZED_WORKTREE_ROOT"
+            ],
+            "command": "nix",
+            "label": "Format Code"
+          }
+        ]
+      '';
+
+      settingsPath = ".config/zed/tasks.json";
+    in
+    ''
+      assertFileExists "home-files/${settingsPath}"
+      assertFileContent "home-files/${settingsPath}" "${expectedContent}"
+    '';
+}


### PR DESCRIPTION
### Description

Add three new options for controlling mutability, following the `mutableExtensionsDir` convention from `programs.vscode`:

- `mutableUserSettings`
- `mutableUserKeymaps`
- `mutableUserTasks`

Disabling any of these options will create a symlink to the respective config file generated in `/nix/store`, ensuring immutability. They are all enabled by default, which makes this change backwards-compatible.

Ref: https://github.com/nix-community/home-manager/pull/6993
Closes: https://github.com/nix-community/home-manager/issues/8001
Closes https://github.com/nix-community/home-manager/pull/7908

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
