### PR TITLE
tmpfiles: echo the onChange command and respect `$DRY_RUN`

### DIFF
--- a/modules/misc/tmpfiles.nix
+++ b/modules/misc/tmpfiles.nix
@@ -37,7 +37,9 @@ in
           # Please change the option ‘systemd.user.tmpfiles.rules’ instead.
           ${lib.concatStringsSep "\n" cfg.rules}
         '';
-        onChange = "${pkgs.systemd}/bin/systemd-tmpfiles --user --remove --create";
+        onChange = ''
+          run ${pkgs.systemd}/bin/systemd-tmpfiles --user --remove --create ''${DRY_RUN:+--dry-run}
+        '';
       };
       "systemd/user/basic.target.wants/systemd-tmpfiles-setup.service".source =
         "${pkgs.systemd}/example/systemd/user/systemd-tmpfiles-setup.service";


### PR DESCRIPTION
### Description

Adjust the `onChange` command such that it is echoed and the `--dry-run` flag is set whenever `$DRY_RUN` is set. These changes adhere to the intention described for [`home.activation`](https://nix-community.github.io/home-manager/options.xhtml#opt-home.activation).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
