### PR TITLE
xdg-portal: assert that required paths are linked on NixOS

### DIFF
--- a/modules/misc/xdg-portal.nix
+++ b/modules/misc/xdg-portal.nix
@@ -1,5 +1,6 @@
 {
   config,
+  osConfig,
   pkgs,
   lib,
   ...
@@ -31,14 +32,14 @@ in
       description = ''
         Whether to enable [XDG desktop integration](https://github.com/flatpak/xdg-desktop-portal).
 
-        Note, if you use the NixOS module and have `useUserPackages = true`,
-        make sure to add
+        Note, if you installed Home Manager via its NixOS module and
+        'home-manager.useUserPackages' is enabled, make sure to add
 
         ``` nix
         environment.pathsToLink = [ "/share/xdg-desktop-portal" "/share/applications" ];
         ```
 
-        to your system configuration so that the portal definitions and DE
+        to your NixOS configuration so that the portal definitions and DE
         provided configurations get linked.
       '';
     };
@@ -145,6 +146,25 @@ in
         {
           assertion = cfg.extraPortals != [ ];
           message = "Setting xdg.portal.enable to true requires a portal implementation in xdg.portal.extraPortals such as xdg-desktop-portal-gtk or xdg-desktop-portal-kde.";
+        }
+
+        {
+          assertion =
+            let
+              onNixos = pkgs.stdenv.hostPlatform.isLinux && config.submoduleSupport.enable;
+              isLinked = path: lib.elem path osConfig.environment.pathsToLink;
+            in
+            onNixos && osConfig.home-manager.useUserPackages
+            -> isLinked "/share/applications" && isLinked "/share/xdg-desktop-portal";
+          message = ''
+            xdg.portal: since you installed Home Manager via its NixOS module and
+            'home-manager.useUserPackages' is enabled, you need to add
+
+            environment.pathsToLink = [ `/share/applications` `/share/xdg-desktop-portal` ];
+
+            to your NixOS configuration so that the portal definitions and DE
+            provided configurations get linked.
+          '';
         }
       ];
 


### PR DESCRIPTION
### Description

The description of `xdg.portal.enable` that certain paths need to be added to NixOS' `environment.pathsToLink` option when Home Manager is installed as a submodule and `home-manager.useUserPackages` is enabled. This PR adds precisely this check as an assertion.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
