### PR TITLE
espanso: fix accessibility permissions prompt for macos

### DIFF
--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -206,7 +206,7 @@ in
       enable = true;
       config = {
         ProgramArguments = [
-          "${cfg.package}/bin/espanso"
+          "${cfg.package}/Applications/Espanso.app/Contents/MacOS/espanso"
           "launcher"
         ];
         EnvironmentVariables.PATH = "${cfg.package}/bin:/usr/bin:/bin:/usr/sbin:/sbin";

--- a/tests/modules/services/espanso/darwin/launchd.plist
+++ b/tests/modules/services/espanso/darwin/launchd.plist
@@ -18,7 +18,7 @@
 	<string>org.nix-community.home.espanso</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>@espanso@/bin/espanso</string>
+		<string>@espanso@/Applications/Espanso.app/Contents/MacOS/espanso</string>
 		<string>launcher</string>
 	</array>
 	<key>RunAtLoad</key>


### PR DESCRIPTION
### Description

On macos 26 it seems that one has to run the binary from within the
application bundle to get the Accessibility prompt to work as expected

fixes https://github.com/nix-community/home-manager/issues/8179

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
