### PR TITLE
snixembed: add waybar incompatibility warning

### DIFF
--- a/modules/services/snixembed.nix
+++ b/modules/services/snixembed.nix
@@ -7,6 +7,7 @@
 
 let
   cfg = config.services.snixembed;
+  waybarCfg = config.programs.waybar;
 in
 {
   meta.maintainers = [ lib.maintainers.DamienCassou ];
@@ -32,6 +33,10 @@ in
     assertions = [
       (lib.hm.assertions.assertPlatform "services.snixembed" pkgs lib.platforms.linux)
     ];
+    warnings = lib.optional waybarCfg.enable ''
+      snixembed and waybar should not be enabled at the same time.
+      You may experience inconsistent tray behavior as a result.
+    '';
 
     systemd.user.services.snixembed = {
       Install.WantedBy = [ "graphical-session.target" ];


### PR DESCRIPTION
### Description

If snixembed is enabled and you try to use the waybar tray the two tools conflict with each other and often waybar's tray will not show any icons (seems like a race between which program starts first). This adds a warning about it, as the problem can be difficult to diagnose.

I spent many days trying to diagnose this problem awhile back and hope to prevent anyone else from having to do the same. 

I will note testing failed with an unrelated error, so didn't continue to run them. The change shouldn't impact existing tests I think though.

```
trying https://github.com/Floorp-Projects/Floorp/releases/download/v12.7.0/floorp-linux-x86_64.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0   0     0   0     0     0     0  --:--:-- --:--:-- --:--:--     0
100 86791k 100 86791k   0     0  5262k     0   0:00:16  0:00:16 --:--:--  1163k
error: hash mismatch in fixed-output derivation '/nix/store/dbzy5dld892qnmjmsnm81vq1fjplknlw-floorp-linux-x86_64.tar.xz.drv':
         specified: sha256-jpfLrHCQzDc062POI+aUlaAIDciBxhI7GzsYvHtt72I=
            got:    sha256-feIRCZuyB8xwUoI1FMWJQ6yupgC2aAavADQ9mrk0zMM=
```

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.
