### PR TITLE
fontconfig: fix cache existence tests

### DIFF
--- a/tests/modules/misc/fontconfig/default.nix
+++ b/tests/modules/misc/fontconfig/default.nix
@@ -1,24 +1,7 @@
 {
   fontconfig-no-font-package = ./no-font-package.nix;
   fontconfig-single-font-package = ./single-font-package.nix;
-  # Disabled due to test failing with message
-  #
-  #  Expected directory home-path/lib/fontconfig/cache to exist but it was not found.
-  #
-  # Verbose output from fc-cache:
-  #
-  #  Font directories:
-  #          /nix/store/da…g5-home-manager-path/lib/X11/fonts
-  #          /nix/store/da…g5-home-manager-path/share/fonts
-  #          /nix/store/da…g5-home-manager-path/share/fonts/truetype
-  #  /nix/store/da…g5-home-manager-path/lib/X11/fonts: skipping, no such directory
-  #  /nix/store/da…g5-home-manager-path/share/fonts: caching, new cache contents: 1 fonts, 1 dirs
-  #  /nix/store/da…g5-home-manager-path/share/fonts/truetype: caching, new cache contents: 3 fonts, 0 dirs
-  #  /nix/store/da…g5-home-manager-path/share/fonts/truetype: skipping, looped directory detected
-  #  /nix/store/da…g5-home-manager-path/lib/fontconfig/cache: cleaning cache directory
-  #  /nix/store/da…g5-home-manager-path/lib/fontconfig/cache: invalid cache file: 786068e7df13f7c2105017ef3d78e351-x86_64.cache-7
-  #  /nix/store/da…g5-home-manager-path/lib/fontconfig/cache: invalid cache file: 4766193978ddda4bd196f2b98c00fb00-x86_64.cache-7
-  #fontconfig-multiple-font-packages = ./multiple-font-packages.nix;
+  fontconfig-multiple-font-packages = ./multiple-font-packages.nix;
 
   fontconfig-default-rendering = ./default-rendering.nix;
   fontconfig-custom-rendering = ./custom-rendering.nix;

--- a/tests/modules/misc/fontconfig/multiple-font-packages.nix
+++ b/tests/modules/misc/fontconfig/multiple-font-packages.nix
@@ -1,15 +1,17 @@
-{ pkgs, ... }:
+{ realPkgs, ... }:
+
 {
-  config = {
-    home.packages = [
-      pkgs.comic-relief
-      pkgs.unifont
-    ];
+  fonts.fontconfig.enable = true;
 
-    fonts.fontconfig.enable = true;
+  # Use `realPkgs` here since the creation of the fontconfig cache relies on the
+  # `fc-cache` binary and actual (non-stubbed) fonts.
+  test.unstubs = [ (self: super: { inherit (realPkgs) fontconfig; }) ];
+  home.packages = [
+    realPkgs.comic-relief
+    realPkgs.unifont
+  ];
 
-    nmt.script = ''
-      assertDirectoryNotEmpty home-path/lib/fontconfig/cache
-    '';
-  };
+  nmt.script = ''
+    assertDirectoryNotEmpty home-path/lib/fontconfig/cache
+  '';
 }

--- a/tests/modules/misc/fontconfig/single-font-package.nix
+++ b/tests/modules/misc/fontconfig/single-font-package.nix
@@ -1,17 +1,12 @@
+{ realPkgs, ... }:
+
 {
-  config,
-  lib,
-  pkgs,
-  realPkgs,
-  ...
-}:
-
-lib.mkIf config.test.enableBig {
-  home.packages = [ pkgs.comic-relief ];
-
   fonts.fontconfig.enable = true;
 
-  _module.args.pkgs = lib.mkForce realPkgs;
+  # Use `realPkgs` here since the creation of the fontconfig cache relies on the
+  # `fc-cache` binary and actual (non-stubbed) fonts.
+  test.unstubs = [ (self: super: { inherit (realPkgs) fontconfig; }) ];
+  home.packages = [ realPkgs.comic-relief ];
 
   nmt.script = ''
     assertDirectoryNotEmpty home-path/lib/fontconfig/cache


### PR DESCRIPTION
### Description

The `fontconfig-multiple-font-packages` test was disabled in f119d4d1 due to unknown reasons. I found that unstubbing fontconfig and the font packages fixes the test.

I also changed the `fontconfig-single-font-packages` test such that it only unstubs the required packages instead of the whole `pkgs` in order to keep the test small.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
