### PR TITLE
gotify-desktop: init module

### DIFF
--- a/modules/misc/news/2025/11/2025-11-24_12-05-54.nix
+++ b/modules/misc/news/2025/11/2025-11-24_12-05-54.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+{
+  time = "2025-11-24T11:05:54+00:00";
+  condition = pkgs.stdenv.hostPlatform.isLinux;
+  message = ''
+    A new module is available: 'services.gotify-desktop'
+
+    gotify-desktop is a small daemon to receive messages from a Gotify server
+    and forward them as desktop notifications. It supports message priorities,
+    automatic reconnection, retrieval of missed messages
+    and automatic deletion of shown messages.
+  '';
+}

--- a/modules/services/gotify-desktop.nix
+++ b/modules/services/gotify-desktop.nix
@@ -1,0 +1,125 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.gotify-desktop;
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  meta.maintainers = with lib.hm.maintainers; [
+    joker9944
+  ];
+
+  options.services.gotify-desktop =
+    let
+      inherit (lib)
+        mkEnableOption
+        mkPackageOption
+        mkOption
+        literalExpression
+        types
+        ;
+    in
+    {
+      enable = mkEnableOption "Gotify daemon to receive messages and forward them as desktop notifications";
+
+      package = mkPackageOption pkgs "gotify-desktop" { };
+
+      settings = mkOption {
+        type = types.submodule {
+          freeformType = tomlFormat.type;
+
+          options = {
+            gotify = mkOption {
+              type = types.nullOr (
+                types.submodule {
+                  freeformType = tomlFormat.type;
+
+                  options = {
+                    url = mkOption {
+                      type = types.nullOr tomlFormat.type;
+                      default = null;
+                      example = "wss://gotify.example.com:8443";
+                      description = ''
+                        Gotify server websocket URL, use wss:// prefix for TLS, or ws:// for unencrypted.
+                      '';
+                    };
+
+                    token = mkOption {
+                      type = types.nullOr tomlFormat.type;
+                      default = null;
+                      example = literalExpression ''
+                        "gotify-token"
+                        or
+                        { command = "''${lib.getExe pkgs.libsecret} lookup Title 'Gotify token'"; }
+                        or
+                        { command = "''${lib.getExe' pkgs.coreutils "cat"} /foo/bar/token"; }
+                      '';
+                      description = ''
+                        Secret Gotify client token.
+                        Either directly as string or as command for fetching client token.
+                      '';
+                    };
+                  };
+                }
+              );
+              default = null;
+              internal = true;
+            };
+          };
+        };
+        default = { };
+        example = literalExpression ''
+          {
+            # optional, if true, deletes messages that have been handled, defaults to false
+            gotify.auto_delete = true;
+
+            # optional, ignores messages with priority lower than given value, defaults to 0
+            notification.min_priority = 1;
+
+            # optional, run the given command for each message, with the following environment variables set: GOTIFY_MSG_PRIORITY, GOTIFY_MSG_TITLE and GOTIFY_MSG_TEXT.
+            action.on_msg_command = "/usr/bin/beep";
+          }
+        '';
+        description = ''
+          Configuration settings for gotify-desktop. All available options can be found here:
+          <https://github.com/desbma/gotify-desktop/blob/master/README.md#configuration>
+        '';
+      };
+    };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "services.gotify-desktop" pkgs lib.platforms.linux)
+    ];
+
+    xdg.configFile."gotify-desktop/config.toml" =
+      let
+        # Filter null defaults for maximum flexibility when only settings.gotify.url or settings.gotify.token is set
+        filteredSettings = lib.filterAttrsRecursive (_: value: value != null) cfg.settings;
+      in
+      lib.mkIf (filteredSettings != { }) {
+        source = tomlFormat.generate "gotify-desktop-config.toml" filteredSettings;
+      };
+
+    # Based on systemd service example provided by package
+    # https://github.com/desbma/gotify-desktop/blob/521dbf4d175833b6338856248c7c6b383c1e5fa6/gotify-desktop.service
+    systemd.user.services.gotify-desktop = {
+      Unit = {
+        Description = "Gotify daemon to send desktop notifications";
+        PartOf = [ "graphical-session.target" ];
+      };
+
+      Service = {
+        ExecStart = lib.getExe cfg.package;
+        Restart = "always";
+        RestartSec = "5s";
+      };
+
+      Install.WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}

--- a/tests/modules/services/gotify-desktop/config-arbitrary-settings.toml
+++ b/tests/modules/services/gotify-desktop/config-arbitrary-settings.toml
@@ -1,0 +1,2 @@
+[foo]
+bar = "foobar"

--- a/tests/modules/services/gotify-desktop/config-command-token.toml
+++ b/tests/modules/services/gotify-desktop/config-command-token.toml
@@ -1,0 +1,2 @@
+[gotify.token]
+command = "secret-token-command"

--- a/tests/modules/services/gotify-desktop/config-full-settings.toml
+++ b/tests/modules/services/gotify-desktop/config-full-settings.toml
@@ -1,0 +1,8 @@
+[foo]
+bar = "foobar"
+
+[gotify]
+url = "wss://foo.bar"
+
+[gotify.token]
+command = "secret-token-command"

--- a/tests/modules/services/gotify-desktop/config-str-token.toml
+++ b/tests/modules/services/gotify-desktop/config-str-token.toml
@@ -1,0 +1,2 @@
+[gotify]
+token = "secret-token"

