### PR TITLE
bash: don't explicitly set checkwinsize

### DIFF
--- a/modules/programs/bash.nix
+++ b/modules/programs/bash.nix
@@ -114,10 +114,6 @@ in
           # Append to history file rather than replacing it.
           "histappend"
 
-          # check the window size after each command and, if
-          # necessary, update the values of LINES and COLUMNS.
-          "checkwinsize"
-
           # Extended globbing.
           "extglob"
           "globstar"

--- a/tests/modules/programs/fabric-ai/bashrc
+++ b/tests/modules/programs/fabric-ai/bashrc
@@ -7,7 +7,6 @@ HISTFILESIZE=100000
 HISTSIZE=10000
 
 shopt -s histappend
-shopt -s checkwinsize
 shopt -s extglob
 shopt -s globstar
 shopt -s checkjobs


### PR DESCRIPTION
### Description

checkwinsize is enabled by default since bash5.

It's not much hassle if enabled, but it's not necessary anymore and it conflicts if attempting to piggy-back on `.bashrc` with other kinda-compatible shells (e.g. osh).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
