### PR TITLE
vdirsyncer: Add option to request vcard 4.0

### DIFF
--- a/modules/programs/vdirsyncer/accounts.nix
+++ b/modules/programs/vdirsyncer/accounts.nix
@@ -118,6 +118,15 @@ in
       '';
     };
 
+    useVcard4 = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Specifies whether vdirsyncer should request vCards in version 4.0.
+        If set to `false` then vdirsyncer will default to version 3.0.
+      '';
+    };
+
     verify = mkOption {
       type = types.nullOr types.path;
       default = null;

--- a/modules/programs/vdirsyncer/default.nix
+++ b/modules/programs/vdirsyncer/default.nix
@@ -101,6 +101,8 @@ let
         end_date = "${v.end}"''
     else if (n == "itemTypes") then
       "item_types = ${listString (map wrap v)}"
+    else if (n == "useVcard4") then
+      ''use_vcard_4 = ${v}''
     else if (n == "userName") then
       ''username = "${v}"''
     else if (n == "userNameCommand") then


### PR DESCRIPTION
### Description

I have added an option for vdirsyncer to request vCards in version 4.0 from CardDAV servers. vdirsyncer has this feature built in (see the [manual](https://vdirsyncer.pimutils.org/en/stable/config.html#storage-carddav) or the corresponding PR pimutils/vdirsyncer#1066) and this brings support for it to home-manager. This should cover my feature request #7838.

*Note 1: When I ran the tests I got back some errors, but I got the exact same errors when I ran the tests on the master branch without my changes. I can't say right now whether this was me running the tests incorrectly or not, but at least I did not add any new error messages.*

*Note 2: This is my first PR on home-manager and I'm still figuring out how things are working here and with NixOS in general. So if there is anything I should change or improve on, don't hesitate to tell me :)*

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```