### PR TITLE
programs/ssh: use 'toKeyValue' for 'extraOptions'

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -451,7 +451,13 @@ let
       ++ map (f: "  LocalForward" + addressPort f.bind + addressPort f.host) cf.localForwards
       ++ map (f: "  RemoteForward" + addressPort f.bind + addressPort f.host) cf.remoteForwards
       ++ map (f: "  DynamicForward" + addressPort f) cf.dynamicForwards
-      ++ mapAttrsToList (n: v: "  ${n} ${v}") cf.extraOptions
+      ++ [
+        (lib.generators.toKeyValue {
+          mkKeyValue = lib.generators.mkKeyValueDefault { } " ";
+          listsAsDuplicateKeys = true;
+          indent = "  ";
+        } cf.extraOptions)
+      ]
     );
 
 in

--- a/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts-expected.conf
+++ b/tests/modules/programs/ssh/forwards-dynamic-valid-bind-no-asserts-expected.conf
@@ -1,7 +1,9 @@
 Host dynamicBindAddressWithPort
   DynamicForward [127.0.0.1]:3000
+
 Host dynamicBindPathNoPort
   DynamicForward /run/user/1000/gnupg/S.gpg-agent.extra
+
 
 
   

--- a/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
+++ b/tests/modules/programs/ssh/match-blocks-attrs-expected.conf
@@ -2,8 +2,10 @@ Host * !github.com
   Port 516
   IdentityFile file1
   IdentityFile file2
+
 Host abc
   ProxyJump jump-host
+
 Host xyz
   SetEnv BAR="_bar_ 42" FOO="foo12"
   ServerAliveInterval 60
@@ -13,8 +15,10 @@ Host xyz
   RemoteForward [localhost]:8081 [10.0.0.2]:80
   RemoteForward /run/user/1000/gnupg/S.gpg-agent.extra /run/user/1000/gnupg/S.gpg-agent
   DynamicForward [localhost]:2839
+
 Host ordered
   Port 1
+
 
 
   

--- a/tests/modules/programs/ssh/match-blocks-match-and-hosts-expected.conf
+++ b/tests/modules/programs/ssh/match-blocks-match-and-hosts-expected.conf
@@ -1,9 +1,12 @@
 Host * !github.com
   Port 516
+
 Host abc
   Port 2222
+
 Match host xyz canonical
   Port 2223
+
 
 
   

--- a/tests/modules/programs/ssh/old-defaults-expected.conf
+++ b/tests/modules/programs/ssh/old-defaults-expected.conf
@@ -11,4 +11,5 @@ Host *
   ControlMaster no
   ControlPath ~/.ssh/master-%r@%n:%p
   ControlPersist no
+
   

--- a/tests/modules/programs/ssh/old-defaults-extra-config-expected.conf
+++ b/tests/modules/programs/ssh/old-defaults-extra-config-expected.conf
@@ -11,6 +11,7 @@ Host *
   ControlMaster no
   ControlPath ~/.ssh/master-%r@%n:%p
   ControlPersist no
+
   MyExtraOption no
   AnotherOption 3
   

--- a/tests/modules/programs/ssh/renamed-options-expected.conf
+++ b/tests/modules/programs/ssh/renamed-options-expected.conf
@@ -11,4 +11,5 @@ Host *
   ControlMaster yes
   ControlPath ~/.ssh/myfile-%r@%n:%p
   ControlPersist 10m
+
   


### PR DESCRIPTION
A first step towards refactoring the module.

Unfortunately the config is not consistent in using comma-separated values or repeated keys for lists, since the user can always add commas by themselves, we should default to repeated keys in the generator.

### Description

In answer to the barrage of PRs adding individual options, we can at the very least point them towards the pre-existing `extraOptions` settings instead of naming _every_ option in the module...

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [X] Change is backwards compatible.

- [X] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [X] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [X] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [X] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
