### PR TITLE
go-freeze: Add module to configure package

### DIFF
--- a/modules/misc/news/2025/10/2025-10-25_14-37-46.nix
+++ b/modules/misc/news/2025/10/2025-10-25_14-37-46.nix
@@ -1,0 +1,31 @@
+{
+  time = "2025-10-25T21:37:46+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.go-freeze`
+
+    `go-freeze` is a CLI tool that to generate mages of code and terminal
+    output.
+
+    This module allows for defining named configuration files via
+    `settings.<name>` attributes, ex.
+
+    ```nix
+    {
+      programs.go-freeze = {
+        enable = true;
+
+        settings.user = {
+          theme = "gruvbox-dark";
+        };
+      };
+    }
+    ```
+
+    ...  which may be activated at runtime by name;
+
+    ```bash
+    go-freeze -c user -l bash <<<'echo "hello world"';
+    ```
+  '';
+}

--- a/modules/programs/go-freeze.nix
+++ b/modules/programs/go-freeze.nix
@@ -1,0 +1,98 @@
+{
+  config,
+  lib,
+  # pkgs,
+  ...
+}:
+let
+  # TODO: remove following and uncomment `pkgs` above after;
+  # - NixOS/nixpkgs# is accepted
+  # - nix-community/home-manager is updated
+  pkgs = import /home/s0ands0/git/hub/NixOS/nixpkgs/wt/add-go-freeze { };
+
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    literalExpression
+    ;
+
+  inherit (lib.types) submodule;
+
+  inherit (pkgs.formats) json;
+
+  jsonFormat = json { };
+
+  cfg = config.programs.go-freeze;
+in
+{
+  options.programs.go-freeze = {
+    enable = mkEnableOption "Enable pianobar";
+
+    package = mkPackageOption pkgs "go-freeze" {
+      nullable = true;
+    };
+
+    settings = mkOption {
+      default = { };
+
+      description = ''
+        Attribute set of named configuration files to write.
+      '';
+
+      example = literalExpression ''
+        {
+          programs.go-freeze = {
+            enable = true;
+
+            settings.user = {
+              background = "#171717";
+              margin = [0 0 0 0];
+              padding = [20 40 20 20];
+              window = false;
+              width = 0;
+              height = 0;
+              config = "default";
+              theme = "gruvbox-dark";
+              border = { radius = 0; width = 0; color = "#515151"; };
+              shadow = { blur = 0; x = 0; y = 0; };
+              font = {
+                family = "Liberation Mono";
+                file = "''${pkgs.liberation_ttf_v2}/share/fonts/truetype/LiberationMono-Regular.ttf";
+                size = 14;
+                ligatures = false;
+              };
+              line_height = 1.2;
+              line_numbers = false;
+            };
+          };
+        }
+      '';
+
+      type = lib.types.attrsOf (submodule {
+        freeformType = jsonFormat.type;
+      });
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+    xdg.configFile = lib.mkIf (cfg.settings != { }) (
+      lib.listToAttrs (
+        lib.mapAttrsToList (name: value: {
+          name = "go-freeze/${name}.json";
+          value.source = jsonFormat.generate "go-freeze-config-${name}" value;
+        }) cfg.settings
+      )
+    );
+
+    home.packages = mkIf (cfg.package != null) [
+      cfg.package
+    ];
+  };
+
+  meta.maintainers = [
+    lib.maintainers.S0AndS0
+  ];
+}

--- a/tests/modules/programs/go-freeze/default.nix
+++ b/tests/modules/programs/go-freeze/default.nix
@@ -1,0 +1,4 @@
+{
+  go-freeze-minimally-required-configs = ./minimally-required-configs.nix;
+  go-freeze-settings-user = ./settings-user.nix;
+}

--- a/tests/modules/programs/go-freeze/minimally-required-configs.nix
+++ b/tests/modules/programs/go-freeze/minimally-required-configs.nix
@@ -1,0 +1,3 @@
+{
+  programs.go-freeze.enable = true;
+}

--- a/tests/modules/programs/go-freeze/settings-user.nix
+++ b/tests/modules/programs/go-freeze/settings-user.nix
@@ -1,0 +1,91 @@
+{ pkgs, ... }:
+{
+  programs.go-freeze = {
+    enable = true;
+
+    settings.user = {
+      background = "#171717";
+      margin = [
+        0
+        0
+        0
+        0
+      ];
+      padding = [
+        20
+        40
+        20
+        20
+      ];
+      window = false;
+      width = 0;
+      height = 0;
+      config = "default";
+      theme = "gruvbox-dark";
+      border = {
+        radius = 0;
+        width = 0;
+        color = "#515151";
+      };
+      shadow = {
+        blur = 0;
+        x = 0;
+        y = 0;
+      };
+      font = {
+        family = "Liberation Mono";
+        file = "${pkgs.liberation_ttf_v2}/share/fonts/truetype/LiberationMono-Regular.ttf";
+        size = 14;
+        ligatures = false;
+      };
+      line_height = 1.2;
+      line_numbers = false;
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/go-freeze/user.json
+
+    assertFileContent home-files/.config/go-freeze/user.json \
+    ${builtins.toFile "expected.config_go-freeze_user.json" ''
+      {
+        "background": "#171717",
+        "border": {
+          "color": "#515151",
+          "radius": 0,
+          "width": 0
+        },
+        "config": "default",
+        "font": {
+          "family": "Liberation Mono",
+          "file": "${pkgs.liberation_ttf_v2}/share/fonts/truetype/LiberationMono-Regular.ttf",
+          "ligatures": false,
+          "size": 14
+        },
+        "height": 0,
+        "line_height": 1.2,
+        "line_numbers": false,
+        "margin": [
+          0,
+          0,
+          0,
+          0
+        ],
+        "padding": [
+          20,
+          40,
+          20,
+          20
+        ],
+        "shadow": {
+          "blur": 0,
+          "x": 0,
+          "y": 0
+        },
+        "theme": "gruvbox-dark",
+        "width": 0,
+        "window": false
+      }
+    ''}
+  '';
+}


### PR DESCRIPTION
:warning: This PR requires `NixOS/nixpkgs#455648` to be accepted and `flake.lock` file here to be updated.

### Description

This module allows for defining named configuration files via `settings.<name>` attributes, ex.

```nix
{
  programs.go-freeze = {
    enable = true;

    settings.user = {
      theme = "gruvbox-dark";
    };
  };
}
```

...  which may be activated at runtime by name;

```bash
go-freeze -c user -l bash <<<'echo "hello world"';
```


### Checklist

- [ ] Change is backwards compatible.
   > Nope; requires `NixOS/nixpkgs#455648` to be accepted and `flake.lock` file here to be updated
- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.
- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
   > Note; check `TODO` in `modules/programs/go-freeze.nix` related to `pkgs`
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like
   ```
   {component}: {description}

   {long description}
   ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module
  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
