### PR TITLE
restic: change cache directory to $XDG_CACHE_HOME/restic

### DIFF
--- a/modules/services/restic.nix
+++ b/modules/services/restic.nix
@@ -475,7 +475,7 @@ in
               CacheDirectoryMode = "0700";
               PrivateTmp = true;
 
-              Environment = mkEnvironment backup ++ [ "RESTIC_CACHE_DIR=%C" ];
+              Environment = mkEnvironment backup ++ [ "RESTIC_CACHE_DIR=%C/${serviceName}" ];
 
               ExecStart =
                 lib.optional doBackup backupCmd
@@ -591,7 +591,7 @@ in
                 lib.concatLines
               ]}
 
-              RESTIC_CACHE_DIR=$HOME/.cache/${serviceName}
+              RESTIC_CACHE_DIR=${config.xdg.cacheHome}/${serviceName}
 
               PATH=${
                 lib.pipe environment [


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Restic's default cache dir is `$XDG_CACHE_HOME/restic`, as defined [here](https://restic.readthedocs.io/en/stable/manual_rest.html#caching) in the docs. Closes #8287.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
