### PR TITLE
glab: coerce glab tmpfile rule argument to string

### DIFF
--- a/modules/programs/glab.nix
+++ b/modules/programs/glab.nix
@@ -38,7 +38,7 @@ in
     # mode 0600.
     systemd.user.tmpfiles.settings.glab = lib.mkIf (cfg.settings != { }) {
       rules."${config.xdg.configHome}/glab-cli/config.yml" = {
-        "C+$".argument = yaml.generate "glab-config" cfg.settings;
+        "C+$".argument = "${yaml.generate "glab-config" cfg.settings}";
         z.mode = "0600";
       };
     };


### PR DESCRIPTION
### Description

Coerce the `argument` in glab's tmpfile rule to a string. I missed that in #8092.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
