### PR TITLE
ghostty: Add systemd intergration

### DIFF
--- a/modules/misc/news/2025/11/2025-11-03_22-56-50.nix
+++ b/modules/misc/news/2025/11/2025-11-03_22-56-50.nix
@@ -1,0 +1,14 @@
+{ config, pkgs, ... }:
+{
+  time = "2025-11-03T21:56:50+00:00";
+  condition = config.programs.ghostty.enable && pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    Ghostty:  now enables the user systemd service by default.
+
+    Running Ghostty via these systemd units is the recommended way to run
+    Ghostty. The two most important benefits provided by Ghostty's systemd
+    integrations are: instantaneous launching and centralized logging.
+
+    See https://ghostty.org/docs/linux/systemd for all details
+  '';
+}

--- a/tests/modules/programs/ghostty/empty-settings.nix
+++ b/tests/modules/programs/ghostty/empty-settings.nix
@@ -1,5 +1,9 @@
+{ realPkgs, ... }:
 {
-  programs.ghostty.enable = true;
+  programs.ghostty = {
+    enable = true;
+    package = realPkgs.ghostty;
+  };
 
   nmt.script = ''
     assertPathNotExists home-files/.config/ghostty/config

--- a/tests/modules/programs/ghostty/example-settings.nix
+++ b/tests/modules/programs/ghostty/example-settings.nix
@@ -1,8 +1,8 @@
-{ config, ... }:
+{ realPkgs, ... }:
 {
   programs.ghostty = {
     enable = true;
-    package = config.lib.test.mkStubPackage { };
+    package = realPkgs.ghostty;
 
     settings = {
       theme = "catppuccin-mocha";

--- a/tests/modules/programs/ghostty/example-theme.nix
+++ b/tests/modules/programs/ghostty/example-theme.nix
@@ -1,6 +1,8 @@
+{ realPkgs, ... }:
 {
   programs.ghostty = {
     enable = true;
+    package = realPkgs.ghostty;
 
     themes = {
       catppuccin-mocha = {


### PR DESCRIPTION
### Description

Ghostty defines a systemd unit for preloading terminal sessions. Because the unit files are scanned from `dbus-1` and `systemd` folders in the package source, `app-com.mitchellh.ghostty.service` is available on the system but can't be enabled. 

As far as I could tell you can't do `systemd.services."app-com.mitchellh.ghostty.service".enabled"` for these 'imported' units so I recreated them. I've looked at how `emacs` and `waybar` do their user level systemd-units and came to this solution. 

If there is a better way of importing the dbus unit or enabling the existing imported services please let me know. 

Closes https://github.com/nix-community/home-manager/issues/8027

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like