### PR TITLE
news: add backupCommand entry

### DIFF
--- a/modules/misc/news/2025/10/2025-10-30_12-25-46.nix
+++ b/modules/misc/news/2025/10/2025-10-30_12-25-46.nix
@@ -1,0 +1,17 @@
+{
+  time = "2025-10-30T17:25:46+00:00";
+  condition = true;
+  message = ''
+    A new option 'backupCommand' is now available for Home Manager activation.
+
+    This option allows you to specify a custom command to run on existing files
+    during activation. If set, it takes precedence over 'backupFileExtension',
+    but can work together with it by referencing the '$HOME_MANAGER_BACKUP_EXT'
+    environment variable in your command.
+
+    This enables advanced backup workflows, such as moving files to trash or
+    archiving with custom tools, before managing them with Home Manager.
+
+    The option is available in standalone, NixOS, and nix-darwin configurations.
+  '';
+}


### PR DESCRIPTION
Introduced in https://github.com/nix-community/home-manager/pull/7153

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
