### PR TITLE
kitty: make package nullable

### DIFF
--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -124,7 +124,7 @@ in
   options.programs.kitty = {
     enable = mkEnableOption "Kitty terminal emulator";
 
-    package = lib.mkPackageOption pkgs "kitty" { };
+    package = lib.mkPackageOption pkgs "kitty" { nullable = true; };
 
     darwinLaunchOptions = mkOption {
       type = types.nullOr (types.listOf types.str);
@@ -293,7 +293,7 @@ in
       }
     ];
 
-    home.packages = [ cfg.package ] ++ optionalPackage cfg.font;
+    home.packages = (optionalPackage cfg) ++ (optionalPackage cfg.font);
 
     programs.kitty.extraConfig = mkMerge [
       (mkIf (cfg.font != null) (


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

I want to use Kitty from homebrew in macOS but keep my configuration from Nix. This PR allow this by allowing `programs.kitty.package = null`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
