### PR TITLE
npm: add module

### DIFF
--- a/modules/misc/news/2025/12/2025-12-06_11-03-01.nix
+++ b/modules/misc/news/2025/12/2025-12-06_11-03-01.nix
@@ -1,0 +1,10 @@
+{
+  time = "2025-12-06T10:03:01+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.npm`
+
+    It allows you manage your npm user configuration (`.npmrc`)
+    and install a specific version of the package.
+  '';
+}

--- a/modules/programs/npm.nix
+++ b/modules/programs/npm.nix
@@ -1,0 +1,74 @@
+# https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/npm.nix
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.npm;
+
+  xdgConfigHome = lib.removePrefix config.home.homeDirectory config.xdg.configHome;
+  configFile = if config.home.preferXdgDirectories then "${xdgConfigHome}/npm/npmrc" else ".npmrc";
+
+  iniFormat = pkgs.formats.ini {
+    listsAsDuplicateKeys = true;
+  };
+
+  toNpmrc =
+    let
+      mkLine = lib.generators.mkKeyValueDefault { } "=";
+      mkLines = k: v: if lib.isList v then map (x: mkLine "${k}[]" x) v else [ (mkLine k v) ];
+    in
+    attrs: lib.concatLines (lib.concatLists (lib.mapAttrsToList mkLines attrs));
+in
+{
+  meta.maintainers = with lib.maintainers; [ mirkolenz ];
+
+  options = {
+    programs.npm = {
+      enable = lib.mkEnableOption "{command}`npm` user config";
+
+      package = lib.mkPackageOption pkgs [ "nodejs" ] {
+        example = "nodejs_24";
+        nullable = true;
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.attrsOf iniFormat.lib.types.atom;
+        description = ''
+          The user-specific npm configuration.
+          See <https://docs.npmjs.com/cli/using-npm/config> and
+          <https://docs.npmjs.com/cli/configuring-npm/npmrc>
+          for more information.
+        '';
+        default = {
+          prefix = "\${HOME}/.npm";
+        };
+        example = lib.literalExpression ''
+          {
+            color = true;
+            include = [
+              "dev"
+              "prod"
+            ];
+            init-license = "MIT";
+            prefix = "''${HOME}/.npm";
+          }
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home = {
+      packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+      file.${configFile} = lib.mkIf (cfg.settings != { }) {
+        text = toNpmrc cfg.settings;
+      };
+      sessionVariables = lib.mkIf (cfg.settings != { }) {
+        NPM_CONFIG_USERCONFIG = "${config.home.homeDirectory}/${configFile}";
+      };
+    };
+  };
+}

--- a/tests/modules/programs/npm/default.nix
+++ b/tests/modules/programs/npm/default.nix
@@ -1,0 +1,4 @@
+{
+  npm-example-settings = ./example-settings.nix;
+  npm-no-settings = ./no-settings.nix;
+}

--- a/tests/modules/programs/npm/example-settings.nix
+++ b/tests/modules/programs/npm/example-settings.nix
@@ -1,0 +1,36 @@
+{ pkgs, ... }:
+
+{
+  programs.npm = {
+    enable = true;
+    settings = {
+      color = true;
+      include = [
+        "dev"
+        "prod"
+      ];
+      init-license = "MIT";
+      prefix = "\${HOME}/.npm";
+    };
+  };
+
+  test.stubs.nodejs = { };
+
+  nmt.script =
+    let
+      configPath = "home-files/.npmrc";
+      expectedConfig = pkgs.writeText "npmrc-expected" ''
+        color=true
+        include[]=dev
+        include[]=prod
+        init-license=MIT
+        prefix=''${HOME}/.npm
+      '';
+    in
+    ''
+      assertFileExists "${configPath}"
+      assertFileContent "${configPath}" "${expectedConfig}"
+      assertFileContains home-path/etc/profile.d/hm-session-vars.sh \
+        'export NPM_CONFIG_USERCONFIG="/home/hm-user/.npmrc"'
+    '';
+}

--- a/tests/modules/programs/npm/no-settings.nix
+++ b/tests/modules/programs/npm/no-settings.nix
@@ -1,0 +1,17 @@
+{ ... }:
+
+{
+  programs.npm = {
+    enable = true;
+    settings = { };
+  };
+
+  test.stubs.nodejs = { };
+
+  nmt.script = ''
+    assertPathNotExists home-files/.npmrc
+    assertFileExists home-path/etc/profile.d/hm-session-vars.sh
+    assertFileNotRegex home-path/etc/profile.d/hm-session-vars.sh \
+      "export NPM_CONFIG_USERCONFIG="
+  '';
+}


### PR DESCRIPTION
### Description

Add module for configuring `.npmrc` via home manager. Inspired by the [NixOS module](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/npm.nix).

I'm not sure if the tests are set up correctly. Since the package is a nested attrset, I didn't use a stub, but set the package to null instead. Please let me know if there's a better way to handle this.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
