### PR TITLE
home-manager: define a central package

### DIFF
--- a/modules/programs/home-manager.nix
+++ b/modules/programs/home-manager.nix
@@ -25,10 +25,20 @@ in
           {file}`$HOME/.nixpkgs/home-manager` will be attempted.
         '';
       };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        readOnly = true;
+        description = "The {command}`home-manager` package.";
+        default = pkgs.callPackage ../../home-manager { inherit (cfg) path; };
+        defaultText = lib.literalExpression ''
+          pkgs.callPackage ../../home-manager { inherit (config.programs.home-manager) path; };
+        '';
+      };
     };
   };
 
   config = lib.mkIf (cfg.enable && !config.submoduleSupport.enable) {
-    home.packages = [ (pkgs.callPackage ../../home-manager { inherit (cfg) path; }) ];
+    home.packages = [ cfg.package ];
   };
 }

--- a/modules/services/home-manager-auto-expire.nix
+++ b/modules/services/home-manager-auto-expire.nix
@@ -9,9 +9,7 @@ let
 
   cfg = config.services.home-manager.autoExpire;
 
-  homeManagerPackage = pkgs.callPackage ../../home-manager {
-    path = config.programs.home-manager.path;
-  };
+  homeManagerPackage = config.programs.home-manager.package;
 
   script = pkgs.writeShellScript "home-manager-auto-expire" (
     ''

--- a/modules/services/home-manager-auto-upgrade.nix
+++ b/modules/services/home-manager-auto-upgrade.nix
@@ -9,9 +9,7 @@ let
 
   cfg = config.services.home-manager.autoUpgrade;
 
-  homeManagerPackage = pkgs.callPackage ../../home-manager {
-    path = config.programs.home-manager.path;
-  };
+  homeManagerPackage = config.programs.home-manager.package;
 
   autoUpgradeApp = pkgs.writeShellApplication {
     name = "home-manager-auto-upgrade";


### PR DESCRIPTION
### Description

The same home manager derivation is duplicated in three places. This PR centralizes the definition by making it available through the `programs.home-manager.package` option.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
