### PR TITLE
home-manager-auto-upgrade: add flake support

### DIFF
--- a/modules/misc/news/2025/10/2025-10-25_15-45-39.nix
+++ b/modules/misc/news/2025/10/2025-10-25_15-45-39.nix
@@ -1,0 +1,12 @@
+{
+  time = "2025-10-25T14:45:39+00:00";
+  condition = true;
+  message = ''
+    The home-manager auto-upgrade service now supports updating Nix flakes.
+
+    Enable this by setting `services.home-manager.autoUpgrade.useFlake = true;`.
+
+    The flake directory can be configured with `services.home-manager.autoUpgrade.flakeDir`,
+    which defaults to the configured XDG config home (typically `~/.config/home-manager`).
+  '';
+}

--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -15,12 +15,28 @@ let
 
   autoUpgradeApp = pkgs.writeShellApplication {
     name = "home-manager-auto-upgrade";
-    text = ''
-      echo "Update Nix's channels"
-      nix-channel --update
-      echo "Upgrade Home Manager"
-      home-manager switch
-    '';
+    text =
+      if cfg.useFlake then
+        ''
+          set -e
+          if [[ ! -f "$FLAKE_DIR/flake.nix" ]]; then
+              echo "No flake.nix found in $FLAKE_DIR." >&2
+              exit 1
+          fi
+          echo "Changing to flake directory $FLAKE_DIR"
+          cd "$FLAKE_DIR"
+          echo "Update flake inputs"
+          nix flake update
+          echo "Upgrade Home Manager"
+          home-manager switch --flake .
+        ''
+      else
+        ''
+          echo "Update Nix's channels"
+          nix-channel --update
+          echo "Upgrade Home Manager"
+          home-manager switch
+        '';
     runtimeInputs = with pkgs; [
       homeManagerPackage
       nix
@@ -47,6 +63,20 @@ in
           {manpage}`systemd.time(7)`.
         '';
       };
+
+      useFlake = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether to use 'nix flake update' instead of 'nix-channel --update'.";
+      };
+
+      flakeDir = lib.mkOption {
+        type = lib.types.str;
+        default = "${config.xdg.configHome}/home-manager";
+        defaultText = lib.literalExpression ''"''${config.xdg.configHome}/home-manager"'';
+        example = "/home/user/dotfiles";
+        description = "The directory of the flake to update.";
+      };
     };
   };
 
@@ -70,7 +100,10 @@ in
 
       services.home-manager-auto-upgrade = {
         Unit.Description = "Home Manager upgrade";
-        Service.ExecStart = "${autoUpgradeApp}/bin/home-manager-auto-upgrade";
+        Service = {
+          ExecStart = "${autoUpgradeApp}/bin/home-manager-auto-upgrade";
+          Environment = lib.mkIf cfg.useFlake [ "FLAKE_DIR=${cfg.flakeDir}" ];
+        };
       };
     };
   };

--- a/tests/modules/services/home-manager-auto-upgrade/default.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/default.nix
@@ -2,4 +2,5 @@
 
 lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
   home-manager-auto-upgrade-basic-configuration = ./basic-configuration.nix;
+  home-manager-auto-upgrade-flake-configuration = ./flake-configuration.nix;
 }

--- a/tests/modules/services/home-manager-auto-upgrade/flake-configuration.nix
+++ b/tests/modules/services/home-manager-auto-upgrade/flake-configuration.nix
@@ -1,0 +1,17 @@
+{
+  services.home-manager.autoUpgrade = {
+    enable = true;
+    frequency = "daily";
+    useFlake = true;
+    flakeDir = "/tmp/my-flake";
+  };
+
+  nmt.script = ''
+    serviceFile="home-files/.config/systemd/user/home-manager-auto-upgrade.service"
+    assertFileExists "$serviceFile"
+    assertFileRegex "$serviceFile" "FLAKE_DIR=/tmp/my-flake"
+
+    scriptPath=$(grep -oP 'ExecStart=\K.+' "$TESTED/$serviceFile")
+    assertFileRegex "$scriptPath" "nix flake update"
+  '';
+}


### PR DESCRIPTION
### Description

Adds the ability for the auto-upgrade service to update a Nix flake instead of Nix channels. Fixes #338

This is controlled by a new `useFlake` boolean option. When enabled, the service will run `nix flake update` in the directory specified by the `flakeDir` option.

`flakeDir` defaults to the standard Home Manager configuration directory (`~/.config/home-manager`), making this feature work out-of-the-box for most users. The path is passed to the upgrade script via an environment variable in the systemd service unit.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
