### PR TITLE
clipmenu: Add environmentVariables option

### DIFF
--- a/modules/misc/news/2025/12/2025-12-01_16-08-56.nix
+++ b/modules/misc/news/2025/12/2025-12-01_16-08-56.nix
@@ -1,0 +1,8 @@
+{
+  time = "2025-12-01T15:08:56+00:00";
+  condition = true;
+  message = ''
+    The option 'services.clipmenu.launcher' has been deprecated, please
+    use 'services.clipmenu.environmentVariables.CM_LAUNCHER' instead.
+  '';
+}


### PR DESCRIPTION
### Description

Add `environmentVariables` option for setting e.g. `CM_MAX_CLIPS` for `clipmenud`.

From what I gather, variables set in `home.sessionVariables` are not picked up by the service, so the `lancher` option does not currently work. With this change, `CM_LAUNCHER` can be set with `environmentVariables`, so I suggest deprecating the `launcher` option.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
