### PR TITLE
easyeffects: Fix service hanging on system shutdown

### DIFF
--- a/modules/services/easyeffects.nix
+++ b/modules/services/easyeffects.nix
@@ -133,6 +133,7 @@ in
         KillMode = "mixed";
         Restart = "on-failure";
         RestartSec = 5;
+        TimeoutStopSec = 10;
       };
     };
   };


### PR DESCRIPTION
### Description

EasyEffects requires PipeWire and DBus to function. However, during system shutdown, EasyEffects was stopping after these dependencies, causing it to hang and provoke a stop job for user manager. The service now uses 'Before' directives to ensure EasyEffects stops before PipeWire and DBus during shutdown. I have also added 'Type=dbus' and 'BusName' and 'KillMode=mixed' for proper service management. I have rebooted my system 6 times in which EasyEffects has not hanged even once. Fixes #6448 

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
