### PR TITLE
saml2aws: init module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -381,6 +381,18 @@
     github = "mipmip";
     githubId = 658612;
   };
+  mokrinsky = {
+    name = "mokrinsky";
+    email = "463907+mokrinsky@users.noreply.github.com";
+    github = "mokrinsky";
+    githubId = 463907;
+    keys = [
+      {
+        longkeyid = "rsa4096/0x73CC011921471A15";
+        fingerprint = "EA54 E892 D96C 779E 1FA6  4E0A 73CC 0119 2147 1A15";
+      }
+    ];
+  };
   msfjarvis = {
     email = "me@msfjarvis.dev";
     github = "msfjarvis";

--- a/modules/misc/news/2025/11/2025-11-05_14-54-50.nix
+++ b/modules/misc/news/2025/11/2025-11-05_14-54-50.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-11-05T12:54:50+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'programs.saml2aws'.
+
+    saml2aws is a CLI tool which enables you to login and retrieve AWS temporary credentials using a SAML IDP. It support a bunch of SAML providers, from cloud ones like Akamai, Okta or OneLogin, to corporate or self-hosted like Authentik, KeyCloak or ADFS.
+  '';
+}

--- a/modules/programs/saml2aws.nix
+++ b/modules/programs/saml2aws.nix
@@ -1,0 +1,94 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.saml2aws;
+  iniFormat = pkgs.formats.ini { };
+  inherit (lib) mkIf mkOption types;
+in
+{
+  meta.maintainers = [ lib.hm.maintainers.mokrinsky ];
+
+  options.programs.saml2aws = {
+    enable = lib.mkEnableOption "saml2aws CLI tool";
+
+    package = lib.mkPackageOption pkgs "saml2aws" {
+      default = "saml2aws";
+      nullable = true;
+    };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption {
+      inherit config;
+      extraDescription = ''If enabled, this will install autocompletion for bash.'';
+    };
+
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption {
+      inherit config;
+      extraDescription = ''If enabled, this will install autocompletion for zsh.'';
+    };
+
+    configLocation = mkOption {
+      default = "${config.home.homeDirectory}/.saml2aws";
+      defaultText = lib.literalExpression ''"''${config.home.homeDirectory}/.saml2aws"'';
+      type = types.str;
+      example = lib.literalExpression ''"''${config.home.homeDirectory}/.config/.saml2aws"'';
+      description = ''
+        Environment variable to specify the location of saml2aws configuration.
+      '';
+    };
+
+    credentials = mkOption {
+      type = types.submodule { freeformType = iniFormat.type; };
+      default = { };
+      example = lib.literalExpression ''
+        {
+          aws = {
+            name = "aws";
+            url = "https://domain.tld/uri/of/your/auth/endpoint";
+            username = "username";
+            provider = "Authentik";
+            mfa = "Auto";
+            skip_verify = false;
+            timeout = 0;
+            aws_urn = "urn:amazon:webservices";
+            aws_session_duration = 3600;
+            aws_profile = "123456789000";
+            saml_cache = false;
+            disable_remember_device = false;
+            disable_sessions = false;
+            download_browser_driver = false;
+            headless = false;
+          };
+        }
+      '';
+      description = ''
+        Configuration written to {file}`$HOME/.saml2aws` or config.programs.saml2aws.configLocation.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home = {
+      packages = mkIf (cfg.package != null) [ cfg.package ];
+
+      sessionVariables.SAML2AWS_CONFIGFILE = cfg.configLocation;
+
+      file."${cfg.configLocation}" = mkIf (cfg.credentials != { }) {
+        source = iniFormat.generate "saml2aws-credentials-${config.home.username}" cfg.credentials;
+      };
+    };
+
+    programs.bash.initExtra = mkIf cfg.enableBashIntegration ''
+      eval "$(${lib.getExe cfg.package} --completion-script-bash)"
+    '';
+
+    programs.zsh.initContent = mkIf cfg.enableZshIntegration ''
+      eval "$(${lib.getExe cfg.package} --completion-script-zsh)"
+    '';
+
+  };
+}

--- a/tests/modules/programs/saml2aws/default.nix
+++ b/tests/modules/programs/saml2aws/default.nix
@@ -1,0 +1,3 @@
+{
+  saml2aws = ./saml2aws.nix;
+}

--- a/tests/modules/programs/saml2aws/saml2aws.conf
+++ b/tests/modules/programs/saml2aws/saml2aws.conf
@@ -1,0 +1,16 @@
+[aws]
+aws_profile=123456789000
+aws_session_duration=3600
+aws_urn=urn:amazon:webservices
+disable_remember_device=false
+disable_sessions=false
+download_browser_driver=false
+headless=false
+mfa=Auto
+name=aws
+provider=Authentik
+saml_cache=false
+skip_verify=false
+timeout=0
+url=https://domain.tld/uri/of/your/auth/endpoint
+username=username

--- a/tests/modules/programs/saml2aws/saml2aws.nix
+++ b/tests/modules/programs/saml2aws/saml2aws.nix
@@ -1,0 +1,33 @@
+{
+  programs = {
+    saml2aws = {
+      enable = true;
+      credentials = {
+        aws = {
+          name = "aws";
+          url = "https://domain.tld/uri/of/your/auth/endpoint";
+          username = "username";
+          provider = "Authentik";
+          mfa = "Auto";
+          skip_verify = false;
+          timeout = 0;
+          aws_urn = "urn:amazon:webservices";
+          aws_session_duration = 3600;
+          aws_profile = "123456789000";
+          saml_cache = false;
+          disable_remember_device = false;
+          disable_sessions = false;
+          download_browser_driver = false;
+          headless = false;
+        };
+
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileExists home-files/.saml2aws
+    assertFileContent home-files/.saml2aws \
+      ${./saml2aws.conf}
+  '';
+}


### PR DESCRIPTION
Adding module to configure [saml2aws](https://github.com/Versent/saml2aws) utility.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
