### PR TITLE
modules/programs/ssh: support pubkeyAuthentication

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -118,6 +118,24 @@ let
         '';
       };
 
+      pubkeyAuthentication = mkOption {
+        default = null;
+        type = types.nullOr (
+          types.enum [
+            "yes"
+            "no"
+            "unbound"
+            "host-bound"
+          ]
+        );
+        description = ''
+          Specifies whether to try public key authentication.
+          The argument must be one of: `yes` (the default), `no`, `unbound`, or `host-bound`.
+          The final two options relate to the OpenSSH host-bound authentication protocol extension.
+          See {manpage}`ssh_config(5)` for details.
+        '';
+      };
+
       forwardX11 = mkOption {
         type = types.bool;
         default = false;
@@ -419,6 +437,7 @@ let
       [ "${matchHead}" ]
       ++ optional (cf.port != null) "  Port ${toString cf.port}"
       ++ optional (cf.forwardAgent != null) "  ForwardAgent ${lib.hm.booleans.yesNo cf.forwardAgent}"
+      ++ optional (cf.pubkeyAuthentication != null) "  PubkeyAuthentication ${cf.pubkeyAuthentication}"
       ++ optional cf.forwardX11 "  ForwardX11 yes"
       ++ optional cf.forwardX11Trusted "  ForwardX11Trusted yes"
       ++ optional cf.identitiesOnly "  IdentitiesOnly yes"


### PR DESCRIPTION
### Description

Allow configuring PubkeyAuthentication in the ssh config through module options.

This is a pretty straight-forward module-option -> config key change.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
