### PR TITLE
lazygit: fix nushell and fish integrations

### DIFF
--- a/modules/programs/lazygit.nix
+++ b/modules/programs/lazygit.nix
@@ -85,10 +85,15 @@ in
 
     programs =
       let
+        lazygitNewDirFilePath =
+          if config.home.preferXdgDirectories then
+            "${config.xdg.cacheHome}/lazygit/newdir"
+          else
+            "~/.lazygit/newdir";
+
         bashIntegration = ''
-          ${cfg.shellWrapperName}()
-          {
-              export LAZYGIT_NEW_DIR_FILE=~/.lazygit/newdir
+          ${cfg.shellWrapperName}() {
+              export LAZYGIT_NEW_DIR_FILE=${lazygitNewDirFilePath}
               lazygit "$@"
               if [ -f $LAZYGIT_NEW_DIR_FILE ]; then
                 cd "$(cat $LAZYGIT_NEW_DIR_FILE)"
@@ -98,17 +103,19 @@ in
         '';
 
         fishIntegration = ''
-          set -x LAZYGIT_NEW_DIR_FILE ~/.lazygit/newdir
-          command lazygit $argv
-          if test -f $LAZYGIT_NEW_DIR_FILE
-            cd (cat $LAZYGIT_NEW_DIR_FILE)
-            rm -f $LAZYGIT_NEW_DIR_FILE
+          function ${cfg.shellWrapperName}
+            set -x LAZYGIT_NEW_DIR_FILE ${lazygitNewDirFilePath}
+            command lazygit $argv
+            if test -f $LAZYGIT_NEW_DIR_FILE
+              cd (cat $LAZYGIT_NEW_DIR_FILE)
+              rm -f $LAZYGIT_NEW_DIR_FILE
+            end
           end
         '';
 
         nushellIntegration = ''
           def --env ${cfg.shellWrapperName} [...args] {
-            $env.LAZYGIT_NEW_DIR_FILE = "~/.lazygit/newdir"
+            $env.LAZYGIT_NEW_DIR_FILE = "${lazygitNewDirFilePath}" | path expand
             lazygit ...$args
             if ($env.LAZYGIT_NEW_DIR_FILE | path exists) {
               cd (open $env.LAZYGIT_NEW_DIR_FILE)


### PR DESCRIPTION
### Description
The lazygit nushell integration was creating a literal `~` directory in the current working directory because the path was not manually expanded.

I also noticed that there was no code in the fish integration that used `cfg.shellWrapperName` to define a function so I think that it was also broken.

Also `${config.xdg.cacheHome/lazygit/newdir}` is now used instead of `~/.lazygit/newdir` if `home.preferXdgDirectories` is enabled.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
