### PR TITLE
vicinae: move from programs to services

### DIFF
--- a/modules/services/vicinae.nix
+++ b/modules/services/vicinae.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  cfg = config.programs.vicinae;
+  cfg = config.services.vicinae;
 
   jsonFormat = pkgs.formats.json { };
   tomlFormat = pkgs.formats.toml { };
@@ -16,7 +16,48 @@ in
 {
   meta.maintainers = [ lib.maintainers.leiserfg ];
 
-  options.programs.vicinae = {
+  imports =
+    map
+      (
+        path:
+        lib.mkRenamedOptionModule
+          (
+            [
+              "programs"
+              "vicinae"
+            ]
+            ++ path
+          )
+          (
+            [
+              "services"
+              "vicinae"
+            ]
+            ++ path
+          )
+      )
+      [
+        [ "enable" ]
+        [ "package" ]
+        [
+          "systemd"
+          "enable"
+        ]
+        [
+          "systemd"
+          "autoStart"
+        ]
+        [
+          "systemd"
+          "target"
+        ]
+        [ "useLayerShell" ]
+        [ "extensions" ]
+        [ "themes" ]
+        [ "settings" ]
+      ];
+
+  options.services.vicinae = {
     enable = lib.mkEnableOption "vicinae launcher daemon";
 
     package = lib.mkPackageOption pkgs "vicinae" { nullable = true; };
@@ -153,10 +194,10 @@ in
 
   config = lib.mkIf cfg.enable {
     assertions = [
-      (lib.hm.assertions.assertPlatform "programs.vicinae" pkgs lib.platforms.linux)
+      (lib.hm.assertions.assertPlatform "services.vicinae" pkgs lib.platforms.linux)
       {
         assertion = cfg.systemd.enable -> cfg.package != null;
-        message = "{option}programs.vicinae.systemd.enable requires non null {option}programs.vicinae.package";
+        message = "{option}services.vicinae.systemd.enable requires non null {option}services.vicinae.package";
       }
     ];
     lib.vicinae.mkExtension = (

--- a/tests/modules/services/vicinae/default.nix
+++ b/tests/modules/services/vicinae/default.nix
@@ -1,4 +1,5 @@
 { lib, pkgs, ... }:
 lib.optionalAttrs (pkgs.stdenv.hostPlatform.isLinux) {
   vicinae-example-settings = ./example-settings.nix;
+  vicinae-old-progams = ./old-programs.nix;
 }

--- a/tests/modules/services/vicinae/example-settings.nix
+++ b/tests/modules/services/vicinae/example-settings.nix
@@ -1,0 +1,90 @@
+{
+  pkgs,
+  config,
+  ...
+}:
+
+{
+  services.vicinae = {
+    enable = true;
+    systemd.enable = true;
+
+    settings = {
+      faviconService = "twenty";
+      font = {
+        size = 10;
+      };
+      popToRootOnClose = false;
+      rootSearch = {
+        searchFiles = false;
+      };
+      theme = {
+        name = "vicinae-dark";
+      };
+      window = {
+        csd = true;
+        opacity = 0.95;
+        rounding = 10;
+      };
+    };
+    themes = {
+      catppuccin-mocha = {
+        meta = {
+          version = 1;
+          name = "Catppuccin Mocha";
+          description = "Cozy feeling with color-rich accents";
+          variant = "dark";
+          icon = "icons/catppuccin-mocha.png";
+          inherits = "vicinae-dark";
+        };
+
+        colors = {
+          core = {
+            background = "#1E1E2E";
+            foreground = "#CDD6F4";
+            secondary_background = "#181825";
+            border = "#313244";
+            accent = "#89B4FA";
+          };
+          accents = {
+            blue = "#89B4FA";
+            green = "#A6E3A1";
+            magenta = "#F5C2E7";
+            orange = "#FAB387";
+            purple = "#CBA6F7";
+            red = "#F38BA8";
+            yellow = "#F9E2AF";
+            cyan = "#94E2D5";
+          };
+        };
+      };
+    };
+
+    extensions = [
+      (config.lib.vicinae.mkRayCastExtension {
+        name = "gif-search";
+        sha256 = "sha256-G7il8T1L+P/2mXWJsb68n4BCbVKcrrtK8GnBNxzt73Q=";
+        rev = "4d417c2dfd86a5b2bea202d4a7b48d8eb3dbaeb1";
+      })
+      (config.lib.vicinae.mkExtension {
+        name = "test-extension";
+        src =
+          pkgs.fetchFromGitHub {
+            owner = "schromp";
+            repo = "vicinae-extensions";
+            rev = "f8be5c89393a336f773d679d22faf82d59631991";
+            sha256 = "sha256-zk7WIJ19ITzRFnqGSMtX35SgPGq0Z+M+f7hJRbyQugw=";
+          }
+          + "/test-extension";
+      })
+    ];
+  };
+
+  nmt.script = ''
+    assertFileExists      "home-files/.config/vicinae/vicinae.json"
+    assertFileExists      "home-files/.config/systemd/user/vicinae.service"
+    assertFileExists      "home-files/.local/share/vicinae/themes/catppuccin-mocha.toml"
+    assertFileExists      "home-files/.local/share/vicinae/extensions/gif-search/package.json"
+    assertFileExists      "home-files/.local/share/vicinae/extensions/test-extension/package.json"
+  '';
+}

--- a/tests/modules/services/vicinae/old-programs.nix
+++ b/tests/modules/services/vicinae/old-programs.nix
@@ -1,6 +1,8 @@
 {
+  lib,
   pkgs,
   config,
+  options,
   ...
 }:
 
@@ -79,6 +81,28 @@
       })
     ];
   };
+
+  test.asserts.warnings.expected =
+    let
+      pathToString = lib.foldl (acc: next: "${acc}.${next}");
+    in
+    lib.map
+      (
+        path:
+        "The option `${pathToString "programs.vicinae" path}' defined in ${
+          lib.showFiles (lib.attrByPath (path ++ [ "files" ]) "" options.programs.vicinae)
+        } has been renamed to `${pathToString "services.vicinae" path}'."
+      )
+      [
+        [ "settings" ]
+        [ "themes" ]
+        [ "extensions" ]
+        [
+          "systemd"
+          "enable"
+        ]
+        [ "enable" ]
+      ];
 
   nmt.script = ''
     assertFileExists      "home-files/.config/vicinae/vicinae.json"


### PR DESCRIPTION
### Description

mentioned here https://github.com/nix-community/home-manager/pull/8093#issuecomment-3477860526. allows for the home-manager option to be a drop in replacement for the vicinae home-manager module.

<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
