### PR TITLE
kraftkit: init module

### DIFF
--- a/modules/misc/news/2025/10/2025-10-26_14-36-05.nix
+++ b/modules/misc/news/2025/10/2025-10-26_14-36-05.nix
@@ -1,0 +1,10 @@
+{
+  time = "2025-10-26T07:36:05+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.kraftkit`.
+
+    kraftkit is a CLI tool for building custom, minimal, immutable lightweight
+    unikernel virtual machines based on Unikraft.
+  '';
+}

--- a/modules/programs/kraftkit.nix
+++ b/modules/programs/kraftkit.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    mkIf
+    literalExpression
+    ;
+
+  cfg = config.programs.kraftkit;
+  yamlFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.folliehiyuki ];
+
+  options.programs.kraftkit = {
+    enable = mkEnableOption "kraftkit - CLI to build and use customized unikernel VMs";
+
+    package = mkPackageOption pkgs "kraft" { nullable = true; };
+
+    settings = mkOption {
+      type = yamlFormat.type;
+      default = { };
+      description = ''
+        Configuration written to {file}`$XDG_CONFIG_HOME/kraftkit/config.yaml`.
+      '';
+      example = literalExpression ''
+        no_prompt = true;
+        log = {
+          level = "info";
+          type = "fancy";
+        };
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."kraftkit/config.yaml" = mkIf (cfg.settings != { }) {
+      source = yamlFormat.generate "kraftkit-config" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/kraftkit/default.nix
+++ b/tests/modules/programs/kraftkit/default.nix
@@ -1,0 +1,1 @@
+{ kraftkit-example-settings = ./example-settings.nix; }

--- a/tests/modules/programs/kraftkit/example-config-expected.yaml
+++ b/tests/modules/programs/kraftkit/example-config-expected.yaml
@@ -1,0 +1,6 @@
+collect_anonymous_telemetry: false
+log:
+  level: info
+  timestamps: false
+  type: fancy
+no_check_updates: true

--- a/tests/modules/programs/kraftkit/example-settings.nix
+++ b/tests/modules/programs/kraftkit/example-settings.nix
@@ -1,0 +1,24 @@
+{ config, ... }:
+{
+  programs.kraftkit = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+
+    settings = {
+      no_check_updates = true;
+      collect_anonymous_telemetry = false;
+      log = {
+        level = "info";
+        timestamps = false;
+        type = "fancy";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists "home-files/.config/kraftkit/config.yaml"
+    assertFileContent \
+      "home-files/.config/kraftkit/config.yaml" \
+      ${./example-config-expected.yaml}
+  '';
+}


### PR DESCRIPTION
### Description

This PR adds a new module to install and configure https://github.com/unikraft/kraftkit.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
