### PR TITLE
fish: added repaint to binds

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -261,6 +261,7 @@ let
         };
         erase = mkEnableOption "remove bind";
         silent = mkEnableOption "Operate silently";
+        repaint = mkEnableOption "redraw prompt after command";
         operate = mkOption {
           description = "Operate on preset bindings or user bindings";
           type =
@@ -324,6 +325,7 @@ let
         {
           silent,
           erase,
+          repaint,
           operate,
           mode,
           setsMode,
@@ -344,7 +346,11 @@ let
             ];
 
           cmdNormal = lib.concatStringsSep " " (
-            [ "bind" ] ++ opts ++ [ k ] ++ map lib.escapeShellArg (lib.flatten [ command ])
+            [ "bind" ]
+            ++ opts
+            ++ [ k ]
+            ++ map lib.escapeShellArg (lib.flatten [ command ])
+            ++ lib.optional repaint "repaint"
           );
 
           cmdErase = lib.concatStringsSep "  " (


### PR DESCRIPTION
### Description

I noticed that setting `bind.<name>.command` to `<command> repaint` wrote `bind <keybind> '<command> repaint'` which wasn't working. This fixes that by adding a new option for binds.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
