### PR TITLE
fish: avoid shadowing builtin completions

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -628,9 +628,30 @@ in
                 mkdir -p $out
                 for src in $srcs; do
                   if [ -d $src/share/man ]; then
-                    find -L $src/share/man -type f \
-                      -exec python ${cfg.package}/share/fish/tools/create_manpage_completions.py --directory $out {} + \
-                      > /dev/null
+                    while IFS= read -r manpage; do
+                      # Approximate the corresponding command for this manpage
+                      bin="$(basename "$manpage")"
+                      bin="''${bin%%.*}"
+                      bin="$src/bin/$bin"
+
+                      # Check for builtin completion
+                      if
+                        [ -e "$bin" ] &&
+                        fish \
+                          --no-config \
+                          --command 'complete --do-complete $argv[1]' \
+                          -- "$bin" \
+                          >/dev/null 2>&1
+                      then
+                        echo "Found builtin completion for $bin (skipping)"
+                        continue
+                      fi
+
+                      # Generate completion based on the manpage
+                      python ${cfg.package}/share/fish/tools/create_manpage_completions.py \
+                        --directory "$out" "$manpage" > /dev/null
+
+                    done < <(find -L "$src/share/man" -type f)
                   fi
                 done
               '';


### PR DESCRIPTION
### Description

The fish shell comes with builtin completions. For example, git completion supports context-aware completion of things like commit hashes, branch names, sub-commands, etc.

On the other hand, we can generate _basic_ completion based on man pages. These are not context-aware, but are better than nothing.

Until fish 4.2, builtin completions were explicitly loaded from `share/fish/completions`, however that is now deprecated and disabled. In effect, this means generating manpage-based completion will now shadow and disable builtin completion. Thanks @dotboris for identifying the underlying issue!

Avoid that, by only generating completion when fish does not have builtin support for the command.

Fixes #8178

Note: this will need porting to NixOS too ([NixOS issue](https://github.com/NixOS/nixpkgs/issues/462025), [NixOS code](https://github.com/NixOS/nixpkgs/blob/5ae3b07d8d6527c42f17c876e404993199144b6a/nixos/modules/programs/fish.nix#L271-L293)). As I personally don't use the NixOS module, I figured I'd get feedback in home-manager first, before doing that. cc NixOS maintainers: @llakala @SigmaSquadron


<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
