### PR TITLE
rclone: add option to set log-level

### DIFF
--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -112,13 +112,15 @@ in
                         enable = lib.mkEnableOption "this mount";
 
                         logLevel = lib.mkOption {
-                          type = lib.types.enum [
-                            "ERROR"
-                            "NOTICE"
-                            "INFO"
-                            "DEBUG"
-                          ];
-                          default = "NOTICE";
+                          type = lib.types.nullOr (
+                            lib.types.enum [
+                              "ERROR"
+                              "NOTICE"
+                              "INFO"
+                              "DEBUG"
+                            ]
+                          );
+                          default = null;
                           example = "INFO";
                           description = ''
                             Set the log-level.
@@ -363,8 +365,9 @@ in
                     Environment = [
                       # fusermount/fusermount3
                       "PATH=/run/wrappers/bin"
-                      "RCLONE_LOG_LEVEL=${mount.logLevel}"
-                    ];
+                    ]
+                    ++ lib.optional (mount.logLevel != null) "RCLONE_LOG_LEVEL=${mount.logLevel}";
+
                     ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${mount.mountPoint}";
                     ExecStart = lib.concatStringsSep " " [
                       (lib.getExe cfg.package)


### PR DESCRIPTION
### Description

Add an option to set rclone's log-level per mount:
```nix
programs.rclone.remotes.<name>.mounts.<name>.logLevel = "DEBUG";
```
If no value is set, it'll use rclone's implicit default ("NOTICE")

Previously, the debug log-level got enforced (via "-vv"), which caused noisy logs, and there was no easy way to change that.

Note: rclone global-flags can't be configured in the config file. So, this uses the environment variable approach.

references:
- https://rclone.org/docs/#logging
- https://rclone.org/docs/#v-vv-verbose

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
