### PR TITLE
home-manager.useGlobalPkgs: default to true

### DIFF
--- a/modules/misc/news/2025/12/2025-12-11_14-45-59.nix
+++ b/modules/misc/news/2025/12/2025-12-11_14-45-59.nix
@@ -1,0 +1,11 @@
+{
+  time = "2025-12-11T13:45:59+00:00";
+  condition = true;
+  message = ''
+    BREAKING CHANGE:
+
+    home-manager.useGlobalPkgs is true by default and will become ineffective after 26.11.
+    Using a different set of pkgs for home-manager and nixos has been a constant source of confusion
+    for newcomers and does not make a lot of sense so we are getting rid of this option.
+  '';
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -77,7 +77,9 @@ let
 
     (lib.optional useNixpkgsModule ./misc/nixpkgs.nix)
 
-    (lib.optional (!useNixpkgsModule) ./misc/nixpkgs-disabled.nix)
+    (lib.optional (!useNixpkgsModule) (
+      lib.warn "useNixpkgsModule is going to be ineffective after 26.11" ./misc/nixpkgs-disabled.nix
+    ))
 
     (
       if minimal then

--- a/nixos/common.nix
+++ b/nixos/common.nix
@@ -85,10 +85,14 @@ in
       installation of user packages through the
       {option}`users.users.<name>.packages` option'';
 
-    useGlobalPkgs = mkEnableOption ''
-      using the system configuration's `pkgs`
-      argument in Home Manager. This disables the Home Manager
-      options {option}`nixpkgs.*`'';
+    useGlobalPkgs =
+      mkEnableOption ''
+        using the system configuration's `pkgs`
+        argument in Home Manager. This disables the Home Manager
+          options {option}`nixpkgs.*`''
+      // {
+        default = true;
+      };
 
     backupCommand = mkOption {
       type = types.nullOr (types.either types.str types.path);


### PR DESCRIPTION



### Description

home-manager.useGlobalPkgs is true by default and will become ineffective after 26.11. Using a different set of pkgs for home-manager and nixos has been a constant source of confusion for newcomers and does not make a lot of sense so we are getting rid of this option.

I can't see a usecase for it so if you use this knowingly, let me know why please.


### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [x] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [x] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
