### PR TITLE
thunderbird: fix aliases SMTP configuration not being listed as usable

### DIFF
--- a/modules/programs/thunderbird.nix
+++ b/modules/programs/thunderbird.nix
@@ -9,6 +9,7 @@ let
     attrValues
     concatStringsSep
     filter
+    flatten
     length
     literalExpression
     mapAttrsToList
@@ -918,7 +919,14 @@ in
               calendarAccounts = getAccountsForProfile name enabledCalendarAccountsWithId;
               contactAccounts = getAccountsForProfile name enabledContactAccountsWithId;
 
-              smtp = filter (a: a.smtp != null) emailAccounts;
+              accountsSmtp = filter (a: a.smtp != null) emailAccounts;
+              aliasesSmtp =
+                let
+                  getAliasesWithSmtp = a: filter (al: builtins.isAttrs al && al.smtp != null) a.aliases;
+                  getAliasesWithId = a: map (al: al // { id = getId a al; }) (getAliasesWithSmtp a);
+                in
+                flatten (map getAliasesWithId emailAccounts);
+              smtp = accountsSmtp ++ aliasesSmtp;
 
               feedAccounts = addId (attrValues profile.feedAccounts);
 

--- a/tests/modules/programs/thunderbird/thunderbird-expected-first-darwin.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-first-darwin.js
@@ -120,7 +120,7 @@ user_pref("mail.smtpserver.smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfa
 user_pref("mail.smtpserver.smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.port", 456);
 user_pref("mail.smtpserver.smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.try_ssl", 3);
 user_pref("mail.smtpserver.smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.username", "home.manager");
-user_pref("mail.smtpservers", "smtp_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc,smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f");
+user_pref("mail.smtpservers", "smtp_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc,smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f,smtp_b24ca86ede61ed219e6c87cfec261aae2c72785f812489ea943d114d1f39f55b");
 user_pref("privacy.donottrackheader.enabled", true);
 
 user_pref("mail.html_compose", false);

--- a/tests/modules/programs/thunderbird/thunderbird-expected-first-linux.js
+++ b/tests/modules/programs/thunderbird/thunderbird-expected-first-linux.js
@@ -120,7 +120,7 @@ user_pref("mail.smtpserver.smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfa
 user_pref("mail.smtpserver.smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.port", 456);
 user_pref("mail.smtpserver.smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.try_ssl", 3);
 user_pref("mail.smtpserver.smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f.username", "home.manager");
-user_pref("mail.smtpservers", "smtp_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc,smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f");
+user_pref("mail.smtpservers", "smtp_bcd3ace52bed41febb6cdc2fb1303aebaa573e0d993872da503950901bb6c6fc,smtp_cda3f13b64c1db7d4b58ce07a31304a362d7dcaf14476bfabcca913ae41ada9f,smtp_b24ca86ede61ed219e6c87cfec261aae2c72785f812489ea943d114d1f39f55b");
 user_pref("privacy.donottrackheader.enabled", true);
 
 user_pref("mail.html_compose", false);


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

This fixes the SMTP configuration of an alias appearing blank in Thunderbird identities (and thus making it not usable).

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
