### PR TITLE
opkssh: init module

### DIFF
--- a/modules/misc/news/2025/11/2025-11-04_13-00-00.nix
+++ b/modules/misc/news/2025/11/2025-11-04_13-00-00.nix
@@ -1,0 +1,11 @@
+{
+  time = "2025-11-04T13:00:00+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.opkssh'.
+
+    opkssh is a tool which enables ssh to be used with OpenID Connect allowing SSH access to be managed via identities instead of long-lived SSH keys. It does not replace SSH, but instead generates SSH public keys containing PK Tokens and configures sshd to verify them. These PK Tokens contain standard OpenID Connect ID Tokens.
+
+    This protocol builds on the OpenPubkey which adds user public keys to OpenID Connect without breaking compatibility with existing OpenID Provider.
+  '';
+}

--- a/modules/programs/opkssh.nix
+++ b/modules/programs/opkssh.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.opkssh;
+
+  yamlFormat = pkgs.formats.yaml { };
+
+in
+{
+  meta.maintainers = [ lib.maintainers.swarsel ];
+
+  options.programs.opkssh = {
+    enable = lib.mkEnableOption "enable the OpenPubkey SSH client";
+
+    package = lib.mkPackageOption pkgs "opkssh" { nullable = true; };
+
+    settings = lib.mkOption {
+      inherit (yamlFormat) type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+        default_provider = "kanidm";
+
+        providers = [
+          {
+            alias = "kanidm";
+            issuer = "https://idm.example.com/oauth2/openid/opkssh";
+            client_id = "opkssh";
+            scopes = "openid email profile";
+            redirect_uris = [
+              "http://localhost:3000/login-callback"
+              "http://localhost:10001/login-callback"
+              "http://localhost:11110/login-callback"
+            ];
+          };
+        ];
+        }
+      '';
+      description = ''
+        Configuration written to {file}`$HOME/.opk/config.yml`.
+        See <https://github.com/openpubkey/opkssh/blob/main/docs/config.md#client-config-opkconfigyml>.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    home.file."${config.home.homeDirectory}/.opk/config.yml" = lib.mkIf (cfg.settings != { }) {
+      source = yamlFormat.generate "opkssh-config-${config.home.username}.yml" cfg.settings;
+    };
+
+  };
+}

--- a/tests/modules/programs/opkssh/default.nix
+++ b/tests/modules/programs/opkssh/default.nix
@@ -1,0 +1,3 @@
+{
+  opkssh-basic-config = ./opkssh-basic-config.nix;
+}

--- a/tests/modules/programs/opkssh/opkssh-basic-config.nix
+++ b/tests/modules/programs/opkssh/opkssh-basic-config.nix
@@ -1,0 +1,42 @@
+_: {
+  programs.opkssh = {
+    enable = true;
+    settings = {
+      default_provider = "test-provider";
+      providers = [
+        {
+          alias = "test-provider";
+          issuer = "https://test.domain/oauth2/openid/opkssh";
+          client_id = "opkssh";
+          scopes = "openid email profile";
+          redirect_uris = [
+            "http://localhost:3000/login-callback"
+            "http://localhost:10001/login-callback"
+            "http://localhost:11110/login-callback"
+          ];
+        }
+      ];
+    };
+  };
+
+  nmt.script = ''
+    configFile=home-files/.opk/config.yml
+
+    assertFileExists "$configFile"
+
+    configFileNormalized="$(normalizeStorePaths "$configFile")"
+
+    assertFileContent "$configFileNormalized" ${builtins.toFile "expected.service" ''
+      default_provider: test-provider
+      providers:
+      - alias: test-provider
+        client_id: opkssh
+        issuer: https://test.domain/oauth2/openid/opkssh
+        redirect_uris:
+        - http://localhost:3000/login-callback
+        - http://localhost:10001/login-callback
+        - http://localhost:11110/login-callback
+        scopes: openid email profile
+    ''}
+  '';
+}


### PR DESCRIPTION
Adds a module for [opkssh](https://github.com/openpubkey/opkssh).
### Description

<!--

Please provide a brief description of your change.

-->


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
