### PR TITLE
delta: prevent jujutsu integration from overriding user settings

### DIFF
--- a/modules/programs/delta.nix
+++ b/modules/programs/delta.nix
@@ -135,14 +135,21 @@ in
       })
 
       (lib.mkIf (cfg.enable && cfg.enableJujutsuIntegration) {
+        assertions = [
+          {
+            assertion = config.programs.jujutsu.enable or false;
+            message = "programs.delta.enableJujutsuIntegration requires programs.jujutsu.enable to be true";
+          }
+        ];
+
         programs.jujutsu.settings = {
-          merge-tools.delta.diff-expected-exit-codes = [
+          merge-tools.delta.diff-expected-exit-codes = lib.mkDefault [
             0
             1
           ];
           ui = {
-            diff-formatter = ":git";
-            pager = "${lib.getExe cfg.package}";
+            diff-formatter = lib.mkDefault ":git";
+            pager = lib.mkDefault "${lib.getExe cfg.package}";
           };
         };
       })


### PR DESCRIPTION
- wrap all jujutsu settings with `lib.mkDefault` to allow user overrides
- add assertion to ensure `programs.jujutsu.enable` is true
- prevents hard conflicts when users customize jujutsu configuration


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
