### PR TITLE
glab: init module

### DIFF
--- a/modules/misc/news/2025/10/2025-10-27_00-33-43.nix
+++ b/modules/misc/news/2025/10/2025-10-27_00-33-43.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-10-26T23:33:43+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.glab'.
+
+    `glab` is an open source GitLab CLI tool that brings GitLab to your terminal.
+  '';
+}

--- a/modules/programs/glab.nix
+++ b/modules/programs/glab.nix
@@ -1,0 +1,52 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.glab;
+
+  yaml = pkgs.formats.yaml { };
+
+in
+{
+  meta.maintainers = [ lib.maintainers.bmrips ];
+
+  options.programs.glab = {
+    enable = lib.mkEnableOption "{command}`glab`.";
+    package = lib.mkPackageOption pkgs "glab" { nullable = true; };
+    aliases = lib.mkOption {
+      type = with lib.types; attrsOf str;
+      default = { };
+      description = "Aliases written to {file}`$XDG_CONFIG_HOME/glab-cli/aliases.yml`.";
+      example.co = "mr checkout";
+    };
+    settings = lib.mkOption {
+      inherit (yaml) type;
+      default = { };
+      description = "Configuration written to {file}`$XDG_CONFIG_HOME/glab-cli/config.yml`.";
+      example.check_update = false;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    # Use `systemd-tmpfiles` since glab requires its configuration file to have
+    # mode 0600.
+    systemd.user.tmpfiles.rules =
+      let
+        target = "${config.xdg.configHome}/glab-cli/config.yml";
+      in
+      lib.mkIf (cfg.settings != { }) [
+        "C+ ${target} - - - - ${yaml.generate "glab-config" cfg.settings}"
+        "z  ${target} 0600"
+      ];
+
+    xdg.configFile."glab-cli/aliases.yml" = lib.mkIf (cfg.aliases != { }) {
+      source = yaml.generate "glab-aliases" cfg.aliases;
+    };
+  };
+}

--- a/tests/modules/programs/glab/aliases.nix
+++ b/tests/modules/programs/glab/aliases.nix
@@ -1,0 +1,16 @@
+{ pkgs, ... }:
+
+{
+  programs.glab = {
+    enable = true;
+    aliases.co = "mr checkout";
+  };
+
+  nmt.script = ''
+    aliasesFile=home-files/.config/glab-cli/aliases.yml
+    assertFileExists $aliasesFile
+    assertFileContent $aliasesFile ${pkgs.writeText "glab-aliases.expected" ''
+      co: mr checkout
+    ''}
+  '';
+}

--- a/tests/modules/programs/glab/default.nix
+++ b/tests/modules/programs/glab/default.nix
@@ -1,0 +1,3 @@
+{
+  glab-aliases = ./aliases.nix;
+}


### PR DESCRIPTION
### Description

Add a module for `glab`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
