### PR TITLE
news: add defaultEditor entry

### DIFF
--- a/modules/misc/news/2025/12/2025-12-11_13-04-30.nix
+++ b/modules/misc/news/2025/12/2025-12-11_13-04-30.nix
@@ -1,0 +1,32 @@
+{ config, ... }:
+
+{
+  time = "2025-12-11T19:04:30+00:00";
+  condition =
+    let
+      helixEnabled = config.programs.helix.enable && config.programs.helix.defaultEditor;
+      kakouneEnabled = config.programs.kakoune.enable && config.programs.kakoune.defaultEditor;
+      neovimEnabled = config.programs.neovim.enable && config.programs.neovim.defaultEditor;
+      vimEnabled = config.programs.vim.enable && config.programs.vim.defaultEditor;
+      emacsEnabled = config.services.emacs.enable && config.services.emacs.defaultEditor;
+    in
+    helixEnabled || kakouneEnabled || neovimEnabled || vimEnabled || emacsEnabled;
+  message = ''
+    The 'defaultEditor' option now sets both {env}`EDITOR` and {env}`VISUAL`
+    environment variables.
+
+    Previously, only {env}`EDITOR` was set. The {env}`VISUAL` variable is now
+    also configured to point to the same editor, which is the expected behavior
+    for modern terminal editors.
+
+    This change affects the following modules:
+    - programs.helix
+    - programs.kakoune
+    - programs.neovim
+    - programs.vim
+    - services.emacs
+
+    No action is required. This change should improve compatibility with tools
+    that check {env}`VISUAL` before {env}`EDITOR`.
+  '';
+}


### PR DESCRIPTION
Let users know about new variable being set.

### Description

Follow up to https://github.com/nix-community/home-manager/pull/8322
<!--

Please provide a brief description of your change.

-->

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://nix-community.github.io/home-manager/#sec-guidelines

-->

- [ ] Change is backwards compatible.

- [ ] Code formatted with `nix fmt` or
      `nix-shell -p treefmt nixfmt deadnix keep-sorted --run treefmt`.

- [ ] Code tested through `nix run .#tests -- test-all` or
      `nix-shell --pure tests -A run.all`.

- [ ] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [ ] Commit messages are formatted like

  ```
  {component}: {description}

  {long description}
  ```

  See [CONTRIBUTING](https://nix-community.github.io/home-manager/#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/a51598236f23c89e59ee77eb8e0614358b0e896c/modules/programs/lesspipe.nix#L11).
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
  - [ ] Basic tests added. See [Tests](https://nix-community.github.io/home-manager/index.xhtml#sec-tests)

- If this PR adds an exciting new feature or contains a breaking change.
  - [ ] Generate a news entry. See [News](https://nix-community.github.io/home-manager/index.xhtml#sec-news)
