### PR TITLE
ssh-agent: set $SSH_AUTH_SOCK in non-interactive shells

### DIFF
--- a/modules/services/ssh-agent.nix
+++ b/modules/services/ssh-agent.nix
@@ -84,13 +84,11 @@ in
                 '';
           in
           {
-            bash.initExtra = lib.mkIf cfg.enableBashIntegration bashIntegration;
-
-            zsh.initContent = lib.mkIf cfg.enableZshIntegration bashIntegration;
-
-            fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration fishIntegration;
-
-            nushell.extraConfig = lib.mkIf cfg.enableNushellIntegration nushellIntegration;
+            # $SSH_AUTH_SOCK has to be set early since other tools rely on it
+            bash.profileExtra = lib.mkIf cfg.enableBashIntegration (lib.mkOrder 900 bashIntegration);
+            fish.shellInit = lib.mkIf cfg.enableFishIntegration (lib.mkOrder 900 fishIntegration);
+            nushell.extraConfig = lib.mkIf cfg.enableNushellIntegration (lib.mkOrder 900 nushellIntegration);
+            zsh.envExtra = lib.mkIf cfg.enableZshIntegration (lib.mkOrder 900 bashIntegration);
           };
       }
 

--- a/tests/modules/services/ssh-agent/darwin/bash-integration.nix
+++ b/tests/modules/services/ssh-agent/darwin/bash-integration.nix
@@ -8,7 +8,7 @@
 
   nmt.script = ''
     assertFileContains \
-      home-files/.bashrc \
+      home-files/.profile \
       'export SSH_AUTH_SOCK=$(@getconf-system_cmds@/bin/getconf DARWIN_USER_TEMP_DIR)/ssh-agent'
   '';
 }


### PR DESCRIPTION
### Description

This PR is a follow-up on #8099.

- Since #8099, the module sets `$SSH_AUTH_SOCK` through shells' options for interactive shell initialization instead of `home.sessionVariablesExtra`. The replacement was not faithful, however, since `home.sessionVariablesExtra` is sourced also in non-interactive shells. With this PR, the shells' profile options (where `home.sessionVariablesExtra` is sourced) are used to set `$SSH_AUTH_SOCK`.
- ~#8099 introduced shell integration options that guard the code for setting `$SSH_AUTH_SOCK`. To my understanding it is crucial for the ssh-agent that this env var is set, hence I do not see a reason to have these options. Consequently, this PR removes them.~

  ~Note that this change is _not_ backwards-compatible!~

Fixes #8129.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
