### PR TITLE
tests: `hostPlatform` -> `stdenv.hostPlatform`

### DIFF
--- a/tests/modules/programs/firefox/profiles/overwrite/default.nix
+++ b/tests/modules/programs/firefox/profiles/overwrite/default.nix
@@ -39,7 +39,7 @@ in
       nmt.script =
         let
           binPath =
-            if pkgs.hostPlatform.isDarwin then
+            if pkgs.stdenv.hostPlatform.isDarwin then
               "Applications/${cfg.darwinAppName}.app/Contents/MacOS"
             else
               "bin";

--- a/tests/modules/programs/firefox/profiles/settings/default.nix
+++ b/tests/modules/programs/firefox/profiles/settings/default.nix
@@ -39,7 +39,7 @@ in
       nmt.script =
         let
           binPath =
-            if pkgs.hostPlatform.isDarwin then
+            if pkgs.stdenv.hostPlatform.isDarwin then
               "Applications/${cfg.darwinAppName}.app/Contents/MacOS"
             else
               "bin";

--- a/tests/modules/programs/firefox/profiles/userchrome/default.nix
+++ b/tests/modules/programs/firefox/profiles/userchrome/default.nix
@@ -37,7 +37,7 @@ in
       nmt.script =
         let
           binPath =
-            if pkgs.hostPlatform.isDarwin then
+            if pkgs.stdenv.hostPlatform.isDarwin then
               "Applications/${cfg.darwinAppName}.app/Contents/MacOS"
             else
               "bin";

--- a/tests/modules/programs/firefox/state-version-19_09.nix
+++ b/tests/modules/programs/firefox/state-version-19_09.nix
@@ -13,7 +13,7 @@ in
 {
   imports = [ firefoxMockOverlay ];
 
-  config = lib.mkIf (config.test.enableBig && !pkgs.hostPlatform.isDarwin) (
+  config = lib.mkIf (config.test.enableBig && !pkgs.stdenv.hostPlatform.isDarwin) (
     {
       home.stateVersion = "19.09";
     }


### PR DESCRIPTION
### Description

https://github.com/NixOS/nixpkgs/pull/456527 removed the `pkgs.hostPlatform` alias. Hence, this PR replaces all of its occurrences with `pkgs.stdenv.hostPlatform`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
