### PR TITLE
tomat: add module

### DIFF
--- a/modules/misc/news/2025/11/2025-11-06_12-50-53.nix
+++ b/modules/misc/news/2025/11/2025-11-06_12-50-53.nix
@@ -1,0 +1,9 @@
+{
+  time = "2025-11-06T11:50:53+00:00";
+  condition = true;
+  message = ''
+    A new module is available: 'services.tomat'.
+
+    tomat is a Pomodoro timer for status bars and the command line. It is easily configurable and support both desktop and sound notifications.
+  '';
+}

--- a/modules/services/tomat.nix
+++ b/modules/services/tomat.nix
@@ -1,0 +1,74 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.tomat;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ jolars ];
+
+  options.services.tomat = {
+    enable = lib.mkEnableOption "Tomat Pomodoro server";
+
+    package = lib.mkPackageOption pkgs "tomat" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule { freeformType = tomlFormat.type; };
+
+      default = { };
+
+      example = {
+        timer = {
+          work = 25;
+          break = 5;
+          auto_advance = false;
+        };
+
+        sound = {
+          enabled = true;
+        };
+
+        notification = {
+          enabled = true;
+        };
+      };
+
+      description = ''
+        Tomat configuration.
+        See <https://github.com/jolars/tomat/blob/main/docs/configuration.md> for supported values.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile = {
+      "tomat/config.toml" = lib.mkIf (cfg.settings != { }) {
+        source = tomlFormat.generate "tomat-config.toml" cfg.settings;
+      };
+    };
+
+    systemd.user.services.tomat = {
+      Unit = {
+        Description = "Tomat Pomodoro server";
+        After = [ "graphical.target" ];
+      };
+
+      Service = {
+        ExecStart = "${lib.getExe cfg.package} daemon run";
+        Restart = "always";
+        RestartSec = 5;
+      };
+
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+    };
+  };
+}

--- a/tests/modules/services/tomat/default.nix
+++ b/tests/modules/services/tomat/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  tomat-service = ./tomat.nix;
+}

--- a/tests/modules/services/tomat/expected-config.toml
+++ b/tests/modules/services/tomat/expected-config.toml
@@ -1,0 +1,3 @@
+[timer]
+break = 10
+work = 60

--- a/tests/modules/services/tomat/expected.service
+++ b/tests/modules/services/tomat/expected.service
@@ -1,0 +1,11 @@
+[Install]
+WantedBy=default.target
+
+[Service]
+ExecStart=@tomat@/bin/tomat daemon run
+Restart=always
+RestartSec=5
+
+[Unit]
+After=graphical.target
+Description=Tomat Pomodoro server

--- a/tests/modules/services/tomat/tomat.nix
+++ b/tests/modules/services/tomat/tomat.nix
@@ -1,0 +1,25 @@
+{
+  services.tomat = {
+    enable = true;
+
+    settings = {
+      timer = {
+        break = 10;
+        work = 60;
+      };
+    };
+  };
+
+  nmt.script =
+    let
+      serviceFile = "home-files/.config/systemd/user/tomat.service";
+      configFile = "home-files/.config/tomat/config.toml";
+    in
+    ''
+      assertFileExists "${serviceFile}"
+      assertFileExists "${configFile}"
+
+      assertFileContent "${serviceFile}" ${./expected.service}
+      assertFileContent "${configFile}" ${./expected-config.toml}
+    '';
+}


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

tomat is a Pomodoro timer for status bars like waybar and polybar. It is based on a client-server architecture that enables it to gracefully handle interruptions and service restarts.

This module sets up the service and makes the CLI application available.

I am the maintainer of tomat. The source is at <https://github.com/jolars/tomat>

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
