### PR TITLE
ci: revert actions/checkout to v5 due to update-flake-lock incompatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci:"
+    ignore:
+      # Ignore v6 until update-flake-lock upgrades to create-pull-request@v7.0.9+
+      - dependency-name: "actions/checkout"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +19,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci:"
+    ignore:
+      # Ignore v6 until update-flake-lock upgrades to create-pull-request@v7.0.9+
+      - dependency-name: "actions/checkout"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -35,7 +35,12 @@ jobs:
             echo "email=$id+$name@users.noreply.github.com"
           } >> "$GITHUB_OUTPUT"
       - name: Checkout repository
-        uses: actions/checkout@v6
+        # NOTE: v6 is incompatible with update-flake-lock@v27 due to credential
+        # storage changes. update-flake-lock uses peter-evans/create-pull-request@v6.0.5
+        # which doesn't work with v6's $RUNNER_TEMP credential storage.
+        # Can upgrade to v6 once update-flake-lock uses create-pull-request@v7.0.9+
+        # See: https://github.com/peter-evans/create-pull-request/issues/690
+        uses: actions/checkout@v5
         with:
           ref: ${{ matrix.branch }}
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Root cause: DeterminateSystems/update-flake-lock@v27 uses peter-evans/create-pull-request@v6.0.5 internally, which is incompatible with actions/checkout@v6's new credential storage mechanism.

The Problem Chain:
- actions/checkout@v6 moved credentials from .git/config to $RUNNER_TEMP (security improvement)
- peter-evans/create-pull-request@v6.0.5 cannot access credentials from the new $RUNNER_TEMP location
- This causes exit code 128 when update-flake-lock tries to create PRs

The Fix:
- create-pull-request@v7.0.9 fixed v6 compatibility
- However, update-flake-lock@v27 (released July 2025) hasn't upgraded yet
- Reverting to v5 restores working credential access

Next Steps:
- Can upgrade to v6 once update-flake-lock uses create-pull-request@v7.0.9+
  - https://github.com/DeterminateSystems/update-flake-lock/pull/224
- Dependabot configured to ignore v6 upgrades until compatibility is fixed

Fixes: https://github.com/nix-community/home-manager/actions/runs/19712979574
See: https://github.com/peter-evans/create-pull-request/issues/690

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
