### PR TITLE
treewide: meta.maintainers at top

### DIFF
--- a/modules/i18n/input-method/default.nix
+++ b/modules/i18n/input-method/default.nix
@@ -45,6 +45,11 @@ let
       '';
 in
 {
+  meta.maintainers = with lib.maintainers; [
+    da157
+    kranzes
+  ];
+
   imports = [
     ./fcitx5.nix
     ./hime.nix
@@ -132,9 +137,4 @@ in
       gtk3Cache
     ];
   };
-
-  meta.maintainers = with lib.maintainers; [
-    da157
-    kranzes
-  ];
 }

--- a/modules/misc/nix-remote-build.nix
+++ b/modules/misc/nix-remote-build.nix
@@ -12,6 +12,8 @@ let
   cfg = config.nix;
 in
 {
+  meta.maintainers = [ lib.maintainers.GaetanLepage ];
+
   options = {
     nix = {
       buildMachines = mkOption {
@@ -202,6 +204,4 @@ in
       };
     }
   );
-
-  meta.maintainers = [ lib.maintainers.GaetanLepage ];
 }

--- a/modules/misc/nix.nix
+++ b/modules/misc/nix.nix
@@ -147,6 +147,8 @@ let
 
 in
 {
+  meta.maintainers = [ ];
+
   options.nix = {
     enable =
       mkEnableOption ''
@@ -363,6 +365,4 @@ in
       xdg.configFile."nix/nix.conf".source = nixConf;
     })
   ]);
-
-  meta.maintainers = [ ];
 }

--- a/modules/misc/xdg-terminal-exec.nix
+++ b/modules/misc/xdg-terminal-exec.nix
@@ -8,6 +8,8 @@ let
   cfg = config.xdg.terminal-exec;
 in
 {
+  meta.maintainers = with lib.maintainers; [ nukdokplex ];
+
   options = {
     xdg.terminal-exec = {
       enable = lib.mkEnableOption ''
@@ -50,6 +52,4 @@ in
       ) { text = lib.concatLines terminals; }
     ) cfg.settings;
   };
-
-  meta.maintainers = with lib.maintainers; [ nukdokplex ];
 }

--- a/modules/programs/autorandr.nix
+++ b/modules/programs/autorandr.nix
@@ -338,6 +338,8 @@ let
 
 in
 {
+  meta.maintainers = [ lib.maintainers.uvnikita ];
+
   options = {
     programs.autorandr = {
       enable = lib.mkEnableOption "Autorandr";
@@ -432,6 +434,4 @@ in
       (lib.mkMerge (mapAttrsToList profileToFiles cfg.profiles))
     ];
   };
-
-  meta.maintainers = [ lib.maintainers.uvnikita ];
 }

--- a/modules/programs/bottom.nix
+++ b/modules/programs/bottom.nix
@@ -12,6 +12,8 @@ let
 
 in
 {
+  meta.maintainers = [ ];
+
   options = {
     programs.bottom = {
       enable = lib.mkEnableOption ''
@@ -53,6 +55,4 @@ in
       source = tomlFormat.generate "bottom.toml" cfg.settings;
     };
   };
-
-  meta.maintainers = [ ];
 }

--- a/modules/programs/boxxy.nix
+++ b/modules/programs/boxxy.nix
@@ -91,6 +91,8 @@ let
   };
 in
 {
+  meta.maintainers = with lib.hm.maintainers; [ nikp123 ];
+
   options.programs.boxxy = {
     enable = lib.mkEnableOption "boxxy: Boxes in badly behaving applications";
 
@@ -114,6 +116,4 @@ in
 
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
   };
-
-  meta.maintainers = with lib.hm.maintainers; [ nikp123 ];
 }

--- a/modules/programs/desktoppr.nix
+++ b/modules/programs/desktoppr.nix
@@ -10,6 +10,8 @@ let
 in
 
 {
+  meta.maintainers = with lib.maintainers; [ andre4ik3 ];
+
   options.programs.desktoppr = {
     enable = lib.mkEnableOption "managing the desktop picture/wallpaper on macOS using desktoppr";
     package = lib.mkPackageOption pkgs "desktoppr" { };
@@ -100,6 +102,4 @@ in
       run "${lib.getExe cfg.package}" manage
     '';
   };
-
-  meta.maintainers = with lib.maintainers; [ andre4ik3 ];
 }

