### PR TITLE
delta: add jujutsu integration option

### DIFF
--- a/modules/programs/delta.nix
+++ b/modules/programs/delta.nix
@@ -64,6 +64,16 @@ in
       '';
     };
 
+    enableJujutsuIntegration = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable jujutsu integration for delta.
+
+        When enabled, delta will be configured as jujutsus's pager, diff filter, and merge tool.
+      '';
+    };
+
     finalPackage = mkOption {
       type = types.package;
       readOnly = true;
@@ -122,6 +132,19 @@ in
             interactive.diffFilter = "${deltaCommand} --color-only";
             delta = cfg.options;
           };
+      })
+
+      (lib.mkIf (cfg.enable && cfg.enableJujutsuIntegration) {
+        programs.jujutsu.settings = {
+          merge-tools.delta.diff-expected-exit-codes = [
+            0
+            1
+          ];
+          ui = {
+            diff-formatter = ":git";
+            pager = "${lib.getExe cfg.package}";
+          };
+        };
       })
     ];
 }

--- a/tests/modules/programs/delta/default.nix
+++ b/tests/modules/programs/delta/default.nix
@@ -3,5 +3,7 @@
   delta-final-package = ./delta-final-package.nix;
   delta-with-git-integration = ./delta-with-git-integration.nix;
   delta-without-git-integration = ./delta-without-git-integration.nix;
+  delta-with-jujutsu-integration = ./delta-with-jujutsu-integration.nix;
+  delta-without-jujutsu-integration = ./delta-without-jujutsu-integration.nix;
   delta-migration = ./delta-migration.nix;
 }

--- a/tests/modules/programs/delta/delta-with-jujutsu-integration.nix
+++ b/tests/modules/programs/delta/delta-with-jujutsu-integration.nix
@@ -1,0 +1,21 @@
+{ config, lib, ... }:
+{
+  programs.delta = {
+    enable = true;
+    enableJujutsuIntegration = true;
+  };
+
+  programs.jujutsu.enable = true;
+
+  nmt.script = ''
+    assertFileExists home-files/.config/jj/config.toml
+    assertFileContent home-files/.config/jj/config.toml ${builtins.toFile "expected" ''
+      [merge-tools.delta]
+      diff-expected-exit-codes = [0, 1]
+
+      [ui]
+      diff-formatter = ":git"
+      pager = "${lib.getExe config.programs.delta.package}"
+    ''}
+  '';
+}

--- a/tests/modules/programs/delta/delta-without-jujutsu-integration.nix
+++ b/tests/modules/programs/delta/delta-without-jujutsu-integration.nix
@@ -1,0 +1,10 @@
+{
+  programs.delta = {
+    enable = true;
+    enableJujutsuIntegration = false;
+  };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.config/jj/config.toml
+  '';
+}


### PR DESCRIPTION
Add an `enableJujutsuIntegration` option.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
