### PR TITLE
home-environment: extend release check to include pkgs

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -570,14 +570,25 @@ in
     warnings =
       let
         hmRelease = config.home.version.release;
-        nixpkgsRelease = lib.trivial.release;
-        releaseMismatch = config.home.enableNixpkgsReleaseCheck && hmRelease != nixpkgsRelease;
+        libRelease = lib.trivial.release;
+        pkgsRelease = pkgs.lib.trivial.release;
+        releaseMismatch = hmRelease != libRelease || hmRelease != pkgsRelease;
+
+        versionsSummary =
+          if libRelease == pkgsRelease then
+            ''
+              Home Manager version ${hmRelease} and
+              Nixpkgs version ${libRelease}.''
+          else
+            ''
+              Home Manager version: ${hmRelease}
+              Nixpkgs version used to evaluate Home Manager: ${libRelease}
+              Nixpkgs version used for packages (`pkgs`): ${pkgsRelease}'';
       in
-      lib.optional releaseMismatch ''
+      lib.optional (config.home.enableNixpkgsReleaseCheck && releaseMismatch) ''
         You are using
 
-          Home Manager version ${hmRelease} and
-          Nixpkgs version ${nixpkgsRelease}.
+          ${lib.replaceString "\n" "\n  " versionsSummary}
 
         Using mismatched versions is likely to cause errors and unexpected
         behavior. It is therefore highly recommended to use a release of Home

--- a/tests/modules/home-environment/default.nix
+++ b/tests/modules/home-environment/default.nix
@@ -2,4 +2,5 @@
   home-session-path = ./session-path.nix;
   home-session-search-variables = ./session-search-variables.nix;
   home-session-variables = ./session-variables.nix;
+  home-nixpkgs-release-check-pkgs = ./nixpkgs-release-check-pkgs.nix;
 }

--- a/tests/modules/home-environment/nixpkgs-release-check-pkgs.nix
+++ b/tests/modules/home-environment/nixpkgs-release-check-pkgs.nix
@@ -1,0 +1,39 @@
+{ lib, ... }:
+let
+  releaseInfo = lib.importJSON ../../../release.json;
+  hmRelease = releaseInfo.release;
+  pkgsRelease = "<invalid>";
+in
+{
+  test.asserts.warnings.expected = [
+    ''
+      You are using
+
+        Home Manager version: ${hmRelease}
+        Nixpkgs version used to evaluate Home Manager: ${hmRelease}
+        Nixpkgs version used for packages (`pkgs`): ${pkgsRelease}
+
+      Using mismatched versions is likely to cause errors and unexpected
+      behavior. It is therefore highly recommended to use a release of Home
+      Manager that corresponds with your chosen release of Nixpkgs.
+
+      If you insist then you can disable this warning by adding
+
+        home.enableNixpkgsReleaseCheck = false;
+
+      to your configuration.
+    ''
+  ];
+
+  nixpkgs.overlays = [
+    (final: prev: {
+      lib = prev.lib.extend (
+        final: prev: {
+          trivial = prev.trivial // {
+            release = pkgsRelease;
+          };
+        }
+      );
+    })
+  ];
+}


### PR DESCRIPTION
### Description

`lib` is imported from the Nixpkgs used to **instantiate Home Manager itself**, and therefore does not vary inside the module fixpoint. By contrast, `pkgs` *is* user-configurable (via `nixpkgs.*` or `_module.args`) and may come from a **different** Nixpkgs revision than the one providing `lib`.

As a result, mismatches between Home Manager's release and the release of the `pkgs` instance are both more common and more likely to cause subtle, difficult-to-diagnose issues.

This change extends the release check to also consider `pkgs.lib.trivial.release`, allowing Home Manager to detect/reveal when `pkgs` and `lib` originate from different Nixpkgs releases.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
