### PR TITLE
easyeffects: Make service compatible with v8.0.x

### DIFF
--- a/tests/modules/services/easyeffects/example-preset.nix
+++ b/tests/modules/services/easyeffects/example-preset.nix
@@ -27,6 +27,6 @@
 
   nmt.script = ''
     assertFileContent \
-      home-files/.config/easyeffects/input/example-preset.json "${./example-preset.json}"
+      home-files/.local/share/easyeffects/input/example-preset.json "${./example-preset.json}"
   '';
 }


### PR DESCRIPTION
### Description

Fixes #8185 

The upstream easyeffects project has migrated from GTK to Qt, deprecating --gapplication-service and removing DBus integration. See #8185 for more details.
Tested with version `8.0.3` and `7.2.5` , uses `lib.versionOlder cfg.package.version "8.0.0"` to be backwards compatible.

- Removed DBus service configuration (Type=dbus, BusName)
- Move presets and config dir from $XDG_CONFIG_HOME to $XDG_DATA_HOME (new upstream location)

**Other notes**
Since they have moved config directory, it will warn show warnings because of empty dirs. These warnings will also show in the service until you remove them. I dont think this is a problem and new users will not experience this. 
```bash
easyeffects --version
easyeffects: presets_directory_manager.cpp:140  Old /home/hausken/.config/easyeffects/output directory detected. Migrating its files to /home/hausken/.local/share/easyeffects/output
easyeffects: presets_directory_manager.cpp:149  Could not copy any file. Aborting migration of /home/hausken/.config/easyeffects/output
easyeffects: presets_directory_manager.cpp:140  Old /home/hausken/.config/easyeffects/irs directory detected. Migrating its files to /home/hausken/.local/share/easyeffects/irs
easyeffects: presets_directory_manager.cpp:149  Could not copy any file. Aborting migration of /home/hausken/.config/easyeffects/irs
easyeffects: presets_directory_manager.cpp:140  Old /home/hausken/.config/easyeffects/rnnoise directory detected. Migrating its files to /home/hausken/.local/share/easyeffects/rnnoise
easyeffects: presets_directory_manager.cpp:149  Could not copy any file. Aborting migration of /home/hausken/.config/easyeffects/rnnoise
easyeffects: presets_directory_manager.cpp:140  Old /home/hausken/.config/easyeffects/autoload/output directory detected. Migrating its files to /home/hausken/.local/share/easyeffects/autoload/output
easyeffects: presets_directory_manager.cpp:149  Could not copy any file. Aborting migration of /home/hausken/.config/easyeffects/autoload/output
```

--

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
