### PR TITLE
treewide: assertions at top of config

### DIFF
--- a/modules/misc/xdg-portal.nix
+++ b/modules/misc/xdg-portal.nix
@@ -127,19 +127,6 @@ in
       portalsDir = "${config.home.profileDirectory}/share/xdg-desktop-portal/portals";
     in
     mkIf cfg.enable {
-      warnings = optional (cfg.configPackages == [ ] && cfg.config == { }) ''
-        xdg-desktop-portal 1.17 reworked how portal implementations are loaded, you
-        should either set `xdg.portal.config` or `xdg.portal.configPackages`
-        to specify which portal backend to use for the requested interface.
-
-        https://github.com/flatpak/xdg-desktop-portal/blob/1.18.1/doc/portals.conf.rst.in
-
-        If you simply want to keep the behaviour in < 1.17, which uses the first
-        portal implementation found in lexicographical order, use the following:
-
-        xdg.portal.config.common.default = "*";
-      '';
-
       assertions = [
         (lib.hm.assertions.assertPlatform "xdg.portal" pkgs lib.platforms.linux)
 
@@ -167,6 +154,19 @@ in
           '';
         }
       ];
+
+      warnings = optional (cfg.configPackages == [ ] && cfg.config == { }) ''
+        xdg-desktop-portal 1.17 reworked how portal implementations are loaded, you
+        should either set `xdg.portal.config` or `xdg.portal.configPackages`
+        to specify which portal backend to use for the requested interface.
+
+        https://github.com/flatpak/xdg-desktop-portal/blob/1.18.1/doc/portals.conf.rst.in
+
+        If you simply want to keep the behaviour in < 1.17, which uses the first
+        portal implementation found in lexicographical order, use the following:
+
+        xdg.portal.config.common.default = "*";
+      '';
 
       home = {
         packages = packages ++ cfg.configPackages;

--- a/modules/programs/aerc/default.nix
+++ b/modules/programs/aerc/default.nix
@@ -221,22 +221,6 @@ in
 
     in
     mkIf cfg.enable {
-      warnings =
-        if genAccountsConf && (cfg.extraConfig.general.unsafe-accounts-conf or false) == false then
-          [
-            ''
-              aerc: `programs.aerc.enable` is set, but `...extraConfig.general.unsafe-accounts-conf` is set to false or unset.
-              This will prevent aerc from starting; see `unsafe-accounts-conf` in the man page aerc-config(5):
-              > By default, the file permissions of accounts.conf must be restrictive and only allow reading by the file owner (0600).
-              > Set this option to true to ignore this permission check. Use this with care as it may expose your credentials.
-              These permissions are not possible with home-manager, since the generated file is in the nix-store (permissions 0444).
-              Therefore, please set `programs.aerc.extraConfig.general.unsafe-accounts-conf = true`.
-              This option is safe; if `passwordCommand` is properly set, no credentials will be written to the nix store.
-            ''
-          ]
-        else
-          [ ];
-
       assertions = [
         {
           assertion =
@@ -253,6 +237,22 @@ in
           '';
         }
       ];
+
+      warnings =
+        if genAccountsConf && (cfg.extraConfig.general.unsafe-accounts-conf or false) == false then
+          [
+            ''
+              aerc: `programs.aerc.enable` is set, but `...extraConfig.general.unsafe-accounts-conf` is set to false or unset.
+              This will prevent aerc from starting; see `unsafe-accounts-conf` in the man page aerc-config(5):
+              > By default, the file permissions of accounts.conf must be restrictive and only allow reading by the file owner (0600).
+              > Set this option to true to ignore this permission check. Use this with care as it may expose your credentials.
+              These permissions are not possible with home-manager, since the generated file is in the nix-store (permissions 0444).
+              Therefore, please set `programs.aerc.extraConfig.general.unsafe-accounts-conf = true`.
+              This option is safe; if `passwordCommand` is properly set, no credentials will be written to the nix store.
+            ''
+          ]
+        else
+          [ ];
 
       home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 

--- a/modules/programs/lieer.nix
+++ b/modules/programs/lieer.nix
@@ -252,25 +252,6 @@ in
 
   config = mkIf cfg.enable (
     lib.mkMerge [
-      (mkIf (missingNotmuchAccounts != [ ]) {
-        warnings = [
-          ''
-            lieer is enabled for the following email accounts, but notmuch is not:
-
-                ${concatStringsSep "\n    " missingNotmuchAccounts}
-
-            Notmuch can be enabled with:
-
-                ${concatStringsSep "\n    " notmuchConfigHelp}
-
-            If you have configured notmuch outside of Home Manager, you can suppress this
-            warning with:
-
-                programs.lieer.notmuchSetupWarning = false;
-          ''
-        ];
-      })
-
       {
         assertions = [
           {
@@ -297,6 +278,25 @@ in
 
         home.file = lib.listToAttrs (map configFile lieerAccounts);
       }
+
+      (mkIf (missingNotmuchAccounts != [ ]) {
+        warnings = [
+          ''
+            lieer is enabled for the following email accounts, but notmuch is not:
+
+                ${concatStringsSep "\n    " missingNotmuchAccounts}
+
+            Notmuch can be enabled with:
+
+                ${concatStringsSep "\n    " notmuchConfigHelp}
+
+            If you have configured notmuch outside of Home Manager, you can suppress this
+            warning with:
+
+                programs.lieer.notmuchSetupWarning = false;
+          ''
+        ];
+      })
     ]
   );
 }

--- a/modules/programs/neomutt/default.nix
+++ b/modules/programs/neomutt/default.nix
@@ -484,6 +484,13 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = ((filter (b: (lib.length (lib.toList b.map)) == 0) (cfg.binds ++ cfg.macros)) == [ ]);
+        message = "The 'programs.neomutt.(binds|macros).map' list must contain at least one element.";
+      }
+    ];
+
     home.packages = [ cfg.package ];
     home.file =
       let
@@ -540,13 +547,6 @@ in
           ]
         );
     };
