### PR TITLE
ghostty: Add systemd integration

### DIFF
--- a/modules/misc/news/2025/11/2025-11-03_22-56-50.nix
+++ b/modules/misc/news/2025/11/2025-11-03_22-56-50.nix
@@ -1,0 +1,14 @@
+{ config, pkgs, ... }:
+{
+  time = "2025-11-03T21:56:50+00:00";
+  condition = config.programs.ghostty.enable && pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    Ghostty:  now enables the user systemd service by default.
+
+    Running Ghostty via these systemd units is the recommended way to run
+    Ghostty. The two most important benefits provided by Ghostty's systemd
+    integrations are: instantaneous launching and centralized logging.
+
+    See https://ghostty.org/docs/linux/systemd for all details
+  '';
+}

--- a/modules/programs/ghostty.nix
+++ b/modules/programs/ghostty.nix
@@ -114,6 +114,24 @@ in
         defaultText = lib.literalMD "`true` if programs.ghostty.package is not null";
       };
 
+      systemd = lib.mkOption {
+        type = lib.types.submodule {
+          options = {
+            enable = lib.mkEnableOption "the Ghostty systemd user service" // {
+              default = pkgs.stdenv.hostPlatform.isLinux;
+              defaultText = lib.literalMD "`true` on Linux, `false` otherwise";
+            };
+          };
+        };
+        default = { };
+        description = ''
+          Configuration for Ghostty's systemd integration.
+          This enables additional speed and features.
+
+          See <https://ghostty.org/docs/linux/systemd> for more information.
+        '';
+      };
+
       enableBashIntegration = mkShellIntegrationOption (
         lib.hm.shell.mkBashIntegrationOption { inherit config; }
       );
@@ -193,6 +211,22 @@ in
           };
           config.map-syntax = [ "${config.xdg.configHome}/ghostty/config:Ghostty Config" ];
         };
+      })
+
+      (lib.mkIf cfg.systemd.enable {
+        assertions = [
+          {
+            assertion = cfg.systemd.enable -> cfg.package != null;
+            message = "programs.ghostty.systemd.enable cannot be true when programs.ghostty.package is null";
+          }
+          {
+            assertion = cfg.systemd.enable -> pkgs.stdenv.hostPlatform.isLinux;
+            message = "Ghostty systemd integration cannot be enabled for non-linux platforms";
+          }
+        ];
+        xdg.configFile."systemd/user/app-com.mitchellh.ghostty.service".source =
+          "${cfg.package}/share/systemd/user/app-com.mitchellh.ghostty.service";
+        dbus.packages = [ cfg.package ];
       })
 
       (lib.mkIf cfg.enableBashIntegration {

--- a/tests/modules/programs/ghostty/empty-settings.nix
+++ b/tests/modules/programs/ghostty/empty-settings.nix
@@ -1,5 +1,9 @@
+{ config, ... }:
 {
-  programs.ghostty.enable = true;
+  programs.ghostty = {
+    enable = true;
+    package = config.lib.test.mkStubPackage { outPath = null; };
+  };
 
   nmt.script = ''
     assertPathNotExists home-files/.config/ghostty/config

--- a/tests/modules/programs/ghostty/example-settings.nix
+++ b/tests/modules/programs/ghostty/example-settings.nix
@@ -2,7 +2,7 @@
 {
   programs.ghostty = {
     enable = true;
-    package = config.lib.test.mkStubPackage { };
+    package = config.lib.test.mkStubPackage { outPath = null; };
 
     settings = {
       theme = "catppuccin-mocha";

--- a/tests/modules/programs/ghostty/example-theme.nix
+++ b/tests/modules/programs/ghostty/example-theme.nix
@@ -1,6 +1,8 @@
+{ config, ... }:
 {
   programs.ghostty = {
     enable = true;
+    package = config.lib.test.mkStubPackage { outPath = null; };
 
     themes = {
       catppuccin-mocha = {


### PR DESCRIPTION
### Description

Ghostty defines a systemd unit for preloading terminal sessions. Because the unit files are scanned from `dbus-1` and `systemd` folders in the package source, `app-com.mitchellh.ghostty.service` is available on the system but can't be enabled. 

As far as I could tell you can't do `systemd.services."app-com.mitchellh.ghostty.service".enabled"` for these 'imported' units. The current strategy is getting them from the package and manually setting them with `xdg.configFile`

Closes https://github.com/nix-community/home-manager/issues/8027
Supersedes https://github.com/nix-community/home-manager/pull/8120

### Checklist

- [x] Change is backwards compatible.
- [x] New news item created
- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.
- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.
- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).
- [x] Commit messages are formatted like