### PR TITLE
home-environment: add home.uid option

### DIFF
--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -193,6 +193,13 @@ in
       description = "The user's username.";
     };
 
+    home.uid = mkOption {
+      type = types.nullOr types.ints.unsigned;
+      default = null;
+      example = 1000;
+      description = "The user's uid.";
+    };
+
     home.homeDirectory = mkOption {
       type = types.path;
       defaultText = literalExpression ''
@@ -842,6 +849,9 @@ in
           if [[ ! -v SKIP_SANITY_CHECKS ]]; then
             checkUsername ${lib.escapeShellArg config.home.username}
             checkHomeDirectory ${lib.escapeShellArg config.home.homeDirectory}
+            ${lib.optionalString (config.home.uid != null) ''
+              checkUid ${toString config.home.uid}
+            ''}
           fi
 
           ${lib.optionalString config.home.activationGenerateGcRoot ''

--- a/modules/lib-bash/activation-init.sh
+++ b/modules/lib-bash/activation-init.sh
@@ -117,6 +117,17 @@ function checkHomeDirectory() {
   fi
 }
 
+function checkUid() {
+  local expectedUid="$1"
+  local actualUid
+  actualUid="$(id -u)"
+
+  if [[ "$actualUid" != "$expectedUid" ]]; then
+    _iError 'Error: UID is "%s" but we expect "%s"' "$actualUid" "$expectedUid"
+    exit 1
+  fi
+}
+
 # Note, the VERBOSE_ECHO variable is deprecated and should not be used inside
 # the Home Manager project. It is provided here for backwards compatibility.
 if [[ -v VERBOSE ]]; then

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -53,6 +53,7 @@ let
 
             home.username = config.users.users.${name}.name;
             home.homeDirectory = config.users.users.${name}.home;
+            home.uid = mkIf (config.users.users.${name}.uid != null) config.users.users.${name}.uid;
 
             # Forward `nix.enable` from the OS configuration. The
             # conditional is to check whether nix-darwin is new enough

--- a/tests/modules/home-environment/default.nix
+++ b/tests/modules/home-environment/default.nix
@@ -3,4 +3,6 @@
   home-session-search-variables = ./session-search-variables.nix;
   home-session-variables = ./session-variables.nix;
   home-nixpkgs-release-check-pkgs = ./nixpkgs-release-check-pkgs.nix;
+  home-uid = ./uid.nix;
+  home-uid-null = ./uid-null.nix;
 }

--- a/tests/modules/home-environment/uid-null.nix
+++ b/tests/modules/home-environment/uid-null.nix
@@ -1,0 +1,7 @@
+{
+  # home.uid defaults to null, so checkUid should not be called in the activation script
+
+  nmt.script = ''
+    assertFileNotRegex activate "checkUid [0-9]+"
+  '';
+}

--- a/tests/modules/home-environment/uid.nix
+++ b/tests/modules/home-environment/uid.nix
@@ -1,0 +1,7 @@
+{
+  home.uid = 1000;
+
+  nmt.script = ''
+    assertFileContains activate "checkUid 1000"
+  '';
+}


### PR DESCRIPTION
### Description

Add a home.uid option similar to home.username. When set, the
activation script verifies the current UID matches the expected
value using the new checkUid function.

When using the NixOS or nix-darwin modules, home.uid is
auto-discovered from users.users.<name>.uid when that value
is set.

This is useful for constructing paths that depend on the user's
UID, such as /run/user/<uid> paths for gpg-agent sockets or
other user-specific runtime directories.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
