### PR TITLE
programs/bluetuith: init

### DIFF
--- a/modules/misc/news/2025/11/2025-11-15_09-54-20.nix
+++ b/modules/misc/news/2025/11/2025-11-15_09-54-20.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+
+{
+  time = "2025-11-15T08:54:20+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'programs.bluetuith'.
+
+    bluetuith is a TUI-based Bluetooth connection manager, which can interact
+    with Bluetooth adapters and devices. It aims to be a replacement to most
+    Bluetooth managers, like blueman.
+  '';
+}

--- a/modules/programs/bluetuith.nix
+++ b/modules/programs/bluetuith.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.bluetuith;
+
+  jsonFormat = pkgs.formats.json { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [
+    poseidon-rises
+  ];
+
+  options.programs.bluetuith = {
+    enable = lib.mkEnableOption "Bluetuith";
+
+    package = lib.mkPackageOption pkgs "bluetuith" { nullable = true; };
+
+    settings = lib.mkOption {
+      type = jsonFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          adapter = "hci0";
+          receive-dir = "/home/user/files";
+
+          keybindings = {
+            Menu = "Alt+m";
+          };
+
+          theme = {
+            Adapter = "red";
+          };
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/bluetuith/bluetuith.conf`.
+
+        See <https://bluetuith-org.github.io/bluetuith/Configuration.html> for
+        details.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.bluetuith" pkgs lib.platforms.linux)
+    ];
+
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."bluetuith/bluetuith.conf" = lib.mkIf (cfg.settings != { }) {
+      source = jsonFormat.generate "bluetuith.conf" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/bluetuith/default.nix
+++ b/tests/modules/programs/bluetuith/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  bluetuith-empty-settings = ./empty-settings.nix;
+  bluetuith-example-settings = ./example-settings.nix;
+}

--- a/tests/modules/programs/bluetuith/empty-settings.nix
+++ b/tests/modules/programs/bluetuith/empty-settings.nix
@@ -1,0 +1,13 @@
+{ config, ... }:
+{
+  config = {
+    programs.bluetuith = {
+      enable = true;
+      package = config.lib.test.mkStubPackage { };
+    };
+
+    nmt.script = ''
+      assertPathNotExists home-files/.config/bluetuith
+    '';
+  };
+}

--- a/tests/modules/programs/bluetuith/example-settings.nix
+++ b/tests/modules/programs/bluetuith/example-settings.nix
@@ -1,0 +1,25 @@
+{
+  programs.bluetuith = {
+    enable = true;
+
+    settings = {
+      adapter = "hci0";
+      receive-dir = "/home/user/files";
+
+      keybindings = {
+        Menu = "Alt-m";
+      };
+
+      theme = {
+        Adapter = "red";
+      };
+    };
+  };
+
+  nmt.script = ''
+    assertFileContent \
+      "home-files/.config/bluetuith/bluetuith.conf" \
+      ${./expected-settings-output.conf}
+  '';
+
+}

--- a/tests/modules/programs/bluetuith/expected-settings-output.conf
+++ b/tests/modules/programs/bluetuith/expected-settings-output.conf
@@ -1,0 +1,10 @@
+{
+  "adapter": "hci0",
+  "keybindings": {
+    "Menu": "Alt-m"
+  },
+  "receive-dir": "/home/user/files",
+  "theme": {
+    "Adapter": "red"
+  }
+}


### PR DESCRIPTION
### Description

Create the `programs.bluetuith` module.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
