### PR TITLE
generic-linux-gpu: export setupPackage and drivers from targets.genericLinux.gpu to configuration

### DIFF
--- a/modules/targets/generic-linux/gpu/default.nix
+++ b/modules/targets/generic-linux/gpu/default.nix
@@ -72,6 +72,18 @@
           `NIX_STATE_DIR` environment variable.
         '';
       };
+
+      setupPackage = mkOption {
+        type = types.package;
+        readOnly = true;
+        description = "Resulting setup package.";
+      };
+
+      drivers = mkOption {
+        type = types.package;
+        readOnly = true;
+        description = "Resulting drivers package.";
+      };
     };
 
   config =
@@ -101,7 +113,6 @@
         inherit (cfg) nixStateDirectory;
         nonNixosGpuEnv = drivers;
       };
-
     in
     lib.mkIf cfg.enable {
       assertions = lib.optionals cfg.nvidia.enable [
@@ -149,6 +160,10 @@
             warnEcho "  sudo ${setupPath}"
           fi
         '';
+
+      targets.genericLinux.gpu = {
+        inherit setupPackage drivers;
+      };
     };
 
   meta.maintainers = with lib.hm.maintainers; [ exzombie ];


### PR DESCRIPTION
### Description

See #8187

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
