### PR TITLE
docs: added a note on conflicts to the standalone installation section

### DIFF
--- a/docs/manual/installation/standalone.md
+++ b/docs/manual/installation/standalone.md
@@ -33,6 +33,28 @@
     $ nix-shell '<home-manager>' -A install
     ```
 
+    :::{.note}
+    If there are any conflicts with files that Home Manager installs (for
+    example `~/.profile`), then the installation command by default will abort.
+    
+    In order to set a conflict resolution strategy you can run the installation
+    command with the `HOME_MANAGER_BACKUP_EXT` environment variable set in order
+    to automatically backup conflicting files with a given extension:
+
+    ``` shell
+    $ HOME_MANAGER_BACKUP_EXT="bak" nix-shell '<home-manager>' -A install
+    ```
+
+    If an old file `~/.profile` conflicts with the one installed by Home
+    Manager, its contents will be moved to `~/.profile.bak`. If you want to
+    instead destroy conflicting files, you can run with the installation command
+    like so:
+
+    ``` shell
+    $ HOME_MANAGER_BACKUP_OVERWRITE=1 nix-shell '<home-manager>' -A install
+    ```
+    :::
+
     Once finished, Home Manager should be active and available in your
     user environment.
 


### PR DESCRIPTION

### Description

When running the installer through `nix-shell "<home-manager>" -A install`, any conflicts will lead to the installation aborting. This can be a problem if you installed the `~/.config/home-manager/home.nix` before home-manager itself. There is very little documentation on how to fix this in the manual, so after figuring out how to do it, I decided to extend the documentation on the standalone installation with this information.

#### Potential issues

- Wording: What use case this info box is addressing is not explicitly mentioned, may be a problem because it's prominent positioning could confuse users about what they should worry about

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
