### PR TITLE
nixos/common: guard nix.package access when nix.enable is false

### DIFF
--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -68,7 +68,9 @@ let
 
               # Make activation script use same version of Nix as system as a whole.
               # This avoids problems with Nix not being in PATH.
-              inherit (config.nix) package;
+              # Only set package when nix is enabled to avoid errors when
+              # nix-darwin has nix.enable = false (e.g., Determinate Nix users).
+              package = mkIf config.nix.enable config.nix.package;
             };
           };
         }


### PR DESCRIPTION
## Summary

When nix-darwin has `nix.enable = false` (e.g., for Determinate Nix users), accessing `config.nix.package` throws an error:

```
error: nix.package: accessed when `nix.enable` is off; this is a bug in
nix-darwin or a third‐party module
```

This regression was introduced in commit a521eab when adding the `home.uid` option. The code restructuring changed `inherit (config.nix) package` to be evaluated unconditionally, whereas PR #6383 had previously ensured this worked correctly.

## Fix

The fix wraps the package assignment in `mkIf config.nix.enable` to only access `config.nix.package` when nix management is enabled in the host OS configuration.

## Testing

- Tested locally with nix-darwin and `nix.enable = false` (Determinate Nix)
- Build succeeds after this change

## Related

- Fixes #8303
- Regression from a521eab (home-environment: add home.uid option)
- Original fix was in #6383