### PR TITLE
chromium: add finalPackage option

### DIFF
--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -38,6 +38,15 @@ let
         description = "The ${name} package to use.";
       };
 
+      finalPackage = mkOption {
+        inherit visible;
+        type = types.package;
+        readOnly = true;
+        description = ''
+          Resulting customized ${name} package
+        '';
+      };
+
       commandLineArgs = mkOption {
         inherit visible;
         type = types.listOf types.str;
@@ -212,15 +221,17 @@ let
 
     in
     lib.mkIf cfg.enable {
-      home.packages = lib.mkIf (cfg.package != null) [
-        (
-          if cfg.commandLineArgs != [ ] then
-            cfg.package.override {
-              commandLineArgs = lib.concatStringsSep " " cfg.commandLineArgs;
-            }
-          else
-            cfg.package
-        )
+      programs.${browser}.finalPackage = lib.mkIf (cfg.package != null) (
+        if cfg.commandLineArgs != [ ] then
+          cfg.package.override {
+            commandLineArgs = lib.concatStringsSep " " cfg.commandLineArgs;
+          }
+        else
+          cfg.package
+      );
+
+      home.packages = lib.mkIf (cfg.finalPackage != null) [
+        cfg.finalPackage
       ];
       home.file = lib.optionalAttrs (!isProprietaryChrome) (
         lib.listToAttrs ((map extensionJson cfg.extensions) ++ (map dictionary cfg.dictionaries))


### PR DESCRIPTION
### Description

Adds a finalPackage option to chromium-based browsers. Allows users to use overriden package binary in their setups, without relying on PATH availability.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
