### PR TITLE
swww: add package to service path

### DIFF
--- a/modules/services/swww.nix
+++ b/modules/services/swww.nix
@@ -50,6 +50,9 @@ in
 
       Service = {
         ExecStart = "${lib.getExe' cfg.package "swww-daemon"} ${lib.escapeShellArgs cfg.extraArgs}";
+        Environment = [
+          "PATH=$PATH:${lib.makeBinPath [ cfg.package ]}"
+        ];
         Restart = "always";
         RestartSec = 10;
       };

--- a/tests/modules/services/swww/swww-graphical-session-target.service
+++ b/tests/modules/services/swww/swww-graphical-session-target.service
@@ -2,6 +2,7 @@
 WantedBy=graphical-session.target
 
 [Service]
+Environment=PATH=$PATH:@swww@/bin
 ExecStart=@swww@/bin/swww-daemon --no-cache --layer bottom
 Restart=always
 RestartSec=10


### PR DESCRIPTION
### Description

`swww-daemon` calls `swww` from PATH on startup when it finds an image in the cache https://github.com/LGFae/swww/blob/main/daemon/src/wallpaper.rs#L293

If the service is run without the user's path exported into the systemd environment, or without swww in the path, this call fails with `no such file or directory` and no wallpaper is set.

This PR adds the swww binary to the path of the systemd service so that it's always found.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
