### PR TITLE
pimsync: Make storage names unique

### DIFF
--- a/modules/programs/pimsync/default.nix
+++ b/modules/programs/pimsync/default.nix
@@ -51,7 +51,7 @@
 
       localStorage = calendar: name: acc: {
         name = "storage";
-        params = [ "${name}-local" ];
+        params = [ "${if calendar then "calendar" else "contacts"}-${name}-local" ];
         children =
           (attrsToDirectives {
             inherit (acc.local) path;
@@ -63,7 +63,7 @@
 
       remoteStorage = calendar: name: acc: {
         name = "storage";
-        params = [ "${name}-remote" ];
+        params = [ "${if calendar then "calendar" else "contacts"}-${name}-remote" ];
         children =
           (attrsToDirectives {
             inherit (acc.remote) url;
@@ -91,8 +91,8 @@
         params = lib.singleton "${if calendar then "calendar" else "contacts"}-${name}";
         children =
           (attrsToDirectives {
-            storage_a = "${name}-local";
-            storage_b = "${name}-remote";
+            storage_a = "${if calendar then "calendar" else "contacts"}-${name}-local";
+            storage_b = "${if calendar then "calendar" else "contacts"}-${name}-remote";
           })
           ++ acc.pimsync.extraPairDirectives;
       };

--- a/tests/modules/programs/pimsync/basic.nix
+++ b/tests/modules/programs/pimsync/basic.nix
@@ -1,6 +1,6 @@
 {
   accounts.calendar = {
-    accounts.caldav = {
+    accounts.mine = {
       pimsync.enable = true;
       remote = {
         passwordCommand = [
@@ -23,7 +23,7 @@
   };
 
   accounts.contact = {
-    accounts.carddav = {
+    accounts.mine = {
       pimsync.enable = true;
       remote = {
         passwordCommand = [

--- a/tests/modules/programs/pimsync/basic.scfg
+++ b/tests/modules/programs/pimsync/basic.scfg
@@ -1,14 +1,18 @@
-storage caldav-local {
-	fileext .ics
-	path /home/hm-user/.local/state/calendar/caldav
-	type vdir/icalendar
-}
-storage http-local {
+storage calendar-http-local {
 	fileext .ics
 	path /home/hm-user/.local/state/calendar/http
 	type vdir/icalendar
 }
-storage caldav-remote {
+storage calendar-mine-local {
+	fileext .ics
+	path /home/hm-user/.local/state/calendar/mine
+	type vdir/icalendar
+}
+storage calendar-http-remote {
+	type webcal
+	url https://example.com/calendar
+}
+storage calendar-mine-remote {
 	type caldav
 	url https://caldav.example.com
 	username alice
@@ -16,24 +20,20 @@ storage caldav-remote {
 		cmd pass caldav
 	}
 }
-storage http-remote {
-	type webcal
-	url https://example.com/calendar
-}
-pair calendar-caldav {
-	storage_a caldav-local
-	storage_b caldav-remote
-}
 pair calendar-http {
-	storage_a http-local
-	storage_b http-remote
+	storage_a calendar-http-local
+	storage_b calendar-http-remote
 }
-storage carddav-local {
+pair calendar-mine {
+	storage_a calendar-mine-local
+	storage_b calendar-mine-remote
+}
+storage contacts-mine-local {
 	fileext .vcf
-	path /home/hm-user/.local/state/contact/carddav
+	path /home/hm-user/.local/state/contact/mine
 	type vdir/vcard
 }
-storage carddav-remote {
+storage contacts-mine-remote {
 	type carddav
 	url https://carddav.example.com
 	username bob
@@ -41,8 +41,8 @@ storage carddav-remote {
 		cmd pass carddav
 	}
 }
-pair contacts-carddav {
-	storage_a carddav-local
-	storage_b carddav-remote
+pair contacts-mine {
+	storage_a contacts-mine-local
+	storage_b contacts-mine-remote
 }
 status_path /test/dir


### PR DESCRIPTION
### Description

This includes the calendar/contacts prefix in the storage name as well as the pair name to ensure that if the same name is used for contacts and calendar then it is correctly referenced.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
