### PR TITLE
 fish: ensure generated completions considered after embedded completions

### DIFF
--- a/modules/programs/fish.nix
+++ b/modules/programs/fish.nix
@@ -645,7 +645,7 @@ in
           # Support completion for `man` by building a cache for `apropos`.
           programs.man.generateCaches = lib.mkDefault true;
 
-          xdg.dataFile."fish/home-manager_generated_completions".source =
+          xdg.dataFile."fish/home-manager/generated_completions".source =
             let
               # Paths later in the list will overwrite those already linked
               destructiveSymlinkJoin =
@@ -696,7 +696,7 @@ in
               set -l post_joined (string replace $prev_joined "" $joined)
               set -l prev (string split " " (string trim $prev_joined))
               set -l post (string split " " (string trim $post_joined))
-              set fish_complete_path $prev "${config.xdg.dataHome}/fish/home-manager_generated_completions" $post
+              set fish_complete_path $prev "${config.xdg.dataHome}/fish/home-manager/generated_completions" $post
             end
           '';
         }

--- a/tests/modules/programs/atuin/fish.nix
+++ b/tests/modules/programs/atuin/fish.nix
@@ -7,7 +7,7 @@
   };
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/atuin/no-shell.nix
+++ b/tests/modules/programs/atuin/no-shell.nix
@@ -14,7 +14,7 @@
   };
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/atuin/nushell.nix
+++ b/tests/modules/programs/atuin/nushell.nix
@@ -15,7 +15,7 @@
   _module.args.pkgs = lib.mkForce realPkgs;
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/atuin/set-flags.nix
+++ b/tests/modules/programs/atuin/set-flags.nix
@@ -16,7 +16,7 @@
   };
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/fish/binds.nix
+++ b/tests/modules/programs/fish/binds.nix
@@ -29,7 +29,7 @@
     };
 
     # Needed to avoid error with dummy fish package.
-    xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+    xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
       builtins.toFile "empty" ""
     );
 

--- a/tests/modules/programs/fish/completions.nix
+++ b/tests/modules/programs/fish/completions.nix
@@ -25,7 +25,7 @@ in
       };
     };
 
-    xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+    xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
       builtins.toFile "empty" ""
     );
 

--- a/tests/modules/programs/fish/functions.nix
+++ b/tests/modules/programs/fish/functions.nix
@@ -29,7 +29,7 @@ in
     };
 
     # Needed to avoid error with dummy fish package.
-    xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+    xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
       builtins.toFile "empty" ""
     );
 

--- a/tests/modules/programs/fish/no-functions.nix
+++ b/tests/modules/programs/fish/no-functions.nix
@@ -8,7 +8,7 @@
     };
 
     # Needed to avoid error with dummy fish package.
-    xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+    xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
       builtins.toFile "empty" ""
     );
 

--- a/tests/modules/programs/fish/plugins.nix
+++ b/tests/modules/programs/fish/plugins.nix
@@ -47,7 +47,7 @@ in
     };
 
     # Needed to avoid error with dummy fish package.
-    xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+    xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
       builtins.toFile "empty" ""
     );
 

--- a/tests/modules/programs/nix-index/assert-on-command-not-found.nix
+++ b/tests/modules/programs/nix-index/assert-on-command-not-found.nix
@@ -8,7 +8,7 @@
   programs.command-not-found.enable = true;
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/nix-index/integrations.nix
+++ b/tests/modules/programs/nix-index/integrations.nix
@@ -14,7 +14,7 @@ in
   programs.nushell.enable = true;
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/oh-my-posh/fish.nix
+++ b/tests/modules/programs/oh-my-posh/fish.nix
@@ -11,7 +11,7 @@
   };
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/pls/fish.nix
+++ b/tests/modules/programs/pls/fish.nix
@@ -12,7 +12,7 @@
   };
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/powerline-go/fish.nix
+++ b/tests/modules/programs/powerline-go/fish.nix
@@ -21,7 +21,7 @@
   };
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/scmpuff/fish.nix
+++ b/tests/modules/programs/scmpuff/fish.nix
@@ -7,7 +7,7 @@
   };
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/scmpuff/no-aliases.nix
+++ b/tests/modules/programs/scmpuff/no-aliases.nix
@@ -10,7 +10,7 @@
   };
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/scmpuff/no-fish.nix
+++ b/tests/modules/programs/scmpuff/no-fish.nix
@@ -10,7 +10,7 @@
   };
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 

--- a/tests/modules/programs/zellij/enable-shells.nix
+++ b/tests/modules/programs/zellij/enable-shells.nix
@@ -18,7 +18,7 @@
   };
 
   # Needed to avoid error with dummy fish package.
-  xdg.dataFile."fish/home-manager_generated_completions".source = lib.mkForce (
+  xdg.dataFile."fish/home-manager/generated_completions".source = lib.mkForce (
     builtins.toFile "empty" ""
   );
 


### PR DESCRIPTION
### Description

Simpler and potentially more robust alternative to #8226.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