--- a/modules/programs/direnv.nix
+++ b/modules/programs/direnv.nix
@@ -23,6 +23,12 @@ let
 
 in
 {
+  meta.maintainers = with lib.maintainers; [
+    khaneliman
+    rycee
+    shikanime
+  ];
+
   imports = [
     (mkRenamedOptionModule
       [
@@ -38,12 +44,6 @@ in
       "nix-direnv"
       "enableFlakes"
     ] "Flake support is now always enabled.")
-  ];
-
-  meta.maintainers = with lib.maintainers; [
-    khaneliman
-    rycee
-    shikanime
   ];
 
   options.programs.direnv = {

--- a/modules/programs/eza.nix
+++ b/modules/programs/eza.nix
@@ -9,6 +9,8 @@ let
   yamlFormat = pkgs.formats.yaml { };
 in
 {
+  meta.maintainers = [ lib.maintainers.cafkafk ];
+
   imports =
     let
       msg = ''
@@ -35,9 +37,6 @@ in
       "git"
     ])
     ++ [ (lib.mkRemovedOptionModule [ "programs" "eza" "enableAliases" ] msg) ];
-
-  meta.maintainers = [ lib.maintainers.cafkafk ];
-
   options.programs.eza = {
     enable = lib.mkEnableOption "eza, a modern replacement for {command}`ls`";
 

--- a/modules/programs/firefox/profiles/bookmarks.nix
+++ b/modules/programs/firefox/profiles/bookmarks.nix
@@ -75,13 +75,13 @@ let
     '';
 in
 {
+  # We're currently looking for a maintainer who actively uses bookmarks!
+  meta.maintainers = with maintainers; [ kira-bruneau ];
+
   imports = [
     (pkgs.path + "/nixos/modules/misc/assertions.nix")
     (pkgs.path + "/nixos/modules/misc/meta.nix")
   ];
-
-  # We're currently looking for a maintainer who actively uses bookmarks!
-  meta.maintainers = with maintainers; [ kira-bruneau ];
 
   options = {
     enable = mkOption {

--- a/modules/programs/firefox/profiles/search.nix
+++ b/modules/programs/firefox/profiles/search.nix
@@ -422,10 +422,9 @@ let
     // lib.optionalAttrs (iconMapObj != { }) { inherit iconMapObj; };
 in
 {
-  imports = [ (pkgs.path + "/nixos/modules/misc/meta.nix") ];
-
   meta.maintainers = with lib.maintainers; [ kira-bruneau ];
 
+  imports = [ (pkgs.path + "/nixos/modules/misc/meta.nix") ];
   options = {
     enable = mkOption {
       type = with types; bool;

--- a/modules/programs/fzf.nix
+++ b/modules/programs/fzf.nix
@@ -62,6 +62,8 @@ let
       '';
 in
 {
+  meta.maintainers = with lib.maintainers; [ khaneliman ];
+
   imports = [
     (lib.mkRemovedOptionModule [
       "programs"
@@ -69,9 +71,6 @@ in
       "historyWidgetCommand"
     ] "This option is no longer supported by fzf.")
   ];
-
-  meta.maintainers = with lib.maintainers; [ khaneliman ];
-
   options.programs.fzf = {
     enable = lib.mkEnableOption "fzf - a command-line fuzzy finder";
 

--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -92,6 +92,8 @@ let
     };
 in
 {
+  meta.maintainers = with lib.maintainers; [ khaneliman ];
+
   imports = [
     (lib.mkChangedOptionModule
       [ "programs" "kitty" "theme" ]
@@ -122,9 +124,6 @@ in
       )
     )
   ];
-
-  meta.maintainers = with lib.maintainers; [ khaneliman ];
-
   options.programs.kitty = {
     enable = mkEnableOption "Kitty terminal emulator";
 

--- a/modules/programs/lsd.nix
+++ b/modules/programs/lsd.nix
@@ -10,6 +10,8 @@ let
   yamlFormat = pkgs.formats.yaml { };
 in
 {
+  meta.maintainers = [ ];
+
   imports =
     let
       msg = ''
@@ -21,9 +23,6 @@ in
         configuration.'';
     in
     [ (lib.mkRemovedOptionModule [ "programs" "lsd" "enableAliases" ] msg) ];
-
-  meta.maintainers = [ ];
-
   options.programs.lsd = {
     enable = lib.mkEnableOption "lsd";
 

--- a/modules/programs/lutris.nix
+++ b/modules/programs/lutris.nix
@@ -30,6 +30,8 @@ let
   formatWineName = (package: toLower package.name);
 in
 {
+  meta.maintainers = [ lib.hm.maintainers.bikku ];
+
   options.programs.lutris = {
     enable = mkEnableOption "lutris.";
     package = lib.mkPackageOption pkgs "lutris" { };
@@ -150,7 +152,6 @@ in
       );
     };
   };
-  meta.maintainers = [ lib.hm.maintainers.bikku ];
   config = mkIf cfg.enable {
     assertions = [
       (lib.hm.assertions.assertPlatform "programs.lutris" pkgs lib.platforms.linux)

--- a/modules/programs/mangohud.nix
+++ b/modules/programs/mangohud.nix
@@ -41,6 +41,8 @@ let
 
 in
 {
+  meta.maintainers = with lib.maintainers; [ zeratax ];
+
   options = {
     programs.mangohud = {
       enable = lib.mkEnableOption "Mangohud";
@@ -113,6 +115,4 @@ in
       n: v: lib.nameValuePair "MangoHud/${n}.conf" { text = renderSettings v; }
     ) cfg.settingsPerApplication;
   };
-
-  meta.maintainers = with lib.maintainers; [ zeratax ];
 }

--- a/modules/programs/mpv.nix
+++ b/modules/programs/mpv.nix
@@ -66,6 +66,11 @@ let
 
 in
 {
+  meta.maintainers = with lib.maintainers; [
+    thiagokokada
+    chuangzhu
+  ];
+
   options = {
     programs.mpv = {
       enable = lib.mkEnableOption "mpv";
@@ -250,9 +255,4 @@ in
       }
     ]
   );
-
-  meta.maintainers = with lib.maintainers; [
-    thiagokokada
-    chuangzhu
-  ];
 }

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -96,6 +96,8 @@ let
       }"'';
 in
 {
+  meta.maintainers = with lib.maintainers; [ khaneliman ];
+
   imports = [
     (mkRemovedOptionModule [
       "programs"
@@ -116,9 +118,6 @@ in
               configure.customRC -> programs.neovim.extraConfig
     '')
   ];
-
-  meta.maintainers = with lib.maintainers; [ khaneliman ];
-
   options = {
     programs.neovim = {
       enable = mkEnableOption "Neovim";

--- a/modules/programs/obsidian.nix
+++ b/modules/programs/obsidian.nix
@@ -48,6 +48,8 @@ let
   ];
 in
 {
+  meta.maintainers = [ lib.hm.maintainers.karaolidis ];
+
   options.programs.obsidian = {
     enable = mkEnableOption "obsidian";
     package = mkPackageOption pkgs "obsidian" { nullable = true; };
@@ -573,6 +575,4 @@ in
         }
       ];
     };
-
-  meta.maintainers = [ lib.hm.maintainers.karaolidis ];
 }

--- a/modules/programs/pistol.nix
+++ b/modules/programs/pistol.nix
@@ -42,6 +42,8 @@ let
   };
 in
 {
+  meta.maintainers = [ lib.maintainers.mtoohey ];
+
   imports = [
     (lib.mkRemovedOptionModule [
       "programs"
@@ -49,9 +51,6 @@ in
       "config"
     ] "Pistol is now configured with programs.pistol.associations.")
   ];
-
-  meta.maintainers = [ lib.maintainers.mtoohey ];
-
   options.programs.pistol = {
     enable = lib.mkEnableOption "file previewer for terminal file managers";
 

--- a/modules/programs/pls.nix
+++ b/modules/programs/pls.nix
@@ -15,6 +15,8 @@ let
   };
 in
 {
+  meta.maintainers = [ lib.maintainers.arjan-s ];
+
   imports =
     let
       msg = ''
@@ -26,9 +28,6 @@ in
         configuration.'';
     in
     [ (lib.mkRemovedOptionModule [ "programs" "pls" "enableAliases" ] msg) ];
-
-  meta.maintainers = [ lib.maintainers.arjan-s ];
-
   options.programs.pls = {
     enable = lib.mkEnableOption "pls, a modern replacement for {command}`ls`";
 

--- a/modules/programs/radicle.nix
+++ b/modules/programs/radicle.nix
@@ -50,6 +50,11 @@ let
   publicExplorerSuffix = "$rid$path";
 in
 {
+  meta.maintainers = with lib.maintainers; [
+    lorenzleutgeb
+    matthiasbeyer
+  ];
+
   options = {
     programs.radicle = {
       enable = mkEnableOption "Radicle";
@@ -261,9 +266,4 @@ in
         );
     };
   };
-
-  meta.maintainers = with lib.maintainers; [
-    lorenzleutgeb
-    matthiasbeyer
-  ];
 }

--- a/modules/programs/ranger.nix
+++ b/modules/programs/ranger.nix
@@ -10,6 +10,8 @@ let
   cfg = config.programs.ranger;
 in
 {
+  meta.maintainers = [ lib.hm.maintainers.fpob ];
+
   options.programs.ranger = {
     enable = lib.mkEnableOption "ranger file manager";
 
@@ -204,6 +206,4 @@ in
       })
     ]
   );
-
-  meta.maintainers = [ lib.hm.maintainers.fpob ];
 }

--- a/modules/programs/rclone.nix
+++ b/modules/programs/rclone.nix
@@ -14,6 +14,8 @@ let
 
 in
 {
+  meta.maintainers = with lib.maintainers; [ jess ];
+
   imports = [
     (lib.mkRemovedOptionModule [ "programs" "rclone" "writeAfter" ] ''
       The writeAfter option has been removed because rclone configuration is now handled by a
@@ -399,6 +401,4 @@ in
         mountServices
       ];
     };
-
-  meta.maintainers = with lib.maintainers; [ jess ];
 }

--- a/modules/programs/rio.nix
+++ b/modules/programs/rio.nix
@@ -22,6 +22,8 @@ let
   settingsFormat = pkgs.formats.toml { };
 in
 {
+  meta.maintainers = [ lib.maintainers.otavio ];
+
   options.programs.rio = {
     enable = mkEnableOption null // {
       description = ''
@@ -60,8 +62,6 @@ in
       '';
     };
   };
-  meta.maintainers = [ lib.maintainers.otavio ];
-
   config = mkIf cfg.enable (mkMerge [
     {
       home.packages = mkIf (cfg.package != null) [ cfg.package ];

--- a/modules/programs/rofi.nix
+++ b/modules/programs/rofi.nix
@@ -135,6 +135,8 @@ let
   modes = map (mode: if isString mode then mode else "${mode.name}:${mode.path}") cfg.modes;
 in
 {
+  meta.maintainers = with lib.maintainers; [ ];
+
   options.programs.rofi = {
     enable = lib.mkEnableOption "Rofi: A window switcher, application launcher and dmenu replacement";
 
@@ -366,6 +368,4 @@ in
         }
     );
   };
-
-  meta.maintainers = with lib.maintainers; [ ];
 }

--- a/modules/programs/sbt.nix
+++ b/modules/programs/sbt.nix
@@ -99,14 +99,13 @@ let
 
 in
 {
+  meta.maintainers = [ lib.maintainers.kubukoz ];
+
   imports = [
     (lib.mkRemovedOptionModule [ "programs" "sbt" "baseConfigPath" ]
       "Use programs.sbt.baseUserConfigPath instead, but note that the semantics are slightly different."
     )
   ];
-
-  meta.maintainers = [ lib.maintainers.kubukoz ];
-
   options.programs.sbt = {
     enable = lib.mkEnableOption "sbt";
 

--- a/modules/programs/senpai.nix
+++ b/modules/programs/senpai.nix
@@ -10,6 +10,8 @@ let
   cfg = config.programs.senpai;
 in
 {
+  meta.maintainers = [ lib.maintainers.malte-v ];
+
   options.programs.senpai = {
     enable = lib.mkEnableOption "senpai";
     package = lib.mkPackageOption pkgs "senpai" { };
@@ -132,6 +134,4 @@ in
       in
       lib.hm.generators.toSCFG { } (attrsToDirectiveList cfg.config);
   };
-
-  meta.maintainers = [ lib.maintainers.malte-v ];
 }

--- a/modules/programs/sioyek.nix
+++ b/modules/programs/sioyek.nix
@@ -21,6 +21,8 @@ let
 
 in
 {
+  meta.maintainers = [ lib.maintainers.podocarp ];
+
   options = {
     programs.sioyek = {
       enable = lib.mkEnableOption "Sioyek, a PDF viewer designed for reading research papers and technical books";
@@ -80,6 +82,4 @@ in
       })
     ]
   );
-
-  meta.maintainers = [ lib.maintainers.podocarp ];
 }

--- a/modules/programs/xmobar.nix
+++ b/modules/programs/xmobar.nix
@@ -8,6 +8,8 @@ let
   cfg = config.programs.xmobar;
 in
 {
+  meta.maintainers = [ lib.maintainers.t4ccer ];
+
   options.programs.xmobar = {
     enable = lib.mkEnableOption "Xmobar, a minimalistic status bar";
 
@@ -51,6 +53,4 @@ in
     home.packages = [ cfg.package ];
     xdg.configFile."xmobar/.xmobarrc".text = cfg.extraConfig;
   };
-
-  meta.maintainers = [ lib.maintainers.t4ccer ];
 }

--- a/modules/programs/zsh/default.nix
+++ b/modules/programs/zsh/default.nix
@@ -26,14 +26,13 @@ let
   inherit (import ./lib.nix { inherit config lib; }) homeDir dotDirAbs dotDirRel;
 in
 {
+  meta.maintainers = [ lib.maintainers.khaneliman ];
+
   imports = [
     ./plugins
     ./deprecated.nix
     ./history.nix
   ];
-
-  meta.maintainers = [ lib.maintainers.khaneliman ];
-
   options =
     let
       syntaxHighlightingModule = types.submodule {

--- a/modules/services/espanso.nix
+++ b/modules/services/espanso.nix
@@ -38,6 +38,13 @@ let
   yaml = pkgs.formats.yaml { };
 in
 {
+  meta.maintainers = with lib.maintainers; [
+    bobvanderlinden
+    liyangau
+    n8henrie
+    phanirithvij
+  ];
+
   imports = [
     (mkRemovedOptionModule [
       "services"
@@ -45,12 +52,7 @@ in
       "settings"
     ] "Use services.espanso.configs and services.espanso.matches instead.")
   ];
-  meta.maintainers = with lib.maintainers; [
-    bobvanderlinden
-    liyangau
-    n8henrie
-    phanirithvij
-  ];
+
   options = {
     services.espanso = {
       enable = mkEnableOption "Espanso: cross platform text expander in Rust";

--- a/modules/services/ludusavi.nix
+++ b/modules/services/ludusavi.nix
@@ -16,6 +16,7 @@ let
       cfg.configFile;
 in
 {
+  meta.maintainers = [ lib.maintainers.PopeRigby ];
 
   options.services.ludusavi = {
     enable = lib.mkEnableOption "Ludusavi game backup tool";
@@ -109,6 +110,4 @@ in
 
     home.packages = [ cfg.package ];
   };
-
-  meta.maintainers = [ lib.maintainers.PopeRigby ];
 }

--- a/modules/services/mpdscribble.nix
+++ b/modules/services/mpdscribble.nix
@@ -19,6 +19,8 @@ let
   };
 in
 {
+  meta.maintainers = [ lib.hm.maintainers.msyds ];
+
   options.services.mpdscribble = {
 
     enable = lib.mkEnableOption ''
@@ -225,6 +227,4 @@ in
         };
       };
   };
-
-  meta.maintainers = [ lib.hm.maintainers.msyds ];
 }

--- a/modules/services/picom.nix
+++ b/modules/services/picom.nix
@@ -86,6 +86,8 @@ let
 
 in
 {
+  meta.maintainers = with lib.maintainers; [ thiagokokada ];
+
   imports = [
     (mkRemovedOptionModule [
       "services"
@@ -431,6 +433,4 @@ in
       };
     };
   };
-
-  meta.maintainers = with lib.maintainers; [ thiagokokada ];
 }

--- a/modules/services/radicle.nix
+++ b/modules/services/radicle.nix
@@ -38,6 +38,11 @@ let
   env = attrs: (mapAttrsToList (generators.mkKeyValueDefault { } "=") attrs) ++ gitPath;
 in
 {
+  meta.maintainers = with lib.maintainers; [
+    lorenzleutgeb
+    matthiasbeyer
+  ];
+
   options = {
     services.radicle = {
       node = {
@@ -237,9 +242,4 @@ in
       RAD_SOCKET = "\${XDG_RUNTIME_DIR:-/run/user/$UID}/radicle-node/control.sock";
     };
   };
-
-  meta.maintainers = with lib.maintainers; [
-    lorenzleutgeb
-    matthiasbeyer
-  ];
 }

--- a/modules/services/restic.nix
+++ b/modules/services/restic.nix
@@ -79,6 +79,8 @@ let
     };
 in
 {
+  meta.maintainers = [ lib.maintainers.jess ];
+
   options.services.restic = {
     enable = lib.mkEnableOption "restic";
 
@@ -606,6 +608,4 @@ in
       }
     ]
   );
-
-  meta.maintainers = [ lib.maintainers.jess ];
 }


### PR DESCRIPTION
Just make it consistent throughout codebase and easier to find maintainers for a module.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
