### PR TITLE
home-manager: remove `rollback` subcommand

### DIFF
--- a/home-manager/home-manager
+++ b/home-manager/home-manager
@@ -1329,9 +1329,6 @@ case $COMMAND in
     remove-generations)
         doRmGenerations "${COMMAND_ARGS[@]}"
         ;;
-    rollback)
-        doRollback
-        ;;
     expire-generations)
         if [[ ${#COMMAND_ARGS[@]} != 1 ]]; then
             _i 'expire-generations expects one argument, got %d.' "${#COMMAND_ARGS[@]}" >&2


### PR DESCRIPTION
### Description

This removes the possibility of running `home-manager rollback`. It was added by mistake at some point and has never worked since it immediately calls a non-existent function `doRollback`.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