--- a/tests/modules/services/gotify-desktop/config-url.toml
+++ b/tests/modules/services/gotify-desktop/config-url.toml
@@ -1,0 +1,2 @@
+[gotify]
+url = "wss://foo.bar"

--- a/tests/modules/services/gotify-desktop/default.nix
+++ b/tests/modules/services/gotify-desktop/default.nix
@@ -1,0 +1,10 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  gotify-desktop-url = ./gotify-desktop-url.nix;
+  gotify-desktop-str-token = ./gotify-desktop-str-token.nix;
+  gotify-desktop-command-token = ./gotify-desktop-command-token.nix;
+  gotify-desktop-arbitrary-settings = ./gotify-desktop-arbitrary-settings.nix;
+  gotify-desktop-empty-settings = ./gotify-desktop-empty-settings.nix;
+  gotify-desktop-full-settings = ./gotify-desktop-full-settings.nix;
+}

--- a/tests/modules/services/gotify-desktop/gotify-desktop-arbitrary-settings.nix
+++ b/tests/modules/services/gotify-desktop/gotify-desktop-arbitrary-settings.nix
@@ -1,0 +1,17 @@
+{
+  services.gotify-desktop = {
+    enable = true;
+
+    settings.foo.bar = "foobar";
+  };
+
+  nmt.script = ''
+    servicePath=home-files/.config/systemd/user
+    configPath=home-files/.config/gotify-desktop
+
+    assertFileExists $servicePath/gotify-desktop.service
+    assertFileExists $configPath/config.toml
+
+    assertFileContent $configPath/config.toml ${./config-arbitrary-settings.toml}
+  '';
+}

--- a/tests/modules/services/gotify-desktop/gotify-desktop-command-token.nix
+++ b/tests/modules/services/gotify-desktop/gotify-desktop-command-token.nix
@@ -1,0 +1,17 @@
+{
+  services.gotify-desktop = {
+    enable = true;
+
+    settings.gotify.token.command = "secret-token-command";
+  };
+
+  nmt.script = ''
+    servicePath=home-files/.config/systemd/user
+    configPath=home-files/.config/gotify-desktop
+
+    assertFileExists $servicePath/gotify-desktop.service
+    assertFileExists $configPath/config.toml
+
+    assertFileContent $configPath/config.toml ${./config-command-token.toml}
+  '';
+}

--- a/tests/modules/services/gotify-desktop/gotify-desktop-empty-settings.nix
+++ b/tests/modules/services/gotify-desktop/gotify-desktop-empty-settings.nix
@@ -1,0 +1,11 @@
+{
+  services.gotify-desktop.enable = true;
+
+  nmt.script = ''
+    servicePath=home-files/.config/systemd/user
+    configPath=home-files/.config/gotify-desktop
+
+    assertFileExists $servicePath/gotify-desktop.service
+    assertPathNotExists $configPath/config.toml
+  '';
+}

--- a/tests/modules/services/gotify-desktop/gotify-desktop-full-settings.nix
+++ b/tests/modules/services/gotify-desktop/gotify-desktop-full-settings.nix
@@ -1,0 +1,24 @@
+{
+  services.gotify-desktop = {
+    enable = true;
+
+    settings = {
+      gotify = {
+        url = "wss://foo.bar";
+        token.command = "secret-token-command";
+      };
+
+      foo.bar = "foobar";
+    };
+  };
+
+  nmt.script = ''
+    servicePath=home-files/.config/systemd/user
+    configPath=home-files/.config/gotify-desktop
+
+    assertFileExists $servicePath/gotify-desktop.service
+    assertFileExists $configPath/config.toml
+
+    assertFileContent $configPath/config.toml ${./config-full-settings.toml}
+  '';
+}

--- a/tests/modules/services/gotify-desktop/gotify-desktop-str-token.nix
+++ b/tests/modules/services/gotify-desktop/gotify-desktop-str-token.nix
@@ -1,0 +1,17 @@
+{
+  services.gotify-desktop = {
+    enable = true;
+
+    settings.gotify.token = "secret-token";
+  };
+
+  nmt.script = ''
+    servicePath=home-files/.config/systemd/user
+    configPath=home-files/.config/gotify-desktop
+
+    assertFileExists $servicePath/gotify-desktop.service
+    assertFileExists $configPath/config.toml
+
+    assertFileContent $configPath/config.toml ${./config-str-token.toml}
+  '';
+}

--- a/tests/modules/services/gotify-desktop/gotify-desktop-url.nix
+++ b/tests/modules/services/gotify-desktop/gotify-desktop-url.nix
@@ -1,0 +1,17 @@
+{
+  services.gotify-desktop = {
+    enable = true;
+
+    settings.gotify.url = "wss://foo.bar";
+  };
+
+  nmt.script = ''
+    servicePath=home-files/.config/systemd/user
+    configPath=home-files/.config/gotify-desktop
+
+    assertFileExists $servicePath/gotify-desktop.service
+    assertFileExists $configPath/config.toml
+
+    assertFileContent $configPath/config.toml ${./config-url.toml}
+  '';
+}


### PR DESCRIPTION
### Description

Add a new service module: gotify-desktop a Gotify message forward daemon.

Notable things:
 - gotify-desktop does support darwin but I'm not sure how to create the systemd service equivalent for darwin. So I designed the module as linux only.
 - The token option is a bit weird but is in the expected format for the service.
 - Running all tests fails on a unrelated test, but all added tests run successfully.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
