### PR TITLE
gpg-agent: fix syntax-breaking extraneous new line

### DIFF
--- a/modules/services/gpg-agent.nix
+++ b/modules/services/gpg-agent.nix
@@ -25,17 +25,23 @@ let
     GPG_TTY="$(tty)"
     export GPG_TTY
   ''
-  + optionalString cfg.enableSshSupport "${gpgSshSupportStr} > /dev/null";
+  + optionalString cfg.enableSshSupport ''
+    ${gpgSshSupportStr} > /dev/null
+  '';
 
   gpgZshInitStr = ''
     export GPG_TTY=$TTY
   ''
-  + optionalString cfg.enableSshSupport "${gpgSshSupportStr} > /dev/null";
+  + optionalString cfg.enableSshSupport ''
+    ${gpgSshSupportStr} > /dev/null
+  '';
 
   gpgFishInitStr = ''
     set -gx GPG_TTY (tty)
   ''
-  + optionalString cfg.enableSshSupport "${gpgSshSupportStr} > /dev/null";
+  + optionalString cfg.enableSshSupport ''
+    ${gpgSshSupportStr} > /dev/null
+  '';
 
   gpgNushellInitStr = ''
     $env.GPG_TTY = (tty)


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

With the recent refactor to the `gpg-agent` module (#8100), in particular, with the relocation of the redirections to `/dev/null`, a new line character was inadvertedly introduced between the affected command and its redirection to `/dev/null`.
This breaks the `~/.config/fish/config.fish` file; `fish` will croak:

```console
~/.config/fish/config.fish (line 20): Missing end to balance this begin
status is-interactive; and begin
                           ^~~~^
from sourcing file ~/.config/fish/config.fish
	called during startup
source: Error while reading file “/home/pancho/.config/fish/config.fish”
```

It also affects `~/.bashrc`, since the redirection ends up in its own line, becoming a no-op, instead of the intended effect of silencing the previous command.

(It might possibly affect the other shells too).

This PR fixes that, by ensuring that the string holding the command does not contain the extraneous new line character to begin with.

Pinging @khaneliman and @jaredmontoya, authors of #8100, and apparently not `fish` users :stuck_out_tongue_winking_eye:.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
