### PR TITLE
television: add nushell integration

### DIFF
--- a/modules/programs/television.nix
+++ b/modules/programs/television.nix
@@ -86,6 +86,7 @@ in
     enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
     enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
+    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
   };
 
   config = lib.mkIf cfg.enable {
@@ -113,6 +114,10 @@ in
     '';
     programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
       ${lib.getExe cfg.package} init fish | source
+    '';
+    programs.nushell.extraConfig = lib.mkIf cfg.enableNushellIntegration ''
+      mkdir ($nu.data-dir | path join "vendor/autoload")
+      ${lib.getExe cfg.package} init nu | save -f ($nu.data-dir | path join "vendor/autoload/tv.nu")
     '';
   };
 }


### PR DESCRIPTION
### Description

Add `Nushell` integration for the `television` module.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Commit messages are formatted like