### PR TITLE
treewide: remove no-ops

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -17,23 +17,21 @@
         lib
         pkgs
         ;
-      configuration =
-        { ... }:
-        {
-          imports = modules ++ [
-            {
-              programs.home-manager.path = builtins.path {
-                path = ../.;
-                name = "source";
-              };
-            }
-          ];
+      configuration = {
+        imports = modules ++ [
+          {
+            programs.home-manager.path = builtins.path {
+              path = ../.;
+              name = "source";
+            };
+          }
+        ];
 
-          nixpkgs = {
-            config = lib.mkDefault pkgs.config;
+        nixpkgs = {
+          config = lib.mkDefault pkgs.config;
 
-            inherit (pkgs) overlays;
-          };
+          inherit (pkgs) overlays;
         };
+      };
     };
 }

--- a/modules/programs/nnn.nix
+++ b/modules/programs/nnn.nix
@@ -13,43 +13,40 @@ let
 
   renderSettings = settings: lib.concatStringsSep ";" (lib.mapAttrsToList renderSetting settings);
 
-  pluginModule = types.submodule (
-    { ... }:
-    {
-      options = {
-        src = mkOption {
-          type = with types; nullOr path;
-          example = literalExpression ''
-            (pkgs.fetchFromGitHub {
-              owner = "jarun";
-              repo = "nnn";
-              rev = "v4.0";
-              sha256 = "sha256-Hpc8YaJeAzJoEi7aJ6DntH2VLkoR6ToP6tPYn3llR7k=";
-            }) + "/plugins";
-          '';
-          default = null;
-          description = ''
-            Path to the plugin folder.
-          '';
-        };
-
-        mappings = mkOption {
-          type = with types; attrsOf str;
-          description = ''
-            Key mappings to the plugins.
-          '';
-          default = { };
-          example = literalExpression ''
-            {
-              c = "fzcd";
-              f = "finder";
-              v = "imgview";
-            };
-          '';
-        };
+  pluginModule = types.submodule ({
+    options = {
+      src = mkOption {
+        type = with types; nullOr path;
+        example = literalExpression ''
+          (pkgs.fetchFromGitHub {
+            owner = "jarun";
+            repo = "nnn";
+            rev = "v4.0";
+            sha256 = "sha256-Hpc8YaJeAzJoEi7aJ6DntH2VLkoR6ToP6tPYn3llR7k=";
+          }) + "/plugins";
+        '';
+        default = null;
+        description = ''
+          Path to the plugin folder.
+        '';
       };
-    }
-  );
+
+      mappings = mkOption {
+        type = with types; attrsOf str;
+        description = ''
+          Key mappings to the plugins.
+        '';
+        default = { };
+        example = literalExpression ''
+          {
+            c = "fzcd";
+            f = "finder";
+            v = "imgview";
+          };
+        '';
+      };
+    };
+  });
 in
 {
   meta.maintainers = with lib.maintainers; [ thiagokokada ];

--- a/modules/services/swayidle.nix
+++ b/modules/services/swayidle.nix
@@ -21,49 +21,45 @@ in
   options.services.swayidle =
     let
 
-      timeoutModule =
-        { ... }:
-        {
-          options = {
-            timeout = mkOption {
-              type = types.ints.positive;
-              example = 60;
-              description = "Timeout in seconds.";
-            };
+      timeoutModule = {
+        options = {
+          timeout = mkOption {
+            type = types.ints.positive;
+            example = 60;
+            description = "Timeout in seconds.";
+          };
 
-            command = mkOption {
-              type = types.str;
-              description = "Command to run after timeout seconds of inactivity.";
-            };
+          command = mkOption {
+            type = types.str;
+            description = "Command to run after timeout seconds of inactivity.";
+          };
 
-            resumeCommand = mkOption {
-              type = with types; nullOr str;
-              default = null;
-              description = "Command to run when there is activity again.";
-            };
+          resumeCommand = mkOption {
+            type = with types; nullOr str;
+            default = null;
+            description = "Command to run when there is activity again.";
           };
         };
+      };
 
-      eventModule =
-        { ... }:
-        {
-          options = {
-            event = mkOption {
-              type = types.enum [
-                "before-sleep"
-                "after-resume"
-                "lock"
-                "unlock"
-              ];
-              description = "Event name.";
-            };
+      eventModule = {
+        options = {
+          event = mkOption {
+            type = types.enum [
+              "before-sleep"
+              "after-resume"
+              "lock"
+              "unlock"
+            ];
+            description = "Event name.";
+          };
 
-            command = mkOption {
-              type = types.str;
-              description = "Command to run when event occurs.";
-            };
+          command = mkOption {
+            type = types.str;
+            description = "Command to run when event occurs.";
           };
         };
+      };
 
     in
     {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -42,7 +42,7 @@ let
       if lib.isDerivation value then scrubbedValue // newDrvAttrs else scrubbedValue
     else
       value;
-  scrubDerivations = attrs: lib.mapAttrs scrubDerivation attrs;
+  scrubDerivations = lib.mapAttrs scrubDerivation;
 
   # Globally unscrub a few selected packages that are used by a wide selection of tests.
   whitelist =
@@ -111,10 +111,7 @@ let
             pkgs =
               let
                 overlays =
-                  config.test.stubOverlays
-                  ++ lib.optionals (
-                    config.nixpkgs.overlays != null && config.nixpkgs.overlays != [ ]
-                  ) config.nixpkgs.overlays;
+                  config.test.stubOverlays ++ lib.optionals (config.nixpkgs.overlays != null) config.nixpkgs.overlays;
                 stubbedPkgs =
                   if overlays == [ ] then
                     scrubbedPkgs

--- a/tests/integration/nixos/basics.nix
+++ b/tests/integration/nixos/basics.nix
@@ -4,29 +4,25 @@
   name = "nixos-basics";
   meta.maintainers = [ pkgs.lib.maintainers.rycee ];
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ ../../../nixos ]; # Import the HM NixOS module.
+  nodes.machine = {
+    imports = [ ../../../nixos ]; # Import the HM NixOS module.
 
-      virtualisation.memorySize = 2048;
+    virtualisation.memorySize = 2048;
 
-      users.users.alice = {
-        isNormalUser = true;
-        description = "Alice Foobar";
-        password = "foobar";
-        uid = 1000;
-      };
-
-      home-manager.users.alice =
-        { ... }:
-        {
-          home.stateVersion = "24.11";
-          home.file.test.text = "testfile";
-          # Enable a light-weight systemd service.
-          services.pueue.enable = true;
-        };
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
     };
+
+    home-manager.users.alice = {
+      home.stateVersion = "24.11";
+      home.file.test.text = "testfile";
+      # Enable a light-weight systemd service.
+      services.pueue.enable = true;
+    };
+  };
 
   testScript = ''
     def login_as_alice():

--- a/tests/integration/nixos/legacy-profile-management-new-conf.nix
+++ b/tests/integration/nixos/legacy-profile-management-new-conf.nix
@@ -1,4 +1,3 @@
-{ ... }:
 {
   imports = [ ../../../nixos ]; # Import the HM NixOS module.
 
@@ -9,11 +8,9 @@
   };
 
   home-manager = {
-    users.alice =
-      { ... }:
-      {
-        home.stateVersion = "24.11";
-        home.file.test.text = "testfile new profile";
-      };
+    users.alice = {
+      home.stateVersion = "24.11";
+      home.file.test.text = "testfile new profile";
+    };
   };
 }

--- a/tests/integration/nixos/legacy-profile-management.nix
+++ b/tests/integration/nixos/legacy-profile-management.nix
@@ -4,52 +4,46 @@
   name = "nixos-legacy-profile-management";
   meta.maintainers = [ pkgs.lib.maintainers.rycee ];
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [
-        # Make the nixpkgs channel available.
-        "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix"
-        # Import the HM NixOS module.
-        ../../../nixos
-      ];
+  nodes.machine = {
+    imports = [
+      # Make the nixpkgs channel available.
+      "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix"
+      # Import the HM NixOS module.
+      ../../../nixos
+    ];
 
-      system.stateVersion = "24.11";
+    system.stateVersion = "24.11";
 
-      users.users.alice = {
-        isNormalUser = true;
-      };
+    users.users.alice = {
+      isNormalUser = true;
+    };
 
-      specialisation = {
-        legacy.configuration = {
-          home-manager = {
-            # Force legacy profile management.
-            enableLegacyProfileManagement = true;
+    specialisation = {
+      legacy.configuration = {
+        home-manager = {
+          # Force legacy profile management.
+          enableLegacyProfileManagement = true;
 
-            users.alice =
-              { ... }:
-              {
-                home.stateVersion = "24.11";
-                home.file.test.text = "testfile legacy";
-              };
+          users.alice = {
+            home.stateVersion = "24.11";
+            home.file.test.text = "testfile legacy";
           };
         };
+      };
 
-        modern.configuration = {
-          home-manager = {
-            # Assert that we expect the option to default to false.
-            enableLegacyProfileManagement = pkgs.lib.mkOptionDefault false;
+      modern.configuration = {
+        home-manager = {
+          # Assert that we expect the option to default to false.
+          enableLegacyProfileManagement = pkgs.lib.mkOptionDefault false;
 
-            users.alice =
-              { ... }:
-              {
-                home.stateVersion = "24.11";
-                home.file.test.text = "testfile modern";
-              };
+          users.alice = {
+            home.stateVersion = "24.11";
+            home.file.test.text = "testfile modern";
           };
         };
       };
     };
+  };
 
   testScript =
     { nodes, ... }:

--- a/tests/integration/standalone/alice-home-specialisation.nix
+++ b/tests/integration/standalone/alice-home-specialisation.nix
@@ -1,5 +1,3 @@
-{ ... }:
-
 {
   home.username = "alice";
   home.homeDirectory = "/home/alice";

--- a/tests/integration/standalone/flake-basics.nix
+++ b/tests/integration/standalone/flake-basics.nix
@@ -4,28 +4,26 @@
   name = "standalone-flake-basics";
   meta.maintainers = [ pkgs.lib.maintainers.rycee ];
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-      virtualisation.memorySize = 3072;
-      nix = {
-        registry.home-manager.to = {
-          type = "path";
-          path = ../../..;
-        };
-        settings.extra-experimental-features = [
-          "nix-command"
-          "flakes"
-        ];
+  nodes.machine = {
+    imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
+    virtualisation.memorySize = 3072;
+    nix = {
+      registry.home-manager.to = {
+        type = "path";
+        path = ../../..;
       };
-      users.users.alice = {
-        isNormalUser = true;
-        description = "Alice Foobar";
-        password = "foobar";
-        uid = 1000;
-      };
+      settings.extra-experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
     };
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
+    };
+  };
 
   testScript = ''
     start_all()

--- a/tests/integration/standalone/home-with-symbols.nix
+++ b/tests/integration/standalone/home-with-symbols.nix
@@ -10,19 +10,17 @@ in
   name = "home-with-symbols";
   meta.maintainers = [ pkgs.lib.maintainers.rycee ];
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-      virtualisation.memorySize = 2048;
-      users.users.alice = {
-        isNormalUser = true;
-        description = "Alice Foobar";
-        password = "foobar";
-        uid = 1000;
-        home = nixHome;
-      };
+  nodes.machine = {
+    imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
+    virtualisation.memorySize = 2048;
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
+      home = nixHome;
     };
+  };
 
   testScript = ''
     import shlex

--- a/tests/integration/standalone/kitty.nix
+++ b/tests/integration/standalone/kitty.nix
@@ -3,18 +3,16 @@
   name = "kitty-theme-path";
   meta.maintainers = [ pkgs.lib.maintainers.rycee ];
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-      virtualisation.memorySize = 2048;
-      users.users.alice = {
-        isNormalUser = true;
-        description = "Alice Foobar";
-        password = "foobar";
-        uid = 1000;
-      };
+  nodes.machine = {
+    imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
+    virtualisation.memorySize = 2048;
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
     };
+  };
 
   testScript = ''
     start_all()

--- a/tests/integration/standalone/mu/default.nix
+++ b/tests/integration/standalone/mu/default.nix
@@ -2,18 +2,16 @@
 {
   name = "mu-store-init";
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-      virtualisation.memorySize = 2048;
-      users.users.alice = {
-        isNormalUser = true;
-        description = "Alice Foobar";
-        password = "foobar";
-        uid = 1000;
-      };
+  nodes.machine = {
+    imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
+    virtualisation.memorySize = 2048;
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
     };
+  };
 
   testScript = ''
     start_all()

--- a/tests/integration/standalone/nh.nix
+++ b/tests/integration/standalone/nh.nix
@@ -9,30 +9,28 @@ in
   name = "works-with-nh-stable";
   meta.maintainers = [ pkgs.lib.maintainers.rycee ];
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-      virtualisation.memorySize = 2048;
-      environment.systemPackages = [ pkgs.nh ];
-      nix = {
-        registry.home-manager.to = {
-          type = "path";
-          path = ../../..;
-        };
-        settings.extra-experimental-features = [
-          "nix-command"
-          "flakes"
-        ];
+  nodes.machine = {
+    imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
+    virtualisation.memorySize = 2048;
+    environment.systemPackages = [ pkgs.nh ];
+    nix = {
+      registry.home-manager.to = {
+        type = "path";
+        path = ../../..;
       };
-      users.users.alice = {
-        isNormalUser = true;
-        description = "Alice Foobar";
-        password = "foobar";
-        uid = 1000;
-        inherit home;
-      };
+      settings.extra-experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
     };
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
+      inherit home;
+    };
+  };
 
   testScript = ''
     import shlex

--- a/tests/integration/standalone/restic.nix
+++ b/tests/integration/standalone/restic.nix
@@ -24,20 +24,18 @@ in
 {
   name = "restic";
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-      virtualisation.memorySize = 2048;
-      users.users.alice = {
-        isNormalUser = true;
-        description = "Alice Foobar";
-        password = "foobar";
-        uid = 1000;
-      };
-
-      security.polkit.enable = true;
+  nodes.machine = {
+    imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
+    virtualisation.memorySize = 2048;
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
     };
+
+    security.polkit.enable = true;
+  };
 
   testScript = ''
     start_all()

--- a/tests/integration/standalone/specialisation.nix
+++ b/tests/integration/standalone/specialisation.nix
@@ -4,18 +4,16 @@
   name = "standalone-specialisation";
   meta.maintainers = [ pkgs.lib.maintainers.rycee ];
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-      virtualisation.memorySize = 2048;
-      users.users.alice = {
-        isNormalUser = true;
-        description = "Alice Foobar";
-        password = "foobar";
-        uid = 1000;
-      };
+  nodes.machine = {
+    imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
+    virtualisation.memorySize = 2048;
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
     };
+  };
 
   testScript = ''
     start_all()

--- a/tests/integration/standalone/standard-basics.nix
+++ b/tests/integration/standalone/standard-basics.nix
@@ -4,18 +4,16 @@
   name = "standalone-standard-basics";
   meta.maintainers = [ pkgs.lib.maintainers.rycee ];
 
-  nodes.machine =
-    { ... }:
-    {
-      imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
-      virtualisation.memorySize = 2048;
-      users.users.alice = {
-        isNormalUser = true;
-        description = "Alice Foobar";
-        password = "foobar";
-        uid = 1000;
-      };
+  nodes.machine = {
+    imports = [ "${pkgs.path}/nixos/modules/installer/cd-dvd/channel.nix" ];
+    virtualisation.memorySize = 2048;
+    users.users.alice = {
+      isNormalUser = true;
+      description = "Alice Foobar";
+      password = "foobar";
+      uid = 1000;
     };
+  };
 
   testScript = ''
     start_all()

--- a/tests/modules/config/home-cursor/default.nix
+++ b/tests/modules/config/home-cursor/default.nix
@@ -36,35 +36,33 @@ in
       };
     };
 
-  home-cursor-legacy-disabled =
-    { ... }:
-    {
-      config = {
-        home.pointerCursor = null;
+  home-cursor-legacy-disabled = {
+    config = {
+      home.pointerCursor = null;
 
-        home.stateVersion = "24.11";
+      home.stateVersion = "24.11";
 
-        test.asserts.warnings.expected = [
-          ''
-            Setting home.pointerCursor to null is deprecated.
-            Please update your configuration to explicitly set:
+      test.asserts.warnings.expected = [
+        ''
+          Setting home.pointerCursor to null is deprecated.
+          Please update your configuration to explicitly set:
 
-              home.pointerCursor.enable = false;
-          ''
-        ];
+            home.pointerCursor.enable = false;
+        ''
+      ];
 
-        nmt.script = ''
-          assertPathNotExists home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme
+      nmt.script = ''
+        assertPathNotExists home-path/share/icons/catppuccin-macchiato-blue-cursors/index.theme
 
-          hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
-          assertFileExists $hmEnvFile
-          assertFileNotRegex $hmEnvFile 'XCURSOR_THEME="catppuccin-macchiato-blue-standard"'
-          assertFileNotRegex $hmEnvFile 'XCURSOR_SIZE="32"'
-          assertFileNotRegex $hmEnvFile 'HYPRCURSOR_THEME="catppuccin-macchiato-blue-standard"'
-          assertFileNotRegex $hmEnvFile 'HYPRCURSOR_SIZE="32"'
-        '';
-      };
+        hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
+        assertFileExists $hmEnvFile
+        assertFileNotRegex $hmEnvFile 'XCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileNotRegex $hmEnvFile 'XCURSOR_SIZE="32"'
+        assertFileNotRegex $hmEnvFile 'HYPRCURSOR_THEME="catppuccin-macchiato-blue-standard"'
+        assertFileNotRegex $hmEnvFile 'HYPRCURSOR_SIZE="32"'
+      '';
     };
+  };
 
   home-cursor-legacy-disabled-with-enable =
     { config, ... }:

--- a/tests/modules/config/i18n/default.nix
+++ b/tests/modules/config/i18n/default.nix
@@ -1,21 +1,19 @@
 {
-  i18n =
-    { ... }:
-    {
-      config = {
-        nmt.script = ''
-          hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
-          assertFileExists $hmEnvFile
-          assertFileRegex $hmEnvFile \
-            '^export LOCALE_ARCHIVE_._..=".*/lib/locale/locale-archive"$'
+  i18n = {
+    config = {
+      nmt.script = ''
+        hmEnvFile=home-path/etc/profile.d/hm-session-vars.sh
+        assertFileExists $hmEnvFile
+        assertFileRegex $hmEnvFile \
+          '^export LOCALE_ARCHIVE_._..=".*/lib/locale/locale-archive"$'
 
-          envFile=home-files/.config/environment.d/10-home-manager.conf
-          assertFileExists $envFile
-          assertFileRegex $envFile \
-            '^LOCALE_ARCHIVE_._..=.*/lib/locale/locale-archive$'
-        '';
-      };
+        envFile=home-files/.config/environment.d/10-home-manager.conf
+        assertFileExists $envFile
+        assertFileRegex $envFile \
+          '^LOCALE_ARCHIVE_._..=.*/lib/locale/locale-archive$'
+      '';
     };
+  };
 
   i18n-custom-locales =
     { config, pkgs, ... }:

--- a/tests/modules/home-environment/session-path.nix
+++ b/tests/modules/home-environment/session-path.nix
@@ -1,22 +1,8 @@
-{ ... }:
-
 {
-  imports = [
-    (
-      { ... }:
-      {
-        config.home.sessionPath = [ "foo" ];
-      }
-    )
-    (
-      { ... }:
-      {
-        config.home.sessionPath = [
-          "bar"
-          "baz"
-        ];
-      }
-    )
+  home.sessionPath = [
+    "bar"
+    "baz"
+    "foo"
   ];
 
   nmt.script = ''

--- a/tests/modules/home-environment/session-search-variables.nix
+++ b/tests/modules/home-environment/session-search-variables.nix
@@ -1,22 +1,8 @@
-{ ... }:
-
 {
-  imports = [
-    (
-      { ... }:
-      {
-        config.home.sessionSearchVariables.TEST = [ "foo" ];
-      }
-    )
-    (
-      { ... }:
-      {
-        config.home.sessionSearchVariables.TEST = [
-          "bar"
-          "baz"
-        ];
-      }
-    )
+  home.sessionSearchVariables.TEST = [
+    "bar"
+    "baz"
+    "foo"
   ];
 
   nmt.script = ''

--- a/tests/modules/home-environment/session-variables.nix
+++ b/tests/modules/home-environment/session-variables.nix
@@ -37,16 +37,14 @@ let
 
 in
 {
-  config = {
-    home.sessionVariables = {
-      V1 = "v1";
-      V2 = "v2-${config.home.sessionVariables.V1}";
-    };
-
-    nmt.script = ''
-      assertFileExists home-path/etc/profile.d/hm-session-vars.sh
-      assertFileContent home-path/etc/profile.d/hm-session-vars.sh \
-        ${expected}
-    '';
+  home.sessionVariables = {
+    V1 = "v1";
+    V2 = "v2-${config.home.sessionVariables.V1}";
   };
+
+  nmt.script = ''
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileContent home-path/etc/profile.d/hm-session-vars.sh \
+      ${expected}
+  '';
 }

--- a/tests/modules/misc/xdg/mime.nix
+++ b/tests/modules/misc/xdg/mime.nix
@@ -1,29 +1,26 @@
-{ ... }:
 {
-  config = {
-    xdg.mime.enable = true;
-    xdg.desktopEntries = {
-      mime-test = {
-        # mime info test
-        name = "mime-test";
-        mimeType = [
-          "text/html"
-          "text/xml"
-        ];
-      };
-
+  xdg.mime.enable = true;
+  xdg.desktopEntries = {
+    mime-test = {
+      # mime info test
+      name = "mime-test";
+      mimeType = [
+        "text/html"
+        "text/xml"
+      ];
     };
 
-    nmt.script = ''
-      assertFileExists home-path/share/applications/mimeinfo.cache # Check that update-desktop-database created file
-      # Check that update-desktop-database file matches expected
-      assertFileContent \
-        home-path/share/applications/mimeinfo.cache \
-        ${./mime-expected.cache}
-
-      assertDirectoryExists home-path/share/mime # Check that update-mime-database created directory
-      assertDirectoryNotEmpty home-path/share/mime # Check that update-mime-database created files
-
-    '';
   };
+
+  nmt.script = ''
+    assertFileExists home-path/share/applications/mimeinfo.cache # Check that update-desktop-database created file
+    # Check that update-desktop-database file matches expected
+    assertFileContent \
+      home-path/share/applications/mimeinfo.cache \
+      ${./mime-expected.cache}
+
+    assertDirectoryExists home-path/share/mime # Check that update-mime-database created directory
+    assertDirectoryNotEmpty home-path/share/mime # Check that update-mime-database created files
+
+  '';
 }

--- a/tests/modules/programs/ashell/empty-settings.nix
+++ b/tests/modules/programs/ashell/empty-settings.nix
@@ -1,5 +1,3 @@
-{ ... }:
-
 {
   programs.ashell = {
     enable = true;

--- a/tests/modules/programs/git-worktree-switcher/bash.nix
+++ b/tests/modules/programs/git-worktree-switcher/bash.nix
@@ -1,5 +1,3 @@
-{ ... }:
-
 {
   programs = {
     bash.enable = true;

--- a/tests/modules/programs/keepassxc/default-settings.nix
+++ b/tests/modules/programs/keepassxc/default-settings.nix
@@ -1,5 +1,3 @@
-{ ... }:
-
 {
   programs.keepassxc = {
     enable = true;

--- a/tests/modules/programs/keepassxc/example-settings.nix
+++ b/tests/modules/programs/keepassxc/example-settings.nix
@@ -1,5 +1,3 @@
-{ ... }:
-
 {
   programs.keepassxc = {
     enable = true;

--- a/tests/modules/programs/kubeswitch/fish.nix
+++ b/tests/modules/programs/kubeswitch/fish.nix
@@ -1,5 +1,3 @@
-{ ... }:
-
 {
   programs = {
     kubeswitch.enable = true;

--- a/tests/modules/programs/lazydocker/custom-settings.nix
+++ b/tests/modules/programs/lazydocker/custom-settings.nix
@@ -1,4 +1,3 @@
-{ ... }:
 {
   programs.lazydocker = {
     enable = true;

--- a/tests/modules/programs/lazydocker/default-settings.nix
+++ b/tests/modules/programs/lazydocker/default-settings.nix
@@ -1,4 +1,3 @@
-{ ... }:
 {
   programs.lazydocker.enable = true;
   test.stubs.lazydocker = { };

--- a/tests/modules/programs/swaylock/disabled.nix
+++ b/tests/modules/programs/swaylock/disabled.nix
@@ -1,4 +1,3 @@
-{ ... }:
 {
   programs.swaylock.settings = { };
 

--- a/tests/modules/programs/uv/no-settings.nix
+++ b/tests/modules/programs/uv/no-settings.nix
@@ -1,4 +1,3 @@
-{ ... }:
 {
   programs.uv = {
     enable = true;

--- a/tests/modules/programs/zsh/history-ignore-pattern.nix
+++ b/tests/modules/programs/zsh/history-ignore-pattern.nix
@@ -1,20 +1,11 @@
 {
-  imports = [
-    (
-      { ... }:
-      {
-        config.programs.zsh.history.ignorePatterns = [ "echo *" ];
-      }
-    )
-    (
-      { ... }:
-      {
-        config.programs.zsh.history.ignorePatterns = [ "rm *" ];
-      }
-    )
-  ];
-
-  programs.zsh.enable = true;
+  programs.zsh = {
+    enable = true;
+    history.ignorePatterns = [
+      "echo *"
+      "rm *"
+    ];
+  };
 
   nmt.script = ''
     assertFileContains home-files/.zshrc "HISTORY_IGNORE='(echo *|rm *)'"

--- a/tests/modules/services/clipse/clipse-sway-session-target.nix
+++ b/tests/modules/services/clipse/clipse-sway-session-target.nix
@@ -1,5 +1,3 @@
-{ ... }:
-
 {
   services.clipse = {
     enable = true;

--- a/tests/modules/services/easyeffects/example-preset.nix
+++ b/tests/modules/services/easyeffects/example-preset.nix
@@ -1,5 +1,3 @@
-{ ... }:
-
 {
   services.easyeffects = {
     enable = true;

--- a/tests/modules/services/easyeffects/service.nix
+++ b/tests/modules/services/easyeffects/service.nix
@@ -1,5 +1,3 @@
-{ ... }:
-
 {
   services.easyeffects = {
     enable = true;

--- a/tests/modules/systemd/slices.nix
+++ b/tests/modules/systemd/slices.nix
@@ -1,5 +1,3 @@
-{ ... }:
-
 {
   systemd.user.slices.app-test = {
     Unit = {

--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -108,8 +108,7 @@ in
     lib.test.mkStubPackage = mkStubPackage;
 
     test.stubOverlays =
-      [ ]
-      ++ lib.optional (config.test.stubs != { }) (
+      lib.optional (config.test.stubs != { }) (
         self: super:
         lib.mapAttrs (
           n: v:


### PR DESCRIPTION
### Description

While working with the code base, I removed some no-ops, especially redundant `{ ... }:` module arguments.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
