### PR TITLE
aerospace: don't use ifd

### DIFF
--- a/modules/programs/aerospace.nix
+++ b/modules/programs/aerospace.nix
@@ -320,7 +320,7 @@ in
     home = {
       packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
-      file.".config/aerospace/aerospace.toml".text =
+      file.".config/aerospace/aerospace.toml".source =
         let
           generatedConfig = tomlFormat.generate "aerospace" (
             filterNulls (
@@ -332,8 +332,15 @@ in
               }
             )
           );
+          extraConfig = pkgs.writeText "aerospace-extra-config" cfg.extraConfig;
         in
-        builtins.readFile generatedConfig + lib.optionalString (cfg.extraConfig != "") "${cfg.extraConfig}";
+        pkgs.runCommandLocal "aerospace.toml"
+          {
+            inherit generatedConfig extraConfig;
+          }
+          ''
+            cat "$generatedConfig" "$extraConfig" > "$out"
+          '';
     };
 
     launchd.agents.aerospace = {


### PR DESCRIPTION
### Description

PR #8010 switched to using IFD for the generated `aerospace.toml` (even when `extraConfig` isn't used), this PR switches to concatenating the two configs (generated + extra) at build time instead of at evaluation time.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
