### PR TITLE
cbatticon: add `package` to options

### DIFF
--- a/modules/services/cbatticon.nix
+++ b/modules/services/cbatticon.nix
@@ -9,8 +9,6 @@ let
 
   cfg = config.services.cbatticon;
 
-  package = pkgs.cbatticon;
-
   makeCommand =
     commandName: commandArg:
     optional (commandArg != null) (
@@ -21,7 +19,7 @@ let
     );
 
   commandLine = lib.concatStringsSep " " (
-    [ "${package}/bin/cbatticon" ]
+    [ (lib.getExe cfg.package) ]
     ++ makeCommand "command-critical-level" cfg.commandCriticalLevel
     ++ makeCommand "command-left-click" cfg.commandLeftClick
     ++ optional (cfg.iconType != null) "--icon-type ${cfg.iconType}"
@@ -43,6 +41,8 @@ in
   options = {
     services.cbatticon = {
       enable = lib.mkEnableOption "cbatticon";
+
+      package = lib.mkPackageOption pkgs "cbatticon" { };
 
       commandCriticalLevel = mkOption {
         type = types.nullOr types.lines;
@@ -127,7 +127,7 @@ in
       (lib.hm.assertions.assertPlatform "services.cbatticon" pkgs lib.platforms.linux)
     ];
 
-    home.packages = [ package ];
+    home.packages = [ cfg.package ];
 
     systemd.user.services.cbatticon = {
       Unit = {


### PR DESCRIPTION
### Description
I opened this PR to allow users to use a custom verison of the unmaitained cbatticon
See awaiting PR on nixpkgs: https://github.com/NixOS/nixpkgs/pull/456171


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
