### PR TITLE
anki: enable tests on Darwin

### DIFF
--- a/tests/modules/programs/anki/default.nix
+++ b/tests/modules/programs/anki/default.nix
@@ -1,7 +1,4 @@
-{ lib, pkgs, ... }:
-
-# Anki is currently marked as broken on Darwin (2025/06/23)
-lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+{
   anki-minimal-config = ./minimal-config.nix;
   anki-full-config = ./full-config.nix;
 }


### PR DESCRIPTION
Anki is no longer marked as broken in nixpkgs.

### Description

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```