### PR TITLE
home-environment: require home.uid for stateVersion >= 26.05

### DIFF
--- a/docs/release-notes/rl-2605.md
+++ b/docs/release-notes/rl-2605.md
@@ -15,3 +15,9 @@ changes are only active if the `home.stateVersion` option is set to
 
 - The `gtk.gtk4.theme` option does not mirror `gtk.theme` by default
   anymore.
+
+- The `home.uid` option is now required. When using Home Manager as a
+  NixOS or nix-darwin module, this is automatically set from
+  `users.users.<name>.uid` if that option is defined. For standalone
+  usage or when the system user has no explicit UID, set `home.uid`
+  to your user's UID (run `id -u` to find it).

--- a/modules/home-environment.nix
+++ b/modules/home-environment.nix
@@ -197,7 +197,13 @@ in
       type = types.nullOr types.ints.unsigned;
       default = null;
       example = 1000;
-      description = "The user's uid.";
+      description = ''
+        The user's UID. Required for state version 26.05 and later.
+
+        When using Home Manager as a NixOS or nix-darwin module, this value
+        is automatically set from {option}`users.users.<name>.uid` when that
+        option is defined.
+      '';
     };
 
     home.homeDirectory = mkOption {
@@ -571,6 +577,16 @@ in
       {
         assertion = config.home.homeDirectory != "";
         message = "Home directory could not be determined";
+      }
+      {
+        assertion = lib.versionOlder config.home.stateVersion "26.05" || config.home.uid != null;
+        message = ''
+          User ID (UID) could not be determined. Please set 'home.uid' to your
+          user's UID. You can find your UID by running 'id -u' in your terminal.
+
+          If you are using Home Manager as a NixOS or nix-darwin module, you can
+          alternatively set 'users.users.<name>.uid' in your system configuration.
+        '';
       }
     ];
 

--- a/modules/misc/news/2025/12/2025-12-04_18-39-36.nix
+++ b/modules/misc/news/2025/12/2025-12-04_18-39-36.nix
@@ -1,0 +1,17 @@
+{ config, lib, ... }:
+
+{
+  time = "2025-12-04T18:39:36+00:00";
+  condition = lib.versionAtLeast config.home.stateVersion "26.05";
+  message = ''
+    The 'home.uid' option is now required for state version 26.05 and later.
+
+    When using Home Manager as a NixOS or nix-darwin module, this value is
+    automatically set from 'users.users.<name>.uid' when that option is defined.
+
+    For standalone usage, or when the system user has no explicit UID, add to
+    your configuration:
+
+        home.uid = 1000;  # Replace with your actual UID (run 'id -u')
+  '';
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -128,6 +128,7 @@ let
             username = "hm-user";
             homeDirectory = "/home/hm-user";
             stateVersion = lib.mkDefault "18.09";
+            uid = lib.mkDefault 1000;
           };
 
           # Avoid including documentation since this will cause

--- a/tests/modules/home-environment/default.nix
+++ b/tests/modules/home-environment/default.nix
@@ -5,4 +5,5 @@
   home-nixpkgs-release-check-pkgs = ./nixpkgs-release-check-pkgs.nix;
   home-uid = ./uid.nix;
   home-uid-null = ./uid-null.nix;
+  home-uid-required = ./uid-required.nix;
 }

--- a/tests/modules/home-environment/uid-null.nix
+++ b/tests/modules/home-environment/uid-null.nix
@@ -1,5 +1,6 @@
 {
-  # home.uid defaults to null, so checkUid should not be called in the activation script
+  # Test that when home.uid is null, checkUid should not be called in the activation script
+  home.uid = null;
 
   nmt.script = ''
     assertFileNotRegex activate "checkUid [0-9]+"

--- a/tests/modules/home-environment/uid-required.nix
+++ b/tests/modules/home-environment/uid-required.nix
@@ -1,0 +1,15 @@
+{
+  home.stateVersion = "26.05";
+  # Test that home.uid is required for stateVersion 26.05+
+  home.uid = null;
+
+  test.asserts.assertions.expected = [
+    ''
+      User ID (UID) could not be determined. Please set 'home.uid' to your
+      user's UID. You can find your UID by running 'id -u' in your terminal.
+
+      If you are using Home Manager as a NixOS or nix-darwin module, you can
+      alternatively set 'users.users.<name>.uid' in your system configuration.
+    ''
+  ];
+}


### PR DESCRIPTION
### Description

Follow-up to #8284 addressing [the discussion](https://github.com/nix-community/home-manager/pull/8284#issuecomment-3612667507) about making `home.uid` mandatory.

This PR makes `home.uid` required for users with `stateVersion` 26.05 or later

### Who is affected

Users with `stateVersion >= 26.05` who don't have `home.uid` set:

1. **Standalone users** - Must set `home.uid` manually
2. **NixOS/nix-darwin users without explicit `users.users.<name>.uid`** - The module only auto-discovers when `uid` is explicitly set in the system config. Users relying on auto-assigned UIDs must either:
   - Set `users.users.<name>.uid` explicitly in their NixOS/nix-darwin config, OR
   - Set `home.uid` directly in their home-manager config

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
