### PR TITLE
home-environment: split home.uid nixos and nix-darwin inheritance

### DIFF
--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -14,7 +14,24 @@ in
   imports = [ ../nixos/common.nix ];
 
   config = lib.mkMerge [
-    { home-manager.extraSpecialArgs.darwinConfig = config; }
+    {
+      home-manager = {
+        extraSpecialArgs.darwinConfig = config;
+
+        sharedModules = [
+          (
+            { name, ... }:
+            {
+              key = "home-manager#darwin-shared-module";
+
+              config = {
+                home.uid = lib.mkIf (config.users.users.${name} ? uid) config.users.users.${name}.uid;
+              };
+            }
+          )
+        ];
+      };
+    }
     (lib.mkIf (cfg.users != { }) {
       system.activationScripts.postActivation.text = lib.concatStringsSep "\n" (
         lib.mapAttrsToList (

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -53,7 +53,6 @@ let
 
             home.username = config.users.users.${name}.name;
             home.homeDirectory = config.users.users.${name}.home;
-            home.uid = mkIf (config.users.users.${name}.uid != null) config.users.users.${name}.uid;
 
             # Forward `nix.enable` from the OS configuration. The
             # conditional is to check whether nix-darwin is new enough

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -31,18 +31,24 @@ in
         extraSpecialArgs.nixosConfig = config;
 
         sharedModules = [
-          {
-            key = "home-manager#nixos-shared-module";
+          (
+            { name, ... }:
+            {
+              key = "home-manager#nixos-shared-module";
 
-            config = {
-              # The per-user directory inside /etc/profiles is not known by
-              # fontconfig by default.
-              fonts.fontconfig.enable = lib.mkDefault (cfg.useUserPackages && config.fonts.fontconfig.enable);
+              config = {
+                # The per-user directory inside /etc/profiles is not known by
+                # fontconfig by default.
+                fonts.fontconfig.enable = lib.mkDefault (cfg.useUserPackages && config.fonts.fontconfig.enable);
 
-              # Inherit glibcLocales setting from NixOS.
-              i18n.glibcLocales = lib.mkDefault config.i18n.glibcLocales;
-            };
-          }
+                # Inherit glibcLocales setting from NixOS.
+                i18n.glibcLocales = lib.mkDefault config.i18n.glibcLocales;
+
+                # Inherit user's UID from NixOS
+                home.uid = lib.mkIf (config.users.users.${name}.uid != null) config.users.users.${name}.uid;
+              };
+            }
+          )
         ];
       };
     }


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Should fix #8291, though I don't have any Darwin devices so I can't test this.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
