### PR TITLE
lorri-notify: restart if events stream is disconnected

### DIFF
--- a/modules/services/lorri.nix
+++ b/modules/services/lorri.nix
@@ -100,6 +100,12 @@ in
         };
 
         Service = {
+          # Don't start until lorri daemon is actually running
+          ExecStartPre = pkgs.writeShellScript "lorri-notify-check" ''
+            lorri info --shell-file . | grep 'Lorri Daemon Status:.*running'
+          '';
+          RestartSec = "5s";
+
           ExecStart =
             let
               jqFile = ''
@@ -125,6 +131,7 @@ in
                 with pkgs;
                 [
                   bash
+                  gnugrep
                   jq
                   findutils
                   libnotify


### PR DESCRIPTION

### Description

<!--

Please provide a brief description of your change.

-->Before this patch, when events stream got disconnected (maybe because a home rebuild), lorri-notify service wouldn't auto-restart.

---

don't start until daemon is really running 

Sometimes a race condition will make the events stream start after the
daemon is running, and then no events will be streamed.

This fixes the problem by checking the daemon status and failing the
unit if not ready yet. It will restart 5 seconds later, which will
probably be enough.

@moduon MT-1075

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
