### PR TITLE
starship: add presets option

### DIFF
--- a/modules/misc/news/2026/01/2026-01-11_16-02-12.nix
+++ b/modules/misc/news/2026/01/2026-01-11_16-02-12.nix
@@ -1,0 +1,9 @@
+{ config, ... }:
+{
+  time = "2026-01-11T16:02:12+00:00";
+  condition = config.programs.starship.enable;
+  message = ''
+    The starship module has a new option, programs.starship.presets, which
+    allows for merging user configuration with Starship's bundled presets.
+  '';
+}

--- a/modules/programs/starship.nix
+++ b/modules/programs/starship.nix
@@ -49,6 +49,17 @@ in
       '';
     };
 
+    presets = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      example = [ "nerd-font-symbols" ];
+      description = ''
+        Preset files to be merged with settings in order.
+
+        See <https://starship.rs/presets/> for the full list of available presets.
+      '';
+    };
+
     enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
 
     enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
@@ -99,9 +110,29 @@ in
 
       sessionVariables.STARSHIP_CONFIG = cfg.configPath;
 
-      file.${cfg.configPath} = mkIf (cfg.settings != { }) {
-        source = tomlFormat.generate "starship-config" cfg.settings;
-      };
+      file.${cfg.configPath} =
+        let
+          settingsFile = tomlFormat.generate "starship-config" cfg.settings;
+        in
+        if cfg.presets == [ ] then
+          { source = settingsFile; }
+        else
+          {
+            source =
+              pkgs.runCommand "starship.toml"
+                {
+                  nativeBuildInputs = [ pkgs.yq ];
+                }
+                ''
+                  tomlq -s -t 'reduce .[] as $item ({}; . * $item)' \
+                    ${
+                      lib.concatStringsSep " " (map (f: "${cfg.package}/share/starship/presets/${f}.toml") cfg.presets)
+                    } \
+                    ${settingsFile} \
+                    > $out
+                '';
+          };
+
     };
 
     programs.bash.initExtra = mkIf cfg.enableBashIntegration ''


### PR DESCRIPTION
### Description

Fixes #7297. Mirrors https://github.com/NixOS/nixpkgs/commit/68543ba85f86b22d12a5d32de55d0f1eb6eddfb6.

I'm not sure how to do test cases that don't have to be manually updated along with Starship. Is it alright to use IFD in the test and compare attrsets parsed from TOML?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
