### PR TITLE
lorri: add darwin launchd support

### DIFF
--- a/modules/misc/news/2025/12/2025-12-17_22-05-17.nix
+++ b/modules/misc/news/2025/12/2025-12-17_22-05-17.nix
@@ -1,0 +1,11 @@
+{ config, pkgs, ... }:
+
+{
+  time = "2025-12-17T22:05:17+00:00";
+  condition = config.services.lorri.enabled || pkgs.stdenv.isDarwin;
+  message = ''
+    The option `services.lorri` is now supported on darwin.
+
+    lorri is a nix-shell replacement for project development.
+  '';
+}

--- a/tests/modules/services/lorri/default.nix
+++ b/tests/modules/services/lorri/default.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+  lorri-launchd-service = ./launchd-service.nix;
+}

--- a/tests/modules/services/lorri/launchd-service.nix
+++ b/tests/modules/services/lorri/launchd-service.nix
@@ -1,0 +1,13 @@
+args:
+
+{
+  config = {
+    services.lorri.enable = true;
+
+    nmt.script = ''
+      serviceFile="LaunchAgents/org.nix-community.home.lorri.plist"
+      serviceFileNormalized="$(normalizeStorePaths "$serviceFile")"
+      assertFileExists "$serviceFile"
+  '';
+  };
+}


### PR DESCRIPTION
### Description

Add a Darwin daemon for [lorri](https://github.com/nix-community/lorri)

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like
