### PR TITLE
nix-index: add nushell integration

### DIFF
--- a/modules/misc/news/2025/11/2025-11-25_11-33-50.nix
+++ b/modules/misc/news/2025/11/2025-11-25_11-33-50.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+
+{
+  time = "2025-11-25T11:33:50+00:00";
+  condition = config.programs.nix-index.enable && config.programs.nushell.enable;
+  message = ''
+    The nix-index module now adds a command-not-found handler to Nushell by default.
+
+    This can be disabled:
+      programs.nix-index.enableNushellIntegration = false;
+  '';
+}

--- a/modules/programs/nix-index.nix
+++ b/modules/programs/nix-index.nix
@@ -23,6 +23,8 @@ in
     enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
 
     enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+
+    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
   };
 
   config = lib.mkIf cfg.enable {
@@ -65,5 +67,9 @@ in
             ${wrapper} $argv
         end
       '';
+
+    programs.nushell.settings.hooks.command_not_found = lib.mkIf cfg.enableNushellIntegration (
+      lib.hm.nushell.mkNushellInline "source ${cfg.package}/etc/profile.d/command-not-found.nu"
+    );
   };
 }

--- a/tests/modules/programs/nix-index/integrations.nix
+++ b/tests/modules/programs/nix-index/integrations.nix
@@ -11,6 +11,7 @@ in
   programs.bash.enable = true;
   programs.fish.enable = true;
   programs.zsh.enable = true;
+  programs.nushell.enable = true;
 
   # Needed to avoid error with dummy fish package.
   xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
@@ -36,5 +37,11 @@ in
     assertFileExists home-files/.config/fish/config.fish
     assertFileRegex \
       home-files/.config/fish/config.fish '${fishRegex}'
+
+    # Nushell integration
+    assertFileExists home-files/.config/nushell/config.nu
+    assertFileContains \
+      home-files/.config/nushell/config.nu \
+      '$env.config.hooks.command_not_found = (source @nix-index@/etc/profile.d/command-not-found.nu)'
   '';
 }


### PR DESCRIPTION
### Description

Adds a `command-not-found` handler by default, see the Nushell section at https://github.com/nix-community/nix-index?tab=readme-ov-file#usage-as-a-command-not-found-replacement

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
