### PR TITLE
ty: add module

### DIFF
--- a/modules/misc/news/2025/12/2025-12-06_11-05-43.nix
+++ b/modules/misc/news/2025/12/2025-12-06_11-05-43.nix
@@ -1,0 +1,10 @@
+{
+  time = "2025-12-06T10:05:43+00:00";
+  condition = true;
+  message = ''
+    A new module is available: `programs.ty`
+
+    It allows to manage the configuration and package
+    of the Python language server `ty` by Astral.
+  '';
+}

--- a/modules/programs/ty.nix
+++ b/modules/programs/ty.nix
@@ -1,0 +1,51 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    literalExpression
+    ;
+
+  tomlFormat = pkgs.formats.toml { };
+  cfg = config.programs.ty;
+in
+{
+  meta.maintainers = with lib.maintainers; [ mirkolenz ];
+
+  options.programs.ty = {
+    enable = mkEnableOption "ty";
+
+    package = mkPackageOption pkgs "ty" { nullable = true; };
+
+    settings = mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          rules.index-out-of-bounds = "ignore";
+        }
+      '';
+      description = ''
+        Configuration written to
+        {file}`$XDG_CONFIG_HOME/ty/ty.toml`.
+        See <https://docs.astral.sh/ty/configuration/>
+        and <https://docs.astral.sh/ty/reference/configuration/>
+        for more information.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = lib.mkIf (cfg.package != null) [ cfg.package ];
+
+    xdg.configFile."ty/ty.toml" = lib.mkIf (cfg.settings != { }) {
+      source = tomlFormat.generate "ty-config.toml" cfg.settings;
+    };
+  };
+}

--- a/tests/modules/programs/ty/default.nix
+++ b/tests/modules/programs/ty/default.nix
@@ -1,0 +1,4 @@
+{
+  ty-example-settings = ./example-settings.nix;
+  ty-no-settings = ./no-settings.nix;
+}

--- a/tests/modules/programs/ty/example-settings.nix
+++ b/tests/modules/programs/ty/example-settings.nix
@@ -1,0 +1,25 @@
+{ pkgs, ... }:
+
+{
+  programs.ty = {
+    enable = true;
+    settings = {
+      rules.index-out-of-bounds = "ignore";
+    };
+  };
+
+  test.stubs.ty = { };
+
+  nmt.script =
+    let
+      expectedConfigPath = "home-files/.config/ty/ty.toml";
+      expectedConfigContent = pkgs.writeText "ty.config-custom.expected" ''
+        [rules]
+        index-out-of-bounds = "ignore"
+      '';
+    in
+    ''
+      assertFileExists "${expectedConfigPath}"
+      assertFileContent "${expectedConfigPath}" "${expectedConfigContent}"
+    '';
+}

--- a/tests/modules/programs/ty/no-settings.nix
+++ b/tests/modules/programs/ty/no-settings.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+{
+  programs.ty = {
+    enable = true;
+  };
+
+  test.stubs.ty = { };
+
+  nmt.script =
+    let
+      expectedConfigPath = "home-files/.config/ty/ty.toml";
+    in
+    ''
+      assertPathNotExists "${expectedConfigPath}"
+    '';
+}


### PR DESCRIPTION
### Description

Added the module `programs.ty`. It allows to manage the configuration and package of the Python language server `ty` by Astral.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [x] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
