### PR TITLE
programs/ssh: use 'toList'

### DIFF
--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -151,14 +151,7 @@ let
       identityFile = mkOption {
         type = with types; either (listOf str) (nullOr str);
         default = [ ];
-        apply =
-          p:
-          if p == null then
-            [ ]
-          else if lib.isString p then
-            [ p ]
-          else
-            p;
+        apply = p: if p == null then [ ] else lib.toList p;
         description = ''
           Specifies files from which the user identity is read.
           Identities will be tried in the given order.
@@ -168,14 +161,7 @@ let
       identityAgent = mkOption {
         type = with types; either (listOf str) (nullOr str);
         default = [ ];
-        apply =
-          p:
-          if p == null then
-            [ ]
-          else if lib.isString p then
-            [ p ]
-          else
-            p;
+        apply = p: if p == null then [ ] else lib.toList p;
         description = ''
           Specifies the location of the ssh identity agent.
         '';
@@ -265,14 +251,7 @@ let
       certificateFile = mkOption {
         type = with types; either (listOf str) (nullOr str);
         default = [ ];
-        apply =
-          p:
-          if p == null then
-            [ ]
-          else if lib.isString p then
-            [ p ]
-          else
-            p;
+        apply = p: if p == null then [ ] else lib.toList p;
         description = ''
           Specifies files from which the user certificate is read.
         '';


### PR DESCRIPTION
### Description

Another simple refactoring I noticed while looking at `matchBlockModule`.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
