### PR TITLE
tmux: use idempotent new-session to avoid duplicate sessions

### DIFF
--- a/modules/programs/tmux.nix
+++ b/modules/programs/tmux.nix
@@ -57,7 +57,11 @@ let
       # We need to set default-shell before calling new-session
       set  -g default-shell "${cfg.shell}"
     ''}
-    ${optionalString cfg.newSession "new-session"}
+    ${optionalString cfg.newSession ''
+      # Use -A to make new-session idempotent: attach if session "0" exists,
+      # otherwise create it. This prevents duplicate sessions when multiple
+      # configs (e.g., system and user) both enable newSession.
+      new-session -A -s 0''}
 
     ${optionalString cfg.reverseSplit ''
       bind -N "Split the pane into two, left and right" v split-window -h

--- a/tests/modules/programs/tmux/emacs-with-plugins.conf
+++ b/tests/modules/programs/tmux/emacs-with-plugins.conf
@@ -3,7 +3,10 @@ set  -g default-terminal "screen"
 set  -g base-index      0
 setw -g pane-base-index 0
 
-new-session
+# Use -A to make new-session idempotent: attach if session "0" exists,
+# otherwise create it. This prevents duplicate sessions when multiple
+# configs (e.g., system and user) both enable newSession.
+new-session -A -s 0
 
 bind -N "Split the pane into two, left and right" v split-window -h
 bind -N "Split the pane into two, top and bottom" s split-window -v

--- a/tests/modules/programs/tmux/vi-all-true.conf
+++ b/tests/modules/programs/tmux/vi-all-true.conf
@@ -3,7 +3,10 @@ set  -g default-terminal "screen"
 set  -g base-index      0
 setw -g pane-base-index 0
 
-new-session
+# Use -A to make new-session idempotent: attach if session "0" exists,
+# otherwise create it. This prevents duplicate sessions when multiple
+# configs (e.g., system and user) both enable newSession.
+new-session -A -s 0
 
 bind -N "Split the pane into two, left and right" v split-window -h
 bind -N "Split the pane into two, top and bottom" s split-window -v


### PR DESCRIPTION
### Description

When both system-level (e.g., NixOS programs.tmux) and home-manager
tmux configs set newSession = true, tmux would create two sessions
on startup since both /etc/tmux.conf and ~/.config/tmux/tmux.conf
contain the new-session command.

Change new-session to new-session -A -s 0, which attaches to session
"0" if it exists, otherwise creates it. This makes the command
idempotent so multiple configs can safely enable newSession.

c.f. https://github.com/NixOS/nixpkgs/pull/468337

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
