### PR TITLE
fix: Don't "[a]ttempt to evaluate package pkgs.trash-cli"

### DIFF
--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -85,7 +85,7 @@ in
     backupCommand = mkOption {
       type = types.nullOr (types.either types.str types.path);
       default = null;
-      example = lib.literalExpression "''${pkgs.trash-cli}/bin/trash";
+      example = lib.literalExpression "\${pkgs.trash-cli}/bin/trash";
       description = ''
         On activation run this command on each existing file
         rather than exiting with an error.


### PR DESCRIPTION
Closes #8161.

### Description



### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
