### PR TITLE
infat: add module

### DIFF
--- a/modules/misc/news/2025/11/2025-11-27_08-22-14.nix
+++ b/modules/misc/news/2025/11/2025-11-27_08-22-14.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+{
+  time = "2025-11-27T07:22:14+00:00";
+  condition = pkgs.stdenv.hostPlatform.isDarwin;
+  message = ''
+    A new module is available: 'programs.infat'.
+    Infat is a command line tool to set default openers
+    for file formats and url schemes on macOS.
+  '';
+}

--- a/modules/programs/infat.nix
+++ b/modules/programs/infat.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.infat;
+  tomlFormat = pkgs.formats.toml { };
+
+  configDir =
+    if config.xdg.enable then
+      config.xdg.configHome
+    else
+      "${config.home.homeDirectory}/Library/Application Support";
+
+  configFile = "${configDir}/infat/config.toml";
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    mirkolenz
+  ];
+
+  options = {
+    programs.infat = {
+      enable = lib.mkEnableOption "infat";
+      package = lib.mkPackageOption pkgs "infat" { nullable = true; };
+      settings = lib.mkOption {
+        type = tomlFormat.type;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            extensions = {
+              md = "TextEdit";
+              html = "Safari";
+              pdf = "Preview";
+            };
+            schemes = {
+              mailto = "Mail";
+              web = "Safari";
+            };
+            types = {
+              plain-text = "VSCode";
+            };
+          }
+        '';
+        description = ''
+          Configuration written to
+          {file}`$XDG_CONFIG_HOME/infat/config.toml`.
+        '';
+      };
+      autoActivate = lib.mkEnableOption "auto-activate infat" // {
+        default = true;
+        example = false;
+        description = ''
+          Automatically activate infat on startup.
+          This is useful if you want to use infat as a
+          default application handler for certain file types.
+          If you don't want this, set this to false.
+          This option is only effective if `settings` is set.
+        '';
+      };
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      (lib.hm.assertions.assertPlatform "programs.infat" pkgs lib.platforms.darwin)
+    ];
+    home = {
+      packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+      file.${configFile} = lib.mkIf (cfg.settings != { }) {
+        source = tomlFormat.generate "infat-settings.toml" cfg.settings;
+      };
+      activation = lib.mkIf (cfg.settings != { } && cfg.package != null && cfg.autoActivate) {
+        infat = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          run ${lib.getExe cfg.package} --config "${configFile}" $VERBOSE_ARG
+        '';
+      };
+    };
+  };
+}

--- a/tests/modules/programs/infat/default.nix
+++ b/tests/modules/programs/infat/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs, ... }:
+
+lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+  infat-example-settings = ./example-settings.nix;
+  infat-no-settings = ./no-settings.nix;
+}

--- a/tests/modules/programs/infat/example-settings.nix
+++ b/tests/modules/programs/infat/example-settings.nix
@@ -1,0 +1,39 @@
+{ pkgs, ... }:
+
+{
+  programs.infat = {
+    enable = true;
+    settings = {
+      extensions = {
+        md = "TextEdit";
+      };
+      schemes = {
+        web = "Safari";
+      };
+      types = {
+        plain-text = "VSCode";
+      };
+    };
+  };
+
+  test.stubs.infat = { };
+
+  nmt.script =
+    let
+      expectedConfigPath = "home-files/.config/infat/config.toml";
+      expectedConfigContent = pkgs.writeText "infat.config.expected" ''
+        [extensions]
+        md = "TextEdit"
+
+        [schemes]
+        web = "Safari"
+
+        [types]
+        plain-text = "VSCode"
+      '';
+    in
+    ''
+      assertFileExists "${expectedConfigPath}"
+      assertFileContent "${expectedConfigPath}" "${expectedConfigContent}"
+    '';
+}

--- a/tests/modules/programs/infat/no-settings.nix
+++ b/tests/modules/programs/infat/no-settings.nix
@@ -1,0 +1,13 @@
+{
+  programs.infat.enable = true;
+
+  test.stubs.infat = { };
+
+  nmt.script =
+    let
+      expectedConfigPath = "home-files/.config/infat/config.toml";
+    in
+    ''
+      assertPathNotExists "${expectedConfigPath}"
+    '';
+}


### PR DESCRIPTION
### Description

Added a new module: 'programs.infat'. Infat is a command line tool to set default openers for file formats and url schemes on macOS. Full disclosure: I created the module myself and used codex to generate the tests based on the existing ones for uv.

One thing I'm unsure about: Should the news entry be its own commit or is it fine as-is?

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
