### PR TITLE
git: make package nullable

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -41,6 +41,7 @@ in
         enable = mkEnableOption "Git";
 
         package = lib.mkPackageOption pkgs "git" {
+          nullable = true;
           example = "pkgs.gitFull";
           extraDescription = ''
             Use {var}`pkgs.gitFull`
@@ -328,7 +329,7 @@ in
   config = mkIf cfg.enable (
     lib.mkMerge [
       {
-        home.packages = [ cfg.package ];
+        home.packages = lib.optionals (cfg.package != null) [ cfg.package ];
 
         assertions = [
           {
@@ -516,7 +517,7 @@ in
             Type = "oneshot";
             ExecStart =
               let
-                exe = lib.getExe cfg.package;
+                exe = if cfg.package != null then lib.getExe cfg.package else "git";
               in
               ''
                 "${exe}" for-each-repo --keep-going --config=maintenance.repo maintenance run --schedule=%i
@@ -553,7 +554,7 @@ in
         launchd.agents =
           let
             baseArguments = [
-              "${lib.getExe cfg.package}"
+              "${if cfg.package != null then lib.getExe cfg.package else "git"}"
               "for-each-repo"
               "--keep-going"
               "--config=maintenance.repo"


### PR DESCRIPTION
### Description

Some platforms (e.g. macOS) provide their customized version of git with exclusive features, and user might want to use that instead. This PR makes the `package` option of `programs.git` nullable; when set to `null`, home-manager won't manage git installation.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] ~~Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).~~ The change is simple enough not to add test cases.

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
