### PR TITLE
targets/darwin: do not use sudo to check for App Management

### DIFF
--- a/modules/targets/darwin/copyapps.nix
+++ b/modules/targets/darwin/copyapps.nix
@@ -18,11 +18,9 @@ in
         defaultText = lib.literalExpression ''pkgs.stdenv.hostPlatform.isDarwin && (lib.versionAtLeast config.home.stateVersion "25.11")'';
       };
 
-    enableChecks =
-      lib.mkEnableOption "enable App Management checks (needs sudo; may ask sudo twice with nix-darwin)"
-      // {
-        default = true;
-      };
+    enableChecks = lib.mkEnableOption "enable App Management checks" // {
+      default = true;
+    };
 
     directory = lib.mkOption {
       type = lib.types.str;
@@ -48,7 +46,7 @@ in
             ensureAppManagement() {
               for appBundle in '${cfg.directory}/'*.app; do
                 if [[ -d "$appBundle" ]]; then
-                  if ! run /usr/bin/sudo /usr/bin/touch "$appBundle/.DS_Store" &> /dev/null; then
+                  if ! run /usr/bin/touch "$appBundle/.DS_Store" &> /dev/null; then
                     return 1
                   fi
                 fi
@@ -61,16 +59,16 @@ in
               if [[ "$(/bin/launchctl managername)" != Aqua ]]; then
                 # It is possible to grant the App Management permission to `sshd-keygen-wrapper`, however
                 # there are many pitfalls like requiring the primary user to grant the permission and to
-                # be logged in when `darwin-rebuild` is run over SSH and it will still fail sometimes...
+                # be logged in when home-manager is run over SSH and it will still fail sometimes...
                 printf >&2 '\e[1;31merror: permission denied when trying to update apps over SSH, aborting activation\e[0m\n'
-                printf >&2 'Apps could not be updated as `darwin-rebuild` requires Full Disk Access to work over SSH.\n'
+                printf >&2 'Apps could not be updated as home-manager requires Full Disk Access to work over SSH.\n'
                 printf >&2 'You can either:\n'
                 printf >&2 '\n'
                 printf >&2 '  grant Full Disk Access to all programs run over SSH\n'
                 printf >&2 '\n'
                 printf >&2 'or\n'
                 printf >&2 '\n'
-                printf >&2 '  run `darwin-rebuild` in a graphical session.\n'
+                printf >&2 '  run home-manager in a graphical session.\n'
                 printf >&2 '\n'
                 printf >&2 'The option "Allow full disk access for remote users" can be found by\n'
                 printf >&2 'navigating to System Settings > General > Sharing > Remote Login\n'
@@ -83,7 +81,7 @@ in
 
                 if ! ensureAppManagement; then
                   printf >&2 '\e[1;31merror: permission denied when trying to update apps, aborting activation\e[0m\n'
-                  printf >&2 '`darwin-rebuild` requires permission to update your apps, please accept the notification\n'
+                  printf >&2 'home-manager requires permission to update your apps, please accept the notification\n'
                   printf >&2 'and grant the permission for your terminal emulator in System Settings.\n'
                   printf >&2 '\n'
                   printf >&2 'If you did not get a notification, you can navigate to System Settings > Privacy & Security > App Management.\n'


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This is writing `.DS_Store` files as root in "~/Applications/Home Manager Apps/<app>", and causing errors during the `rsync` call since it will try to delete any files that is not present in the app bundle.

Fix #8067.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
