### PR TITLE
treewide: defaultEditor also sets {env}`VISUAL`

### DIFF
--- a/modules/programs/helix.nix
+++ b/modules/programs/helix.nix
@@ -49,7 +49,8 @@ in
       default = false;
       description = ''
         Whether to configure {command}`hx` as the default
-        editor using the {env}`EDITOR` environment variable.
+        editor using the {env}`EDITOR` and {env}`VISUAL`
+        environment variables.
       '';
     };
 
@@ -225,7 +226,10 @@ in
       else
         [ cfg.package ];
 
-    home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "hx"; };
+    home.sessionVariables = mkIf cfg.defaultEditor {
+      EDITOR = "hx";
+      VISUAL = "hx";
+    };
 
     xdg.configFile =
       let

--- a/modules/programs/kakoune.nix
+++ b/modules/programs/kakoune.nix
@@ -705,7 +705,8 @@ in
         default = false;
         description = ''
           Whether to configure {command}`kak` as the default
-          editor using the {env}`EDITOR` environment variable.
+          editor using the {env}`EDITOR` and {env}`VISUAL`
+          environment variables.
         '';
       };
 
@@ -755,7 +756,10 @@ in
     programs.kakoune.finalPackage = lib.mkIf (cfg.package != null) kakouneWithPlugins;
 
     home.packages = lib.mkIf (cfg.finalPackage != null) [ cfg.finalPackage ];
-    home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "kak"; };
+    home.sessionVariables = mkIf cfg.defaultEditor {
+      EDITOR = "kak";
+      VISUAL = "kak";
+    };
     xdg.configFile = lib.mkMerge [
       { "kak/kakrc".source = configFile; }
       (mkIf (cfg.colorSchemePackage != null) {

--- a/modules/programs/neovim.nix
+++ b/modules/programs/neovim.nix
@@ -289,7 +289,8 @@ in
         default = false;
         description = ''
           Whether to configure {command}`nvim` as the default
-          editor using the {env}`EDITOR` environment variable.
+          editor using the {env}`EDITOR` and {env}`VISUAL`
+          environment variables.
         '';
       };
 
@@ -453,7 +454,10 @@ in
 
       home.packages = [ cfg.finalPackage ];
 
-      home.sessionVariables = mkIf cfg.defaultEditor { EDITOR = "nvim"; };
+      home.sessionVariables = mkIf cfg.defaultEditor {
+        EDITOR = "nvim";
+        VISUAL = "nvim";
+      };
 
       home.shellAliases = mkIf cfg.vimdiffAlias { vimdiff = "nvim -d"; };
 

--- a/modules/programs/vim.nix
+++ b/modules/programs/vim.nix
@@ -162,7 +162,8 @@ in
         default = false;
         description = ''
           Whether to configure {command}`vim` as the default
-          editor using the {env}`EDITOR` environment variable.
+          editor using the {env}`EDITOR` and {env}`VISUAL`
+          environment variables.
         '';
       };
     };
@@ -213,7 +214,10 @@ in
 
       home.packages = [ cfg.package ];
 
-      home.sessionVariables = lib.mkIf cfg.defaultEditor { EDITOR = "vim"; };
+      home.sessionVariables = lib.mkIf cfg.defaultEditor {
+        EDITOR = "vim";
+        VISUAL = "vim";
+      };
 
       programs.vim = {
         package = vim;

--- a/modules/services/emacs.nix
+++ b/modules/services/emacs.nix
@@ -113,7 +113,8 @@ in
       example = !default;
       description = ''
         Whether to configure {command}`emacsclient` as the default
-        editor using the {env}`EDITOR` environment variable.
+        editor using the {env}`EDITOR` and {env}`VISUAL`
+        environment variables.
       '';
     };
   };
@@ -121,11 +122,16 @@ in
   config = mkIf cfg.enable (
     lib.mkMerge [
       {
-        home.sessionVariables = mkIf cfg.defaultEditor {
-          EDITOR = lib.getBin (
-            pkgs.writeShellScript "editor" ''exec ${lib.getBin cfg.package}/bin/emacsclient "''${@:---create-frame}"''
-          );
-        };
+        home.sessionVariables =
+          let
+            editorBin = lib.getBin (
+              pkgs.writeShellScript "editor" ''exec ${lib.getBin cfg.package}/bin/emacsclient "''${@:---create-frame}"''
+            );
+          in
+          mkIf cfg.defaultEditor {
+            EDITOR = editorBin;
+            VISUAL = editorBin;
+          };
       }
 
       (mkIf pkgs.stdenv.isLinux {


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

The defaultEditor option sets {env}`EDITOR` however strictly speaking {env}`EDITOR` is intended for editors that are fully compatible with teletype terminals (ex: `ed` or `vi`'s `ex` mode).

The {env}`VISUAL variable is intended for modern "visual mode" terminal editors (ex: `vi` or `emacs`).

Technically speaking editors that are assigned to {env}`EDITOR` should be configured to operate in teletype compatible mode (see `vi -e` and `vim -e`).

We don't do this currently because for most users this would be unintuitive behavior when a script or program mistakenly checks {env}`EDITOR` instead of first checking {env}`VISUAL`.

In the future it may be worthwhile to introduce an additional option to these modules to configure {env}`EDITOR` in a strictly conforming manner (i.e. using the teletype/`ex` mode flags or unsetting {env}`EDITOR` entirely).

Closes #8314

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [x] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module: N/A

- If this PR adds an exciting new feature or contains a breaking change: N/A