-
-    assertions = [
-      {
-        assertion = ((filter (b: (lib.length (lib.toList b.map)) == 0) (cfg.binds ++ cfg.macros)) == [ ]);
-        message = "The 'programs.neomutt.(binds|macros).map' list must contain at least one element.";
-      }
-    ];
 
     warnings =
       let

--- a/modules/programs/nix-search-tv.nix
+++ b/modules/programs/nix-search-tv.nix
@@ -55,6 +55,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.package != null || cfg.enableTelevisionIntegration;
+        message = "Cannot enable television integration when config.programs.nix-search-tv.package is null.";
+      }
+    ];
+
     home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
 
     xdg.configFile."nix-search-tv/config.json" = lib.mkIf (cfg.settings != { }) {
@@ -75,12 +82,5 @@ in
         preview.command = ''${path} preview "{}"'';
       }
     );
-
-    assertions = [
-      {
-        assertion = cfg.package != null || cfg.enableTelevisionIntegration;
-        message = "Cannot enable television integration when config.programs.nix-search-tv.package is null.";
-      }
-    ];
   };
 }

--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -785,13 +785,6 @@ in
   };
 
   config = mkIf cfg.enable {
-    warnings = lib.optionals (!cfg.darwinSetupWarning) [
-      ''
-        Using programs.thunderbird.darwinSetupWarning is deprecated and will be
-        removed in the future. Thunderbird is now supported on Darwin.
-      ''
-    ];
-
     assertions = [
       (
         let
@@ -882,6 +875,13 @@ in
             '';
         }
       )
+    ];
+
+    warnings = lib.optionals (!cfg.darwinSetupWarning) [
+      ''
+        Using programs.thunderbird.darwinSetupWarning is deprecated and will be
+        removed in the future. Thunderbird is now supported on Darwin.
+      ''
     ];
 
     home.packages = [

--- a/modules/programs/zed-editor.nix
+++ b/modules/programs/zed-editor.nix
@@ -219,6 +219,13 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.extraPackages != [ ] -> cfg.package != null;
+        message = "{option}programs.zed-editor.extraPackages requires non null {option}programs.zed-editor.package";
+      }
+    ];
+
     home.packages = mkIf (cfg.package != null) (
       if cfg.extraPackages != [ ] then
         [
@@ -306,13 +313,6 @@ in
       (mkIf (!cfg.mutableUserDebug && cfg.userDebug != [ ]) {
         "zed/debug.json".source = jsonFormat.generate "zed-user-debug" cfg.userDebug;
       })
-    ];
-
-    assertions = [
-      {
-        assertion = cfg.extraPackages != [ ] -> cfg.package != null;
-        message = "{option}programs.zed-editor.extraPackages requires non null {option}programs.zed-editor.package";
-      }
     ];
   };
 }

--- a/modules/services/kdeconnect.nix
+++ b/modules/services/kdeconnect.nix
@@ -30,11 +30,11 @@ in
 
   config = lib.mkMerge [
     (lib.mkIf cfg.enable {
-      home.packages = [ cfg.package ];
-
       assertions = [
         (lib.hm.assertions.assertPlatform "services.kdeconnect" pkgs lib.platforms.linux)
       ];
+
+      home.packages = [ cfg.package ];
 
       systemd.user.services.kdeconnect = {
         Unit = {

--- a/modules/services/window-managers/i3-sway/sway.nix
+++ b/modules/services/window-managers/i3-sway/sway.nix
@@ -704,20 +704,6 @@ in
 
   config = mkIf cfg.enable (
     lib.mkMerge [
-      (mkIf (cfg.config != null) {
-        warnings =
-          (optional (lib.isList cfg.config.fonts) "Specifying sway.config.fonts as a list is deprecated. Use the attrset version instead.")
-          ++ lib.flatten (
-            map (
-              b:
-              optional (lib.isList b.fonts) "Specifying sway.config.bars[].fonts as a list is deprecated. Use the attrset version instead."
-            ) cfg.config.bars
-          )
-          ++ [
-            (mkIf cfg.config.focus.forceWrapping "sway.config.focus.forceWrapping is deprecated, use focus.wrapping instead.")
-          ];
-      })
-
       {
         assertions = [
           (lib.hm.assertions.assertPlatform "wayland.windowManager.sway" pkgs lib.platforms.linux)
@@ -753,6 +739,20 @@ in
           };
         };
       }
+
+      (mkIf (cfg.config != null) {
+        warnings =
+          (optional (lib.isList cfg.config.fonts) "Specifying sway.config.fonts as a list is deprecated. Use the attrset version instead.")
+          ++ lib.flatten (
+            map (
+              b:
+              optional (lib.isList b.fonts) "Specifying sway.config.bars[].fonts as a list is deprecated. Use the attrset version instead."
+            ) cfg.config.bars
+          )
+          ++ [
+            (mkIf cfg.config.focus.forceWrapping "sway.config.focus.forceWrapping is deprecated, use focus.wrapping instead.")
+          ];
+      })
     ]
   );
 }


### PR DESCRIPTION
Moving assertions to be consistently at top of the config blocks.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
