### PR TITLE
xsession: only require xdg autostart target if explicitely enabled

### DIFF
--- a/modules/xsession.nix
+++ b/modules/xsession.nix
@@ -188,10 +188,13 @@ in
         hm-graphical-session = {
           Unit = {
             Description = "Home Manager X session";
-            Requires = [
-              "graphical-session-pre.target"
-              "xdg-desktop-autostart.target"
-            ];
+            Requires =
+              let
+                requires = lib.optional (config.xdg.autostart.enable) "xdg-desktop-autostart.target" ++ [
+                  "graphical-session-pre.target"
+                ];
+              in
+              requires;
             BindsTo = [
               "graphical-session.target"
               "tray.target"


### PR DESCRIPTION
### Description

This is a fix for PR #7108 that forcibly enables xdg-desktop-autostart units, whether or not `config.xdg.autostart` is enabled. Partially fixes #7708, there is still a risk for conflict if `xdg.autostart` and `services.picom` are enabled.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
