### PR TITLE
claude-code: fix wrapper to inject --mcp-config after subcommands

### DIFF
--- a/tests/modules/programs/claude-code/expected-mcp-wrapper
+++ b/tests/modules/programs/claude-code/expected-mcp-wrapper
@@ -1,2 +1,3 @@
-#! /nix/store/00000000000000000000000000000000-bash/bin/bash -e
-exec -a "$0" "/nix/store/00000000000000000000000000000000-claude-code/bin/.claude-wrapped"  --mcp-config /nix/store/00000000000000000000000000000000-claude-code-mcp-config.json "$@" 
+#!/nix/store/00000000000000000000000000000000-bash/bin/bash
+exec "/nix/store/00000000000000000000000000000000-claude-code/bin/claude-code" "$@" --mcp-config "/nix/store/00000000000000000000000000000000-claude-code-mcp-config.json"
+


### PR DESCRIPTION
The previous implementation used `wrapProgram --add-flags` which prepended `--mcp-config` to all invocations, breaking subcommands like `claude doctor` and `claude mcp`.

Claude CLI's parser requires the --mcp-config flag to come after the subcommand, not before it.

This change replaces the wrapProgram approach with a custom bash wrapper that injects --mcp-config after the subcommand

All subcommands now work correctly with MCP servers configured.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
