### PR TITLE
fish: added name option to abbrModule

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -166,6 +166,14 @@ let
 
   abbrModule = types.submodule {
     options = {
+      name = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = ''
+          The abbreviation name that is replaced by the expansion.
+        '';
+      };
+
       expansion = mkOption {
         type = with types; nullOr str;
         default = null;
@@ -289,8 +297,9 @@ let
 
   abbrsStr = lib.concatStringsSep "\n" (
     lib.mapAttrsToList (
-      name: def:
+      attrName: def:
       let
+        name = if isAttrs def && def.name != null then def.name else attrName;
         mods =
           lib.cli.toGNUCommandLineShell
             {

--- a/tests/modules/programs/fish/abbrs.nix
+++ b/tests/modules/programs/fish/abbrs.nix
@@ -39,12 +39,18 @@
           command = "git";
           expansion = "checkout";
         };
-        s = {
+        status = {
+          name = "s";
           command = [
             "git"
             "hg"
           ];
           expansion = "status";
+        };
+        show = {
+          name = "s";
+          command = "systemctl";
+          expansion = "show";
         };
         dotdot = {
           regex = "^\\.\\.+$";
@@ -79,6 +85,8 @@
           "abbr --add --command git -- co checkout"
         assertFileContains home-files/.config/fish/config.fish \
           "abbr --add --command git --command hg -- s status"
+        assertFileContains home-files/.config/fish/config.fish \
+          "abbr --add --command systemctl -- s show"
         assertFileContains home-files/.config/fish/config.fish \
           "abbr --add --function multicd --regex '^\.\.+$' -- dotdot"
       '';


### PR DESCRIPTION
### Description

Fish 4.2.0 now allows for [abbreviations of the same name with different commands to coexist](https://github.com/fish-shell/fish-shell/commit/9d3acbdd8205c68f399158a3e783c657dca83f81). I've added a `name` option so that we can do something like:
```nix
shellAbbrs = {
    foo-bar = {
        name = "bar";
        command = "foo";
        expansion = "baz";
    };
    baz-bar = {
        name = "bar";
        command = "baz";
        expansion = "foo";
    };
};
```
Which generates:
```fish
abbr --add --command baz -- bar foo
abbr --add --command foo -- bar baz
```
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
