### PR TITLE
ssh: add strictHostKeyChecking option

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -404,6 +404,16 @@ let
         example = "10m";
         description = "Whether control socket should remain open in the background.";
       };
+
+      strictHostKeyChecking = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Whether to add hosts to the {file}`~/.ssh/known_hosts` file.
+
+          See {manpage}`ssh_config(5)` for more information.
+        '';
+      };
     };
 
     #    config.host = mkDefault dagName;
@@ -445,6 +455,7 @@ let
       ++ optional (cf.controlMaster != null) "  ControlMaster ${cf.controlMaster}"
       ++ optional (cf.controlPath != null) "  ControlPath ${cf.controlPath}"
       ++ optional (cf.controlPersist != null) "  ControlPersist ${cf.controlPersist}"
+      ++ optional (cf.strictHostKeyChecking != null) "  StrictHostKeyChecking ${cf.strictHostKeyChecking}"
       ++ map (file: "  IdentityFile ${file}") cf.identityFile
       ++ map (file: "  IdentityAgent ${file}") cf.identityAgent
       ++ map (file: "  CertificateFile ${file}") cf.certificateFile

--- a/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
+++ b/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
@@ -8,6 +8,7 @@ Host xyz
   SetEnv BAR="_bar_ 42" FOO="foo12"
   ServerAliveInterval 60
   ServerAliveCountMax 10
+  StrictHostKeyChecking accept-new
   IdentityFile file
   LocalForward [localhost]:8080 [10.0.0.1]:80
   RemoteForward [localhost]:8081 [10.0.0.2]:80

--- a/tests/modules/programs/ssh/match-blocks-attrs.nix
+++ b/tests/modules/programs/ssh/match-blocks-attrs.nix
@@ -39,6 +39,7 @@
             FOO = "foo12";
             BAR = "_bar_ 42";
           };
+          strictHostKeyChecking = "accept-new";
         };
 
         "* !github.com" = {


### PR DESCRIPTION
### Description

This option controls the StrictHostKeyChecking option for SSH.

It is useful for ignoring host SSH key changes when e.g. connecting to a host that frequently changes the host SSH key like a devboard or postmarketOS phone.
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
