### PR TITLE
zed-editor: options to generate debug.json

### DIFF
--- a/tests/modules/programs/zed-editor/debug-empty.nix
+++ b/tests/modules/programs/zed-editor/debug-empty.nix
@@ -1,0 +1,83 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    userDebug = [
+      {
+        label = "PHP: Listen to Xdebug";
+        adapter = "Xdebug";
+        request = "launch";
+        port = 9003;
+      }
+      {
+        label = "PHP: Debug this test";
+        adapter = "Xdebug";
+        request = "launch";
+        program = "vendor/bin/phpunit";
+        args = [
+          "--filter"
+          "$ZED_SYMBOL"
+        ];
+      }
+    ];
+  };
+
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  nmt.script =
+    let
+      preexistingDebug = builtins.toFile "preexisting.json" "";
+
+      expectedContent = builtins.toFile "expected.json" ''
+        [
+          {
+            "adapter": "Xdebug",
+            "args": [
+              "--filter",
+              "$ZED_SYMBOL"
+            ],
+            "label": "PHP: Debug this test",
+            "program": "vendor/bin/phpunit",
+            "request": "launch"
+          },
+          {
+            "adapter": "Xdebug",
+            "label": "PHP: Listen to Xdebug",
+            "port": 9003,
+            "request": "launch"
+          }
+        ]
+      '';
+
+      debugPath = ".config/zed/debug.json";
+      activationScript = pkgs.writeScript "activation" config.home.activation.zedDebugActivation.data;
+    in
+    ''
+      export HOME=$TMPDIR/hm-user
+
+      # Simulate preexisting debug
+      mkdir -p $HOME/.config/zed
+      cat ${preexistingDebug} > $HOME/${debugPath}
+
+      # Run the activation script
+      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+      chmod +x $TMPDIR/activate
+      $TMPDIR/activate
+
+      # Validate the merged debug
+      assertFileExists "$HOME/${debugPath}"
+      assertFileContent "$HOME/${debugPath}" "${expectedContent}"
+
+      # Test idempotency
+      $TMPDIR/activate
+      assertFileExists "$HOME/${debugPath}"
+      assertFileContent "$HOME/${debugPath}" "${expectedContent}"
+    '';
+}

--- a/tests/modules/programs/zed-editor/debug-immutable.nix
+++ b/tests/modules/programs/zed-editor/debug-immutable.nix
@@ -1,0 +1,58 @@
+# Test custom keymap functionality
+{ config, ... }:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    mutableUserDebug = false;
+    userDebug = [
+      {
+        label = "PHP: Listen to Xdebug";
+        adapter = "Xdebug";
+        request = "launch";
+        port = 9003;
+      }
+      {
+        label = "PHP: Debug this test";
+        adapter = "Xdebug";
+        request = "launch";
+        program = "vendor/bin/phpunit";
+        args = [
+          "--filter"
+          "$ZED_SYMBOL"
+        ];
+      }
+    ];
+  };
+
+  nmt.script =
+    let
+      expectedContent = builtins.toFile "expected.json" ''
+        [
+          {
+            "adapter": "Xdebug",
+            "label": "PHP: Listen to Xdebug",
+            "port": 9003,
+            "request": "launch"
+          },
+          {
+            "adapter": "Xdebug",
+            "args": [
+              "--filter",
+              "$ZED_SYMBOL"
+            ],
+            "label": "PHP: Debug this test",
+            "program": "vendor/bin/phpunit",
+            "request": "launch"
+          }
+        ]
+      '';
+
+      settingsPath = ".config/zed/debug.json";
+    in
+    ''
+      assertFileExists "home-files/${settingsPath}"
+      assertFileContent "home-files/${settingsPath}" "${expectedContent}"
+    '';
+}

--- a/tests/modules/programs/zed-editor/debug.nix
+++ b/tests/modules/programs/zed-editor/debug.nix
@@ -1,0 +1,100 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  programs.zed-editor = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { };
+    userDebug = [
+      {
+        label = "PHP: Listen to Xdebug";
+        adapter = "Xdebug";
+        request = "launch";
+        port = 9003;
+      }
+      {
+        label = "PHP: Debug this test";
+        adapter = "Xdebug";
+        request = "launch";
+        program = "vendor/bin/phpunit";
+        args = [
+          "--filter"
+          "$ZED_SYMBOL"
+        ];
+      }
+    ];
+  };
+
+  home.homeDirectory = lib.mkForce "/@TMPDIR@/hm-user";
+
+  nmt.script =
+    let
+      preexistingDebug = builtins.toFile "preexisting.json" ''
+        [
+          {
+            "label": "Debug active Python file",
+            "adapter": "Debugpy",
+            "program": "$ZED_FILE",
+            "request": "launch",
+            "cwd": "$ZED_WORKTREE_ROOT"
+          }
+        ]
+      '';
+
+      expectedContent = builtins.toFile "expected.json" ''
+        [
+          {
+            "label": "Debug active Python file",
+            "adapter": "Debugpy",
+            "program": "$ZED_FILE",
+            "request": "launch",
+            "cwd": "$ZED_WORKTREE_ROOT"
+          },
+          {
+            "adapter": "Xdebug",
+            "args": [
+              "--filter",
+              "$ZED_SYMBOL"
+            ],
+            "label": "PHP: Debug this test",
+            "program": "vendor/bin/phpunit",
+            "request": "launch"
+          },
+          {
+            "adapter": "Xdebug",
+            "label": "PHP: Listen to Xdebug",
+            "port": 9003,
+            "request": "launch"
+          }
+        ]
+      '';
+
+      debugPath = ".config/zed/debug.json";
+      activationScript = pkgs.writeScript "activation" config.home.activation.zedDebugActivation.data;
+    in
+    ''
+      export HOME=$TMPDIR/hm-user
+
+      # Simulate preexisting debug
+      mkdir -p $HOME/.config/zed
+      cat ${preexistingDebug} > $HOME/${debugPath}
+
+      # Run the activation script
+      substitute ${activationScript} $TMPDIR/activate --subst-var TMPDIR
+      chmod +x $TMPDIR/activate
+      $TMPDIR/activate
+
+      # Validate the merged debug
+      assertFileExists "$HOME/${debugPath}"
+      assertFileContent "$HOME/${debugPath}" "${expectedContent}"
+
+      # Test idempotency
+      $TMPDIR/activate
+      assertFileExists "$HOME/${debugPath}"
+      assertFileContent "$HOME/${debugPath}" "${expectedContent}"
+    '';
+}

--- a/tests/modules/programs/zed-editor/default.nix
+++ b/tests/modules/programs/zed-editor/default.nix
@@ -11,5 +11,8 @@
   zed-tasks = ./tasks.nix;
   zed-tasks-immutable = ./tasks-immutable.nix;
   zed-tasks-empty = ./tasks-empty.nix;
+  zed-debug = ./debug.nix;
+  zed-debug-immutable = ./debug-immutable.nix;
+  zed-debug-empty = ./debug-empty.nix;
   zed-themes = ./themes;
 }


### PR DESCRIPTION
### Description

Add `mutableUserDebug` and `userDebug` options to generate `debug.json` file. The options are heavily inspired by `mutableUserTasks` and `userTasks` options implementation.

Closes #8091

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
