### PR TITLE
delta: add test where git integration is disabled

### DIFF
--- a/tests/modules/programs/delta/default.nix
+++ b/tests/modules/programs/delta/default.nix
@@ -2,5 +2,6 @@
   delta-basic = ./delta-basic.nix;
   delta-final-package = ./delta-final-package.nix;
   delta-with-git-integration = ./delta-with-git-integration.nix;
+  delta-without-git-integration = ./delta-without-git-integration.nix;
   delta-migration = ./delta-migration.nix;
 }

--- a/tests/modules/programs/delta/delta-with-git-integration.nix
+++ b/tests/modules/programs/delta/delta-with-git-integration.nix
@@ -28,5 +28,8 @@
     assertFileContains home-files/.config/git/config 'commit-decoration-style = "bold yellow box ul"'
     assertFileContains home-files/.config/git/config 'file-decoration-style = "none"'
     assertFileContains home-files/.config/git/config 'file-style = "bold yellow ul"'
+
+    # the wrapper should be created only if git integration is disabled
+    assertPathNotExists home-path/bin/.delta-wrapped
   '';
 }

--- a/tests/modules/programs/delta/delta-without-git-integration.nix
+++ b/tests/modules/programs/delta/delta-without-git-integration.nix
@@ -1,0 +1,22 @@
+{ config, ... }:
+{
+  programs.delta = {
+    enable = true;
+    enableGitIntegration = false;
+    package = config.lib.test.mkStubPackage {
+      name = "delta";
+      buildScript = /* sh */ ''
+        mkdir -p $out/bin
+        echo "#!/bin/sh" > $out/bin/delta
+        chmod +x $out/bin/delta
+      '';
+    };
+    options.features = "line-numbers decorations";
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/git/config
+    # the wrapper should be created only if git integration is disabled
+    assertFileExists home-path/bin/.delta-wrapped
+  '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
