### PR TITLE
treewide: `fold` -> `foldr`

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -18,7 +18,7 @@ let
     let
       f = w: x: builtins.trace "[1;31mwarning: ${w}[0m" x;
     in
-    lib.fold f res res.config.warnings;
+    lib.foldr f res res.config.warnings;
 
   extendedLib = import ./lib/stdlib-extended.nix lib;
 

--- a/modules/misc/nixpkgs-disabled.nix
+++ b/modules/misc/nixpkgs-disabled.nix
@@ -46,7 +46,7 @@ let
         traceXIfNot = c: if c x then true else lib.traceSeqN 1 x false;
       in
       traceXIfNot isConfig;
-    merge = args: lib.fold (def: mergeConfig def.value) { };
+    merge = args: lib.foldr (def: mergeConfig def.value) { };
   };
 
   # Copied from nixpkgs.nix.

--- a/modules/misc/nixpkgs.nix
+++ b/modules/misc/nixpkgs.nix
@@ -43,7 +43,7 @@ let
         traceXIfNot = c: if c x then true else lib.traceSeqN 1 x false;
       in
       traceXIfNot isConfig;
-    merge = args: lib.fold (def: mergeConfig def.value) { };
+    merge = args: lib.foldr (def: mergeConfig def.value) { };
   };
 
   overlayType = lib.mkOptionType {

--- a/modules/services/udiskie.nix
+++ b/modules/services/udiskie.nix
@@ -11,7 +11,7 @@ let
     types
     ;
 
-  mergeSets = sets: lib.lists.fold lib.attrsets.recursiveUpdate { } sets;
+  mergeSets = sets: lib.lists.foldr lib.attrsets.recursiveUpdate { } sets;
 
   yaml = pkgs.formats.yaml { };
 

--- a/modules/services/way-displays.nix
+++ b/modules/services/way-displays.nix
@@ -17,7 +17,7 @@ let
     mkOption
     types
     ;
-  mergeSets = sets: lists.fold attrsets.recursiveUpdate { } sets;
+  mergeSets = sets: lists.foldr attrsets.recursiveUpdate { } sets;
   cfg = config.services.way-displays;
   yaml = pkgs.formats.yaml { };
 in


### PR DESCRIPTION
deprecated in https://github.com/NixOS/nixpkgs/commit/f4d36941eba6c290a1f839b77f85d9579f087c22

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
