### PR TITLE
ci: update checkout and update-flake-lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,6 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci:"
-    ignore:
-      # Ignore v6 until update-flake-lock upgrades to create-pull-request@v7.0.9+
-      - dependency-name: "actions/checkout"
-        update-types: ["version-update:semver-major"]
-
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "release-25.11"
@@ -20,6 +15,3 @@ updates:
     commit-message:
       prefix: "ci:"
     ignore:
-      # Ignore v6 until update-flake-lock upgrades to create-pull-request@v7.0.9+
-      - dependency-name: "actions/checkout"
-        update-types: ["version-update:semver-major"]

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -35,19 +35,14 @@ jobs:
             echo "email=$id+$name@users.noreply.github.com"
           } >> "$GITHUB_OUTPUT"
       - name: Checkout repository
-        # NOTE: v6 is incompatible with update-flake-lock@v27 due to credential
-        # storage changes. update-flake-lock uses peter-evans/create-pull-request@v6.0.5
-        # which doesn't work with v6's $RUNNER_TEMP credential storage.
-        # Can upgrade to v6 once update-flake-lock uses create-pull-request@v7.0.9+
-        # See: https://github.com/peter-evans/create-pull-request/issues/690
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
       - name: Install Nix
         uses: cachix/install-nix-action@v31
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v27
+        uses: DeterminateSystems/update-flake-lock@v28
         with:
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           git-committer-name: ${{ steps.user-info.outputs.name || 'github-actions[bot]' }}


### PR DESCRIPTION
https://github.com/DeterminateSystems/update-flake-lock/releases/tag/v28 updated with checkout v6 support.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
